### PR TITLE
Enrich audit checklist and provenance links

### DIFF
--- a/src/components/audit/AuditApp.tsx
+++ b/src/components/audit/AuditApp.tsx
@@ -1,25 +1,14 @@
 "use client";
 
+import { ArrowUpRight } from "lucide-react";
 import { useMemo, useState } from "react";
 import type { AuditRule, ExtractedVariable } from "@/lib/audit/sample";
 import { EXTRACTED_VARIABLES, SAMPLE_RULES } from "@/lib/audit/sample";
+import Checklist, { type ChecklistState } from "@/components/audit/Checklist";
+import { CHECKLIST_ITEMS } from "@/lib/audit/checklist";
 
-const qaChecklist = [
-  { key: "parsed", label: "PDF parsed" },
-  { key: "anchors", label: "anchors matched" },
-  { key: "hash", label: "hash verified" },
-] as const;
-
-type QaKey = (typeof qaChecklist)[number]["key"];
-
-type QaState = Record<QaKey, boolean>;
-
-function buildInitialQaState(): QaState {
-  return {
-    parsed: false,
-    anchors: false,
-    hash: false,
-  };
+function buildInitialQaState(): ChecklistState {
+  return Object.fromEntries(CHECKLIST_ITEMS.map(item => [item.id, false]));
 }
 
 function getRulesForFile(file: File): AuditRule[] {
@@ -39,7 +28,7 @@ export default function AuditApp() {
   const [fileName, setFileName] = useState<string | null>(null);
   const [rules, setRules] = useState<AuditRule[]>([]);
   const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
-  const [qaState, setQaState] = useState<QaState>(buildInitialQaState());
+  const [checklistState, setChecklistState] = useState<ChecklistState>(buildInitialQaState());
   const [variables, setVariables] = useState<ExtractedVariable[]>([]);
 
   const selectedRule = useMemo(
@@ -52,12 +41,12 @@ export default function AuditApp() {
     const extractedRules = getRulesForFile(file);
     setRules(extractedRules);
     setSelectedRuleId(extractedRules[0]?.id ?? null);
-    setQaState({ parsed: true, anchors: false, hash: false });
+    setChecklistState(() => ({ ...buildInitialQaState(), "raw-pages": true }));
     setVariables(getVariablesForFile(file));
   };
 
-  const toggleQa = (key: QaKey) => {
-    setQaState(prev => ({ ...prev, [key]: !prev[key] }));
+  const toggleQa = (key: string) => {
+    setChecklistState(prev => ({ ...prev, [key]: !prev[key] }));
   };
 
   return (
@@ -75,7 +64,7 @@ export default function AuditApp() {
               fileName={fileName}
               rule={selectedRule}
               variables={variables}
-              qaState={qaState}
+              checklistState={checklistState}
               onToggleQa={toggleQa}
             />
           </section>
@@ -148,7 +137,21 @@ function RuleList({ rules, selectedRuleId, onSelect }: RuleListProps) {
                 className={`flex w-full flex-col gap-2 px-4 py-3 text-left transition ${isActive ? "bg-slate-100" : "hover:bg-slate-50"}`}
               >
                 <span className="text-sm font-medium text-slate-900">{rule.title}</span>
-                <span className="text-xs text-slate-600">Section: <span className="font-medium text-slate-900">{rule.sectionId}</span></span>
+                <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600">
+                  <span>
+                    Section: <span className="font-medium text-slate-900">{rule.sectionId}</span>
+                  </span>
+                  <a
+                    href={rule.rawUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-0.5 font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+                    onClick={event => event.stopPropagation()}
+                  >
+                    Raw p.{rule.rawPage}
+                    <ArrowUpRight className="h-3 w-3" />
+                  </a>
+                </div>
                 <span className="text-xs text-slate-500">SHA256: {rule.sha256}</span>
               </button>
             </li>
@@ -163,11 +166,11 @@ type ResultsPanelProps = {
   fileName: string | null;
   rule: AuditRule | null;
   variables: ExtractedVariable[];
-  qaState: QaState;
-  onToggleQa: (key: QaKey) => void;
+  checklistState: ChecklistState;
+  onToggleQa: (key: string) => void;
 };
 
-function ResultsPanel({ fileName, rule, variables, qaState, onToggleQa }: ResultsPanelProps) {
+function ResultsPanel({ fileName, rule, variables, checklistState, onToggleQa }: ResultsPanelProps) {
   return (
     <section className="space-y-6">
       <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
@@ -182,26 +185,41 @@ function ResultsPanel({ fileName, rule, variables, qaState, onToggleQa }: Result
         </header>
 
         {rule ? (
-          <div className="space-y-4">
-            <article className="space-y-3">
-              <div>
+          <div className="space-y-5">
+            <article className="space-y-4">
+              <div className="space-y-2">
                 <h4 className="text-base font-semibold text-slate-900">{rule.title}</h4>
                 <p className="text-sm text-slate-600">{rule.summary}</p>
+                <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600">
+                  <ProvenanceLink href={`${rule.pdfId ? `/pdf/${rule.pdfId}${rule.anchor}` : rule.anchor}`} label="Anchor" value={rule.anchor} />
+                  <ProvenanceLink href={rule.rawUrl} label="Raw page" value={`p.${rule.rawPage}`} />
+                  <ProvenanceLink href={rule.rawUrl} label="SHA256" value={rule.sha256} isHash />
+                </div>
               </div>
-              <dl className="grid gap-3 text-sm sm:grid-cols-2">
-                <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-                  <dt className="text-xs uppercase text-slate-500">Anchor</dt>
-                  <dd className="font-mono text-xs text-slate-900">{rule.anchor}</dd>
+
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+                <div className="space-y-3">
+                  <h5 className="text-sm font-semibold text-slate-900">Processed excerpt</h5>
+                  <p className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm leading-relaxed text-slate-700">
+                    {rule.summary}
+                  </p>
                 </div>
-                <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-                  <dt className="text-xs uppercase text-slate-500">Section ID</dt>
-                  <dd className="font-mono text-xs text-slate-900">{rule.sectionId}</dd>
+                <div className="space-y-3">
+                  <h5 className="text-sm font-semibold text-slate-900">Raw PDF spot-check</h5>
+                  <div className="overflow-hidden rounded-lg border border-slate-200 bg-slate-50">
+                    <object
+                      key={rule.rawUrl}
+                      data={rule.rawUrl}
+                      type="application/pdf"
+                      className="h-64 w-full"
+                    >
+                      <div className="p-3 text-xs text-slate-600">
+                        PDF preview unavailable. <a className="font-semibold text-slate-900" href={rule.rawUrl} target="_blank" rel="noopener noreferrer">Open raw document</a>.
+                      </div>
+                    </object>
+                  </div>
                 </div>
-                <div className="sm:col-span-2 rounded-lg border border-slate-200 bg-slate-50 p-3">
-                  <dt className="text-xs uppercase text-slate-500">SHA256</dt>
-                  <dd className="font-mono text-xs text-slate-900 break-all">{rule.sha256}</dd>
-                </div>
-              </dl>
+              </div>
             </article>
 
             <section className="space-y-3">
@@ -210,10 +228,22 @@ function ResultsPanel({ fileName, rule, variables, qaState, onToggleQa }: Result
                 {variables.map(variable => (
                   <li key={variable.id} className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm">
                     <div className="text-xs font-semibold uppercase text-slate-500">{variable.label}</div>
-                    <div className="text-sm font-mono text-slate-900">{variable.value}</div>
+                    <a
+                      href={variable.rawAnchor}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-1 inline-flex items-center gap-1 font-mono text-sm text-slate-900 underline decoration-dotted underline-offset-2"
+                    >
+                      {variable.value}
+                      <ArrowUpRight className="h-3 w-3" />
+                    </a>
                     <div className="mt-2 space-y-1 text-xs text-slate-600">
-                      <p>Section: <span className="font-mono text-slate-900">{variable.sectionId}</span></p>
-                      <p className="break-all">SHA256: {variable.sha256}</p>
+                      <p>
+                        Section: <ProvenanceLink href={variable.rawAnchor} value={variable.sectionId} />
+                      </p>
+                      <p className="break-all">
+                        SHA256: <ProvenanceLink href={variable.rawAnchor} value={variable.sha256} isHash />
+                      </p>
                     </div>
                   </li>
                 ))}
@@ -226,25 +256,32 @@ function ResultsPanel({ fileName, rule, variables, qaState, onToggleQa }: Result
       </div>
 
       <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-        <header className="mb-4">
-          <h4 className="text-sm font-semibold text-slate-900">QA/QC mini-checklist</h4>
-          <p className="text-sm text-slate-600">Toggle checks as you validate the uploaded document.</p>
-        </header>
-        <div className="space-y-3">
-          {qaChecklist.map(item => (
-            <label key={item.key} className="flex items-center gap-3 text-sm text-slate-700">
-              <input
-                type="checkbox"
-                className="h-4 w-4 rounded border-slate-300 text-slate-800 focus:ring-slate-600"
-                checked={qaState[item.key]}
-                onChange={() => onToggleQa(item.key)}
-              />
-              {item.label}
-            </label>
-          ))}
-        </div>
+        <Checklist state={checklistState} onToggle={onToggleQa} />
       </section>
     </section>
+  );
+}
+
+type ProvenanceLinkProps = {
+  href: string;
+  label?: string;
+  value: string;
+  isHash?: boolean;
+};
+
+function ProvenanceLink({ href, label, value, isHash }: ProvenanceLinkProps) {
+  const displayValue = isHash ? `${value.slice(0, 12)}…` : value;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+    >
+      {label ? <span className="text-slate-500">{label}</span> : null}
+      <span className="font-mono">{displayValue}</span>
+      <ArrowUpRight className="h-3 w-3" />
+    </a>
   );
 }
 

--- a/src/components/audit/Checklist.tsx
+++ b/src/components/audit/Checklist.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { ChecklistItem } from "@/lib/audit/checklist";
+import { CHECKLIST_ITEMS } from "@/lib/audit/checklist";
+
+export type ChecklistState = Record<string, boolean>;
+
+type ChecklistProps = {
+  state: ChecklistState;
+  onToggle: (id: string) => void;
+};
+
+const categoryLabels: Record<ChecklistItem["category"], string> = {
+  raw: "Raw",
+  processed: "Processed",
+  provenance: "Provenance",
+};
+
+export default function Checklist({ state, onToggle }: ChecklistProps) {
+  return (
+    <div className="space-y-4">
+      <header>
+        <h4 className="text-sm font-semibold text-slate-900">QA/QC spot-checks</h4>
+        <p className="text-sm text-slate-600">Track raw PDF vs processed output before signing off.</p>
+      </header>
+      <ul className="space-y-3">
+        {CHECKLIST_ITEMS.map(item => (
+          <li key={item.id} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-slate-900">{item.label}</p>
+                <p className="text-xs text-slate-500">{categoryLabels[item.category]}</p>
+              </div>
+              <label className="flex items-center gap-2 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-slate-300 text-slate-800 focus:ring-slate-600"
+                  checked={Boolean(state[item.id])}
+                  onChange={() => onToggle(item.id)}
+                />
+                <span className="text-xs text-slate-500">Mark</span>
+              </label>
+            </div>
+            <p className="mt-2 text-xs text-slate-600">{item.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/audit/checklist.ts
+++ b/src/lib/audit/checklist.ts
@@ -1,0 +1,27 @@
+export type ChecklistItem = {
+  id: string;
+  label: string;
+  description: string;
+  category: "raw" | "processed" | "provenance";
+};
+
+export const CHECKLIST_ITEMS: ChecklistItem[] = [
+  {
+    id: "raw-pages",
+    label: "Raw PDF page rendered",
+    description: "Confirm the source PDF page displays correctly for comparison.",
+    category: "raw",
+  },
+  {
+    id: "processed-rules",
+    label: "Rules extracted correctly",
+    description: "Verify the processed rule text matches the raw document.",
+    category: "processed",
+  },
+  {
+    id: "anchors-provenance",
+    label: "Anchors & hashes verified",
+    description: "Spot-check that anchor IDs resolve and the SHA-256 hash matches the raw section.",
+    category: "provenance",
+  },
+];

--- a/src/lib/audit/sample.ts
+++ b/src/lib/audit/sample.ts
@@ -5,6 +5,9 @@ export type AuditRule = {
   anchor: string;
   sectionId: string;
   sha256: string;
+  rawPage: number;
+  rawUrl: string;
+  pdfId: string;
 };
 
 export type ExtractedVariable = {
@@ -13,6 +16,9 @@ export type ExtractedVariable = {
   value: string;
   sectionId: string;
   sha256: string;
+  rawPage: number;
+  rawAnchor: string;
+  pdfId: string;
 };
 
 export const SAMPLE_RULES: AuditRule[] = [
@@ -23,6 +29,9 @@ export const SAMPLE_RULES: AuditRule[] = [
     anchor: "#baseline-carbon-4412",
     sectionId: "SEC-3.1",
     sha256: "8b4c0b1fa541a0c93ad8d95567acbbbe42a9f6fb9e31f4f0c1a88d730c7f61fa",
+    rawPage: 12,
+    rawUrl: "/pdf/baseline-carbon-44-12#page=12",
+    pdfId: "baseline-carbon-44-12",
   },
   {
     id: "rule-sampling-confidence",
@@ -31,6 +40,9 @@ export const SAMPLE_RULES: AuditRule[] = [
     anchor: "#sampling-confidence-9010",
     sectionId: "SEC-4.2",
     sha256: "d1e57ef0bb0c2226f08e9e812309161cbb2e27c6fd5953dd75d99b97f1eed8f9",
+    rawPage: 24,
+    rawUrl: "/pdf/baseline-carbon-44-12#page=24",
+    pdfId: "baseline-carbon-44-12",
   },
   {
     id: "rule-buffer-pool",
@@ -39,6 +51,9 @@ export const SAMPLE_RULES: AuditRule[] = [
     anchor: "#buffer-pool-risk-table",
     sectionId: "SEC-5.4",
     sha256: "f3a6f980c8d3e48361f306e02e9a7df3de229a3d4e753d2c73e957a920d06d42",
+    rawPage: 33,
+    rawUrl: "/pdf/baseline-carbon-44-12#page=33",
+    pdfId: "baseline-carbon-44-12",
   },
 ];
 
@@ -49,6 +64,9 @@ export const EXTRACTED_VARIABLES: ExtractedVariable[] = [
     value: "44/12",
     sectionId: "SEC-3.1",
     sha256: "8b4c0b1fa541a0c93ad8d95567acbbbe42a9f6fb9e31f4f0c1a88d730c7f61fa",
+    rawPage: 12,
+    rawAnchor: "/pdf/baseline-carbon-44-12#page=12&highlight=44/12",
+    pdfId: "baseline-carbon-44-12",
   },
   {
     id: "var-confidence",
@@ -56,6 +74,9 @@ export const EXTRACTED_VARIABLES: ExtractedVariable[] = [
     value: "90/10",
     sectionId: "SEC-4.2",
     sha256: "d1e57ef0bb0c2226f08e9e812309161cbb2e27c6fd5953dd75d99b97f1eed8f9",
+    rawPage: 24,
+    rawAnchor: "/pdf/baseline-carbon-44-12#page=24&highlight=90%25",
+    pdfId: "baseline-carbon-44-12",
   },
   {
     id: "var-buffer",
@@ -63,5 +84,8 @@ export const EXTRACTED_VARIABLES: ExtractedVariable[] = [
     value: "Medium",
     sectionId: "SEC-5.4",
     sha256: "f3a6f980c8d3e48361f306e02e9a7df3de229a3d4e753d2c73e957a920d06d42",
+    rawPage: 33,
+    rawAnchor: "/pdf/baseline-carbon-44-12#page=33&highlight=buffer",
+    pdfId: "baseline-carbon-44-12",
   },
 ];


### PR DESCRIPTION
## What
- Added a QA/QC checklist component to the `/audit` flow for spot-checking raw vs processed results.  
- Reworked the audit results panel so every rule/variable links to its raw PDF anchor and SHA badge, with inline raw previews.  
- Expanded deterministic sample data with PDF IDs, page numbers, and anchor URLs.  
- Updated related files:
  - `src/lib/audit/checklist.ts`
  - `src/components/audit/Checklist.tsx`
  - `src/components/audit/AuditApp.tsx`
  - `src/lib/audit/sample.ts`

## Why
- Satisfies audit requirements by surfacing provenance for every number.  
- Enables reviewers to jump directly from processed results to raw source proof.  
- Provides a structured checklist so auditors can confirm quality line-by-line.  

## Testing
- `npm run lint` passes.  

Signed-off-by: Fred Egbuedike <fredilly@article6.org>
