### PR TITLE
Engine demo API; enable internal adapter

### DIFF
--- a/src/app/api/engine-demo/route.ts
+++ b/src/app/api/engine-demo/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const query = String(body?.query ?? body?.text ?? "").trim();
+  const engineTag = process.env.NEXT_PUBLIC_ENGINE_TAG || "mvp-baselines-v1";
+
+  // Deterministic demo payload; replace later with real engine output.
+  return NextResponse.json({
+    engineTag,
+    metrics: [{ key: "demo", value: "ok" }],
+    results: [
+      {
+        id: "DEMO-44-12",
+        section: "Approved baseline carbon fraction 44/12",
+        refs: [
+          { type: "pdf", path: "/api/pdf/baseline-carbon-44-12.pdf", page: 1 },
+        ],
+        score: 1.0,
+        echo: query,
+      },
+    ],
+  });
+}

--- a/src/app/api/query/route.ts
+++ b/src/app/api/query/route.ts
@@ -1,15 +1,16 @@
 export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 
-type QueryRequest = { query?: string };
+type QueryRequest = { query?: string; text?: string };
 
+const INTERNAL_DEMO_ENGINE = "internal:demo";
 const ENGINE_PATH = "/query";
 
-function resolveEngineEndpoint(): URL {
-  const base = process.env.ENGINE_URL;
-  if (!base) throw new Error("ENGINE_URL is not configured");
+function resolveEngineEndpoint(base?: string): URL {
+  const engineBase = base ?? process.env.ENGINE_URL;
+  if (!engineBase) throw new Error("ENGINE_URL is not configured");
   const sanitizedPath = ENGINE_PATH.startsWith("/") ? ENGINE_PATH : `/${ENGINE_PATH}`;
-  const trimmedBase = base.replace(/\/+$/, "");
+  const trimmedBase = engineBase.replace(/\/+$/, "");
   if (trimmedBase.endsWith(sanitizedPath)) {
     return new URL(trimmedBase);
   }
@@ -23,9 +24,54 @@ function buildHeaders(): HeadersInit {
   return headers;
 }
 
+async function parseJsonResponse(res: Response, context: string, httpLabel: string) {
+  const raw = await res.text();
+  let parsed: unknown = undefined;
+  if (raw) {
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      throw new Error(`Invalid ${context} response JSON: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  if (!res.ok) {
+    const payload = parsed && typeof parsed === "object" ? parsed : { error: raw || `${httpLabel} HTTP ${res.status}` };
+    return NextResponse.json(payload, { status: res.status });
+  }
+
+  return NextResponse.json(parsed ?? {});
+}
+
+async function forwardToInternalDemo(query: string) {
+  const internalTarget = new URL(
+    "/api/engine-demo",
+    process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000",
+  );
+
+  const res = await fetch(internalTarget, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query }),
+    cache: "no-store",
+  }).catch((error: unknown) => {
+    throw new Error(
+      `Failed to reach internal demo adapter: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  });
+
+  return parseJsonResponse(res, "internal demo", "Internal demo");
+}
+
 async function forwardToEngine(query: string) {
-  const engineUrl = resolveEngineEndpoint();
-  const res = await fetch(engineUrl, {
+  const engineUrl = process.env.ENGINE_URL;
+
+  if (engineUrl === INTERNAL_DEMO_ENGINE) {
+    return forwardToInternalDemo(query);
+  }
+
+  const engineEndpoint = resolveEngineEndpoint(engineUrl);
+  const res = await fetch(engineEndpoint, {
     method: "POST",
     headers: buildHeaders(),
     body: JSON.stringify({ query }),
@@ -34,27 +80,13 @@ async function forwardToEngine(query: string) {
     throw new Error(`Failed to reach engine: ${error instanceof Error ? error.message : String(error)}`);
   });
 
-  const raw = await res.text();
-  let parsed: unknown = undefined;
-  if (raw) {
-    try {
-      parsed = JSON.parse(raw);
-    } catch (error) {
-      throw new Error(`Invalid engine response JSON: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
-
-  if (!res.ok) {
-    const payload = parsed && typeof parsed === "object" ? parsed : { error: raw || `Engine HTTP ${res.status}` };
-    return NextResponse.json(payload, { status: res.status });
-  }
-
-  return NextResponse.json(parsed ?? {});
+  return parseJsonResponse(res, "engine", "Engine");
 }
 
 export async function POST(req: Request) {
-  const { query }: QueryRequest = await req.json().catch(() => ({}));
-  if (!query || typeof query !== "string") {
+  const body: QueryRequest = await req.json().catch(() => ({}));
+  const query = (body.query ?? body.text ?? "").trim();
+  if (!query) {
     return NextResponse.json({ error: "Missing required field: query" }, { status: 400 });
   }
 
@@ -68,7 +100,7 @@ export async function POST(req: Request) {
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
-  const query = url.searchParams.get("text") || url.searchParams.get("query") || "";
+  const query = (url.searchParams.get("text") || url.searchParams.get("query") || "").trim();
   if (!query) {
     return NextResponse.json({ error: "Missing query. Provide ?text=... or ?query=..." }, { status: 400 });
   }


### PR DESCRIPTION
WHAT
- Added a deterministic /api/engine-demo endpoint for investor demos inside the app.
- Updated /api/query to route requests to the internal demo when ENGINE_URL=internal:demo.

WHY
- This enables preview deployments to run the investor demo without needing an external engine connection.

------
https://chatgpt.com/codex/tasks/task_e_68cc0cef80dc8331a99d4857a4992cb9