### PR TITLE
Manifest polish: UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ The first request sets `__Secure-vercel-bypass` and Vercel accepts that cookie f
 - `/manifest` Searchable manifest — filter rules by methodology/tags and jump to anchored PDFs.
 - `/registry/mock` Mock issuance — preview dummy tCO₂e issuance and balances for investor storytelling.
 
+### Manifest surface
+
+- A live badge polls `/api/manifest/health` every 30 seconds. Green indicates the static or remote manifest responded successfully; red marks degraded upstream connectivity. Hover for the last refresh timestamp, rule count, and whether the payload came from the static snapshot or remote engine.
+- Filters persist in the URL: search terms are stored under `?q=` and tag selections under `?tags=tag-a,tag-b`. Reloading the page restores the filter state, and the “Clear tags” pill removes all active tag filters in one click.
+- Each rule card exposes one-click affordances — copy the full SHA-256 hash, preview the anchored PDF page via tooltip, export the lean JSON via `/api/manifest/rule/[sha]`, and compare text across methodology versions through the version switcher modal.
+
 Implementation notes:
 
 - The chat experience is optimised for mobile-first use with a minimal, card-based layout. On small screens the insights pane collapses behind the “Toggle insights” button; larger displays show messages and rule cards side-by-side.

--- a/src/app/api/manifest/rule/[sha]/route.ts
+++ b/src/app/api/manifest/rule/[sha]/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+import { loadManifestAll } from "@/lib/manifestSource";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(_request: Request, context: { params: { sha: string } }) {
+  const sha = context.params.sha;
+  if (!sha || typeof sha !== "string") {
+    return NextResponse.json({ error: "Missing SHA" }, { status: 400 });
+  }
+
+  const normalized = sha.trim().toLowerCase();
+  if (!normalized) {
+    return NextResponse.json({ error: "Invalid SHA" }, { status: 400 });
+  }
+
+  try {
+    const entries = await loadManifestAll({ showAll: true });
+    const match = entries.find(entry => (entry.sha256 ?? "").toLowerCase() === normalized);
+    if (!match) {
+      return NextResponse.json({ error: "Rule not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(match, {
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Disposition": `attachment; filename="rule-${normalized}.json"`,
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+        Pragma: "no-cache",
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/manifest/_components/MethodologyGroup.tsx
+++ b/src/app/manifest/_components/MethodologyGroup.tsx
@@ -1,0 +1,45 @@
+import RuleCard, { type RuleCardProps } from "./RuleCard";
+import { ManifestRule } from "../_types";
+
+export type MethodologyGroupProps = {
+  methodology: string;
+  rules: ManifestRule[];
+  visibleCount: number;
+  onTagToggle: (tag: string) => void;
+  isTagActive: (tag: string) => boolean;
+  versionLookup: (rule: ManifestRule) => RuleCardProps["versions"];
+};
+
+export function MethodologyGroup({
+  methodology,
+  rules,
+  visibleCount,
+  onTagToggle,
+  isTagActive,
+  versionLookup,
+}: MethodologyGroupProps) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-3">
+        <h2 className="text-lg font-semibold text-slate-900">{methodology}</h2>
+        <span className="inline-flex min-w-8 items-center justify-center rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+          {visibleCount}
+        </span>
+      </div>
+      <ul className="space-y-4">
+        {rules.map(rule => (
+          <li key={`${rule.id}-${rule.version}`}>
+            <RuleCard
+              rule={rule}
+              onTagToggle={onTagToggle}
+              isTagActive={isTagActive}
+              versions={versionLookup(rule)}
+            />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default MethodologyGroup;

--- a/src/app/manifest/_components/RuleCard.tsx
+++ b/src/app/manifest/_components/RuleCard.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ExternalLink, FileJson } from "lucide-react";
+import clsx from "clsx";
+
+import HashCopyButton from "@/components/manifest/HashCopyButton";
+import { Tooltip } from "@/components/ui/Tooltip";
+import { ManifestRule, RuleVersionOption } from "../_types";
+import { TagChip } from "./TagChip";
+import VersionSwitcher from "./VersionSwitcher";
+import { getRulePdfPage, getRulePdfUrl } from "./pdfUtils";
+
+export type RuleCardProps = {
+  rule: ManifestRule;
+  onTagToggle: (tag: string) => void;
+  isTagActive: (tag: string) => boolean;
+  versions: RuleVersionOption[];
+};
+
+export function RuleCard({ rule, onTagToggle, isTagActive, versions }: RuleCardProps) {
+  const [exporting, setExporting] = useState(false);
+  const pdfUrl = getRulePdfUrl(rule);
+  const pdfPage = getRulePdfPage(rule);
+  const tags = Array.isArray(rule.tags) ? rule.tags : [];
+  const truncatedHash = useMemo(() => {
+    if (!rule.sha256) return "—";
+    return `${rule.sha256.slice(0, 12)}…`;
+  }, [rule.sha256]);
+
+  const handleExport = async () => {
+    if (!rule.sha256 || exporting) return;
+    setExporting(true);
+    try {
+      const response = await fetch(`/api/manifest/rule/${rule.sha256}`);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `rule-${rule.sha256}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.warn("[RuleCard] Failed to export JSON", error);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <article className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-slate-300 hover:shadow">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900">{rule.rule}</h3>
+          <p className="text-sm text-slate-600">{rule.methodology} · {rule.version}</p>
+        </div>
+        <VersionSwitcher rule={rule} versions={versions} />
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        {tags.length > 0 ? (
+          tags.map(tag => (
+            <TagChip key={tag} tag={tag} active={isTagActive(tag)} onToggle={onTagToggle} />
+          ))
+        ) : (
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-500">No tags</span>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600">
+        <div className="flex items-center gap-2">
+          <span className="font-mono">SHA256 {truncatedHash}</span>
+          <HashCopyButton hash={rule.sha256} />
+        </div>
+        <div className="flex items-center gap-2">
+          <Tooltip content={pdfPage ? `Open PDF • page ${pdfPage}` : "Open PDF"}>
+            <a
+              href={pdfUrl || "#"}
+              target={pdfUrl.startsWith("/") ? "_blank" : undefined}
+              rel={pdfUrl.startsWith("/") ? "noopener noreferrer" : undefined}
+              className={clsx(
+                "inline-flex h-11 min-w-11 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-4 font-medium text-slate-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2",
+                pdfUrl
+                  ? "hover:border-slate-300 hover:text-slate-900"
+                  : "cursor-not-allowed opacity-40",
+              )}
+              aria-disabled={!pdfUrl}
+            >
+              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+              <span className="text-sm">Open PDF</span>
+            </a>
+          </Tooltip>
+          <Tooltip content="Export rule JSON">
+            <button
+              type="button"
+              className="inline-flex h-11 min-w-11 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-4 font-medium text-slate-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 hover:border-slate-300 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-40"
+              onClick={handleExport}
+              disabled={!rule.sha256 || exporting}
+              aria-label="Export rule JSON"
+            >
+              <FileJson className="h-4 w-4" aria-hidden="true" />
+              <span className="text-sm">Export JSON</span>
+            </button>
+          </Tooltip>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default RuleCard;

--- a/src/app/manifest/_components/TagChip.tsx
+++ b/src/app/manifest/_components/TagChip.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import clsx from "clsx";
+
+type TagChipProps = {
+  tag: string;
+  active?: boolean;
+  onToggle?: (tag: string) => void;
+};
+
+export function TagChip({ tag, active = false, onToggle }: TagChipProps) {
+  const handleClick = () => {
+    onToggle?.(tag);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={clsx(
+        "inline-flex h-11 min-w-11 items-center justify-center rounded-full border px-4 text-sm font-medium capitalize transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2",
+        active
+          ? "border-emerald-500 bg-emerald-50 text-emerald-700"
+          : "border-slate-200 bg-slate-50 text-slate-700 hover:border-slate-300 hover:text-slate-900",
+      )}
+      aria-pressed={active}
+      aria-label={active ? `Remove tag ${tag}` : `Filter by tag ${tag}`}
+    >
+      {tag}
+    </button>
+  );
+}
+
+export default TagChip;

--- a/src/app/manifest/_components/VersionDiffModal.tsx
+++ b/src/app/manifest/_components/VersionDiffModal.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { X, ExternalLink } from "lucide-react";
+
+import { ManifestRule } from "../_types";
+import { getRulePdfPage, getRulePdfUrl } from "./pdfUtils";
+
+export type VersionDiffModalProps = {
+  open: boolean;
+  onClose: () => void;
+  current: ManifestRule;
+  target: ManifestRule;
+};
+
+type DiffSegment = {
+  text: string;
+  type: "same" | "added" | "removed";
+};
+
+function tokenize(text: string) {
+  return text.match(/\S+|\s+/g) ?? [];
+}
+
+function appendSegment(segments: DiffSegment[], type: DiffSegment["type"], text: string) {
+  if (!text) return;
+  const sanitizedType = text.trim().length === 0 ? "same" : type;
+  const last = segments[segments.length - 1];
+  if (last && last.type === sanitizedType) {
+    last.text += text;
+  } else {
+    segments.push({ type: sanitizedType, text });
+  }
+}
+
+function diffTokens(leftText: string, rightText: string) {
+  const leftTokens = tokenize(leftText);
+  const rightTokens = tokenize(rightText);
+  const m = leftTokens.length;
+  const n = rightTokens.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+  for (let i = m - 1; i >= 0; i -= 1) {
+    for (let j = n - 1; j >= 0; j -= 1) {
+      if (leftTokens[i] === rightTokens[j]) {
+        dp[i][j] = dp[i + 1][j + 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i + 1][j], dp[i][j + 1]);
+      }
+    }
+  }
+
+  const leftSegments: DiffSegment[] = [];
+  const rightSegments: DiffSegment[] = [];
+  let i = 0;
+  let j = 0;
+
+  while (i < m && j < n) {
+    if (leftTokens[i] === rightTokens[j]) {
+      appendSegment(leftSegments, "same", leftTokens[i]);
+      appendSegment(rightSegments, "same", rightTokens[j]);
+      i += 1;
+      j += 1;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      appendSegment(leftSegments, "removed", leftTokens[i]);
+      i += 1;
+    } else {
+      appendSegment(rightSegments, "added", rightTokens[j]);
+      j += 1;
+    }
+  }
+
+  while (i < m) {
+    appendSegment(leftSegments, "removed", leftTokens[i]);
+    i += 1;
+  }
+
+  while (j < n) {
+    appendSegment(rightSegments, "added", rightTokens[j]);
+    j += 1;
+  }
+
+  return { leftSegments, rightSegments };
+}
+
+function renderSegments(segments: DiffSegment[]) {
+  return segments.map((segment, index) => {
+    if (segment.type === "same") {
+      return <span key={index}>{segment.text}</span>;
+    }
+    const highlightClass = segment.type === "added" ? "bg-emerald-100 text-emerald-800" : "bg-rose-100 text-rose-800";
+    return (
+      <mark key={index} className={`rounded px-0.5 ${highlightClass}`}>
+        {segment.text}
+      </mark>
+    );
+  });
+}
+
+function PdfLink({ rule }: { rule: ManifestRule }) {
+  const href = getRulePdfUrl(rule);
+  if (!href) return null;
+  const page = getRulePdfPage(rule);
+  const label = page ? `PDF page ${page}` : "Open PDF";
+  const external = href.startsWith("/");
+  return (
+    <a
+      href={href}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noopener noreferrer" : undefined}
+      className="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 transition hover:text-indigo-700"
+    >
+      <ExternalLink className="h-4 w-4" aria-hidden="true" />
+      {label}
+    </a>
+  );
+}
+
+export default function VersionDiffModal({ open, onClose, current, target }: VersionDiffModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => {
+      window.removeEventListener("keydown", handleKey);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const { leftSegments, rightSegments } = diffTokens(current.rule ?? "", target.rule ?? "");
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-4 py-8"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Compare rule versions"
+      onClick={onClose}
+    >
+      <div
+        className="relative grid w-full max-w-4xl gap-6 rounded-2xl bg-white p-6 shadow-2xl lg:grid-cols-2"
+        onClick={event => event.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close version comparison"
+          className="absolute right-4 top-4 inline-flex h-11 min-w-11 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:border-slate-300 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2"
+        >
+          <X className="h-5 w-5" aria-hidden="true" />
+        </button>
+        <section className="space-y-3">
+          <header className="space-y-1">
+            <h3 className="text-lg font-semibold text-slate-900">{current.methodology} · {current.version}</h3>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Rule {current.ruleId}</p>
+            <PdfLink rule={current} />
+          </header>
+          <div className="space-y-3 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-800">
+            <div className="leading-relaxed text-slate-700">{renderSegments(leftSegments)}</div>
+          </div>
+        </section>
+        <section className="space-y-3">
+          <header className="space-y-1">
+            <h3 className="text-lg font-semibold text-slate-900">{target.methodology} · {target.version}</h3>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Rule {target.ruleId}</p>
+            <PdfLink rule={target} />
+          </header>
+          <div className="space-y-3 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-800">
+            <div className="leading-relaxed text-slate-700">{renderSegments(rightSegments)}</div>
+          </div>
+        </section>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/app/manifest/_components/VersionSwitcher.tsx
+++ b/src/app/manifest/_components/VersionSwitcher.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import clsx from "clsx";
+
+import { ManifestRule, RuleVersionOption } from "../_types";
+import VersionDiffModal from "./VersionDiffModal";
+
+type VersionSwitcherProps = {
+  rule: ManifestRule;
+  versions: RuleVersionOption[];
+};
+
+export default function VersionSwitcher({ rule, versions }: VersionSwitcherProps) {
+  const [selectedVersion, setSelectedVersion] = useState<string>("");
+  const [showModal, setShowModal] = useState(false);
+  const [comparisonRule, setComparisonRule] = useState<ManifestRule | null>(null);
+
+  const comparable = useMemo(() => {
+    return versions
+      .filter(option => option.rule)
+      .map(option => option as Required<RuleVersionOption>)
+      .sort((a, b) => a.version.localeCompare(b.version));
+  }, [versions]);
+
+  const hasAlternatives = comparable.some(option => option.version !== rule.version);
+
+  const handleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextVersion = event.target.value;
+    setSelectedVersion(nextVersion);
+    const match = comparable.find(option => option.version === nextVersion);
+    if (!match || match.rule.version === rule.version) return;
+    setComparisonRule(match.rule);
+    setShowModal(true);
+  };
+
+  return (
+    <>
+      <label className="inline-flex flex-col text-xs font-medium text-slate-500">
+        Version
+        <select
+          value={selectedVersion}
+          onChange={handleSelect}
+          disabled={!hasAlternatives}
+          className={clsx(
+            "mt-1 h-11 min-w-[12rem] rounded-full border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2",
+            hasAlternatives ? "hover:border-slate-300 hover:text-slate-900" : "cursor-not-allowed opacity-50",
+          )}
+          aria-label="Compare methodology versions"
+        >
+          <option value="">
+            {hasAlternatives ? "Select version" : "Single version"}
+          </option>
+          {comparable.map(option => (
+            <option key={option.version} value={option.version} disabled={option.version === rule.version}>
+              {option.version === rule.version ? `${option.version} (current)` : option.version}
+            </option>
+          ))}
+        </select>
+      </label>
+      {comparisonRule ? (
+        <VersionDiffModal
+          open={showModal}
+          onClose={() => {
+            setShowModal(false);
+            setSelectedVersion("");
+            setComparisonRule(null);
+          }}
+          current={rule}
+          target={comparisonRule}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/src/app/manifest/_components/pdfUtils.ts
+++ b/src/app/manifest/_components/pdfUtils.ts
@@ -1,0 +1,20 @@
+import { ManifestRule } from "../_types";
+
+export function getRulePdfUrl(rule: ManifestRule) {
+  if (rule.pdfId) {
+    const anchor = rule.anchor ?? "";
+    return `/pdf/${rule.pdfId}${anchor}`;
+  }
+  if (rule.anchor) return rule.anchor;
+  const href = (rule as { pdfHref?: string }).pdfHref;
+  if (typeof href === "string") return href;
+  return "";
+}
+
+export function getRulePdfPage(rule: ManifestRule) {
+  if (typeof rule.pdfPage === "number") return rule.pdfPage;
+  const anchor = rule.anchor ?? "";
+  const match = anchor.match(/page=(\d+)/i);
+  if (match) return Number.parseInt(match[1] ?? "", 10);
+  return undefined;
+}

--- a/src/app/manifest/_state/useManifestFilters.ts
+++ b/src/app/manifest/_state/useManifestFilters.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export type ManifestFiltersState = {
+  search: string;
+  tags: string[];
+};
+
+export function parseTags(raw: string | null | undefined) {
+  if (!raw) return [] as string[];
+  return raw
+    .split(",")
+    .map(tag => tag.trim())
+    .filter(tag => tag.length > 0)
+    .map(tag => decodeURIComponent(tag.toLowerCase()))
+    .filter((tag, index, arr) => arr.indexOf(tag) === index);
+}
+
+export function serializeFilters(state: ManifestFiltersState) {
+  const params = new URLSearchParams();
+  const trimmed = state.search.trim();
+  if (trimmed) params.set("q", trimmed);
+  if (state.tags.length > 0) params.set("tags", state.tags.join(","));
+  return params.toString();
+}
+
+function arraysEqual(a: string[], b: string[]) {
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) return false;
+  }
+  return true;
+}
+
+export function useManifestFilters() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [search, setSearch] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
+  const [initialized, setInitialized] = useState(false);
+
+  const currentParams = useMemo(() => searchParams?.toString() ?? "", [searchParams]);
+
+  useEffect(() => {
+    const qParam = searchParams?.get("q") ?? "";
+    const tagParam = parseTags(searchParams?.get("tags"));
+    setSearch(prev => (prev === qParam ? prev : qParam));
+    setTags(prev => (arraysEqual(prev, tagParam) ? prev : tagParam));
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!initialized) {
+      setInitialized(true);
+      return;
+    }
+    const nextParams = serializeFilters({ search, tags });
+    if (nextParams === currentParams) return;
+    const nextUrl = nextParams ? `${pathname}?${nextParams}` : pathname;
+    router.replace(nextUrl, { scroll: false });
+  }, [search, tags, router, pathname, currentParams, initialized]);
+
+  const toggleTag = useCallback((tag: string) => {
+    setTags(prev => {
+      const normalized = tag.toLowerCase();
+      return prev.includes(normalized)
+        ? prev.filter(existing => existing !== normalized)
+        : [...prev, normalized].sort();
+    });
+  }, []);
+
+  const clearTags = useCallback(() => {
+    setTags([]);
+  }, []);
+
+  const isTagSelected = useCallback((tag: string) => {
+    const normalized = tag.toLowerCase();
+    return tags.includes(normalized);
+  }, [tags]);
+
+  return {
+    search,
+    setSearch,
+    selectedTags: tags,
+    toggleTag,
+    clearTags,
+    isTagSelected,
+  } as const;
+}

--- a/src/app/manifest/_types.ts
+++ b/src/app/manifest/_types.ts
@@ -1,0 +1,19 @@
+import type { ManifestEntry } from "@/lib/manifest/cards";
+
+export type ManifestRule = ManifestEntry & {
+  ruleId: string;
+  methodology: string;
+  version: string;
+  rule: string;
+  tags: string[];
+  sha256?: string;
+  pdfId?: string;
+  anchor?: string;
+  pdfPage?: number;
+  source?: string;
+};
+
+export type RuleVersionOption = {
+  version: string;
+  rule?: ManifestRule;
+};

--- a/src/components/ManifestHealthBadge.tsx
+++ b/src/components/ManifestHealthBadge.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
+
+import { Tooltip } from "@/components/ui/Tooltip";
+
+type HealthStatus = "ok" | "degraded" | "loading";
+
+type HealthResponse = {
+  count?: number;
+  updatedAt?: string;
+  engineUrl?: string;
+  error?: string;
+};
+
+type HealthState = {
+  status: HealthStatus;
+  count: number;
+  updatedAt?: string;
+  source: "static" | "remote";
+};
+
+const POLL_INTERVAL = 30_000;
+
+async function fetchHealth(): Promise<HealthState> {
+  try {
+    const response = await fetch("/api/manifest/health", { cache: "no-store" });
+    const json = (await response.json()) as HealthResponse;
+    const status: HealthStatus = response.ok && !json.error ? "ok" : "degraded";
+    const source = json.engineUrl && json.engineUrl !== "static" ? "remote" : "static";
+    return {
+      status,
+      count: typeof json.count === "number" ? json.count : 0,
+      updatedAt: json.updatedAt,
+      source,
+    };
+  } catch (error) {
+    console.warn("[ManifestHealthBadge] health request failed", error);
+    return {
+      status: "degraded",
+      count: 0,
+      source: "static",
+    };
+  }
+}
+
+export default function ManifestHealthBadge() {
+  const [health, setHealth] = useState<HealthState>({ status: "loading", count: 0, source: "static" });
+
+  useEffect(() => {
+    let mounted = true;
+    let timer: number | null = null;
+
+    const load = async () => {
+      const next = await fetchHealth();
+      if (mounted) {
+        setHealth(next);
+      }
+    };
+
+    load();
+    timer = window.setInterval(load, POLL_INTERVAL);
+
+    return () => {
+      mounted = false;
+      if (timer) window.clearInterval(timer);
+    };
+  }, []);
+
+  const badgeClass = useMemo(() => {
+    switch (health.status) {
+      case "ok":
+        return "bg-emerald-100 text-emerald-800 border-emerald-200";
+      case "degraded":
+        return "bg-rose-100 text-rose-800 border-rose-200";
+      default:
+        return "bg-slate-100 text-slate-600 border-slate-200";
+    }
+  }, [health.status]);
+
+  const label =
+    health.status === "loading"
+      ? "Manifest health"
+      : health.status === "ok"
+      ? `Manifest healthy (${health.count})`
+      : "Manifest degraded";
+
+  const tooltipContent = (
+    <div className="space-y-1">
+      <p className="font-medium">{health.status === "ok" ? "Healthy" : health.status === "degraded" ? "Degraded" : "Loading"}</p>
+      <p className="text-xs text-slate-200">Last updated: {health.updatedAt ? new Date(health.updatedAt).toLocaleString() : "—"}</p>
+      <p className="text-xs text-slate-200 capitalize">Source: {health.source}</p>
+      <p className="text-xs text-slate-200">Rules: {health.count}</p>
+    </div>
+  );
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <span
+        className={clsx(
+          "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm font-medium",
+          badgeClass,
+        )}
+      >
+        <span className="inline-block h-2 w-2 rounded-full bg-current" aria-hidden="true" />
+        {label}
+      </span>
+    </Tooltip>
+  );
+}

--- a/src/components/manifest/HashCopyButton.tsx
+++ b/src/components/manifest/HashCopyButton.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Copy, Check } from "lucide-react";
+import { Tooltip } from "@/components/ui/Tooltip";
+import clsx from "clsx";
+
+type HashCopyButtonProps = {
+  hash: string | undefined;
+  className?: string;
+};
+
+export function HashCopyButton({ hash, className }: HashCopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+  const isCopyable = typeof hash === "string" && hash.length > 0;
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    if (!isCopyable) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(hash);
+      } else {
+        const fallback = document.createElement("textarea");
+        fallback.value = hash;
+        fallback.setAttribute("readonly", "true");
+        fallback.style.position = "absolute";
+        fallback.style.left = "-9999px";
+        document.body.appendChild(fallback);
+        fallback.select();
+        document.execCommand("copy");
+        document.body.removeChild(fallback);
+      }
+      setCopied(true);
+      if (timeoutRef.current) window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = window.setTimeout(() => {
+        setCopied(false);
+        timeoutRef.current = null;
+      }, 1500);
+    } catch (error) {
+      console.warn("[HashCopyButton] Failed to copy hash", error);
+    }
+  };
+
+  return (
+    <Tooltip
+      content={copied ? "Copied" : isCopyable ? "Copy SHA-256" : "Hash unavailable"}
+      delay={copied ? 0 : 150}
+    >
+      <button
+        type="button"
+        aria-label="Copy SHA-256"
+        onClick={handleCopy}
+        disabled={!isCopyable}
+        className={clsx(
+          "inline-flex h-11 min-w-11 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40",
+          copied ? "border-emerald-500 text-emerald-600" : "hover:border-slate-300 hover:text-slate-900",
+          className,
+        )}
+      >
+        {copied ? <Check className="h-5 w-5" aria-hidden="true" /> : <Copy className="h-5 w-5" aria-hidden="true" />}
+      </button>
+    </Tooltip>
+  );
+}
+
+export default HashCopyButton;

--- a/src/components/manifest/ManifestApp.tsx
+++ b/src/components/manifest/ManifestApp.tsx
@@ -1,216 +1,269 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { Search, Filter } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Search } from "lucide-react";
 
-type ManifestEntry = {
-  id: string;
-  methodology: string;
-  version: string;
-  rule: string;
-  tags: string[];
-  pdfId?: string;
-  anchor?: string;
-  sha256?: string;
-};
+import ManifestHealthBadge from "@/components/ManifestHealthBadge";
+import { MethodologyGroup } from "@/app/manifest/_components/MethodologyGroup";
+import { TagChip } from "@/app/manifest/_components/TagChip";
+import { ManifestRule, RuleVersionOption } from "@/app/manifest/_types";
+import { useManifestFilters } from "@/app/manifest/_state/useManifestFilters";
+
+type VersionIndex = Map<string, Map<string, ManifestRule>>;
+
+function normalizeEntry(entry: Record<string, unknown>): ManifestRule {
+  const methodology = String(
+    entry.methodology ?? entry.methodology_id ?? entry.methodologyId ?? "",
+  );
+  const version = String(
+    entry.version ?? entry.methodology_version ?? entry.methodologyVersion ?? "",
+  );
+  const id = String(entry.id ?? entry.rule_id ?? entry.ruleId ?? "");
+  const ruleId = String(entry.rule_id ?? entry.ruleId ?? entry.id ?? id);
+  const ruleText = String(
+    entry.rule ?? entry.text ?? entry.section_title ?? entry.sectionTitle ?? id,
+  );
+  const tags = Array.isArray(entry.tags)
+    ? (entry.tags as unknown[]).map(tag => String(tag))
+    : [];
+  const sha256 = typeof entry.sha256 === "string" ? entry.sha256 : undefined;
+  const anchor = typeof entry.anchor === "string"
+    ? entry.anchor
+    : typeof (entry as { pdf?: { anchor?: string } }).pdf?.anchor === "string"
+    ? (entry as { pdf: { anchor: string } }).pdf.anchor
+    : undefined;
+  const pdfId = typeof entry.pdfId === "string"
+    ? entry.pdfId
+    : typeof entry.pdf_id === "string"
+    ? entry.pdf_id
+    : typeof (entry as { pdf?: { id?: string } }).pdf?.id === "string"
+    ? (entry as { pdf: { id: string } }).pdf.id
+    : undefined;
+  const pdfPage = typeof (entry as { pdf?: { page?: number } }).pdf?.page === "number"
+    ? (entry as { pdf: { page: number } }).pdf.page
+    : undefined;
+
+  return {
+    id,
+    ruleId,
+    methodology,
+    version,
+    rule: ruleText,
+    tags,
+    sha256,
+    anchor,
+    pdfId,
+    pdfPage,
+  } satisfies ManifestRule;
+}
+
+function buildVersionIndex(entries: ManifestRule[]): VersionIndex {
+  const index: VersionIndex = new Map();
+  for (const entry of entries) {
+    const ruleKey = `${entry.methodology.toLowerCase()}::${(entry.ruleId || entry.id).toLowerCase()}`;
+    if (!index.has(ruleKey)) {
+      index.set(ruleKey, new Map());
+    }
+    index.get(ruleKey)!.set(entry.version, entry);
+  }
+  return index;
+}
+
+function getVersionsForRule(index: VersionIndex, rule: ManifestRule): RuleVersionOption[] {
+  const ruleKey = `${rule.methodology.toLowerCase()}::${(rule.ruleId || rule.id).toLowerCase()}`;
+  const versions = index.get(ruleKey);
+  if (!versions) {
+    return [{ version: rule.version, rule }];
+  }
+  return Array.from(versions.entries()).map(([version, entry]) => ({ version, rule: entry }));
+}
 
 export default function ManifestApp() {
-  const [query, setQuery] = useState("");
-  const [methodologyFilter, setMethodologyFilter] = useState("all");
-  const [entries, setEntries] = useState<ManifestEntry[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [entries, setEntries] = useState<ManifestRule[]>([]);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [methodologyFilter, setMethodologyFilter] = useState("all");
+  const { search, setSearch, selectedTags, toggleTag, clearTags, isTagSelected } = useManifestFilters();
 
   useEffect(() => {
-    const controller = new AbortController();
-    const timeout = setTimeout(async () => {
+    let cancelled = false;
+    const load = async () => {
       setLoading(true);
       setError(null);
-
       try {
-        const trimmedQuery = query.trim();
-        const searchParams = new URLSearchParams({ all: "1" });
-        if (trimmedQuery) {
-          searchParams.set("q", trimmedQuery);
-        }
-        const params = `?${searchParams.toString()}`;
-        const response = await fetch(`/api/manifest${params}`, {
-          signal: controller.signal,
-          cache: "no-store",
-        });
+        const response = await fetch("/api/manifest?all=1", { cache: "no-store" });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data: unknown = await response.json();
-        let payload: ManifestEntry[] = [];
-        if (Array.isArray(data)) {
-          payload = data as ManifestEntry[];
-        } else if (typeof data === "object" && data !== null) {
-          const maybe = data as { results?: unknown; rules?: unknown };
-          if (Array.isArray(maybe.results)) {
-            payload = maybe.results as ManifestEntry[];
-          } else if (Array.isArray(maybe.rules)) {
-            payload = maybe.rules as ManifestEntry[];
-          }
+        const items = Array.isArray(data)
+          ? data
+          : data && typeof data === "object"
+          ? (data as { results?: unknown[]; rules?: unknown[] }).results ??
+            (data as { results?: unknown[]; rules?: unknown[] }).rules ??
+            []
+          : [];
+        const normalized = (items as Record<string, unknown>[]).map(normalizeEntry);
+        if (!cancelled) {
+          setEntries(normalized);
         }
-        setEntries(payload);
       } catch (err) {
-        if ((err as { name?: string }).name !== "AbortError") {
+        if (!cancelled) {
           setError(err instanceof Error ? err.message : String(err));
           setEntries([]);
         }
       } finally {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
-    }, 200);
-
-    return () => {
-      controller.abort();
-      clearTimeout(timeout);
     };
-  }, [query]);
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const versionIndex = useMemo(() => buildVersionIndex(entries), [entries]);
 
   const methodologies = useMemo(() => {
-    const unique = new Set<string>(entries.map(entry => entry.methodology));
+    const unique = new Set(entries.map(entry => entry.methodology));
     return ["all", ...Array.from(unique).sort((a, b) => a.localeCompare(b))];
   }, [entries]);
 
-  const uniqueMethodologies = useMemo(() => {
-    const methodologiesMap = new Map<string, ManifestEntry[]>();
-
-    entries.forEach(entry => {
-      if (!methodologiesMap.has(entry.methodology)) {
-        methodologiesMap.set(entry.methodology, []);
+  const filteredEntries = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return entries.filter(entry => {
+      if (methodologyFilter !== "all" && entry.methodology !== methodologyFilter) {
+        return false;
       }
-      methodologiesMap.get(entry.methodology)!.push(entry);
+      if (selectedTags.length > 0) {
+        const tagSet = new Set(entry.tags.map(tag => tag.toLowerCase()));
+        const matchesTags = selectedTags.every(tag => tagSet.has(tag));
+        if (!matchesTags) return false;
+      }
+      if (!query) return true;
+      const haystack = `${entry.rule} ${entry.methodology} ${entry.version} ${entry.ruleId} ${entry.tags.join(" ")} ${entry.sha256 ?? ""}`.toLowerCase();
+      return haystack.includes(query);
     });
+  }, [entries, methodologyFilter, selectedTags, search]);
 
-    return Array.from(methodologiesMap.entries())
+  const grouped = useMemo(() => {
+    const map = new Map<string, ManifestRule[]>();
+    for (const entry of filteredEntries) {
+      if (!map.has(entry.methodology)) {
+        map.set(entry.methodology, []);
+      }
+      map.get(entry.methodology)!.push(entry);
+    }
+    return Array.from(map.entries())
       .map(([methodology, rules]) => ({
         methodology,
-        rules,
+        rules: rules.sort((a, b) => a.rule.localeCompare(b.rule)),
       }))
-      .filter(
-        ({ methodology }) =>
-          methodologyFilter === "all" || methodology === methodologyFilter,
-      );
-  }, [entries, methodologyFilter]);
+      .sort((a, b) => a.methodology.localeCompare(b.methodology));
+  }, [filteredEntries]);
 
-  const resultsCount = useMemo(() => {
-    return uniqueMethodologies.reduce((acc, { rules }) => acc + rules.length, 0);
-  }, [uniqueMethodologies]);
+  const resultsCount = useMemo(() => filteredEntries.length, [filteredEntries]);
+
+  const versionLookup = useCallback((rule: ManifestRule) => getVersionsForRule(versionIndex, rule), [versionIndex]);
 
   return (
-    <div className="min-h-screen bg-slate-50 py-12">
-      <div className="mx-auto flex max-w-5xl flex-col gap-6 px-4">
-        <header className="space-y-3">
-          <h1 className="text-2xl font-semibold text-slate-900">Methodology manifest</h1>
-          <p className="text-sm text-slate-600">
-            Search rules across methodologies, jump to anchors, and confirm hashes. Use the filters below to narrow by methodology or keyword.
-          </p>
+    <main className="min-h-screen bg-slate-50">
+      <div className="mx-auto max-w-6xl space-y-6 px-6 py-12">
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-3">
+            <h1 className="text-2xl font-semibold text-slate-900">Methodology manifest</h1>
+            <p className="max-w-3xl text-sm text-slate-600">
+              Search rules across methodologies, jump to anchored PDFs, filter by tags, and confirm hashes before exporting lean JSON snapshots.
+            </p>
+          </div>
+          <ManifestHealthBadge />
         </header>
 
-        <section className="grid gap-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm lg:grid-cols-[2fr_minmax(0,1fr)]">
-          <label className="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-            <Search className="h-4 w-4 text-slate-400" />
-            <input
-              type="search"
-              placeholder="Search by keyword, tag, or version"
-              value={query}
-              onChange={event => setQuery(event.target.value)}
-              className="flex-1 bg-transparent text-sm text-slate-900 outline-none placeholder:text-slate-400"
-            />
-          </label>
+        <section className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+            <label className="flex items-center gap-3 rounded-full border border-slate-200 bg-slate-50 px-4">
+              <Search className="h-5 w-5 text-slate-400" aria-hidden="true" />
+              <input
+                type="search"
+                placeholder="Search by keyword, tag, or version"
+                value={search}
+                onChange={event => setSearch(event.target.value)}
+                className="h-11 flex-1 bg-transparent text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none"
+              />
+            </label>
+            <label className="flex items-center gap-3 rounded-full border border-slate-200 bg-slate-50 px-4 text-sm font-medium text-slate-700">
+              <span className="text-xs uppercase tracking-wide text-slate-500">Methodology</span>
+              <select
+                value={methodologyFilter}
+                onChange={event => setMethodologyFilter(event.target.value)}
+                className="h-11 flex-1 rounded-full bg-transparent text-sm text-slate-900 focus:outline-none"
+              >
+                {methodologies.map(methodology => (
+                  <option key={methodology} value={methodology}>
+                    {methodology === "all" ? "All methodologies" : methodology}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
 
-          <label className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-            <Filter className="h-4 w-4 text-slate-400" />
-            <select
-              value={methodologyFilter}
-              onChange={event => setMethodologyFilter(event.target.value)}
-              className="flex-1 bg-transparent text-sm text-slate-900 outline-none"
-            >
-              {methodologies.map(value => (
-                <option key={value} value={value}>
-                  {value === "all" ? "All methodologies" : value}
-                </option>
+          {selectedTags.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Active tags</span>
+              {selectedTags.map(tag => (
+                <TagChip key={tag} tag={tag} active onToggle={toggleTag} />
               ))}
-            </select>
-          </label>
+              <button
+                type="button"
+                onClick={clearTags}
+                className="inline-flex h-11 min-w-11 items-center justify-center rounded-full border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2"
+              >
+                Clear tags
+              </button>
+            </div>
+          ) : null}
         </section>
 
-        <section className="space-y-3">
-          <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+        <section className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-wide text-slate-500">
             <span>
               {loading
-                ? "Searching…"
+                ? "Loading manifest…"
                 : error
-                ? "Error"
+                ? "Unable to load manifest"
                 : `${resultsCount} result${resultsCount === 1 ? "" : "s"}`}
             </span>
-            <span>Click entries to open the PDF at the anchored section.</span>
+            <span>Click a rule to explore provenance and copies.</span>
           </div>
 
-          <div className="space-y-6">
-            {uniqueMethodologies.map(({ methodology, rules }) => (
-              <div key={methodology}>
-                <h2 className="text-lg font-medium text-slate-800">{methodology}</h2>
-                <ul className="mt-3 space-y-3">
-                  {rules.map(rule => (
-                    <li key={rule.id}>
-                      <ManifestCard entry={rule} />
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-            {!loading && !error && resultsCount === 0 ? (
-              <div className="rounded-xl border border-dashed border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
-                No manifest entries match your filters yet.
-              </div>
-            ) : null}
-          </div>
           {error ? (
-            <p className="mt-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
+            <p className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
               {error}
             </p>
           ) : null}
+
+          {!loading && !error && resultsCount === 0 ? (
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-white p-10 text-center text-sm text-slate-500">
+              No manifest entries match your filters yet.
+            </div>
+          ) : null}
+
+          <div className="space-y-6">
+            {grouped.map(group => (
+              <MethodologyGroup
+                key={group.methodology}
+                methodology={group.methodology}
+                rules={group.rules}
+                visibleCount={group.rules.length}
+                onTagToggle={toggleTag}
+                isTagActive={isTagSelected}
+                versionLookup={versionLookup}
+              />
+            ))}
+          </div>
         </section>
       </div>
-    </div>
-  );
-}
-
-type ManifestCardProps = {
-  entry: ManifestEntry;
-};
-
-function ManifestCard({ entry }: ManifestCardProps) {
-  const anchorPath = entry.anchor ?? "";
-  const pdfId = entry.pdfId ?? "";
-  const url = pdfId ? `/pdf/${pdfId}${anchorPath}` : anchorPath || "#";
-  const shaLabel = entry.sha256 ? `${entry.sha256.slice(0, 12)}…` : "n/a";
-  const tags = entry.tags?.length ? entry.tags.join(", ") : "—";
-  return (
-    <article className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-slate-300 hover:shadow">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h2 className="text-lg font-semibold text-slate-900">{entry.rule}</h2>
-        <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">
-          {entry.methodology} · {entry.version}
-        </span>
-      </div>
-      <p className="mt-3 text-sm text-slate-600">Tags: {tags}</p>
-
-      <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-slate-600">
-        {url !== "#" ? (
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
-          >
-            View anchor
-          </a>
-        ) : null}
-        <span className="font-mono">SHA256 {shaLabel}</span>
-      </div>
-    </article>
+    </main>
   );
 }

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { cloneElement, isValidElement, ReactElement, ReactNode, useEffect, useRef, useState } from "react";
+import clsx from "clsx";
+
+type TooltipProps = {
+  children: ReactElement;
+  content: ReactNode;
+  delay?: number;
+  placement?: "top" | "bottom" | "left" | "right";
+  className?: string;
+};
+
+export function Tooltip({ children, content, delay = 150, placement = "top", className }: TooltipProps) {
+  const [open, setOpen] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+  const clearTimer = () => {
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  const show = () => {
+    clearTimer();
+    timeoutRef.current = window.setTimeout(() => {
+      setOpen(true);
+      timeoutRef.current = null;
+    }, delay);
+  };
+
+  const hide = () => {
+    clearTimer();
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      clearTimer();
+    };
+  }, []);
+
+  if (!isValidElement(children)) {
+    throw new Error("Tooltip expects a single valid React element child");
+  }
+
+  const enhancedChild = cloneElement(children, {
+    ref: (node: HTMLElement | null) => {
+      const { ref } = children as { ref?: React.Ref<HTMLElement> };
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref && typeof ref === "object") {
+        (ref as any).current = node;
+      }
+    },
+    onMouseEnter: (event: React.MouseEvent<HTMLElement>) => {
+      children.props.onMouseEnter?.(event);
+      show();
+    },
+    onMouseLeave: (event: React.MouseEvent<HTMLElement>) => {
+      children.props.onMouseLeave?.(event);
+      hide();
+    },
+    onFocus: (event: React.FocusEvent<HTMLElement>) => {
+      children.props.onFocus?.(event);
+      show();
+    },
+    onBlur: (event: React.FocusEvent<HTMLElement>) => {
+      children.props.onBlur?.(event);
+      hide();
+    },
+  });
+
+  const positionClass = {
+    top: "bottom-full left-1/2 -translate-x-1/2 -translate-y-2",
+    bottom: "top-full left-1/2 -translate-x-1/2 translate-y-2",
+    left: "right-full top-1/2 -translate-y-1/2 -translate-x-2",
+    right: "left-full top-1/2 -translate-y-1/2 translate-x-2",
+  }[placement];
+
+  return (
+    <span className={clsx("relative inline-flex", className)}>
+      {enhancedChild}
+      {open ? (
+        <span
+          role="tooltip"
+          className={clsx(
+            "pointer-events-none absolute z-30 max-w-xs rounded-lg bg-slate-900 px-3 py-1 text-xs font-medium text-white shadow-lg",
+            positionClass,
+          )}
+        >
+          {content}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+export default Tooltip;

--- a/tests/api/rule.export.test.ts
+++ b/tests/api/rule.export.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, beforeAll } from "@jest/globals";
+
+import { GET } from "@/app/api/manifest/rule/[sha]/route";
+
+const KNOWN_SHA = "eece4efeea1e33859370f4a08278b5e93aae51740505e98b3c7eb6e94d9f4f29";
+
+describe("GET /api/manifest/rule/[sha]", () => {
+  beforeAll(() => {
+    process.env.ENGINE_ADAPTER = "demo";
+  });
+
+  it("returns a JSON attachment for a known hash", async () => {
+    const request = new Request(`http://localhost/api/manifest/rule/${KNOWN_SHA}`);
+    const response = await GET(request, { params: { sha: KNOWN_SHA } });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("content-disposition")).toContain(`rule-${KNOWN_SHA.toLowerCase()}`);
+    const json = await response.json();
+    expect(json.sha256).toBe(KNOWN_SHA);
+  });
+
+  it("returns 404 when the hash is missing", async () => {
+    const request = new Request("http://localhost/api/manifest/rule/not-found");
+    const response = await GET(request, { params: { sha: "not-found" } });
+    expect(response.status).toBe(404);
+    const json = await response.json();
+    expect(json.error).toBe("Rule not found");
+  });
+});

--- a/tests/manifest/filters.test.tsx
+++ b/tests/manifest/filters.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { parseTags, serializeFilters } from "@/app/manifest/_state/useManifestFilters";
+
+describe("manifest filter helpers", () => {
+  it("parses comma-separated tags into a unique, lowercase list", () => {
+    expect(parseTags("calc, eligibility, Calc , , baseline")).toEqual([
+      "calc",
+      "eligibility",
+      "baseline",
+    ]);
+  });
+
+  it("serializes filters while omitting empty values", () => {
+    expect(
+      serializeFilters({
+        search: "",
+        tags: [],
+      }),
+    ).toBe("");
+
+    expect(
+      serializeFilters({
+        search: " baseline ",
+        tags: ["calc", "eligibility"],
+      }),
+    ).toBe("q=baseline&tags=calc%2Celigibility");
+  });
+});

--- a/tests/manifest/hashCopy.test.tsx
+++ b/tests/manifest/hashCopy.test.tsx
@@ -1,0 +1,68 @@
+/** @jest-environment jsdom */
+
+import { beforeEach, describe, expect, it, afterEach, jest } from "@jest/globals";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+import HashCopyButton from "@/components/manifest/HashCopyButton";
+
+describe("HashCopyButton", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const originalNavigator = global.navigator;
+  let originalClipboard: Clipboard | undefined;
+  const writeText = jest.fn(() => Promise.resolve());
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    if (!global.navigator) {
+      (global as any).navigator = {} as Navigator;
+    }
+    originalClipboard = (global.navigator as any).clipboard;
+    (global.navigator as any).clipboard = { writeText } as Clipboard;
+    act(() => {
+      root = createRoot(container);
+      root.render(<HashCopyButton hash="abc123" />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    writeText.mockClear();
+    if (originalClipboard === undefined) {
+      delete (global.navigator as any).clipboard;
+    } else {
+      (global.navigator as any).clipboard = originalClipboard;
+    }
+    if (!originalNavigator) {
+      delete (global as any).navigator;
+    } else {
+      (global as any).navigator = originalNavigator;
+    }
+  });
+
+  it("copies the provided hash and resets state", async () => {
+    const button = container.querySelector("button")!;
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith("abc123");
+    expect(button.className).toContain("border-emerald-500");
+
+    act(() => {
+      jest.advanceTimersByTime(1600);
+    });
+
+    expect(button.className).not.toContain("border-emerald-500");
+  });
+});


### PR DESCRIPTION
## Summary
- add manifest hash copy affordance, PDF tooltip, and version diff modal on rule cards
- surface manifest health badge, tag-aware filtering, and methodology counts within the page chrome
- expose JSON export API for rules, update documentation, and add targeted tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68fec95cc2808331813ef8b8b9878c19