### PR TITLE
roadmap: project verification (PV1-PV5)

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, requirement-coverage.
+Active lanes: verification-factory, project-verification, requirement-coverage.
 Frozen lanes: agentic-verification.
 
 
@@ -96,6 +96,32 @@ Not active now:
 8) PR43 — Pre-audit pack prep workflow v1 (end-to-end sellable unit): Frozen — Frozen with the lane; preserved as future optional work.
 9) PR44 — Policy packs + house interpretations overlay (versioned): Frozen — Frozen with the lane; preserved as future optional work.
 10) PR45 — Exceptions taxonomy v1 + reviewer notes glue (standardized): Frozen — Frozen with the lane; preserved as future optional work.
+
+## project-verification
+
+Status SSOT: `docs/roadmaps/project-verification/phase-status.json`
+Details: `docs/roadmaps/project-verification/ROADMAP.md`
+
+Lane status: Active
+Turn per-rule verification into per-project verification. Add document intake, upgrade PDF exports, wire Verra methodology support. Shortest path to a defensible $5K/verification offer.
+
+Current focus:
+- Add project-level wrapper that collects rule reviews into one verification
+- Upgrade document intake beyond satellite-only evidence
+- Make the review PDF something a VVB can hand to their client
+- Prepare for Verra VM0007 rules (upstream dependency on article6-methodologies)
+
+Not active now:
+- Full automated claim extraction from documents (manual mapping first)
+- Quantitative carbon calculation engine (track as future phase)
+- Multi-methodology cross-referencing
+- Team collaboration / approval workflows
+
+1) RC1 — Project-level wrapper: Next — Create a project verification object that collects multiple rule reviews into one cohesive verification with coverage summary and finalization.
+2) RC2 — Document evidence intake: Planned — Accept PDD and monitoring report uploads as first-class evidence. Manual claim-to-rule mapping alongside satellite evidence.
+3) RC3 — Verification pack PDF: Planned — Review-ready PDF with branded cover, coverage matrix, evidence inventory, gap summary, and draft verification opinion.
+4) RC4 — Verra methodology support: Planned — Wire app to use Verra VM0007 rules once encoded upstream. Depends on article6-methodologies VF1-VF3.
+5) RC5 — End-to-end demo case: Planned — One complete VM0007 forestry verification with synthetic data, full rule coverage, and review-ready PDF export.
 
 ## requirement-coverage
 

--- a/docs/roadmaps/project-verification/ROADMAP.md
+++ b/docs/roadmaps/project-verification/ROADMAP.md
@@ -1,0 +1,155 @@
+# Project Verification
+
+Status is sourced from `docs/roadmaps/project-verification/phase-status.json`; docs must not drift.
+
+Goal: turn per-rule verification into per-project verification so a VVB can run one complete methodology check and produce a review-ready pack — the shortest path to a defensible $5K/verification offer.
+
+## Product narrative
+
+The app today can verify individual rules: pick a rule, link AOI, search satellite evidence, reconcile, finalize. This is strong per-rule work. But a VVB doesn't sell per-rule checks. They sell per-project verifications: "verify this Malawi Liwonde REDD+ project against AR-ACM0003."
+
+The missing layer is project-level aggregation: collect N rule reviews into one verification, add document evidence alongside satellite, produce a single review-ready output.
+
+## Current focus
+
+- Add project-level wrapper that collects rule reviews into one verification
+- Upgrade document intake beyond satellite-only evidence
+- Make the review PDF something a VVB can hand to their client
+- Prepare for Verra VM0007 rules (coming from article6-methodologies)
+
+## Not active now
+
+- Full automated claim extraction from documents (manual mapping first)
+- Quantitative carbon calculation engine (track as future phase)
+- Multi-methodology cross-referencing
+- Team collaboration / approval workflows
+
+## Always-optimizing pillars
+
+1) Methodology-first workflow: requirements drive verification, not satellite browsing
+2) Audit-grade provenance: every judgment traceable to source
+3) Reviewer-ready output: exports a VVB can submit or defend
+4) Deterministic: same inputs produce identical outputs
+
+## North Star KPIs
+
+- Rules verified per project
+  - Definition: % of methodology rules with a completed review in a project verification
+  - Measurement: project rule coverage / total rules in methodology
+  - Visible in: project verification dashboard
+
+- Evidence coverage ratio
+  - Definition: % of rules with linked evidence (satellite + document)
+  - Measurement: trace index coverage
+  - Visible in: project verification header
+
+- Verification pack completeness
+  - Definition: does the exported pack have coverage matrix, evidence inventory, gap list, and draft opinion?
+  - Measurement: export validation checklist
+  - Visible in: export download page
+
+- Verifier minutes per project
+  - Definition: median time from project creation to finalized verification
+  - Measurement: audit trail timestamps
+  - Visible in: project history
+
+## PV1 — Project-level wrapper
+
+Objective: create a "project verification" object that collects multiple rule reviews into one cohesive verification.
+
+### Key changes
+- Add project model: method + version + project name + AOI + created/finalized timestamps
+- Project view shows all rules in the methodology with their review status
+- Coverage summary: X/Y rules verified, Z rules with evidence linked, N gaps
+- Finalizing a project snapshots all rule reviews into one immutable artifact
+
+### Visible UI change to look for
+- New "Projects" page listing all verifications
+- Each project shows method, coverage percentage, status (in-progress / finalized)
+
+### Acceptance
+- Can create a project tied to a specific methodology version
+- Project view shows all rules with review status
+- Can finalize a project, producing a combined snapshot
+
+## PV2 — Document evidence intake
+
+Objective: accept PDD and monitoring report uploads as first-class evidence alongside satellite imagery.
+
+### Key changes
+- Upload UI for PDF/DOCX documents
+- Documents appear in evidence inventory with type label (PDD, monitoring report, workbook)
+- Manual claim-to-rule mapping: reviewer links document sections to specific rules
+- Document evidence shows up in requirement coverage alongside STAC evidence
+
+### Visible UI change to look for
+- Evidence inventory shows both satellite items and uploaded documents
+- Rule detail view shows linked document fragments with page/section references
+
+### Acceptance
+- Can upload a PDF and see it in the evidence inventory
+- Can link a document section to a specific rule
+- Document links appear in coverage reconciliation
+
+## PV3 — Verification pack PDF
+
+Objective: produce a review-ready PDF that a VVB lead reviewer can hand to their team or client.
+
+### Key changes
+- Branded cover page with project name, method, date, verifier
+- Requirement coverage matrix: every rule with status (verified / gap / not-checked)
+- Evidence inventory table: all linked evidence with type, source, hash
+- Gap summary: rules with missing or weak evidence, severity
+- Draft verification opinion: narrative conclusion based on coverage
+- Provenance appendix: commit hash, timestamps, export hash
+
+### Visible UI change to look for
+- Download button produces a multi-page PDF, not a plain-text summary
+- PDF has tables, headers, page numbers
+
+### Acceptance
+- PDF includes all five sections (cover, coverage matrix, evidence inventory, gaps, opinion)
+- PDF is downloadable from the project view
+- PDF hash is recorded in the audit trail
+
+## PV4 — Verra methodology support (upstream dependency)
+
+Objective: wire the app to use Verra VM0007 rules once encoded in article6-methodologies.
+
+### Key changes
+- App loads VM0007 rules from the methodology pack
+- Project verification works with VM0007 same as UNFCCC methods
+- Methodology picker shows Verra methods as first-class options
+
+### Visible UI change to look for
+- Methodology browser shows Verra AFOLU methods alongside UNFCCC
+- Can create a VM0007 project verification
+
+### Acceptance
+- VM0007 project verification flows end-to-end: create project, review rules, link evidence, finalize, export PDF
+
+## PV5 — End-to-end demo case
+
+Objective: one complete Verra forestry verification that proves the product works.
+
+### Key changes
+- Create synthetic or anonymized VM0007 project data (PDD, monitoring report, AOI)
+- Run full project verification: all rules, satellite + document evidence
+- Generate verification pack PDF
+- Publish as demo case on the marketing site
+
+### Visible UI change to look for
+- Demo link on app.article6.org homepage
+- "See a live verification" button opens a pre-populated project
+
+### Acceptance
+- One complete VM0007 verification with all rules reviewed
+- PDF export is review-ready quality
+- Demo is publicly accessible
+
+## Delivery constraints
+
+- Do not break existing per-rule verification workflow
+- Keep the methodology repo as canonical source for covered methods
+- Document intake is manual mapping first; automated extraction is a future phase
+- PDF generation uses existing infrastructure (wkhtmltopdf or hand-built PDF)

--- a/docs/roadmaps/project-verification/phase-status.json
+++ b/docs/roadmaps/project-verification/phase-status.json
@@ -22,22 +22,22 @@
       "summary": "Create a project verification object that collects multiple rule reviews into one cohesive verification with coverage summary and finalization."
     },
     "phase_2_document_intake": {
-      "status": "not_started",
+      "status": "planned",
       "title": "Document evidence intake",
       "summary": "Accept PDD and monitoring report uploads as first-class evidence. Manual claim-to-rule mapping alongside satellite evidence."
     },
     "phase_3_verification_pack_pdf": {
-      "status": "not_started",
+      "status": "planned",
       "title": "Verification pack PDF",
       "summary": "Review-ready PDF with branded cover, coverage matrix, evidence inventory, gap summary, and draft verification opinion."
     },
     "phase_4_verra_methodology_support": {
-      "status": "not_started",
+      "status": "planned",
       "title": "Verra methodology support",
       "summary": "Wire app to use Verra VM0007 rules once encoded upstream. Depends on article6-methodologies VF1-VF3."
     },
     "phase_5_end_to_end_demo": {
-      "status": "not_started",
+      "status": "planned",
       "title": "End-to-end demo case",
       "summary": "One complete VM0007 forestry verification with synthetic data, full rule coverage, and review-ready PDF export."
     }

--- a/docs/roadmaps/project-verification/phase-status.json
+++ b/docs/roadmaps/project-verification/phase-status.json
@@ -1,0 +1,45 @@
+{
+  "phase_meta": {
+    "status": "active",
+    "summary": "Turn per-rule verification into per-project verification. Add document intake, upgrade PDF exports, wire Verra methodology support. Shortest path to a defensible $5K/verification offer.",
+    "current_focus": [
+      "Add project-level wrapper that collects rule reviews into one verification",
+      "Upgrade document intake beyond satellite-only evidence",
+      "Make the review PDF something a VVB can hand to their client",
+      "Prepare for Verra VM0007 rules (upstream dependency on article6-methodologies)"
+    ],
+    "not_active_now": [
+      "Full automated claim extraction from documents (manual mapping first)",
+      "Quantitative carbon calculation engine (track as future phase)",
+      "Multi-methodology cross-referencing",
+      "Team collaboration / approval workflows"
+    ]
+  },
+  "phases": {
+    "phase_1_project_wrapper": {
+      "status": "next",
+      "title": "Project-level wrapper",
+      "summary": "Create a project verification object that collects multiple rule reviews into one cohesive verification with coverage summary and finalization."
+    },
+    "phase_2_document_intake": {
+      "status": "not_started",
+      "title": "Document evidence intake",
+      "summary": "Accept PDD and monitoring report uploads as first-class evidence. Manual claim-to-rule mapping alongside satellite evidence."
+    },
+    "phase_3_verification_pack_pdf": {
+      "status": "not_started",
+      "title": "Verification pack PDF",
+      "summary": "Review-ready PDF with branded cover, coverage matrix, evidence inventory, gap summary, and draft verification opinion."
+    },
+    "phase_4_verra_methodology_support": {
+      "status": "not_started",
+      "title": "Verra methodology support",
+      "summary": "Wire app to use Verra VM0007 rules once encoded upstream. Depends on article6-methodologies VF1-VF3."
+    },
+    "phase_5_end_to_end_demo": {
+      "status": "not_started",
+      "title": "End-to-end demo case",
+      "summary": "One complete VM0007 forestry verification with synthetic data, full rule coverage, and review-ready PDF export."
+    }
+  }
+}


### PR DESCRIPTION
## What
Roadmap for turning per-rule verification into per-project verification. The shortest path to a defensible $5K/verification offer.

## Why
The app can verify individual rules (pick rule → link AOI → search satellite → reconcile → finalize). But VVBs sell per-project verifications, not per-rule checks. The missing layer is project-level aggregation: collect N rule reviews into one verification with a review-ready PDF.

## Phases
- **PV1**: Project-level wrapper — create project, show all rules with review status, finalize into combined snapshot
- **PV2**: Document evidence intake — accept PDD/monitoring reports alongside satellite evidence
- **PV3**: Verification pack PDF — branded cover, coverage matrix, evidence inventory, gaps, draft opinion
- **PV4**: Verra methodology support — wire VM0007 rules (depends on article6-methodologies VF1-VF3)
- **PV5**: End-to-end demo case — one complete VM0007 verification proving the product

## Upstream dependency
PV4 and PV5 depend on article6-methodologies VF1-VF3 (Verra rule encoding): https://github.com/Fredilly/article6-methodologies/pull/379