### PR TITLE
feat: add vision lab layout and PWA shell

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "Article6",
+  "short_name": "Article6",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#111111",
+  "icons": [
+    { "src": "/next.svg", "sizes": "192x192", "type": "image/svg+xml" },
+    { "src": "/vercel.svg", "sizes": "512x512", "type": "image/svg+xml" }
+  ]
+}

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charSet="utf-8" />
+  <title>Offline</title>
+</head>
+<body class="p-6">
+  <p>You are offline. Please reconnect.</p>
+</body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,16 @@
+const CACHE = "a6-cache-v1";
+const OFFLINE_URL = "/offline.html";
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE).then((cache) => cache.addAll([OFFLINE_URL]))
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.mode === "navigate") {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.open(CACHE).then((c) => c.match(OFFLINE_URL)))
+    );
+  }
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,12 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --radius: 1rem;
+}
+
+html.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 @theme inline {
@@ -12,15 +18,20 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+.card {
+  @apply rounded-2xl border bg-background shadow-sm;
+}
+
+.btn {
+  @apply inline-flex items-center justify-center rounded-2xl px-4 py-2 border bg-background text-foreground hover:bg-foreground hover:text-background;
+}
+
+.btn-secondary {
+  @apply opacity-80;
 }

--- a/src/app/labs/vlm/page.tsx
+++ b/src/app/labs/vlm/page.tsx
@@ -1,0 +1,31 @@
+import AppLayout from "@/components/layout/AppLayout";
+import PageTemplate from "@/components/PageTemplate";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+export default function VLMPage() {
+  return (
+    <AppLayout breadcrumb={<span>Home ▸ Labs ▸ Vision</span>}>
+      <PageTemplate
+        title="Vision Lab"
+        subtitle="Upload a map screenshot or image and chat. (Backend hook comes later.)"
+        actions={
+          <div className="flex gap-2 sticky top-0">
+            <Button>Upload image</Button>
+            <Button variant="secondary">Clear</Button>
+          </div>
+        }
+      >
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="space-y-3">
+            <Card className="p-4 h-[60vh] overflow-auto">ChatPane (placeholder)</Card>
+            <p className="text-xs text-muted-foreground">
+              Typing and streaming to be wired to API in next task.
+            </p>
+          </div>
+          <Card className="p-4 h-[60vh]">PreviewPane (image placeholder)</Card>
+        </div>
+      </PageTemplate>
+    </AppLayout>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ServiceWorkerRegister from "@/components/ServiceWorkerRegister";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -15,6 +16,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Coming Soon",
   description: "Our website is coming soon. Stay tuned!",
+  manifest: "/manifest.json",
 };
 
 export default function RootLayout({
@@ -23,10 +25,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ServiceWorkerRegister />
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,1 @@
-export default function Home() {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-background text-foreground">
-      <div className="text-center">
-        <h1 className="text-4xl md:text-6xl font-bold">Nature&apos;s agent is coming soon</h1>
-      </div>
-    </div>
-  );
-}
+export { default } from "./labs/vlm/page";

--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+export default function PageTemplate({
+  title,
+  subtitle,
+  actions,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-4">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+          {subtitle ? (
+            <p className="text-muted-foreground">{subtitle}</p>
+          ) : null}
+        </div>
+        {actions ? <div className="shrink-0">{actions}</div> : null}
+      </header>
+      <div>{children}</div>
+    </section>
+  );
+}

--- a/src/components/ServiceWorkerRegister.tsx
+++ b/src/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { useEffect } from "react";
+
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js").catch((err) => {
+        console.error("SW registration failed", err);
+      });
+    }
+  }, []);
+  return null;
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [mode, setMode] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initial = (stored as "light" | "dark" | null) ?? (prefersDark ? "dark" : "light");
+    setMode(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  const toggle = () => {
+    const next = mode === "dark" ? "light" : "dark";
+    setMode(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    window.localStorage.setItem("theme", next);
+  };
+
+  return (
+    <button onClick={toggle} className="btn" aria-label="Toggle dark mode">
+      {mode === "dark" ? "Light" : "Dark"}
+    </button>
+  );
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,28 @@
+"use client";
+import ThemeToggle from "@/components/ThemeToggle";
+
+export default function AppLayout({
+  children,
+  breadcrumb,
+}: {
+  children: React.ReactNode;
+  breadcrumb?: React.ReactNode;
+}) {
+  return (
+    <div>
+      <a href="#content" className="sr-only focus:not-sr-only">Skip to content</a>
+      <header className="border-b">
+        <div className="max-w-6xl mx-auto p-6 flex items-center justify-between">
+          <span className="font-semibold tracking-tight">Article6</span>
+          <ThemeToggle />
+        </div>
+      </header>
+      <main id="content" className="max-w-6xl mx-auto p-6 space-y-6">
+        {breadcrumb ? (
+          <nav className="text-sm text-muted-foreground">{breadcrumb}</nav>
+        ) : null}
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "default" | "secondary";
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className = "", variant = "default", ...props }, ref) => {
+    const base = "btn focus-visible:outline-2 focus-visible:outline-offset-2";
+    const variantClass = variant === "secondary" ? "btn-secondary" : "";
+    return (
+      <button
+        ref={ref}
+        className={`${base} ${variantClass} ${className}`}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,5 @@
+import * as React from "react";
+
+export function Card({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={`card ${className}`} {...props} />;
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,41 @@
+"use client";
+import * as React from "react";
+
+const DialogContext = React.createContext<{
+  open: boolean;
+  setOpen: (o: boolean) => void;
+} | null>(null);
+
+export function Dialog({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <DialogContext.Provider value={{ open, setOpen }}>
+      {children}
+    </DialogContext.Provider>
+  );
+}
+
+export function DialogTrigger({ children }: { children: React.ReactNode }) {
+  const ctx = React.useContext(DialogContext);
+  if (!ctx) return null;
+  return (
+    <span onClick={() => ctx.setOpen(true)} className="inline-block">
+      {children}
+    </span>
+  );
+}
+
+export function DialogContent({ children }: { children: React.ReactNode }) {
+  const ctx = React.useContext(DialogContext);
+  if (!ctx || !ctx.open) return null;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="card p-6 max-w-md w-full">
+        {children}
+        <button onClick={() => ctx.setOpen(false)} className="btn mt-4 w-full">
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className = "", ...props }, ref) => (
+    <input
+      ref={ref}
+      className={`rounded-2xl border px-3 py-2 bg-background text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 ${className}`}
+      {...props}
+    />
+  )
+);
+Input.displayName = "Input";

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,36 @@
+"use client";
+import * as React from "react";
+
+const TabsContext = React.createContext<{
+  value: string;
+  setValue: (v: string) => void;
+} | null>(null);
+
+export function Tabs({ defaultValue, children }: { defaultValue: string; children: React.ReactNode }) {
+  const [value, setValue] = React.useState(defaultValue);
+  return <TabsContext.Provider value={{ value, setValue }}>{children}</TabsContext.Provider>;
+}
+
+export function TabsList({ className = "", children }: { className?: string; children: React.ReactNode }) {
+  return <div className={`flex gap-2 ${className}`}>{children}</div>;
+}
+
+export function TabsTrigger({ value, children }: { value: string; children: React.ReactNode }) {
+  const ctx = React.useContext(TabsContext);
+  if (!ctx) return null;
+  const active = ctx.value === value;
+  return (
+    <button
+      className={`px-3 py-1 rounded-2xl border ${active ? "bg-foreground text-background" : ""}`}
+      onClick={() => ctx.setValue(value)}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function TabsContent({ value, children }: { value: string; children: React.ReactNode }) {
+  const ctx = React.useContext(TabsContext);
+  if (!ctx || ctx.value !== value) return null;
+  return <div className="pt-4">{children}</div>;
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
+  ({ className = "", ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={`rounded-2xl border px-3 py-2 bg-background text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 ${className}`}
+      {...props}
+    />
+  )
+);
+Textarea.displayName = "Textarea";


### PR DESCRIPTION
## Summary
- add reusable AppLayout and PageTemplate components
- scaffold ui kit and Vision Lab page
- wire up manifest and basic service worker for PWA

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ccaa2ea88331968be898ceb30c16