### PR TITLE
feat(manifest): hash copy, health badge, tag filters, rule counts, PD…

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The first request sets `__Secure-vercel-bypass` and Vercel accepts that cookie f
 
 - `/` Chat landing — mobile-first chat experience with insights pane.
 - `/audit` Dry-run audit workflow — upload PDFs, view anchors/hashes, check QA/QC.
-- `/manifest` Searchable manifest — filter rules by methodology/tags and jump to anchored PDFs.
+- `/manifest` Searchable manifest — live health badge, tag-aware URLs, clipboard hashes, JSON export, and cross-version diffs on rule cards.
 - `/registry/mock` Mock issuance — preview dummy tCO₂e issuance and balances for investor storytelling.
 
 Implementation notes:

--- a/src/app/api/manifest/health/route.ts
+++ b/src/app/api/manifest/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { loadManifestAll } from "@/lib/manifestSource";
+import { resolveEngineMode } from "@/lib/engine/config";
+import { loadManifestWithMeta } from "@/lib/manifestSource";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -10,26 +11,42 @@ const RESPONSE_HEADERS = {
   Pragma: "no-cache",
 } as const;
 
+type HealthStatus = "ok" | "degraded";
+
 export async function GET() {
   try {
-    const entries = await loadManifestAll({ showAll: true });
+    const result = await loadManifestWithMeta({ showAll: true });
+    const mode = resolveEngineMode();
+    const degraded = mode === "remote" && result.source === "static" && Boolean(result.error);
+    const status: HealthStatus = degraded ? "degraded" : "ok";
+
     return NextResponse.json(
       {
-        count: entries.length,
-        updatedAt: new Date().toISOString(),
-        engineUrl: process.env.ENGINE_URL ?? "static",
+        status,
+        lastUpdated: result.fetchedAt,
+        source: result.source,
+        ruleCount: result.entries.length,
+        error: result.error ?? null,
       },
-      { headers: RESPONSE_HEADERS },
+      {
+        status: status === "ok" ? 200 : 503,
+        headers: RESPONSE_HEADERS,
+      },
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return NextResponse.json(
       {
+        status: "degraded" satisfies HealthStatus,
+        lastUpdated: new Date().toISOString(),
+        source: "static" as const,
+        ruleCount: 0,
         error: message,
-        updatedAt: new Date().toISOString(),
-        engineUrl: process.env.ENGINE_URL ?? "static",
       },
-      { status: 500, headers: RESPONSE_HEADERS },
+      {
+        status: 503,
+        headers: RESPONSE_HEADERS,
+      },
     );
   }
 }

--- a/src/app/api/manifest/rule/[sha]/route.ts
+++ b/src/app/api/manifest/rule/[sha]/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { loadManifestWithMeta } from "@/lib/manifestSource";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const RESPONSE_HEADERS = {
+  "Cache-Control": "no-store, no-cache, must-revalidate",
+  Pragma: "no-cache",
+} as const;
+
+type RouteParams = {
+  params: {
+    sha: string;
+  };
+};
+
+export async function GET(_request: Request, context: RouteParams) {
+  const shaParam = context.params?.sha?.trim();
+  if (!shaParam) {
+    return NextResponse.json(
+      { error: "Missing SHA parameter" },
+      { status: 400, headers: RESPONSE_HEADERS },
+    );
+  }
+
+  const normalizedSha = shaParam.toLowerCase();
+
+  try {
+    const result = await loadManifestWithMeta({ showAll: true });
+    const match = result.entries.find(
+      entry => entry.sha256?.toLowerCase() === normalizedSha,
+    );
+
+    if (!match) {
+      return NextResponse.json(
+        { error: `Rule with sha256 ${shaParam} not found` },
+        { status: 404, headers: RESPONSE_HEADERS },
+      );
+    }
+
+    const body = JSON.stringify(match, null, 2);
+    return new Response(body, {
+      status: 200,
+      headers: {
+        ...RESPONSE_HEADERS,
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Disposition": `attachment; filename="rule-${normalizedSha}.json"`,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json(
+      { error: message },
+      { status: 500, headers: RESPONSE_HEADERS },
+    );
+  }
+}

--- a/src/app/manifest/_components/MethodologyGroup.tsx
+++ b/src/app/manifest/_components/MethodologyGroup.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { type ReactNode } from "react";
+
+type MethodologyGroupProps = {
+  methodology: string;
+  visibleCount: number;
+  children: ReactNode;
+};
+
+export default function MethodologyGroup({
+  methodology,
+  visibleCount,
+  children,
+}: MethodologyGroupProps) {
+  return (
+    <section>
+      <header className="flex items-center gap-3">
+        <h2 className="text-lg font-semibold text-slate-900">{methodology}</h2>
+        <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600">
+          {visibleCount} {visibleCount === 1 ? "rule" : "rules"}
+        </span>
+      </header>
+      <div className="mt-4 space-y-4">{children}</div>
+    </section>
+  );
+}

--- a/src/app/manifest/_components/RuleCard.tsx
+++ b/src/app/manifest/_components/RuleCard.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useMemo } from "react";
+import HashCopyButton from "@/components/manifest/HashCopyButton";
+import Tooltip from "@/components/ui/Tooltip";
+import TagChip from "@/app/manifest/_components/TagChip";
+import VersionSwitcher from "@/app/manifest/_components/VersionSwitcher";
+import { type ManifestEntry } from "@/lib/manifest/cards";
+
+type RuleCardProps = {
+  entry: ManifestEntry;
+  activeTags: string[];
+  onToggleTag: (tag: string) => void;
+  relatedVersions: ManifestEntry[];
+  onSelectVersion: (entry: ManifestEntry) => void;
+};
+
+function buildAnchorUrl(entry: ManifestEntry) {
+  const anchorPath = entry.anchor ?? "";
+  const pdfId = entry.pdfId ?? "";
+  if (pdfId) return `/pdf/${pdfId}${anchorPath}`;
+  return anchorPath || "#";
+}
+
+function extractPageFromAnchor(anchor?: string | null) {
+  if (!anchor) return null;
+  const match = anchor.match(/page=(\d{1,4})/i);
+  if (match && match[1]) {
+    const page = Number.parseInt(match[1], 10);
+    return Number.isFinite(page) ? page : null;
+  }
+  return null;
+}
+
+export default function RuleCard({
+  entry,
+  activeTags,
+  onToggleTag,
+  relatedVersions,
+  onSelectVersion,
+}: RuleCardProps) {
+  const shortHash = entry.sha256 ? `${entry.sha256.slice(0, 12)}…` : "n/a";
+  const anchorUrl = buildAnchorUrl(entry);
+  const hasAnchor = anchorUrl !== "#";
+  const pageNumber = extractPageFromAnchor(entry.anchor);
+  const exportHref = entry.sha256 ? `/api/manifest/rule/${entry.sha256}` : "";
+  const tooltipLabel = pageNumber ? `Open PDF • page ${pageNumber}` : "Open PDF";
+
+  const sortedTags = useMemo(() => [...(entry.tags ?? [])].sort((a, b) => a.localeCompare(b)), [entry.tags]);
+
+  return (
+    <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-slate-300 hover:shadow-md">
+      <header className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold text-slate-900">{entry.rule}</h3>
+          <p className="text-sm text-slate-600">
+            {entry.methodology} · {entry.version}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <VersionSwitcher
+            methodology={entry.methodology}
+            currentVersion={entry.version}
+            options={relatedVersions}
+            onSelect={onSelectVersion}
+          />
+          <div className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-600">
+            <span className="font-mono">SHA256 {shortHash}</span>
+            <HashCopyButton hash={entry.sha256} />
+          </div>
+        </div>
+      </header>
+
+      {sortedTags.length ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {sortedTags.map(tag => (
+            <TagChip
+              key={tag}
+              label={tag}
+              active={activeTags.includes(tag)}
+              onToggle={() => onToggleTag(tag)}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="mt-4 text-sm text-slate-500">No tags recorded.</p>
+      )}
+
+      <footer className="mt-6 flex flex-wrap items-center gap-3 text-sm">
+        {hasAnchor ? (
+          <Tooltip content={tooltipLabel}>
+            <a
+              href={anchorUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex min-h-[2.75rem] items-center justify-center rounded-full border border-slate-200 bg-white px-4 font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2"
+            >
+              Open PDF
+            </a>
+          </Tooltip>
+        ) : null}
+        <a
+          href={exportHref || undefined}
+          download={entry.sha256 ? `rule-${entry.sha256}.json` : undefined}
+          className={`inline-flex min-h-[2.75rem] items-center justify-center rounded-full border px-4 font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2 ${
+            exportHref
+              ? "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:text-slate-900"
+              : "cursor-not-allowed border-slate-100 bg-slate-100 text-slate-400"
+          }`}
+          aria-disabled={!exportHref}
+        >
+          Export JSON
+        </a>
+      </footer>
+    </article>
+  );
+}

--- a/src/app/manifest/_components/TagChip.tsx
+++ b/src/app/manifest/_components/TagChip.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+type TagChipProps = {
+  label: string;
+  active: boolean;
+  onToggle: () => void;
+};
+
+export default function TagChip({ label, active, onToggle }: TagChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      className={`inline-flex min-h-[2.75rem] items-center justify-center rounded-full border px-4 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2 ${
+        active
+          ? "border-slate-800 bg-slate-800 text-white"
+          : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:text-slate-900"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/app/manifest/_components/VersionDiffModal.tsx
+++ b/src/app/manifest/_components/VersionDiffModal.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect } from "react";
+import { type ManifestEntry } from "@/lib/manifest/cards";
+
+type VersionDiffModalProps = {
+  open: boolean;
+  current: ManifestEntry | null;
+  comparison: ManifestEntry | null;
+  onClose: () => void;
+};
+
+type DiffSegment = {
+  type: "same" | "added" | "removed";
+  text: string;
+};
+
+function buildAnchorUrl(entry: ManifestEntry | null) {
+  if (!entry) return "#";
+  const anchorPath = entry.anchor ?? "";
+  const pdfId = entry.pdfId ?? "";
+  if (pdfId) return `/pdf/${pdfId}${anchorPath}`;
+  return anchorPath || "#";
+}
+
+function diffWords(previousText: string, nextText: string): DiffSegment[] {
+  const aWords = previousText.trim().length ? previousText.split(/\s+/) : [];
+  const bWords = nextText.trim().length ? nextText.split(/\s+/) : [];
+  const m = aWords.length;
+  const n = bWords.length;
+  const lcs: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+  for (let i = m - 1; i >= 0; i -= 1) {
+    for (let j = n - 1; j >= 0; j -= 1) {
+      if (aWords[i] === bWords[j]) {
+        lcs[i][j] = lcs[i + 1][j + 1] + 1;
+      } else {
+        lcs[i][j] = Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+      }
+    }
+  }
+
+  const segments: DiffSegment[] = [];
+  let i = 0;
+  let j = 0;
+  const pushSegment = (type: DiffSegment["type"], text: string) => {
+    if (!text) return;
+    const last = segments[segments.length - 1];
+    if (last && last.type === type) {
+      last.text += ` ${text}`;
+    } else {
+      segments.push({ type, text });
+    }
+  };
+
+  while (i < m && j < n) {
+    if (aWords[i] === bWords[j]) {
+      pushSegment("same", aWords[i]);
+      i += 1;
+      j += 1;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      pushSegment("removed", aWords[i]);
+      i += 1;
+    } else {
+      pushSegment("added", bWords[j]);
+      j += 1;
+    }
+  }
+
+  while (i < m) {
+    pushSegment("removed", aWords[i]);
+    i += 1;
+  }
+  while (j < n) {
+    pushSegment("added", bWords[j]);
+    j += 1;
+  }
+
+  return segments;
+}
+
+function renderDiff(segments: DiffSegment[]) {
+  return segments.map((segment, index) => {
+    if (segment.type === "same") {
+      return (
+        <span key={index} className="text-slate-800">
+          {segment.text}{" "}
+        </span>
+      );
+    }
+    if (segment.type === "added") {
+      return (
+        <span key={index} className="rounded bg-emerald-100 px-1 text-emerald-800">
+          {segment.text}{" "}
+        </span>
+      );
+    }
+    return (
+      <span key={index} className="rounded bg-rose-100 px-1 text-rose-800 line-through">
+        {segment.text}{" "}
+      </span>
+    );
+  });
+}
+
+export default function VersionDiffModal({
+  open,
+  current,
+  comparison,
+  onClose,
+}: VersionDiffModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKey);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKey);
+    };
+  }, [open, onClose]);
+
+  if (!open || !current || !comparison) return null;
+
+  const diffSegments = diffWords(current.rule ?? "", comparison.rule ?? "");
+  const hasDiff = diffSegments.some(segment => segment.type !== "same");
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Compare methodology versions"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4 py-8"
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[90vh] w-full max-w-4xl overflow-auto rounded-2xl bg-white p-6 shadow-2xl"
+        onClick={event => event.stopPropagation()}
+      >
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900">
+              {current.methodology} · {current.id}
+            </h2>
+            <p className="text-sm text-slate-600">
+              Comparing {current.version} to {comparison.version}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-11 min-w-[2.75rem] items-center justify-center rounded-full border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2"
+          >
+            Close
+          </button>
+        </header>
+
+        <div className="mt-6 grid gap-6 md:grid-cols-2">
+          {[current, comparison].map(entry => (
+            <div key={`${entry.methodology}-${entry.version}`} className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+                {entry.version}
+              </h3>
+              <p className="mt-3 text-sm text-slate-700">{entry.rule}</p>
+              <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-slate-600">
+                {entry.tags?.map(tag => (
+                  <span
+                    key={`${entry.version}-${tag}`}
+                    className="rounded-full bg-white px-2 py-1 font-medium text-slate-700"
+                  >
+                    {tag}
+                  </span>
+                ))}
+                <a
+                  href={buildAnchorUrl(entry)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex min-h-[2.75rem] items-center rounded-full border border-slate-200 bg-white px-3 font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2"
+                >
+                  Open PDF
+                </a>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <section className="mt-6">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Diff</h3>
+          <p className="mt-3 text-sm leading-relaxed text-slate-800">
+            {hasDiff ? renderDiff(diffSegments) : "Rule text is identical across the selected versions."}
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/manifest/_components/VersionSwitcher.tsx
+++ b/src/app/manifest/_components/VersionSwitcher.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { type ManifestEntry } from "@/lib/manifest/cards";
+
+type VersionSwitcherProps = {
+  methodology: string;
+  currentVersion: string;
+  options: ManifestEntry[];
+  onSelect: (entry: ManifestEntry) => void;
+};
+
+export default function VersionSwitcher({
+  methodology,
+  currentVersion,
+  options,
+  onSelect,
+}: VersionSwitcherProps) {
+  const hasAlternatives = options.length > 1;
+
+  function handleChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    const selectedVersion = event.target.value;
+    if (selectedVersion === currentVersion) return;
+    const match = options.find(entry => entry.version === selectedVersion);
+    if (match) onSelect(match);
+  }
+
+  return (
+    <label className="inline-flex min-h-[2.75rem] items-center gap-2 rounded-full border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:border-slate-300 focus-within:outline focus-within:outline-2 focus-within:outline-slate-500 focus-within:outline-offset-2">
+      <span className="hidden sm:inline">Version</span>
+      <select
+        className="min-h-[2.5rem] bg-transparent text-sm text-slate-800 focus:outline-none"
+        aria-label={`Compare ${methodology} versions`}
+        value={currentVersion}
+        onChange={handleChange}
+        disabled={!hasAlternatives}
+      >
+        {options.map(entry => (
+          <option key={entry.version} value={entry.version}>
+            {entry.version}
+            {entry.version === currentVersion ? " (current)" : ""}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/app/manifest/_state/useManifestFilters.ts
+++ b/src/app/manifest/_state/useManifestFilters.ts
@@ -1,0 +1,158 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type FiltersState = {
+  query: string;
+  methodology: string;
+  tags: string[];
+};
+
+const DEFAULT_STATE: FiltersState = {
+  query: "",
+  methodology: "all",
+  tags: [],
+};
+
+function parseTags(value: string | null): string[] {
+  if (!value) return [];
+  return Array.from(
+    new Set(
+      value
+        .split(",")
+        .map(tag => tag.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function parseFilters(params: URLSearchParams | Readonly<URLSearchParams>): FiltersState {
+  const query = params.get("q") ?? "";
+  const methodology = params.get("methodology") ?? DEFAULT_STATE.methodology;
+  const tags = parseTags(params.get("tags"));
+  return {
+    query,
+    methodology: methodology || DEFAULT_STATE.methodology,
+    tags,
+  };
+}
+
+function buildSearchString(state: FiltersState) {
+  const params = new URLSearchParams();
+  if (state.query.trim()) params.set("q", state.query.trim());
+  if (state.methodology && state.methodology !== DEFAULT_STATE.methodology) {
+    params.set("methodology", state.methodology);
+  }
+  if (state.tags.length) params.set("tags", state.tags.join(","));
+  return params.toString();
+}
+
+export type ManifestFilters = {
+  query: string;
+  setQuery: (value: string) => void;
+  methodology: string;
+  setMethodology: (value: string) => void;
+  activeTags: string[];
+  toggleTag: (tag: string) => void;
+  clearTags: () => void;
+  searchString: string;
+};
+
+export default function useManifestFilters(): ManifestFilters {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [filters, setFiltersState] = useState<FiltersState>(() =>
+    parseFilters(new URLSearchParams(searchParams)),
+  );
+
+  const lastAppliedRef = useRef<string | null>(null);
+
+  const applyUrl = useCallback(
+    (next: FiltersState) => {
+      const search = buildSearchString(next);
+      lastAppliedRef.current = search;
+      const href = search ? `${pathname}?${search}` : pathname;
+      router.replace(href, { scroll: false });
+    },
+    [pathname, router],
+  );
+
+  const setFilters = useCallback(
+    (updater: FiltersState | ((prev: FiltersState) => FiltersState)) => {
+      setFiltersState(prev => {
+        const next = typeof updater === "function" ? (updater as (prev: FiltersState) => FiltersState)(prev) : updater;
+        applyUrl(next);
+        return next;
+      });
+    },
+    [applyUrl],
+  );
+
+  useEffect(() => {
+    const incoming = new URLSearchParams(searchParams);
+    const incomingString = incoming.toString();
+    if (incomingString === (lastAppliedRef.current ?? "")) {
+      lastAppliedRef.current = null;
+      return;
+    }
+    const parsed = parseFilters(incoming);
+    setFiltersState(parsed);
+  }, [searchParams]);
+
+  const setQuery = useCallback(
+    (value: string) => {
+      setFilters(prev => ({
+        ...prev,
+        query: value,
+      }));
+    },
+    [setFilters],
+  );
+
+  const setMethodology = useCallback(
+    (value: string) => {
+      setFilters(prev => ({
+        ...prev,
+        methodology: value || DEFAULT_STATE.methodology,
+      }));
+    },
+    [setFilters],
+  );
+
+  const toggleTag = useCallback(
+    (tag: string) => {
+      const normalized = tag.trim();
+      if (!normalized) return;
+      setFilters(prev => {
+        const hasTag = prev.tags.includes(normalized);
+        const nextTags = hasTag
+          ? prev.tags.filter(existing => existing !== normalized)
+          : [...prev.tags, normalized];
+        return { ...prev, tags: nextTags };
+      });
+    },
+    [setFilters],
+  );
+
+  const clearTags = useCallback(() => {
+    setFilters(prev => {
+      if (!prev.tags.length) return prev;
+      return { ...prev, tags: [] };
+    });
+  }, [setFilters]);
+
+  const searchString = useMemo(() => buildSearchString(filters), [filters]);
+
+  return {
+    query: filters.query,
+    setQuery,
+    methodology: filters.methodology,
+    setMethodology,
+    activeTags: filters.tags,
+    toggleTag,
+    clearTags,
+    searchString,
+  };
+}

--- a/src/components/ManifestHealthBadge.tsx
+++ b/src/components/ManifestHealthBadge.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Tooltip from "@/components/ui/Tooltip";
+
+type HealthStatus = "ok" | "degraded";
+
+type ManifestHealthPayload = {
+  status: HealthStatus;
+  lastUpdated: string;
+  source: "remote" | "static";
+  ruleCount: number;
+  error?: string | null;
+};
+
+type HealthState = {
+  status: HealthStatus;
+  lastUpdated: string | null;
+  source: "remote" | "static" | null;
+  ruleCount: number | null;
+  error?: string | null;
+};
+
+const INITIAL_STATE: HealthState = {
+  status: "degraded",
+  lastUpdated: null,
+  source: null,
+  ruleCount: null,
+  error: "Awaiting status…",
+};
+
+export default function ManifestHealthBadge() {
+  const [health, setHealth] = useState<HealthState>(INITIAL_STATE);
+  const [loading, setLoading] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const formattedTimestamp = useMemo(() => {
+    if (!health.lastUpdated) return "—";
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        dateStyle: "short",
+        timeStyle: "short",
+      }).format(new Date(health.lastUpdated));
+    } catch {
+      return health.lastUpdated;
+    }
+  }, [health.lastUpdated]);
+
+  const fetchHealth = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch("/api/manifest/health", {
+        method: "GET",
+        cache: "no-store",
+      });
+      const payload = (await response.json()) as ManifestHealthPayload;
+      if (mountedRef.current) {
+        setHealth({
+          status: payload.status,
+          lastUpdated: payload.lastUpdated ?? new Date().toISOString(),
+          source: payload.source,
+          ruleCount: payload.ruleCount,
+          error: payload.error ?? null,
+        });
+      }
+    } catch (error) {
+      if (mountedRef.current) {
+        setHealth({
+          status: "degraded",
+          lastUpdated: new Date().toISOString(),
+          source: "static",
+          ruleCount: null,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!cancelled) {
+        await fetchHealth();
+      }
+    })();
+    const interval = window.setInterval(() => {
+      if (!cancelled) {
+        void fetchHealth();
+      }
+    }, 30_000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [fetchHealth]);
+
+  const tooltipContent = (
+    <div className="flex flex-col gap-1 text-left">
+      <span className="font-semibold">
+        Status: {health.status === "ok" ? "OK" : "Degraded"}
+      </span>
+      <span>Source: {health.source ?? "unknown"}</span>
+      <span>Rules: {health.ruleCount ?? "—"}</span>
+      <span>Updated: {formattedTimestamp}</span>
+      {health.error ? <span className="text-rose-200">{health.error}</span> : null}
+    </div>
+  );
+
+  const badgeClasses =
+    health.status === "ok"
+      ? "bg-emerald-100 text-emerald-700 border-emerald-200"
+      : "bg-rose-100 text-rose-700 border-rose-200";
+
+  const dotClasses = health.status === "ok" ? "bg-emerald-500" : "bg-rose-500";
+  const label = health.status === "ok" ? "Manifest healthy" : "Manifest degraded";
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <button
+        type="button"
+        onClick={() => void fetchHealth()}
+        className={`flex h-11 items-center gap-2 rounded-full border px-3 text-xs font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2 ${badgeClasses}`}
+        aria-live="polite"
+      >
+        <span className={`h-2.5 w-2.5 rounded-full ${dotClasses}`} aria-hidden="true" />
+        <span>{label}</span>
+        <span className="sr-only">
+          {loading ? "Refreshing status" : `Last updated ${formattedTimestamp}`}
+        </span>
+      </button>
+    </Tooltip>
+  );
+}

--- a/src/components/manifest/HashCopyButton.tsx
+++ b/src/components/manifest/HashCopyButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check, Copy } from "lucide-react";
+import Tooltip from "@/components/ui/Tooltip";
+
+type HashCopyButtonProps = {
+  hash?: string;
+};
+
+export default function HashCopyButton({ hash }: HashCopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  const canCopy = Boolean(hash);
+  const tooltipContent = copyError
+    ? copyError
+    : copied
+    ? "Copied"
+    : "Copy SHA-256";
+
+  async function handleCopy() {
+    if (!hash || !canCopy) return;
+    try {
+      await navigator.clipboard.writeText(hash);
+      setCopyError(null);
+      setCopied(true);
+    } catch (error) {
+      setCopyError(
+        error instanceof Error ? error.message : "Unable to copy hash. Use manual selection.",
+      );
+    }
+  }
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <button
+        type="button"
+        aria-label="Copy SHA-256"
+        onClick={handleCopy}
+        disabled={!canCopy}
+        className={`flex h-11 w-11 items-center justify-center rounded-full border text-slate-600 transition 
+          ${canCopy ? "border-slate-200 bg-white hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2" : "cursor-not-allowed border-slate-100 bg-slate-100 text-slate-300"}`}
+      >
+        {copied ? <Check className="h-4 w-4" aria-hidden="true" /> : <Copy className="h-4 w-4" aria-hidden="true" />}
+        <span className="sr-only">Copy SHA-256 hash</span>
+      </button>
+    </Tooltip>
+  );
+}

--- a/src/components/manifest/ManifestApp.tsx
+++ b/src/components/manifest/ManifestApp.tsx
@@ -1,62 +1,62 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { Search, Filter } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Filter, Search } from "lucide-react";
+import ManifestHealthBadge from "@/components/ManifestHealthBadge";
+import useManifestFilters from "@/app/manifest/_state/useManifestFilters";
+import MethodologyGroup from "@/app/manifest/_components/MethodologyGroup";
+import RuleCard from "@/app/manifest/_components/RuleCard";
+import VersionDiffModal from "@/app/manifest/_components/VersionDiffModal";
+import { type ManifestEntry } from "@/lib/manifest/cards";
 
-type ManifestEntry = {
-  id: string;
-  methodology: string;
-  version: string;
-  rule: string;
-  tags: string[];
-  pdfId?: string;
-  anchor?: string;
-  sha256?: string;
+type VersionModalState = {
+  current: ManifestEntry;
+  comparison: ManifestEntry;
 };
 
 export default function ManifestApp() {
-  const [query, setQuery] = useState("");
-  const [methodologyFilter, setMethodologyFilter] = useState("all");
   const [entries, setEntries] = useState<ManifestEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [modalState, setModalState] = useState<VersionModalState | null>(null);
+
+  const filters = useManifestFilters();
 
   useEffect(() => {
     const controller = new AbortController();
-    const timeout = setTimeout(async () => {
+    const debounce = window.setTimeout(async () => {
       setLoading(true);
       setError(null);
-
       try {
-        const trimmedQuery = query.trim();
-        const searchParams = new URLSearchParams({ all: "1" });
+        const trimmedQuery = filters.query.trim();
+        const params = new URLSearchParams();
         if (trimmedQuery) {
-          searchParams.set("q", trimmedQuery);
+          params.set("q", trimmedQuery);
+        } else {
+          params.set("all", "1");
         }
-        const params = `?${searchParams.toString()}`;
-        const response = await fetch(`/api/manifest${params}`, {
-          signal: controller.signal,
+        const response = await fetch(`/api/manifest?${params.toString()}`, {
+          method: "GET",
           cache: "no-store",
+          signal: controller.signal,
         });
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const data: unknown = await response.json();
-        let payload: ManifestEntry[] = [];
-        if (Array.isArray(data)) {
-          payload = data as ManifestEntry[];
-        } else if (typeof data === "object" && data !== null) {
-          const maybe = data as { results?: unknown; rules?: unknown };
-          if (Array.isArray(maybe.results)) {
-            payload = maybe.results as ManifestEntry[];
-          } else if (Array.isArray(maybe.rules)) {
-            payload = maybe.rules as ManifestEntry[];
-          }
+        if (!response.ok) {
+          throw new Error(`Manifest request failed with ${response.status}`);
         }
-        setEntries(payload);
-      } catch (err) {
-        if ((err as { name?: string }).name !== "AbortError") {
-          setError(err instanceof Error ? err.message : String(err));
-          setEntries([]);
+        const payload = (await response.json()) as ManifestEntry[] | { results?: ManifestEntry[]; rules?: ManifestEntry[] };
+        let manifest: ManifestEntry[] = [];
+        if (Array.isArray(payload)) {
+          manifest = payload;
+        } else if (payload?.results && Array.isArray(payload.results)) {
+          manifest = payload.results;
+        } else if (payload?.rules && Array.isArray(payload.rules)) {
+          manifest = payload.rules;
         }
+        setEntries(manifest);
+      } catch (fetchError) {
+        if ((fetchError as { name?: string }).name === "AbortError") return;
+        setEntries([]);
+        setError(fetchError instanceof Error ? fetchError.message : String(fetchError));
       } finally {
         setLoading(false);
       }
@@ -64,153 +64,191 @@ export default function ManifestApp() {
 
     return () => {
       controller.abort();
-      clearTimeout(timeout);
+      window.clearTimeout(debounce);
     };
-  }, [query]);
+  }, [filters.query]);
 
-  const methodologies = useMemo(() => {
+  const methodologyOptions = useMemo(() => {
     const unique = new Set<string>(entries.map(entry => entry.methodology));
     return ["all", ...Array.from(unique).sort((a, b) => a.localeCompare(b))];
   }, [entries]);
 
-  const uniqueMethodologies = useMemo(() => {
-    const methodologiesMap = new Map<string, ManifestEntry[]>();
-
+  const versionMap = useMemo(() => {
+    const map = new Map<string, ManifestEntry[]>();
     entries.forEach(entry => {
-      if (!methodologiesMap.has(entry.methodology)) {
-        methodologiesMap.set(entry.methodology, []);
-      }
-      methodologiesMap.get(entry.methodology)!.push(entry);
+      const key = `${entry.methodology}::${entry.id}`;
+      const list = map.get(key) ?? [];
+      list.push(entry);
+      map.set(key, list);
     });
+    map.forEach(list => {
+      list.sort((a, b) => a.version.localeCompare(b.version));
+    });
+    return map;
+  }, [entries]);
 
-    return Array.from(methodologiesMap.entries())
+  const filteredEntries = useMemo(() => {
+    return entries.filter(entry => {
+      const methodologyMatch =
+        filters.methodology === "all" || entry.methodology === filters.methodology;
+      const tagsMatch = filters.activeTags.every(tag =>
+        (entry.tags ?? []).includes(tag),
+      );
+      return methodologyMatch && tagsMatch;
+    });
+  }, [entries, filters.methodology, filters.activeTags]);
+
+  const groupedEntries = useMemo(() => {
+    const grouping = new Map<string, ManifestEntry[]>();
+    filteredEntries.forEach(entry => {
+      const current = grouping.get(entry.methodology) ?? [];
+      current.push(entry);
+      grouping.set(entry.methodology, current);
+    });
+    return Array.from(grouping.entries())
       .map(([methodology, rules]) => ({
         methodology,
-        rules,
+        rules: rules.sort((a, b) => a.id.localeCompare(b.id)),
       }))
-      .filter(
-        ({ methodology }) =>
-          methodologyFilter === "all" || methodology === methodologyFilter,
-      );
-  }, [entries, methodologyFilter]);
+      .sort((a, b) => a.methodology.localeCompare(b.methodology));
+  }, [filteredEntries]);
 
-  const resultsCount = useMemo(() => {
-    return uniqueMethodologies.reduce((acc, { rules }) => acc + rules.length, 0);
-  }, [uniqueMethodologies]);
+  const resultCount = filteredEntries.length;
+
+  const handleVersionSelect = useCallback(
+    (base: ManifestEntry, comparison: ManifestEntry) => {
+      setModalState({ current: base, comparison });
+    },
+    [],
+  );
 
   return (
     <div className="min-h-screen bg-slate-50 py-12">
-      <div className="mx-auto flex max-w-5xl flex-col gap-6 px-4">
-        <header className="space-y-3">
-          <h1 className="text-2xl font-semibold text-slate-900">Methodology manifest</h1>
-          <p className="text-sm text-slate-600">
-            Search rules across methodologies, jump to anchors, and confirm hashes. Use the filters below to narrow by methodology or keyword.
-          </p>
+      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4">
+        <header className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-3">
+            <h1 className="text-3xl font-semibold text-slate-900">Methodology manifest</h1>
+            <p className="max-w-2xl text-sm text-slate-600">
+              Search rules across methodologies, jump to anchored evidence, filter by tags, and compare versions without leaving the page.
+            </p>
+          </div>
+          <ManifestHealthBadge />
         </header>
 
-        <section className="grid gap-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm lg:grid-cols-[2fr_minmax(0,1fr)]">
-          <label className="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-            <Search className="h-4 w-4 text-slate-400" />
+        <section className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <label className="flex min-h-[2.75rem] items-center gap-3 rounded-full border border-slate-200 bg-slate-50 px-4">
+            <Search className="h-4 w-4 text-slate-400" aria-hidden="true" />
             <input
               type="search"
               placeholder="Search by keyword, tag, or version"
-              value={query}
-              onChange={event => setQuery(event.target.value)}
-              className="flex-1 bg-transparent text-sm text-slate-900 outline-none placeholder:text-slate-400"
+              value={filters.query}
+              onChange={event => filters.setQuery(event.target.value)}
+              className="flex-1 bg-transparent text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none"
             />
           </label>
 
-          <label className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-            <Filter className="h-4 w-4 text-slate-400" />
+          <label className="flex min-h-[2.75rem] items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4">
+            <Filter className="h-4 w-4 text-slate-400" aria-hidden="true" />
             <select
-              value={methodologyFilter}
-              onChange={event => setMethodologyFilter(event.target.value)}
-              className="flex-1 bg-transparent text-sm text-slate-900 outline-none"
+              value={filters.methodology}
+              onChange={event => filters.setMethodology(event.target.value)}
+              className="flex-1 bg-transparent text-sm text-slate-900 focus:outline-none"
             >
-              {methodologies.map(value => (
-                <option key={value} value={value}>
-                  {value === "all" ? "All methodologies" : value}
+              {methodologyOptions.map(option => (
+                <option key={option} value={option}>
+                  {option === "all" ? "All methodologies" : option}
                 </option>
               ))}
             </select>
           </label>
+
+          {filters.activeTags.length ? (
+            <div className="lg:col-span-2">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="text-sm font-medium text-slate-600">Active tags:</span>
+                {filters.activeTags.map(tag => (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => filters.toggleTag(tag)}
+                    className="inline-flex min-h-[2.75rem] items-center rounded-full border border-slate-200 bg-slate-800 px-4 text-sm font-medium text-white transition hover:bg-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2"
+                  >
+                    {tag}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  onClick={filters.clearTags}
+                  className="inline-flex min-h-[2.75rem] items-center rounded-full border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2"
+                >
+                  Clear tags
+                </button>
+              </div>
+            </div>
+          ) : null}
         </section>
 
-        <section className="space-y-3">
-          <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
-            <span>
+        <section className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
               {loading
                 ? "Searching…"
                 : error
                 ? "Error"
-                : `${resultsCount} result${resultsCount === 1 ? "" : "s"}`}
+                : `${resultCount} result${resultCount === 1 ? "" : "s"}`}
             </span>
-            <span>Click entries to open the PDF at the anchored section.</span>
+            <span className="text-xs text-slate-500">
+              Copy hashes, export JSON, and open anchors without leaving context.
+            </span>
           </div>
 
-          <div className="space-y-6">
-            {uniqueMethodologies.map(({ methodology, rules }) => (
-              <div key={methodology}>
-                <h2 className="text-lg font-medium text-slate-800">{methodology}</h2>
-                <ul className="mt-3 space-y-3">
-                  {rules.map(rule => (
-                    <li key={rule.id}>
-                      <ManifestCard entry={rule} />
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-            {!loading && !error && resultsCount === 0 ? (
-              <div className="rounded-xl border border-dashed border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
-                No manifest entries match your filters yet.
-              </div>
-            ) : null}
-          </div>
           {error ? (
-            <p className="mt-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
+            <p className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
               {error}
             </p>
           ) : null}
+
+          {!loading && !error && resultCount === 0 ? (
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-white p-12 text-center text-sm text-slate-500">
+              No manifest entries match your filters yet.
+            </div>
+          ) : null}
+
+          <div className="space-y-10">
+            {groupedEntries.map(({ methodology, rules }) => (
+              <MethodologyGroup
+                key={methodology}
+                methodology={methodology}
+                visibleCount={rules.length}
+              >
+                <div className="space-y-4">
+                  {rules.map(entry => {
+                    const versionKey = `${entry.methodology}::${entry.id}`;
+                    const relatedVersions = versionMap.get(versionKey) ?? [entry];
+                    return (
+                      <RuleCard
+                        key={`${entry.methodology}-${entry.version}-${entry.id}`}
+                        entry={entry}
+                        activeTags={filters.activeTags}
+                        onToggleTag={filters.toggleTag}
+                        relatedVersions={relatedVersions}
+                        onSelectVersion={selected => handleVersionSelect(entry, selected)}
+                      />
+                    );
+                  })}
+                </div>
+              </MethodologyGroup>
+            ))}
+          </div>
         </section>
       </div>
+
+      <VersionDiffModal
+        open={modalState !== null}
+        current={modalState?.current ?? null}
+        comparison={modalState?.comparison ?? null}
+        onClose={() => setModalState(null)}
+      />
     </div>
-  );
-}
-
-type ManifestCardProps = {
-  entry: ManifestEntry;
-};
-
-function ManifestCard({ entry }: ManifestCardProps) {
-  const anchorPath = entry.anchor ?? "";
-  const pdfId = entry.pdfId ?? "";
-  const url = pdfId ? `/pdf/${pdfId}${anchorPath}` : anchorPath || "#";
-  const shaLabel = entry.sha256 ? `${entry.sha256.slice(0, 12)}…` : "n/a";
-  const tags = entry.tags?.length ? entry.tags.join(", ") : "—";
-  return (
-    <article className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-slate-300 hover:shadow">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h2 className="text-lg font-semibold text-slate-900">{entry.rule}</h2>
-        <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">
-          {entry.methodology} · {entry.version}
-        </span>
-      </div>
-      <p className="mt-3 text-sm text-slate-600">Tags: {tags}</p>
-
-      <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-slate-600">
-        {url !== "#" ? (
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
-          >
-            View anchor
-          </a>
-        ) : null}
-        <span className="font-mono">SHA256 {shaLabel}</span>
-      </div>
-    </article>
   );
 }

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import {
+  cloneElement,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+
+type TooltipProps = {
+  children: ReactElement;
+  content: ReactNode;
+  delay?: number;
+};
+
+export function Tooltip({ children, content, delay = 150 }: TooltipProps) {
+  const [open, setOpen] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+  const id = useId();
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const show = useCallback(() => {
+    clearTimer();
+    timeoutRef.current = window.setTimeout(() => {
+      setOpen(true);
+    }, delay);
+  }, [clearTimer, delay]);
+
+  const hide = useCallback(() => {
+    clearTimer();
+    setOpen(false);
+  }, [clearTimer]);
+
+  useEffect(() => {
+    return () => clearTimer();
+  }, [clearTimer]);
+
+  const triggerProps = {
+    onMouseEnter: (event: React.MouseEvent) => {
+      children.props.onMouseEnter?.(event);
+      if (!event.defaultPrevented) show();
+    },
+    onMouseLeave: (event: React.MouseEvent) => {
+      children.props.onMouseLeave?.(event);
+      if (!event.defaultPrevented) hide();
+    },
+    onFocus: (event: React.FocusEvent) => {
+      children.props.onFocus?.(event);
+      if (!event.defaultPrevented) show();
+    },
+    onBlur: (event: React.FocusEvent) => {
+      children.props.onBlur?.(event);
+      if (!event.defaultPrevented) hide();
+    },
+    onKeyDown: (event: React.KeyboardEvent) => {
+      if (event.key === "Escape") hide();
+      children.props.onKeyDown?.(event);
+    },
+    "aria-describedby": open ? id : undefined,
+  };
+
+  return (
+    <span className="relative inline-flex">
+      {cloneElement(children, triggerProps)}
+      <span
+        id={id}
+        role="tooltip"
+        className={`pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 -translate-y-2 transform rounded-md bg-slate-900 px-2 py-1 text-xs font-medium text-white shadow transition-opacity ${
+          open ? "opacity-100" : "opacity-0"
+        }`}
+      >
+        {content}
+      </span>
+    </span>
+  );
+}
+
+export default Tooltip;

--- a/src/lib/manifestSource.ts
+++ b/src/lib/manifestSource.ts
@@ -13,75 +13,110 @@ export type ManifestLoadOptions = {
   showAll?: boolean;
 };
 
-export async function loadManifestAll(options: ManifestLoadOptions = {}): Promise<ManifestEntry[]> {
+export type ManifestLoadResult = {
+  entries: ManifestEntry[];
+  source: "remote" | "static";
+  fetchedAt: string;
+  error?: string;
+};
+
+async function loadRemoteManifest(
+  manifestEntries: ManifestEntry[],
+  options: { rawQuery: string; showAll: boolean },
+): Promise<ManifestLoadResult> {
+  const engineUrl = resolveEngineEndpoint();
+  const manifestUrl = new URL(engineUrl);
+  const normalizedPath = manifestUrl.pathname.replace(/\/$/, "");
+  manifestUrl.pathname = normalizedPath.endsWith("/query")
+    ? `${normalizedPath.slice(0, -6)}/manifest`
+    : `${normalizedPath}/manifest`;
+
+  if (options.showAll) {
+    manifestUrl.searchParams.set("all", "1");
+  } else if (options.rawQuery) {
+    manifestUrl.searchParams.set("q", options.rawQuery);
+  }
+  manifestUrl.searchParams.set("view", "cards");
+
+  const response = await fetch(manifestUrl, {
+    method: "GET",
+    headers: buildEngineHeaders(),
+    cache: "no-store",
+  });
+
+  const bodyText = await response.text();
+  let parsedBody: unknown = null;
+  if (bodyText) {
+    try {
+      parsedBody = JSON.parse(bodyText);
+    } catch (error) {
+      throw new Error(
+        `Invalid engine manifest JSON: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(`Engine manifest responded ${response.status}: ${bodyText || "no body"}`);
+  }
+
+  const remoteEntries = Array.isArray(parsedBody)
+    ? parsedBody
+    : parsedBody && typeof parsedBody === "object"
+    ? (parsedBody as { results?: unknown[]; rules?: unknown[] }).results ??
+      (parsedBody as { results?: unknown[]; rules?: unknown[] }).rules
+    : undefined;
+
+  if (!Array.isArray(remoteEntries)) {
+    throw new Error("Engine manifest response missing rules array");
+  }
+
+  const manifestIndex = buildManifestIndex(manifestEntries);
+  return {
+    entries: remoteEntries.map(entry =>
+      coerceManifestEntry(entry as RemoteManifestEntry, manifestIndex),
+    ),
+    source: "remote",
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+function buildStaticResult(
+  manifestEntries: ManifestEntry[],
+  options: { rawQuery: string; showAll: boolean },
+  error?: string,
+): ManifestLoadResult {
+  return {
+    entries: filterEntries(manifestEntries, options.rawQuery, options.showAll),
+    source: "static",
+    fetchedAt: new Date().toISOString(),
+    error,
+  };
+}
+
+export async function loadManifestWithMeta(
+  options: ManifestLoadOptions = {},
+): Promise<ManifestLoadResult> {
   const rawQuery = options.rawQuery?.trim() ?? "";
   const showAll = options.showAll ?? rawQuery.length === 0;
-
-  // Always load static manifest for enrichment/fallback.
   const manifestEntries = await loadManifestEntries();
 
   if (resolveEngineMode() === "remote") {
     try {
-      const engineUrl = resolveEngineEndpoint();
-      const manifestUrl = new URL(engineUrl);
-      const normalizedPath = manifestUrl.pathname.replace(/\/$/, "");
-      manifestUrl.pathname = normalizedPath.endsWith("/query")
-        ? `${normalizedPath.slice(0, -6)}/manifest`
-        : `${normalizedPath}/manifest`;
-
-      if (showAll) {
-        manifestUrl.searchParams.set("all", "1");
-      } else if (rawQuery) {
-        manifestUrl.searchParams.set("q", rawQuery);
-      }
-      manifestUrl.searchParams.set("view", "cards");
-
-      const response = await fetch(manifestUrl, {
-        method: "GET",
-        headers: buildEngineHeaders(),
-        cache: "no-store",
-      });
-
-      const bodyText = await response.text();
-      let parsedBody: unknown = null;
-      if (bodyText) {
-        try {
-          parsedBody = JSON.parse(bodyText);
-        } catch (error) {
-          throw new Error(
-            `Invalid engine manifest JSON: ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-      }
-
-      if (!response.ok) {
-        throw new Error(`Engine manifest responded ${response.status}: ${bodyText || "no body"}`);
-      }
-
-      const remoteEntries = Array.isArray(parsedBody)
-        ? parsedBody
-        : parsedBody && typeof parsedBody === "object"
-        ? (parsedBody as { results?: unknown[]; rules?: unknown[] }).results ??
-          (parsedBody as { results?: unknown[]; rules?: unknown[] }).rules
-        : undefined;
-
-      if (!Array.isArray(remoteEntries)) {
-        throw new Error("Engine manifest response missing rules array");
-      }
-
-      const manifestIndex = buildManifestIndex(manifestEntries);
-      return remoteEntries.map(entry =>
-        coerceManifestEntry(entry as RemoteManifestEntry, manifestIndex),
-      );
+      return await loadRemoteManifest(manifestEntries, { rawQuery, showAll });
     } catch (error) {
-      console.warn(
-        "[manifest] Remote manifest unavailable, using static dataset:",
-        error instanceof Error ? error.message : String(error),
-      );
-      // Fall through to static manifest below.
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn("[manifest] Remote manifest unavailable, using static dataset:", message);
+      return buildStaticResult(manifestEntries, { rawQuery, showAll }, message);
     }
   }
 
-  return filterEntries(manifestEntries, rawQuery, showAll);
+  return buildStaticResult(manifestEntries, { rawQuery, showAll });
 }
 
+export async function loadManifestAll(
+  options: ManifestLoadOptions = {},
+): Promise<ManifestEntry[]> {
+  const result = await loadManifestWithMeta(options);
+  return result.entries;
+}

--- a/tests/api/rule.export.test.ts
+++ b/tests/api/rule.export.test.ts
@@ -1,0 +1,51 @@
+import { GET } from "@/app/api/manifest/rule/[sha]/route";
+import { loadManifestWithMeta } from "@/lib/manifestSource";
+
+jest.mock("@/lib/manifestSource");
+
+const mockedLoadManifestWithMeta = loadManifestWithMeta as jest.MockedFunction<typeof loadManifestWithMeta>;
+
+describe("GET /api/manifest/rule/[sha]", () => {
+  beforeEach(() => {
+    mockedLoadManifestWithMeta.mockReset();
+  });
+
+  it("returns a JSON attachment when the SHA matches", async () => {
+    const entry = {
+      id: "R-1-0001",
+      methodology: "AR-ACM0003",
+      version: "v02-0",
+      rule: "Example",
+      tags: ["eligibility"],
+      sha256: "abc123",
+    };
+    mockedLoadManifestWithMeta.mockResolvedValue({
+      entries: [entry],
+      source: "static",
+      fetchedAt: "2025-01-01T00:00:00.000Z",
+    });
+
+    const request = new Request("http://localhost/api/manifest/rule/abc123");
+    const response = await GET(request, { params: { sha: "abc123" } });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="rule-abc123.json"');
+    expect(response.headers.get("Content-Type")).toContain("application/json");
+
+    const payload = await response.json();
+    expect(payload).toEqual(entry);
+  });
+
+  it("returns 404 when the SHA is not found", async () => {
+    mockedLoadManifestWithMeta.mockResolvedValue({
+      entries: [],
+      source: "static",
+      fetchedAt: "2025-01-01T00:00:00.000Z",
+    });
+
+    const request = new Request("http://localhost/api/manifest/rule/missing");
+    const response = await GET(request, { params: { sha: "missing" } });
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toMatch(/not found/i);
+  });
+});

--- a/tests/manifest/filters.test.tsx
+++ b/tests/manifest/filters.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { useEffect } from "react";
+import { act } from "react-dom/test-utils";
+import { createRoot, type Root } from "react-dom/client";
+import useManifestFilters, { type ManifestFilters } from "@/app/manifest/_state/useManifestFilters";
+
+const replaceMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+  usePathname: () => "/manifest",
+  useSearchParams: () => new URLSearchParams("q=baseline&tags=calc"),
+}));
+
+function Harness({ onReady }: { onReady: (filters: ManifestFilters) => void }) {
+  const filters = useManifestFilters();
+  useEffect(() => {
+    onReady(filters);
+  }, [filters, onReady]);
+  return null;
+}
+
+async function renderHook(): Promise<{ filters: ManifestFilters; root: Root; container: HTMLDivElement }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  let resolved = false;
+  let captured: ManifestFilters | null = null;
+
+  await act(async () => {
+    root.render(
+      <Harness
+        onReady={filters => {
+          if (!resolved) {
+            resolved = true;
+            captured = filters;
+          }
+        }}
+      />,
+    );
+  });
+
+  if (!captured) {
+    throw new Error("Failed to capture manifest filters");
+  }
+
+  return { filters: captured, root, container };
+}
+
+describe("useManifestFilters", () => {
+  beforeEach(() => {
+    replaceMock.mockClear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("removes a tag from the URL when toggled off", async () => {
+    const { filters, root, container } = await renderHook();
+
+    await act(async () => {
+      filters.toggleTag("calc");
+    });
+
+    const lastCall = replaceMock.mock.calls[replaceMock.mock.calls.length - 1];
+    expect(lastCall).toEqual(["/manifest?q=baseline", { scroll: false }]);
+
+    root.unmount();
+    container.remove();
+  });
+
+  it("applies methodology updates to the URL", async () => {
+    const { filters, root, container } = await renderHook();
+
+    await act(async () => {
+      filters.setMethodology("AR-AMS0003");
+    });
+
+    const lastCall = replaceMock.mock.calls[replaceMock.mock.calls.length - 1];
+    expect(lastCall).toEqual([
+      "/manifest?q=baseline&methodology=AR-AMS0003&tags=calc",
+      { scroll: false },
+    ]);
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/tests/manifest/hashCopy.test.tsx
+++ b/tests/manifest/hashCopy.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import HashCopyButton from "@/components/manifest/HashCopyButton";
+
+describe("HashCopyButton", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    (navigator.clipboard.writeText as jest.Mock).mockReset();
+  });
+
+  it("copies the provided hash when clicked", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<HashCopyButton hash="abc123" />);
+    });
+
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+
+    await act(async () => {
+      button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("abc123");
+
+    await act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    root.unmount();
+    container.remove();
+  });
+
+  it("stays disabled when hash is missing", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<HashCopyButton />);
+    });
+
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.hasAttribute("disabled")).toBe(true);
+
+    await act(async () => {
+      button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+
+    root.unmount();
+    container.remove();
+  });
+});


### PR DESCRIPTION
## ✨ Feature: Major Manifest Polish & UX Enhancements

---

### 🚀 What's Changed

* **Rebuilt `/manifest` experience** with:
    * URL-synced filters and tag toggles for persistent state.
    * Methodology grouping and version comparisons.
    * New **Health Badge** for quick status insights (`src/components/manifest/ManifestApp.tsx:25`, `src/components/ManifestHealthBadge.tsx:32`, `src/app/api/manifest/health/route.ts:16`).

* **Added richer Rule Cards** including:
    * One-click **hash copy** button (`src/components/manifest/HashCopyButton.tsx:4`).
    * PDF tooltips for direct link access.
    * **JSON export** support, backed by a new API route and manifest metadata plumbing (`src/app/manifest/_components/RuleCard.tsx:35`, `src/lib/manifestSource.ts:16`, `src/app/api/manifest/rule/[sha]/route.ts:19`).

* **Documentation & Testing:**
    * Expanded UX documented in **`README.md:81`**.
    * New behaviors covered with focused Jest specs (e.g., hash copy, filters, and API exports) (`tests/manifest/hashCopy.test.tsx:1`, `tests/manifest/filters.test.tsx:1`, `tests/api/rule.export.test.ts:1`).

---

### 🎯 Why This Change

* Fulfills the seven manifest polish items: **accessible hash copying**, **health insights**, **tag-based navigation**, **methodology tallies**, **PDF affordances**, **JSON exports**, and **version diffing**—while preserving offline/remote parity.

---

