### PR TITLE
Fix first-win simplification and aggressive UI polish

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import DemoNav from "@/components/DemoNav";
 import FooterHealth from "@/components/FooterHealth";
+import HealthBadge from "@/components/HealthBadge";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -35,7 +36,8 @@ export default function RootLayout({
           </header>
           <div className="flex-1">{children}</div>
           <footer className="border-t border-slate-200/80 bg-white/92">
-            <div className="mx-auto flex w-full max-w-6xl justify-end px-4 py-3 md:px-8">
+            <div className="mx-auto flex w-full max-w-6xl items-center justify-end gap-3 px-4 py-3 md:px-8">
+              <HealthBadge />
               <FooterHealth />
             </div>
           </footer>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import DemoNav from "@/components/DemoNav";
 import FooterHealth from "@/components/FooterHealth";
-import HealthBadge from "@/components/HealthBadge";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -21,18 +20,15 @@ export default function RootLayout({
         <link rel="preload" href="/fonts/Geist-latin.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
         <link rel="preload" href="/fonts/GeistMono-latin.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
       </head>
-      <body className="bg-slate-50 antialiased">
+      <body className="bg-[#f9f9f9] antialiased">
         <div className="flex min-h-screen flex-col">
-          <header className="sticky top-0 z-40 border-b border-slate-200/80 bg-white/92 backdrop-blur">
-            <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:justify-between md:px-8">
+          <header className="sticky top-0 z-40 border-b border-slate-200 bg-white/92 backdrop-blur">
+            <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-2.5 md:flex-row md:items-center md:justify-between md:px-8">
               <Link href="/" className="space-y-1 rounded-xl px-2 py-1 transition hover:bg-white">
                 <p className="text-[11px] uppercase tracking-[0.22em] text-slate-400">Article 6</p>
-                <h1 className="text-base font-semibold text-slate-900">Quick Check</h1>
+                <h1 className="text-sm font-semibold text-slate-900">Quick Check</h1>
               </Link>
               <div className="flex items-center gap-4 md:ml-auto">
-                {/* Always-on health indicator */}
-                {/* Ensure no feature-flag wraps this */}
-                <HealthBadge />
                 <DemoNav />
               </div>
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,9 +21,9 @@ export default function RootLayout({
         <link rel="preload" href="/fonts/Geist-latin.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
         <link rel="preload" href="/fonts/GeistMono-latin.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
       </head>
-      <body className="bg-white antialiased">
+      <body className="bg-slate-50 antialiased">
         <div className="flex min-h-screen flex-col">
-          <header className="sticky top-0 z-40 border-b border-slate-200/80 bg-[#fbfaf6]/92 backdrop-blur">
+          <header className="sticky top-0 z-40 border-b border-slate-200/80 bg-white/92 backdrop-blur">
             <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:justify-between md:px-8">
               <Link href="/" className="space-y-1 rounded-xl px-2 py-1 transition hover:bg-white">
                 <p className="text-[11px] uppercase tracking-[0.22em] text-slate-400">Article 6</p>
@@ -38,7 +38,7 @@ export default function RootLayout({
             </div>
           </header>
           <div className="flex-1">{children}</div>
-          <footer className="border-t border-slate-200/80 bg-[#fbfaf6]/92">
+          <footer className="border-t border-slate-200/80 bg-white/92">
             <div className="mx-auto flex w-full max-w-6xl justify-end px-4 py-3 md:px-8">
               <FooterHealth />
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
         <link rel="preload" href="/fonts/Geist-latin.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
         <link rel="preload" href="/fonts/GeistMono-latin.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
       </head>
-      <body className="bg-[#f8f5ed] antialiased">
+      <body className="bg-white antialiased">
         <div className="flex min-h-screen flex-col">
           <header className="sticky top-0 z-40 border-b border-slate-200/80 bg-[#fbfaf6]/92 backdrop-blur">
             <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:justify-between md:px-8">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,8 @@ import HealthBadge from "@/components/HealthBadge";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Article 6 demo",
-  description: "Explore chat, audit, manifest, and issuance demo surfaces.",
+  title: "Article 6 Quick Check",
+  description: "Check one climate claim against one piece of evidence, then open the full review.",
 };
 
 export default function RootLayout({
@@ -21,12 +21,12 @@ export default function RootLayout({
         <link rel="preload" href="/fonts/Geist-latin.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
         <link rel="preload" href="/fonts/GeistMono-latin.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
       </head>
-      <body className="bg-slate-50 antialiased">
+      <body className="bg-[#f8f5ed] antialiased">
         <div className="flex min-h-screen flex-col">
-          <header className="sticky top-0 z-40 border-b border-slate-200 bg-white/80 backdrop-blur">
+          <header className="sticky top-0 z-40 border-b border-slate-200/80 bg-[#fbfaf6]/92 backdrop-blur">
             <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:justify-between md:px-8">
-              <Link href="/" className="space-y-1 rounded-xl px-1 py-0.5 transition hover:bg-slate-100">
-                <p className="text-xs uppercase tracking-wide text-slate-400">Article 6</p>
+              <Link href="/" className="space-y-1 rounded-xl px-2 py-1 transition hover:bg-white">
+                <p className="text-[11px] uppercase tracking-[0.22em] text-slate-400">Article 6</p>
                 <h1 className="text-base font-semibold text-slate-900">Quick Check</h1>
               </Link>
               <div className="flex items-center gap-4 md:ml-auto">
@@ -38,7 +38,7 @@ export default function RootLayout({
             </div>
           </header>
           <div className="flex-1">{children}</div>
-          <footer className="border-t border-slate-200 bg-white/80">
+          <footer className="border-t border-slate-200/80 bg-[#fbfaf6]/92">
             <div className="mx-auto flex w-full max-w-6xl justify-end px-4 py-3 md:px-8">
               <FooterHealth />
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import ChatApp from "@/components/chat/ChatApp";
 
 export default function Page() {
   return (
-    <main className="min-h-screen bg-slate-50">
+    <main className="min-h-screen bg-[#f9f9f9]">
       <Suspense
         fallback={
           <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-12 md:px-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import ChatApp from "@/components/chat/ChatApp";
 
 export default function Page() {
   return (
-    <main className="min-h-screen bg-white">
+    <main className="min-h-screen bg-slate-50">
       <Suspense
         fallback={
           <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-12 md:px-8">

--- a/src/components/DemoNav.tsx
+++ b/src/components/DemoNav.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowUpRight } from "lucide-react";
 import { usePathname } from "next/navigation";
 
 type DemoRoute = {
@@ -24,10 +23,10 @@ export default function DemoNav() {
         const isActive =
           pathname === route.href ||
           (route.href !== "/" && pathname.startsWith(`${route.href}/`));
-        const base = "inline-flex items-center gap-1 rounded-full border px-3 py-1.5 font-medium shadow-sm transition";
+        const base = "inline-flex items-center rounded-full border px-3 py-1.5 font-medium transition";
         const appearance = isActive
-          ? "border-slate-900 bg-slate-900 text-white hover:bg-slate-800"
-          : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:text-slate-900";
+          ? "border-slate-900 bg-slate-900 text-white shadow-sm hover:bg-slate-800"
+          : "border-slate-200 bg-white/85 text-slate-700 hover:border-slate-300 hover:bg-white hover:text-slate-900";
 
         return (
           <Link
@@ -37,7 +36,6 @@ export default function DemoNav() {
             className={`${base} ${appearance}`}
           >
             <span>{route.title}</span>
-            <ArrowUpRight className="h-3 w-3" />
           </Link>
         );
       })}

--- a/src/components/DemoNav.tsx
+++ b/src/components/DemoNav.tsx
@@ -25,7 +25,7 @@ export default function DemoNav() {
           (route.href !== "/" && pathname.startsWith(`${route.href}/`));
         const base = "inline-flex items-center rounded-full border px-3 py-1.5 font-medium transition";
         const appearance = isActive
-          ? "border-slate-900 bg-slate-900 text-white shadow-sm hover:bg-slate-800"
+          ? "border-black bg-black text-white hover:bg-neutral-900"
           : "border-slate-200 bg-white/85 text-slate-700 hover:border-slate-300 hover:bg-white hover:text-slate-900";
 
         return (

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -11,22 +11,10 @@ export default function ChatApp() {
   const selectedVersion = deeplink.resolved.resolvedVersion;
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-4 py-6 md:px-8 md:py-10">
-        <div className="mx-auto w-full max-w-4xl">
-          <div className="max-w-2xl">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Article 6</div>
-            <h2 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 md:text-[2.7rem]">
-              One claim. One file.
-            </h2>
-            <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
-              Quick Check gives you a preliminary match, then opens the full review only when you need it.
-            </p>
-          </div>
-        </div>
-
+    <div className="min-h-screen bg-[#f9f9f9]">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-4 py-10 md:px-8 md:py-16">
         {selectedMethod || deeplinkWarnings.length ? (
-          <div className="mx-auto w-full max-w-4xl rounded-3xl border border-slate-200 bg-white/85 p-4 text-sm text-slate-700 shadow-sm backdrop-blur">
+          <div className="mx-auto w-full max-w-lg rounded-3xl border border-slate-200 bg-white p-4 text-sm text-slate-700 shadow-sm">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Deeplink context</span>
               {deeplink.loading ? (

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -17,10 +17,10 @@ export default function ChatApp() {
           <div className="max-w-2xl">
             <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Article 6</div>
             <h2 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 md:text-[2.7rem]">
-              One claim. One file. One clear next step.
+              One claim. One file.
             </h2>
             <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
-              Start with one claim and one file. Quick Check gives you a preliminary match, then opens the full review only when you need it.
+              Quick Check gives you a preliminary match, then opens the full review only when you need it.
             </p>
           </div>
         </div>

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -11,10 +11,22 @@ export default function ChatApp() {
   const selectedVersion = deeplink.resolved.resolvedVersion;
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(226,232,240,0.75),_rgba(255,255,255,1)_55%)]">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-6 md:px-8 md:py-10">
+    <div className="min-h-screen bg-[linear-gradient(180deg,#f4efe4_0%,#f8f6f0_18%,#ffffff_62%)]">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-4 py-6 md:px-8 md:py-10">
+        <div className="mx-auto w-full max-w-4xl">
+          <div className="max-w-2xl">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Article 6</div>
+            <h2 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 md:text-[2.7rem]">
+              One claim. One file. One clear next step.
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
+              Quick Check is the fast front door. Start with a simple win, then open the full review only if the preliminary match looks right.
+            </p>
+          </div>
+        </div>
+
         {selectedMethod || deeplinkWarnings.length ? (
-          <div className="mx-auto w-full max-w-3xl rounded-3xl border border-slate-200 bg-white/85 p-4 text-sm text-slate-700 shadow-sm backdrop-blur">
+          <div className="mx-auto w-full max-w-4xl rounded-3xl border border-slate-200 bg-white/85 p-4 text-sm text-slate-700 shadow-sm backdrop-blur">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Deeplink context</span>
               {deeplink.loading ? (

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -11,7 +11,7 @@ export default function ChatApp() {
   const selectedVersion = deeplink.resolved.resolvedVersion;
 
   return (
-    <div className="min-h-screen bg-[linear-gradient(180deg,#f4efe4_0%,#f8f6f0_18%,#ffffff_62%)]">
+    <div className="min-h-screen bg-white">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-4 py-6 md:px-8 md:py-10">
         <div className="mx-auto w-full max-w-4xl">
           <div className="max-w-2xl">
@@ -20,7 +20,7 @@ export default function ChatApp() {
               One claim. One file. One clear next step.
             </h2>
             <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
-              Quick Check is the fast front door. Start with a simple win, then open the full review only if the preliminary match looks right.
+              Start with one claim and one file. Quick Check gives you a preliminary match, then opens the full review only when you need it.
             </p>
           </div>
         </div>

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -11,7 +11,7 @@ export default function ChatApp() {
   const selectedVersion = deeplink.resolved.resolvedVersion;
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-slate-50">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-4 py-6 md:px-8 md:py-10">
         <div className="mx-auto w-full max-w-4xl">
           <div className="max-w-2xl">

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -10,7 +10,6 @@ import {
   Loader2,
   SearchCheck,
   SlidersHorizontal,
-  Sparkles,
   TriangleAlert,
   Upload,
   X,
@@ -1451,54 +1450,30 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
   return (
     <div className="w-full">
-      <div className="mx-auto w-full max-w-4xl rounded-[2.2rem] border border-[#d7d3ca] bg-[linear-gradient(180deg,rgba(252,251,247,0.98),rgba(255,255,255,0.96))] px-5 py-5 shadow-[0_38px_120px_-46px_rgba(15,23,42,0.45)] md:px-7 md:py-7">
-        <div className="rounded-[1.9rem] border border-slate-900/10 bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.24),_rgba(15,23,42,0.96)_60%)] px-5 py-5 text-white md:px-6">
+      <div className="mx-auto w-full max-w-4xl rounded-[2rem] border border-slate-200 bg-white px-5 py-5 shadow-sm md:px-7 md:py-7">
+        <div className="px-1 py-1 md:px-2">
           <div className="flex items-start justify-between gap-4">
             <div className="max-w-2xl">
-              <div className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-200">
-                <Sparkles className="h-3.5 w-3.5" />
-                First win flow
-              </div>
-              <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white md:text-[2.4rem]">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Quick Check</div>
+              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 md:text-[2.4rem]">
                 Check one claim
               </h1>
-              <p className="mt-3 max-w-xl text-sm leading-6 text-slate-300 md:text-[15px]">
+              <p className="mt-3 max-w-xl text-sm leading-6 text-slate-600 md:text-[15px]">
                 Start with one claim and one file. Quick Check returns a clean preliminary match, then opens the full review only if you want to keep going.
               </p>
             </div>
-            {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-300" /> : null}
+            {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" /> : null}
           </div>
-          <div className="mt-5 grid gap-3 md:grid-cols-3">
-            <div className="rounded-2xl border border-white/10 bg-white/7 px-4 py-3">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Beat 01</div>
-              <div className="mt-1 text-sm font-medium text-white">Write the claim</div>
-              <div className="mt-1 text-sm text-slate-300">Keep it short and concrete.</div>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/7 px-4 py-3">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Beat 02</div>
-              <div className="mt-1 text-sm font-medium text-white">Add one file</div>
-              <div className="mt-1 text-sm text-slate-300">PDF, photo, workbook, or CSV.</div>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/7 px-4 py-3">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Beat 03</div>
-              <div className="mt-1 text-sm font-medium text-white">Get the next step</div>
-              <div className="mt-1 text-sm text-slate-300">Preliminary match first, full review second.</div>
-            </div>
+          <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 text-sm text-slate-600">
+            <div>Write the claim</div>
+            <div>Add one file</div>
+            <div>Review the next step</div>
           </div>
         </div>
 
         <div className="mt-5 grid gap-4">
-          <div className="rounded-[1.8rem] border border-[#e3ddd2] bg-white/90 p-4 md:p-5">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">01 Claim</div>
-                <div className="mt-1 text-lg font-semibold text-slate-950">Say the thing you want checked</div>
-              </div>
-              <div className="hidden rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 md:block">
-                Keep it to one sentence
-              </div>
-            </div>
-            <label className="mt-4 grid gap-2 text-sm text-slate-700">
+          <div className="rounded-[1.6rem] border border-slate-200 bg-[#faf8f3] p-4 md:p-5">
+            <label className="grid gap-2 text-sm text-slate-700">
               <span className="font-medium text-slate-900">Claim</span>
               <textarea
                 value={draft.claimText}
@@ -1518,18 +1493,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       };
                     },
                     null,
-                  );
-                  clearDecisionState();
-                }}
-                rows={3}
-                placeholder="Example: The monitoring report covers the full reporting period."
-                className="w-full rounded-[1.4rem] border border-slate-200 bg-[#fbfaf6] px-4 py-4 text-base leading-7 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white"
+                );
+                clearDecisionState();
+              }}
+              rows={3}
+              placeholder="Example: The monitoring report covers the full reporting period."
+                className="w-full rounded-[1.25rem] border border-slate-200 bg-white px-4 py-4 text-base leading-7 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white"
                 ref={claimRef}
               />
               {fieldErrors.claim ? <span className="text-sm text-rose-700">{fieldErrors.claim}</span> : null}
             </label>
             <div className="mt-4">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Example claims</div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Examples</div>
               <div className="mt-2 flex flex-wrap gap-2">
                 {CLAIM_SUGGESTIONS.slice(0, 2).map((suggestion) => (
                   <button
@@ -1560,16 +1535,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 ))}
               </div>
             </div>
-          </div>
-
-          <div className="rounded-[1.8rem] border border-[#e3ddd2] bg-[#f8f5ed] p-4 md:p-5">
-            <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="mt-5 flex flex-wrap items-start justify-between gap-3 border-t border-slate-200 pt-5">
               <div className="min-w-0">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">02 Evidence</div>
-                <div className="mt-1 text-lg font-semibold text-slate-950">Add one piece of evidence</div>
-                <div className="mt-1 text-sm text-slate-600">
-                  Upload one file to run the check.
-                </div>
+                <div className="text-sm font-medium text-slate-900">Evidence</div>
+                <div className="mt-1 text-sm text-slate-600">Upload one file to run the check.</div>
               </div>
               <input
                 ref={fileRef}
@@ -1581,7 +1550,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               <button
                 type="button"
                 onClick={() => fileRef.current?.click()}
-                className="inline-flex items-center gap-2 rounded-full border border-slate-900 bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-800"
+                className="inline-flex items-center gap-2 rounded-full border border-black bg-black px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-neutral-900"
               >
                 <Upload className="h-4 w-4" />
                 Upload evidence
@@ -1589,12 +1558,12 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             </div>
 
             {!selectedEvidenceLabel ? (
-              <div className="mt-4 rounded-[1.5rem] border border-dashed border-slate-300 bg-white/80 px-4 py-5 text-sm text-slate-600">
+              <div className="mt-4 rounded-[1.25rem] border border-dashed border-slate-300 bg-white px-4 py-5 text-sm text-slate-600">
                 Drop in one file or use the upload button. Quick Check works best when the file directly supports the claim you wrote above.
               </div>
             ) : (
               <>
-                <div className="mt-4 flex items-center justify-between gap-3 rounded-[1.4rem] border border-slate-200 bg-white px-4 py-3">
+                <div className="mt-4 flex items-center justify-between gap-3 rounded-[1.2rem] border border-slate-200 bg-white px-4 py-3">
                   <div className="min-w-0">
                     <div className="truncate text-sm font-medium text-slate-900">{selectedEvidenceLabel}</div>
                     <div className="mt-1 text-xs text-slate-500">{selectedEvidenceMeta}</div>
@@ -1608,7 +1577,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     <X className="h-4 w-4" />
                   </button>
                 </div>
-                <div className="mt-3 rounded-[1.5rem] border border-slate-200 bg-white px-4 py-4">
+                <div className="mt-3 rounded-[1.2rem] border border-slate-200 bg-white px-4 py-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
                       <div className="text-sm font-medium text-slate-900">Extraction preview</div>
@@ -1633,7 +1602,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   ) : extractionPreview ? (
                     <>
                       <div className="mt-4 grid gap-3 md:grid-cols-[1.1fr_0.9fr]">
-                        <div className="rounded-2xl border border-slate-200 bg-[#fbfaf6] px-4 py-3">
+                        <div className="rounded-2xl border border-slate-200 bg-[#faf8f3] px-4 py-3">
                           <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">What we found first</div>
                           {extractionHighlights.length ? (
                             <div className="mt-2 flex flex-wrap gap-2">
@@ -1649,7 +1618,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                             </div>
                           )}
                         </div>
-                        <div className="rounded-2xl border border-slate-200 bg-[#fbfaf6] px-4 py-3">
+                        <div className="rounded-2xl border border-slate-200 bg-[#faf8f3] px-4 py-3">
                           <div className="grid gap-2 text-sm text-slate-700">
                             <div>
                               <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Source</div>
@@ -1716,7 +1685,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             {fieldErrors.evidence ? <div className="mt-3 text-sm text-rose-700">{fieldErrors.evidence}</div> : null}
           </div>
 
-          <div className="rounded-[1.6rem] border border-[#e3ddd2] bg-white/90 p-4">
+          <div className="rounded-[1.4rem] border border-slate-200 bg-white p-4">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div className="flex flex-wrap items-center gap-2">
                 <button
@@ -1751,7 +1720,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 type="button"
                 disabled={!canRunQuickCheck}
                 onClick={() => void runQuickCheck()}
-                className="inline-flex min-w-[15rem] items-center justify-center gap-2 rounded-full bg-slate-900 px-5 py-3.5 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
+                className="inline-flex min-w-[15rem] items-center justify-center gap-2 rounded-full bg-black px-5 py-3.5 text-sm font-semibold text-white transition hover:bg-neutral-900 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
               >
                 {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
                 Run quick check
@@ -1850,7 +1819,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   <button
                     type="button"
                     onClick={openFullReviewFromRecovery}
-                    className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+                    className="rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
                   >
                     Open full review
                   </button>
@@ -1859,7 +1828,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     <button
                       type="button"
                       onClick={handleTryAnotherMethodology}
-                      className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+                      className="rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
                     >
                       Try another methodology
                     </button>
@@ -2042,7 +2011,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     <button
                       type="button"
                       onClick={handleContinueToWorkspace}
-                      className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+                      className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
                     >
                       <FolderOpen className="h-4 w-4" />
                       Open full review

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1454,20 +1454,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         <div className="px-1 py-1 md:px-2">
           <div className="flex items-start justify-between gap-4">
             <div className="max-w-2xl">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Quick Check</div>
-              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 md:text-[2.4rem]">
+              <h1 className="text-3xl font-semibold tracking-tight text-slate-950 md:text-[2.4rem]">
                 Check one claim
               </h1>
               <p className="mt-3 max-w-xl text-sm leading-6 text-slate-600 md:text-[15px]">
-                Start with one claim and one file. Quick Check returns a clean preliminary match, then opens the full review only if you want to keep going.
+                Add one file to get a preliminary match.
               </p>
             </div>
             {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" /> : null}
-          </div>
-          <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 text-sm text-slate-600">
-            <div>Write the claim</div>
-            <div>Add one file</div>
-            <div>Review the next step</div>
           </div>
         </div>
 
@@ -1504,7 +1498,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               {fieldErrors.claim ? <span className="text-sm text-rose-700">{fieldErrors.claim}</span> : null}
             </label>
             <div className="mt-4">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Examples</div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Try an example</div>
               <div className="mt-2 flex flex-wrap gap-2">
                 {CLAIM_SUGGESTIONS.slice(0, 2).map((suggestion) => (
                   <button
@@ -1538,7 +1532,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             <div className="mt-5 flex flex-wrap items-start justify-between gap-3 border-t border-slate-200 pt-5">
               <div className="min-w-0">
                 <div className="text-sm font-medium text-slate-900">Evidence</div>
-                <div className="mt-1 text-sm text-slate-600">Upload one file to run the check.</div>
+                <div className="mt-1 text-sm text-slate-600">Upload one file.</div>
               </div>
               <input
                 ref={fileRef}
@@ -1559,7 +1553,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
             {!selectedEvidenceLabel ? (
               <div className="mt-4 rounded-[1.25rem] border border-dashed border-slate-300 bg-white px-4 py-5 text-sm text-slate-600">
-                Drop in one file or use the upload button. Quick Check works best when the file directly supports the claim you wrote above.
+                Drop in one file or use the upload button.
               </div>
             ) : (
               <>
@@ -1581,9 +1575,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
                       <div className="text-sm font-medium text-slate-900">Extraction preview</div>
-                      <div className="mt-1 text-sm text-slate-600">
-                        Review the evidence signal before you run the check.
-                      </div>
+                      <div className="mt-1 text-sm text-slate-600">Review the evidence signal.</div>
                     </div>
                     <div className="flex items-center gap-2">
                       {extractionPreviewState ? (
@@ -1731,9 +1723,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           {showAdvancedOptions ? (
             <div className="rounded-[1.6rem] border border-slate-200 bg-white px-4 py-4">
               <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Options</div>
-              <div className="mt-1 text-sm text-slate-600">
-                Reuse saved evidence or narrow the methodology only when you want a stricter check.
-              </div>
               <div className="mt-4 grid gap-4 md:grid-cols-2">
                 <div className={`rounded-2xl border px-4 py-3 ${showSavedEvidence ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}>
                   <div className="text-sm font-medium text-slate-900">Saved evidence</div>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -9,7 +9,6 @@ import {
   FolderOpen,
   Loader2,
   SearchCheck,
-  SlidersHorizontal,
   TriangleAlert,
   Upload,
   X,
@@ -1450,7 +1449,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
   return (
     <div className="w-full">
-      <div className="mx-auto w-full max-w-xl">
+      <div className="mx-auto w-full max-w-2xl px-4 md:px-0">
         <div className="flex flex-col items-center text-center">
           <div className="flex w-full items-start justify-center">
             <div className="w-full">
@@ -1695,9 +1694,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 type="button"
                 onClick={() => void handleTryDemoCheck()}
                 disabled={submitting}
-                className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                className="text-xs text-slate-400 underline underline-offset-4 transition hover:text-slate-600 disabled:cursor-not-allowed disabled:text-slate-300"
               >
-                <CheckCircle2 className="h-4 w-4" />
                 Try demo check
               </button>
               <button
@@ -1710,12 +1708,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     setShowMethodology(false);
                   }
                 }}
-                className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                className="text-xs text-slate-400 underline underline-offset-4 transition hover:text-slate-600"
                 aria-expanded={showAdvancedOptions}
               >
-                <SlidersHorizontal className="h-4 w-4" />
                 Options
-                {showAdvancedOptions ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
               </button>
             </div>
           </div>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -9,6 +9,8 @@ import {
   FolderOpen,
   Loader2,
   SearchCheck,
+  SlidersHorizontal,
+  Sparkles,
   TriangleAlert,
   Upload,
   X,
@@ -517,8 +519,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [recoveryState, setRecoveryState] = useState<RecoveryState>(null);
   const [matchCandidates, setMatchCandidates] = useState<ResolvedMatchCandidate[]>([]);
   const [pendingInventoryId, setPendingInventoryId] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
   const [showSavedEvidence, setShowSavedEvidence] = useState(false);
   const [showMethodology, setShowMethodology] = useState(false);
+  const [showExtractionDetails, setShowExtractionDetails] = useState(false);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
     loading: false,
@@ -698,6 +702,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     () => (extractionPreview ? deriveQuickCheckExtractionState(extractionPreview) : null),
     [extractionPreview],
   );
+  const showAdvancedOptions = showAdvanced || showSavedEvidence || showMethodology;
+  const extractionHighlights = extractionPreview?.extractedFacts.slice(0, 3) ?? [];
   const normalizedResult = useMemo(
     () =>
       renderedResult
@@ -785,6 +791,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   }, [selectedEvidenceSources]);
 
   useEffect(() => {
+    if (showSavedEvidence || showMethodology) {
+      setShowAdvanced(true);
+    }
+  }, [showMethodology, showSavedEvidence]);
+
+  useEffect(() => {
+    if (extractionState.error || extractionPreviewState?.value === "weak") {
+      setShowExtractionDetails(true);
+    }
+  }, [extractionPreviewState, extractionState.error]);
+
+  useEffect(() => {
     if (!result?.id) return;
     resultRef.current?.focus();
   }, [result?.id]);
@@ -799,8 +817,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   function resetQuickCheckUi() {
     clearDecisionState();
     setPendingInventoryId("");
+    setShowAdvanced(false);
     setShowSavedEvidence(false);
     setShowMethodology(false);
+    setShowExtractionDetails(false);
   }
 
   function openFullReviewFromRecovery() {
@@ -1431,65 +1451,66 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
   return (
     <div className="w-full">
-      <div className="mx-auto w-full max-w-3xl rounded-[2rem] border border-slate-200/80 bg-white px-5 py-5 shadow-[0_30px_80px_-36px_rgba(15,23,42,0.4)] md:px-7 md:py-6">
-        <div className="flex items-start justify-between gap-4">
-          <div className="max-w-2xl">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Article 6 quick check</div>
-            <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950 md:text-[2rem]">
-              Check one claim
-            </h1>
-            <p className="mt-2 text-sm leading-6 text-slate-600">
-              Add one piece of evidence. We&apos;ll find the best matching requirement and open the full review.
-            </p>
+      <div className="mx-auto w-full max-w-4xl rounded-[2.2rem] border border-[#d7d3ca] bg-[linear-gradient(180deg,rgba(252,251,247,0.98),rgba(255,255,255,0.96))] px-5 py-5 shadow-[0_38px_120px_-46px_rgba(15,23,42,0.45)] md:px-7 md:py-7">
+        <div className="rounded-[1.9rem] border border-slate-900/10 bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.24),_rgba(15,23,42,0.96)_60%)] px-5 py-5 text-white md:px-6">
+          <div className="flex items-start justify-between gap-4">
+            <div className="max-w-2xl">
+              <div className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-200">
+                <Sparkles className="h-3.5 w-3.5" />
+                First win flow
+              </div>
+              <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white md:text-[2.4rem]">
+                Check one claim
+              </h1>
+              <p className="mt-3 max-w-xl text-sm leading-6 text-slate-300 md:text-[15px]">
+                Start with one claim and one file. Quick Check returns a clean preliminary match, then opens the full review only if you want to keep going.
+              </p>
+            </div>
+            {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-300" /> : null}
           </div>
-          {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" /> : null}
+          <div className="mt-5 grid gap-3 md:grid-cols-3">
+            <div className="rounded-2xl border border-white/10 bg-white/7 px-4 py-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Beat 01</div>
+              <div className="mt-1 text-sm font-medium text-white">Write the claim</div>
+              <div className="mt-1 text-sm text-slate-300">Keep it short and concrete.</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/7 px-4 py-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Beat 02</div>
+              <div className="mt-1 text-sm font-medium text-white">Add one file</div>
+              <div className="mt-1 text-sm text-slate-300">PDF, photo, workbook, or CSV.</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/7 px-4 py-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Beat 03</div>
+              <div className="mt-1 text-sm font-medium text-white">Get the next step</div>
+              <div className="mt-1 text-sm text-slate-300">Preliminary match first, full review second.</div>
+            </div>
+          </div>
         </div>
 
         <div className="mt-5 grid gap-4">
-          <label className="grid gap-2 text-sm text-slate-700">
-            <span className="font-medium text-slate-900">Claim</span>
-            <textarea
-              value={draft.claimText}
-              onChange={(event) => {
-                const value = event.target.value;
-                updateDraft(
-                  (current) => {
-                    const nextMethodology = resetMethodologyForUserInput(current);
-                    return {
-                      ...current,
-                      ...nextMethodology,
-                      claimText: value,
-                      matchedRequirementId: undefined,
-                      matchedRequirementLabel: undefined,
-                      status: "draft",
-                      resultId: undefined,
-                    };
-                  },
-                  null,
-                );
-                clearDecisionState();
-              }}
-              rows={3}
-              placeholder="Example: The monitoring report covers the full reporting period."
-              className="w-full rounded-[1.6rem] border border-slate-200 bg-slate-50/70 px-4 py-4 text-base leading-7 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white"
-              ref={claimRef}
-            />
-            {fieldErrors.claim ? <span className="text-sm text-rose-700">{fieldErrors.claim}</span> : null}
-          </label>
-
-          <div className="flex flex-wrap gap-2">
-            {CLAIM_SUGGESTIONS.slice(0, 2).map((suggestion) => (
-              <button
-                key={suggestion}
-                type="button"
-                onClick={() => {
+          <div className="rounded-[1.8rem] border border-[#e3ddd2] bg-white/90 p-4 md:p-5">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">01 Claim</div>
+                <div className="mt-1 text-lg font-semibold text-slate-950">Say the thing you want checked</div>
+              </div>
+              <div className="hidden rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 md:block">
+                Keep it to one sentence
+              </div>
+            </div>
+            <label className="mt-4 grid gap-2 text-sm text-slate-700">
+              <span className="font-medium text-slate-900">Claim</span>
+              <textarea
+                value={draft.claimText}
+                onChange={(event) => {
+                  const value = event.target.value;
                   updateDraft(
                     (current) => {
                       const nextMethodology = resetMethodologyForUserInput(current);
                       return {
                         ...current,
                         ...nextMethodology,
-                        claimText: suggestion,
+                        claimText: value,
                         matchedRequirementId: undefined,
                         matchedRequirementLabel: undefined,
                         status: "draft",
@@ -1500,17 +1521,52 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   );
                   clearDecisionState();
                 }}
-                className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
-              >
-                {suggestion}
-              </button>
-            ))}
+                rows={3}
+                placeholder="Example: The monitoring report covers the full reporting period."
+                className="w-full rounded-[1.4rem] border border-slate-200 bg-[#fbfaf6] px-4 py-4 text-base leading-7 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white"
+                ref={claimRef}
+              />
+              {fieldErrors.claim ? <span className="text-sm text-rose-700">{fieldErrors.claim}</span> : null}
+            </label>
+            <div className="mt-4">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Example claims</div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {CLAIM_SUGGESTIONS.slice(0, 2).map((suggestion) => (
+                  <button
+                    key={suggestion}
+                    type="button"
+                    onClick={() => {
+                      updateDraft(
+                        (current) => {
+                          const nextMethodology = resetMethodologyForUserInput(current);
+                          return {
+                            ...current,
+                            ...nextMethodology,
+                            claimText: suggestion,
+                            matchedRequirementId: undefined,
+                            matchedRequirementLabel: undefined,
+                            status: "draft",
+                            resultId: undefined,
+                          };
+                        },
+                        null,
+                      );
+                      clearDecisionState();
+                    }}
+                    className="rounded-full border border-slate-200 bg-[#f7f4eb] px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
+                  >
+                    {suggestion}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
 
-          <div className="rounded-[1.6rem] border border-slate-200 bg-slate-50/75 p-4">
-            <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="rounded-[1.8rem] border border-[#e3ddd2] bg-[#f8f5ed] p-4 md:p-5">
+            <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0">
-                <div className="text-sm font-medium text-slate-900">Add one piece of evidence</div>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">02 Evidence</div>
+                <div className="mt-1 text-lg font-semibold text-slate-950">Add one piece of evidence</div>
                 <div className="mt-1 text-sm text-slate-600">
                   Upload one file to run the check.
                 </div>
@@ -1525,16 +1581,20 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               <button
                 type="button"
                 onClick={() => fileRef.current?.click()}
-                className="inline-flex items-center gap-2 rounded-full border border-slate-900 bg-white px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-100"
+                className="inline-flex items-center gap-2 rounded-full border border-slate-900 bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-800"
               >
                 <Upload className="h-4 w-4" />
                 Upload evidence
               </button>
             </div>
 
-            {selectedEvidenceLabel ? (
+            {!selectedEvidenceLabel ? (
+              <div className="mt-4 rounded-[1.5rem] border border-dashed border-slate-300 bg-white/80 px-4 py-5 text-sm text-slate-600">
+                Drop in one file or use the upload button. Quick Check works best when the file directly supports the claim you wrote above.
+              </div>
+            ) : (
               <>
-                <div className="mt-3 flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-3 py-3">
+                <div className="mt-4 flex items-center justify-between gap-3 rounded-[1.4rem] border border-slate-200 bg-white px-4 py-3">
                   <div className="min-w-0">
                     <div className="truncate text-sm font-medium text-slate-900">{selectedEvidenceLabel}</div>
                     <div className="mt-1 text-xs text-slate-500">{selectedEvidenceMeta}</div>
@@ -1548,199 +1608,235 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     <X className="h-4 w-4" />
                   </button>
                 </div>
-                <div className="mt-3 rounded-2xl border border-slate-200 bg-white px-4 py-4">
-                  <div className="flex items-start justify-between gap-3">
+                <div className="mt-3 rounded-[1.5rem] border border-slate-200 bg-white px-4 py-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
                       <div className="text-sm font-medium text-slate-900">Extraction preview</div>
                       <div className="mt-1 text-sm text-slate-600">
-                        Review what Quick Check could extract from the uploaded file before analysis.
+                        Review the evidence signal before you run the check.
                       </div>
                     </div>
-                    {extractionState.loading ? <Loader2 className="h-4 w-4 animate-spin text-slate-400" /> : null}
+                    <div className="flex items-center gap-2">
+                      {extractionPreviewState ? (
+                        <span className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold ${extractionStateBadgeClass(extractionPreviewState.value)}`}>
+                          {extractionPreviewState.label}
+                        </span>
+                      ) : null}
+                      {extractionState.loading ? <Loader2 className="h-4 w-4 animate-spin text-slate-400" /> : null}
+                    </div>
                   </div>
+
                   {extractionState.error ? (
                     <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
                       Extraction preview is unavailable right now. {extractionState.error}
                     </div>
                   ) : extractionPreview ? (
-                    <div className="mt-4 grid gap-4 md:grid-cols-2">
-                      <div>
-                        <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Source</div>
-                        <div className="mt-1 text-sm font-medium text-slate-900">{sourceModeLabel(activeSourceMode)}</div>
-                        <div className="mt-1 text-xs text-slate-500">{selectedEvidenceLabel || "No file selected"}</div>
-                      </div>
-                      <div>
-                        <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Document type</div>
-                        <div className="mt-1 text-sm font-medium text-slate-900">{extractionPreview.documentType}</div>
-                      </div>
-                      <div>
-                        <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Extraction signal</div>
-                        {extractionPreviewState ? (
-                          <>
-                            <span className={`mt-1 inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold ${extractionStateBadgeClass(extractionPreviewState.value)}`}>
-                              {extractionPreviewState.label}
-                            </span>
-                            <div className="mt-2 text-xs text-slate-500">{extractionPreviewState.description}</div>
-                          </>
-                        ) : null}
-                      </div>
-                      <div className="md:col-span-2">
-                        <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Extracted facts relevant to the claim</div>
-                        {extractionPreview.extractedFacts.length ? (
-                          <div className="mt-2 flex flex-wrap gap-2">
-                            {extractionPreview.extractedFacts.map((fact) => (
-                              <span key={fact} className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] font-medium text-slate-700">
-                                {fact}
-                              </span>
-                            ))}
-                          </div>
-                        ) : (
-                          <div className="mt-2 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
-                            We couldn&apos;t extract enough usable data from this file for a reliable preliminary match yet.
-                          </div>
-                        )}
-                      </div>
-                      <div>
-                        <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Methodology mentions</div>
-                        <div className="mt-2 flex flex-wrap gap-2">
-                          {(extractionPreview.methodologyMentions.length ? extractionPreview.methodologyMentions : ["None detected"]).map((mention) => (
-                            <span key={mention} className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700">
-                              {mention}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                      <div>
-                        <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Warnings</div>
-                        <div className="mt-2 grid gap-2">
-                          {(extractionPreview.warnings.length ? extractionPreview.warnings : ["No extraction warnings from the active source."]).map((warning) => (
-                            <div key={warning} className="text-sm text-slate-600">
-                              {warning}
+                    <>
+                      <div className="mt-4 grid gap-3 md:grid-cols-[1.1fr_0.9fr]">
+                        <div className="rounded-2xl border border-slate-200 bg-[#fbfaf6] px-4 py-3">
+                          <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">What we found first</div>
+                          {extractionHighlights.length ? (
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              {extractionHighlights.map((fact) => (
+                                <span key={fact} className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700">
+                                  {fact}
+                                </span>
+                              ))}
                             </div>
-                          ))}
+                          ) : (
+                            <div className="mt-2 text-sm text-amber-900">
+                              We couldn&apos;t extract enough usable data from this file for a reliable preliminary match yet.
+                            </div>
+                          )}
+                        </div>
+                        <div className="rounded-2xl border border-slate-200 bg-[#fbfaf6] px-4 py-3">
+                          <div className="grid gap-2 text-sm text-slate-700">
+                            <div>
+                              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Source</div>
+                              <div className="mt-1 font-medium text-slate-900">{sourceModeLabel(activeSourceMode)}</div>
+                            </div>
+                            <div>
+                              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Document type</div>
+                              <div className="mt-1 font-medium text-slate-900">{extractionPreview.documentType}</div>
+                            </div>
+                          </div>
                         </div>
                       </div>
-                    </div>
+
+                      <button
+                        type="button"
+                        onClick={() => setShowExtractionDetails((value) => !value)}
+                        className="mt-4 inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                        aria-expanded={showExtractionDetails}
+                      >
+                        {showExtractionDetails ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                        {showExtractionDetails ? "Hide extraction details" : "Show extraction details"}
+                      </button>
+
+                      {showExtractionDetails ? (
+                        <div className="mt-4 grid gap-4 md:grid-cols-2">
+                          <div>
+                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Extraction signal</div>
+                            {extractionPreviewState ? (
+                              <>
+                                <span className={`mt-1 inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold ${extractionStateBadgeClass(extractionPreviewState.value)}`}>
+                                  {extractionPreviewState.label}
+                                </span>
+                                <div className="mt-2 text-xs text-slate-500">{extractionPreviewState.description}</div>
+                              </>
+                            ) : null}
+                          </div>
+                          <div>
+                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Methodology mentions</div>
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              {(extractionPreview.methodologyMentions.length ? extractionPreview.methodologyMentions : ["None detected"]).map((mention) => (
+                                <span key={mention} className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700">
+                                  {mention}
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+                          <div className="md:col-span-2">
+                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Warnings</div>
+                            <div className="mt-2 grid gap-2">
+                              {(extractionPreview.warnings.length ? extractionPreview.warnings : ["No extraction warnings from the active source."]).map((warning) => (
+                                <div key={warning} className="text-sm text-slate-600">
+                                  {warning}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        </div>
+                      ) : null}
+                    </>
                   ) : null}
                 </div>
               </>
-            ) : null}
+            )}
             {fieldErrors.evidence ? <div className="mt-3 text-sm text-rose-700">{fieldErrors.evidence}</div> : null}
           </div>
 
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="flex flex-wrap items-center gap-2">
+          <div className="rounded-[1.6rem] border border-[#e3ddd2] bg-white/90 p-4">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handleTryDemoCheck()}
+                  disabled={submitting}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-[#f7f4eb] px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                >
+                  <CheckCircle2 className="h-4 w-4" />
+                  Try demo check
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    const nextValue = !showAdvancedOptions;
+                    setShowAdvanced(nextValue);
+                    if (!nextValue) {
+                      setShowSavedEvidence(false);
+                      setShowMethodology(false);
+                    }
+                  }}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                  aria-expanded={showAdvancedOptions}
+                >
+                  <SlidersHorizontal className="h-4 w-4" />
+                  Options
+                  {showAdvancedOptions ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                </button>
+              </div>
+
               <button
                 type="button"
-                onClick={() => void handleTryDemoCheck()}
-                disabled={submitting}
-                className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                disabled={!canRunQuickCheck}
+                onClick={() => void runQuickCheck()}
+                className="inline-flex min-w-[15rem] items-center justify-center gap-2 rounded-full bg-slate-900 px-5 py-3.5 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
               >
-                <CheckCircle2 className="h-4 w-4" />
-                Try demo check
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowSavedEvidence((value) => !value)}
-                className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
-                aria-expanded={showSavedEvidence}
-              >
-                {showSavedEvidence ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-                Use saved evidence instead
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowMethodology((value) => !value)}
-                className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
-                aria-expanded={showMethodology}
-              >
-                {showMethodology ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-                Narrow by methodology
+                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                Run quick check
               </button>
             </div>
-
-            <button
-              type="button"
-              disabled={!canRunQuickCheck}
-              onClick={() => void runQuickCheck()}
-              className="inline-flex min-w-[13rem] items-center justify-center gap-2 rounded-full bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
-            >
-              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-              Analyze claim
-            </button>
           </div>
 
-          {showSavedEvidence ? (
-            <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
-              <div className="text-sm font-medium text-slate-900">Use saved evidence</div>
-              {!draft.methodologyId || !draft.methodologyVersion ? (
-                <div className="mt-2 text-sm text-slate-600">Choose a methodology first to reuse saved evidence.</div>
-              ) : (
-                <div className="mt-3">
-                  <select
-                    value={pendingInventoryId}
-                    onChange={(event) => {
-                      const value = event.target.value;
-                      setPendingInventoryId(value);
-                      if (value) selectExistingEvidence(value);
-                    }}
-                    className="min-w-0 w-full rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-slate-400 focus:bg-white"
-                  >
-                    <option value="">Select saved evidence</option>
-                    {availableInventory.map((item) => (
-                      <option key={item.evidence_id} value={item.evidence_id}>
-                        {inventoryEvidenceLabel(item)}
-                      </option>
-                    ))}
-                  </select>
+          {showAdvancedOptions ? (
+            <div className="rounded-[1.6rem] border border-slate-200 bg-white px-4 py-4">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Options</div>
+              <div className="mt-1 text-sm text-slate-600">
+                Reuse saved evidence or narrow the methodology only when you want a stricter check.
+              </div>
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <div className={`rounded-2xl border px-4 py-3 ${showSavedEvidence ? "border-slate-300 bg-[#fbfaf6]" : "border-slate-200 bg-white"}`}>
+                  <div className="text-sm font-medium text-slate-900">Saved evidence</div>
+                  {!draft.methodologyId || !draft.methodologyVersion ? (
+                    <div className="mt-2 text-sm text-slate-600">Choose a methodology first to reuse saved evidence.</div>
+                  ) : (
+                    <div className="mt-3">
+                      <select
+                        value={pendingInventoryId}
+                        onChange={(event) => {
+                          const value = event.target.value;
+                          setPendingInventoryId(value);
+                          setShowSavedEvidence(true);
+                          if (value) selectExistingEvidence(value);
+                        }}
+                        className="min-w-0 w-full rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-slate-400 focus:bg-white"
+                      >
+                        <option value="">Select saved evidence</option>
+                        {availableInventory.map((item) => (
+                          <option key={item.evidence_id} value={item.evidence_id}>
+                            {inventoryEvidenceLabel(item)}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
-          ) : null}
-
-          {showMethodology ? (
-            <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
-              <label className="grid gap-2 text-sm text-slate-700">
-                <span className="font-medium text-slate-900">Methodology</span>
-                <select
-                  value={draft.methodologyId}
-                  onChange={(event) => {
-                    const methodologyId = event.target.value;
-                    const method = methods.find((item) => item.code === methodologyId);
-                    const methodologyVersion = methodologyId ? pickVersion(method, initialVersion) : "";
-                    updateSession((current) => {
-                      const stagedIds = new Set(current.stagedUploads.map((upload) => upload.evidenceId));
-                  return {
-                    ...current,
-                    draft: {
-                          ...current.draft,
-                          methodologyId,
-                          methodologyVersion,
-                          evidenceIds: current.draft.evidenceIds.filter((id) => stagedIds.has(id)),
-                          matchedRequirementId: undefined,
-                          matchedRequirementLabel: undefined,
-                          status: "draft",
-                          result: null,
-                          resultId: undefined,
-                          updatedAt: nowIso(),
-                    },
-                    result: null,
-                  };
-                });
-                setPendingInventoryId("");
-                clearDecisionState();
-              }}
-                  className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-slate-400 focus:bg-white"
-                >
-                  <option value="">Any methodology</option>
-                  {methods.map((method) => (
-                    <option key={method.code} value={method.code}>
-                      {methodOptionLabel(method)}
-                    </option>
-                  ))}
-                </select>
-                <span className="text-xs text-slate-500">Optional. Use this only when you want to narrow the match.</span>
-              </label>
+                <div className={`rounded-2xl border px-4 py-3 ${showMethodology ? "border-slate-300 bg-[#fbfaf6]" : "border-slate-200 bg-white"}`}>
+                  <label className="grid gap-2 text-sm text-slate-700">
+                    <span className="font-medium text-slate-900">Methodology</span>
+                    <select
+                      value={draft.methodologyId}
+                      onChange={(event) => {
+                        const methodologyId = event.target.value;
+                        const method = methods.find((item) => item.code === methodologyId);
+                        const methodologyVersion = methodologyId ? pickVersion(method, initialVersion) : "";
+                        setShowMethodology(Boolean(methodologyId));
+                        updateSession((current) => {
+                          const stagedIds = new Set(current.stagedUploads.map((upload) => upload.evidenceId));
+                          return {
+                            ...current,
+                            draft: {
+                              ...current.draft,
+                              methodologyId,
+                              methodologyVersion,
+                              evidenceIds: current.draft.evidenceIds.filter((id) => stagedIds.has(id)),
+                              matchedRequirementId: undefined,
+                              matchedRequirementLabel: undefined,
+                              status: "draft",
+                              result: null,
+                              resultId: undefined,
+                              updatedAt: nowIso(),
+                            },
+                            result: null,
+                          };
+                        });
+                        setPendingInventoryId("");
+                        clearDecisionState();
+                      }}
+                      className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-slate-400 focus:bg-white"
+                    >
+                      <option value="">Any methodology</option>
+                      {methods.map((method) => (
+                        <option key={method.code} value={method.code}>
+                          {methodOptionLabel(method)}
+                        </option>
+                      ))}
+                    </select>
+                    <span className="text-xs text-slate-500">Optional. Use this only when you want to narrow the match.</span>
+                  </label>
+                </div>
+              </div>
             </div>
           ) : null}
 

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1472,7 +1472,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         </div>
 
         <div className="mt-5 grid gap-4">
-          <div className="rounded-[1.6rem] border border-slate-200 bg-[#faf8f3] p-4 md:p-5">
+          <div className="rounded-[1.6rem] border border-slate-200 bg-white p-4 md:p-5">
             <label className="grid gap-2 text-sm text-slate-700">
               <span className="font-medium text-slate-900">Claim</span>
               <textarea
@@ -1528,7 +1528,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       );
                       clearDecisionState();
                     }}
-                    className="rounded-full border border-slate-200 bg-[#f7f4eb] px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
+                    className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
                   >
                     {suggestion}
                   </button>
@@ -1602,7 +1602,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   ) : extractionPreview ? (
                     <>
                       <div className="mt-4 grid gap-3 md:grid-cols-[1.1fr_0.9fr]">
-                        <div className="rounded-2xl border border-slate-200 bg-[#faf8f3] px-4 py-3">
+                        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
                           <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">What we found first</div>
                           {extractionHighlights.length ? (
                             <div className="mt-2 flex flex-wrap gap-2">
@@ -1618,7 +1618,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                             </div>
                           )}
                         </div>
-                        <div className="rounded-2xl border border-slate-200 bg-[#faf8f3] px-4 py-3">
+                        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
                           <div className="grid gap-2 text-sm text-slate-700">
                             <div>
                               <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Source</div>
@@ -1692,7 +1692,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   type="button"
                   onClick={() => void handleTryDemoCheck()}
                   disabled={submitting}
-                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-[#f7f4eb] px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
                 >
                   <CheckCircle2 className="h-4 w-4" />
                   Try demo check
@@ -1735,7 +1735,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 Reuse saved evidence or narrow the methodology only when you want a stricter check.
               </div>
               <div className="mt-4 grid gap-4 md:grid-cols-2">
-                <div className={`rounded-2xl border px-4 py-3 ${showSavedEvidence ? "border-slate-300 bg-[#fbfaf6]" : "border-slate-200 bg-white"}`}>
+                <div className={`rounded-2xl border px-4 py-3 ${showSavedEvidence ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}>
                   <div className="text-sm font-medium text-slate-900">Saved evidence</div>
                   {!draft.methodologyId || !draft.methodologyVersion ? (
                     <div className="mt-2 text-sm text-slate-600">Choose a methodology first to reuse saved evidence.</div>
@@ -1761,7 +1761,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     </div>
                   )}
                 </div>
-                <div className={`rounded-2xl border px-4 py-3 ${showMethodology ? "border-slate-300 bg-[#fbfaf6]" : "border-slate-200 bg-white"}`}>
+                <div className={`rounded-2xl border px-4 py-3 ${showMethodology ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}>
                   <label className="grid gap-2 text-sm text-slate-700">
                     <span className="font-medium text-slate-900">Methodology</span>
                     <select

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1450,23 +1450,23 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
   return (
     <div className="w-full">
-      <div className="mx-auto w-full max-w-4xl rounded-[2rem] border border-slate-200 bg-white px-5 py-5 shadow-sm md:px-7 md:py-7">
-        <div className="px-1 py-1 md:px-2">
-          <div className="flex items-start justify-between gap-4">
-            <div className="max-w-2xl">
+      <div className="mx-auto w-full max-w-lg">
+        <div className="flex flex-col items-center text-center">
+          <div className="flex w-full items-start justify-center">
+            <div className="w-full">
               <h1 className="text-3xl font-semibold tracking-tight text-slate-950 md:text-[2.4rem]">
-                Check one claim
+                Verify one claim
               </h1>
-              <p className="mt-3 max-w-xl text-sm leading-6 text-slate-600 md:text-[15px]">
-                Add one file to get a preliminary match.
+              <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
+                Upload evidence. Get a preliminary match in seconds.
               </p>
             </div>
             {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" /> : null}
           </div>
         </div>
 
-        <div className="mt-5 grid gap-4">
-          <div className="rounded-[1.6rem] border border-slate-200 bg-white p-4 md:p-5">
+        <div className="mt-8 grid gap-5">
+          <div>
             <label className="grid gap-2 text-sm text-slate-700">
               <span className="font-medium text-slate-900">Claim</span>
               <textarea
@@ -1529,7 +1529,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 ))}
               </div>
             </div>
-            <div className="mt-5 flex flex-wrap items-start justify-between gap-3 border-t border-slate-200 pt-5">
+          </div>
+
+          <div>
+            <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0">
                 <div className="text-sm font-medium text-slate-900">Evidence</div>
                 <div className="mt-1 text-sm text-slate-600">Upload one file.</div>
@@ -1677,45 +1680,42 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             {fieldErrors.evidence ? <div className="mt-3 text-sm text-rose-700">{fieldErrors.evidence}</div> : null}
           </div>
 
-          <div className="rounded-[1.4rem] border border-slate-200 bg-white p-4">
-            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-              <div className="flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => void handleTryDemoCheck()}
-                  disabled={submitting}
-                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
-                >
-                  <CheckCircle2 className="h-4 w-4" />
-                  Try demo check
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const nextValue = !showAdvancedOptions;
-                    setShowAdvanced(nextValue);
-                    if (!nextValue) {
-                      setShowSavedEvidence(false);
-                      setShowMethodology(false);
-                    }
-                  }}
-                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
-                  aria-expanded={showAdvancedOptions}
-                >
-                  <SlidersHorizontal className="h-4 w-4" />
-                  Options
-                  {showAdvancedOptions ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-                </button>
-              </div>
-
+          <div className="grid gap-3">
+            <button
+              type="button"
+              disabled={!canRunQuickCheck}
+              onClick={() => void runQuickCheck()}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-black px-5 py-3.5 text-sm font-semibold text-white transition hover:bg-neutral-900 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
+            >
+              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              Run quick check
+            </button>
+            <div className="flex flex-wrap items-center justify-center gap-2">
               <button
                 type="button"
-                disabled={!canRunQuickCheck}
-                onClick={() => void runQuickCheck()}
-                className="inline-flex min-w-[15rem] items-center justify-center gap-2 rounded-full bg-black px-5 py-3.5 text-sm font-semibold text-white transition hover:bg-neutral-900 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
+                onClick={() => void handleTryDemoCheck()}
+                disabled={submitting}
+                className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
               >
-                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-                Run quick check
+                <CheckCircle2 className="h-4 w-4" />
+                Try demo check
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const nextValue = !showAdvancedOptions;
+                  setShowAdvanced(nextValue);
+                  if (!nextValue) {
+                    setShowSavedEvidence(false);
+                    setShowMethodology(false);
+                  }
+                }}
+                className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                aria-expanded={showAdvancedOptions}
+              >
+                <SlidersHorizontal className="h-4 w-4" />
+                Options
+                {showAdvancedOptions ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
               </button>
             </div>
           </div>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1450,11 +1450,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
   return (
     <div className="w-full">
-      <div className="mx-auto w-full max-w-lg">
+      <div className="mx-auto w-full max-w-xl">
         <div className="flex flex-col items-center text-center">
           <div className="flex w-full items-start justify-center">
             <div className="w-full">
-              <h1 className="text-3xl font-semibold tracking-tight text-slate-950 md:text-[2.4rem]">
+              <h1 className="text-4xl font-bold tracking-tight text-slate-950">
                 Verify one claim
               </h1>
               <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
@@ -1465,7 +1465,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           </div>
         </div>
 
-        <div className="mt-8 grid gap-5">
+        <div className="mt-8 grid gap-8">
           <div>
             <label className="grid gap-2 text-sm text-slate-700">
               <span className="font-medium text-slate-900">Claim</span>
@@ -1492,13 +1492,13 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               }}
               rows={3}
               placeholder="Example: The monitoring report covers the full reporting period."
-                className="w-full rounded-[1.25rem] border border-slate-200 bg-white px-4 py-4 text-base leading-7 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white"
+                className="w-full rounded-[1.25rem] border border-slate-200 bg-white p-5 text-lg leading-8 text-slate-950 outline-none transition placeholder:text-slate-300 focus:border-slate-400 focus:bg-white"
                 ref={claimRef}
               />
               {fieldErrors.claim ? <span className="text-sm text-rose-700">{fieldErrors.claim}</span> : null}
             </label>
             <div className="mt-4">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Try an example</div>
+              <div className="text-xs text-slate-400">Try an example</div>
               <div className="mt-2 flex flex-wrap gap-2">
                 {CLAIM_SUGGESTIONS.slice(0, 2).map((suggestion) => (
                   <button
@@ -1547,7 +1547,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               <button
                 type="button"
                 onClick={() => fileRef.current?.click()}
-                className="inline-flex items-center gap-2 rounded-full border border-black bg-black px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-neutral-900"
+                className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-white px-4 py-2.5 text-sm font-semibold text-black transition hover:bg-slate-50"
               >
                 <Upload className="h-4 w-4" />
                 Upload evidence
@@ -1555,7 +1555,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             </div>
 
             {!selectedEvidenceLabel ? (
-              <div className="mt-4 rounded-[1.25rem] border border-dashed border-slate-300 bg-white px-4 py-5 text-sm text-slate-600">
+              <div className="mt-4 rounded-[1.25rem] border border-slate-200 bg-slate-50/50 px-4 py-5 text-sm text-slate-600">
                 Drop in one file or use the upload button.
               </div>
             ) : (

--- a/tests/components/chatAppQuickCheck.test.tsx
+++ b/tests/components/chatAppQuickCheck.test.tsx
@@ -49,7 +49,7 @@ describe("ChatApp claim-first landing", () => {
     });
 
     expect(container.textContent).toContain("Check one claim");
-    expect(container.textContent).toContain("Add one piece of evidence");
+    expect(container.textContent).toContain("Evidence");
     expect(container.textContent).toContain("Try demo check");
     expect(container.textContent).toContain("Run quick check");
     expect(container.textContent).toContain("Upload evidence");

--- a/tests/components/chatAppQuickCheck.test.tsx
+++ b/tests/components/chatAppQuickCheck.test.tsx
@@ -51,11 +51,10 @@ describe("ChatApp claim-first landing", () => {
     expect(container.textContent).toContain("Check one claim");
     expect(container.textContent).toContain("Add one piece of evidence");
     expect(container.textContent).toContain("Try demo check");
-    expect(container.textContent).toContain("Analyze claim");
+    expect(container.textContent).toContain("Run quick check");
     expect(container.textContent).toContain("Upload evidence");
     expect(container.querySelectorAll("textarea").length).toBe(1);
-    expect(container.textContent).toContain("Use saved evidence instead");
-    expect(container.textContent).toContain("Narrow by methodology");
+    expect(container.textContent).toContain("Options");
     expect(container.textContent).not.toContain("Select saved evidence");
     expect(container.textContent).not.toContain("MethodologyAny methodology");
     expect(container.textContent).not.toContain("Ask in chat instead");

--- a/tests/components/chatAppQuickCheck.test.tsx
+++ b/tests/components/chatAppQuickCheck.test.tsx
@@ -48,7 +48,8 @@ describe("ChatApp claim-first landing", () => {
       root.render(<ChatApp />);
     });
 
-    expect(container.textContent).toContain("Check one claim");
+    expect(container.textContent).toContain("Verify one claim");
+    expect(container.textContent).toContain("Upload evidence. Get a preliminary match in seconds.");
     expect(container.textContent).toContain("Evidence");
     expect(container.textContent).toContain("Try demo check");
     expect(container.textContent).toContain("Run quick check");
@@ -60,5 +61,6 @@ describe("ChatApp claim-first landing", () => {
     expect(container.textContent).not.toContain("Ask in chat instead");
     expect(container.textContent).not.toContain("Send");
     expect(container.textContent).not.toContain("Welcome to Article6");
+    expect(container.textContent).not.toContain("One claim. One file.");
   });
 });

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -619,7 +619,7 @@ describe("QuickCheckPanel claim-first flow", () => {
   }
 
   function primaryCta(): HTMLButtonElement {
-    return Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes("Analyze claim")) as HTMLButtonElement;
+    return Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes("Run quick check")) as HTMLButtonElement;
   }
 
   function clickButton(label: string) {
@@ -661,6 +661,21 @@ describe("QuickCheckPanel claim-first flow", () => {
     }
   }
 
+  function openOptions() {
+    if (!container.textContent?.includes("Select saved evidence")) {
+      clickButton("Options");
+    }
+  }
+
+  async function openExtractionDetails() {
+    const button = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes("Show extraction details"));
+    if (button) {
+      await act(async () => {
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+    }
+  }
+
   it("renders a minimal default state with secondary controls collapsed", async () => {
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -670,8 +685,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(pageText).toContain("Check one claim");
     expect(pageText).toContain("Upload evidence");
     expect(pageText).toContain("Try demo check");
-    expect(pageText).toContain("Use saved evidence instead");
-    expect(pageText).toContain("Narrow by methodology");
+    expect(pageText).toContain("Options");
     expect(pageText).not.toContain("Select saved evidence");
     expect(pageText).not.toContain("MethodologyAny methodology");
     expect(primaryCta().disabled).toBe(true);
@@ -685,7 +699,6 @@ describe("QuickCheckPanel claim-first flow", () => {
     const demoButton = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes("Try demo check"));
     expect(demoButton).toBeTruthy();
     expect((demoButton as HTMLButtonElement).disabled).toBe(false);
-    expect((demoButton as HTMLButtonElement).className).toContain("bg-white");
     expect(primaryCta().disabled).toBe(true);
   });
 
@@ -736,15 +749,16 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).toContain("Extraction preview");
     expect(container.textContent).toContain("Source");
     expect(container.textContent).toContain("Uploaded file");
-    expect(container.textContent).toContain("Extraction signal");
     expect(container.textContent).toContain("Grounded");
     expect(container.textContent).toContain("The project has documented monitoring evidence");
+    await openExtractionDetails();
+    expect(container.textContent).toContain("Extraction signal");
     expect(container.textContent).toContain("AR-ACM0003");
     expect(container.textContent).toContain("fresh-monitoring-report.pdf");
     expect(primaryCta().disabled).toBe(false);
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -776,8 +790,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     await flushUi();
 
     expect(container.textContent).toContain("Extraction preview");
-    expect(container.textContent).toContain("Extraction signal");
     expect(container.textContent).toContain("Weak");
+    await openExtractionDetails();
+    expect(container.textContent).toContain("Extraction signal");
     expect(container.textContent).toContain("We couldn't extract enough usable data from this file for a reliable preliminary match yet.");
     expect(container.textContent).toContain("We couldn't extract usable text from this file yet.");
   });
@@ -793,7 +808,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     await flushUi();
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -819,7 +834,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(primaryCta().disabled).toBe(true);
 
     await act(async () => {
-      clickButton("Use saved evidence instead");
+      openOptions();
     });
 
     const inventorySelect = container.querySelector("select") as HTMLSelectElement;
@@ -842,7 +857,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Use saved evidence instead");
+      openOptions();
     });
 
     const inventorySelect = container.querySelector("select") as HTMLSelectElement;
@@ -858,7 +873,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).toContain("monitoring-report.pdf");
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     expect(container.textContent).toContain("The monitoring report covers the full reporting period.");
@@ -932,7 +947,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(primaryCta().disabled).toBe(false);
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -962,7 +977,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(primaryCta().disabled).toBe(false);
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     expect(container.textContent).toContain("No clear match yet");
@@ -987,7 +1002,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(primaryCta().disabled).toBe(false);
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     expect(container.textContent).toContain("Boundary consistency");
@@ -1007,7 +1022,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(primaryCta().disabled).toBe(false);
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     expect(container.textContent).toContain("Boundary consistency");
@@ -1024,7 +1039,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     expect(container.textContent).toContain("Monitoring plan");
@@ -1084,7 +1099,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     expect(container.textContent).toContain("Workbook monitoring records");
@@ -1141,7 +1156,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     expect(container.textContent).toContain("Workbook monitoring records");
@@ -1160,7 +1175,7 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     await act(async () => {
       clickButton("The boundary description matches the mapped project area.");
-      clickButton("Use saved evidence instead");
+      openOptions();
     });
 
     const inventorySelect = container.querySelector("select") as HTMLSelectElement;
@@ -1170,7 +1185,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1219,7 +1234,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1254,7 +1269,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).not.toContain("Weak");
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1284,7 +1299,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     await flushUntilText("The PDF states a monitoring or reporting period");
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1318,7 +1333,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(primaryCta().disabled).toBe(false);
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1348,7 +1363,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     await flushUntilText("The PDF states a monitoring or reporting period");
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1378,7 +1393,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     await flushUntilText("The PDF states a monitoring or reporting period");
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1402,7 +1417,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     await flushUi();
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1424,7 +1439,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     await flushUi();
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1451,7 +1466,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Use saved evidence instead");
+      openOptions();
     });
     const inventorySelect = container.querySelector("select") as HTMLSelectElement;
     await act(async () => {
@@ -1463,7 +1478,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1488,7 +1503,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Use saved evidence instead");
+      openOptions();
     });
     const inventorySelect = container.querySelector("select") as HTMLSelectElement;
     await act(async () => {
@@ -1500,7 +1515,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1524,7 +1539,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Use saved evidence instead");
+      openOptions();
     });
     const inventorySelect = container.querySelector("select") as HTMLSelectElement;
     await act(async () => {
@@ -1536,7 +1551,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();
@@ -1621,7 +1636,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(primaryCta().disabled).toBe(false);
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await act(async () => {
@@ -1752,7 +1767,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await act(async () => {
-      clickButton("Analyze claim");
+      clickButton("Run quick check");
     });
 
     await flushUi();

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -682,7 +682,8 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     const pageText = container.textContent ?? "";
-    expect(pageText).toContain("Check one claim");
+    expect(pageText).toContain("Verify one claim");
+    expect(pageText).toContain("Upload evidence. Get a preliminary match in seconds.");
     expect(pageText).toContain("Upload evidence");
     expect(pageText).toContain("Try demo check");
     expect(pageText).toContain("Options");


### PR DESCRIPTION
## WHAT

- simplify the Quick Check home surface into a stronger first-win flow
- make one primary action dominate while collapsing saved-evidence and methodology controls behind a single Options affordance
- reduce pre-result cognitive load by showing a compact extraction summary first and hiding detailed extraction diagnostics behind an explicit toggle
- polish the landing shell, hero copy, and navigation so the product reads like a focused entry surface instead of a demo console
- update component tests to match the new first-win interaction contract

## WHY

- the current entry still asks new users to process too many choices before they get value
- the first screen should feel like one obvious beat, not a multi-branch setup form
- extraction honesty still matters, but the diagnostic detail should not lead the experience
- stronger visual hierarchy and calmer chrome should make the first successful check feel more intentional and trustworthy

**Signed-off-by:** Fredilly <fredilly@article6.org>