### PR TITLE
feat: add chat interface and echo backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+INFERENCE_BASE_URL=http://localhost:8000/v1
+INFERENCE_API_KEY=
+MODEL_ID=Qwen2.5-VL-7B-Instruct

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# app.article6
+# Automated Carbon Compliance
+
+A minimal Next.js application with a chat interface.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+Visit `http://localhost:3000`.
+
+### Environment Variables
+Copy `.env.example` to `.env` and set:
+
+- `INFERENCE_BASE_URL` – endpoint for inference (default `http://localhost:8000/v1`)
+- `INFERENCE_API_KEY` – API key for model provider
+- `MODEL_ID` – model identifier (`Qwen2.5-VL-7B-Instruct`)
+
+## Testing
+
+```bash
+npm test
+```
+
+## Future Work
+- Replace echo endpoint with real Qwen2.5-VL inference. You can self-host with vLLM or use an OpenAI-compatible router and set the env vars above.
+- Add file upload and map viewer.

--- a/__tests__/api-chat.spec.ts
+++ b/__tests__/api-chat.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { POST } from '../src/app/api/chat/route';
+
+describe('POST /api/chat', () => {
+  it('echoes message', async () => {
+    const res = await POST(
+      new Request('http://localhost/api/chat', {
+        method: 'POST',
+        body: JSON.stringify({ message: 'ping' }),
+      })
+    );
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.echo).toBe('ping');
+  });
+
+  it('returns 400 on invalid', async () => {
+    const res = await POST(
+      new Request('http://localhost/api/chat', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/chat-store.spec.ts
+++ b/__tests__/chat-store.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { useChatStore } from '../src/lib/chat-store';
+
+describe('chat store', () => {
+  it('handles send, append and clear', () => {
+    const store = useChatStore;
+    store.getState().clear();
+
+    const userMsg = store.getState().send('hello');
+    expect(store.getState().messages).toHaveLength(1);
+    expect(userMsg.role).toBe('user');
+    expect(store.getState().pending).toBe(true);
+
+    const assistantMsg = store
+      .getState()
+      .append({ role: 'assistant', content: 'hello' });
+    expect(assistantMsg.role).toBe('assistant');
+    expect(store.getState().messages).toHaveLength(2);
+    expect(store.getState().pending).toBe(false);
+
+    store.getState().clear();
+    expect(store.getState().messages).toHaveLength(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.0.0",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.379.0",
+    "lucide-react": "^0.450.0",
     "next": "^15.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.0.0",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.450.0",
+    "lucide-react": "^0.451.0",
     "next": "^15.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -6,22 +6,35 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write .",
+    "test": "vitest"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "^1.0.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.379.0",
     "next": "^15.4.6",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "swr": "^2.2.5",
+    "zustand": "^4.5.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^16.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
+    "prettier": "^3.3.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.1"
   }
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+const bodySchema = z.object({ message: z.string().min(1) });
+
+export async function POST(req: Request) {
+  const log = (info: Record<string, unknown>) =>
+    console.log(JSON.stringify(info));
+  try {
+    const json = await req.json();
+    const { message } = bodySchema.parse(json);
+
+    log({ level: 'info', event: 'chat', model: process.env.MODEL_ID });
+
+    // Future model call
+    // await fetch(`${process.env.INFERENCE_BASE_URL}/chat/completions`, {
+    //   method: 'POST',
+    //   headers: {
+    //     'Content-Type': 'application/json',
+    //     Authorization: `Bearer ${process.env.INFERENCE_API_KEY}`,
+    //   },
+    //   body: JSON.stringify({
+    //     model: process.env.MODEL_ID,
+    //     messages: [{ role: 'user', content: message }],
+    //   }),
+    // });
+
+    return Response.json({
+      echo: message,
+      model: process.env.MODEL_ID || 'Qwen2.5-VL',
+    });
+  } catch {
+    return new Response('Invalid request', { status: 400 });
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,8 @@
 /* Custom scrollbars */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #223042 #0E141B;
+  /* Subtle scrollbar akin to ChatGPT */
+  scrollbar-color: #565869 #2A2B32;
 }
 
 *::-webkit-scrollbar {
@@ -11,10 +12,10 @@
 }
 
 *::-webkit-scrollbar-track {
-  background: #0E141B;
+  background: #2A2B32;
 }
 
 *::-webkit-scrollbar-thumb {
-  background: #223042;
+  background: #565869;
   border-radius: 9999px;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,20 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
+/* Custom scrollbars */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #223042 #0E141B;
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+*::-webkit-scrollbar {
+  width: 8px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+*::-webkit-scrollbar-track {
+  background: #0E141B;
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+*::-webkit-scrollbar-thumb {
+  background: #223042;
+  border-radius: 9999px;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,21 +13,21 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Coming Soon",
-  description: "Our website is coming soon. Stay tuned!",
+  title: "Automated Carbon Compliance",
+  description: "Verify climate claims",
 };
 
 export default function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+}: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}
       >
-        {children}
+        <div className="container mx-auto flex min-h-screen flex-1">
+          {children}
+        </div>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,8 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
 export const metadata: Metadata = {
   title: "Automated Carbon Compliance",
@@ -23,10 +15,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}
+        className={`${inter.variable} bg-bg text-text antialiased selection:bg-accent/30 tracking-tight leading-relaxed text-[15px] md:text-[16px]`}
       >
-        <div className="container mx-auto flex min-h-screen flex-1">
-          {children}
+        <div className="min-h-dvh grid">
+          <div className="max-w-7xl mx-auto px-6 md:px-8 flex flex-1 w-full">{children}</div>
         </div>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,9 @@
 import { Shell } from '@/components/Shell';
 
 export default function Home() {
-  return <Shell />;
+  return (
+    <div className="flex flex-1 w-full">
+      <Shell />
+    </div>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,5 @@
+import { Shell } from '@/components/Shell';
+
 export default function Home() {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-background text-foreground">
-      <div className="text-center">
-        <h1 className="text-4xl md:text-6xl font-bold">Nature&apos;s agent is coming soon</h1>
-      </div>
-    </div>
-  );
+  return <Shell />;
 }

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -28,24 +28,25 @@ export function ChatPane() {
   };
 
   return (
-    <div className="flex h-full flex-col">
-      <header className="border-b p-4 font-semibold">
-        Automated Carbon Compliance
+    <div className="relative flex flex-col h-full">
+      <header className="border-b border-border bg-panel/70 backdrop-blur p-4 md:p-6">
+        <h1 className="text-lg font-semibold">Automated Carbon Compliance</h1>
       </header>
-      <div className="flex-1 space-y-2 overflow-y-auto p-4">
+      <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-4">
         {messages.length === 0 ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            What would you like to verify?
+          <div className="mx-auto my-24 max-w-xl text-center p-8 rounded-2xl bg-panelElev ring-1 ring-border">
+            <h2 className="text-2xl font-semibold">What would you like to verify?</h2>
+            <p className="mt-2 text-subtext">Start by sending a message.</p>
           </div>
         ) : (
           messages.map((m) => (
             <div
               key={m.id}
               className={clsx(
-                'max-w-[80%] overflow-hidden rounded px-3 py-2 text-sm break-words',
+                'max-w-[72ch] px-4 py-3 ring-1 ring-border break-words',
                 m.role === 'user'
-                  ? 'ml-auto bg-primary text-primary-foreground'
-                  : 'mr-auto bg-muted'
+                  ? 'ml-auto rounded-2xl rounded-tr-md bg-[#1B2631]'
+                  : 'mr-auto rounded-2xl rounded-tl-md bg-[#121A22]'
               )}
             >
               {m.content}
@@ -53,8 +54,8 @@ export function ChatPane() {
           ))
         )}
       </div>
-      <form onSubmit={handleSubmit} className="border-t p-4">
-        <div className="flex gap-2">
+      <form onSubmit={handleSubmit} className="border-t border-border bg-panel/80 backdrop-blur">
+        <div className="max-w-3xl mx-auto py-4 px-4 md:px-0 flex gap-2">
           <input
             ref={inputRef}
             type="text"
@@ -66,12 +67,12 @@ export function ChatPane() {
               }
             }}
             placeholder="What would you like to verify?"
-            className="flex-1 rounded border px-3 py-2 text-sm"
+            className="flex-1 h-12 px-4 rounded-xl bg-[#131A22] ring-1 ring-border placeholder:text-subtext focus:ring-2 focus:ring-accent/60 outline-none"
           />
           <button
             type="submit"
             disabled={pending}
-            className="rounded bg-primary px-4 py-2 text-sm text-primary-foreground disabled:opacity-50"
+            className="h-12 px-4 rounded-xl bg-accent text-black font-medium hover:brightness-110 disabled:opacity-50 transition-colors duration-200 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
           >
             Send
           </button>

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { FormEvent, useRef, useState } from 'react';
+import clsx from 'clsx';
+import { postChat } from '@/lib/api';
+import { useChatStore } from '@/lib/chat-store';
+
+export function ChatPane() {
+  const { messages, pending, send, append } = useChatStore();
+  const [input, setInput] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const content = input.trim();
+    if (!content) return;
+    send(content);
+    setInput('');
+    inputRef.current?.focus();
+    try {
+      const res = await postChat(content);
+      append({ role: 'assistant', content: res.echo });
+    } catch (err) {
+      console.error(err);
+      // ensure pending flag resets on error
+      useChatStore.setState({ pending: false });
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border-b p-4 font-semibold">
+        Automated Carbon Compliance
+      </header>
+      <div className="flex-1 space-y-2 overflow-y-auto p-4">
+        {messages.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            What would you like to verify?
+          </div>
+        ) : (
+          messages.map((m) => (
+            <div
+              key={m.id}
+              className={clsx(
+                'max-w-[80%] overflow-hidden rounded px-3 py-2 text-sm break-words',
+                m.role === 'user'
+                  ? 'ml-auto bg-primary text-primary-foreground'
+                  : 'mr-auto bg-muted'
+              )}
+            >
+              {m.content}
+            </div>
+          ))
+        )}
+      </div>
+      <form onSubmit={handleSubmit} className="border-t p-4">
+        <div className="flex gap-2">
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && e.shiftKey) {
+                return;
+              }
+            }}
+            placeholder="What would you like to verify?"
+            className="flex-1 rounded border px-3 py-2 text-sm"
+          />
+          <button
+            type="submit"
+            disabled={pending}
+            className="rounded bg-primary px-4 py-2 text-sm text-primary-foreground disabled:opacity-50"
+          >
+            Send
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -29,12 +29,12 @@ export function ChatPane() {
 
   return (
     <div className="relative flex flex-col h-full">
-      <header className="border-b border-border bg-panel/70 backdrop-blur p-4 md:p-6">
+      <header className="border-b border-border bg-bg p-4 md:p-6">
         <h1 className="text-lg font-semibold">Automated Carbon Compliance</h1>
       </header>
       <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-4">
         {messages.length === 0 ? (
-          <div className="mx-auto my-24 max-w-xl text-center p-8 rounded-2xl bg-panelElev ring-1 ring-border">
+          <div className="mx-auto my-24 max-w-xl text-center p-8 rounded-2xl bg-panel ring-1 ring-border">
             <h2 className="text-2xl font-semibold">What would you like to verify?</h2>
             <p className="mt-2 text-subtext">Start by sending a message.</p>
           </div>
@@ -43,10 +43,10 @@ export function ChatPane() {
             <div
               key={m.id}
               className={clsx(
-                'max-w-[72ch] px-4 py-3 ring-1 ring-border break-words',
+                'max-w-[72ch] px-4 py-3 break-words',
                 m.role === 'user'
-                  ? 'ml-auto rounded-2xl rounded-tr-md bg-[#1B2631]'
-                  : 'mr-auto rounded-2xl rounded-tl-md bg-[#121A22]'
+                  ? 'ml-auto rounded-2xl rounded-tr-md bg-[#444654]'
+                  : 'mr-auto rounded-2xl rounded-tl-md bg-bg'
               )}
             >
               {m.content}
@@ -54,7 +54,7 @@ export function ChatPane() {
           ))
         )}
       </div>
-      <form onSubmit={handleSubmit} className="border-t border-border bg-panel/80 backdrop-blur">
+      <form onSubmit={handleSubmit} className="border-t border-border bg-bg">
         <div className="max-w-3xl mx-auto py-4 px-4 md:px-0 flex gap-2">
           <input
             ref={inputRef}
@@ -67,12 +67,12 @@ export function ChatPane() {
               }
             }}
             placeholder="What would you like to verify?"
-            className="flex-1 h-12 px-4 rounded-xl bg-[#131A22] ring-1 ring-border placeholder:text-subtext focus:ring-2 focus:ring-accent/60 outline-none"
+            className="flex-1 h-12 px-4 rounded-xl bg-panel ring-1 ring-border placeholder:text-subtext focus:ring-2 focus:ring-accent/60 outline-none"
           />
           <button
             type="submit"
             disabled={pending}
-            className="h-12 px-4 rounded-xl bg-accent text-black font-medium hover:brightness-110 disabled:opacity-50 transition-colors duration-200 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+            className="h-12 px-4 rounded-xl bg-accent text-black font-medium hover:bg-accent/90 disabled:opacity-50 transition-colors duration-200 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
           >
             Send
           </button>

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -16,19 +16,21 @@ export function Shell() {
   }, []);
 
   return (
-    <div className="flex h-full">
-      <Sidebar open={open} onOpenChange={setOpen} />
-      <div className="flex flex-1 flex-col">
-        <div className="flex h-12 items-center border-b px-4">
-          <button
-            type="button"
-            onClick={() => setOpen((o) => !o)}
-            className="mr-2"
-          >
-            <PanelLeft className="h-5 w-5" />
-          </button>
+    <div className="w-full h-full rounded-2xl bg-panel shadow-soft ring-1 ring-border overflow-hidden">
+      <div className="grid h-full grid-cols-1 md:grid-cols-[280px,1fr]">
+        <Sidebar open={open} onOpenChange={setOpen} />
+        <div className="relative flex flex-col">
+          <div className="sticky top-0 z-10 flex h-12 items-center border-b border-border bg-panel/80 backdrop-blur supports-[backdrop-filter]:bg-panel/80 px-4">
+            <button
+              type="button"
+              onClick={() => setOpen((o) => !o)}
+              className="h-9 px-3 rounded-xl bg-panelElev hover:bg-panelElev/80 ring-1 ring-border transition-colors duration-200 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+            >
+              <PanelLeft className="h-5 w-5" />
+            </button>
+          </div>
+          <ChatPane />
         </div>
-        <ChatPane />
       </div>
     </div>
   );

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { PanelLeft } from 'lucide-react';
+import { Sidebar } from './Sidebar';
+import { ChatPane } from './ChatPane';
+
+export function Shell() {
+  const [open, setOpen] = useState(false);
+
+  // expand sidebar by default on desktop
+  useEffect(() => {
+    if (matchMedia('(min-width: 768px)').matches) {
+      setOpen(true);
+    }
+  }, []);
+
+  return (
+    <div className="flex h-full">
+      <Sidebar open={open} onOpenChange={setOpen} />
+      <div className="flex flex-1 flex-col">
+        <div className="flex h-12 items-center border-b px-4">
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            className="mr-2"
+          >
+            <PanelLeft className="h-5 w-5" />
+          </button>
+        </div>
+        <ChatPane />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -20,11 +20,11 @@ export function Shell() {
       <div className="grid h-full grid-cols-1 md:grid-cols-[280px,1fr]">
         <Sidebar open={open} onOpenChange={setOpen} />
         <div className="relative flex flex-col">
-          <div className="sticky top-0 z-10 flex h-12 items-center border-b border-border bg-panel/80 backdrop-blur supports-[backdrop-filter]:bg-panel/80 px-4">
+          <div className="sticky top-0 z-10 flex h-12 items-center border-b border-border bg-bg/80 backdrop-blur supports-[backdrop-filter]:bg-bg/80 px-4">
             <button
               type="button"
               onClick={() => setOpen((o) => !o)}
-              className="h-9 px-3 rounded-xl bg-panelElev hover:bg-panelElev/80 ring-1 ring-border transition-colors duration-200 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+              className="h-9 px-3 rounded-xl bg-panel hover:bg-panelElev ring-1 ring-border transition-colors duration-200 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
             >
               <PanelLeft className="h-5 w-5" />
             </button>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import * as Collapsible from '@radix-ui/react-collapsible';
+import clsx from 'clsx';
+
+interface SidebarProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function Sidebar({ open, onOpenChange }: SidebarProps) {
+  return (
+    <Collapsible.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      className={clsx(
+        'h-full transition-all',
+        open ? 'w-64' : 'w-0 overflow-hidden'
+      )}
+    >
+      <Collapsible.Content className="flex h-full flex-col border-r bg-background">
+        <div className="border-b p-4 font-semibold">Projects</div>
+        <div className="flex-1 p-4 text-sm text-muted-foreground">
+          No projects yet
+        </div>
+        <div className="border-t p-4">
+          <button
+            type="button"
+            className="w-full rounded bg-primary px-3 py-2 text-sm text-primary-foreground"
+          >
+            New Project
+          </button>
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,7 +19,9 @@ export function Sidebar({ open, onOpenChange }: SidebarProps) {
       )}
     >
       <Collapsible.Content className="flex h-full flex-col bg-panelElev border-r border-border">
-        <div className="border-b border-border p-4 text-sm uppercase tracking-wider text-subtext/70">Projects</div>
+        <div className="border-b border-border p-4 text-sm uppercase tracking-wider text-subtext/70">
+          Projects
+        </div>
         <div className="flex-1 p-4 text-sm text-subtext">No projects yet</div>
         <div className="border-t border-border p-4">
           <button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,19 +14,17 @@ export function Sidebar({ open, onOpenChange }: SidebarProps) {
       open={open}
       onOpenChange={onOpenChange}
       className={clsx(
-        'h-full transition-all',
+        'h-full transition-[width] duration-200 motion-reduce:transition-none',
         open ? 'w-64' : 'w-0 overflow-hidden'
       )}
     >
-      <Collapsible.Content className="flex h-full flex-col border-r bg-background">
-        <div className="border-b p-4 font-semibold">Projects</div>
-        <div className="flex-1 p-4 text-sm text-muted-foreground">
-          No projects yet
-        </div>
-        <div className="border-t p-4">
+      <Collapsible.Content className="flex h-full flex-col bg-panelElev border-r border-border">
+        <div className="border-b border-border p-4 text-sm uppercase tracking-wider text-subtext/70">Projects</div>
+        <div className="flex-1 p-4 text-sm text-subtext">No projects yet</div>
+        <div className="border-t border-border p-4">
           <button
             type="button"
-            className="w-full rounded bg-primary px-3 py-2 text-sm text-primary-foreground"
+            className="h-9 w-full rounded-xl bg-accent text-black font-medium hover:brightness-110 shadow-soft transition-colors duration-200 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
           >
             New Project
           </button>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,16 @@
+export type ChatResponse = {
+  echo: string;
+  model: string;
+};
+
+export async function postChat(message: string): Promise<ChatResponse> {
+  const res = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message }),
+  });
+  if (!res.ok) {
+    throw new Error('Request failed');
+  }
+  return (await res.json()) as ChatResponse;
+}

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand';
+import type { ChatMessage } from './types';
+
+// simple deterministic id generator
+let idCounter = 0;
+const nextId = () => `${++idCounter}`;
+
+type State = {
+  messages: ChatMessage[];
+  pending: boolean;
+};
+
+type Actions = {
+  send: (content: string) => ChatMessage;
+  append: (message: Omit<ChatMessage, 'id'>) => ChatMessage;
+  clear: () => void;
+};
+
+export const useChatStore = create<State & Actions>((set) => ({
+  messages: [],
+  pending: false,
+  send: (content) => {
+    const message: ChatMessage = {
+      id: nextId(),
+      role: 'user',
+      content,
+    };
+    set((state) => ({
+      messages: [...state.messages, message],
+      pending: true,
+    }));
+    return message;
+  },
+  append: (message) => {
+    const msg: ChatMessage = { ...message, id: nextId() };
+    set((state) => ({
+      messages: [...state.messages, msg],
+      pending: false,
+    }));
+    return msg;
+  },
+  clear: () => set({ messages: [], pending: false }),
+}));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,5 @@
+export type ChatMessage = {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,32 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        bg: '#0B0F14',
+        panel: '#11161D',
+        panelElev: '#141B23',
+        border: '#1E2630',
+        text: '#E6EDF6',
+        subtext: '#9CB0C3',
+        accent: '#35A0FF',
+        'accent-2': '#6BE675',
+      },
+      fontFamily: {
+        sans: ['var(--font-sans)', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
+      borderRadius: {
+        xl: '14px',
+        '2xl': '20px',
+      },
+      boxShadow: {
+        soft: '0 6px 24px rgba(0,0,0,0.25)',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,14 +5,15 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        bg: '#0B0F14',
-        panel: '#11161D',
-        panelElev: '#141B23',
-        border: '#1E2630',
-        text: '#E6EDF6',
-        subtext: '#9CB0C3',
-        accent: '#35A0FF',
-        'accent-2': '#6BE675',
+        // ChatGPT-inspired dark palette
+        bg: '#343541',
+        panel: '#40414F',
+        panelElev: '#202123',
+        border: '#565869',
+        text: '#ECECF1',
+        subtext: '#ACB1C9',
+        accent: '#10A37F',
+        'accent-2': '#2A8C63',
       },
       fontFamily: {
         sans: ['var(--font-sans)', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- implement modular chat UI with collapsible sidebar
- add zustand store and echoing chat API
- document environment setup and testing

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d79c48448331a0cee7c3fcdd281a