### PR TITLE
feat: render engine results with titles and text

### DIFF
--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -104,7 +104,7 @@ export default function ChatApp() {
           Engine: <span className="font-mono">{engineTag || DEFAULT_ENGINE_TAG}</span>
         </div>
         <div className="flex flex-wrap gap-3">
-          {metrics?.map((m, i) => (
+          {metrics.map((m, i) => (
             <span key={`${m.key}-${i}`} className="font-mono">
               {m.key}: {String(m.value)}
             </span>

--- a/src/components/chat/SidePane.tsx
+++ b/src/components/chat/SidePane.tsx
@@ -1,12 +1,19 @@
 import React from "react";
+import type { EngineResult } from "@/lib/engine/types";
 
-export type EngineResult = {
-  id: string;
-  section: string;
-  refs?: string[];
-  sha256?: string;
-  score?: number;
-};
+function pickTitle(result: EngineResult) {
+  return (
+    result.section_title ??
+    result.sectionTitle ??
+    result.section ??
+    result.text?.split("\n")[0]?.slice(0, 120) ??
+    result.id
+  );
+}
+
+function pickBody(result: EngineResult) {
+  return result.text ?? result.section ?? "";
+}
 
 export default function SidePane({ results }: { results: EngineResult[] }) {
   return (
@@ -17,15 +24,22 @@ export default function SidePane({ results }: { results: EngineResult[] }) {
           {results.map((r) => (
             <li key={r.id} className="rounded-xl border p-3">
               <div className="flex items-center justify-between gap-2">
-                <div className="font-medium truncate">{r.id}</div>
+                <div className="font-medium truncate" title={pickTitle(r)}>
+                  {pickTitle(r)}
+                </div>
                 {typeof r.score === "number" && (
-                  <span className="text-xs text-gray-500">{r.score.toFixed(2)}</span>
+                  <span className="text-xs font-semibold text-gray-700 bg-gray-100 px-2 py-0.5 rounded-full">
+                    {r.score.toFixed(2)}
+                  </span>
                 )}
               </div>
               <p className="text-sm text-gray-700 whitespace-pre-line mt-1 line-clamp-5">
-                {r.section}
+                {pickBody(r) || "No excerpt available."}
               </p>
               <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-gray-600">
+                <span className="font-mono truncate max-w-full" title={r.id}>
+                  id: {r.id}
+                </span>
                 {r.refs?.length ? <span>refs: {r.refs.join(", ")}</span> : null}
                 {r.sha256 ? <span className="font-mono">sha256: {r.sha256}</span> : null}
               </div>

--- a/src/lib/chat/client.ts
+++ b/src/lib/chat/client.ts
@@ -1,4 +1,6 @@
 import type { ChatMessage } from "./schema";
+import type { QueryResponse } from "@/lib/engine/types";
+export type { QueryResponse } from "@/lib/engine/types";
 
 export async function sendChat(messages: ChatMessage[]): Promise<ChatMessage[]> {
   const res = await fetch("/api/chat", {
@@ -13,11 +15,6 @@ export async function sendChat(messages: ChatMessage[]): Promise<ChatMessage[]> 
   const data = (await res.json()) as { messages: ChatMessage[] };
   return data.messages;
 }
-
-// Retrieval API client
-export type RetrievalMetric = { key: string; value: number | string };
-export type EngineResult = { id: string; section: string; refs?: string[]; sha256?: string; score?: number };
-export type QueryResponse = { engineTag: string; metrics: RetrievalMetric[]; results: EngineResult[] };
 
 export async function retrieveQuery(text: string): Promise<QueryResponse> {
   const res = await fetch("/api/query?text=" + encodeURIComponent(text), { method: "GET" });

--- a/src/lib/engine/demo.ts
+++ b/src/lib/engine/demo.ts
@@ -28,6 +28,8 @@ export async function runDemoAdapter(query: string): Promise<QueryResponse> {
     const results = records.slice(0, Math.min(3, records.length)).map((record, idx) => ({
       id: record.id,
       section: `Demo match for "${query}" using ${record.sourcePath || record.fileRelative}`,
+      section_title: record.id,
+      text: `Demo evidence for "${query}".\nSource: ${record.sourcePath || record.fileRelative}`,
       refs: [record.sourcePath || record.fileRelative],
       sha256: record.sha256,
       score: Number((1 - idx * 0.1).toFixed(2)),

--- a/src/lib/engine/types.ts
+++ b/src/lib/engine/types.ts
@@ -1,7 +1,10 @@
 export type RetrievalMetric = { key: string; value: number | string };
 export type EngineResult = {
   id: string;
-  section: string;
+  section?: string;
+  section_title?: string;
+  sectionTitle?: string;
+  text?: string;
   refs?: string[];
   sha256?: string;
   score?: number;

--- a/tests/api/query.route.test.ts
+++ b/tests/api/query.route.test.ts
@@ -20,7 +20,18 @@ describe("/api/query route", () => {
 
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
-        JSON.stringify({ engineTag: "demo", metrics: [], results: [{ id: "1", section: "section" }] }),
+        JSON.stringify({
+          engineTag: "demo",
+          metrics: [],
+          results: [
+            {
+              id: "1",
+              section: "fallback",
+              section_title: "Sample Title",
+              text: "Sample text from engine",
+            },
+          ],
+        }),
         { status: 200, headers: { "Content-Type": "application/json" } }
       )
     );
@@ -45,6 +56,8 @@ describe("/api/query route", () => {
       Authorization: "Bearer demo-token",
     });
     expect(json.results[0].id).toBe("1");
+    expect(json.results[0].section_title).toBe("Sample Title");
+    expect(json.results[0].text).toBe("Sample text from engine");
   });
 
   it("forward GET delegates query param", async () => {
@@ -83,7 +96,6 @@ describe("/api/query route", () => {
     const payload = await res.json();
     expect(payload.error).toMatch(/ENGINE_URL is not configured/);
   });
-});
   it("returns demo payload when adapter is demo", async () => {
     process.env.ENGINE_ADAPTER = "demo";
     delete process.env.ENGINE_URL;
@@ -106,4 +118,8 @@ describe("/api/query route", () => {
     expect(body.engineTag).toBe("demo-tag");
     expect(body.metrics.find((m: any) => m.key === "mode")?.value).toBe("demo");
     expect(body.results.length).toBeGreaterThan(0);
+    const result = body.results[0];
+    expect(result.section_title ?? result.sectionTitle).toBeTruthy();
+    expect(result.text).toBeTruthy();
   });
+});


### PR DESCRIPTION
## What
- extend engine result types to include section titles and text and expose them through the chat client
- update SidePane cards to show title, body, score badge, and identifiers instead of blank sections
- adjust demo adapter and tests so demo mode populates the new fields and coverage stays intact

## Why
- the engine already returns section_title/text, so the UI should surface them for rule-card context during verification
- keeps demo fallback usable while ensuring regression coverage for both adapters

## Testing
- `npx node@20.11.1 node_modules/.bin/next lint`
- `npx node@20.11.1 node_modules/.bin/tsc --noEmit`
- `npx node@20.11.1 node_modules/.bin/vitest run tests/api/query.route.test.ts`
- `npx node@20.11.1 node_modules/.bin/next build`

Signed-off-by: fredilly@article6.org
