### PR TITLE
feat(map): restore map state from URL for shareable demo links

### DIFF
--- a/docs/projects/ui-manifest-overhaul/ROADMAP.md
+++ b/docs/projects/ui-manifest-overhaul/ROADMAP.md
@@ -21,25 +21,21 @@ Acceptance
 
 ## M2 — Method detail panel + tabs (2–3 days)
 - Desktop two-panel layout OR list + detail pane
-- Tabs: Overview, Versions, Rules, Document, Rich, Map
+- Tabs: Overview, Versions, Rules, Document, Rich
 - Trust strip on Overview (repo SHA, generated_at, hashes, export)
-- Stable URLs preserve selected method+version + active tab
 
 Acceptance
 - Selecting a method shows version timeline
 - Trust strip shows copy actions for hashes + source SHA
-- Copy/paste URL restores the same tab + selection (no resets when switching tabs)
 - Vercel green
 
 ## M3 — Evidence deep dive (2–4 days)
 - Rules tab: searchable list, tag chips
-- Rule drawer: rule id, text, tags; linked sections/anchors
-- Document tab: outline tree with deep links; cross-highlighting between rules ↔ sections
-- Rich tab: show extracted evidence, deltas, and citations (if available)
+- Rule drawer: rule id, text, tags, linked sections/anchors
+- Document tab: sections outline tree; clicking highlights related rules
 
 Acceptance
 - At least one end-to-end “rule → evidence anchor” jump works
-- Cross-highlighting is obvious and non-breaking
 
 ## M4 — Chat as Method Assistant (2–3 days)
 - Guided prompts (8–12)
@@ -50,32 +46,17 @@ Acceptance
 Acceptance
 - Guided prompts produce grounded responses with evidence links
 
-## M5 — Evidence Map integration (2–4 days)
-- “View evidence map” CTA from Method+Version detail (only enabled when method+version selected)
-- Inputs: STAC URL (preferred) OR GeoJSON upload; optional AOI polygon + date range
-- Outputs: render overlays + metadata; Rule ↔ Evidence traceability (rule IDs + section anchors)
-- Trust strip shows provenance + exact evidence-layer identifier (URL or content hash)
-- Export “Evidence Snapshot” JSON (method+version, AOI, layer refs, selected features, hashes)
-- Non-goal: no pass/fail verification claims unless backed by explicit rule text + evidence links
+## M5 — GeoVista MVP (2–4 days)
+- Verify Location CTA from method detail
+- Map/pin or lat/lon input
+- Mock API route first + fixtures
+- “Method ↔ Site Fit” panel mapping checks to rule ids
+- Export Verification Snapshot JSON
 
 Acceptance
-- Evidence map loads and renders from STAC URL and from GeoJSON upload
-- Selecting a feature shows its linked rule IDs / section anchors (when present)
-- Exported Evidence Snapshot is stable and reproducible for the same inputs
+- Demo flow works without external dependencies (mocked)
 
----
-
-## Definition of Done (Investor Demo)
-1) Pick method+version → view Trust Strip
-2) Open a rule → jump to an evidence anchor in the document
-3) View evidence map overlay for the same context
-4) Export Evidence Snapshot (and audit pack if present)
-5) Share the URL and confirm it restores the same state
-
-## WHAT
-- Update roadmap to remove verification-specific milestones and align to Evidence Map integration + current IA.
-
-## WHY
-- Keep investor-demo scope consistent with the system prompt (evidence-centric, no verification product claims).
-
-Signed-off-by: Fred E <fredilly@article6.org>
+## M6 — Real GeoVista wiring (later)
+- /api/geovista/verify with env key
+- caching, rate limit, error UX
+- optional persistence of snapshots

--- a/docs/projects/ui-manifest-overhaul/ROADMAP.md
+++ b/docs/projects/ui-manifest-overhaul/ROADMAP.md
@@ -21,21 +21,25 @@ Acceptance
 
 ## M2 — Method detail panel + tabs (2–3 days)
 - Desktop two-panel layout OR list + detail pane
-- Tabs: Overview, Versions, Rules, Document, Rich
+- Tabs: Overview, Versions, Rules, Document, Rich, Map
 - Trust strip on Overview (repo SHA, generated_at, hashes, export)
+- Stable URLs preserve selected method+version + active tab
 
 Acceptance
 - Selecting a method shows version timeline
 - Trust strip shows copy actions for hashes + source SHA
+- Copy/paste URL restores the same tab + selection (no resets when switching tabs)
 - Vercel green
 
 ## M3 — Evidence deep dive (2–4 days)
 - Rules tab: searchable list, tag chips
-- Rule drawer: rule id, text, tags, linked sections/anchors
-- Document tab: sections outline tree; clicking highlights related rules
+- Rule drawer: rule id, text, tags; linked sections/anchors
+- Document tab: outline tree with deep links; cross-highlighting between rules ↔ sections
+- Rich tab: show extracted evidence, deltas, and citations (if available)
 
 Acceptance
 - At least one end-to-end “rule → evidence anchor” jump works
+- Cross-highlighting is obvious and non-breaking
 
 ## M4 — Chat as Method Assistant (2–3 days)
 - Guided prompts (8–12)
@@ -46,17 +50,32 @@ Acceptance
 Acceptance
 - Guided prompts produce grounded responses with evidence links
 
-## M5 — GeoVista MVP (2–4 days)
-- Verify Location CTA from method detail
-- Map/pin or lat/lon input
-- Mock API route first + fixtures
-- “Method ↔ Site Fit” panel mapping checks to rule ids
-- Export Verification Snapshot JSON
+## M5 — Evidence Map integration (2–4 days)
+- “View evidence map” CTA from Method+Version detail (only enabled when method+version selected)
+- Inputs: STAC URL (preferred) OR GeoJSON upload; optional AOI polygon + date range
+- Outputs: render overlays + metadata; Rule ↔ Evidence traceability (rule IDs + section anchors)
+- Trust strip shows provenance + exact evidence-layer identifier (URL or content hash)
+- Export “Evidence Snapshot” JSON (method+version, AOI, layer refs, selected features, hashes)
+- Non-goal: no pass/fail verification claims unless backed by explicit rule text + evidence links
 
 Acceptance
-- Demo flow works without external dependencies (mocked)
+- Evidence map loads and renders from STAC URL and from GeoJSON upload
+- Selecting a feature shows its linked rule IDs / section anchors (when present)
+- Exported Evidence Snapshot is stable and reproducible for the same inputs
 
-## M6 — Real GeoVista wiring (later)
-- /api/geovista/verify with env key
-- caching, rate limit, error UX
-- optional persistence of snapshots
+---
+
+## Definition of Done (Investor Demo)
+1) Pick method+version → view Trust Strip
+2) Open a rule → jump to an evidence anchor in the document
+3) View evidence map overlay for the same context
+4) Export Evidence Snapshot (and audit pack if present)
+5) Share the URL and confirm it restores the same state
+
+## WHAT
+- Update roadmap to remove verification-specific milestones and align to Evidence Map integration + current IA.
+
+## WHY
+- Keep investor-demo scope consistent with the system prompt (evidence-centric, no verification product claims).
+
+Signed-off-by: Fred E <fredilly@article6.org>

--- a/src/app/m/[code]/page.tsx
+++ b/src/app/m/[code]/page.tsx
@@ -3,7 +3,7 @@ import MethodsFinder from "@/app/m/_components/MethodsFinder";
 
 type PageProps = {
   params: Promise<{ code: string }>;
-  searchParams?: Promise<{ rule?: string; section?: string }>;
+  searchParams?: Promise<{ tab?: string; rule?: string; section?: string }>;
 };
 
 export const metadata: Metadata = {
@@ -14,7 +14,10 @@ export const metadata: Metadata = {
 export default async function MethodPage({ params, searchParams }: PageProps) {
   const { code } = await params;
   const resolvedSearch = await Promise.resolve(searchParams);
+  const tab = typeof resolvedSearch?.tab === "string" ? resolvedSearch.tab : undefined;
   const rule = typeof resolvedSearch?.rule === "string" ? resolvedSearch.rule : undefined;
   const section = typeof resolvedSearch?.section === "string" ? resolvedSearch.section : undefined;
-  return <MethodsFinder selectedCode={code} selectedRuleId={rule} selectedSectionId={section} />;
+  const selectedRuleId = tab === "rules" || (!tab && rule) ? rule : undefined;
+  const selectedSectionId = tab === "sections" || (!tab && section) ? section : undefined;
+  return <MethodsFinder selectedCode={code} selectedRuleId={selectedRuleId} selectedSectionId={selectedSectionId} />;
 }

--- a/src/app/m/[code]/v/[ver]/page.tsx
+++ b/src/app/m/[code]/v/[ver]/page.tsx
@@ -3,7 +3,7 @@ import MethodsFinder from "@/app/m/_components/MethodsFinder";
 
 type PageProps = {
   params: Promise<{ code: string; ver: string }>;
-  searchParams?: Promise<{ rule?: string; section?: string }>;
+  searchParams?: Promise<{ tab?: string; rule?: string; section?: string }>;
 };
 
 export const metadata: Metadata = {
@@ -14,14 +14,17 @@ export const metadata: Metadata = {
 export default async function MethodVersionPage({ params, searchParams }: PageProps) {
   const { code, ver } = await params;
   const resolvedSearch = await Promise.resolve(searchParams);
+  const tab = typeof resolvedSearch?.tab === "string" ? resolvedSearch.tab : undefined;
   const rule = typeof resolvedSearch?.rule === "string" ? resolvedSearch.rule : undefined;
   const section = typeof resolvedSearch?.section === "string" ? resolvedSearch.section : undefined;
+  const selectedRuleId = tab === "rules" || (!tab && rule) ? rule : undefined;
+  const selectedSectionId = tab === "sections" || (!tab && section) ? section : undefined;
   return (
     <MethodsFinder
       selectedCode={code}
       selectedVersion={ver}
-      selectedRuleId={rule}
-      selectedSectionId={section}
+      selectedRuleId={selectedRuleId}
+      selectedSectionId={selectedSectionId}
     />
   );
 }

--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import VersionSelector from "@/app/m/_components/VersionSelector";
 import TrustStrip from "@/components/TrustStrip";
 import AssistantPanel from "@/components/assistant/AssistantPanel";
@@ -21,6 +21,7 @@ import type { AOI, EvidencePin } from "@/lib/proofMap/types";
 import type { VerificationRun } from "@/lib/proofMap/types";
 import type { ProofEvidenceItem } from "@/lib/proof/bundle";
 import { importProofBundleText } from "@/lib/proof/import";
+import { formatBboxParam, parseProofMapUrlState } from "@/lib/proofMap/urlState";
 
 type DetailTab = "overview" | "assistant" | "map" | "versions" | "rules" | "sections" | "rich";
 
@@ -69,6 +70,7 @@ export default function MethodDetailPane({
 }: MethodDetailPaneProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [tab, setTab] = useState<DetailTab>(
     initialSectionId ? "sections" : initialRuleId ? "rules" : "overview",
   );
@@ -122,9 +124,12 @@ export default function MethodDetailPane({
   const didApplyFocusFromUrl = useRef(false);
 
   const [aoi, setAoi] = useState<AOI | null>(null);
+  const [aoiUrlRef, setAoiUrlRef] = useState<string | null>(null);
   const [evidencePins, setEvidencePins] = useState<EvidencePin[]>([]);
   const [evidenceSnapshots, setEvidenceSnapshots] = useState<ProofEvidenceItem[]>([]);
   const [verificationRuns, setVerificationRuns] = useState<VerificationRun[]>([]);
+  const [mapViewportBbox, setMapViewportBbox] = useState<[number, number, number, number] | null>(null);
+  const [urlHydrated, setUrlHydrated] = useState(false);
   type StacEvidenceState = {
     aoiFingerprint: string;
     fc: GeoJSON.FeatureCollection;
@@ -462,12 +467,13 @@ export default function MethodDetailPane({
   );
 
   const setFocusParam = useCallback((focusTab: "rules" | "sections", focusId: string) => {
-    if (typeof window === "undefined") return;
-    const url = new URL(window.location.href);
-    url.searchParams.set("tab", focusTab);
-    url.searchParams.set("focus", focusId);
-    window.history.replaceState(null, "", url.toString());
-  }, []);
+    if (!pathname) return;
+    const params = new URLSearchParams(typeof window !== "undefined" ? window.location.search : "");
+    params.set("tab", focusTab);
+    params.set("focus", focusId);
+    const search = params.toString();
+    router.replace(search ? `${pathname}?${search}` : pathname, { scroll: false });
+  }, [pathname, router]);
 
   const ensureSectionsLoaded = useCallback(async (): Promise<SectionListItem[]> => {
     if (!activeVersion) return [];
@@ -620,6 +626,62 @@ export default function MethodDetailPane({
       setRichLoading(false);
     }
   }, [activeVersion, method.code, method.program, method.sector, richEvidence, richLoading]);
+
+  const urlState = useMemo(() => {
+    return parseProofMapUrlState(searchParams);
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!activeVersion) return;
+    if (urlState.tab && urlState.tab !== tab) {
+      setTab(urlState.tab);
+      if (urlState.tab === "rules") void ensureRulesLoaded();
+      if (urlState.tab === "sections") void ensureSectionsLoaded();
+      if (urlState.tab === "rich") void ensureRichLoaded();
+      if (urlState.tab === "assistant") void Promise.all([ensureRulesLoaded(), ensureSectionsLoaded()]);
+    }
+    if (urlState.aoiRef) setAoiUrlRef(urlState.aoiRef);
+    if (urlState.selectedStacItemId) setSelectedStacItemId(urlState.selectedStacItemId);
+    if (urlState.viewportBbox) setMapViewportBbox(urlState.viewportBbox);
+    if (!urlHydrated) setUrlHydrated(true);
+  }, [
+    activeVersion,
+    ensureRichLoaded,
+    ensureRulesLoaded,
+    ensureSectionsLoaded,
+    tab,
+    urlHydrated,
+    urlState.aoiRef,
+    urlState.selectedStacItemId,
+    urlState.tab,
+    urlState.viewportBbox,
+  ]);
+
+  useEffect(() => {
+    if (!pathname) return;
+    if (!activeVersion) return;
+    if (!urlHydrated) return;
+
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", tab);
+
+    const derivedAoiRef = aoi ? (aoi.aoi_fingerprint ?? aoi.id) : aoiUrlRef;
+    if (derivedAoiRef) params.set("aoi", derivedAoiRef);
+    else params.delete("aoi");
+
+    if (selectedStacItemId) params.set("stac", selectedStacItemId);
+    else params.delete("stac");
+
+    if (mapViewportBbox) params.set("bbox", formatBboxParam(mapViewportBbox));
+    else params.delete("bbox");
+
+    if (tab !== "rules" && tab !== "sections") params.delete("focus");
+
+    const next = params.toString();
+    const current = searchParams.toString();
+    if (next === current) return;
+    router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
+  }, [activeVersion, aoi, aoiUrlRef, mapViewportBbox, pathname, router, searchParams, selectedStacItemId, tab, urlHydrated]);
 
   const openRule = useCallback(async (ruleId: string) => {
     setTab("rules");
@@ -783,6 +845,25 @@ export default function MethodDetailPane({
     })();
   }, [activeVersion, ensureSectionsLoaded, initialSectionId, setSectionParam]);
 
+  const setAoiForMap = useCallback(
+    (nextAoi: AOI | null) => {
+      const prevId = aoi?.id ?? null;
+      const nextId = nextAoi?.id ?? null;
+      setAoiAndPersist(nextAoi);
+      setAoiUrlRef(nextAoi ? (nextAoi.aoi_fingerprint ?? nextAoi.id) : null);
+      if (prevId !== nextId) {
+        setSelectedStacItemId(null);
+        setMapViewportBbox(null);
+      }
+    },
+    [aoi?.id, setAoiAndPersist],
+  );
+
+  const removeAoiForMap = useCallback(() => {
+    setAoiForMap(null);
+    setAoiUrlRef(null);
+  }, [setAoiForMap]);
+
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -800,6 +881,7 @@ export default function MethodDetailPane({
             methodCode={method.code}
             versions={sortedVersionsNewestFirst}
             selectedVersion={activeVersion}
+            preserveTab={tab}
           />
         </div>
       </div>
@@ -949,14 +1031,16 @@ export default function MethodDetailPane({
           methodCode={method.code}
           version={activeVersion ?? ""}
           provenanceJson={provenanceJson}
+          restoreViewportBbox={mapViewportBbox}
+          onViewportBboxChange={setMapViewportBbox}
           aoi={aoi}
           evidencePins={evidencePins}
           verificationRuns={verificationRuns}
           stacEvidenceState={stacEvidenceState}
           selectedStacItemId={selectedStacItemId}
           evidenceSnapshots={evidenceSnapshots}
-          onSetAoi={setAoiAndPersist}
-          onRemoveAoi={() => setAoiAndPersist(null)}
+          onSetAoi={setAoiForMap}
+          onRemoveAoi={removeAoiForMap}
           onSetEvidencePins={setEvidencePinsAndPersist}
           onSetVerificationRuns={setVerificationRunsAndPersist}
           onSetStacEvidenceState={(next) => {

--- a/src/app/m/_components/VersionSelector.tsx
+++ b/src/app/m/_components/VersionSelector.tsx
@@ -7,12 +7,14 @@ type VersionSelectorProps = {
   methodCode: string;
   versions: string[];
   selectedVersion?: string;
+  preserveTab?: string;
 };
 
 export default function VersionSelector({
   methodCode,
   versions,
   selectedVersion,
+  preserveTab,
 }: VersionSelectorProps) {
   const router = useRouter();
   const value = selectedVersion ?? "";
@@ -38,7 +40,10 @@ export default function VersionSelector({
         onChange={(event) => {
           const next = event.target.value;
           if (!next) return;
-          router.push(`/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(next)}`);
+          const params = new URLSearchParams();
+          if (preserveTab) params.set("tab", preserveTab);
+          const search = params.toString();
+          router.push(`/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(next)}${search ? `?${search}` : ""}`);
         }}
       >
         <option value="" disabled>

--- a/src/components/map/MapCanvas.tsx
+++ b/src/components/map/MapCanvas.tsx
@@ -13,6 +13,7 @@ type MapCanvasProps = {
   stacEvidenceCentroids?: GeoJSON.FeatureCollection<GeoJSON.Point> | null;
   stacEvidenceCentroidsEnabled?: boolean;
   stacEvidenceRunId?: string | null;
+  autoFitAoi?: boolean;
   selectedStacItemId?: string | null;
   onSelectStacItemId?: (id: string | null) => void;
   onSelectEvidence?: (selection: { id: string; source: "pin" | "polygon" }) => void;
@@ -172,6 +173,7 @@ export default function MapCanvas({
   stacEvidenceCentroids,
   stacEvidenceCentroidsEnabled,
   stacEvidenceRunId,
+  autoFitAoi = true,
   selectedStacItemId,
   onSelectStacItemId,
   onSelectEvidence,
@@ -336,7 +338,7 @@ export default function MapCanvas({
         };
         source.setData(data);
 
-        if (aoi?.bbox) {
+        if (autoFitAoi && aoi?.bbox) {
           try {
             map.fitBounds(
               [
@@ -358,7 +360,7 @@ export default function MapCanvas({
     }
 
     apply();
-  }, [aoi, mapReadyTick]);
+  }, [aoi, autoFitAoi, mapReadyTick]);
 
   useEffect(() => {
     const map = mapRef.current;

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -21,6 +21,8 @@ type ProofMapTabProps = {
   methodCode: string;
   version: string;
   provenanceJson?: unknown | null;
+  restoreViewportBbox?: [number, number, number, number] | null;
+  onViewportBboxChange?: (bbox: [number, number, number, number] | null) => void;
   aoi: AOI | null;
   evidencePins: EvidencePin[];
   verificationRuns: VerificationRun[];
@@ -169,6 +171,8 @@ export default function ProofMapTab({
   methodCode,
   version,
   provenanceJson,
+  restoreViewportBbox,
+  onViewportBboxChange,
   aoi,
   evidencePins,
   verificationRuns,
@@ -194,6 +198,8 @@ export default function ProofMapTab({
   const [mapReadyTick, setMapReadyTick] = useState(0);
   const [stacCentroidsEnabled, setStacCentroidsEnabled] = useState(true);
   const [viewportBbox, setViewportBbox] = useState<[number, number, number, number] | null>(null);
+  const didApplyRestoreViewportRef = useRef(false);
+  const lastAppliedRestoreKeyRef = useRef<string | null>(null);
   const stacEvidenceCardRef = useRef<HTMLDivElement | null>(null);
   const [stacInspectOpen, setStacInspectOpen] = useState(false);
   const [lastSelectionSource, setLastSelectionSource] = useState<"pin" | "polygon" | null>(null);
@@ -503,36 +509,38 @@ export default function ProofMapTab({
   }, [mapReadyTick]);
 
   useEffect(() => {
-    const map = mapRef.current;
-    if (!map || !aoi?.bbox) return;
+    if (!restoreViewportBbox) {
+      didApplyRestoreViewportRef.current = false;
+      lastAppliedRestoreKeyRef.current = null;
+      return;
+    }
 
-    const fit = () => {
-      try {
-        map.resize?.();
-      } catch {
-        // ignore
-      }
+    const map = mapRef.current;
+    if (!map) return;
+    const key = restoreViewportBbox.join(",");
+    if (lastAppliedRestoreKeyRef.current === key) return;
+
+    const apply = () => {
       try {
         map.fitBounds(
           [
-            [aoi.bbox[0], aoi.bbox[1]],
-            [aoi.bbox[2], aoi.bbox[3]],
+            [restoreViewportBbox[0], restoreViewportBbox[1]],
+            [restoreViewportBbox[2], restoreViewportBbox[3]],
           ],
-          { padding: 20, duration: 0 },
+          { padding: 30, duration: 0 },
         );
+        lastAppliedRestoreKeyRef.current = key;
+        didApplyRestoreViewportRef.current = true;
       } catch {
         // ignore
       }
     };
 
     requestAnimationFrame(() => {
-      if (!map.isStyleLoaded?.()) {
-        map.once?.("load", fit);
-        return;
-      }
-      fit();
+      if (!map.isStyleLoaded?.()) map.once?.("load", apply);
+      else apply();
     });
-  }, [aoi, mapReadyTick]);
+  }, [mapReadyTick, restoreViewportBbox]);
 
   return (
     <div className="mt-4 grid gap-4">
@@ -704,9 +712,15 @@ export default function ProofMapTab({
         stacEvidenceCentroids={stacCentroids}
         stacEvidenceCentroidsEnabled={stacCentroidsEnabled}
         stacEvidenceRunId={currentStacEvidence?.runId ?? null}
+        autoFitAoi={!restoreViewportBbox}
         selectedStacItemId={selectedStacItemId}
         onSelectEvidence={({ id, source }) => selectEvidence(id, source)}
-        onViewportBboxChange={(bbox) => setViewportBbox(bbox)}
+        onViewportBboxChange={(bbox) => {
+          setViewportBbox(bbox);
+          if (!onViewportBboxChange) return;
+          if (restoreViewportBbox && !didApplyRestoreViewportRef.current) return;
+          onViewportBboxChange(bbox);
+        }}
         onMapReady={(map) => {
           mapRef.current = map;
           setMapReadyTick((value) => value + 1);

--- a/src/lib/proofMap/urlState.ts
+++ b/src/lib/proofMap/urlState.ts
@@ -1,0 +1,62 @@
+export type DetailTab = "overview" | "assistant" | "map" | "versions" | "rules" | "sections" | "rich";
+
+type SearchParamsLike = { get(key: string): string | null };
+
+export type ProofMapUrlState = {
+  tab?: DetailTab;
+  aoiRef?: string;
+  selectedStacItemId?: string;
+  viewportBbox?: [number, number, number, number];
+};
+
+function asNonEmptyString(value: string | null): string | undefined {
+  const trimmed = (value ?? "").trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function parseDetailTab(value: string | null): DetailTab | undefined {
+  switch ((value ?? "").trim()) {
+    case "overview":
+    case "assistant":
+    case "map":
+    case "versions":
+    case "rules":
+    case "sections":
+    case "rich":
+      return value as DetailTab;
+    default:
+      return undefined;
+  }
+}
+
+export function parseBboxParam(value: string | null): [number, number, number, number] | undefined {
+  const text = (value ?? "").trim();
+  if (!text) return undefined;
+  const parts = text.split(",").map((v) => v.trim());
+  if (parts.length !== 4) return undefined;
+  const nums = parts.map((v) => Number(v));
+  if (nums.some((n) => !Number.isFinite(n))) return undefined;
+  const [west, south, east, north] = nums;
+  if (west < -180 || west > 180) return undefined;
+  if (east < -180 || east > 180) return undefined;
+  if (south < -90 || south > 90) return undefined;
+  if (north < -90 || north > 90) return undefined;
+  if (west > east) return undefined;
+  if (south > north) return undefined;
+  return [west, south, east, north];
+}
+
+export function formatBboxParam(bbox: [number, number, number, number]): string {
+  const [west, south, east, north] = bbox;
+  return [west, south, east, north].map((n) => (Number.isFinite(n) ? n.toFixed(6) : "")).join(",");
+}
+
+export function parseProofMapUrlState(params: SearchParamsLike): ProofMapUrlState {
+  return {
+    tab: parseDetailTab(params.get("tab")),
+    aoiRef: asNonEmptyString(params.get("aoi")),
+    selectedStacItemId: asNonEmptyString(params.get("stac")),
+    viewportBbox: parseBboxParam(params.get("bbox")),
+  };
+}
+

--- a/tests/lib/proofMap.urlState.test.ts
+++ b/tests/lib/proofMap.urlState.test.ts
@@ -1,0 +1,26 @@
+import { formatBboxParam, parseBboxParam, parseProofMapUrlState } from "@/lib/proofMap/urlState";
+
+describe("proofMap urlState", () => {
+  test("parses tab/aoi/stac/bbox from query params", () => {
+    const params = new URLSearchParams({
+      tab: "map",
+      aoi: "aoi_fp_123",
+      stac: "item-1",
+      bbox: "1,2,3,4",
+    });
+
+    expect(parseProofMapUrlState(params)).toEqual({
+      tab: "map",
+      aoiRef: "aoi_fp_123",
+      selectedStacItemId: "item-1",
+      viewportBbox: [1, 2, 3, 4],
+    });
+  });
+
+  test("round-trips bbox formatting", () => {
+    const bbox: [number, number, number, number] = [-122.4194, 37.7749, -121.9, 38.2];
+    const formatted = formatBboxParam(bbox);
+    expect(parseBboxParam(formatted)).toEqual([-122.4194, 37.7749, -121.9, 38.2]);
+  });
+});
+


### PR DESCRIPTION
  ## WHAT
  - Restore Map tab state from URL query params (tab, AOI ref, selected STAC id,
  viewport bbox) and keep it in sync via `replaceState`-style navigation.

  ## WHY
  - Enables reliable demo/share links and prevents Map state resets when
  switching tabs or reloading.

  Signed-off-by: Fred E <fredilly@article6.org>