### PR TITLE
feat: refresh chat ui for mobile-first cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@
 ]
 ```
 - The `/pdf/:id` route resolves the metadata, streams the vendored PDF, and emits `X-SHA256` and `X-Source-Path` headers for verification.
+
+## UI
+
+- The chat experience is optimised for mobile-first use with a minimal, card-based layout. On small screens the insights pane collapses behind the “Toggle insights” button; larger displays show messages and rule cards side-by-side.
+- Result cards surface `section_title`, the matched excerpt, score badge, identifiers, and references when available. Engines returning `section_title`/`text` automatically populate the card header and body.
+- Demo mode (`ENGINE_ADAPTER=demo`) produces meaningful preview cards so the interface stays demonstrable without the remote engine.

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -61,56 +61,76 @@ export default function ChatApp() {
     }
   }
 
+  const metricItems = metrics.slice(0, 4);
+  const hasMetrics = metricItems.length > 0;
+
   return (
-    <div className="mx-auto max-w-6xl p-4 md:p-6">
-      <header className="flex items-center justify-between gap-3 pb-3">
-        <div className="flex items-center gap-3">
-          <button
-            aria-label="Toggle side pane"
-            className="rounded-xl border px-3 py-2 hover:bg-gray-50"
-            onClick={() => setOpen(v => !v)}
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-stone-100">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-6 md:px-8 md:py-10">
+        <header className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <button
+              aria-label="Toggle insights"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white shadow-sm transition hover:border-gray-300 hover:shadow"
+              onClick={() => setOpen(v => !v)}
+            >
+              <Menu className="h-5 w-5 text-gray-500" />
+            </button>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-400">Article 6 Verification</p>
+              <h1 className="text-xl font-semibold text-gray-900 md:text-2xl">
+                What would you like to verify today?
+              </h1>
+            </div>
+          </div>
+          <PanelsTopLeft className="h-6 w-6 text-gray-300" />
+        </header>
+
+        {hasMetrics ? (
+          <div className="flex flex-wrap gap-2">
+            {metricItems.map((m, i) => (
+              <span
+                key={`${m.key}-${i}`}
+                className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-600 shadow-sm"
+              >
+                <span className="text-gray-400">{m.key}</span>
+                <span className="font-semibold text-gray-800">{String(m.value)}</span>
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,3.5fr)_minmax(0,2fr)]">
+          <section
+            className={cn(
+              "flex h-[70vh] flex-col rounded-[1.5rem] border border-gray-200/70 bg-white/80 shadow-sm backdrop-blur lg:h-[72vh]",
+            )}
           >
-            <Menu className="h-5 w-5" />
-          </button>
-          <h1 className="text-xl md:text-2xl font-semibold">
-            What would you like to verify?
-          </h1>
-        </div>
-        <PanelsTopLeft className="h-5 w-5 text-gray-400" />
-      </header>
+            <MessageList messages={messages} />
+            <Composer disabled={busy} onSend={onSend} onUploadImage={onUploadImage} />
+          </section>
 
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
-        <section
-          className={cn(
-            "md:col-span-8 rounded-2xl border bg-white",
-            "flex flex-col h-[70vh]"
-          )}
-        >
-          <MessageList messages={messages} />
-          <Composer disabled={busy} onSend={onSend} onUploadImage={onUploadImage} />
-        </section>
-        <aside
-          className={cn(
-            "md:col-span-4 rounded-2xl border bg-white h-[70vh] transition-all",
-            open ? "opacity-100" : "opacity-0 md:hidden pointer-events-none"
-          )}
-        >
-          <SidePane results={results} />
-        </aside>
-      </div>
-
-      <footer className="mt-4 text-xs text-gray-600 flex items-center justify-between">
-        <div>
-          Engine: <span className="font-mono">{engineTag || DEFAULT_ENGINE_TAG}</span>
+          <aside
+            className={cn(
+              "lg:static lg:block",
+              open ? "block" : "hidden lg:block"
+            )}
+          >
+            <SidePane results={results} />
+          </aside>
         </div>
-        <div className="flex flex-wrap gap-3">
-          {metrics.map((m, i) => (
-            <span key={`${m.key}-${i}`} className="font-mono">
-              {m.key}: {String(m.value)}
+
+        <footer className="mt-2 flex flex-wrap items-center justify-between gap-3 text-xs text-gray-500">
+          <div>
+            Engine: <span className="font-mono">{engineTag || DEFAULT_ENGINE_TAG}</span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <span className="rounded-full border border-gray-200 bg-white px-2 py-1 font-mono">
+              {messages.length - 1} exchanges
             </span>
-          ))}
-        </div>
-      </footer>
+          </div>
+        </footer>
+      </div>
     </div>
   );
 }

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -8,11 +8,11 @@ export default function MessageList({ messages }: { messages: ChatMessage[] }) {
     ref.current?.scrollTo({ top: ref.current.scrollHeight, behavior: "smooth" });
   }, [messages]);
   return (
-    <div ref={ref} className="flex-1 overflow-y-auto p-4 space-y-3">
+    <div ref={ref} className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
       {messages.map((m, i) => (
         <div
           key={i}
-          className={m.role === "user" ? "ml-auto max-w-[80%]" : "mr-auto max-w-[80%]"}
+          className={m.role === "user" ? "ml-auto max-w-[78%]" : "mr-auto max-w-[78%]"}
         >
           {m.image ? (
             <Image
@@ -21,14 +21,14 @@ export default function MessageList({ messages }: { messages: ChatMessage[] }) {
               width={1024}
               height={1024}
               unoptimized
-              className="rounded-2xl h-auto w-full max-w-md object-contain"
+              className="rounded-3xl h-auto w-full max-w-md border border-gray-200 object-contain shadow-sm"
             />
           ) : (
             <div
               className={
                 m.role === "user"
-                  ? "rounded-2xl bg-black text-white px-4 py-2"
-                  : "rounded-2xl bg-gray-100 px-4 py-2"
+                  ? "rounded-3xl bg-gray-900 px-5 py-3 text-sm leading-6 text-white shadow"
+                  : "rounded-3xl border border-gray-200 bg-white px-5 py-3 text-sm leading-6 text-gray-700 shadow-sm"
               }
             >
               {m.content}

--- a/src/components/chat/SidePane.tsx
+++ b/src/components/chat/SidePane.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { EngineResult } from "@/lib/engine/types";
 
-function pickTitle(result: EngineResult) {
+export function pickTitle(result: EngineResult) {
   return (
     result.section_title ??
     result.sectionTitle ??
@@ -11,43 +11,67 @@ function pickTitle(result: EngineResult) {
   );
 }
 
-function pickBody(result: EngineResult) {
+export function pickBody(result: EngineResult) {
   return result.text ?? result.section ?? "";
 }
 
 export default function SidePane({ results }: { results: EngineResult[] }) {
+  const hasResults = results?.length > 0;
+
   return (
-    <div className="h-full p-4 space-y-3 overflow-y-auto">
-      <h2 className="text-lg font-semibold">Rule cards</h2>
-      {results?.length ? (
+    <div className="flex h-full flex-col gap-4 overflow-y-auto rounded-[1.25rem] border border-gray-200/60 bg-white/70 p-4 shadow-sm backdrop-blur">
+      <div>
+        <p className="text-xs uppercase tracking-wide text-gray-400">Insights</p>
+        <h2 className="text-lg font-semibold text-gray-900">Rule cards</h2>
+      </div>
+
+      {hasResults ? (
         <ul className="space-y-3">
-          {results.map((r) => (
-            <li key={r.id} className="rounded-xl border p-3">
-              <div className="flex items-center justify-between gap-2">
-                <div className="font-medium truncate" title={pickTitle(r)}>
-                  {pickTitle(r)}
+          {results.map((r) => {
+            const title = pickTitle(r);
+            const body = pickBody(r) || "No excerpt available.";
+            return (
+              <li
+                key={r.id}
+                className="group rounded-2xl border border-gray-200 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-[11px] uppercase tracking-wide text-gray-400">Section</p>
+                    <h3 className="text-sm font-semibold text-gray-900 line-clamp-2" title={title}>
+                      {title}
+                    </h3>
+                  </div>
+                  {typeof r.score === "number" && (
+                    <span className="rounded-full bg-gray-900/90 px-2 py-0.5 text-xs font-medium text-white shadow-sm">
+                      {r.score.toFixed(2)}
+                    </span>
+                  )}
                 </div>
-                {typeof r.score === "number" && (
-                  <span className="text-xs font-semibold text-gray-700 bg-gray-100 px-2 py-0.5 rounded-full">
-                    {r.score.toFixed(2)}
+
+                <p className="mt-3 text-sm leading-6 text-gray-600 line-clamp-4" title={body}>
+                  {body}
+                </p>
+
+                <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-gray-100 pt-2 text-[11px] text-gray-500">
+                  <span className="max-w-full truncate font-mono text-gray-400" title={r.id}>
+                    {r.id}
                   </span>
-                )}
-              </div>
-              <p className="text-sm text-gray-700 whitespace-pre-line mt-1 line-clamp-5">
-                {pickBody(r) || "No excerpt available."}
-              </p>
-              <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-gray-600">
-                <span className="font-mono truncate max-w-full" title={r.id}>
-                  id: {r.id}
-                </span>
-                {r.refs?.length ? <span>refs: {r.refs.join(", ")}</span> : null}
-                {r.sha256 ? <span className="font-mono">sha256: {r.sha256}</span> : null}
-              </div>
-            </li>
-          ))}
+                  {r.refs?.length ? (
+                    <span className="truncate" title={r.refs.join(", ")}>
+                      refs: {r.refs.join(", ")}
+                    </span>
+                  ) : null}
+                  {r.sha256 ? <span className="font-mono">sha256: {r.sha256}</span> : null}
+                </div>
+              </li>
+            );
+          })}
         </ul>
       ) : (
-        <p className="text-sm text-gray-500">No results yet. Ask a question.</p>
+        <div className="flex flex-1 flex-col items-center justify-center rounded-2xl border border-dashed border-gray-200 py-12 text-center text-sm text-gray-500">
+          <p>Ask a question to see matched rules and supporting evidence.</p>
+        </div>
       )}
     </div>
   );

--- a/tests/components/sidepane.test.ts
+++ b/tests/components/sidepane.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { pickTitle, pickBody } from "@/components/chat/SidePane";
+
+describe("SidePane helpers", () => {
+  it("prefers explicit section_title over other fields", () => {
+    const title = pickTitle({ id: "node-1", section_title: "Declared title" });
+    expect(title).toBe("Declared title");
+  });
+
+  it("falls back to camelCase sectionTitle", () => {
+    const title = pickTitle({ id: "node-2", sectionTitle: "Camel Title" });
+    expect(title).toBe("Camel Title");
+  });
+
+  it("uses first line of text when title fields absent", () => {
+    const title = pickTitle({ id: "node-3", text: "Primary line\nSecondary" });
+    expect(title).toBe("Primary line");
+  });
+
+  it("ultimately falls back to the id", () => {
+    const title = pickTitle({ id: "node-4" });
+    expect(title).toBe("node-4");
+  });
+
+  it("prefers text body but falls back to section", () => {
+    expect(pickBody({ id: "node-5", text: "Body copy" })).toBe("Body copy");
+    expect(pickBody({ id: "node-6", section: "Fallback" })).toBe("Fallback");
+    expect(pickBody({ id: "node-7" })).toBe("");
+  });
+});


### PR DESCRIPTION
## What
- restyle ChatApp layout with a softer gradient shell, responsive insights toggle, and elevated rule cards
- update message bubbles and side panel cards for minimal, modern presentation on mobile and desktop
- document new UI guidelines and add sidepane helper tests to lock in the title/body fallbacks

## Why
- ensure engine responses render clean, readable content on phones and large screens alike
- clarify the expected styling contract and guard the new helper logic with regression tests

## Testing
- `npx node@20.11.1 node_modules/.bin/next lint`
- `npx node@20.11.1 node_modules/.bin/tsc --noEmit`
- `npx node@20.11.1 node_modules/.bin/vitest run`
- `npx node@20.11.1 node_modules/.bin/next build`

Signed-off-by: fredilly@article6.org
