### PR TITLE
feat: add demo engine adapter for /api/query

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 ## Environment
 
-- Create a `.env.local` with at least `ENGINE_URL` pointing at the engine base URL (for example `https://engine.example.com`). Optionally set `ENGINE_BEARER` if the engine requires bearer authentication and `NEXT_PUBLIC_ENGINE_TAG` to tweak the default UI label.
+- Create a `.env.local` with at least `ENGINE_URL` pointing at the engine base URL (for example `https://engine.example.com`). Optionally set `ENGINE_BEARER` if the engine requires bearer authentication, `ENGINE_ADAPTER` to force `remote` or `demo` mode, and `NEXT_PUBLIC_ENGINE_TAG` to tweak the default UI label.
 - The API route appends `/query` to the configured base, so the underlying service must expose `POST /query`.
+  - If `ENGINE_ADAPTER=demo` (or `ENGINE_URL` is omitted), the internal demo adapter returns deterministic sample results sourced from `data/methodologies/META.json`.
 
 ### Vercel deployment
 
 - This repository includes a `vercel.json` that only sets `NEXT_PUBLIC_ENGINE_TAG`; all runtime values should be injected via Vercel environment variables.
-- Use `vercel env add` or the dashboard to assign `ENGINE_URL` for Preview and Production (they can differ per environment).
+- Use `vercel env add` or the dashboard to assign `ENGINE_URL` for Preview and Production (they can differ per environment). If you prefer the internal demo adapter, set `ENGINE_ADAPTER=demo` and leave `ENGINE_URL` unset.
 - If the engine requires auth, add `ENGINE_BEARER` via `vercel env add`; the API route reads it automatically when present.
 - If an engine key is required, create `ENGINE_BEARER` via the dashboard or CLI; it is optional and read automatically by `/api/query`.
 - Override `NEXT_PUBLIC_ENGINE_TAG` per-environment if you want the footer badge to differ between Preview/Production builds.

--- a/src/app/api/query/route.ts
+++ b/src/app/api/query/route.ts
@@ -1,9 +1,19 @@
 export const runtime = "nodejs";
 import { NextResponse } from "next/server";
+import { runDemoAdapter } from "@/lib/engine/demo";
+import type { QueryResponse } from "@/lib/engine/types";
 
 type QueryRequest = { query?: string };
+type EngineMode = "remote" | "demo";
 
 const ENGINE_PATH = "/query";
+
+function resolveEngineMode(): EngineMode {
+  const adapter = process.env.ENGINE_ADAPTER?.toLowerCase();
+  if (adapter === "demo") return "demo";
+  if (adapter === "remote") return "remote";
+  return process.env.ENGINE_URL ? "remote" : "demo";
+}
 
 function resolveEngineEndpoint(): URL {
   const base = process.env.ENGINE_URL;
@@ -24,6 +34,11 @@ function buildHeaders(): HeadersInit {
 }
 
 async function forwardToEngine(query: string) {
+  if (resolveEngineMode() === "demo") {
+    const payload = await runDemoAdapter(query);
+    return NextResponse.json(payload satisfies QueryResponse);
+  }
+
   const engineUrl = resolveEngineEndpoint();
   const res = await fetch(engineUrl, {
     method: "POST",

--- a/src/lib/engine/demo.ts
+++ b/src/lib/engine/demo.ts
@@ -1,0 +1,57 @@
+import { allPdfRecords } from "@/lib/pdf/metadata";
+import type { QueryResponse } from "./types";
+
+const FALLBACK_RESULTS: QueryResponse = {
+  engineTag: process.env.NEXT_PUBLIC_ENGINE_TAG ?? "demo-baselines",
+  metrics: [
+    { key: "mode", value: "demo" },
+    { key: "results", value: 0 },
+  ],
+  results: [],
+};
+
+export async function runDemoAdapter(query: string): Promise<QueryResponse> {
+  const start = Date.now();
+  try {
+    const records = await allPdfRecords();
+    if (!records.length) {
+      return {
+        ...FALLBACK_RESULTS,
+        metrics: [
+          { key: "mode", value: "demo" },
+          { key: "results", value: 0 },
+          { key: "latency_ms", value: Date.now() - start },
+        ],
+      };
+    }
+
+    const results = records.slice(0, Math.min(3, records.length)).map((record, idx) => ({
+      id: record.id,
+      section: `Demo match for "${query}" using ${record.sourcePath || record.fileRelative}`,
+      refs: [record.sourcePath || record.fileRelative],
+      sha256: record.sha256,
+      score: Number((1 - idx * 0.1).toFixed(2)),
+    }));
+
+    return {
+      engineTag: process.env.NEXT_PUBLIC_ENGINE_TAG ?? "demo-baselines",
+      metrics: [
+        { key: "mode", value: "demo" },
+        { key: "query_length", value: query.length },
+        { key: "latency_ms", value: Date.now() - start },
+        { key: "results", value: results.length },
+      ],
+      results,
+    };
+  } catch (error) {
+    return {
+      engineTag: process.env.NEXT_PUBLIC_ENGINE_TAG ?? "demo-baselines",
+      metrics: [
+        { key: "mode", value: "demo" },
+        { key: "latency_ms", value: Date.now() - start },
+        { key: "error", value: error instanceof Error ? error.message : String(error) },
+      ],
+      results: [],
+    };
+  }
+}

--- a/src/lib/engine/types.ts
+++ b/src/lib/engine/types.ts
@@ -1,0 +1,13 @@
+export type RetrievalMetric = { key: string; value: number | string };
+export type EngineResult = {
+  id: string;
+  section: string;
+  refs?: string[];
+  sha256?: string;
+  score?: number;
+};
+export type QueryResponse = {
+  engineTag: string;
+  metrics: RetrievalMetric[];
+  results: EngineResult[];
+};

--- a/tests/api/query.route.test.ts
+++ b/tests/api/query.route.test.ts
@@ -16,6 +16,7 @@ describe("/api/query route", () => {
   it("forwards POST to ENGINE_URL with bearer token", async () => {
     process.env.ENGINE_URL = "https://engine.example";
     process.env.ENGINE_BEARER = "demo-token";
+    process.env.ENGINE_ADAPTER = "remote";
 
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
@@ -48,6 +49,7 @@ describe("/api/query route", () => {
 
   it("forward GET delegates query param", async () => {
     process.env.ENGINE_URL = "https://engine.example";
+    process.env.ENGINE_ADAPTER = "remote";
 
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ engineTag: "demo", metrics: [], results: [] }), {
@@ -67,6 +69,7 @@ describe("/api/query route", () => {
 
   it("returns 502 when ENGINE_URL missing", async () => {
     delete process.env.ENGINE_URL;
+    process.env.ENGINE_ADAPTER = "remote";
 
     const res = await POST(
       new Request("http://localhost/api/query", {
@@ -81,3 +84,26 @@ describe("/api/query route", () => {
     expect(payload.error).toMatch(/ENGINE_URL is not configured/);
   });
 });
+  it("returns demo payload when adapter is demo", async () => {
+    process.env.ENGINE_ADAPTER = "demo";
+    delete process.env.ENGINE_URL;
+    process.env.NEXT_PUBLIC_ENGINE_TAG = "demo-tag";
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await POST(
+      new Request("http://localhost/api/query", {
+        method: "POST",
+        body: JSON.stringify({ query: "baseline" }),
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.engineTag).toBe("demo-tag");
+    expect(body.metrics.find((m: any) => m.key === "mode")?.value).toBe("demo");
+    expect(body.results.length).toBeGreaterThan(0);
+  });


### PR DESCRIPTION
What:
- support ENGINE_ADAPTER=demo to return vendored PDF samples when no remote engine is configured
- refactor /api/query to select between demo and remote adapters using shared engine types
- document adapter controls and add unit coverage for both code paths

Why:
- ensure demos work without external infrastructure while keeping proxy behavior intact for production engines
- provide deterministic evidence responses to unblock verification flows during audits and sales readouts
- prevent regressions around proxy headers/payloads and demo fallback behavior

Signed-off-by: fredilly@article6.org