### PR TITLE
feat: group duplicate rule cards by snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@
 ## UI
 
 - The chat experience is optimised for mobile-first use with a minimal, card-based layout. On small screens the insights pane collapses behind the “Toggle insights” button; larger displays show messages and rule cards side-by-side.
-- Result cards surface `section_title`, the matched excerpt, score badge, identifiers, and references when available. Engines returning `section_title`/`text` automatically populate the card header and body.
+- Result cards surface `section_title`, the matched excerpt, score badge, identifiers, and references when available. Identical snippets are grouped automatically; expand a group to inspect every variant while retaining provenance (`id`, `refs`, `sha256`). Engines returning `section_title`/`text` automatically populate the card header and body.
 - Demo mode (`ENGINE_ADAPTER=demo`) produces meaningful preview cards so the interface stays demonstrable without the remote engine.

--- a/src/components/chat/SidePane.tsx
+++ b/src/components/chat/SidePane.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import type { EngineResult } from "@/lib/engine/types";
 
 export function pickTitle(result: EngineResult) {
@@ -15,8 +15,79 @@ export function pickBody(result: EngineResult) {
   return result.text ?? result.section ?? "";
 }
 
+type GroupedResult = {
+  key: string;
+  title: string;
+  body: string;
+  items: EngineResult[];
+  primary: EngineResult;
+};
+
+function VariantRow({ item, isPrimary }: { item: EngineResult; isPrimary: boolean }) {
+  return (
+    <div className="rounded-xl border border-gray-200/70 bg-white/70 px-3 py-2 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-600">
+        <span className="font-mono" title={item.id}>
+          {item.id}
+        </span>
+        <div className="flex items-center gap-2">
+          {typeof item.score === "number" ? (
+            <span className="rounded-full bg-gray-900/80 px-2 py-0.5 text-[11px] font-medium text-white">
+              {item.score.toFixed(2)}
+            </span>
+          ) : null}
+          {isPrimary ? (
+            <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+              primary
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <div className="mt-2 space-y-1 text-[11px] text-gray-500">
+        {item.refs?.length ? <p className="truncate">refs: {item.refs.join(", ")}</p> : null}
+        {item.sha256 ? <p className="font-mono">sha256: {item.sha256}</p> : null}
+      </div>
+    </div>
+  );
+}
+
+export function buildGroups(results: EngineResult[]): GroupedResult[] {
+  const map = new Map<string, GroupedResult>();
+
+  results.forEach((result, index) => {
+    const title = pickTitle(result);
+    const body = pickBody(result) || "";
+    const key = `${title}::${body}`;
+    const existing = map.get(key);
+
+    if (existing) {
+      existing.items.push(result);
+      if ((result.score ?? -Infinity) > (existing.primary.score ?? -Infinity)) {
+        existing.primary = result;
+      }
+    } else {
+      map.set(key, {
+        key: `${key}-${index}`,
+        title,
+        body,
+        items: [result],
+        primary: result,
+      });
+    }
+  });
+
+  return Array.from(map.values()).sort((a, b) => (b.primary.score ?? 0) - (a.primary.score ?? 0));
+}
+
 export default function SidePane({ results }: { results: EngineResult[] }) {
-  const hasResults = results?.length > 0;
+  const groups = useMemo(() => buildGroups(results ?? []), [results]);
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+
+  const hasResults = groups.length > 0;
+
+  const toggleGroup = (groupKey: string) => {
+    setExpandedGroups((prev) => ({ ...prev, [groupKey]: !prev[groupKey] }));
+  };
 
   return (
     <div className="flex h-full flex-col gap-4 overflow-y-auto rounded-[1.25rem] border border-gray-200/60 bg-white/70 p-4 shadow-sm backdrop-blur">
@@ -27,12 +98,16 @@ export default function SidePane({ results }: { results: EngineResult[] }) {
 
       {hasResults ? (
         <ul className="space-y-3">
-          {results.map((r) => {
-            const title = pickTitle(r);
-            const body = pickBody(r) || "No excerpt available.";
+          {groups.map((group) => {
+            const { primary, items, title, body, key } = group;
+            const displayBody = body || "No excerpt available.";
+            const isExpanded = expandedGroups[key] ?? false;
+            const variants = items.length;
+            const otherItems = items.filter((item) => item !== primary);
+
             return (
               <li
-                key={r.id}
+                key={key}
                 className="group rounded-2xl border border-gray-200 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md"
               >
                 <div className="flex items-start justify-between gap-3">
@@ -42,28 +117,62 @@ export default function SidePane({ results }: { results: EngineResult[] }) {
                       {title}
                     </h3>
                   </div>
-                  {typeof r.score === "number" && (
+                  {typeof primary.score === "number" && (
                     <span className="rounded-full bg-gray-900/90 px-2 py-0.5 text-xs font-medium text-white shadow-sm">
-                      {r.score.toFixed(2)}
+                      {primary.score.toFixed(2)}
                     </span>
                   )}
                 </div>
 
-                <p className="mt-3 text-sm leading-6 text-gray-600 line-clamp-4" title={body}>
-                  {body}
+                <p className="mt-3 text-sm leading-6 text-gray-600 line-clamp-4" title={displayBody}>
+                  {displayBody}
                 </p>
 
                 <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-gray-100 pt-2 text-[11px] text-gray-500">
-                  <span className="max-w-full truncate font-mono text-gray-400" title={r.id}>
-                    {r.id}
+                  <span className="max-w-full truncate font-mono text-gray-400" title={primary.id}>
+                    {primary.id}
                   </span>
-                  {r.refs?.length ? (
-                    <span className="truncate" title={r.refs.join(", ")}>
-                      refs: {r.refs.join(", ")}
+                  {primary.refs?.length ? (
+                    <span className="truncate" title={primary.refs.join(", ")}>
+                      refs: {primary.refs.join(", ")}
                     </span>
                   ) : null}
-                  {r.sha256 ? <span className="font-mono">sha256: {r.sha256}</span> : null}
+                  {primary.sha256 ? <span className="font-mono">sha256: {primary.sha256}</span> : null}
+                  {variants > 1 ? (
+                    <span className="rounded-full border border-gray-200 bg-white px-2 py-0.5 font-medium text-gray-600">
+                      {variants} variants
+                    </span>
+                  ) : null}
+                  {!isExpanded && otherItems.length ? (
+                    <span
+                      className="max-w-full truncate text-gray-400"
+                      title={otherItems.map((item) => item.id).join(", ")}
+                    >
+                      +{otherItems.length} more: {otherItems.slice(0, 2).map((item) => item.id).join(",")}
+                      {otherItems.length > 2 ? "…" : ""}
+                    </span>
+                  ) : null}
                 </div>
+
+                {variants > 1 && (
+                  <div className="mt-3 space-y-3">
+                    <button
+                      type="button"
+                      onClick={() => toggleGroup(key)}
+                      className="inline-flex items-center gap-2 text-xs font-medium text-gray-600 underline-offset-4 transition hover:text-gray-900 hover:underline"
+                    >
+                      {isExpanded ? "Hide variants" : `Show ${variants - 1} other variant${variants - 1 === 1 ? "" : "s"}`}
+                    </button>
+
+                    {isExpanded && (
+                      <div className="space-y-2 rounded-2xl border border-dashed border-gray-200 bg-gray-50/80 p-3">
+                        {items.map((item, idx) => (
+                          <VariantRow key={`${item.id}-${idx}`} item={item} isPrimary={item === primary} />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
               </li>
             );
           })}

--- a/tests/components/sidepane.test.ts
+++ b/tests/components/sidepane.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { pickTitle, pickBody } from "@/components/chat/SidePane";
+import { pickTitle, pickBody, buildGroups } from "@/components/chat/SidePane";
 
 describe("SidePane helpers", () => {
   it("prefers explicit section_title over other fields", () => {
@@ -26,5 +26,20 @@ describe("SidePane helpers", () => {
     expect(pickBody({ id: "node-5", text: "Body copy" })).toBe("Body copy");
     expect(pickBody({ id: "node-6", section: "Fallback" })).toBe("Fallback");
     expect(pickBody({ id: "node-7" })).toBe("");
+  });
+
+  it("groups identical title/body pairs while preserving provenance", () => {
+    const input = [
+      { id: "a", section_title: "Title", text: "Body", refs: ["ref1"] },
+      { id: "b", section_title: "Title", text: "Body", refs: ["ref2"] },
+      { id: "c", section_title: "Different", text: "Other" },
+    ];
+
+    const groups = buildGroups(input as any);
+    expect(groups).toHaveLength(2);
+    const first = groups.find((g) => g.items.length === 2)!;
+    expect(first.items.map((i) => i.id).sort()).toEqual(["a", "b"]);
+    expect(first.title).toBe("Title");
+    expect(first.body).toBe("Body");
   });
 });


### PR DESCRIPTION
## What
- collapse engine results with identical title/body into grouped rule cards while preserving all ids, refs, and hashes
- add expandable variant panels plus variant counters so reviewers can inspect every provenance without cluttering the default view
- extend README guidance and helper tests to cover grouping and fallback behaviour

## Why
- eliminate duplicated cards in the insights pane while keeping provenance and evidence traceable on demand
- protect the grouping helpers with regression tests so future engine responses continue to render correctly

## Testing
- `npx node@20.11.1 node_modules/.bin/next lint`
- `npx node@20.11.1 node_modules/.bin/tsc --noEmit`
- `npx node@20.11.1 node_modules/.bin/vitest run`
- `npx node@20.11.1 node_modules/.bin/next build`

Signed-off-by: fredilly@article6.org
