### PR TITLE
fix: support phase-based roadmap auto updates and align RC5 status

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 - slug: N/A
 - ack: human
 - items:
+  <!-- - RC5: in_progress -->
   <!-- - PR12: done -->
   <!-- - PR13: in_progress -->
 

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -25,6 +25,23 @@ jobs:
         run: |
           node scripts/roadmap/infer-pr-key.mjs --title "$PR_TITLE" --body "$PR_BODY" --branch "$PR_BRANCH" --output "$GITHUB_OUTPUT" || true
 
+      - name: Parse roadmap directive
+        id: directive
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          node --input-type=module -e '
+            import fs from "node:fs";
+            import { parseRoadmapDirective } from "./scripts/roadmap/roadmap-lib.mjs";
+            const body = process.env.PR_BODY ?? "";
+            const output = process.env.GITHUB_OUTPUT;
+            const directive = parseRoadmapDirective(body);
+            const slug = directive?.slug && !["n/a","na","none"].includes(String(directive.slug).trim().toLowerCase())
+              ? String(directive.slug).trim()
+              : "";
+            fs.appendFileSync(output, `slug=${slug}\n`, "utf8");
+          '
+
       - name: Find SSOT
         id: ssot
         if: steps.infer.outputs.prKey != ''
@@ -32,19 +49,17 @@ jobs:
           node scripts/roadmap/find-ssot-for-pr.mjs --pr "${{ steps.infer.outputs.prKey }}" --output "$GITHUB_OUTPUT" --allow-missing
 
       - name: Apply labels
-        if: steps.infer.outputs.prKey != '' && steps.ssot.outputs.slug != ''
+        if: steps.ssot.outputs.slug != '' || steps.directive.outputs.slug != ''
         uses: actions/github-script@v7
         env:
           PR_KEY: ${{ steps.infer.outputs.prKey }}
-          PHASE_SLUG: ${{ steps.ssot.outputs.slug }}
+          PHASE_SLUG: ${{ steps.ssot.outputs.slug || steps.directive.outputs.slug }}
         with:
           script: |
             const prKey = process.env.PR_KEY;
             const slug = process.env.PHASE_SLUG;
             const prNumber = context.payload.pull_request?.number;
-            if (!prKey || !slug || !prNumber) return;
-
-            const prLabel = `pr:${prKey}`;
+            if (!slug || !prNumber) return;
             const phaseLabel = `phase:${slug}`;
 
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -76,7 +91,7 @@ jobs:
             });
             const existing = new Set(existingLabels.map((label) => label.name));
 
-            for (const label of [prLabel, phaseLabel]) {
+            for (const label of [phaseLabel, ...(prKey ? [`pr:${prKey}`] : [])]) {
               if (!existing.has(label)) {
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,
@@ -89,7 +104,8 @@ jobs:
               }
             }
 
-            const labelsToApply = [prLabel, phaseLabel];
+            const labelsToApply = [phaseLabel];
+            if (prKey) labelsToApply.push(`pr:${prKey}`);
             for (const label of areaLabels) {
               if (label === "area:ui" && !existing.has(label)) continue;
               if (existing.has(label)) labelsToApply.push(label);

--- a/.github/workflows/roadmap-directive-gate.yml
+++ b/.github/workflows/roadmap-directive-gate.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           node-version: 20
       - name: Roadmap directive gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/roadmap/check-roadmap-directive.mjs
       - name: Roadmap monotonic gate
         run: node scripts/roadmap/gate-roadmap-monotonic.mjs

--- a/docs/roadmaps/README.md
+++ b/docs/roadmaps/README.md
@@ -17,15 +17,18 @@ Directive format:
 ### Roadmap-Update
 - slug: <slug>
 - items:
+  - RC5: in_progress
   - PR10: in_progress
 ```
 
 Allowed statuses: planned | next | active | in_progress | done | blocked | deferred | frozen | parked
 
-On merge, automation updates `docs/roadmaps/<slug>/phase-status.json` and
-regenerates `docs/roadmaps/SUMMARY.md`. `in_progress` is fine while a PR is open,
-but merged PR items are finalized to `done` automatically. Manual edits to those
-files should be avoided.
+Use `RC<n>` to update a roadmap phase directly when the SSOT is phase-based, and
+use `PR<n>` when the roadmap tracks explicit PR items. On merge, automation
+updates `docs/roadmaps/<slug>/phase-status.json` and regenerates
+`docs/roadmaps/SUMMARY.md`. `in_progress` is fine while a PR is open, but merged
+items are finalized to `done` automatically. Manual edits to those files should
+be avoided.
 If no status changes are needed, the automation skips creating a bot PR.
 
 Invariants:

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -120,7 +120,7 @@ Not active now:
 2) RC2 — Evidence inventory: Done — Normalize evidence assets before deeper ingestion work.
 3) RC3 — Spreadsheet/workbook intake: Done — Bring workbook evidence into the coverage workflow.
 4) RC4 — Monitoring report intake: Done — Capture monitoring report evidence with stable provenance.
-5) RC5 — PDD intake: Planned — Ingest uploaded project design documentation into the app evidence inventory with stable section/page/fragment provenance and support one-to-many requirement linking.
+5) RC5 — PDD intake: Done — Ingest uploaded project design documentation into the app evidence inventory with stable section/page/fragment provenance and support one-to-many requirement linking.
 6) RC6 — Methodology version diff / impact mode: Planned — Use canonical methodology version and diff metadata to identify coverage rows and linked evidence that may need review in the app.
 7) RC7 — Fallback raw methodology PDF intake for uncovered methods: Planned — Enable lower-confidence fallback raw methodology PDF intake only for uncovered methods while preserving canonical methodology outputs as the default for covered methods.
 8) RC8 — Additional GIS formats later: Deferred — Defer broader GIS intake until reconciliation fundamentals are stable.

--- a/docs/roadmaps/requirement-coverage/phase-status.json
+++ b/docs/roadmaps/requirement-coverage/phase-status.json
@@ -36,7 +36,7 @@
       "summary": "Capture monitoring report evidence with stable provenance."
     },
     "phase_5_pdd_intake": {
-      "status": "planned",
+      "status": "done",
       "title": "PDD intake",
       "summary": "Ingest uploaded project design documentation into the app evidence inventory with stable section/page/fragment provenance and support one-to-many requirement linking."
     },

--- a/scripts/roadmap/apply-merged-pr.mjs
+++ b/scripts/roadmap/apply-merged-pr.mjs
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { generateRoadmapContent, normalizePrId, normalizeStatus, parseRoadmapDirective } from "./roadmap-lib.mjs";
+import {
+  generateRoadmapContent,
+  getRoadmapItemStatus,
+  normalizePrId,
+  normalizeStatus,
+  parseRoadmapDirective,
+  setRoadmapItemStatus,
+} from "./roadmap-lib.mjs";
 import { finalizeMergedItems } from "./finalize-merged.mjs";
 
 const ALLOWED_STATUSES = new Set(["planned", "next", "in-progress", "done", "blocked"]);
@@ -21,9 +28,11 @@ function readEvent(eventPath) {
 }
 
 function updateSsotStatus(ssot, ssotPath, updates) {
-  const next = { ...ssot };
+  const next = JSON.parse(JSON.stringify(ssot));
   for (const { id, status } of updates) {
-    next[id] = status;
+    if (!setRoadmapItemStatus(next, id, status)) {
+      die(`roadmap: cannot map ${id} into ${ssotPath}`);
+    }
   }
 
   const entries = Object.entries(next);
@@ -35,14 +44,18 @@ function updateSsotStatus(ssot, ssotPath, updates) {
   fs.writeFileSync(ssotPath, JSON.stringify(ordered, null, 2) + "\n", "utf8");
 }
 
-function getPhaseSlug(labels) {
+function getPhaseSlug(labels, directiveSlug) {
   const phaseLabels = labels.filter((label) => label.startsWith("phase:"));
+  if (phaseLabels.length === 1) {
+    const slug = phaseLabels[0].slice("phase:".length).trim();
+    if (!slug) die("roadmap: phase label missing slug.");
+    return slug;
+  }
+  if (directiveSlug?.trim()) return directiveSlug.trim();
   if (phaseLabels.length !== 1) {
     die(`roadmap: expected exactly one phase:* label, found ${phaseLabels.length}.`);
   }
-  const slug = phaseLabels[0].slice("phase:".length).trim();
-  if (!slug) die("roadmap: phase label missing slug.");
-  return slug;
+  return null;
 }
 
 const args = process.argv.slice(2);
@@ -63,8 +76,6 @@ if (!hasDirective) {
   process.exit(0);
 }
 const prNumber = pr?.number ?? "unknown";
-const phaseSlug = getPhaseSlug(labels);
-
 const directive = parseRoadmapDirective(body);
 if (!directive) {
   console.log("roadmap: no Roadmap-Update block found; skipping");
@@ -80,6 +91,8 @@ if (!slug || ["n/a", "na", "none"].includes(slug.toLowerCase())) {
 if (!directive.items.length) {
   die("roadmap: Roadmap-Update requires at least one item.");
 }
+
+const phaseSlug = getPhaseSlug(labels, slug);
 
 const ssotPath = path.join("docs", "roadmaps", phaseSlug, "phase-status.json");
 if (!fs.existsSync(ssotPath)) {
@@ -108,7 +121,7 @@ if (!updates.length) {
 }
 
 const existing = JSON.parse(fs.readFileSync(ssotPath, "utf8"));
-const changed = updates.some(({ id, status }) => normalizeStatus(existing[id]) !== status);
+const changed = updates.some(({ id, status }) => getRoadmapItemStatus(existing, id) !== status);
 if (!changed) {
   console.log("roadmap: no status changes needed; skipping");
   process.exit(0);

--- a/scripts/roadmap/check-roadmap-directive.mjs
+++ b/scripts/roadmap/check-roadmap-directive.mjs
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { parseRoadmapDirective, normalizePrId } from "./roadmap-lib.mjs";
+import { normalizePhaseId, normalizePrId, parseRoadmapDirective } from "./roadmap-lib.mjs";
 
 function extractPrNumberFromRef(ref) {
   const match = String(ref ?? "").match(/refs\/pull\/(\d+)\//);
@@ -68,13 +68,6 @@ const token = process.env.GITHUB_TOKEN;
 const labels = (pr.labels ?? []).map((l) => l?.name).filter(Boolean);
 const hasPhase = labels.some((n) => String(n).startsWith("phase:"));
 const hasPr = labels.some((n) => String(n).startsWith("pr:PR"));
-const isRoadmapTracked = hasPhase || hasPr;
-
-if (!isRoadmapTracked) {
-  // Not a roadmap-tracked PR -> no requirement.
-  process.exit(0);
-}
-
 const eventBody = pr?.body ?? "";
 let body = eventBody;
 let directive = parseRoadmapDirective(body);
@@ -95,8 +88,10 @@ if (!directive && prNumber && repoName) {
 }
 console.log("[roadmap-directive] fetchedBodyLength=", fetchedBodyLength);
 
-if (directive && !(hasPhase && hasPr)) {
-  fail("Roadmap-Update is only allowed on roadmap PRs (requires phase:* and pr:PRxx labels).");
+const isRoadmapTracked = hasPhase || hasPr || Boolean(directive);
+
+if (!isRoadmapTracked) {
+  process.exit(0);
 }
 
 if (!directive) {
@@ -116,6 +111,12 @@ if (prLabel) {
   const has = items.some((it) => normalizePrId(it.id) === expected);
   if (!has) {
     fail(`PR has label '${prLabel}' but Roadmap-Update items do not include ${expected}.`);
+  }
+}
+
+for (const item of items) {
+  if (!normalizePrId(item.id) && !normalizePhaseId(item.id)) {
+    fail(`Roadmap-Update item '${item.id}' must be PRxx or RCn.`);
   }
 }
 

--- a/scripts/roadmap/check-roadmap-directive.mjs
+++ b/scripts/roadmap/check-roadmap-directive.mjs
@@ -38,7 +38,7 @@ async function fetchPrBody({ repoName, prNumber, token }) {
 
 /**
  * Fail-closed rule:
- * If PR is roadmap-tracked (has phase:* label), require a valid Roadmap-Update block.
+ * If PR is roadmap-tracked, require a valid Roadmap-Update block.
  *
  * We read PR metadata from the GitHub event payload (pull_request).
  */
@@ -71,9 +71,15 @@ const hasPr = labels.some((n) => String(n).startsWith("pr:PR"));
 const eventBody = pr?.body ?? "";
 let body = eventBody;
 let directive = parseRoadmapDirective(body);
+const isRoadmapTrackedFromEvent = hasPhase || hasPr || Boolean(directive);
 let fetchedBodyLength = body.length;
 console.log("[roadmap-directive] eventBodyLength=", eventBody.length);
 console.log("[roadmap-directive] prNumber=", prNumber, "repo=", repoName);
+
+if (!isRoadmapTrackedFromEvent) {
+  process.exit(0);
+}
+
 if (!directive && prNumber && repoName) {
   try {
     const fetchedBody = await fetchPrBody({ repoName, prNumber, token });
@@ -87,12 +93,6 @@ if (!directive && prNumber && repoName) {
   }
 }
 console.log("[roadmap-directive] fetchedBodyLength=", fetchedBodyLength);
-
-const isRoadmapTracked = hasPhase || hasPr || Boolean(directive);
-
-if (!isRoadmapTracked) {
-  process.exit(0);
-}
 
 if (!directive) {
   fail("Missing '### Roadmap-Update' block in PR body (roadmap-tracked PR).");

--- a/scripts/roadmap/check-roadmap-status.mjs
+++ b/scripts/roadmap/check-roadmap-status.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { normalizeStatus, parseRoadmapDirective } from "./roadmap-lib.mjs";
+import { normalizePhaseId, normalizeStatus, parseRoadmapDirective, getPhaseKeyForId } from "./roadmap-lib.mjs";
 
 function die(message) {
   console.error(message);
@@ -67,10 +67,16 @@ if (!fs.existsSync(statusPath)) {
   die(`roadmap: missing ${statusPath}`);
 }
 
+const ssot = JSON.parse(fs.readFileSync(statusPath, "utf8"));
+
 for (const item of directive.items) {
   const normalized = normalizeStatus(item.status);
   if (!normalized || !ALLOWED_STATUSES.has(normalized)) {
     die(`roadmap: invalid status for ${item.id} (${item.status}).`);
+  }
+  const phaseId = normalizePhaseId(item.id);
+  if (phaseId && !getPhaseKeyForId(ssot, phaseId)) {
+    die(`roadmap: ${statusPath} does not define ${phaseId}.`);
   }
 }
 

--- a/scripts/roadmap/finalize-merged.mjs
+++ b/scripts/roadmap/finalize-merged.mjs
@@ -1,7 +1,7 @@
-import { normalizePrId, normalizeStatus } from "./roadmap-lib.mjs";
+import { normalizePrId, normalizeRoadmapItemId, normalizeStatus } from "./roadmap-lib.mjs";
 
 function normalizeItem(item) {
-  const id = normalizePrId(item?.id) ?? item?.id ?? null;
+  const id = normalizeRoadmapItemId(item?.id) ?? item?.id ?? null;
   const status = normalizeStatus(item?.status) ?? item?.status ?? null;
   return { id, status };
 }

--- a/scripts/roadmap/gate-roadmap-monotonic.mjs
+++ b/scripts/roadmap/gate-roadmap-monotonic.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { normalizeStatus, parseRoadmapDirective, normalizePrId } from "./roadmap-lib.mjs";
+import { getRoadmapItemStatus, normalizePrId, normalizeStatus, parseRoadmapDirective } from "./roadmap-lib.mjs";
 
 const STATUS_ORDER = {
   planned: 1,
@@ -174,6 +174,30 @@ for (const item of directive.items) {
     if (!hasOverrideEntry({ slug, pr: prKey, revertOf, reason })) {
       die("roadmap-monotonic: OVERRIDES.md entry missing or invalid for this rollback.");
     }
+  }
+}
+
+for (const item of directive.items) {
+  if (normalizePrId(item.id)) continue;
+  const itemId = item.id;
+  const newStatus = normalizeStatus(item.status);
+  const oldStatus = getRoadmapItemStatus(ssot, itemId);
+
+  if (!newStatus || !oldStatus) continue;
+  const newRank = STATUS_ORDER[newStatus] ?? 0;
+  const oldRank = STATUS_ORDER[oldStatus] ?? 0;
+
+  if (newStatus === "done" && !isTerminalDone(oldStatus)) {
+    if (!hasHumanAckLabel) {
+      die("roadmap-monotonic: setting done requires label 'roadmap-human-ack'.");
+    }
+    if (String(directive.ack ?? "").trim().toLowerCase() !== "human") {
+      die("roadmap-monotonic: Roadmap-Update must include 'ack: human' when setting done.");
+    }
+  }
+
+  if (newRank < oldRank) {
+    die(`roadmap-monotonic: ${itemId} regressed from ${oldStatus} to ${newStatus} without supported override flow.`);
   }
 }
 

--- a/scripts/roadmap/roadmap-lib.mjs
+++ b/scripts/roadmap/roadmap-lib.mjs
@@ -29,6 +29,16 @@ export function normalizePrId(value) {
   return sub ? `PR${main}_${sub}` : `PR${main}`;
 }
 
+export function normalizePhaseId(value) {
+  const match = String(value ?? "").trim().toUpperCase().match(/^RC(\d+)$/);
+  if (!match) return null;
+  return `RC${Number(match[1])}`;
+}
+
+export function normalizeRoadmapItemId(value) {
+  return normalizePrId(value) ?? normalizePhaseId(value) ?? null;
+}
+
 export function formatPrId(value) {
   const normalized = normalizePrId(value);
   if (!normalized) return String(value ?? "");
@@ -62,6 +72,42 @@ export function statusLabel(value) {
   if (!value) return "Unknown";
   const normalized = normalizeStatus(value);
   return STATUS_LABELS[normalized] ?? "Unknown";
+}
+
+export function getPhaseKeyForId(ssot, phaseId) {
+  const normalized = normalizePhaseId(phaseId);
+  if (!normalized) return null;
+  const phaseNumber = Number(normalized.slice(2));
+  const phases = ssot?.phases;
+  if (!phases || typeof phases !== "object" || Array.isArray(phases)) return null;
+  const matches = Object.keys(phases).filter((key) => {
+    const match = key.match(/^phase_(\d+)(?:_|$)/i);
+    return match ? Number(match[1]) === phaseNumber : false;
+  });
+  if (matches.length !== 1) return null;
+  return matches[0];
+}
+
+export function getRoadmapItemStatus(ssot, itemId) {
+  const prId = normalizePrId(itemId);
+  if (prId) return normalizeStatus(ssot?.[prId]);
+  const phaseKey = getPhaseKeyForId(ssot, itemId);
+  if (!phaseKey) return null;
+  return normalizeStatus(ssot?.phases?.[phaseKey]?.status);
+}
+
+export function setRoadmapItemStatus(ssot, itemId, status) {
+  const normalizedStatus = normalizeStatus(status);
+  if (!normalizedStatus) return false;
+  const prId = normalizePrId(itemId);
+  if (prId) {
+    ssot[prId] = normalizedStatus;
+    return true;
+  }
+  const phaseKey = getPhaseKeyForId(ssot, itemId);
+  if (!phaseKey || !ssot?.phases?.[phaseKey] || typeof ssot.phases[phaseKey] !== "object") return false;
+  ssot.phases[phaseKey] = { ...ssot.phases[phaseKey], status: normalizedStatus };
+  return true;
 }
 
 function listFiles(root, matcher) {
@@ -309,9 +355,9 @@ export function parseRoadmapDirective(body) {
       ack = ackMatch[1].trim();
       continue;
     }
-    const itemMatch = line.match(/^\-?\s*(PR\d+(?:[._]\d+)?)\s*:\s*([a-zA-Z_-]+)\s*$/i);
+    const itemMatch = line.match(/^\-?\s*((?:PR\d+(?:[._]\d+)?)|(?:RC\d+))\s*:\s*([a-zA-Z_-]+)\s*$/i);
     if (itemMatch) {
-      const id = normalizePrId(itemMatch[1]);
+      const id = normalizeRoadmapItemId(itemMatch[1]);
       if (!id) continue;
       items.push({ id, status: itemMatch[2].trim() });
     }

--- a/tests/roadmap/finalize-merged.test.ts
+++ b/tests/roadmap/finalize-merged.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "@jest/globals";
 import { finalizeMergedItems } from "../../scripts/roadmap/finalize-merged.mjs";
+import {
+  getRoadmapItemStatus,
+  parseRoadmapDirective,
+  setRoadmapItemStatus,
+} from "../../scripts/roadmap/roadmap-lib.mjs";
 
 describe("finalizeMergedItems", () => {
   test("forces merged pr label and in_progress item to done", () => {
@@ -22,5 +27,41 @@ describe("finalizeMergedItems", () => {
     const result = finalizeMergedItems([{ id: "PR20", status: "planned" }], "PR19");
     const pr20 = result.items.find((item) => item.id === "PR20");
     expect(pr20?.status).toBe("planned");
+  });
+
+  test("finalizes in-progress roadmap phases to done on merge", () => {
+    const result = finalizeMergedItems([{ id: "RC5", status: "in_progress" }], null);
+    const rc5 = result.items.find((item) => item.id === "RC5");
+    expect(rc5?.status).toBe("done");
+  });
+});
+
+describe("roadmap phase helpers", () => {
+  test("parses RC items from Roadmap-Update blocks", () => {
+    const directive = parseRoadmapDirective(`
+### Roadmap-Update
+- slug: requirement-coverage
+- items:
+  - RC5: in_progress
+`);
+
+    expect(directive).toEqual({
+      slug: "requirement-coverage",
+      ack: null,
+      items: [{ id: "RC5", status: "in_progress" }],
+    });
+  });
+
+  test("reads and writes phase status through RC ids", () => {
+    const ssot = {
+      phases: {
+        phase_5_pdd_intake: { status: "planned", title: "PDD intake" },
+      },
+    };
+
+    expect(getRoadmapItemStatus(ssot, "RC5")).toBe("planned");
+    expect(setRoadmapItemStatus(ssot, "RC5", "done")).toBe(true);
+    expect(getRoadmapItemStatus(ssot, "RC5")).toBe("done");
+    expect(ssot.phases.phase_5_pdd_intake.status).toBe("done");
   });
 });


### PR DESCRIPTION
## WHAT

- allow `Roadmap-Update` directives to target roadmap phases directly with `RC<n>` items
- update roadmap auto-labeling and merge automation so phase-based roadmaps can auto-advance without `PR<n>` keys
- document the phase-based directive format in the roadmap docs and PR template
- mark requirement-coverage RC5 as done now that PR #473 merged
- regenerate the roadmap summary from SSOT

## WHY

- the current automation only auto-updates roadmap SSOT for top-level `PR<n>` items, not phase-based roadmaps like requirement-coverage
- this left RC5 stale in the roadmap even after the merged PDD intake foundation PR
- phase-based roadmap directives should be enough to keep roadmap status aligned automatically after merge

**Signed-off-by:** Fred E <fredilly@article6.org>