### PR TITLE
Fix/consume rich rule v1 and version lineage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 - slug: N/A
 - ack: human
 - items:
+  <!-- - RC5: in_progress -->
   <!-- - PR12: done -->
   <!-- - PR13: in_progress -->
 

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -25,6 +25,23 @@ jobs:
         run: |
           node scripts/roadmap/infer-pr-key.mjs --title "$PR_TITLE" --body "$PR_BODY" --branch "$PR_BRANCH" --output "$GITHUB_OUTPUT" || true
 
+      - name: Parse roadmap directive
+        id: directive
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          node --input-type=module -e '
+            import fs from "node:fs";
+            import { parseRoadmapDirective } from "./scripts/roadmap/roadmap-lib.mjs";
+            const body = process.env.PR_BODY ?? "";
+            const output = process.env.GITHUB_OUTPUT;
+            const directive = parseRoadmapDirective(body);
+            const slug = directive?.slug && !["n/a","na","none"].includes(String(directive.slug).trim().toLowerCase())
+              ? String(directive.slug).trim()
+              : "";
+            fs.appendFileSync(output, `slug=${slug}\n`, "utf8");
+          '
+
       - name: Find SSOT
         id: ssot
         if: steps.infer.outputs.prKey != ''
@@ -32,19 +49,17 @@ jobs:
           node scripts/roadmap/find-ssot-for-pr.mjs --pr "${{ steps.infer.outputs.prKey }}" --output "$GITHUB_OUTPUT" --allow-missing
 
       - name: Apply labels
-        if: steps.infer.outputs.prKey != '' && steps.ssot.outputs.slug != ''
+        if: steps.ssot.outputs.slug != '' || steps.directive.outputs.slug != ''
         uses: actions/github-script@v7
         env:
           PR_KEY: ${{ steps.infer.outputs.prKey }}
-          PHASE_SLUG: ${{ steps.ssot.outputs.slug }}
+          PHASE_SLUG: ${{ steps.ssot.outputs.slug || steps.directive.outputs.slug }}
         with:
           script: |
             const prKey = process.env.PR_KEY;
             const slug = process.env.PHASE_SLUG;
             const prNumber = context.payload.pull_request?.number;
-            if (!prKey || !slug || !prNumber) return;
-
-            const prLabel = `pr:${prKey}`;
+            if (!slug || !prNumber) return;
             const phaseLabel = `phase:${slug}`;
 
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -76,7 +91,7 @@ jobs:
             });
             const existing = new Set(existingLabels.map((label) => label.name));
 
-            for (const label of [prLabel, phaseLabel]) {
+            for (const label of [phaseLabel, ...(prKey ? [`pr:${prKey}`] : [])]) {
               if (!existing.has(label)) {
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,
@@ -89,7 +104,8 @@ jobs:
               }
             }
 
-            const labelsToApply = [prLabel, phaseLabel];
+            const labelsToApply = [phaseLabel];
+            if (prKey) labelsToApply.push(`pr:${prKey}`);
             for (const label of areaLabels) {
               if (label === "area:ui" && !existing.has(label)) continue;
               if (existing.has(label)) labelsToApply.push(label);

--- a/.github/workflows/roadmap-directive-gate.yml
+++ b/.github/workflows/roadmap-directive-gate.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           node-version: 20
       - name: Roadmap directive gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/roadmap/check-roadmap-directive.mjs
       - name: Roadmap monotonic gate
         run: node scripts/roadmap/gate-roadmap-monotonic.mjs

--- a/docs/roadmaps/README.md
+++ b/docs/roadmaps/README.md
@@ -17,15 +17,18 @@ Directive format:
 ### Roadmap-Update
 - slug: <slug>
 - items:
+  - RC5: in_progress
   - PR10: in_progress
 ```
 
 Allowed statuses: planned | next | active | in_progress | done | blocked | deferred | frozen | parked
 
-On merge, automation updates `docs/roadmaps/<slug>/phase-status.json` and
-regenerates `docs/roadmaps/SUMMARY.md`. `in_progress` is fine while a PR is open,
-but merged PR items are finalized to `done` automatically. Manual edits to those
-files should be avoided.
+Use `RC<n>` to update a roadmap phase directly when the SSOT is phase-based, and
+use `PR<n>` when the roadmap tracks explicit PR items. On merge, automation
+updates `docs/roadmaps/<slug>/phase-status.json` and regenerates
+`docs/roadmaps/SUMMARY.md`. `in_progress` is fine while a PR is open, but merged
+items are finalized to `done` automatically. Manual edits to those files should
+be avoided.
 If no status changes are needed, the automation skips creating a bot PR.
 
 Invariants:

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -120,7 +120,7 @@ Not active now:
 2) RC2 — Evidence inventory: Done — Normalize evidence assets before deeper ingestion work.
 3) RC3 — Spreadsheet/workbook intake: Done — Bring workbook evidence into the coverage workflow.
 4) RC4 — Monitoring report intake: Done — Capture monitoring report evidence with stable provenance.
-5) RC5 — PDD intake: Planned — Ingest uploaded project design documentation into the app evidence inventory with stable section/page/fragment provenance and support one-to-many requirement linking.
+5) RC5 — PDD intake: Done — Ingest uploaded project design documentation into the app evidence inventory with stable section/page/fragment provenance and support one-to-many requirement linking.
 6) RC6 — Methodology version diff / impact mode: Planned — Use canonical methodology version and diff metadata to identify coverage rows and linked evidence that may need review in the app.
 7) RC7 — Fallback raw methodology PDF intake for uncovered methods: Planned — Enable lower-confidence fallback raw methodology PDF intake only for uncovered methods while preserving canonical methodology outputs as the default for covered methods.
 8) RC8 — Additional GIS formats later: Deferred — Defer broader GIS intake until reconciliation fundamentals are stable.

--- a/docs/roadmaps/requirement-coverage/phase-status.json
+++ b/docs/roadmaps/requirement-coverage/phase-status.json
@@ -36,7 +36,7 @@
       "summary": "Capture monitoring report evidence with stable provenance."
     },
     "phase_5_pdd_intake": {
-      "status": "planned",
+      "status": "done",
       "title": "PDD intake",
       "summary": "Ingest uploaded project design documentation into the app evidence inventory with stable section/page/fragment provenance and support one-to-many requirement linking."
     },

--- a/scripts/roadmap/apply-merged-pr.mjs
+++ b/scripts/roadmap/apply-merged-pr.mjs
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { generateRoadmapContent, normalizePrId, normalizeStatus, parseRoadmapDirective } from "./roadmap-lib.mjs";
+import {
+  generateRoadmapContent,
+  getRoadmapItemStatus,
+  normalizePrId,
+  normalizeStatus,
+  parseRoadmapDirective,
+  setRoadmapItemStatus,
+} from "./roadmap-lib.mjs";
 import { finalizeMergedItems } from "./finalize-merged.mjs";
 
 const ALLOWED_STATUSES = new Set(["planned", "next", "in-progress", "done", "blocked"]);
@@ -21,9 +28,11 @@ function readEvent(eventPath) {
 }
 
 function updateSsotStatus(ssot, ssotPath, updates) {
-  const next = { ...ssot };
+  const next = JSON.parse(JSON.stringify(ssot));
   for (const { id, status } of updates) {
-    next[id] = status;
+    if (!setRoadmapItemStatus(next, id, status)) {
+      die(`roadmap: cannot map ${id} into ${ssotPath}`);
+    }
   }
 
   const entries = Object.entries(next);
@@ -35,14 +44,18 @@ function updateSsotStatus(ssot, ssotPath, updates) {
   fs.writeFileSync(ssotPath, JSON.stringify(ordered, null, 2) + "\n", "utf8");
 }
 
-function getPhaseSlug(labels) {
+function getPhaseSlug(labels, directiveSlug) {
   const phaseLabels = labels.filter((label) => label.startsWith("phase:"));
+  if (phaseLabels.length === 1) {
+    const slug = phaseLabels[0].slice("phase:".length).trim();
+    if (!slug) die("roadmap: phase label missing slug.");
+    return slug;
+  }
+  if (directiveSlug?.trim()) return directiveSlug.trim();
   if (phaseLabels.length !== 1) {
     die(`roadmap: expected exactly one phase:* label, found ${phaseLabels.length}.`);
   }
-  const slug = phaseLabels[0].slice("phase:".length).trim();
-  if (!slug) die("roadmap: phase label missing slug.");
-  return slug;
+  return null;
 }
 
 const args = process.argv.slice(2);
@@ -63,8 +76,6 @@ if (!hasDirective) {
   process.exit(0);
 }
 const prNumber = pr?.number ?? "unknown";
-const phaseSlug = getPhaseSlug(labels);
-
 const directive = parseRoadmapDirective(body);
 if (!directive) {
   console.log("roadmap: no Roadmap-Update block found; skipping");
@@ -80,6 +91,8 @@ if (!slug || ["n/a", "na", "none"].includes(slug.toLowerCase())) {
 if (!directive.items.length) {
   die("roadmap: Roadmap-Update requires at least one item.");
 }
+
+const phaseSlug = getPhaseSlug(labels, slug);
 
 const ssotPath = path.join("docs", "roadmaps", phaseSlug, "phase-status.json");
 if (!fs.existsSync(ssotPath)) {
@@ -108,7 +121,7 @@ if (!updates.length) {
 }
 
 const existing = JSON.parse(fs.readFileSync(ssotPath, "utf8"));
-const changed = updates.some(({ id, status }) => normalizeStatus(existing[id]) !== status);
+const changed = updates.some(({ id, status }) => getRoadmapItemStatus(existing, id) !== status);
 if (!changed) {
   console.log("roadmap: no status changes needed; skipping");
   process.exit(0);

--- a/scripts/roadmap/check-roadmap-directive.mjs
+++ b/scripts/roadmap/check-roadmap-directive.mjs
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { parseRoadmapDirective, normalizePrId } from "./roadmap-lib.mjs";
+import { normalizePhaseId, normalizePrId, parseRoadmapDirective } from "./roadmap-lib.mjs";
 
 function extractPrNumberFromRef(ref) {
   const match = String(ref ?? "").match(/refs\/pull\/(\d+)\//);
@@ -68,13 +68,6 @@ const token = process.env.GITHUB_TOKEN;
 const labels = (pr.labels ?? []).map((l) => l?.name).filter(Boolean);
 const hasPhase = labels.some((n) => String(n).startsWith("phase:"));
 const hasPr = labels.some((n) => String(n).startsWith("pr:PR"));
-const isRoadmapTracked = hasPhase || hasPr;
-
-if (!isRoadmapTracked) {
-  // Not a roadmap-tracked PR -> no requirement.
-  process.exit(0);
-}
-
 const eventBody = pr?.body ?? "";
 let body = eventBody;
 let directive = parseRoadmapDirective(body);
@@ -95,8 +88,10 @@ if (!directive && prNumber && repoName) {
 }
 console.log("[roadmap-directive] fetchedBodyLength=", fetchedBodyLength);
 
-if (directive && !(hasPhase && hasPr)) {
-  fail("Roadmap-Update is only allowed on roadmap PRs (requires phase:* and pr:PRxx labels).");
+const isRoadmapTracked = hasPhase || hasPr || Boolean(directive);
+
+if (!isRoadmapTracked) {
+  process.exit(0);
 }
 
 if (!directive) {
@@ -116,6 +111,12 @@ if (prLabel) {
   const has = items.some((it) => normalizePrId(it.id) === expected);
   if (!has) {
     fail(`PR has label '${prLabel}' but Roadmap-Update items do not include ${expected}.`);
+  }
+}
+
+for (const item of items) {
+  if (!normalizePrId(item.id) && !normalizePhaseId(item.id)) {
+    fail(`Roadmap-Update item '${item.id}' must be PRxx or RCn.`);
   }
 }
 

--- a/scripts/roadmap/check-roadmap-directive.mjs
+++ b/scripts/roadmap/check-roadmap-directive.mjs
@@ -38,7 +38,7 @@ async function fetchPrBody({ repoName, prNumber, token }) {
 
 /**
  * Fail-closed rule:
- * If PR is roadmap-tracked (has phase:* label), require a valid Roadmap-Update block.
+ * If PR is roadmap-tracked, require a valid Roadmap-Update block.
  *
  * We read PR metadata from the GitHub event payload (pull_request).
  */
@@ -71,9 +71,15 @@ const hasPr = labels.some((n) => String(n).startsWith("pr:PR"));
 const eventBody = pr?.body ?? "";
 let body = eventBody;
 let directive = parseRoadmapDirective(body);
+const isRoadmapTrackedFromEvent = hasPhase || hasPr || Boolean(directive);
 let fetchedBodyLength = body.length;
 console.log("[roadmap-directive] eventBodyLength=", eventBody.length);
 console.log("[roadmap-directive] prNumber=", prNumber, "repo=", repoName);
+
+if (!isRoadmapTrackedFromEvent) {
+  process.exit(0);
+}
+
 if (!directive && prNumber && repoName) {
   try {
     const fetchedBody = await fetchPrBody({ repoName, prNumber, token });
@@ -87,12 +93,6 @@ if (!directive && prNumber && repoName) {
   }
 }
 console.log("[roadmap-directive] fetchedBodyLength=", fetchedBodyLength);
-
-const isRoadmapTracked = hasPhase || hasPr || Boolean(directive);
-
-if (!isRoadmapTracked) {
-  process.exit(0);
-}
 
 if (!directive) {
   fail("Missing '### Roadmap-Update' block in PR body (roadmap-tracked PR).");

--- a/scripts/roadmap/check-roadmap-status.mjs
+++ b/scripts/roadmap/check-roadmap-status.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { normalizeStatus, parseRoadmapDirective } from "./roadmap-lib.mjs";
+import { normalizePhaseId, normalizeStatus, parseRoadmapDirective, getPhaseKeyForId } from "./roadmap-lib.mjs";
 
 function die(message) {
   console.error(message);
@@ -67,10 +67,16 @@ if (!fs.existsSync(statusPath)) {
   die(`roadmap: missing ${statusPath}`);
 }
 
+const ssot = JSON.parse(fs.readFileSync(statusPath, "utf8"));
+
 for (const item of directive.items) {
   const normalized = normalizeStatus(item.status);
   if (!normalized || !ALLOWED_STATUSES.has(normalized)) {
     die(`roadmap: invalid status for ${item.id} (${item.status}).`);
+  }
+  const phaseId = normalizePhaseId(item.id);
+  if (phaseId && !getPhaseKeyForId(ssot, phaseId)) {
+    die(`roadmap: ${statusPath} does not define ${phaseId}.`);
   }
 }
 

--- a/scripts/roadmap/finalize-merged.mjs
+++ b/scripts/roadmap/finalize-merged.mjs
@@ -1,7 +1,7 @@
-import { normalizePrId, normalizeStatus } from "./roadmap-lib.mjs";
+import { normalizePrId, normalizeRoadmapItemId, normalizeStatus } from "./roadmap-lib.mjs";
 
 function normalizeItem(item) {
-  const id = normalizePrId(item?.id) ?? item?.id ?? null;
+  const id = normalizeRoadmapItemId(item?.id) ?? item?.id ?? null;
   const status = normalizeStatus(item?.status) ?? item?.status ?? null;
   return { id, status };
 }

--- a/scripts/roadmap/gate-roadmap-monotonic.mjs
+++ b/scripts/roadmap/gate-roadmap-monotonic.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { normalizeStatus, parseRoadmapDirective, normalizePrId } from "./roadmap-lib.mjs";
+import { getRoadmapItemStatus, normalizePrId, normalizeStatus, parseRoadmapDirective } from "./roadmap-lib.mjs";
 
 const STATUS_ORDER = {
   planned: 1,
@@ -174,6 +174,30 @@ for (const item of directive.items) {
     if (!hasOverrideEntry({ slug, pr: prKey, revertOf, reason })) {
       die("roadmap-monotonic: OVERRIDES.md entry missing or invalid for this rollback.");
     }
+  }
+}
+
+for (const item of directive.items) {
+  if (normalizePrId(item.id)) continue;
+  const itemId = item.id;
+  const newStatus = normalizeStatus(item.status);
+  const oldStatus = getRoadmapItemStatus(ssot, itemId);
+
+  if (!newStatus || !oldStatus) continue;
+  const newRank = STATUS_ORDER[newStatus] ?? 0;
+  const oldRank = STATUS_ORDER[oldStatus] ?? 0;
+
+  if (newStatus === "done" && !isTerminalDone(oldStatus)) {
+    if (!hasHumanAckLabel) {
+      die("roadmap-monotonic: setting done requires label 'roadmap-human-ack'.");
+    }
+    if (String(directive.ack ?? "").trim().toLowerCase() !== "human") {
+      die("roadmap-monotonic: Roadmap-Update must include 'ack: human' when setting done.");
+    }
+  }
+
+  if (newRank < oldRank) {
+    die(`roadmap-monotonic: ${itemId} regressed from ${oldStatus} to ${newStatus} without supported override flow.`);
   }
 }
 

--- a/scripts/roadmap/roadmap-lib.mjs
+++ b/scripts/roadmap/roadmap-lib.mjs
@@ -29,6 +29,16 @@ export function normalizePrId(value) {
   return sub ? `PR${main}_${sub}` : `PR${main}`;
 }
 
+export function normalizePhaseId(value) {
+  const match = String(value ?? "").trim().toUpperCase().match(/^RC(\d+)$/);
+  if (!match) return null;
+  return `RC${Number(match[1])}`;
+}
+
+export function normalizeRoadmapItemId(value) {
+  return normalizePrId(value) ?? normalizePhaseId(value) ?? null;
+}
+
 export function formatPrId(value) {
   const normalized = normalizePrId(value);
   if (!normalized) return String(value ?? "");
@@ -62,6 +72,42 @@ export function statusLabel(value) {
   if (!value) return "Unknown";
   const normalized = normalizeStatus(value);
   return STATUS_LABELS[normalized] ?? "Unknown";
+}
+
+export function getPhaseKeyForId(ssot, phaseId) {
+  const normalized = normalizePhaseId(phaseId);
+  if (!normalized) return null;
+  const phaseNumber = Number(normalized.slice(2));
+  const phases = ssot?.phases;
+  if (!phases || typeof phases !== "object" || Array.isArray(phases)) return null;
+  const matches = Object.keys(phases).filter((key) => {
+    const match = key.match(/^phase_(\d+)(?:_|$)/i);
+    return match ? Number(match[1]) === phaseNumber : false;
+  });
+  if (matches.length !== 1) return null;
+  return matches[0];
+}
+
+export function getRoadmapItemStatus(ssot, itemId) {
+  const prId = normalizePrId(itemId);
+  if (prId) return normalizeStatus(ssot?.[prId]);
+  const phaseKey = getPhaseKeyForId(ssot, itemId);
+  if (!phaseKey) return null;
+  return normalizeStatus(ssot?.phases?.[phaseKey]?.status);
+}
+
+export function setRoadmapItemStatus(ssot, itemId, status) {
+  const normalizedStatus = normalizeStatus(status);
+  if (!normalizedStatus) return false;
+  const prId = normalizePrId(itemId);
+  if (prId) {
+    ssot[prId] = normalizedStatus;
+    return true;
+  }
+  const phaseKey = getPhaseKeyForId(ssot, itemId);
+  if (!phaseKey || !ssot?.phases?.[phaseKey] || typeof ssot.phases[phaseKey] !== "object") return false;
+  ssot.phases[phaseKey] = { ...ssot.phases[phaseKey], status: normalizedStatus };
+  return true;
 }
 
 function listFiles(root, matcher) {
@@ -309,9 +355,9 @@ export function parseRoadmapDirective(body) {
       ack = ackMatch[1].trim();
       continue;
     }
-    const itemMatch = line.match(/^\-?\s*(PR\d+(?:[._]\d+)?)\s*:\s*([a-zA-Z_-]+)\s*$/i);
+    const itemMatch = line.match(/^\-?\s*((?:PR\d+(?:[._]\d+)?)|(?:RC\d+))\s*:\s*([a-zA-Z_-]+)\s*$/i);
     if (itemMatch) {
-      const id = normalizePrId(itemMatch[1]);
+      const id = normalizeRoadmapItemId(itemMatch[1]);
       if (!id) continue;
       items.push({ id, status: itemMatch[2].trim() });
     }

--- a/src/app/m/_components/EvidenceView.tsx
+++ b/src/app/m/_components/EvidenceView.tsx
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import MethodDetailPane from "@/app/m/_components/MethodDetailPane";
 import { getMethodInventory } from "@/app/m/_lib/methodInventory";
+import { loadMethodVersionLineage, resolveMethodVersionFiles } from "@/app/m/_lib/methodVersionMetadata";
 import { loadManifestEntries } from "@/lib/manifest/cards";
 import packConfig from "../../../../config/methodologies_pack.json";
 
@@ -23,10 +24,13 @@ async function loadPackProvenanceJson(): Promise<unknown | null> {
 async function resolveManifestRulesPath(code: string, version: string): Promise<string | null> {
   const entries = await loadManifestEntries();
   const match = entries.find((entry) => entry.methodology === code && entry.version === version);
-  if (!match) return null;
-  const record = match as unknown as Record<string, unknown>;
-  const manifestPath = typeof record.path === "string" ? record.path : null;
-  return manifestPath && manifestPath.trim() ? manifestPath.trim() : null;
+  if (match) {
+    const record = match as unknown as Record<string, unknown>;
+    const manifestPath = typeof record.path === "string" ? record.path : null;
+    if (manifestPath && manifestPath.trim()) return manifestPath.trim();
+  }
+  const resolved = await resolveMethodVersionFiles(code, version);
+  return resolved ? path.relative(process.cwd(), path.join(resolved.dir, "rules.json")) : null;
 }
 
 export default async function EvidenceView({ selectedCode, selectedVersion }: EvidenceViewProps) {
@@ -47,6 +51,10 @@ export default async function EvidenceView({ selectedCode, selectedVersion }: Ev
     selectedMethod && effectiveVersion
       ? await resolveManifestRulesPath(selectedMethod.code, effectiveVersion)
       : null;
+  const versionLineage =
+    selectedMethod && effectiveVersion
+      ? await loadMethodVersionLineage(selectedMethod.code, effectiveVersion, selectedMethod.versions)
+      : null;
 
   return (
     <main className="min-h-screen bg-slate-50">
@@ -63,6 +71,7 @@ export default async function EvidenceView({ selectedCode, selectedVersion }: Ev
               hasRich: selectedMethod.hasRich,
               hasPrevious: selectedMethod.hasPrevious,
               ruleCountByVersion: selectedMethod.ruleCountByVersion,
+              lineage: versionLineage,
             }}
             activeVersion={effectiveVersion}
             packTag={typeof packConfig?.tag === "string" ? packConfig.tag : null}

--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -58,6 +58,7 @@ import { isRuleLikeId } from "@/lib/proofMap/pins";
 import type { ProofEvidenceItem } from "@/lib/proof/bundle";
 import { importProofBundleText } from "@/lib/proof/import";
 import { applyUrlUpdates, parseDetailTab, type DetailTab } from "@/lib/nav/urlState";
+import type { MethodVersionLineage } from "@/app/m/_lib/methodVersionMetadata";
 
 type MethodDetail = {
   code: string;
@@ -69,6 +70,7 @@ type MethodDetail = {
   hasRich: boolean;
   hasPrevious: boolean;
   ruleCountByVersion: Record<string, number | undefined>;
+  lineage?: MethodVersionLineage | null;
 };
 
 type MethodDetailPaneProps = {
@@ -186,11 +188,23 @@ export default function MethodDetailPane({
     title: string;
     snippet: string;
     text?: string;
+    summary?: string;
+    logic?: string;
+    notes?: string;
+    when?: string[];
+    expectedEvidence?: string[];
     tags: string[];
     type?: string;
     sectionId?: string;
     anchor?: string;
     citations?: Array<{ sectionId: string | undefined; anchor: string | undefined; label: string | undefined }>;
+    refs?: {
+      primarySection?: string;
+      sectionAnchor?: string;
+      sectionStableId?: string;
+      sections: string[];
+      tools: string[];
+    };
   };
   type TraceLink = {
     section_id: string;
@@ -213,12 +227,24 @@ export default function MethodDetailPane({
     id: string;
     title: string;
     text: string;
+    summary?: string;
+    logic?: string;
+    notes?: string;
+    when?: string[];
+    expectedEvidence?: string[];
     tags: string[];
     type?: string;
     sha256?: string;
     sectionId?: string;
     anchor?: string;
     citations?: Array<{ sectionId: string | undefined; anchor: string | undefined; label: string | undefined }>;
+    refs?: {
+      primarySection?: string;
+      sectionAnchor?: string;
+      sectionStableId?: string;
+      sections: string[];
+      tools: string[];
+    };
     sourcePath?: string;
   } | null>(null);
   const [ruleDetailLoading, setRuleDetailLoading] = useState(false);
@@ -272,9 +298,12 @@ export default function MethodDetailPane({
   const [selectedStacItemId, setSelectedStacItemId] = useState<string | null>(null);
   const [coverageDrawerOpen, setCoverageDrawerOpen] = useState(false);
 
-  const sortedVersionsNewestFirst = useMemo(() => {
-    return [...method.versions].reverse();
-  }, [method.versions]);
+  const lineageVersions = method.lineage?.lineage?.length ? method.lineage.lineage : method.versions;
+  const versionBadges = [
+    method.lineage?.previousVersion ? `Previous ${method.lineage.previousVersion}` : null,
+    method.lineage?.currentVersion ? `Current ${method.lineage.currentVersion}` : null,
+    method.lineage?.nextVersion ? `Next ${method.lineage.nextVersion}` : null,
+  ].filter(Boolean);
 
   const effectiveAoi = draftAoi ?? currentAoi;
   const evidenceKey = useMemo(() => {
@@ -687,6 +716,12 @@ export default function MethodDetailPane({
         const tags = Array.isArray(record.tags)
           ? record.tags.map((t: unknown) => String(t)).filter(Boolean)
           : [];
+        const when = Array.isArray(record.when)
+          ? record.when.map((item: unknown) => String(item).trim()).filter(Boolean)
+          : [];
+        const expectedEvidence = Array.isArray(record.expectedEvidence)
+          ? record.expectedEvidence.map((item: unknown) => String(item).trim()).filter(Boolean)
+          : [];
         const type = typeof record.type === "string" ? record.type : undefined;
         const sectionId = typeof record.sectionId === "string" ? record.sectionId : undefined;
         const anchor = typeof record.anchor === "string" ? record.anchor : undefined;
@@ -708,7 +743,46 @@ export default function MethodDetailPane({
                   value !== null,
               )
           : undefined;
-        nextRules.push({ id, title, snippet, text, tags, type, sectionId, anchor, citations });
+        const refs =
+          record.refs && typeof record.refs === "object"
+            ? {
+                primarySection:
+                  typeof (record.refs as Record<string, unknown>).primarySection === "string"
+                    ? ((record.refs as Record<string, unknown>).primarySection as string)
+                    : undefined,
+                sectionAnchor:
+                  typeof (record.refs as Record<string, unknown>).sectionAnchor === "string"
+                    ? ((record.refs as Record<string, unknown>).sectionAnchor as string)
+                    : undefined,
+                sectionStableId:
+                  typeof (record.refs as Record<string, unknown>).sectionStableId === "string"
+                    ? ((record.refs as Record<string, unknown>).sectionStableId as string)
+                    : undefined,
+                sections: Array.isArray((record.refs as Record<string, unknown>).sections)
+                  ? ((record.refs as Record<string, unknown>).sections as unknown[]).map((item) => String(item))
+                  : [],
+                tools: Array.isArray((record.refs as Record<string, unknown>).tools)
+                  ? ((record.refs as Record<string, unknown>).tools as unknown[]).map((item) => String(item))
+                  : [],
+              }
+            : undefined;
+        nextRules.push({
+          id,
+          title,
+          snippet,
+          text,
+          summary: typeof record.summary === "string" ? record.summary : undefined,
+          logic: typeof record.logic === "string" ? record.logic : undefined,
+          notes: typeof record.notes === "string" ? record.notes : undefined,
+          when,
+          expectedEvidence,
+          tags,
+          type,
+          sectionId,
+          anchor,
+          citations,
+          refs,
+        });
       }
 
       setRules(nextRules);
@@ -772,6 +846,29 @@ export default function MethodDetailPane({
                 value !== null,
             )
         : undefined;
+      const refs =
+        record.refs && typeof record.refs === "object"
+          ? {
+              primarySection:
+                typeof (record.refs as Record<string, unknown>).primarySection === "string"
+                  ? ((record.refs as Record<string, unknown>).primarySection as string)
+                  : undefined,
+              sectionAnchor:
+                typeof (record.refs as Record<string, unknown>).sectionAnchor === "string"
+                  ? ((record.refs as Record<string, unknown>).sectionAnchor as string)
+                  : undefined,
+              sectionStableId:
+                typeof (record.refs as Record<string, unknown>).sectionStableId === "string"
+                  ? ((record.refs as Record<string, unknown>).sectionStableId as string)
+                  : undefined,
+              sections: Array.isArray((record.refs as Record<string, unknown>).sections)
+                ? ((record.refs as Record<string, unknown>).sections as unknown[]).map((item) => String(item))
+                : [],
+              tools: Array.isArray((record.refs as Record<string, unknown>).tools)
+                ? ((record.refs as Record<string, unknown>).tools as unknown[]).map((item) => String(item))
+                : [],
+            }
+          : undefined;
       setRuleDetail({
         id: typeof record.id === "string" ? record.id : ruleId,
         title:
@@ -781,6 +878,13 @@ export default function MethodDetailPane({
               ? record.id
               : ruleId,
         text: typeof record.text === "string" ? record.text : "",
+        summary: typeof record.summary === "string" ? record.summary : undefined,
+        logic: typeof record.logic === "string" ? record.logic : undefined,
+        notes: typeof record.notes === "string" ? record.notes : undefined,
+        when: Array.isArray(record.when) ? record.when.map((item: unknown) => String(item)).filter(Boolean) : [],
+        expectedEvidence: Array.isArray(record.expectedEvidence)
+          ? record.expectedEvidence.map((item: unknown) => String(item)).filter(Boolean)
+          : [],
         tags: Array.isArray(record.tags)
           ? record.tags.map((t: unknown) => String(t)).filter(Boolean)
           : [],
@@ -789,6 +893,7 @@ export default function MethodDetailPane({
         sectionId: typeof record.sectionId === "string" ? record.sectionId : undefined,
         anchor: typeof record.anchor === "string" ? record.anchor : undefined,
         citations,
+        refs,
         sourcePath: typeof record.sourcePath === "string" ? record.sourcePath : undefined,
       });
     } catch (error) {
@@ -1198,12 +1303,22 @@ export default function MethodDetailPane({
           <p className="text-xs text-slate-500">
             Latest: {method.latestVersion ?? "—"} • Versions: {method.versionCount}
           </p>
+          {versionBadges.length ? (
+            <div className="mt-1 flex flex-wrap gap-2 text-[11px] font-semibold text-slate-600">
+              {versionBadges.map((label) => (
+                <span key={label} className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1">
+                  {label}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </div>
         <div className="w-full sm:max-w-xs">
           <VersionSelector
             methodCode={method.code}
-            versions={sortedVersionsNewestFirst}
+            versions={[...lineageVersions].reverse()}
             selectedVersion={activeVersion}
+            lineage={method.lineage}
           />
         </div>
       </div>
@@ -1263,8 +1378,11 @@ export default function MethodDetailPane({
         ruleText={
           ruleDetailLoading && activeRuleId && ruleDetail?.id !== activeRuleId
             ? "Loading requirement details…"
-            : (ruleDetail?.text ?? activeRequirementRow?.ruleSummary.snippet ?? null)
+            : (ruleDetail?.summary ?? activeRequirementRow?.ruleSummary.summary ?? activeRequirementRow?.ruleSummary.snippet ?? null)
         }
+        ruleLogic={ruleDetail?.logic ?? activeRequirementRow?.ruleSummary.logic ?? null}
+        ruleNotes={ruleDetail?.notes ?? activeRequirementRow?.ruleSummary.notes ?? null}
+        ruleWhen={ruleDetail?.when ?? activeRequirementRow?.ruleSummary.when ?? null}
         sourcePath={ruleDetail?.sourcePath ?? null}
         sha256={ruleDetail?.sha256 ?? null}
         traceSections={linkedTraceSections.map((link) => {
@@ -1446,7 +1564,7 @@ export default function MethodDetailPane({
                       <p className="mt-3 text-sm leading-6 text-slate-700">
                         {ruleDetailLoading && activeRuleId && ruleDetail?.id !== activeRuleId
                           ? "Loading requirement details…"
-                          : (ruleDetail?.text ?? activeRequirementRow.ruleSummary.snippet)}
+                          : (ruleDetail?.summary ?? activeRequirementRow.ruleSummary.summary ?? activeRequirementRow.ruleSummary.snippet)}
                       </p>
                     </div>
 
@@ -1490,7 +1608,7 @@ export default function MethodDetailPane({
                     selectedRequirementText={
                       ruleDetailLoading && activeRuleId && ruleDetail?.id !== activeRuleId
                         ? "Loading requirement details…"
-                        : (ruleDetail?.text ?? null)
+                        : (ruleDetail?.summary ?? null)
                     }
                     selectedRequirementSourcePath={ruleDetail?.sourcePath ?? null}
                     selectedRequirementSha256={ruleDetail?.sha256 ?? null}

--- a/src/app/m/_components/MethodsFinder.tsx
+++ b/src/app/m/_components/MethodsFinder.tsx
@@ -6,6 +6,7 @@ import MethodsFinderShell from "@/app/m/_components/MethodsFinderShell";
 import MethodDetailPane from "@/app/m/_components/MethodDetailPane";
 import { getMethodInventory } from "@/app/m/_lib/methodInventory";
 import { probeMethodRich } from "@/app/m/_lib/methodRich";
+import { loadMethodVersionLineage, resolveMethodVersionFiles } from "@/app/m/_lib/methodVersionMetadata";
 import { normalizeRichEvidence } from "@/lib/rich/normalize";
 import { loadManifestEntries } from "@/lib/manifest/cards";
 import packConfig from "../../../../config/methodologies_pack.json";
@@ -29,10 +30,13 @@ async function loadPackProvenanceJson(): Promise<unknown | null> {
 async function resolveManifestRulesPath(code: string, version: string): Promise<string | null> {
   const entries = await loadManifestEntries();
   const match = entries.find((entry) => entry.methodology === code && entry.version === version);
-  if (!match) return null;
-  const record = match as unknown as Record<string, unknown>;
-  const manifestPath = typeof record.path === "string" ? record.path : null;
-  return manifestPath && manifestPath.trim() ? manifestPath.trim() : null;
+  if (match) {
+    const record = match as unknown as Record<string, unknown>;
+    const manifestPath = typeof record.path === "string" ? record.path : null;
+    if (manifestPath && manifestPath.trim()) return manifestPath.trim();
+  }
+  const resolved = await resolveMethodVersionFiles(code, version);
+  return resolved ? path.relative(process.cwd(), path.join(resolved.dir, "rules.json")) : null;
 }
 
 export default async function MethodsFinder({
@@ -83,6 +87,10 @@ export default async function MethodsFinder({
   const manifestRulesPath =
     selectedMethod && effectiveVersion
       ? await resolveManifestRulesPath(selectedMethod.code, effectiveVersion)
+      : null;
+  const versionLineage =
+    selectedMethod && effectiveVersion
+      ? await loadMethodVersionLineage(selectedMethod.code, effectiveVersion, selectedMethod.versions)
       : null;
 
   return (
@@ -159,6 +167,7 @@ export default async function MethodsFinder({
                     hasRich: selectedMethod.hasRich,
                     hasPrevious: selectedMethod.hasPrevious,
                     ruleCountByVersion: selectedMethod.ruleCountByVersion,
+                    lineage: versionLineage,
                   }}
                   activeVersion={effectiveVersion}
                   initialRuleId={selectedRuleId}

--- a/src/app/m/_components/RequirementCoverageWorkspace.tsx
+++ b/src/app/m/_components/RequirementCoverageWorkspace.tsx
@@ -281,6 +281,15 @@ export default function RequirementCoverageWorkspace({
                   <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Methodology provenance</div>
                   <div className="mt-2 space-y-2 text-sm text-slate-700">
                     <div>{requirementProvenanceHint(selectedRow)}</div>
+                    {selectedRow.provenance.tools.length ? (
+                      <ul className="grid gap-2">
+                        {selectedRow.provenance.tools.map((tool) => (
+                          <li key={tool} className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600">
+                            {tool}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
                     {selectedRow.provenance.citations.length ? (
                       <ul className="grid gap-2">
                         {selectedRow.provenance.citations.slice(0, 4).map((citation, index) => (
@@ -344,7 +353,7 @@ export default function RequirementCoverageWorkspace({
                         ))}
                       </ul>
                     ) : (
-                      <div>No expected evidence metadata</div>
+                      <div>No expected evidence defined for this rule.</div>
                     )}
                   </div>
                 </section>

--- a/src/app/m/_components/RuleDetailModal.tsx
+++ b/src/app/m/_components/RuleDetailModal.tsx
@@ -14,6 +14,9 @@ type RuleDetailModalProps = {
   row: RequirementCoverageRow | null;
   ruleTitle?: string | null;
   ruleText?: string | null;
+  ruleLogic?: string | null;
+  ruleNotes?: string | null;
+  ruleWhen?: string[] | null;
   sourcePath?: string | null;
   sha256?: string | null;
   traceSections?: Array<{
@@ -61,6 +64,9 @@ export default function RuleDetailModal({
   row,
   ruleTitle,
   ruleText,
+  ruleLogic,
+  ruleNotes,
+  ruleWhen,
   sourcePath,
   sha256,
   traceSections = [],
@@ -102,6 +108,8 @@ export default function RuleDetailModal({
     row.provenance.citations.find((citation) => citation.sectionId)?.sectionId ??
     null;
   const categoryLabel = row.ruleSummary.type?.trim() || null;
+  const provenanceTools = row.provenance.tools ?? [];
+  const renderedWhen = ruleWhen?.length ? ruleWhen : row.ruleSummary.when;
 
   return (
     <div
@@ -143,10 +151,38 @@ export default function RuleDetailModal({
         <div className="grid gap-4 px-5 py-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
           <section className="space-y-4">
             <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-              <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Full rule text</div>
+              <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Rule summary</div>
               <p className="mt-3 whitespace-pre-wrap text-sm leading-7 text-slate-800">
-                {ruleText?.trim() || row.ruleSummary.snippet}
+                {ruleText?.trim() || row.ruleSummary.summary || row.ruleSummary.snippet}
               </p>
+              {ruleLogic?.trim() || row.ruleSummary.logic ? (
+                <div className="mt-4">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Logic</div>
+                  <p className="mt-2 whitespace-pre-wrap text-sm leading-7 text-slate-800">
+                    {ruleLogic?.trim() || row.ruleSummary.logic}
+                  </p>
+                </div>
+              ) : null}
+              {ruleNotes?.trim() || row.ruleSummary.notes ? (
+                <div className="mt-4">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Notes</div>
+                  <p className="mt-2 whitespace-pre-wrap text-sm leading-7 text-slate-800">
+                    {ruleNotes?.trim() || row.ruleSummary.notes}
+                  </p>
+                </div>
+              ) : null}
+              {renderedWhen?.length ? (
+                <div className="mt-4">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">When</div>
+                  <ul className="mt-2 grid gap-2 text-sm text-slate-800">
+                    {renderedWhen.map((item) => (
+                      <li key={item} className="rounded-xl border border-slate-200 bg-white px-3 py-2">
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
             </div>
 
             <section className="rounded-2xl border border-slate-200 bg-white p-4">
@@ -165,16 +201,36 @@ export default function RuleDetailModal({
                         {formatPageLabel(primaryTraceSection?.page ?? row.provenance.page)}
                       </span>
                     ) : null}
-                    {row.provenance.anchor ? (
+                    {row.provenance.sectionStableId ? (
                       <span className="rounded-full border border-slate-200 bg-white px-2 py-1">
-                        {row.provenance.anchor.replace(/^#/, "")}
+                        {row.provenance.sectionStableId}
                       </span>
                     ) : null}
-                    {!formatPageLabel(primaryTraceSection?.page ?? row.provenance.page) && !row.provenance.anchor ? (
+                    {row.provenance.sectionAnchor || row.provenance.anchor ? (
+                      <span className="rounded-full border border-slate-200 bg-white px-2 py-1">
+                        {(row.provenance.sectionAnchor ?? row.provenance.anchor ?? "").replace(/^#/, "")}
+                      </span>
+                    ) : null}
+                    {!formatPageLabel(primaryTraceSection?.page ?? row.provenance.page) &&
+                    !row.provenance.sectionAnchor &&
+                    !row.provenance.anchor &&
+                    !row.provenance.sectionStableId ? (
                       <span>{requirementProvenanceHint(row)}</span>
                     ) : null}
                   </div>
                 </div>
+                {provenanceTools.length ? (
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-3">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Tools</div>
+                    <ul className="mt-2 grid gap-2">
+                      {provenanceTools.map((tool) => (
+                        <li key={tool} className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700">
+                          {tool}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
                 {row.provenance.citations.length ? (
                   <ul className="grid gap-2">
                     {row.provenance.citations.slice(0, 4).map((citation, index) => (
@@ -191,7 +247,7 @@ export default function RuleDetailModal({
                   </ul>
                 ) : (
                   <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-3 text-xs text-slate-500">
-                    No provenance citations available.
+                    No methodology refs were provided for this rule.
                   </div>
                 )}
                 {traceSections.length ? (
@@ -245,7 +301,7 @@ export default function RuleDetailModal({
                   </ul>
                 ) : (
                   <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-500">
-                    No expected evidence metadata
+                    This rule does not define expected evidence.
                   </div>
                 )}
               </div>

--- a/src/app/m/_components/VersionSelector.tsx
+++ b/src/app/m/_components/VersionSelector.tsx
@@ -1,25 +1,35 @@
 "use client";
 
 import { useMemo } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+import type { MethodVersionLineage } from "@/app/m/_lib/methodVersionMetadata";
 
 type VersionSelectorProps = {
   methodCode: string;
   versions: string[];
   selectedVersion?: string;
+  lineage?: MethodVersionLineage | null;
 };
 
 export default function VersionSelector({
   methodCode,
   versions,
   selectedVersion,
+  lineage,
 }: VersionSelectorProps) {
   const router = useRouter();
   const value = selectedVersion ?? "";
 
   const options = useMemo(() => {
-    return versions.map((version) => ({ value: version, label: version }));
-  }, [versions]);
+    return versions.map((version) => {
+      let suffix = "";
+      if (version === lineage?.currentVersion) suffix = " (current)";
+      else if (version === lineage?.previousVersion) suffix = " (previous)";
+      else if (version === lineage?.nextVersion) suffix = " (next)";
+      return { value: version, label: `${version}${suffix}` };
+    });
+  }, [lineage?.currentVersion, lineage?.nextVersion, lineage?.previousVersion, versions]);
 
   if (options.length === 0) {
     return (
@@ -30,26 +40,48 @@ export default function VersionSelector({
   }
 
   return (
-    <label className="flex items-center gap-2 text-xs text-slate-600">
-      <span className="shrink-0">Version</span>
-      <select
-        className="w-full rounded-md border border-slate-200 bg-white px-2 py-1 text-sm text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none"
-        value={value}
-        onChange={(event) => {
-          const next = event.target.value;
-          if (!next) return;
-          router.push(`/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(next)}`);
-        }}
-      >
-        <option value="" disabled>
-          Select…
-        </option>
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
+    <div className="grid gap-2">
+      <label className="flex items-center gap-2 text-xs text-slate-600">
+        <span className="shrink-0">Version</span>
+        <select
+          className="w-full rounded-md border border-slate-200 bg-white px-2 py-1 text-sm text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none"
+          value={value}
+          onChange={(event) => {
+            const next = event.target.value;
+            if (!next) return;
+            router.push(`/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(next)}`);
+          }}
+        >
+          <option value="" disabled>
+            Select…
           </option>
-        ))}
-      </select>
-    </label>
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {lineage?.lineage.length && lineage.lineage.length > 1 ? (
+        <div className="flex flex-wrap gap-2 text-[11px]">
+          {lineage.lineage.map((version) => {
+            const active = version === selectedVersion;
+            return (
+              <Link
+                key={version}
+                href={`/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(version)}`}
+                className={`rounded-full border px-2.5 py-1 font-semibold ${
+                  active
+                    ? "border-sky-300 bg-sky-50 text-sky-700"
+                    : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:text-slate-900"
+                }`}
+              >
+                {version}
+              </Link>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/src/app/m/_lib/methodInventory.ts
+++ b/src/app/m/_lib/methodInventory.ts
@@ -1,6 +1,7 @@
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { createHash } from "node:crypto";
+import { collectMethodVersionsFromPack, sortVersions } from "@/app/m/_lib/methodVersionMetadata";
 
 export type MethodInventoryItem = {
   code: string;
@@ -29,6 +30,7 @@ type MethodAccumulator = {
   program?: string;
   sector?: string;
   versions: Set<string>;
+  manifestPaths: Set<string>;
   hashesByVersion: Map<string, string[]>;
   allHashes: string[];
   ruleCountByVersion: Map<string, number>;
@@ -54,23 +56,6 @@ function pickString(entry: Record<string, unknown>, keys: string[]): string | un
     if (typeof value === "string" && value.trim()) return value.trim();
   }
   return undefined;
-}
-
-function versionKey(version: string): [number, number, string] {
-  const trimmed = version.trim();
-  const match = /^v(\d+)[.-](\d+)$/.exec(trimmed);
-  if (!match) return [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY, trimmed];
-  return [Number(match[1] ?? 0), Number(match[2] ?? 0), trimmed];
-}
-
-function sortVersions(versions: string[]): string[] {
-  return [...versions].sort((a, b) => {
-    const [amaj, amin, astr] = versionKey(a);
-    const [bmaj, bmin, bstr] = versionKey(b);
-    if (amaj !== bmaj) return amaj - bmaj;
-    if (amin !== bmin) return amin - bmin;
-    return astr.localeCompare(bstr);
-  });
 }
 
 async function loadManifest(): Promise<Cache> {
@@ -131,6 +116,7 @@ export async function getMethodInventory(): Promise<{
       current = {
         code,
         versions: new Set<string>(),
+        manifestPaths: new Set<string>(),
         hashesByVersion: new Map<string, string[]>(),
         allHashes: [],
         ruleCountByVersion: new Map<string, number>(),
@@ -141,6 +127,8 @@ export async function getMethodInventory(): Promise<{
     current.versions.add(version);
     if (!current.program && program) current.program = program;
     if (!current.sector && sector) current.sector = sector;
+    const manifestPath = pickString(record, ["path"]);
+    if (manifestPath) current.manifestPaths.add(manifestPath);
 
     if (sha) {
       current.allHashes.push(sha);
@@ -158,8 +146,9 @@ export async function getMethodInventory(): Promise<{
     process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ??
     undefined;
 
-  const methods = Array.from(map.values()).map((method) => {
-    const versions = sortVersions(Array.from(method.versions));
+  const methods = await Promise.all(Array.from(map.values()).map(async (method) => {
+    const packVersions = await collectMethodVersionsFromPack(method.code, Array.from(method.manifestPaths));
+    const versions = sortVersions(Array.from(new Set([...method.versions, ...packVersions.versions])));
     const latestVersion = versions.at(-1);
 
     const versionAuditHashes: Record<string, string | undefined> = {};
@@ -180,7 +169,7 @@ export async function getMethodInventory(): Promise<{
       versionCount: versions.length,
       ruleCountByVersion,
       hasRich: false,
-      hasPrevious: false,
+      hasPrevious: packVersions.hasPrevious,
       generated_at: generatedAt,
       source_sha: sourceSha,
       audit_hashes: {
@@ -189,7 +178,7 @@ export async function getMethodInventory(): Promise<{
       },
       versionAuditHashes,
     } satisfies MethodInventoryItem;
-  });
+  }));
 
   methods.sort((a, b) => {
     const program = a.program.localeCompare(b.program);

--- a/src/app/m/_lib/methodRules.ts
+++ b/src/app/m/_lib/methodRules.ts
@@ -2,6 +2,21 @@ import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { loadManifestEntries, type ManifestEntry } from "@/lib/manifest/cards";
+import { resolveMethodVersionFiles } from "@/app/m/_lib/methodVersionMetadata";
+
+export type RuleCitation = {
+  sectionId?: string;
+  anchor?: string;
+  label?: string;
+};
+
+export type RuleReference = {
+  primarySection?: string;
+  sectionAnchor?: string;
+  sectionStableId?: string;
+  sections: string[];
+  tools: string[];
+};
 
 export type RuleSummary = {
   id: string;
@@ -10,13 +25,15 @@ export type RuleSummary = {
   tags: string[];
   type?: string;
   text?: string;
+  summary?: string;
+  logic?: string;
+  notes?: string;
+  when?: string[];
+  expectedEvidence?: string[];
   sectionId?: string;
   anchor?: string;
-  citations?: Array<{
-    sectionId?: string;
-    anchor?: string;
-    label?: string;
-  }>;
+  citations?: RuleCitation[];
+  refs?: RuleReference;
 };
 
 export type RuleFull = RuleSummary & {
@@ -24,11 +41,8 @@ export type RuleFull = RuleSummary & {
   sha256?: string;
   sectionId?: string;
   anchor?: string;
-  citations?: Array<{
-    sectionId?: string;
-    anchor?: string;
-    label?: string;
-  }>;
+  citations?: RuleCitation[];
+  refs?: RuleReference;
   sourcePath?: string;
 };
 
@@ -64,10 +78,47 @@ function pickStringArray(entry: Record<string, unknown>, keys: string[]): string
   return [];
 }
 
+function pickNestedStringArray(entry: Record<string, unknown>, keyPaths: string[][]): string[] {
+  for (const keys of keyPaths) {
+    let current: unknown = entry;
+    let valid = true;
+    for (const key of keys) {
+      if (!current || typeof current !== "object") {
+        valid = false;
+        break;
+      }
+      current = (current as Record<string, unknown>)[key];
+    }
+    if (valid && Array.isArray(current)) {
+      return current.map((item) => String(item).trim()).filter(Boolean);
+    }
+  }
+  return [];
+}
+
 function sectionIdFromAnchor(value?: string): string | undefined {
   if (!value) return undefined;
   const match = value.match(/S-\d{1,6}/i);
   return match ? match[0] : undefined;
+}
+
+function pickRefs(entry: Record<string, unknown>): RuleReference | undefined {
+  const refs = entry.refs && typeof entry.refs === "object" ? (entry.refs as Record<string, unknown>) : null;
+  const sections = refs && Array.isArray(refs.sections) ? refs.sections.map((item) => String(item).trim()).filter(Boolean) : [];
+  const tools = refs && Array.isArray(refs.tools) ? refs.tools.map((item) => String(item).trim()).filter(Boolean) : [];
+  const primarySection = refs ? pickString(refs, ["primary_section", "primarySection"]) : undefined;
+  const sectionAnchor = refs ? pickString(refs, ["section_anchor", "sectionAnchor", "anchor"]) : undefined;
+  const sectionStableId = refs ? pickString(refs, ["section_stable_id", "sectionStableId"]) : undefined;
+
+  if (!primarySection && !sectionAnchor && !sectionStableId && !sections.length && !tools.length) return undefined;
+
+  return {
+    primarySection: primarySection ?? sections[0] ?? undefined,
+    sectionAnchor: sectionAnchor ?? undefined,
+    sectionStableId: sectionStableId ?? primarySection ?? sections[0] ?? undefined,
+    sections,
+    tools,
+  };
 }
 
 function pickCitations(entry: Record<string, unknown>): RuleFull["citations"] {
@@ -108,6 +159,13 @@ function pickCitations(entry: Record<string, unknown>): RuleFull["citations"] {
   }
 
   return citations.length ? citations : undefined;
+}
+
+function pickExpectedEvidence(entry: Record<string, unknown>): string[] {
+  return pickNestedStringArray(entry, [
+    ["requirement_coverage", "expected_evidence"],
+    ["requirementCoverage", "expectedEvidence"],
+  ]);
 }
 
 function stableDerivedId(seed: string): string {
@@ -172,8 +230,13 @@ function coerceRulesFromUnknown(parsed: unknown): RuleFull[] {
     const record = item as Record<string, unknown>;
     const rawId = pickString(record, ["id", "rule_id", "ruleId", "key"]);
     const title = pickString(record, ["title", "label", "name"]) ?? rawId;
-    const text =
-      pickString(record, ["text", "rule", "content", "body", "description", "summary"]) ?? "";
+    const summary = pickString(record, ["summary", "title", "label", "name"]);
+    const logic = pickString(record, ["logic", "text", "rule", "content", "body", "description"]);
+    const notes = pickString(record, ["notes", "note"]);
+    const when = pickStringArray(record, ["when", "conditions"]);
+    const refs = pickRefs(record);
+    const citations = pickCitations(record) ?? refs?.sections.map((sectionId) => ({ sectionId, label: sectionId }));
+    const text = logic ?? summary ?? "";
     const id =
       rawId ??
       (title
@@ -183,13 +246,19 @@ function coerceRulesFromUnknown(parsed: unknown): RuleFull[] {
       id,
       title: title ?? id,
       text,
-      snippet: snippetFromText(text || title || id),
+      summary: summary ?? undefined,
+      logic: logic ?? undefined,
+      notes: notes ?? undefined,
+      when,
+      expectedEvidence: pickExpectedEvidence(record),
+      snippet: snippetFromText(summary || text || title || id),
       tags: pickStringArray(record, ["tags", "labels"]),
       type: pickString(record, ["type", "kind", "category"]),
       sha256: pickString(record, ["sha256", "hash"]),
-      sectionId: pickString(record, ["sectionId", "section_id"]),
-      anchor: pickString(record, ["anchor", "href"]),
-      citations: pickCitations(record),
+      sectionId: pickString(record, ["sectionId", "section_id"]) ?? refs?.primarySection ?? refs?.sectionStableId,
+      anchor: pickString(record, ["anchor", "href"]) ?? refs?.sectionAnchor,
+      citations,
+      refs,
       sourcePath: pickString(record, ["path", "sourcePath", "source_path"]),
     });
   }
@@ -211,6 +280,11 @@ function coerceRulesFromManifest(entries: ManifestEntry[]): RuleFull[] {
         id,
         title,
         text,
+        summary: text,
+        logic: undefined,
+        notes: undefined,
+        when: [],
+        expectedEvidence: [],
         snippet: snippetFromText(text || title),
         tags: Array.isArray(entry.tags) ? entry.tags : [],
         type: undefined,
@@ -240,7 +314,7 @@ export async function loadMethodRules(code: string, version: string): Promise<Ru
       Boolean(entry.id),
   );
 
-  const manifestPath =
+  let manifestPath =
     entries
       .map((entry) =>
         typeof (entry as Record<string, unknown>).path === "string"
@@ -249,21 +323,34 @@ export async function loadMethodRules(code: string, version: string): Promise<Ru
       )
       .find((value): value is string => Boolean(value)) ?? undefined;
 
+  if (!manifestPath) {
+    const resolved = await resolveMethodVersionFiles(normalizedCode, normalizedVersion);
+    if (resolved) {
+      manifestPath = path.relative(process.cwd(), path.join(resolved.dir, "rules.json"));
+    }
+  }
+
   if (manifestPath) {
     const loaded = await tryLoadRulesFile(manifestPath);
     if (loaded) {
       const full = coerceRulesFromUnknown(loaded.parsed);
       const byId = new Map(full.map((rule) => [rule.id, rule]));
-      const rules = full.map(({ id, title, snippet, tags, type, text, sectionId, anchor, citations }) => ({
+      const rules = full.map(({ id, title, snippet, tags, type, text, summary, logic, notes, when, expectedEvidence, sectionId, anchor, citations, refs }) => ({
         id,
         title,
         snippet,
         tags,
         type,
         text,
+        summary,
+        logic,
+        notes,
+        when,
+        expectedEvidence,
         sectionId,
         anchor,
         citations,
+        refs,
       }));
       rules.sort((a, b) => a.id.localeCompare(b.id));
       return { rules, byId, source: loaded.source };
@@ -272,16 +359,22 @@ export async function loadMethodRules(code: string, version: string): Promise<Ru
 
   const full = coerceRulesFromManifest(entries);
   const byId = new Map(full.map((rule) => [rule.id, rule]));
-  const rules = full.map(({ id, title, snippet, tags, type, text, sectionId, anchor, citations }) => ({
+  const rules = full.map(({ id, title, snippet, tags, type, text, summary, logic, notes, when, expectedEvidence, sectionId, anchor, citations, refs }) => ({
     id,
     title,
     snippet,
     tags,
     type,
     text,
+    summary,
+    logic,
+    notes,
+    when,
+    expectedEvidence,
     sectionId,
     anchor,
     citations,
+    refs,
   }));
   rules.sort((a, b) => a.id.localeCompare(b.id));
   return { rules, byId, source: "manifest" };

--- a/src/app/m/_lib/methodSections.ts
+++ b/src/app/m/_lib/methodSections.ts
@@ -1,6 +1,7 @@
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { loadManifestEntries, type ManifestEntry } from "@/lib/manifest/cards";
+import { resolveMethodVersionFiles } from "@/app/m/_lib/methodVersionMetadata";
 
 export type SectionSummary = {
   id: string;
@@ -202,7 +203,7 @@ export async function loadMethodSections(code: string, version: string): Promise
     (entry) => entry.methodology === normalizedCode && entry.version === normalizedVersion,
   );
 
-  const manifestPath =
+  let manifestPath =
     entries
       .map((entry) =>
         typeof (entry as Record<string, unknown>).path === "string"
@@ -210,6 +211,13 @@ export async function loadMethodSections(code: string, version: string): Promise
           : null,
       )
       .find((value): value is string => Boolean(value)) ?? undefined;
+
+  if (!manifestPath) {
+    const resolved = await resolveMethodVersionFiles(normalizedCode, normalizedVersion);
+    if (resolved) {
+      manifestPath = path.relative(process.cwd(), path.join(resolved.dir, "rules.json"));
+    }
+  }
 
   if (manifestPath) {
     const loaded = await tryLoadSectionsFile(manifestPath);

--- a/src/app/m/_lib/methodVersionMetadata.ts
+++ b/src/app/m/_lib/methodVersionMetadata.ts
@@ -1,0 +1,194 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { loadManifestEntries } from "@/lib/manifest/cards";
+
+export type MethodVersionLineage = {
+  familyKey?: string;
+  currentVersion: string;
+  previousVersion?: string;
+  nextVersion?: string;
+  lineage: string[];
+  metaPath?: string;
+};
+
+type ResolvedMethodVersion = {
+  dir: string;
+  metaPath?: string;
+  manifestPath?: string;
+  rootCurrentDir?: string;
+};
+
+function pickString(entry: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = entry[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function versionKey(version: string): [number, number, string] {
+  const trimmed = version.trim();
+  const match = /^v(\d+)[.-](\d+(?:\.\d+)*)$/i.exec(trimmed);
+  if (!match) return [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY, trimmed];
+  const major = Number(match[1] ?? 0);
+  const minorParts = String(match[2] ?? "0")
+    .split(".")
+    .map((part) => Number(part));
+  const minor = minorParts.reduce((acc, part, index) => acc + part / 10 ** (index * 3), 0);
+  return [major, minor, trimmed];
+}
+
+export function sortVersions(versions: string[]): string[] {
+  return [...versions].sort((a, b) => {
+    const [amaj, amin, astr] = versionKey(a);
+    const [bmaj, bmin, bstr] = versionKey(b);
+    if (amaj !== bmaj) return amaj - bmaj;
+    if (amin !== bmin) return amin - bmin;
+    return astr.localeCompare(bstr);
+  });
+}
+
+function resolveRepoRelativeCandidates(manifestPath: string): string[] {
+  const normalized = path.normalize(manifestPath);
+  if (!normalized || path.isAbsolute(normalized)) return [];
+  const direct = path.join(process.cwd(), normalized);
+  const publicPrefixed = normalized.startsWith(`public${path.sep}`) ? null : path.join(process.cwd(), "public", normalized);
+  return Array.from(new Set([direct, publicPrefixed].filter(Boolean) as string[]));
+}
+
+async function tryReadJson(filePath: string): Promise<unknown | null> {
+  try {
+    const raw = await readFile(filePath, "utf8");
+    return JSON.parse(raw);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function manifestDirectoriesForCode(code: string): Promise<Array<{ dir: string; manifestPath: string }>> {
+  const entries = (await loadManifestEntries()).filter(
+    (entry) => entry.methodology === code && typeof (entry as Record<string, unknown>).path === "string",
+  );
+  const directories = new Map<string, string>();
+
+  for (const entry of entries) {
+    const manifestPath = ((entry as Record<string, unknown>).path as string).trim();
+    for (const candidate of resolveRepoRelativeCandidates(manifestPath)) {
+      const dir = path.dirname(candidate);
+      try {
+        await stat(dir);
+        directories.set(dir, candidate);
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return Array.from(directories.entries()).map(([dir, manifestPath]) => ({ dir, manifestPath }));
+}
+
+export async function resolveMethodVersionFiles(code: string, version: string): Promise<ResolvedMethodVersion | null> {
+  const directories = await manifestDirectoriesForCode(code);
+
+  for (const entry of directories) {
+    if (path.basename(entry.dir) === version) {
+      const metaPath = path.join(entry.dir, "META.json");
+      return {
+        dir: entry.dir,
+        metaPath,
+        manifestPath: entry.manifestPath,
+        rootCurrentDir: entry.dir,
+      };
+    }
+  }
+
+  for (const entry of directories) {
+    const previousDir = path.join(entry.dir, "previous", version);
+    try {
+      await stat(previousDir);
+      return {
+        dir: previousDir,
+        metaPath: path.join(previousDir, "META.json"),
+        rootCurrentDir: entry.dir,
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+async function lineageFromRootCurrentDir(rootCurrentDir: string): Promise<string[]> {
+  const versions = new Set<string>([path.basename(rootCurrentDir)]);
+  const previousDir = path.join(rootCurrentDir, "previous");
+  try {
+    const entries = await readdir(previousDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory() && entry.name.trim()) versions.add(entry.name.trim());
+    }
+  } catch {
+    // no previous lineage on disk
+  }
+  return sortVersions(Array.from(versions));
+}
+
+export async function loadMethodVersionLineage(
+  code: string,
+  version: string,
+  knownVersions: string[] = [],
+): Promise<MethodVersionLineage | null> {
+  const resolved = await resolveMethodVersionFiles(code, version);
+  const meta =
+    resolved?.metaPath ? ((await tryReadJson(resolved.metaPath)) as Record<string, unknown> | null) : null;
+  const metaLineage = Array.isArray(meta?.lineage)
+    ? meta.lineage.map((item) => String(item)).filter(Boolean)
+    : [];
+  const rootLineage = resolved?.rootCurrentDir ? await lineageFromRootCurrentDir(resolved.rootCurrentDir) : [];
+  const lineage = sortVersions(Array.from(new Set([...knownVersions, ...rootLineage, ...metaLineage])));
+  const currentIndex = lineage.indexOf(version);
+
+  return {
+    familyKey: pickString(meta ?? {}, ["family_key", "familyKey", "id"]) ?? code,
+    currentVersion: pickString(meta ?? {}, ["current_version", "currentVersion", "version"]) ?? version,
+    previousVersion:
+      pickString(meta ?? {}, ["previous_version", "previousVersion"]) ??
+      (currentIndex > 0 ? lineage[currentIndex - 1] : undefined),
+    nextVersion:
+      pickString(meta ?? {}, ["next_version", "nextVersion"]) ??
+      (currentIndex >= 0 && currentIndex < lineage.length - 1 ? lineage[currentIndex + 1] : undefined),
+    lineage,
+    metaPath: resolved?.metaPath,
+  };
+}
+
+export async function collectMethodVersionsFromPack(
+  code: string,
+  manifestPaths: string[],
+): Promise<{ versions: string[]; hasPrevious: boolean }> {
+  const versions = new Set<string>();
+
+  for (const manifestPath of manifestPaths) {
+    for (const candidate of resolveRepoRelativeCandidates(manifestPath)) {
+      const dir = path.dirname(candidate);
+      versions.add(path.basename(dir));
+      const previousDir = path.join(dir, "previous");
+      try {
+        const entries = await readdir(previousDir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory() && entry.name.trim()) versions.add(entry.name.trim());
+        }
+      } catch {
+        // no previous directory
+      }
+    }
+  }
+
+  const sorted = sortVersions(Array.from(versions));
+  return {
+    versions: sorted,
+    hasPrevious: sorted.length > 1,
+  };
+}

--- a/src/app/m/_lib/requirementCoverage.test.ts
+++ b/src/app/m/_lib/requirementCoverage.test.ts
@@ -16,11 +16,23 @@ describe("buildRequirementCoverageRows", () => {
         title: "Monitoring frequency",
         snippet: "Maintain a monitoring report and spreadsheet workbook.",
         text: "Maintain a monitoring report and spreadsheet workbook for each reporting period.",
+        summary: "Maintain a monitoring report and spreadsheet workbook.",
+        logic: "Maintain a monitoring report and spreadsheet workbook for each reporting period.",
+        notes: "Retain the workbook appendices.",
+        when: ["Each reporting period."],
+        expectedEvidence: ["monitoring-report", "spreadsheet-workbook"],
         tags: ["monitoring"],
         type: "operational",
         sectionId: "S-10",
         anchor: "#S-10",
         citations: [{ sectionId: "S-10", label: "Section 10" }],
+        refs: {
+          primarySection: "S-10",
+          sectionAnchor: "#S-10",
+          sectionStableId: "S-10",
+          sections: ["S-10"],
+          tools: ["UNFCCC/TOOL-1"],
+        },
       },
       {
         id: "R-2",
@@ -52,6 +64,10 @@ describe("buildRequirementCoverageRows", () => {
         ruleSummary: {
           title: "Monitoring frequency",
           snippet: "Maintain a monitoring report and spreadsheet workbook.",
+          summary: "Maintain a monitoring report and spreadsheet workbook.",
+          logic: "Maintain a monitoring report and spreadsheet workbook for each reporting period.",
+          notes: "Retain the workbook appendices.",
+          when: ["Each reporting period."],
           type: "operational",
           tags: ["monitoring"],
         },
@@ -60,6 +76,10 @@ describe("buildRequirementCoverageRows", () => {
           sectionTitle: "Monitoring",
           page: undefined,
           anchor: "#S-10",
+          primarySection: "S-10",
+          sectionAnchor: "#S-10",
+          sectionStableId: "S-10",
+          tools: ["UNFCCC/TOOL-1"],
           citations: [{ sectionId: "S-10", label: "Section 10" }],
         },
         expectedEvidenceTypes: ["monitoring-report", "spreadsheet-workbook"],
@@ -75,6 +95,10 @@ describe("buildRequirementCoverageRows", () => {
         ruleSummary: {
           title: "Eligibility boundary",
           snippet: "Document eligibility and ownership evidence.",
+          summary: undefined,
+          logic: undefined,
+          notes: undefined,
+          when: [],
           type: undefined,
           tags: [],
         },
@@ -83,9 +107,13 @@ describe("buildRequirementCoverageRows", () => {
           sectionTitle: undefined,
           page: undefined,
           anchor: undefined,
+          primarySection: undefined,
+          sectionAnchor: undefined,
+          sectionStableId: undefined,
+          tools: [],
           citations: [],
         },
-        expectedEvidenceTypes: ["eligibility-proof"],
+        expectedEvidenceTypes: [],
         linkedEvidence: [],
         candidateEvidence: [],
         status: "needs-review",
@@ -127,7 +155,7 @@ describe("buildRequirementCoverageRows", () => {
       ],
     });
 
-    expect(summarizeExpectedEvidence(rows[0]?.expectedEvidenceTypes ?? [])).toBe("No expected evidence metadata");
+    expect(summarizeExpectedEvidence(rows[0]?.expectedEvidenceTypes ?? [])).toBe("No expected evidence defined for this rule.");
     expect(summarizeLinkedEvidence(rows[0]?.linkedEvidence ?? [])).toBe("No linked evidence yet");
     expect(requirementProvenanceHint(rows[0]!)).toBe("Provenance pending");
   });

--- a/src/app/m/_lib/requirementCoverage.ts
+++ b/src/app/m/_lib/requirementCoverage.ts
@@ -5,10 +5,21 @@ type RequirementCoverageRuleInput = {
   title: string;
   snippet: string;
   text?: string;
+  summary?: string;
+  logic?: string;
+  notes?: string;
+  when?: string[];
+  expectedEvidence?: string[];
   type?: string;
   tags: string[];
   sectionId?: string;
   anchor?: string;
+  refs?: {
+    primarySection?: string;
+    sectionAnchor?: string;
+    sectionStableId?: string;
+    tools?: string[];
+  };
   citations?: Array<{
     sectionId?: string;
     anchor?: string;
@@ -35,6 +46,10 @@ export type RequirementCoverageProvenance = {
   sectionTitle?: string;
   page?: number;
   anchor?: string;
+  primarySection?: string;
+  sectionAnchor?: string;
+  sectionStableId?: string;
+  tools: string[];
   citations: Array<{
     sectionId?: string;
     anchor?: string;
@@ -64,6 +79,10 @@ export type RequirementCoverageRow = {
   ruleSummary: {
     title: string;
     snippet: string;
+    summary?: string;
+    logic?: string;
+    notes?: string;
+    when: string[];
     type?: string;
     tags: string[];
   };
@@ -140,20 +159,19 @@ function normalizeSnippet(rule: RequirementCoverageRuleInput): string {
 }
 
 function expectedEvidenceTypesForRule(rule: RequirementCoverageRuleInput): RequirementCoverageExpectedEvidenceType[] {
-  const haystack = `${rule.title} ${rule.text} ${rule.tags.join(" ")} ${rule.type ?? ""}`.toLowerCase();
-  const expected = new Set<RequirementCoverageExpectedEvidenceType>();
-
-  if (/(monitor|report|frequency|sampling|inspection)/.test(haystack)) expected.add("monitoring-report");
-  if (/(sheet|spreadsheet|table|workbook|ledger)/.test(haystack)) expected.add("spreadsheet-workbook");
-  if (/\bpdd\b|project design document|project description/.test(haystack)) expected.add("pdd");
-  if (/(gis|geojson|shape|shapefile|stac|aoi|spatial|map)/.test(haystack)) expected.add("gis");
-  if (/(qa|qc|quality|checklist|inspection record)/.test(haystack)) expected.add("qa-qc-record");
-  if (/(eligib|boundary|ownership|legal|title|attestation)/.test(haystack)) expected.add("eligibility-proof");
-  if (/(calculate|formula|equation|parameter|input data|emission factor)/.test(haystack)) {
-    expected.add("calculation-support");
+  const normalized = new Set<RequirementCoverageExpectedEvidenceType>();
+  for (const value of rule.expectedEvidence ?? []) {
+    const key = value.trim().toLowerCase();
+    if (key === "monitoring-report" || key === "monitoring_report") normalized.add("monitoring-report");
+    else if (key === "spreadsheet-workbook" || key === "spreadsheet_workbook" || key === "workbook") normalized.add("spreadsheet-workbook");
+    else if (key === "pdd") normalized.add("pdd");
+    else if (key === "gis") normalized.add("gis");
+    else if (key === "qa-qc-record" || key === "qa_qc_record") normalized.add("qa-qc-record");
+    else if (key === "eligibility-proof" || key === "eligibility_proof") normalized.add("eligibility-proof");
+    else if (key === "calculation-support" || key === "calculation_support") normalized.add("calculation-support");
+    else if (key) normalized.add("other");
   }
-
-  return Array.from(expected);
+  return Array.from(normalized);
 }
 
 function normalizeLinkedEvidence(
@@ -280,7 +298,7 @@ function deriveStatus(
 }
 
 export function summarizeExpectedEvidence(types: RequirementCoverageExpectedEvidenceType[]): string {
-  if (!types.length) return "No expected evidence metadata";
+  if (!types.length) return "No expected evidence defined for this rule.";
   return types.map((type) => EXPECTED_EVIDENCE_LABELS[type] ?? type).join(", ");
 }
 
@@ -295,9 +313,14 @@ export function summarizeLinkedEvidence(items: RequirementCoverageLinkedEvidence
 }
 
 export function requirementProvenanceHint(row: RequirementCoverageRow): string {
-  const sectionLabel = row.provenance.sectionTitle ?? row.provenance.sectionId ?? null;
+  const sectionLabel =
+    row.provenance.primarySection ??
+    row.provenance.sectionTitle ??
+    row.provenance.sectionStableId ??
+    row.provenance.sectionId ??
+    null;
   const pageLabel = typeof row.provenance.page === "number" ? `p. ${row.provenance.page}` : null;
-  const anchorLabel = row.provenance.anchor ? row.provenance.anchor.replace(/^#/, "") : null;
+  const anchorLabel = (row.provenance.sectionAnchor ?? row.provenance.anchor)?.replace(/^#/, "") ?? null;
   return [sectionLabel, pageLabel, anchorLabel].filter(Boolean).join(" • ") || "Provenance pending";
 }
 
@@ -324,6 +347,10 @@ export function buildRequirementCoverageRows(input: BuildRequirementCoverageRows
         ruleSummary: {
           title: rule.title,
           snippet: normalizeSnippet(rule),
+          summary: rule.summary?.trim() || undefined,
+          logic: rule.logic?.trim() || undefined,
+          notes: rule.notes?.trim() || undefined,
+          when: (rule.when ?? []).map((item) => item.trim()).filter(Boolean),
           type: rule.type,
           tags: rule.tags,
         },
@@ -332,6 +359,10 @@ export function buildRequirementCoverageRows(input: BuildRequirementCoverageRows
           sectionTitle: primarySectionId ? sectionTitleById.get(primarySectionId) : undefined,
           page: undefined,
           anchor: rule.anchor,
+          primarySection: rule.refs?.primarySection,
+          sectionAnchor: rule.refs?.sectionAnchor,
+          sectionStableId: rule.refs?.sectionStableId,
+          tools: rule.refs?.tools ?? [],
           citations: rule.citations ?? [],
         },
         expectedEvidenceTypes: expectedEvidenceTypesForRule(rule),

--- a/tests/components/requirementCoverageWorkspace.test.tsx
+++ b/tests/components/requirementCoverageWorkspace.test.tsx
@@ -23,6 +23,10 @@ const rows: RequirementCoverageRow[] = [
       sectionTitle: "Monitoring",
       page: 12,
       anchor: "#S-10",
+      primarySection: "S-10",
+      sectionAnchor: "#S-10",
+      sectionStableId: "S-10",
+      tools: ["UNFCCC/TOOL-1"],
       citations: [{ sectionId: "S-10", label: "Section 10" }],
     },
     expectedEvidenceTypes: ["monitoring-report", "spreadsheet-workbook"],
@@ -60,6 +64,10 @@ const rows: RequirementCoverageRow[] = [
       sectionTitle: "Eligibility",
       page: undefined,
       anchor: "#S-20",
+      primarySection: "S-20",
+      sectionAnchor: "#S-20",
+      sectionStableId: "S-20",
+      tools: [],
       citations: [{ sectionId: "S-20", label: "Section 20" }],
     },
     expectedEvidenceTypes: [],
@@ -155,7 +163,7 @@ describe("RequirementCoverageWorkspace", () => {
     expect(html).toContain("Pages 4-5");
     expect(html).toContain("The project boundary covers compartments 1 through 4.");
     expect(html).toContain("Complete");
-    expect(html).toContain("No expected evidence metadata");
+    expect(html).toContain("No expected evidence defined for this rule.");
     expect(html).toContain("No linked evidence yet");
     expect(html).toContain("No workbook-derived candidates for this requirement yet.");
     expect(html).toContain("Evidence inventory");

--- a/tests/components/ruleDetailModal.test.tsx
+++ b/tests/components/ruleDetailModal.test.tsx
@@ -8,6 +8,10 @@ const linkedRow: RequirementCoverageRow = {
   ruleSummary: {
     title: "Monitoring frequency",
     snippet: "Maintain a monitoring report and spreadsheet workbook.",
+    summary: "Maintain a monitoring report and spreadsheet workbook.",
+    logic: "Maintain a monitoring report and spreadsheet workbook for each reporting period.",
+    notes: "Retain the workbook appendices.",
+    when: ["Each reporting period."],
     type: "operational",
     tags: ["monitoring"],
   },
@@ -16,6 +20,10 @@ const linkedRow: RequirementCoverageRow = {
     sectionTitle: "Monitoring",
     page: 12,
     anchor: "#S-10",
+    primarySection: "S-10",
+    sectionAnchor: "#S-10",
+    sectionStableId: "S-10",
+    tools: ["UNFCCC/TOOL-1"],
     citations: [{ sectionId: "S-10", label: "Section 10" }],
   },
   expectedEvidenceTypes: ["monitoring-report", "spreadsheet-workbook"],
@@ -37,6 +45,10 @@ const sparseRow: RequirementCoverageRow = {
     sectionTitle: undefined,
     page: undefined,
     anchor: undefined,
+    primarySection: undefined,
+    sectionAnchor: undefined,
+    sectionStableId: undefined,
+    tools: [],
     citations: [],
   },
   expectedEvidenceTypes: ["eligibility-proof"],
@@ -58,7 +70,10 @@ describe("RuleDetailModal", () => {
         open
         row={linkedRow}
         ruleTitle="Monitoring frequency"
-        ruleText="Maintain a monitoring report and spreadsheet workbook for each reporting period."
+        ruleText="Maintain a monitoring report and spreadsheet workbook."
+        ruleLogic="Maintain a monitoring report and spreadsheet workbook for each reporting period."
+        ruleNotes="Retain the workbook appendices."
+        ruleWhen={["Each reporting period."]}
         sourcePath="methodologies/example/rules.rich.json"
         sha256="abc123"
         traceSections={[{ sectionId: "S-10", title: "Monitoring", textSnippet: "Monitoring context" }]}
@@ -68,12 +83,16 @@ describe("RuleDetailModal", () => {
     );
 
     expect(html).toContain("R-1");
+    expect(html).toContain("Maintain a monitoring report and spreadsheet workbook.");
     expect(html).toContain("Maintain a monitoring report and spreadsheet workbook for each reporting period.");
+    expect(html).toContain("Retain the workbook appendices.");
+    expect(html).toContain("Each reporting period.");
     expect(html).toContain("Complete");
     expect(html).toContain("Methodology provenance");
     expect(html).toContain("Section 10 · Monitoring");
     expect(html).toContain("p. 12");
     expect(html).toContain("operational");
+    expect(html).toContain("UNFCCC/TOOL-1");
     expect(html).toContain("Audit details");
     expect(html).not.toContain("<details open");
     expect(html).toContain("Monitoring report");
@@ -95,7 +114,7 @@ describe("RuleDetailModal", () => {
       />,
     );
 
-    expect(html).toContain("No expected evidence metadata");
+    expect(html).toContain("This rule does not define expected evidence.");
     expect(html).toContain("Next: link supporting evidence or leave a reviewer note.");
     expect(html).toContain("S-4");
   });

--- a/tests/lib/evidenceInventory.test.ts
+++ b/tests/lib/evidenceInventory.test.ts
@@ -195,7 +195,13 @@ describe("evidence inventory", () => {
       rules: [
         { id: "R-1", title: "Rule 1", snippet: "Rule one", tags: [] },
         { id: "R-2", title: "Rule 2", snippet: "Rule two", tags: [] },
-        { id: "R-3", title: "Workbook rule", snippet: "Spreadsheet workbook table", tags: [] },
+        {
+          id: "R-3",
+          title: "Workbook rule",
+          snippet: "Spreadsheet workbook table",
+          expectedEvidence: ["spreadsheet-workbook"],
+          tags: [],
+        },
       ],
       inventoryItems: inventory,
     });
@@ -304,6 +310,7 @@ describe("evidence inventory", () => {
           id: namespacedRuleId,
           title: "Workbook rule",
           snippet: "Maintain a monitoring report and spreadsheet workbook.",
+          expectedEvidence: ["spreadsheet-workbook"],
           tags: [],
         },
       ],

--- a/tests/roadmap/finalize-merged.test.ts
+++ b/tests/roadmap/finalize-merged.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "@jest/globals";
 import { finalizeMergedItems } from "../../scripts/roadmap/finalize-merged.mjs";
+import {
+  getRoadmapItemStatus,
+  parseRoadmapDirective,
+  setRoadmapItemStatus,
+} from "../../scripts/roadmap/roadmap-lib.mjs";
 
 describe("finalizeMergedItems", () => {
   test("forces merged pr label and in_progress item to done", () => {
@@ -22,5 +27,41 @@ describe("finalizeMergedItems", () => {
     const result = finalizeMergedItems([{ id: "PR20", status: "planned" }], "PR19");
     const pr20 = result.items.find((item) => item.id === "PR20");
     expect(pr20?.status).toBe("planned");
+  });
+
+  test("finalizes in-progress roadmap phases to done on merge", () => {
+    const result = finalizeMergedItems([{ id: "RC5", status: "in_progress" }], null);
+    const rc5 = result.items.find((item) => item.id === "RC5");
+    expect(rc5?.status).toBe("done");
+  });
+});
+
+describe("roadmap phase helpers", () => {
+  test("parses RC items from Roadmap-Update blocks", () => {
+    const directive = parseRoadmapDirective(`
+### Roadmap-Update
+- slug: requirement-coverage
+- items:
+  - RC5: in_progress
+`);
+
+    expect(directive).toEqual({
+      slug: "requirement-coverage",
+      ack: null,
+      items: [{ id: "RC5", status: "in_progress" }],
+    });
+  });
+
+  test("reads and writes phase status through RC ids", () => {
+    const ssot = {
+      phases: {
+        phase_5_pdd_intake: { status: "planned", title: "PDD intake" },
+      },
+    };
+
+    expect(getRoadmapItemStatus(ssot, "RC5")).toBe("planned");
+    expect(setRoadmapItemStatus(ssot, "RC5", "done")).toBe(true);
+    expect(getRoadmapItemStatus(ssot, "RC5")).toBe("done");
+    expect(ssot.phases.phase_5_pdd_intake.status).toBe("done");
   });
 });


### PR DESCRIPTION
## WHAT

- consume rich rule v1 fields in the rule modal
- render methodology provenance from refs
- render expected evidence from requirement_coverage when present
- expose version lineage in the app UI

## WHY

- methodologies now contain richer app-facing rule data and version lineage
- the app is still rendering a thin placeholder model
- this unlocks the payoff from RC5/RC6 and the locked rich-rule v1 contract

**Signed-off-by:** Fred E <fredilly@article6.org>