### PR TITLE
feat: add methodology chips to grouped rule cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@
 ## UI
 
 - The chat experience is optimised for mobile-first use with a minimal, card-based layout. On small screens the insights pane collapses behind the “Toggle insights” button; larger displays show messages and rule cards side-by-side.
-- Result cards surface `section_title`, the matched excerpt, score badge, identifiers, and references when available. Identical snippets are grouped automatically; expand a group to inspect every variant while retaining provenance (`id`, `refs`, `sha256`). Engines returning `section_title`/`text` automatically populate the card header and body.
+- Result cards surface `section_title`, the matched excerpt, score badge, identifiers, references, and methodology chips (id + version) when available. Identical snippets are grouped automatically; expand a group to inspect every variant while retaining provenance (`id`, `refs`, `sha256`, methodology metadata). Engines returning `section_title`/`text` automatically populate the card header and body.
 - Demo mode (`ENGINE_ADAPTER=demo`) produces meaningful preview cards so the interface stays demonstrable without the remote engine.

--- a/src/components/chat/SidePane.tsx
+++ b/src/components/chat/SidePane.tsx
@@ -21,9 +21,13 @@ type GroupedResult = {
   body: string;
   items: EngineResult[];
   primary: EngineResult;
+  methodologies: { id: string; version?: string }[];
 };
 
 function VariantRow({ item, isPrimary }: { item: EngineResult; isPrimary: boolean }) {
+  const methodologyId = item.methodology_id ?? item.methodologyId;
+  const methodologyVersion = item.methodology_version ?? item.methodologyVersion;
+
   return (
     <div className="rounded-xl border border-gray-200/70 bg-white/70 px-3 py-2 shadow-sm">
       <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-600">
@@ -44,6 +48,12 @@ function VariantRow({ item, isPrimary }: { item: EngineResult; isPrimary: boolea
         </div>
       </div>
       <div className="mt-2 space-y-1 text-[11px] text-gray-500">
+        {methodologyId ? (
+          <p className="rounded-full border border-gray-200 bg-white px-2 py-0.5 text-[11px] font-medium text-gray-600">
+            {methodologyId}
+            {methodologyVersion ? ` · v${methodologyVersion}` : ""}
+          </p>
+        ) : null}
         {item.refs?.length ? <p className="truncate">refs: {item.refs.join(", ")}</p> : null}
         {item.sha256 ? <p className="font-mono">sha256: {item.sha256}</p> : null}
       </div>
@@ -59,11 +69,22 @@ export function buildGroups(results: EngineResult[]): GroupedResult[] {
     const body = pickBody(result) || "";
     const key = `${title}::${body}`;
     const existing = map.get(key);
+    const methodologyId = result.methodology_id ?? result.methodologyId;
+    const methodologyVersion = result.methodology_version ?? result.methodologyVersion;
+    const methodologyLabel = methodologyId
+      ? { id: methodologyId, version: methodologyVersion }
+      : null;
 
     if (existing) {
       existing.items.push(result);
       if ((result.score ?? -Infinity) > (existing.primary.score ?? -Infinity)) {
         existing.primary = result;
+      }
+      if (methodologyLabel) {
+        const alreadyPresent = existing.methodologies.some(
+          (entry) => entry.id === methodologyLabel.id && entry.version === methodologyLabel.version
+        );
+        if (!alreadyPresent) existing.methodologies.push(methodologyLabel);
       }
     } else {
       map.set(key, {
@@ -72,6 +93,7 @@ export function buildGroups(results: EngineResult[]): GroupedResult[] {
         body,
         items: [result],
         primary: result,
+        methodologies: methodologyLabel ? [methodologyLabel] : [],
       });
     }
   });
@@ -99,7 +121,7 @@ export default function SidePane({ results }: { results: EngineResult[] }) {
       {hasResults ? (
         <ul className="space-y-3">
           {groups.map((group) => {
-            const { primary, items, title, body, key } = group;
+            const { primary, items, title, body, key, methodologies } = group;
             const displayBody = body || "No excerpt available.";
             const isExpanded = expandedGroups[key] ?? false;
             const variants = items.length;
@@ -138,6 +160,15 @@ export default function SidePane({ results }: { results: EngineResult[] }) {
                     </span>
                   ) : null}
                   {primary.sha256 ? <span className="font-mono">sha256: {primary.sha256}</span> : null}
+                  {methodologies.map((method) => (
+                    <span
+                      key={`${method.id}-${method.version ?? "latest"}`}
+                      className="rounded-full border border-gray-200 bg-white px-2 py-0.5 font-medium text-gray-600"
+                    >
+                      {method.id}
+                      {method.version ? ` · v${method.version}` : ""}
+                    </span>
+                  ))}
                   {variants > 1 ? (
                     <span className="rounded-full border border-gray-200 bg-white px-2 py-0.5 font-medium text-gray-600">
                       {variants} variants

--- a/src/lib/engine/demo.ts
+++ b/src/lib/engine/demo.ts
@@ -33,6 +33,8 @@ export async function runDemoAdapter(query: string): Promise<QueryResponse> {
       refs: [record.sourcePath || record.fileRelative],
       sha256: record.sha256,
       score: Number((1 - idx * 0.1).toFixed(2)),
+      methodology_id: record.id.split("-")[0],
+      methodology_version: "demo",
     }));
 
     return {

--- a/src/lib/engine/types.ts
+++ b/src/lib/engine/types.ts
@@ -8,6 +8,10 @@ export type EngineResult = {
   refs?: string[];
   sha256?: string;
   score?: number;
+  methodology_id?: string;
+  methodologyId?: string;
+  methodology_version?: string;
+  methodologyVersion?: string;
 };
 export type QueryResponse = {
   engineTag: string;

--- a/tests/components/sidepane.test.ts
+++ b/tests/components/sidepane.test.ts
@@ -30,8 +30,22 @@ describe("SidePane helpers", () => {
 
   it("groups identical title/body pairs while preserving provenance", () => {
     const input = [
-      { id: "a", section_title: "Title", text: "Body", refs: ["ref1"] },
-      { id: "b", section_title: "Title", text: "Body", refs: ["ref2"] },
+      {
+        id: "a",
+        section_title: "Title",
+        text: "Body",
+        refs: ["ref1"],
+        methodology_id: "METH-A",
+        methodology_version: "1.0",
+      },
+      {
+        id: "b",
+        section_title: "Title",
+        text: "Body",
+        refs: ["ref2"],
+        methodology_id: "METH-B",
+        methodology_version: "2.1",
+      },
       { id: "c", section_title: "Different", text: "Other" },
     ];
 
@@ -41,5 +55,9 @@ describe("SidePane helpers", () => {
     expect(first.items.map((i) => i.id).sort()).toEqual(["a", "b"]);
     expect(first.title).toBe("Title");
     expect(first.body).toBe("Body");
+    expect(first.methodologies).toEqual([
+      { id: "METH-A", version: "1.0" },
+      { id: "METH-B", version: "2.1" },
+    ]);
   });
 });


### PR DESCRIPTION
What:
- extend engine result typing to capture methodology id/version and include them in grouping logic
- surface methodology chips under each rule card and list every variant’s provenance in the expanded panel
- update demo adapter, README guidance, and helper tests to exercise the new metadata flow

Why:
- analysts need to see which methodologies produce identical snippets without losing drill-down detail
- regression coverage and documentation keep the grouped-card behaviour stable across engine updates

Signed-off-by: fredilly@article6.org