### PR TITLE
Fix/manifest search debug

### DIFF
--- a/public/manifest/index.json
+++ b/public/manifest/index.json
@@ -6,10 +6,14 @@
       "eligibility"
     ],
     "text": "ELIGIBLE if all predicates true; otherwise INELIGIBLE.",
+    "rule": "ELIGIBLE if all predicates true; otherwise INELIGIBLE.",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0010",
@@ -18,10 +22,14 @@
       "parameter"
     ],
     "text": "Default CF = 0.47 t C per t d.m. (trees and shrubs).",
+    "rule": "Default CF = 0.47 t C per t d.m. (trees and shrubs).",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0020",
@@ -30,10 +38,14 @@
       "parameter"
     ],
     "text": "RSR_trees = 0.25; RSR_shrubs = 0.40 (dimensionless).",
+    "rule": "RSR_trees = 0.25; RSR_shrubs = 0.40 (dimensionless).",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0030",
@@ -42,10 +54,14 @@
       "eligibility"
     ],
     "text": "If a pool is excluded from boundary, set its ΔCO2e := 0 by rule.",
+    "rule": "If a pool is excluded from boundary, set its ΔCO2e := 0 by rule.",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0040",
@@ -54,10 +70,14 @@
       "equation"
     ],
     "text": "C_AGB_t = AGB_dm * CF",
+    "rule": "C_AGB_t = AGB_dm * CF",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0045",
@@ -66,10 +86,14 @@
       "equation"
     ],
     "text": "CO2e_pool = C_pool * 44/12",
+    "rule": "CO2e_pool = C_pool * 44/12",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0050",
@@ -78,10 +102,14 @@
       "calc"
     ],
     "text": "Net_project = (dCO2e_AGB + dCO2e_BGB + dCO2e_DOM + dCO2e_Litter + dCO2e_SOC) - leakage",
+    "rule": "Net_project = (dCO2e_AGB + dCO2e_BGB + dCO2e_DOM + dCO2e_Litter + dCO2e_SOC) - leakage",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0060",
@@ -90,10 +118,14 @@
       "leakage"
     ],
     "text": "leakage = L_AS + L_MD",
+    "rule": "leakage = L_AS + L_MD",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0070",
@@ -102,10 +134,14 @@
       "monitoring"
     ],
     "text": "Revisit plots every RevisitInterval years using consistent mensuration protocol.",
+    "rule": "Revisit plots every RevisitInterval years using consistent mensuration protocol.",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0080",
@@ -114,10 +150,14 @@
       "uncertainty"
     ],
     "text": "If RelativePrecision > 10 then apply uncertainty discount per U-table.",
+    "rule": "If RelativePrecision > 10 then apply uncertainty discount per U-table.",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0090",
@@ -126,10 +166,14 @@
       "eligibility"
     ],
     "text": "If ShrubCrownCover_i <= 0.05 then ΔC_shrubs_i := 0.",
+    "rule": "If ShrubCrownCover_i <= 0.05 then ΔC_shrubs_i := 0.",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0100",
@@ -138,10 +182,14 @@
       "equation"
     ],
     "text": "ΔC_year = (C_t2 - C_t1) / T",
+    "rule": "ΔC_year = (C_t2 - C_t1) / T",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0110",
@@ -150,10 +198,14 @@
       "monitoring"
     ],
     "text": "Maintain SOPs and QA/QC per national inventory guidance or IPCC GPG; record all monitored parameters at each verification.",
+    "rule": "Maintain SOPs and QA/QC per national inventory guidance or IPCC GPG; record all monitored parameters at each verification.",
     "methodology": "AR-AMS0003",
     "version": "v01-0",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0001",
@@ -162,10 +214,14 @@
       "eligibility"
     ],
     "text": "ELIGIBLE if all predicates true; otherwise INELIGIBLE.",
+    "rule": "ELIGIBLE if all predicates true; otherwise INELIGIBLE.",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0010",
@@ -174,10 +230,14 @@
       "parameter"
     ],
     "text": "Default CF = 0.47 t C per t d.m. (trees and shrubs).",
+    "rule": "Default CF = 0.47 t C per t d.m. (trees and shrubs).",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0020",
@@ -186,10 +246,14 @@
       "parameter"
     ],
     "text": "RSR_trees = 0.25; RSR_shrubs = 0.40 (dimensionless).",
+    "rule": "RSR_trees = 0.25; RSR_shrubs = 0.40 (dimensionless).",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0030",
@@ -198,10 +262,14 @@
       "eligibility"
     ],
     "text": "If a pool is excluded from boundary, set its ΔCO2e := 0 by rule.",
+    "rule": "If a pool is excluded from boundary, set its ΔCO2e := 0 by rule.",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0040",
@@ -210,10 +278,14 @@
       "equation"
     ],
     "text": "C_AGB_t = AGB_dm * CF",
+    "rule": "C_AGB_t = AGB_dm * CF",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0045",
@@ -222,10 +294,14 @@
       "equation"
     ],
     "text": "CO2e_pool = C_pool * 44/12",
+    "rule": "CO2e_pool = C_pool * 44/12",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0050",
@@ -234,10 +310,14 @@
       "calc"
     ],
     "text": "Net_project = (dCO2e_AGB + dCO2e_BGB + dCO2e_DOM + dCO2e_Litter + dCO2e_SOC) - leakage",
+    "rule": "Net_project = (dCO2e_AGB + dCO2e_BGB + dCO2e_DOM + dCO2e_Litter + dCO2e_SOC) - leakage",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0060",
@@ -246,10 +326,14 @@
       "leakage"
     ],
     "text": "leakage = L_AS + L_MD",
+    "rule": "leakage = L_AS + L_MD",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0070",
@@ -258,10 +342,14 @@
       "monitoring"
     ],
     "text": "Revisit plots every RevisitInterval years using consistent mensuration protocol.",
+    "rule": "Revisit plots every RevisitInterval years using consistent mensuration protocol.",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0080",
@@ -270,10 +358,14 @@
       "uncertainty"
     ],
     "text": "If RelativePrecision > 10 then apply uncertainty discount per U-table.",
+    "rule": "If RelativePrecision > 10 then apply uncertainty discount per U-table.",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0090",
@@ -282,10 +374,14 @@
       "eligibility"
     ],
     "text": "If ShrubCrownCover_i <= 0.05 then ΔC_shrubs_i := 0.",
+    "rule": "If ShrubCrownCover_i <= 0.05 then ΔC_shrubs_i := 0.",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0100",
@@ -294,10 +390,14 @@
       "equation"
     ],
     "text": "ΔC_year = (C_t2 - C_t1) / T",
+    "rule": "ΔC_year = (C_t2 - C_t1) / T",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   },
   {
     "id": "R-1-0110",
@@ -306,9 +406,13 @@
       "monitoring"
     ],
     "text": "Maintain SOPs and QA/QC per national inventory guidance or IPCC GPG; record all monitored parameters at each verification.",
+    "rule": "Maintain SOPs and QA/QC per national inventory guidance or IPCC GPG; record all monitored parameters at each verification.",
     "methodology": "AR-AMS0007",
     "version": "v03-1",
     "family": "UNFCCC/Forestry",
-    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json"
+    "source": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
+    "pdfId": "",
+    "anchor": "",
+    "sha256": ""
   }
 ]

--- a/src/components/manifest/ManifestApp.tsx
+++ b/src/components/manifest/ManifestApp.tsx
@@ -26,8 +26,9 @@ export default function ManifestApp() {
           cache: "no-store",
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const data = (await response.json()) as { results?: ManifestEntry[] };
-        setEntries(Array.isArray(data.results) ? data.results : MANIFEST_ENTRIES);
+        const data = (await response.json()) as { results?: ManifestEntry[]; rules?: ManifestEntry[] };
+        const payload = data.results ?? data.rules ?? [];
+        setEntries(Array.isArray(payload) && payload.length ? payload : MANIFEST_ENTRIES);
       } catch (err) {
         if ((err as { name?: string }).name !== "AbortError") {
           setError(err instanceof Error ? err.message : String(err));
@@ -49,7 +50,7 @@ export default function ManifestApp() {
     return ["all", ...Array.from(unique).sort((a, b) => a.localeCompare(b))];
   }, [entries]);
 
-  const results = useMemo(() => {
+  const visibleResults = useMemo(() => {
     return entries.filter(entry => methodologyFilter === "all" || entry.methodology === methodologyFilter);
   }, [entries, methodologyFilter]);
 
@@ -98,25 +99,25 @@ export default function ManifestApp() {
                 ? "Searching…"
                 : error
                 ? "Error"
-                : `${results.length} result${results.length === 1 ? "" : "s"}`}
+                : `${visibleResults.length} result${visibleResults.length === 1 ? "" : "s"}`}
             </span>
             <span>Click entries to open the PDF at the anchored section.</span>
           </div>
 
           <ul className="space-y-3">
-            {results.map(entry => (
+            {visibleResults.map(entry => (
               <li key={entry.id}>
                 <ManifestCard entry={entry} />
               </li>
             ))}
-            {!loading && !error && results.length === 0 ? (
+            {!loading && !error && visibleResults.length === 0 ? (
               <li className="rounded-xl border border-dashed border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
                 No manifest entries match your filters yet.
               </li>
             ) : null}
           </ul>
           {error ? (
-            <p className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
+            <p className="mt-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
               {error}
             </p>
           ) : null}
@@ -131,11 +132,11 @@ type ManifestCardProps = {
 };
 
 function ManifestCard({ entry }: ManifestCardProps) {
-  const anchor = entry.anchor ?? "";
+  const anchorPath = entry.anchor ?? "";
   const pdfId = entry.pdfId ?? "";
-  const url = pdfId ? `/pdf/${pdfId}${anchor}` : anchor || "#";
+  const url = pdfId ? `/pdf/${pdfId}${anchorPath}` : anchorPath || "#";
+  const shaLabel = entry.sha256 ? `${entry.sha256.slice(0, 12)}…` : "n/a";
   const tags = entry.tags?.length ? entry.tags.join(", ") : "—";
-  const sha = entry.sha256 ? `${entry.sha256.slice(0, 12)}…` : "n/a";
   return (
     <article className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-slate-300 hover:shadow">
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -157,7 +158,7 @@ function ManifestCard({ entry }: ManifestCardProps) {
             View anchor
           </a>
         ) : null}
-        <span className="font-mono">SHA256 {sha}</span>
+        <span className="font-mono">SHA256 {shaLabel}</span>
       </div>
     </article>
   );

--- a/src/components/manifest/ManifestApp.tsx
+++ b/src/components/manifest/ManifestApp.tsx
@@ -2,22 +2,14 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Search, Filter } from "lucide-react";
+import { MANIFEST_ENTRIES } from "@/lib/manifest/data";
 
-type ManifestEntry = {
-  id: string;
-  methodology: string;
-  version: string;
-  rule: string;
-  tags: string[];
-  pdfId?: string;
-  anchor?: string;
-  sha256?: string;
-};
+type ManifestEntry = (typeof MANIFEST_ENTRIES)[number];
 
 export default function ManifestApp() {
   const [query, setQuery] = useState("");
   const [methodologyFilter, setMethodologyFilter] = useState("all");
-  const [entries, setEntries] = useState<ManifestEntry[]>([]);
+  const [entries, setEntries] = useState<ManifestEntry[]>(MANIFEST_ENTRIES);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -35,11 +27,11 @@ export default function ManifestApp() {
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = (await response.json()) as { results?: ManifestEntry[] };
-        setEntries(Array.isArray(data.results) ? data.results : []);
+        setEntries(Array.isArray(data.results) ? data.results : MANIFEST_ENTRIES);
       } catch (err) {
         if ((err as { name?: string }).name !== "AbortError") {
           setError(err instanceof Error ? err.message : String(err));
-          setEntries([]);
+          setEntries(MANIFEST_ENTRIES);
         }
       } finally {
         setLoading(false);

--- a/src/components/manifest/ManifestApp.tsx
+++ b/src/components/manifest/ManifestApp.tsx
@@ -1,40 +1,65 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Search, Filter } from "lucide-react";
-import { MANIFEST_ENTRIES, type ManifestEntry } from "@/lib/manifest/data";
 
-function normalize(value: string) {
-  return value.toLowerCase();
-}
+type ManifestEntry = {
+  id: string;
+  methodology: string;
+  version: string;
+  rule: string;
+  tags: string[];
+  pdfId?: string;
+  anchor?: string;
+  sha256?: string;
+};
 
 export default function ManifestApp() {
   const [query, setQuery] = useState("");
   const [methodologyFilter, setMethodologyFilter] = useState("all");
+  const [entries, setEntries] = useState<ManifestEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timeout = setTimeout(async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const params = query.trim() ? `?q=${encodeURIComponent(query.trim())}` : "";
+        const response = await fetch(`/api/manifest${params}`, {
+          signal: controller.signal,
+          cache: "no-store",
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = (await response.json()) as { results?: ManifestEntry[] };
+        setEntries(Array.isArray(data.results) ? data.results : []);
+      } catch (err) {
+        if ((err as { name?: string }).name !== "AbortError") {
+          setError(err instanceof Error ? err.message : String(err));
+          setEntries([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }, 200);
+
+    return () => {
+      controller.abort();
+      clearTimeout(timeout);
+    };
+  }, [query]);
 
   const methodologies = useMemo(() => {
-    const unique = new Set<string>();
-    for (const entry of MANIFEST_ENTRIES) unique.add(entry.methodology);
-    return ["all", ...Array.from(unique).sort()];
-  }, []);
+    const unique = new Set<string>(entries.map(entry => entry.methodology));
+    return ["all", ...Array.from(unique).sort((a, b) => a.localeCompare(b))];
+  }, [entries]);
 
   const results = useMemo(() => {
-    const normalizedQuery = normalize(query.trim());
-    return MANIFEST_ENTRIES.filter(entry => {
-      const matchesMethodology = methodologyFilter === "all" || entry.methodology === methodologyFilter;
-      if (!matchesMethodology) return false;
-      if (!normalizedQuery) return true;
-      const haystack = [
-        entry.methodology,
-        entry.version,
-        entry.rule,
-        entry.tags.join(" "),
-      ]
-        .map(normalize)
-        .join(" ");
-      return haystack.includes(normalizedQuery);
-    });
-  }, [query, methodologyFilter]);
+    return entries.filter(entry => methodologyFilter === "all" || entry.methodology === methodologyFilter);
+  }, [entries, methodologyFilter]);
 
   return (
     <div className="min-h-screen bg-slate-50 py-12">
@@ -76,7 +101,13 @@ export default function ManifestApp() {
 
         <section className="space-y-3">
           <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
-            <span>{results.length} result{results.length === 1 ? "" : "s"}</span>
+            <span>
+              {loading
+                ? "Searching…"
+                : error
+                ? "Error"
+                : `${results.length} result${results.length === 1 ? "" : "s"}`}
+            </span>
             <span>Click entries to open the PDF at the anchored section.</span>
           </div>
 
@@ -86,12 +117,17 @@ export default function ManifestApp() {
                 <ManifestCard entry={entry} />
               </li>
             ))}
-            {results.length === 0 ? (
+            {!loading && !error && results.length === 0 ? (
               <li className="rounded-xl border border-dashed border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
                 No manifest entries match your filters yet.
               </li>
             ) : null}
           </ul>
+          {error ? (
+            <p className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
+              {error}
+            </p>
+          ) : null}
         </section>
       </div>
     </div>
@@ -103,7 +139,11 @@ type ManifestCardProps = {
 };
 
 function ManifestCard({ entry }: ManifestCardProps) {
-  const url = `/pdf/${entry.pdfId}${entry.anchor}`;
+  const anchor = entry.anchor ?? "";
+  const pdfId = entry.pdfId ?? "";
+  const url = pdfId ? `/pdf/${pdfId}${anchor}` : anchor || "#";
+  const tags = entry.tags?.length ? entry.tags.join(", ") : "—";
+  const sha = entry.sha256 ? `${entry.sha256.slice(0, 12)}…` : "n/a";
   return (
     <article className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-slate-300 hover:shadow">
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -112,18 +152,20 @@ function ManifestCard({ entry }: ManifestCardProps) {
           {entry.methodology} · {entry.version}
         </span>
       </div>
-      <p className="mt-3 text-sm text-slate-600">Tags: {entry.tags.join(", ")}</p>
+      <p className="mt-3 text-sm text-slate-600">Tags: {tags}</p>
 
       <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-slate-600">
-        <a
-          href={url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
-        >
-          View anchor
-        </a>
-        <span className="font-mono">SHA256 {entry.sha256.slice(0, 12)}…</span>
+        {url !== "#" ? (
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+          >
+            View anchor
+          </a>
+        ) : null}
+        <span className="font-mono">SHA256 {sha}</span>
       </div>
     </article>
   );

--- a/src/components/manifest/ManifestApp.tsx
+++ b/src/components/manifest/ManifestApp.tsx
@@ -4,7 +4,16 @@ import { useEffect, useMemo, useState } from "react";
 import { Search, Filter } from "lucide-react";
 import { MANIFEST_ENTRIES } from "@/lib/manifest/data";
 
-type ManifestEntry = (typeof MANIFEST_ENTRIES)[number];
+type ManifestEntry = {
+  id: string;
+  methodology: string;
+  version: string;
+  rule: string;
+  tags: string[];
+  pdfId?: string;
+  anchor?: string;
+  sha256?: string;
+};
 
 export default function ManifestApp() {
   const [query, setQuery] = useState("");


### PR DESCRIPTION
## What
Refreshed `public/manifest/index.json` with the enriched
  dataset emitted by the updated manifest builder so the app ships real
  rule entries by default.
 ## Why After fixing the upstream generator, the frontend needs
  the regenerated index to display actual rule text instead of the
  stubbed entries.
  

**Signed-off-by**: fredilly@article6.org