### PR TITLE
fix: align manifest path with engine

### DIFF
--- a/src/app/api/manifest/route.ts
+++ b/src/app/api/manifest/route.ts
@@ -23,7 +23,13 @@ export async function GET(request: Request) {
   if (resolveEngineMode() === "remote") {
     try {
       const engineUrl = resolveEngineEndpoint();
-      const manifestUrl = new URL("./manifest", engineUrl);
+      const manifestUrl = new URL(engineUrl);
+      const replacedPath = manifestUrl.pathname.replace(/\/?query\/?$/, "/manifest");
+      if (replacedPath !== manifestUrl.pathname) {
+        manifestUrl.pathname = replacedPath;
+      } else {
+        manifestUrl.pathname = `${manifestUrl.pathname.replace(/\/$/, "")}/manifest`;
+      }
       if (query) manifestUrl.searchParams.set("q", query);
 
       const response = await fetch(manifestUrl, {


### PR DESCRIPTION
## What
    - replace the manifest URL builder to reuse the engine base path while
        swapping the query segment for manifest
    - preserve query passthrough and 502 error surfacing when remote fetch fails
## Why
    - previous implementation targeted the host root, so engines hosting /
        manifest alongside /query responded 404
    - ensures remote manifest search returns the engine-provided rules array
## Tests
    - npm test

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>