### PR TITLE
feat(data): sync methodologies artifacts into public/ (pinned + guarded)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ yarn-error.log*
 # vercel
 .vercel
 
+# local build-time artifact sync
+.cache/
+public/methodologies/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/config/methodologies_source.json
+++ b/config/methodologies_source.json
@@ -1,0 +1,5 @@
+{
+  "repo": "Fredilly/article6-methodologies",
+  "ref": "main",
+  "pinned_sha": "88cf072816043f6994cb53fc25ade27791aaa97c"
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "test": "jest --passWithNoTests",
     "check:manifest:api": "node -e \"process.on('unhandledRejection',()=>process.exit(1));(async()=>{try{const r=await fetch('http://localhost:3000/api/manifest?all=1');const j=await r.json().catch(()=>[]);if(!Array.isArray(j)||j.length<10){console.error('Manifest API returned too few items');process.exit(1)}}catch(error){console.error(error);process.exit(1)}})()\"",
     "check:manifest": "node -e \"const x=require('./public/manifest/index.json');if(!Array.isArray(x)||x.length<10){console.error('Manifest too small');process.exit(1)}\"",
-    "dev:manifest:count": "node -e \"console.log(require('./public/manifest/index.json').length)\""
+    "dev:manifest:count": "node -e \"console.log(require('./public/manifest/index.json').length)\"",
+    "sync:methodologies": "bash scripts/sync-methodologies.sh",
+    "check:golden": "bash scripts/check-golden-rich.sh",
+    "vercel-build": "npm run sync:methodologies && npm run check:golden && next build"
   },
   "engines": {
     "node": "20.11.1",

--- a/scripts/check-golden-rich.sh
+++ b/scripts/check-golden-rich.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GOLDEN="public/methodologies/UNFCCC/Forestry/AR-AM0014/v03-0/rules.rich.json"
+[[ -f "$GOLDEN" ]] || { echo "❌ Missing golden rich file: $GOLDEN"; exit 1; }
+echo "✅ Golden rich present: $GOLDEN"

--- a/scripts/sync-methodologies.sh
+++ b/scripts/sync-methodologies.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PIN_FILE="config/methodologies_source.json"
+REPO="$(node -p "require('./${PIN_FILE}').repo")"
+REF="$(node -p "require('./${PIN_FILE}').ref")"
+PINNED_SHA="$(node -p "require('./${PIN_FILE}').pinned_sha || ''")"
+
+WORK=".cache/article6-methodologies"
+SRC_PATH="methodologies"
+DEST="public/methodologies"
+
+echo "[sync] repo=$REPO ref=$REF pinned_sha=${PINNED_SHA:-<none>}"
+
+rm -rf "$WORK"
+mkdir -p "$(dirname "$WORK")"
+
+git clone --filter=blob:none --no-checkout "https://github.com/${REPO}.git" "$WORK" >/dev/null
+cd "$WORK"
+
+# Prefer pinned sha if set; otherwise REF
+TARGET="${PINNED_SHA:-$REF}"
+git fetch --depth=1 origin "$TARGET" >/dev/null
+git sparse-checkout init --cone >/dev/null
+git sparse-checkout set "$SRC_PATH" >/dev/null
+git checkout --detach FETCH_HEAD >/dev/null
+
+cd - >/dev/null
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+rsync -a --delete "$WORK/$SRC_PATH/" "$DEST/"
+
+echo "[sync] copied $WORK/$SRC_PATH -> $DEST"


### PR DESCRIPTION

## WHAT
- Serve real methodology artifacts (including rich) from app.article6:
  - Add a deterministic sync that copies `article6-methodologies/methodologies/**`
    into `public/methodologies/**`.
  - Pin the source to a specific commit SHA (reproducible + investor-safe).
  - Add a build guard that fails if a golden rich file is missing.

## WHY
- Rich is empty because the UI probes `/methodologies/**` but app.article6 has no `public/methodologies/**`.
- We already have rich files in article6-methodologies; we just need to deploy them.