### PR TITLE
Add demo navigation surfaces

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import DemoNav from "@/components/DemoNav";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,6 +28,15 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <header className="border-b border-slate-200 bg-white/80 backdrop-blur">
+          <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-4 md:px-8">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-400">Article 6 demo</p>
+              <h1 className="text-base font-semibold text-slate-900">Verification surfaces</h1>
+            </div>
+            <DemoNav />
+          </div>
+        </header>
         {children}
       </body>
     </html>

--- a/src/components/DemoNav.tsx
+++ b/src/components/DemoNav.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+import { usePathname } from "next/navigation";
+
+type DemoRoute = { href: string; title: string; description: string; primary?: boolean };
+
+const demoRoutes: DemoRoute[] = [
+  {
+    href: "/",
+    title: "Chat",
+    description: "Ask questions and see rule cards instantly.",
+    primary: true,
+  },
+  {
+    href: "/audit",
+    title: "Audit",
+    description: "Upload a PDF, review anchors & hashes, tick QA checks.",
+  },
+  {
+    href: "/manifest",
+    title: "Manifest",
+    description: "Search rule entries by methodology or tag.",
+  },
+  {
+    href: "/registry/mock",
+    title: "Issuance",
+    description: "Preview dummy tCO₂e issuance balances.",
+  },
+] as const;
+
+export default function DemoNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="flex flex-wrap items-center gap-2 text-xs text-gray-600">
+      <span className="font-semibold uppercase tracking-wide text-gray-400">Demo surfaces</span>
+      {demoRoutes.map(route => {
+        const isActive = pathname === route.href || (route.href !== "/" && pathname?.startsWith(route.href));
+        const baseClasses = "inline-flex items-center gap-1 rounded-full border px-3 py-1.5 font-medium shadow-sm transition";
+        const appearance = isActive
+          ? 'border-slate-900 bg-slate-900 text-white hover:bg-slate-800'
+          : route.primary
+          ? 'border-slate-900 bg-slate-900 text-white hover:bg-slate-800'
+          : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:text-gray-900';
+        return (
+          <Link key={route.href} href={route.href} className={`${baseClasses} ${appearance}`}>
+            <span>{route.title}</span>
+            <ArrowUpRight className="h-3 w-3" />
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React from "react";
 import { useState } from "react";
-import Link from "next/link";
 import { sendChat, retrieveQuery, type QueryResponse } from "@/lib/chat/client";
 import type { ChatMessage } from "@/lib/chat/schema";
 import { Menu, PanelsTopLeft } from "lucide-react";
@@ -9,7 +8,6 @@ import SidePane from "./SidePane";
 import MessageList from "./MessageList";
 import Composer from "./Composer";
 import { cn } from "@/lib/utils";
-import { AUDIT_FEATURE_ENABLED } from "@/lib/flags";
 
 const DEFAULT_ENGINE_TAG = process.env.NEXT_PUBLIC_ENGINE_TAG ?? "mvp-baselines-v1";
 
@@ -85,19 +83,7 @@ export default function ChatApp() {
               </h1>
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            {AUDIT_FEATURE_ENABLED ? (
-              <Link
-                href="/audit"
-                className="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-700 shadow-sm transition hover:border-gray-300 hover:text-gray-900"
-              >
-                <PanelsTopLeft className="h-4 w-4" />
-                Dry-run audit
-              </Link>
-            ) : (
-              <PanelsTopLeft className="h-6 w-6 text-gray-300" />
-            )}
-          </div>
+          <PanelsTopLeft className="h-6 w-6 text-gray-300" />
         </header>
 
         {hasMetrics ? (


### PR DESCRIPTION
## What
    - introduce a reusable DemoNav + DemoLegend component surfacing
        links to /, /audit, /manifest, and /registry/mock
    - add a hero strip to the home page so the routes are discoverable
        before the chat pane
    - refresh the chat header to use the shared nav instead of a
        one-off link
 ## Why
    - reduces demo friction by making the three investor surfaces easy
        to reach directly from the landing experience
## Testing
    - npm run lint
#### Signed-off-by: fredilly@article6.org
