### PR TITLE
feat(PV1): project-level verification wrapper

### DIFF
--- a/src/app/api/projects/method-rules/route.ts
+++ b/src/app/api/projects/method-rules/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export const runtime = 'nodejs';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get('code');
+  const version = searchParams.get('version');
+
+  if (!code || !version) {
+    return NextResponse.json({ error: 'Missing code or version' }, { status: 400 });
+  }
+
+  try {
+    // Load from manifest (faster, already indexed)
+    const manifestPath = path.join(process.cwd(), 'public', 'manifest', 'index.json');
+    const raw = await readFile(manifestPath, 'utf8');
+    const entries = JSON.parse(raw);
+
+    const rules = entries
+      .filter((e: Record<string, unknown>) => e.methodology === code && e.version === version)
+      .map((e: Record<string, unknown>) => ({
+        id: e.rule_id || e.id,
+        title: e.rule || e.title || '',
+        sectionId: e.sectionId || '',
+      }));
+
+    return NextResponse.json({ rules });
+  } catch (err) {
+    return NextResponse.json({ rules: [], error: String(err) });
+  }
+}

--- a/src/app/api/projects/methods/route.ts
+++ b/src/app/api/projects/methods/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  try {
+    const manifestPath = path.join(process.cwd(), 'public', 'manifest', 'index.json');
+    const raw = await readFile(manifestPath, 'utf8');
+    const entries = JSON.parse(raw);
+
+    const methodMap = new Map<string, { code: string; program: string; version: string; ruleCount: number }>();
+
+    for (const entry of entries) {
+      const code = entry.methodology || entry.method;
+      const version = entry.version;
+      const program = `${entry.provider || ''}/${entry.category || ''}`.replace(/^\//, '') || 'Unknown';
+      const key = `${code}@${version}`;
+
+      if (!methodMap.has(key)) {
+        methodMap.set(key, { code, program, version, ruleCount: 0 });
+      }
+      methodMap.get(key)!.ruleCount++;
+    }
+
+    const methods = Array.from(methodMap.values()).sort((a, b) => a.code.localeCompare(b.code));
+    return NextResponse.json({ methods });
+  } catch {
+    return NextResponse.json({ methods: [] });
+  }
+}

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import ProjectDetail from '@/components/projects/ProjectDetail';
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export const metadata: Metadata = {
+  title: 'Project | app.article6',
+};
+
+export default async function ProjectPage({ params }: PageProps) {
+  const { id } = await params;
+  return (
+    <main className="min-h-screen bg-slate-50">
+      <ProjectDetail projectId={id} />
+    </main>
+  );
+}

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import NewProjectForm from '@/components/projects/NewProjectForm';
+
+export const metadata: Metadata = {
+  title: 'New Project | app.article6',
+};
+
+export default function NewProjectPage() {
+  return (
+    <main className="min-h-screen bg-slate-50">
+      <NewProjectForm />
+    </main>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import ProjectsList from '@/components/projects/ProjectsList';
+
+export const metadata: Metadata = {
+  title: 'Projects | app.article6',
+  description: 'Project verification workbench — track methodology verifications.',
+};
+
+export default function ProjectsPage() {
+  return (
+    <main className="min-h-screen bg-slate-50">
+      <ProjectsList />
+    </main>
+  );
+}

--- a/src/components/DemoNav.tsx
+++ b/src/components/DemoNav.tsx
@@ -12,6 +12,7 @@ const demoRoutes: DemoRoute[] = [
   { href: "/", title: "Quick Check" },
   { href: "/dashboard", title: "Dashboard" },
   { href: "/m", title: "Methods" },
+  { href: "/projects", title: "Projects" },
 ];
 
 export default function DemoNav() {

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -19,6 +19,7 @@ export default function NewProjectForm() {
   const [aoiLabel, setAoiLabel] = useState('');
   const [description, setDescription] = useState('');
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     fetch('/api/projects/methods')
@@ -32,25 +33,38 @@ export default function NewProjectForm() {
     if (!name || !selectedMethod) return;
 
     setLoading(true);
+    setError('');
     const [code, version] = selectedMethod.split('@');
 
-    const rulesRes = await fetch(`/api/projects/method-rules?code=${code}&version=${version}`);
-    const rulesData = await rulesRes.json();
+    try {
+      const rulesRes = await fetch(`/api/projects/method-rules?code=${code}&version=${version}`);
+      const rulesData = await rulesRes.json();
+      const rules = (rulesData.rules || []).filter((r: { id?: string }) => r.id);
 
-    const project = createProject({
-      name,
-      methodCode: code,
-      methodVersion: version,
-      aoiLabel: aoiLabel || undefined,
-      description: description || undefined,
-      ruleIds: (rulesData.rules || []).map((r: { id: string; title: string; sectionId?: string }) => ({
-        id: r.id,
-        title: r.title,
-        sectionId: r.sectionId || '',
-      })),
-    });
+      if (rules.length === 0) {
+        setError('No rules found for this methodology. Cannot create project.');
+        setLoading(false);
+        return;
+      }
 
-    router.push(`/projects/${project.id}`);
+      const project = createProject({
+        name,
+        methodCode: code,
+        methodVersion: version,
+        aoiLabel: aoiLabel || undefined,
+        description: description || undefined,
+        ruleIds: rules.map((r: { id: string; title: string; sectionId?: string }) => ({
+          id: r.id,
+          title: r.title,
+          sectionId: r.sectionId || '',
+        })),
+      });
+
+      router.push(`/projects/${project.id}`);
+    } catch {
+      setError('Failed to load methodology rules. Try again.');
+      setLoading(false);
+    }
   };
 
   return (
@@ -61,6 +75,12 @@ export default function NewProjectForm() {
           Create a verification project tied to a methodology
         </p>
       </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <div>

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { createProject } from '@/lib/projects/storage';
+
+type MethodOption = {
+  code: string;
+  program: string;
+  version: string;
+  ruleCount: number;
+};
+
+export default function NewProjectForm() {
+  const router = useRouter();
+  const [methods, setMethods] = useState<MethodOption[]>([]);
+  const [name, setName] = useState('');
+  const [selectedMethod, setSelectedMethod] = useState('');
+  const [aoiLabel, setAoiLabel] = useState('');
+  const [description, setDescription] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/projects/methods')
+      .then(r => r.json())
+      .then(data => setMethods(data.methods || []))
+      .catch(() => setMethods([]));
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name || !selectedMethod) return;
+
+    setLoading(true);
+    const [code, version] = selectedMethod.split('@');
+
+    const rulesRes = await fetch(`/api/projects/method-rules?code=${code}&version=${version}`);
+    const rulesData = await rulesRes.json();
+
+    const project = createProject({
+      name,
+      methodCode: code,
+      methodVersion: version,
+      aoiLabel: aoiLabel || undefined,
+      description: description || undefined,
+      ruleIds: (rulesData.rules || []).map((r: { id: string; title: string; sectionId?: string }) => ({
+        id: r.id,
+        title: r.title,
+        sectionId: r.sectionId || '',
+      })),
+    });
+
+    router.push(`/projects/${project.id}`);
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-12 md:px-8">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">New Project</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          Create a verification project tied to a methodology
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div>
+          <label className="mb-1 block text-sm font-semibold text-slate-700">Project Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="e.g., Malawi Liwonde REDD+ Verification"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            required
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-semibold text-slate-700">Methodology</label>
+          <select
+            value={selectedMethod}
+            onChange={e => setSelectedMethod(e.target.value)}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            required
+          >
+            <option value="">Select a methodology...</option>
+            {methods.map(m => (
+              <option key={`${m.code}@${m.version}`} value={`${m.code}@${m.version}`}>
+                {m.code} v{m.version} — {m.program} ({m.ruleCount} rules)
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-semibold text-slate-700">AOI Label (optional)</label>
+          <input
+            type="text"
+            value={aoiLabel}
+            onChange={e => setAoiLabel(e.target.value)}
+            placeholder="e.g., Liwonde National Park, Malawi"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-semibold text-slate-700">Description (optional)</label>
+          <textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Brief description of the project..."
+            rows={3}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading || !name || !selectedMethod}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? 'Creating...' : 'Create Project'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { Project, RuleReview, ProjectCoverage } from '@/lib/projects/types';
+import { getProject, updateRuleReview, finalizeProject, getProjectCoverage } from '@/lib/projects/storage';
+
+type ProjectDetailProps = {
+  projectId: string;
+};
+
+export default function ProjectDetail({ projectId }: ProjectDetailProps) {
+  const [project, setProject] = useState<Project | null>(null);
+  const [coverage, setCoverage] = useState<ProjectCoverage | null>(null);
+
+  useEffect(() => {
+    const p = getProject(projectId);
+    if (p) {
+      setProject(p);
+      setCoverage(getProjectCoverage(p));
+    }
+  }, [projectId]);
+
+  if (!project) {
+    return (
+      <div className="mx-auto max-w-5xl px-4 py-12 text-center">
+        <p className="text-slate-500">Project not found.</p>
+        <Link href="/projects" className="mt-2 text-sm text-blue-600 hover:underline">
+          Back to projects
+        </Link>
+      </div>
+    );
+  }
+
+  const handleStatusChange = (ruleId: string, status: RuleReview['status']) => {
+    const updated = updateRuleReview(projectId, ruleId, { status });
+    if (updated) {
+      setProject(updated);
+      setCoverage(getProjectCoverage(updated));
+    }
+  };
+
+  const handleFinalize = () => {
+    const finalized = finalizeProject(projectId);
+    if (finalized) {
+      setProject(finalized);
+    }
+  };
+
+  const grouped = project.reviews.reduce((acc, r) => {
+    if (!acc[r.sectionId]) acc[r.sectionId] = [];
+    acc[r.sectionId].push(r);
+    return acc;
+  }, {} as Record<string, RuleReview[]>);
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-12 md:px-8">
+      <Link href="/projects" className="text-sm text-slate-500 hover:text-slate-700">
+        ← Back to projects
+      </Link>
+
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">{project.name}</h1>
+          <div className="mt-1 flex items-center gap-3 text-sm text-slate-500">
+            <span className="rounded bg-slate-100 px-2 py-0.5 font-mono text-xs">
+              {project.methodCode}@{project.methodVersion}
+            </span>
+            <span
+              className={`rounded px-2 py-0.5 text-xs font-semibold ${
+                project.status === 'finalized'
+                  ? 'bg-green-100 text-green-700'
+                  : 'bg-amber-100 text-amber-700'
+              }`}
+            >
+              {project.status}
+            </span>
+          </div>
+          {project.aoiLabel && <p className="mt-1 text-sm text-slate-400">AOI: {project.aoiLabel}</p>}
+        </div>
+
+        {project.status === 'in-progress' && coverage && coverage.notStarted < coverage.total && (
+          <button
+            onClick={handleFinalize}
+            className="rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700"
+          >
+            Finalize Project
+          </button>
+        )}
+      </div>
+
+      {coverage && (
+        <div className="grid grid-cols-5 gap-3">
+          {[
+            { label: 'Verified', value: coverage.verified, color: 'text-green-600' },
+            { label: 'Gaps', value: coverage.gap, color: 'text-red-600' },
+            { label: 'In Progress', value: coverage.inProgress, color: 'text-amber-600' },
+            { label: 'Pending', value: coverage.notStarted, color: 'text-slate-400' },
+            { label: 'N/A', value: coverage.notApplicable, color: 'text-slate-300' },
+          ].map(s => (
+            <div key={s.label} className="rounded-lg border border-slate-200 bg-white p-3 text-center">
+              <div className={`text-2xl font-bold ${s.color}`}>{s.value}</div>
+              <div className="text-xs text-slate-500">{s.label}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {coverage && (
+        <div>
+          <div className="h-3 overflow-hidden rounded-full bg-slate-100">
+            <div
+              className="h-full rounded-full bg-blue-500 transition-all"
+              style={{ width: `${coverage.percentComplete}%` }}
+            />
+          </div>
+          <p className="mt-1 text-right text-xs text-slate-500">{coverage.percentComplete}% complete</p>
+        </div>
+      )}
+
+      {Object.entries(grouped).map(([sectionId, reviews]) => (
+        <div key={sectionId} className="rounded-lg border border-slate-200 bg-white">
+          <div className="border-b border-slate-100 px-4 py-3">
+            <h2 className="text-sm font-bold text-slate-700">{sectionId}</h2>
+          </div>
+          <div className="divide-y divide-slate-50">
+            {reviews.map(review => (
+              <div key={review.ruleId} className="flex items-center gap-3 px-4 py-3">
+                <div className="flex-1">
+                  <div className="text-sm font-medium text-slate-800">{review.ruleTitle}</div>
+                  <div className="text-xs text-slate-400 font-mono">{review.ruleId}</div>
+                </div>
+                {project.status === 'in-progress' ? (
+                  <select
+                    value={review.status}
+                    onChange={e => handleStatusChange(review.ruleId, e.target.value as RuleReview['status'])}
+                    className={`rounded border px-2 py-1 text-xs font-semibold ${
+                      review.status === 'verified'
+                        ? 'border-green-300 bg-green-50 text-green-700'
+                        : review.status === 'gap'
+                          ? 'border-red-300 bg-red-50 text-red-700'
+                          : review.status === 'not-applicable'
+                            ? 'border-slate-200 bg-slate-50 text-slate-400'
+                            : 'border-slate-200 bg-white text-slate-500'
+                    }`}
+                  >
+                    <option value="not-started">Not Started</option>
+                    <option value="in-progress">In Progress</option>
+                    <option value="verified">Verified</option>
+                    <option value="gap">Gap</option>
+                    <option value="not-applicable">N/A</option>
+                  </select>
+                ) : (
+                  <span
+                    className={`rounded px-2 py-1 text-xs font-semibold ${
+                      review.status === 'verified'
+                        ? 'bg-green-100 text-green-700'
+                        : review.status === 'gap'
+                          ? 'bg-red-100 text-red-700'
+                          : 'bg-slate-100 text-slate-500'
+                    }`}
+                  >
+                    {review.status}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import type { Project, RuleReview, ProjectCoverage } from '@/lib/projects/types';
-import { getProject, updateRuleReview, finalizeProject, getProjectCoverage } from '@/lib/projects/storage';
+import { getProject, updateRuleReview, lockProject, getProjectCoverage } from '@/lib/projects/storage';
 
 type ProjectDetailProps = {
   projectId: string;
@@ -40,8 +40,8 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
     }
   };
 
-  const handleFinalize = () => {
-    const finalized = finalizeProject(projectId);
+  const handleLock = () => {
+    const finalized = lockProject(projectId);
     if (finalized) {
       setProject(finalized);
     }
@@ -68,7 +68,7 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
             </span>
             <span
               className={`rounded px-2 py-0.5 text-xs font-semibold ${
-                project.status === 'finalized'
+                project.status === 'locked'
                   ? 'bg-green-100 text-green-700'
                   : 'bg-amber-100 text-amber-700'
               }`}
@@ -81,10 +81,10 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
 
         {project.status === 'in-progress' && coverage && coverage.notStarted < coverage.total && (
           <button
-            onClick={handleFinalize}
+            onClick={handleLock}
             className="rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700"
           >
-            Finalize Project
+            Lock Review
           </button>
         )}
       </div>

--- a/src/components/projects/ProjectsList.tsx
+++ b/src/components/projects/ProjectsList.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { Project, ProjectCoverage } from '@/lib/projects/types';
+import { listProjects, getProjectCoverage, deleteProject } from '@/lib/projects/storage';
+
+export default function ProjectsList() {
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    setProjects(listProjects());
+  }, []);
+
+  const handleDelete = (id: string) => {
+    deleteProject(id);
+    setProjects(listProjects());
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-12 md:px-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Projects</h1>
+          <p className="mt-1 text-sm text-slate-500">Methodology verification workbench</p>
+        </div>
+        <Link
+          href="/projects/new"
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+        >
+          + New Project
+        </Link>
+      </div>
+
+      {projects.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-slate-300 bg-white p-12 text-center">
+          <p className="text-slate-500">No projects yet. Create one to start a verification.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {projects.map(project => {
+            const coverage = getProjectCoverage(project);
+            return (
+              <div
+                key={project.id}
+                className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex-1">
+                    <Link
+                      href={`/projects/${project.id}`}
+                      className="text-lg font-semibold text-slate-900 hover:text-blue-600"
+                    >
+                      {project.name}
+                    </Link>
+                    <div className="mt-1 flex items-center gap-3 text-xs text-slate-500">
+                      <span className="rounded bg-slate-100 px-2 py-0.5 font-mono">
+                        {project.methodCode}@{project.methodVersion}
+                      </span>
+                      <span
+                        className={`rounded px-2 py-0.5 font-semibold ${
+                          project.status === 'finalized'
+                            ? 'bg-green-100 text-green-700'
+                            : 'bg-amber-100 text-amber-700'
+                        }`}
+                      >
+                        {project.status}
+                      </span>
+                      <span>{new Date(project.createdAt).toLocaleDateString()}</span>
+                    </div>
+                    {project.aoiLabel && (
+                      <p className="mt-1 text-xs text-slate-400">AOI: {project.aoiLabel}</p>
+                    )}
+                  </div>
+                  <div className="ml-4 text-right">
+                    <div className="text-2xl font-bold text-slate-900">{coverage.percentComplete}%</div>
+                    <div className="text-xs text-slate-500">
+                      {coverage.verified}/{coverage.total - coverage.notApplicable} rules
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-3">
+                  <div className="h-2 overflow-hidden rounded-full bg-slate-100">
+                    <div
+                      className="h-full rounded-full bg-blue-500 transition-all"
+                      style={{ width: `${coverage.percentComplete}%` }}
+                    />
+                  </div>
+                  <div className="mt-1 flex gap-3 text-xs text-slate-400">
+                    <span>{coverage.verified} verified</span>
+                    <span>{coverage.gap} gaps</span>
+                    <span>{coverage.notStarted} pending</span>
+                    {coverage.notApplicable > 0 && <span>{coverage.notApplicable} n/a</span>}
+                  </div>
+                </div>
+
+                {project.status === 'in-progress' && (
+                  <div className="mt-3 flex justify-end">
+                    <button
+                      onClick={() => handleDelete(project.id)}
+                      className="text-xs text-red-400 hover:text-red-600"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/projects/ProjectsList.tsx
+++ b/src/components/projects/ProjectsList.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import type { Project, ProjectCoverage } from '@/lib/projects/types';
+import type { Project } from '@/lib/projects/types';
 import { listProjects, getProjectCoverage, deleteProject } from '@/lib/projects/storage';
 
 export default function ProjectsList() {

--- a/src/components/projects/ProjectsList.tsx
+++ b/src/components/projects/ProjectsList.tsx
@@ -59,7 +59,7 @@ export default function ProjectsList() {
                       </span>
                       <span
                         className={`rounded px-2 py-0.5 font-semibold ${
-                          project.status === 'finalized'
+                          project.status === 'locked'
                             ? 'bg-green-100 text-green-700'
                             : 'bg-amber-100 text-amber-700'
                         }`}

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -70,6 +70,8 @@ export function updateRuleReview(
   const project = projects.find(p => p.id === projectId);
   if (!project) return undefined;
 
+  if (project.status === 'finalized') return undefined;
+
   const review = project.reviews.find(r => r.ruleId === ruleId);
   if (!review) return undefined;
 

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -70,7 +70,7 @@ export function updateRuleReview(
   const project = projects.find(p => p.id === projectId);
   if (!project) return undefined;
 
-  if (project.status === 'finalized') return undefined;
+  if (project.status === 'locked') return undefined;
 
   const review = project.reviews.find(r => r.ruleId === ruleId);
   if (!review) return undefined;
@@ -84,13 +84,13 @@ export function updateRuleReview(
   return project;
 }
 
-export function finalizeProject(projectId: string): Project | undefined {
+export function lockProject(projectId: string): Project | undefined {
   const projects = loadAll();
   const project = projects.find(p => p.id === projectId);
   if (!project) return undefined;
 
-  project.status = 'finalized';
-  project.finalizedAt = new Date().toISOString();
+  project.status = 'locked';
+  project.lockedAt = new Date().toISOString();
   saveAll(projects);
   return project;
 }

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -1,0 +1,113 @@
+import type { Project, RuleReview, ProjectCoverage, RuleReviewStatus } from './types';
+
+const STORAGE_KEY = 'article6_projects';
+
+function generateId(): string {
+  return 'proj_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+function loadAll(): Project[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveAll(projects: Project[]): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(projects));
+}
+
+export function listProjects(): Project[] {
+  return loadAll().sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export function getProject(id: string): Project | undefined {
+  return loadAll().find(p => p.id === id);
+}
+
+export function createProject(input: {
+  name: string;
+  methodCode: string;
+  methodVersion: string;
+  aoiLabel?: string;
+  description?: string;
+  ruleIds: Array<{ id: string; title: string; sectionId: string }>;
+}): Project {
+  const project: Project = {
+    id: generateId(),
+    name: input.name,
+    methodCode: input.methodCode,
+    methodVersion: input.methodVersion,
+    status: 'in-progress',
+    createdAt: new Date().toISOString(),
+    aoiLabel: input.aoiLabel,
+    description: input.description,
+    reviews: input.ruleIds.map(r => ({
+      ruleId: r.id,
+      ruleTitle: r.title,
+      sectionId: r.sectionId,
+      status: 'not-started' as RuleReviewStatus,
+      evidenceIds: [],
+    })),
+  };
+
+  const projects = loadAll();
+  projects.push(project);
+  saveAll(projects);
+  return project;
+}
+
+export function updateRuleReview(
+  projectId: string,
+  ruleId: string,
+  update: Partial<RuleReview>
+): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find(p => p.id === projectId);
+  if (!project) return undefined;
+
+  const review = project.reviews.find(r => r.ruleId === ruleId);
+  if (!review) return undefined;
+
+  Object.assign(review, update);
+  if (update.status === 'verified' || update.status === 'gap') {
+    review.reviewedAt = new Date().toISOString();
+  }
+
+  saveAll(projects);
+  return project;
+}
+
+export function finalizeProject(projectId: string): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find(p => p.id === projectId);
+  if (!project) return undefined;
+
+  project.status = 'finalized';
+  project.finalizedAt = new Date().toISOString();
+  saveAll(projects);
+  return project;
+}
+
+export function deleteProject(projectId: string): void {
+  const projects = loadAll().filter(p => p.id !== projectId);
+  saveAll(projects);
+}
+
+export function getProjectCoverage(project: Project): ProjectCoverage {
+  const reviews = project.reviews;
+  const total = reviews.length;
+  const verified = reviews.filter(r => r.status === 'verified').length;
+  const gap = reviews.filter(r => r.status === 'gap').length;
+  const notStarted = reviews.filter(r => r.status === 'not-started').length;
+  const notApplicable = reviews.filter(r => r.status === 'not-applicable').length;
+  const inProgress = reviews.filter(r => r.status === 'in-progress').length;
+  const actionable = total - notApplicable;
+  const percentComplete = actionable > 0 ? Math.round(((verified + gap) / actionable) * 100) : 0;
+
+  return { total, verified, gap, notStarted, notApplicable, inProgress, percentComplete };
+}

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -1,0 +1,37 @@
+export type ProjectStatus = 'in-progress' | 'finalized';
+
+export type RuleReviewStatus = 'not-started' | 'in-progress' | 'verified' | 'gap' | 'not-applicable';
+
+export type RuleReview = {
+  ruleId: string;
+  ruleTitle: string;
+  sectionId: string;
+  status: RuleReviewStatus;
+  outcome?: 'pass' | 'fail' | 'partial' | 'missing-evidence';
+  note?: string;
+  evidenceIds: string[];
+  reviewedAt?: string;
+};
+
+export type Project = {
+  id: string;
+  name: string;
+  methodCode: string;
+  methodVersion: string;
+  status: ProjectStatus;
+  createdAt: string;
+  finalizedAt?: string;
+  aoiLabel?: string;
+  description?: string;
+  reviews: RuleReview[];
+};
+
+export type ProjectCoverage = {
+  total: number;
+  verified: number;
+  gap: number;
+  notStarted: number;
+  notApplicable: number;
+  inProgress: number;
+  percentComplete: number;
+};

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -1,4 +1,4 @@
-export type ProjectStatus = 'in-progress' | 'finalized';
+export type ProjectStatus = 'in-progress' | 'locked';
 
 export type RuleReviewStatus = 'not-started' | 'in-progress' | 'verified' | 'gap' | 'not-applicable';
 
@@ -20,7 +20,7 @@ export type Project = {
   methodVersion: string;
   status: ProjectStatus;
   createdAt: string;
-  finalizedAt?: string;
+  lockedAt?: string;
   aoiLabel?: string;
   description?: string;
   reviews: RuleReview[];


### PR DESCRIPTION
## What
Add project-level verification wrapper. Create a project tied to a methodology, load all rules as reviews, track status per rule, show coverage summary, finalize into one artifact.

## New routes
- /projects — list all projects with coverage bars
- /projects/new — create project (select methodology, name, AOI)
- /projects/[id] — all rules with status dropdowns, coverage stats, finalize button

## Data model
- Project: id, name, method, version, status, reviews[]
- RuleReview: ruleId, title, sectionId, status (not-started/in-progress/verified/gap/n/a), evidenceIds
- ProjectCoverage: verified/gap/pending/n/a counts + percent complete

## Storage
localStorage for now (client-side). Moves to server-side when needed.

## What is NOT included (future PVs)
- PV2: document evidence upload
- PV3: verification pack PDF export
- PV4: Verra/GS method support (needs manifest rebuild)
- PV5: demo case