### PR TITLE
Gate audit workflow behind feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Environment
 
-- Create a `.env.local` with at least `ENGINE_URL` pointing at the engine base URL (for example `https://engine.example.com`). Optionally set `ENGINE_BEARER` if the engine requires bearer authentication, `ENGINE_ADAPTER` to force `remote` or `demo` mode, `ENGINE_HEALTH_PATH` to probe a bespoke health endpoint (relative to the engine base), and `NEXT_PUBLIC_ENGINE_TAG` to tweak the default UI label.
+- Create a `.env.local` with at least `ENGINE_URL` pointing at the engine base URL (for example `https://engine.example.com`). Optionally set `ENGINE_BEARER` if the engine requires bearer authentication, `ENGINE_ADAPTER` to force `remote` or `demo` mode, `ENGINE_HEALTH_PATH` to probe a bespoke health endpoint (relative to the engine base), `NEXT_PUBLIC_ENGINE_TAG` to tweak the default UI label, and `NEXT_PUBLIC_ENABLE_AUDIT=true` to unlock the `/audit` dry-run workflow.
 - The API route appends `/query` to the configured base, so the underlying service must expose `POST /query`.
   - If `ENGINE_ADAPTER=demo` (or `ENGINE_URL` is omitted), the internal demo adapter returns deterministic sample results sourced from `data/methodologies/META.json`.
 

--- a/src/app/audit/page.tsx
+++ b/src/app/audit/page.tsx
@@ -1,5 +1,7 @@
 import AuditApp from "@/components/audit/AuditApp";
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { AUDIT_FEATURE_ENABLED } from "@/lib/flags";
 
 export const metadata: Metadata = {
   title: "Audit | app.article6",
@@ -7,6 +9,10 @@ export const metadata: Metadata = {
 };
 
 export default function AuditPage() {
+  if (!AUDIT_FEATURE_ENABLED) {
+    notFound();
+  }
+
   return (
     <main className="min-h-screen bg-slate-50">
       <AuditApp />

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from "react";
 import { useState } from "react";
+import Link from "next/link";
 import { sendChat, retrieveQuery, type QueryResponse } from "@/lib/chat/client";
 import type { ChatMessage } from "@/lib/chat/schema";
 import { Menu, PanelsTopLeft } from "lucide-react";
@@ -8,6 +9,7 @@ import SidePane from "./SidePane";
 import MessageList from "./MessageList";
 import Composer from "./Composer";
 import { cn } from "@/lib/utils";
+import { AUDIT_FEATURE_ENABLED } from "@/lib/flags";
 
 const DEFAULT_ENGINE_TAG = process.env.NEXT_PUBLIC_ENGINE_TAG ?? "mvp-baselines-v1";
 
@@ -83,7 +85,19 @@ export default function ChatApp() {
               </h1>
             </div>
           </div>
-          <PanelsTopLeft className="h-6 w-6 text-gray-300" />
+          <div className="flex items-center gap-2">
+            {AUDIT_FEATURE_ENABLED ? (
+              <Link
+                href="/audit"
+                className="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-700 shadow-sm transition hover:border-gray-300 hover:text-gray-900"
+              >
+                <PanelsTopLeft className="h-4 w-4" />
+                Dry-run audit
+              </Link>
+            ) : (
+              <PanelsTopLeft className="h-6 w-6 text-gray-300" />
+            )}
+          </div>
         </header>
 
         {hasMetrics ? (

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,1 @@
+export const AUDIT_FEATURE_ENABLED = process.env.NEXT_PUBLIC_ENABLE_AUDIT === "true";


### PR DESCRIPTION
## What
    - gate /audit route behind NEXT_PUBLIC_ENABLE_AUDIT and surface dry-run link
        from chat header
    - reuse shared feature flag constant for both route guard and client toggle
    - document the flag in README so teams know how to enable the dry-run path

## Why
    - keeps the audit experience hidden until we intentionally roll it out
    - ensures the chat surface exposes the dry-run path end-to-end when the flag
        is set

## Testing
    - npm run lint

    Signed-off-by: fredilly@article6.org
