### PR TITLE
docs: traceable-rule-review-mvp roadmap (T-1 through T-5)

### DIFF
--- a/docs/roadmaps/traceable-rule-review-mvp/PLAN.md
+++ b/docs/roadmaps/traceable-rule-review-mvp/PLAN.md
@@ -1,0 +1,237 @@
+# Traceable Rule Review MVP
+
+Status: `docs/roadmaps/traceable-rule-review-mvp/phase-status.json`.
+
+## Goal
+
+Turn the current methodology/checklist flow into a traceable rule review workspace. The product center is the **rule review record** — a defensible, auditable decision on each methodology rule with status, rationale, evidence reference, and provenance.
+
+## Repo boundary
+
+This roadmap owns **UI, workflow, persistence, and export execution**. It does NOT own methodology semantics, canonical rule contracts, or schema definitions. That is the methodologies repo.
+
+Cross-reference: [methodologies roadmap](https://github.com/Fredilly/article6-methodologies/tree/main/docs/roadmaps/traceable-rule-review-mvp).
+
+## How existing pieces fit
+
+| Piece | Current state | Role in this roadmap |
+|-------|--------------|---------------------|
+| **Methods** | Manifest loads methodology packs (rules.json, rules.rich.json) via `/manifest` | Supply rule text, type, tags, section anchors to review panel |
+| **Complex methods** | Version lineage, diff support (RC-S5) | Review panel shows version context; reviewers see what changed between versions |
+| **AOI** | proofMap/aoi.ts, AOI apply + bbox | Scope STAC searches and evidence to project area |
+| **STAC** | `/api/stac/search`, normalizeStacItems, extractStacArtifacts | Provide satellite support facts for eligible rules (not auto-verify) |
+| **Projects** | Project CRUD, method-rules API, project detail page | Container for a verification; holds all rule reviews for a methodology |
+| **Verification packs** | auditPack, buildAuditPack, verification snapshot | Export target — review records feed into the pack |
+| **Quick Check** | Chat-based quick check flow | Entry point for ad-hoc rule checks; review panel is the structured upgrade |
+
+## Priority
+
+truthfulness > defensibility > clean repo boundaries > UX polish
+
+## Phases
+
+All five phases are strict. Each builds on the previous. Phase IDs and titles match the methodologies repo exactly.
+
+---
+
+## T-1 — Rule Review Record
+
+### Goal
+
+Build the core object: a traceable review record attached to every rule in a project.
+
+### Deliverables
+
+- Clicking a rule in the project view opens an inline review panel (not modal)
+- Panel shows: full rule text, methodology source anchor (from `rules.rich.json` refs), status selector, rationale field, support reference field, evidence link field, provenance footer
+- Status: Pending / Verified / Not Verified / Needs Follow-up
+- Validation: Verified/Not Verified requires rationale + support reference (non-empty)
+- Reviews persist via API endpoints (not just localStorage)
+- Reserved placeholder area for STAC support facts (empty, dashed border)
+
+### Existing pieces used
+
+- `rules.json` / `rules.rich.json` — rule text, type, tags, section refs
+- `RuleCard.tsx` — entry point, expand to review panel
+- `projects/[id]/page.tsx` — project context
+- `api/projects/method-rules/route.ts` — rule loading
+
+### Files to create/modify
+
+- `src/components/verify/RuleReviewPanel.tsx` (new)
+- `src/app/api/reviews/route.ts` (new — CRUD)
+- `src/app/api/reviews/[ruleId]/route.ts` (new)
+- `src/lib/verify/reviewStore.ts` (new)
+- `src/lib/verify/reviewValidation.ts` (new)
+- `src/components/RuleCard.tsx` (modify — expand toggle)
+
+### Visible UI change
+
+Clicking a rule opens a review panel with rule text, rationale, and evidence fields — not just a status dropdown.
+
+### Acceptance criteria
+
+- [ ] Rule text from methodology data displayed in full
+- [ ] Section/source anchor shown when available
+- [ ] Status selector with 4 states
+- [ ] Rationale required for non-pending
+- [ ] Support reference required for non-pending
+- [ ] Evidence link optional
+- [ ] Provenance footer (reviewer, timestamp)
+- [ ] Save disabled until validation passes
+- [ ] Reviews persist via API across reloads
+- [ ] Reserved STAC evidence area visible
+
+---
+
+## T-2 — Defensible Verification
+
+### Goal
+
+Every review decision is traceable by a third party. Reviews become defensible audit artifacts.
+
+### Deliverables
+
+- Evidence attachment: upload file or link URL per rule review
+- Review audit trail: all status changes logged with who/when/what
+- Blocking gate: cannot finalize project until all rules have status + rationale + support
+- Review progress indicator: X of Y rules reviewed, % verified, open items
+- Reviewer identity captured (from session or manual input)
+
+### Existing pieces used
+
+- `EvidenceWorkflowStepper.tsx` — evidence attachment patterns
+- `lib/evidence/inventory.ts` — evidence tracking
+- `lib/verify/runState.ts` — run state management
+- `ProofCoverageChip.tsx` — coverage display patterns
+
+### Visible UI change
+
+Evidence can be attached to reviews. Progress bar shows review completion. Finalize is blocked until complete.
+
+### Acceptance criteria
+
+- [ ] File upload works (PDF, images, docs) per rule
+- [ ] URL evidence links stored and displayed
+- [ ] Audit trail: every status change logged with timestamp + reviewer
+- [ ] Project finalize blocked until all rules have status + rationale + support
+- [ ] Review progress visible (X/Y, %, open items list)
+
+---
+
+## T-3 — STAC / AOI Support Facts
+
+### Goal
+
+Satellite-relevant rules get automatic STAC support facts. AOI scopes the evidence. STAC is support, not auto-verification.
+
+### Deliverables
+
+- Rules tagged `monitoring`, `satellite`, or `remote-sensing` auto-trigger STAC search
+- STAC panel shows: AOI overlap confirmation, temporal coverage, cloud stats, scene list (top 10)
+- AOI from project scope feeds into STAC search
+- STAC facts populate the reserved area from T-1 (no UI redesign)
+- Clear labeling: "Supporting data — reviewer must assess sufficiency"
+
+### Existing pieces used
+
+- `api/stac/search/route.ts` — STAC search
+- `lib/stac/normalizeStacItems.ts` — item normalization
+- `lib/runs/selectLatestOkStacRunForActiveAoi.ts` — AOI-scoped runs
+- `proofMap/aoi.ts` — AOI geometry
+
+### Visible UI change
+
+Satellite rules auto-show STAC scene data. AOI overlap is visible. Non-satellite rules show the reserved area as empty.
+
+### Acceptance criteria
+
+- [ ] STAC facts auto-populate for eligible rules only
+- [ ] AOI overlap shown
+- [ ] Temporal coverage displayed
+- [ ] Cloud stats shown
+- [ ] Top 10 scene IDs listed
+- [ ] Non-satellite rules show empty reserved area (no STAC)
+- [ ] Clear "supporting data" labeling — not auto-verified
+
+---
+
+## T-4 — Document and Workbook Support
+
+### Goal
+
+Upload project documents (PDD, monitoring reports, workbooks). Extract structured facts to support rule reviews.
+
+### Deliverables
+
+- Document upload: accept PDF, store in project
+- Text extraction: extract text from uploaded PDFs
+- Workbook ingestion: parse baseline/removals/leakage calculation spreadsheets
+- Fact surfacing: extracted facts available in review panel as potential support references
+- Quick Check integration: use document text as input for quick check flows
+
+### Existing pieces used
+
+- `lib/evidence/workbook.ts` — workbook parsing
+- `lib/chat/quickCheckPdfExtractor.ts` — PDF text extraction
+- `lib/chat/quickCheckResolver.ts` — resolution logic
+- `lib/intake/storage.ts` — file storage patterns
+
+### Visible UI change
+
+Documents can be uploaded at project level. Extracted text and workbook values appear in review panel as suggestions.
+
+### Acceptance criteria
+
+- [ ] PDF upload at project level works
+- [ ] Text extracted from uploaded PDFs
+- [ ] Workbook (xlsx) parsing produces baseline/removals/leakage values
+- [ ] Extracted facts visible in review panel
+- [ ] Quick Check can use uploaded document text
+
+---
+
+## T-5 — Exportable Verification Output
+
+### Goal
+
+One-click export produces a complete verification opinion document. This is what VVBs pay for.
+
+### Deliverables
+
+- PDF export: "Verification Summary" with all rule reviews, status, rationale, evidence references, provenance
+- JSON export: machine-readable verification snapshot (schema-validated)
+- Provenance trail: full who/when/what chain in export
+- Methodology context: rule source anchors preserved in export
+- Project-level synthesis: aggregate all rule reviews into one opinion
+
+### Existing pieces used
+
+- `exports/auditPack.ts` — audit pack generation
+- `lib/export/buildProvenanceTxt.ts` — provenance text
+- `lib/export/assertVerificationSnapshotInvariants.ts` — snapshot validation
+- `lib/verify/buildReviewSummary.ts` — review summary building
+- `lib/pdf/metadata.ts` — PDF metadata
+
+### Visible UI change
+
+"Export Verification Summary" button produces a PDF covering every rule with full traceability. JSON export also available.
+
+### Acceptance criteria
+
+- [ ] PDF contains: methodology info, every rule with status/rationale/support, provenance chain
+- [ ] JSON export passes schema validation
+- [ ] Provenance trail includes reviewer, timestamp, commit hash
+- [ ] Source anchors preserved in export
+- [ ] Project-level synthesis aggregates all reviews
+
+---
+
+## What this roadmap excludes
+
+- Enterprise SSO / multi-tenant (post-revenue)
+- AI auto-verification (post-moat)
+- Non-Article 6 methodologies
+- Blockchain provenance
+- Methodology semantics (owned by methodologies repo)
+- Schema definitions (owned by methodologies repo)

--- a/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
+++ b/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
@@ -1,0 +1,69 @@
+{
+  "roadmap": "traceable-rule-review-mvp",
+  "repo": "app.article6",
+  "repo_boundary": "UI, workflow, persistence, export execution. Does NOT own methodology semantics or schema definitions.",
+  "goal": "Ship paid verification service — traceable review records for VVBs.",
+  "last_updated_at": "2026-04-15T00:00:00Z",
+  "status": "active",
+  "current_focus": ["T-1: Rule Review Record"],
+  "phases": [
+    {
+      "id": "t-1-rule-review-record",
+      "name": "Rule Review Record",
+      "week": 1,
+      "status": "active",
+      "depends_on": []
+    },
+    {
+      "id": "t-2-defensible-verification",
+      "name": "Defensible Verification",
+      "week": 2,
+      "status": "planned",
+      "depends_on": ["t-1-rule-review-record"]
+    },
+    {
+      "id": "t-3-stac-aoi-support-facts",
+      "name": "STAC / AOI Support Facts",
+      "week": 3,
+      "status": "planned",
+      "depends_on": ["t-2-defensible-verification"]
+    },
+    {
+      "id": "t-4-document-workbook-support",
+      "name": "Document and Workbook Support",
+      "week": 4,
+      "status": "planned",
+      "depends_on": ["t-3-stac-aoi-support-facts"]
+    },
+    {
+      "id": "t-5-exportable-verification-output",
+      "name": "Exportable Verification Output",
+      "week": 5,
+      "status": "planned",
+      "depends_on": ["t-4-document-workbook-support"]
+    }
+  ],
+  "pr_evidence": {},
+  "pr_meta": {
+    "T-1": {
+      "title": "Rule Review Record",
+      "summary": "Build the traceable review record: rule text, status, rationale, support reference, provenance. The monetizable object."
+    },
+    "T-2": {
+      "title": "Defensible Verification",
+      "summary": "Evidence attachment, audit trail, finalize gate. Every decision traceable by a third party."
+    },
+    "T-3": {
+      "title": "STAC / AOI Support Facts",
+      "summary": "Auto-populate satellite support facts for eligible rules. AOI-scoped. Support, not auto-verification."
+    },
+    "T-4": {
+      "title": "Document and Workbook Support",
+      "summary": "Upload PDD, monitoring reports, workbooks. Extract structured facts for review support."
+    },
+    "T-5": {
+      "title": "Exportable Verification Output",
+      "summary": "One-click PDF + JSON export. Full traceability. What VVBs pay for."
+    }
+  }
+}

--- a/docs/roadmaps/verifiable-review-record/PLAN.md
+++ b/docs/roadmaps/verifiable-review-record/PLAN.md
@@ -1,0 +1,201 @@
+# Verifiable Review Record
+
+Status is sourced from `docs/roadmaps/verifiable-review-record/phase-status.json`.
+
+## Goal
+
+Ship a paid verification service ($1.5-2.5K/pilot, scaling to $5K) where VVBs can load a methodology, review every rule with traceable rationale and evidence, and export a defensible verification summary. The product unit is not the rule card — it's the **traceable review record**.
+
+## What we're building
+
+A methodology-aware review workspace with traceable rule-by-rule support and full provenance. Built for VVBs and Article 6 focal points who need to move from weeks of manual review to hours with an auditable trail.
+
+Do not call this a checklist.
+
+## What shipped already
+
+Quick Check + Methods + Projects + per-rule verify + STAC runs. Solid foundation, but feels like a demo, not a paid service. The gap: no rationale capture, no evidence reference, no provenance on review decisions.
+
+## Pricing ladder
+
+- First 5 pilots: $1,500-2,500 per full methodology verification
+- After 3 case studies showing 60-70% time savings: raise to $5K
+- VVBs charge $50-100K/engagement — we save them weeks
+
+## Sequencing
+
+Phases are strict. Each phase builds on the previous. Do not skip ahead.
+
+Methodology repo (article6-methodologies) runs in parallel — see [complete-methodology-coverage](https://github.com/Fredilly/article6-methodologies/tree/main/docs/roadmaps/complete-methodology-coverage) roadmap for encoding work.
+
+---
+
+## VRR-1 — Rule Review Surface (Week 1)
+
+### Goal
+
+Build the monetizable object: a traceable review record attached to every rule.
+
+### Deliverables
+
+- Clicking any rule card expands to show a review panel (inline, not modal)
+- Panel shows: full rule text, methodology source anchor, status selector, rationale field, support reference field, evidence link field, provenance footer, reserved evidence area
+- Status cannot be set to Verified/Not Verified without rationale + support reference (validation)
+- Reviews persist in localStorage (Phase 2 migrates to API)
+
+### Key changes
+
+- New `src/components/verify/RuleReviewPanel.tsx` — the review surface
+- New `src/lib/verify/reviewStore.ts` — localStorage persistence
+- New `src/lib/verify/reviewValidation.ts` — validation logic
+- Modify `src/components/RuleCard.tsx` — add expand toggle + render panel
+- Tests for validation logic
+
+### Visible UI change to look for
+
+Clicking a rule opens or reveals a proper review panel with rule text, rationale, and evidence fields — not just a status dropdown.
+
+### Acceptance criteria
+
+- [ ] Rule text from `rules.json` is displayed in full
+- [ ] Section/source anchor shown when available
+- [ ] Status: Pending / Verified / Not Verified / Needs Follow-up
+- [ ] Rationale required for non-pending status
+- [ ] Support reference required for non-pending status
+- [ ] Evidence link optional
+- [ ] Provenance footer: reviewer, timestamp
+- [ ] Save disabled until validation passes
+- [ ] Review persists across page reloads
+- [ ] Reserved evidence panel placeholder visible
+
+---
+
+## VRR-2 — Defensibility Layer (Week 2)
+
+### Goal
+
+Reviews become defensible. Enforce traceability on every decision.
+
+### Deliverables
+
+- Backend review persistence (API endpoints, not just localStorage)
+- Evidence attachment (upload file or link URL)
+- STAC auto-support for satellite-relevant rules only (AOI overlap, temporal coverage, cloud stats, scene list)
+- Review audit trail: who changed what, when
+- Blocking gate: cannot finalize project without all rules reviewed
+
+### Key changes
+
+- New `src/app/api/reviews/route.ts` — CRUD for reviews
+- New `src/app/api/reviews/[ruleId]/route.ts` — single review endpoint
+- STAC integration in review panel (only for rules tagged `satellite`, `remote-sensing`, or `monitoring`)
+- Modify `RuleReviewPanel.tsx` — add evidence upload, STAC facts display
+- New `src/components/verify/EvidenceAttachment.tsx` — upload/link component
+- Review summary aggregation: show % reviewed, % verified, open items
+
+### Visible UI change to look for
+
+STAC facts auto-populate for satellite rules. Evidence can be attached. Review progress is visible.
+
+### Acceptance criteria
+
+- [ ] Reviews persist server-side via API
+- [ ] File upload works (PDF, images, docs)
+- [ ] URL evidence links work
+- [ ] STAC facts appear for satellite-relevant rules automatically
+- [ ] STAC shows: AOI overlap, temporal coverage, cloud stats, scene IDs
+- [ ] STAC is support facts, NOT auto-verification
+- [ ] Review audit trail records all status changes with timestamps
+- [ ] Project finalize blocked until all rules have status + rationale + support
+
+---
+
+## VRR-3 — Full Methodology Coverage + Export (Week 3)
+
+### Goal
+
+All AR-ACM0003 rules covered. One-click export produces a verification summary.
+
+### Deliverables
+
+- All rules from AR-ACM0003 v02-0 loadable and reviewable (not just R-1-0001)
+- Methodology completeness indicator: "12 of 15 rules reviewed"
+- PDF export: Verification Summary with all review records
+- JSON export: machine-readable verification snapshot
+- Document ingestion MVP: upload PDD fragments, extract basic facts
+
+### Key changes
+
+- Ensure manifest loads all rules from methodology packs
+- New `src/lib/export/verificationSummary.ts` — build summary from reviews
+- PDF generation (wkhtmltopdf or raw HTML — see existing pdf/ patterns)
+- New `src/components/verify/ExportButton.tsx`
+- Document upload + basic text extraction (Phase 4 adds structured extraction)
+
+### Visible UI change to look for
+
+"Export Verification Summary" button produces a PDF with every rule, its review status, rationale, and evidence references.
+
+### Acceptance criteria
+
+- [ ] All AR-ACM0003 v02-0 rules visible and reviewable
+- [ ] Methodology completeness: X of Y rules reviewed
+- [ ] PDF export contains: methodology info, every rule with status/rationale/support, provenance
+- [ ] JSON export passes schema validation
+- [ ] Document upload accepts PDFs, stores them
+- [ ] Basic text extraction from uploaded PDFs available in review panel
+
+---
+
+## VRR-4 — Pilot-Ready MVP (Weeks 4-5)
+
+### Goal
+
+First paid pilot. Real methodology verification with an external VVB or project developer.
+
+### Deliverables
+
+- Project-level synthesis: aggregate all rule reviews into one "Article 6 Verification Opinion"
+- Synthetic workbook → auto calculations (baseline, removals, leakage)
+- Multi-methodology support: AR-ACM0003 + at least one agriculture methodology
+- Role-based access: reviewer vs. observer views
+- Pilot pricing page or onboarding flow
+
+### Key changes
+
+- New `src/lib/verify/verificationOpinion.ts` — project-level synthesis
+- Workbook calculation engine (baseline, uplift, leakage formulas)
+- Multi-methodology routing (load correct rules.json per methodology)
+- Simple auth or share-link for observer access
+- Landing page / pricing messaging update
+
+### Visible UI change to look for
+
+"Generate Verification Opinion" produces a single document covering the entire project. Multiple methodologies work.
+
+### Acceptance criteria
+
+- [ ] Verification Opinion report covers all reviewed rules
+- [ ] Workbook calculations produce correct baseline/removals/leakage
+- [ ] At least 2 methodologies loadable (AR-ACM0003 + agriculture)
+- [ ] Observer can view but not edit reviews
+- [ ] At least 1 external pilot completed
+- [ ] Pricing positioned at $1,500-2,500 for first 5 pilots
+
+---
+
+## Always-optimizing
+
+1. **Truthfulness > defensibility > UX polish** — in that order
+2. A rule is not meaningfully verified without: status + rationale + support + provenance
+3. STAC is support facts, never auto-verification
+4. Every review decision must be traceable by a third party
+5. Ship fast, iterate on feedback — do not over-engineer before pilots
+
+## What this roadmap deliberately excludes
+
+- Enterprise SSO / multi-tenant (post-revenue)
+- AI auto-verification (post-moat)
+- Mobile app (desktop-first for reviewers)
+- Non-Article 6 methodologies (stay focused)
+- Blockchain provenance (nice-to-have, not required for $5K)

--- a/docs/roadmaps/verifiable-review-record/phase-status.json
+++ b/docs/roadmaps/verifiable-review-record/phase-status.json
@@ -1,0 +1,89 @@
+{
+  "roadmap": "verifiable-review-record",
+  "goal": "Ship paid verification service — traceable review records, not clickable checklists.",
+  "last_updated_at": "2026-04-15T00:00:00Z",
+  "status": "active",
+  "pricing": {
+    "pilot_rate": "$1,500-2,500 per methodology verification",
+    "scale_rate": "$5,000 after 3 case studies with 60-70% time savings",
+    "target_pilots": 5
+  },
+  "current_focus": ["VRR-1: Rule Review Surface"],
+  "phases": [
+    {
+      "id": "vrr-1-rule-review-surface",
+      "name": "Rule Review Surface",
+      "week": 1,
+      "status": "active",
+      "depends_on": []
+    },
+    {
+      "id": "vrr-2-defensibility-layer",
+      "name": "Defensibility Layer",
+      "week": 2,
+      "status": "planned",
+      "depends_on": ["vrr-1-rule-review-surface"]
+    },
+    {
+      "id": "vrr-3-full-coverage-export",
+      "name": "Full Methodology Coverage + Export",
+      "week": 3,
+      "status": "planned",
+      "depends_on": ["vrr-2-defensibility-layer"]
+    },
+    {
+      "id": "vrr-4-pilot-ready-mvp",
+      "name": "Pilot-Ready MVP",
+      "weeks": "4-5",
+      "status": "planned",
+      "depends_on": ["vrr-3-full-coverage-export"]
+    }
+  ],
+  "pr_evidence": {},
+  "pr_meta": {
+    "VRR-1": {
+      "title": "Rule Review Surface",
+      "summary": "Build the traceable review record: rule text, status, rationale, support reference, provenance. The monetizable object.",
+      "acceptance": [
+        "Rule text from rules.json displayed in full",
+        "Status selector: Pending/Verified/Not Verified/Needs Follow-up",
+        "Rationale required for non-pending",
+        "Support reference required for non-pending",
+        "Provenance footer with reviewer + timestamp",
+        "Reviews persist across reloads (localStorage)",
+        "Reserved evidence panel placeholder"
+      ]
+    },
+    "VRR-2": {
+      "title": "Defensibility Layer",
+      "summary": "Backend persistence, evidence attachment, STAC support for satellite rules, review audit trail, finalize gate.",
+      "acceptance": [
+        "Reviews persist server-side via API",
+        "File upload and URL evidence links work",
+        "STAC facts auto-populate for satellite rules",
+        "Audit trail records all status changes",
+        "Finalize blocked until all rules reviewed"
+      ]
+    },
+    "VRR-3": {
+      "title": "Full Methodology Coverage + Export",
+      "summary": "All AR-ACM0003 rules reviewable. PDF + JSON verification summary export. Document upload.",
+      "acceptance": [
+        "All AR-ACM0003 v02-0 rules visible and reviewable",
+        "PDF export with all review records",
+        "JSON export passes schema validation",
+        "Document upload + basic text extraction"
+      ]
+    },
+    "VRR-4": {
+      "title": "Pilot-Ready MVP",
+      "summary": "Project-level synthesis, workbook calculations, multi-methodology, observer access. First paid pilot.",
+      "acceptance": [
+        "Verification Opinion report covers all rules",
+        "Workbook calculations (baseline/removals/leakage)",
+        "At least 2 methodologies loadable",
+        "At least 1 external pilot completed"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## WHAT

- Add `docs/roadmaps/traceable-rule-review-mvp/PLAN.md` — 5-phase roadmap for app-side work
- Add `docs/roadmaps/traceable-rule-review-mvp/phase-status.json` — phase tracker with consistent IDs
- Remove old `verifiable-review-record` roadmap (replaced)

## WHY

- Product center is the traceable rule review record, not a clickable checklist
- Consistent phase IDs (T-1 through T-5) across app and methodologies repos
- Clean repo boundary: app owns UI/workflow/persistence/export; methodologies owns schemas/data contracts
- 5-week path to paid pilots ($1.5-2.5K per verification, scaling to $5K)

## Phases

- **T-1** (active): Rule Review Record — review panel with status, rationale, evidence, provenance
- **T-2**: Defensible Verification — evidence attachment, audit trail, finalize gate
- **T-3**: STAC/AOI Support Facts — auto satellite support for eligible rules
- **T-4**: Document and Workbook Support — upload + extract structured facts
- **T-5**: Exportable Verification Output — PDF + JSON export with full traceability

## Cross-repo

- Methodologies contract: https://github.com/Fredilly/article6-methodologies/pull/387
- T-1 issue: #493
