### PR TITLE
feat(chat): modular UI and backend

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,10 @@
+PROVIDER=openrouter
+OPENROUTER_API_KEY=sk-...
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_MODEL=qwen/qwen2.5-vl-7b-instruct
+
+HF_TOKEN=hf_...
+HF_API_URL=https://api-inference.huggingface.co/models/Qwen/Qwen2.5-VL-7B-Instruct
+
+VLLM_BASE_URL=http://localhost:8000/v1
+VLLM_MODEL=Qwen/Qwen2.5-VL-7B-Instruct

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -11,7 +11,14 @@
   "dependencies": {
     "next": "^15.4.6",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "clsx": "^2.1.1",
+    "eventsource-parser": "^1.0.0",
+    "lucide-react": "^0.471.0",
+    "openai": "^4.52.0",
+    "react-markdown": "^9.0.3",
+    "zod": "^3.23.8",
+    "zustand": "^5.0.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -85,7 +85,13 @@ function withImages(
     role: "user",
     content: [
       { type: "text", text: last.content },
-      ...images.map((url) => ({ type: "image_url", image_url: { url } })),
+      ...images.map(
+        (url) =>
+          ({ type: "image_url", image_url: { url } } as unknown as {
+            type: "image_url";
+            image_url: { url: string };
+          })
+      ),
     ],
   };
   return [...mapped.slice(0, -1), userWithImages];

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest } from "next/server";
+import { OpenAI } from "openai";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import { z } from "zod";
+
+const BodySchema = z.object({
+  messages: z.array(z.object({ role: z.string(), content: z.string() })),
+  images: z.array(z.string()).optional(),
+  provider: z.string().optional(),
+  model: z.string().optional(),
+  temperature: z.number().optional(),
+});
+
+function envForProvider(provider: string) {
+  switch (provider) {
+    case "hf":
+      return {
+        token: process.env.HF_TOKEN,
+        url: process.env.HF_API_URL,
+      };
+    case "vllm":
+      return {
+        baseURL: process.env.VLLM_BASE_URL,
+        model: process.env.VLLM_MODEL,
+      };
+    default:
+      return {
+        apiKey: process.env.OPENROUTER_API_KEY,
+        baseURL: process.env.OPENROUTER_BASE_URL,
+        model: process.env.OPENROUTER_MODEL,
+      };
+  }
+}
+
+export async function GET() {
+  const provider = process.env.PROVIDER || "openrouter";
+  const env = envForProvider(provider);
+  return Response.json({ ok: true, provider, model: env.model });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = BodySchema.parse(await req.json());
+    const provider = body.provider || process.env.PROVIDER || "openrouter";
+    if (provider === "hf") {
+      return handleHF(body);
+    }
+    if (provider === "vllm") {
+      return handleOpenAI(
+        body,
+        process.env.VLLM_BASE_URL!,
+        process.env.VLLM_MODEL!,
+        undefined
+      );
+    }
+    return handleOpenAI(
+      body,
+      process.env.OPENROUTER_BASE_URL!,
+      body.model || process.env.OPENROUTER_MODEL!,
+      process.env.OPENROUTER_API_KEY
+    );
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Unknown error";
+    return Response.json({ error: message }, { status: 400 });
+  }
+}
+
+interface TextMessage {
+  role: string;
+  content: string;
+}
+
+function withImages(
+  messages: TextMessage[],
+  images?: string[]
+): ChatCompletionMessageParam[] {
+  if (!images?.length) return messages;
+  const last = messages[messages.length - 1];
+  return [
+    ...(messages.slice(0, -1) as ChatCompletionMessageParam[]),
+    {
+      role: last.role as ChatCompletionMessageParam["role"],
+      content: [
+        { type: "text", text: last.content },
+        ...images.map((url) => ({ type: "image_url", image_url: { url } })),
+      ],
+    },
+  ];
+}
+
+async function handleOpenAI(
+  body: z.infer<typeof BodySchema>,
+  baseURL: string,
+  model: string,
+  apiKey?: string
+) {
+  const client = new OpenAI({ apiKey, baseURL });
+  const stream = await client.chat.completions.create({
+    model,
+    messages: withImages(body.messages, body.images),
+    stream: true,
+    temperature: body.temperature,
+  });
+  const encoder = new TextEncoder();
+  const readable = new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const chunk of stream) {
+          const token = chunk.choices[0]?.delta?.content || "";
+          if (token) {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify({ text: token })}\n\n`)
+            );
+          }
+        }
+        controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+  });
+  return new Response(readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+    },
+  });
+}
+
+async function handleHF(body: z.infer<typeof BodySchema>) {
+  const env = envForProvider("hf");
+  const res = await fetch(env.url!, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ inputs: body.messages[body.messages.length - 1].content }),
+  });
+  const json = await res.json();
+  const text =
+    json?.generated_text ||
+    json?.choices?.[0]?.message?.content ||
+    JSON.stringify(json);
+  const encoder = new TextEncoder();
+  const readable = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify({ text })}\n\n`));
+      controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
+      controller.close();
+    },
+  });
+  return new Response(readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+    },
+  });
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -74,14 +74,18 @@ function withImages(
   messages: TextMessage[],
   images?: string[]
 ): ChatCompletionMessageParam[] {
-  if (!images?.length) return messages;
-  const last = messages[messages.length - 1];
+  const mapped = messages.map<ChatCompletionMessageParam>((m) => ({
+    role: m.role as ChatCompletionMessageParam["role"],
+    content: m.content,
+  }));
+  if (!images?.length) return mapped;
+  const last = mapped[mapped.length - 1];
   return [
-    ...(messages.slice(0, -1) as ChatCompletionMessageParam[]),
+    ...mapped.slice(0, -1),
     {
-      role: last.role as ChatCompletionMessageParam["role"],
+      role: last.role,
       content: [
-        { type: "text", text: last.content },
+        { type: "text", text: last.content as string },
         ...images.map((url) => ({ type: "image_url", image_url: { url } })),
       ],
     },

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -74,10 +74,10 @@ function withImages(
   messages: TextMessage[],
   images?: string[]
 ): ChatCompletionMessageParam[] {
-  const mapped = messages.map<ChatCompletionMessageParam>((m) => ({
+  const mapped = messages.map((m) => ({
     role: m.role as ChatCompletionMessageParam["role"],
     content: m.content,
-  }));
+  })) as ChatCompletionMessageParam[];
   if (!images?.length) return mapped;
   const last = mapped[mapped.length - 1];
   return [

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -80,16 +80,15 @@ function withImages(
   })) as ChatCompletionMessageParam[];
   if (!images?.length) return mapped;
   const last = mapped[mapped.length - 1];
-  return [
-    ...mapped.slice(0, -1),
-    {
-      role: last.role,
-      content: [
-        { type: "text", text: last.content as string },
-        ...images.map((url) => ({ type: "image_url", image_url: { url } })),
-      ],
-    },
-  ];
+  if (last.role !== "user" || typeof last.content !== "string") return mapped;
+  const userWithImages: ChatCompletionMessageParam = {
+    role: "user",
+    content: [
+      { type: "text", text: last.content },
+      ...images.map((url) => ({ type: "image_url", image_url: { url } })),
+    ],
+  };
+  return [...mapped.slice(0, -1), userWithImages];
 }
 
 async function handleOpenAI(

--- a/src/app/api/echo/route.ts
+++ b/src/app/api/echo/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  return NextResponse.json(body);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,8 +13,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Coming Soon",
-  description: "Our website is coming soon. Stay tuned!",
+  title: "Modular Chat UI",
+  description: "Chat with Qwen2.5-VL",
 };
 
 export default function RootLayout({
@@ -24,10 +24,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <div className="max-w-6xl mx-auto p-6 space-y-6">{children}</div>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,5 @@
+import ChatLayout from "@/components/chat/ChatLayout";
+
 export default function Home() {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-background text-foreground">
-      <div className="text-center">
-        <h1 className="text-4xl md:text-6xl font-bold">Nature&apos;s agent is coming soon</h1>
-      </div>
-    </div>
-  );
+  return <ChatLayout />;
 }

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import Sidebar from "./Sidebar";
+import Header from "./Header";
+import MessageList from "./MessageList";
+import Composer from "./Composer";
+
+export default function ChatLayout() {
+  return (
+    <div className="flex h-screen">
+      <Sidebar />
+      <div className="flex flex-col flex-1">
+        <Header />
+        <MessageList />
+        <Composer />
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from "react";
+import { useChat } from "@/lib/useChat";
+
+export default function Composer() {
+  const [text, setText] = useState("");
+  const [images, setImages] = useState("");
+  const { sendMessage } = useChat();
+
+  const doSubmit = () => {
+    if (!text.trim()) return;
+    const imgs = images
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    sendMessage(text, imgs.length ? imgs : undefined);
+    setText("");
+    setImages("");
+  };
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    doSubmit();
+  };
+
+  const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      doSubmit();
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="p-4 border-t space-y-2">
+      <textarea
+        className="w-full border rounded p-2"
+        placeholder="What would you like to verify?"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={onKey}
+        rows={3}
+      />
+      <input
+        type="text"
+        className="w-full border rounded p-2 text-sm"
+        placeholder="Image URLs (comma separated)"
+        value={images}
+        onChange={(e) => setImages(e.target.value)}
+      />
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          className="bg-primary text-primary-foreground px-4 py-2 rounded"
+        >
+          Send
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/chat/Header.tsx
+++ b/src/components/chat/Header.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useState } from "react";
+import clsx from "clsx";
+import { useChatStore } from "@/lib/store";
+
+export default function Header() {
+  const provider = useChatStore((s) => s.provider);
+  const model = useChatStore((s) => s.model);
+  const [ok, setOk] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    fetch("/api/chat")
+      .then((r) => r.json())
+      .then(() => setOk(true))
+      .catch(() => setOk(false));
+  }, [provider, model]);
+
+  return (
+    <div className="flex items-center justify-between border-b p-4">
+      <h1 className="font-semibold">Modular Chat UI</h1>
+      <div className="flex items-center space-x-2 text-sm">
+        <span>{provider}</span>
+        <span>{model}</span>
+        <span
+          className={clsx(
+            "w-2 h-2 rounded-full",
+            ok === null ? "bg-gray-400" : ok ? "bg-green-500" : "bg-red-500"
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import ReactMarkdown from "react-markdown";
+import clsx from "clsx";
+import { useChatStore } from "@/lib/store";
+
+export default function MessageList() {
+  const activeId = useChatStore((s) => s.activeId);
+  const conversation = useChatStore((s) =>
+    activeId ? s.conversations[activeId] : undefined
+  );
+  if (!conversation) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+        Try asking me something...
+      </div>
+    );
+  }
+  return (
+    <div className="flex-1 overflow-y-auto p-4 space-y-4 flex flex-col">
+      {conversation.messages.map((m, i) => (
+        <div
+          key={i}
+          className={clsx(
+            "max-w-prose",
+            m.role === "user" ? "self-end" : "self-start"
+          )}
+        >
+          <div
+            className={clsx(
+              "rounded-lg p-3",
+              m.role === "user"
+                ? "bg-primary text-primary-foreground"
+                : "bg-secondary text-secondary-foreground"
+            )}
+          >
+            <ReactMarkdown>{m.content}</ReactMarkdown>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/chat/ModelPicker.tsx
+++ b/src/components/chat/ModelPicker.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useChatStore } from "@/lib/store";
+
+const models = [
+  { label: "Qwen2.5-VL 7B", value: "qwen/qwen2.5-vl-7b-instruct" },
+  { label: "Qwen2.5-VL 32B", value: "qwen/qwen2.5-vl-32b-instruct" },
+  { label: "Qwen2.5-VL 72B", value: "qwen/qwen2.5-vl-72b-instruct" },
+];
+
+export default function ModelPicker() {
+  const model = useChatStore((s) => s.model);
+  const setModel = useChatStore((s) => s.setModel);
+  return (
+    <select
+      className="w-full border rounded p-2 text-sm"
+      value={model}
+      onChange={(e) => setModel(e.target.value)}
+    >
+      {models.map((m) => (
+        <option key={m.value} value={m.value}>
+          {m.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/chat/Sidebar.tsx
+++ b/src/components/chat/Sidebar.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useChatStore } from "@/lib/store";
+import ModelPicker from "./ModelPicker";
+
+const providers = [
+  { label: "OpenRouter", value: "openrouter" },
+  { label: "HuggingFace", value: "hf" },
+  { label: "vLLM", value: "vllm" },
+];
+
+export default function Sidebar() {
+  const conversations = useChatStore((s) => Object.values(s.conversations));
+  const activeId = useChatStore((s) => s.activeId);
+  const setActive = useChatStore((s) => s.setActive);
+  const newConversation = useChatStore((s) => s.newConversation);
+  const provider = useChatStore((s) => s.provider);
+  const setProvider = useChatStore((s) => s.setProvider);
+  const temperature = useChatStore((s) => s.temperature);
+  const setTemperature = useChatStore((s) => s.setTemperature);
+
+  return (
+    <div className="hidden md:flex md:w-64 border-r flex-col">
+      <div className="p-4 space-y-4">
+        <button
+          onClick={() => newConversation()}
+          className="w-full bg-primary text-primary-foreground p-2 rounded"
+        >
+          New chat
+        </button>
+        <div className="space-y-2">
+          <label className="text-xs font-medium">Provider</label>
+          <select
+            className="w-full border rounded p-2 text-sm"
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+          >
+            {providers.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <ModelPicker />
+        <div className="space-y-1">
+          <label className="text-xs font-medium">Temperature: {temperature.toFixed(1)}</label>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.1}
+            value={temperature}
+            onChange={(e) => setTemperature(parseFloat(e.target.value))}
+            className="w-full"
+          />
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {conversations.map((c) => (
+          <div
+            key={c.id}
+            onClick={() => setActive(c.id)}
+            className={`p-2 cursor-pointer ${c.id === activeId ? "bg-muted" : ""}`}
+          >
+            Chat {c.id}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,51 @@
+import { create } from "zustand";
+
+export type Message = { role: "user" | "assistant"; content: string };
+export type Conversation = { id: string; messages: Message[] };
+
+interface ChatState {
+  conversations: Record<string, Conversation>;
+  activeId: string | null;
+  provider: string;
+  model: string;
+  temperature: number;
+  newConversation: () => string;
+  addMessage: (id: string, message: Message) => void;
+  setActive: (id: string) => void;
+  setModel: (model: string) => void;
+  setProvider: (provider: string) => void;
+  setTemperature: (temp: number) => void;
+}
+
+export const useChatStore = create<ChatState>((set) => ({
+  conversations: {},
+  activeId: null,
+  provider: process.env.PROVIDER || "openrouter",
+  model: process.env.OPENROUTER_MODEL || "qwen/qwen2.5-vl-7b-instruct",
+  temperature: 0.7,
+  newConversation: () => {
+    const id = Date.now().toString();
+    set((state) => ({
+      conversations: {
+        ...state.conversations,
+        [id]: { id, messages: [] },
+      },
+      activeId: id,
+    }));
+    return id;
+  },
+  addMessage: (id, message) =>
+    set((state) => {
+      const convo = state.conversations[id] || { id, messages: [] };
+      return {
+        conversations: {
+          ...state.conversations,
+          [id]: { ...convo, messages: [...convo.messages, message] },
+        },
+      };
+    }),
+  setActive: (id) => set({ activeId: id }),
+  setModel: (model) => set({ model }),
+  setProvider: (provider) => set({ provider }),
+  setTemperature: (temperature) => set({ temperature }),
+}));

--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -1,0 +1,27 @@
+import { createParser } from "eventsource-parser";
+
+export async function streamResponse(
+  res: Response,
+  onToken: (token: string) => void
+) {
+  const reader = res.body?.getReader();
+  if (!reader) return;
+  const decoder = new TextDecoder();
+  const parser = createParser((event) => {
+    if (event.type === "event") {
+      if (event.data === "[DONE]") return;
+      try {
+        const json = JSON.parse(event.data);
+        const text = json.text || json.content || "";
+        if (text) onToken(text);
+      } catch {
+        // ignore
+      }
+    }
+  });
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    parser.feed(decoder.decode(value));
+  }
+}

--- a/src/lib/useChat.ts
+++ b/src/lib/useChat.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { streamResponse } from "@/lib/stream";
+import { useChatStore } from "@/lib/store";
+
+export function useChat() {
+  const sendMessage = async (text: string, images?: string[]) => {
+    const state = useChatStore.getState();
+    const id = state.activeId || state.newConversation();
+    state.addMessage(id, { role: "user", content: text });
+    state.addMessage(id, { role: "assistant", content: "" });
+    const messages = useChatStore.getState().conversations[id].messages;
+
+    const res = await fetch("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages,
+        images,
+        provider: state.provider,
+        model: state.model,
+        temperature: state.temperature,
+      }),
+    });
+
+    await streamResponse(res, (token) => {
+      useChatStore.setState((s) => {
+        const convo = s.conversations[id];
+        const msgs = convo.messages.slice();
+        msgs[msgs.length - 1].content += token;
+        return {
+          conversations: {
+            ...s.conversations,
+            [id]: { ...convo, messages: msgs },
+          },
+        };
+      });
+    });
+  };
+
+  return { sendMessage };
+}


### PR DESCRIPTION
## Summary
- replace root route with modular chat interface
- add Qwen2.5-VL streaming backend and echo endpoint
- wire up Zustand store, streaming utilities, and sidebar controls

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/clsx)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2f1f93d00833197e4f104df0ce408