### PR TITLE
Serve rich manifest cards in production

### DIFF
--- a/src/app/api/manifest/route.ts
+++ b/src/app/api/manifest/route.ts
@@ -1,35 +1,205 @@
 import { NextResponse } from "next/server";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { buildEngineHeaders, resolveEngineEndpoint, resolveEngineMode } from "@/lib/engine/config";
 
 export const runtime = "nodejs";
 
-async function loadManifest() {
-  const fallback: unknown = [];
+type ManifestEntry = {
+  id: string;
+  methodology: string;
+  version: string;
+  rule: string;
+  tags: string[];
+  pdfId?: string;
+  anchor?: string;
+  sha256?: string;
+  [key: string]: unknown;
+};
+
+type RemoteManifestEntry = Record<string, unknown>;
+
+async function loadManifestEntries(): Promise<ManifestEntry[]> {
   try {
     const filePath = path.join(process.cwd(), "public", "manifest", "index.json");
     const contents = await readFile(filePath, "utf8");
-    return JSON.parse(contents) as unknown;
+    const parsed = JSON.parse(contents);
+    return Array.isArray(parsed) ? (parsed as ManifestEntry[]) : [];
   } catch {
-    return fallback;
+    return [];
   }
+}
+
+function manifestKey(methodology?: string, version?: string, ruleId?: string) {
+  if (!methodology || !version || !ruleId) return null;
+  return `${methodology}::${version}::${ruleId}`;
+}
+
+function buildManifestIndex(entries: ManifestEntry[]) {
+  const index = new Map<string, ManifestEntry>();
+  for (const entry of entries) {
+    const key = manifestKey(entry.methodology, entry.version, entry.id);
+    if (key) index.set(key, entry);
+  }
+  return index;
+}
+
+function parseDocIdentifier(value: unknown) {
+  if (typeof value !== "string" || !value) return {};
+  const [methodPart, rulePart] = value.split(":");
+  if (!methodPart) {
+    return { ruleId: rulePart ?? value };
+  }
+  const [methodology, version] = methodPart.split("@");
+  return {
+    methodology: methodology ?? undefined,
+    version: version ?? undefined,
+    ruleId: rulePart ?? undefined,
+  };
+}
+
+function extractRemoteKey(entry: RemoteManifestEntry) {
+  const docDetails = parseDocIdentifier(entry.doc_id);
+  const methodology = typeof entry.methodology_id === "string"
+    ? entry.methodology_id
+    : typeof entry.methodology === "string"
+    ? entry.methodology
+    : docDetails.methodology;
+  const version = typeof entry.version === "string"
+    ? entry.version
+    : typeof entry.methodology_version === "string"
+    ? entry.methodology_version
+    : typeof entry.methodologyVersion === "string"
+    ? entry.methodologyVersion
+    : docDetails.version;
+  const ruleId = typeof entry.rule_id === "string"
+    ? entry.rule_id
+    : typeof entry.id === "string"
+    ? entry.id
+    : typeof entry.ruleId === "string"
+    ? entry.ruleId
+    : docDetails.ruleId;
+
+  return { methodology, version, ruleId };
+}
+
+function coerceManifestEntry(
+  entry: RemoteManifestEntry,
+  manifestIndex: Map<string, ManifestEntry>,
+): ManifestEntry {
+  const { methodology, version, ruleId } = extractRemoteKey(entry);
+  const key = manifestKey(methodology, version, ruleId);
+  if (key) {
+    const match = manifestIndex.get(key);
+    if (match) return match;
+  }
+
+  const ruleText = typeof entry.rule === "string"
+    ? entry.rule
+    : typeof entry.text === "string"
+    ? entry.text
+    : typeof entry.section_title === "string"
+    ? entry.section_title
+    : ruleId ?? "";
+
+  const tags = Array.isArray(entry.tags)
+    ? entry.tags.map(tag => String(tag))
+    : [];
+
+  const pdfId = typeof entry.pdfId === "string" ? entry.pdfId : undefined;
+  const anchor = typeof entry.anchor === "string" ? entry.anchor : undefined;
+  const sha256 = typeof entry.sha256 === "string" ? entry.sha256 : undefined;
+
+  return {
+    id: ruleId ?? (typeof entry.doc_id === "string" ? entry.doc_id : ""),
+    methodology: methodology ?? "",
+    version: version ?? "",
+    rule: ruleText,
+    tags,
+    pdfId,
+    anchor,
+    sha256,
+  };
+}
+
+function filterEntries(entries: ManifestEntry[], rawQuery: string, showAll: boolean) {
+  if (showAll) return entries;
+  const normalizedQuery = rawQuery.toLowerCase();
+  return entries.filter(entry => {
+    const haystack = JSON.stringify(entry).toLowerCase();
+    return haystack.includes(normalizedQuery);
+  });
 }
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const query = (url.searchParams.get("q") ?? "").trim().toLowerCase();
+  const rawQuery = (url.searchParams.get("q") ?? "").trim();
+  const allParam = url.searchParams.get("all") ?? "";
+  const showAll = !rawQuery || ["1", "true", "yes"].includes(allParam.toLowerCase());
 
-  const data = await loadManifest();
-  const entries = Array.isArray(data) ? data : [];
+  const manifestEntries = await loadManifestEntries();
 
-  const results = entries.filter(entry => {
-    if (!query) return true;
-    if (entry && typeof entry === "object") {
-      const haystack = JSON.stringify(entry).toLowerCase();
-      return haystack.includes(query);
+  if (resolveEngineMode() === "remote") {
+    try {
+      const engineUrl = resolveEngineEndpoint();
+      const manifestUrl = new URL(engineUrl);
+      const normalizedPath = manifestUrl.pathname.replace(/\/$/, "");
+      manifestUrl.pathname = normalizedPath.endsWith("/query")
+        ? `${normalizedPath.slice(0, -6)}/manifest`
+        : `${normalizedPath}/manifest`;
+
+      if (showAll) {
+        manifestUrl.searchParams.set("all", "1");
+      } else if (rawQuery) {
+        manifestUrl.searchParams.set("q", rawQuery);
+      }
+      manifestUrl.searchParams.set("view", "cards");
+
+      const response = await fetch(manifestUrl, {
+        method: "GET",
+        headers: buildEngineHeaders(),
+        cache: "no-store",
+      }).catch(error => {
+        throw new Error(`Failed to reach engine manifest: ${error instanceof Error ? error.message : String(error)}`);
+      });
+
+      const rawBody = await response.text();
+      let parsedBody: unknown = null;
+      if (rawBody) {
+        try {
+          parsedBody = JSON.parse(rawBody);
+        } catch (error) {
+          throw new Error(`Invalid engine manifest JSON: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+
+      if (!response.ok) {
+        throw new Error(`Engine manifest responded ${response.status}: ${rawBody || "no body"}`);
+      }
+
+      const remoteEntries = Array.isArray(parsedBody)
+        ? parsedBody
+        : parsedBody && typeof parsedBody === "object"
+        ? (parsedBody as { results?: unknown[]; rules?: unknown[] }).results ??
+          (parsedBody as { results?: unknown[]; rules?: unknown[] }).rules
+        : undefined;
+
+      if (!Array.isArray(remoteEntries)) {
+        throw new Error("Engine manifest response missing rules array");
+      }
+
+      const manifestIndex = buildManifestIndex(manifestEntries);
+      const enriched = remoteEntries.map(entry => coerceManifestEntry(entry as RemoteManifestEntry, manifestIndex));
+
+      return NextResponse.json({ results: enriched });
+    } catch (error) {
+      console.warn(
+        "[manifest] Remote manifest unavailable, using static dataset:",
+        error instanceof Error ? error.message : String(error),
+      );
     }
-    return false;
-  });
+  }
 
-  return NextResponse.json({ results });
+  const filtered = filterEntries(manifestEntries, rawQuery, showAll);
+  return NextResponse.json({ results: filtered });
 }


### PR DESCRIPTION
## What
- request the engine manifest with `view=cards` and map remote results back onto the rich static dataset
- fall back to the static manifest whenever the engine errors while still supporting `?all=1` and keyword filtering

## Why
- production was rendering plain rule strings while the preview used the richer card metadata
- aligning the API output ensures both environments present the same human-friendly manifest entries

## Tests
- npm test

Signed-off-by: Fred Egbuedike <fredilly@article6.org>
