### PR TITLE
docs: traceable-rule-review-mvp SSOT

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, project-verification, requirement-coverage.
+Active lanes: verification-factory, project-verification, requirement-coverage, traceable-rule-review-mvp.
 Frozen lanes: agentic-verification.
 
 
@@ -150,3 +150,21 @@ Not active now:
 6) RC6 — Methodology version diff / impact mode: Planned — Use canonical methodology version and diff metadata to identify coverage rows and linked evidence that may need review in the app.
 7) RC7 — Fallback raw methodology PDF intake for uncovered methods: Planned — Enable lower-confidence fallback raw methodology PDF intake only for uncovered methods while preserving canonical methodology outputs as the default for covered methods.
 8) RC8 — Additional GIS formats later: Deferred — Defer broader GIS intake until reconciliation fundamentals are stable.
+
+## traceable-rule-review-mvp
+
+Status SSOT: `docs/roadmaps/traceable-rule-review-mvp/phase-status.json`
+Details: `docs/roadmaps/traceable-rule-review-mvp/PLAN.md`
+
+Lane status: Active
+Turn per-rule verification into a traceable rule review workspace. The product center is the review record, not the checklist. 5-week path to paid VVB pilots.
+
+Current focus:
+- Build the rule review record: status, rationale, evidence, provenance
+- Verify AR-ACM0003 data contract in methodologies repo (T-1 parallel)
+
+Not active now:
+- STAC auto-verification (support facts only, not auto-verify)
+- AI-assisted review (post-moat)
+- Multi-methodology cross-referencing (after first methodology works)
+

--- a/docs/roadmaps/traceable-rule-review-mvp/PLAN.md
+++ b/docs/roadmaps/traceable-rule-review-mvp/PLAN.md
@@ -1,0 +1,96 @@
+# Traceable Rule Review MVP
+
+SSOT: `docs/roadmaps/traceable-rule-review-mvp/phase-status.json`
+
+## Repo boundary
+
+This roadmap owns **UI, workflow, persistence, and export execution**. It does NOT own methodology semantics, canonical rule contracts, or schema definitions. That is the methodologies repo: [traceable-rule-review-mvp](https://github.com/Fredilly/article6-methodologies/tree/main/docs/roadmaps/traceable-rule-review-mvp).
+
+## Goal
+
+Turn the current methodology/checklist flow into a traceable rule review workspace. The product center is the **rule review record** — a defensible, auditable decision on each methodology rule with status, rationale, evidence reference, and provenance.
+
+## How existing pieces fit
+
+| Piece | Where it lives | Role in this roadmap |
+|-------|---------------|---------------------|
+| Methods | Manifest, `rules.json` / `rules.rich.json` | Supply rule text, type, tags, section anchors to review panel |
+| Complex methods | Version lineage (RC-S5) | Review panel shows version context |
+| AOI | `proofMap/aoi.ts`, `proofMap/aoiApply.ts` | Scope STAC searches and evidence to project area |
+| STAC | `api/stac/search`, `lib/stac/normalizeStacItems` | Provide satellite support facts for eligible rules |
+| Projects | `app/projects/`, `api/projects/` | Container for verification; holds all rule reviews |
+| Verification packs | `exports/auditPack.ts`, `lib/export/buildProvenanceTxt.ts` | Export target — review records feed into the pack |
+| Quick Check | `lib/chat/quickCheck*.ts` | Entry point for ad-hoc checks; review panel is the structured upgrade |
+
+## Priority
+
+truthfulness > defensibility > clean repo boundaries > UX polish
+
+## PR body standard
+
+For every PR related to this roadmap:
+
+```
+Roadmap: traceable-rule-review-mvp
+Roadmap-Phase: <phase-id>
+SSOT: docs/roadmaps/traceable-rule-review-mvp/phase-status.json
+```
+
+## Phases
+
+### Phase 1 — Rule Review Record
+
+Build the core object: a traceable review record attached to every rule in a project.
+
+- Clicking a rule opens an inline review panel (not modal)
+- Panel: full rule text, source anchor, status, rationale, support reference, evidence link, provenance
+- Status: Pending / Verified / Not Verified / Needs Follow-up
+- Validation: non-pending requires rationale + support reference
+- Reviews persist via API
+- Reserved STAC evidence area (empty placeholder)
+
+### Phase 2 — Defensible Verification
+
+Every review decision traceable by a third party.
+
+- Evidence attachment (file upload or URL link) per rule review
+- Audit trail: all status changes logged with who/when/what
+- Blocking gate: finalize blocked until all rules reviewed
+- Review progress: X of Y rules, % verified, open items
+
+### Phase 3 — STAC / AOI Support Facts
+
+Satellite rules get automatic STAC support. AOI scopes evidence.
+
+- Rules tagged `monitoring` auto-trigger STAC search
+- STAC panel: AOI overlap, temporal coverage, cloud stats, top 10 scenes
+- AOI from project scope feeds search
+- STAC populates the reserved area from Phase 1
+- Clear labeling: "Supporting data — reviewer must assess sufficiency"
+
+### Phase 4 — Document and Workbook Support
+
+Upload project documents. Extract structured facts for review support.
+
+- Document upload: PDF, store in project
+- Text extraction from uploaded PDFs
+- Workbook ingestion: baseline/removals/leakage spreadsheets
+- Extracted facts available in review panel as support references
+
+### Phase 5 — Exportable Verification Output
+
+One-click export: what VVBs pay for.
+
+- PDF: all rule reviews, status, rationale, evidence, provenance
+- JSON: machine-readable verification snapshot (schema-validated)
+- Provenance chain: full who/when/what
+- Source anchors preserved in export
+- Project-level synthesis: aggregate all reviews into one opinion
+
+## What this excludes
+
+- Enterprise SSO / multi-tenant
+- AI auto-verification
+- Non-Article 6 methodologies
+- Methodology semantics (owned by methodologies repo)
+- Schema definitions (owned by methodologies repo)

--- a/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
+++ b/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
@@ -1,0 +1,42 @@
+{
+  "phase_meta": {
+    "status": "active",
+    "summary": "Turn per-rule verification into a traceable rule review workspace. The product center is the review record, not the checklist. 5-week path to paid VVB pilots.",
+    "current_focus": [
+      "Build the rule review record: status, rationale, evidence, provenance",
+      "Verify AR-ACM0003 data contract in methodologies repo (T-1 parallel)"
+    ],
+    "not_active_now": [
+      "STAC auto-verification (support facts only, not auto-verify)",
+      "AI-assisted review (post-moat)",
+      "Multi-methodology cross-referencing (after first methodology works)"
+    ]
+  },
+  "phase_1_rule_review_record": {
+    "status": "active",
+    "title": "Rule Review Record",
+    "summary": "Build the traceable review record: rule text, status, rationale, support reference, provenance. The monetizable object. Inline panel, not modal. Validation enforces rationale + support before Verified."
+  },
+  "phase_2_defensible_verification": {
+    "status": "planned",
+    "title": "Defensible Verification",
+    "summary": "Evidence attachment, audit trail, finalize gate. Every decision traceable by a third party. Reviews become defensible audit artifacts."
+  },
+  "phase_3_stac_aoi_support_facts": {
+    "status": "planned",
+    "title": "STAC / AOI Support Facts",
+    "summary": "Auto-populate satellite support facts for eligible rules. AOI-scoped. Support, not auto-verification. STAC fills the reserved area from Phase 1."
+  },
+  "phase_4_document_workbook_support": {
+    "status": "planned",
+    "title": "Document and Workbook Support",
+    "summary": "Upload PDD, monitoring reports, workbooks. Extract structured facts for review support. Quick Check integration."
+  },
+  "phase_5_exportable_verification_output": {
+    "status": "planned",
+    "title": "Exportable Verification Output",
+    "summary": "One-click PDF + JSON export with full traceability. Project-level synthesis. What VVBs pay for."
+  },
+  "pr_evidence": {},
+  "pr_notes": {}
+}

--- a/docs/roadmaps/verifiable-review-record/PLAN.md
+++ b/docs/roadmaps/verifiable-review-record/PLAN.md
@@ -1,0 +1,201 @@
+# Verifiable Review Record
+
+Status is sourced from `docs/roadmaps/verifiable-review-record/phase-status.json`.
+
+## Goal
+
+Ship a paid verification service ($1.5-2.5K/pilot, scaling to $5K) where VVBs can load a methodology, review every rule with traceable rationale and evidence, and export a defensible verification summary. The product unit is not the rule card — it's the **traceable review record**.
+
+## What we're building
+
+A methodology-aware review workspace with traceable rule-by-rule support and full provenance. Built for VVBs and Article 6 focal points who need to move from weeks of manual review to hours with an auditable trail.
+
+Do not call this a checklist.
+
+## What shipped already
+
+Quick Check + Methods + Projects + per-rule verify + STAC runs. Solid foundation, but feels like a demo, not a paid service. The gap: no rationale capture, no evidence reference, no provenance on review decisions.
+
+## Pricing ladder
+
+- First 5 pilots: $1,500-2,500 per full methodology verification
+- After 3 case studies showing 60-70% time savings: raise to $5K
+- VVBs charge $50-100K/engagement — we save them weeks
+
+## Sequencing
+
+Phases are strict. Each phase builds on the previous. Do not skip ahead.
+
+Methodology repo (article6-methodologies) runs in parallel — see [complete-methodology-coverage](https://github.com/Fredilly/article6-methodologies/tree/main/docs/roadmaps/complete-methodology-coverage) roadmap for encoding work.
+
+---
+
+## VRR-1 — Rule Review Surface (Week 1)
+
+### Goal
+
+Build the monetizable object: a traceable review record attached to every rule.
+
+### Deliverables
+
+- Clicking any rule card expands to show a review panel (inline, not modal)
+- Panel shows: full rule text, methodology source anchor, status selector, rationale field, support reference field, evidence link field, provenance footer, reserved evidence area
+- Status cannot be set to Verified/Not Verified without rationale + support reference (validation)
+- Reviews persist in localStorage (Phase 2 migrates to API)
+
+### Key changes
+
+- New `src/components/verify/RuleReviewPanel.tsx` — the review surface
+- New `src/lib/verify/reviewStore.ts` — localStorage persistence
+- New `src/lib/verify/reviewValidation.ts` — validation logic
+- Modify `src/components/RuleCard.tsx` — add expand toggle + render panel
+- Tests for validation logic
+
+### Visible UI change to look for
+
+Clicking a rule opens or reveals a proper review panel with rule text, rationale, and evidence fields — not just a status dropdown.
+
+### Acceptance criteria
+
+- [ ] Rule text from `rules.json` is displayed in full
+- [ ] Section/source anchor shown when available
+- [ ] Status: Pending / Verified / Not Verified / Needs Follow-up
+- [ ] Rationale required for non-pending status
+- [ ] Support reference required for non-pending status
+- [ ] Evidence link optional
+- [ ] Provenance footer: reviewer, timestamp
+- [ ] Save disabled until validation passes
+- [ ] Review persists across page reloads
+- [ ] Reserved evidence panel placeholder visible
+
+---
+
+## VRR-2 — Defensibility Layer (Week 2)
+
+### Goal
+
+Reviews become defensible. Enforce traceability on every decision.
+
+### Deliverables
+
+- Backend review persistence (API endpoints, not just localStorage)
+- Evidence attachment (upload file or link URL)
+- STAC auto-support for satellite-relevant rules only (AOI overlap, temporal coverage, cloud stats, scene list)
+- Review audit trail: who changed what, when
+- Blocking gate: cannot finalize project without all rules reviewed
+
+### Key changes
+
+- New `src/app/api/reviews/route.ts` — CRUD for reviews
+- New `src/app/api/reviews/[ruleId]/route.ts` — single review endpoint
+- STAC integration in review panel (only for rules tagged `satellite`, `remote-sensing`, or `monitoring`)
+- Modify `RuleReviewPanel.tsx` — add evidence upload, STAC facts display
+- New `src/components/verify/EvidenceAttachment.tsx` — upload/link component
+- Review summary aggregation: show % reviewed, % verified, open items
+
+### Visible UI change to look for
+
+STAC facts auto-populate for satellite rules. Evidence can be attached. Review progress is visible.
+
+### Acceptance criteria
+
+- [ ] Reviews persist server-side via API
+- [ ] File upload works (PDF, images, docs)
+- [ ] URL evidence links work
+- [ ] STAC facts appear for satellite-relevant rules automatically
+- [ ] STAC shows: AOI overlap, temporal coverage, cloud stats, scene IDs
+- [ ] STAC is support facts, NOT auto-verification
+- [ ] Review audit trail records all status changes with timestamps
+- [ ] Project finalize blocked until all rules have status + rationale + support
+
+---
+
+## VRR-3 — Full Methodology Coverage + Export (Week 3)
+
+### Goal
+
+All AR-ACM0003 rules covered. One-click export produces a verification summary.
+
+### Deliverables
+
+- All rules from AR-ACM0003 v02-0 loadable and reviewable (not just R-1-0001)
+- Methodology completeness indicator: "12 of 15 rules reviewed"
+- PDF export: Verification Summary with all review records
+- JSON export: machine-readable verification snapshot
+- Document ingestion MVP: upload PDD fragments, extract basic facts
+
+### Key changes
+
+- Ensure manifest loads all rules from methodology packs
+- New `src/lib/export/verificationSummary.ts` — build summary from reviews
+- PDF generation (wkhtmltopdf or raw HTML — see existing pdf/ patterns)
+- New `src/components/verify/ExportButton.tsx`
+- Document upload + basic text extraction (Phase 4 adds structured extraction)
+
+### Visible UI change to look for
+
+"Export Verification Summary" button produces a PDF with every rule, its review status, rationale, and evidence references.
+
+### Acceptance criteria
+
+- [ ] All AR-ACM0003 v02-0 rules visible and reviewable
+- [ ] Methodology completeness: X of Y rules reviewed
+- [ ] PDF export contains: methodology info, every rule with status/rationale/support, provenance
+- [ ] JSON export passes schema validation
+- [ ] Document upload accepts PDFs, stores them
+- [ ] Basic text extraction from uploaded PDFs available in review panel
+
+---
+
+## VRR-4 — Pilot-Ready MVP (Weeks 4-5)
+
+### Goal
+
+First paid pilot. Real methodology verification with an external VVB or project developer.
+
+### Deliverables
+
+- Project-level synthesis: aggregate all rule reviews into one "Article 6 Verification Opinion"
+- Synthetic workbook → auto calculations (baseline, removals, leakage)
+- Multi-methodology support: AR-ACM0003 + at least one agriculture methodology
+- Role-based access: reviewer vs. observer views
+- Pilot pricing page or onboarding flow
+
+### Key changes
+
+- New `src/lib/verify/verificationOpinion.ts` — project-level synthesis
+- Workbook calculation engine (baseline, uplift, leakage formulas)
+- Multi-methodology routing (load correct rules.json per methodology)
+- Simple auth or share-link for observer access
+- Landing page / pricing messaging update
+
+### Visible UI change to look for
+
+"Generate Verification Opinion" produces a single document covering the entire project. Multiple methodologies work.
+
+### Acceptance criteria
+
+- [ ] Verification Opinion report covers all reviewed rules
+- [ ] Workbook calculations produce correct baseline/removals/leakage
+- [ ] At least 2 methodologies loadable (AR-ACM0003 + agriculture)
+- [ ] Observer can view but not edit reviews
+- [ ] At least 1 external pilot completed
+- [ ] Pricing positioned at $1,500-2,500 for first 5 pilots
+
+---
+
+## Always-optimizing
+
+1. **Truthfulness > defensibility > UX polish** — in that order
+2. A rule is not meaningfully verified without: status + rationale + support + provenance
+3. STAC is support facts, never auto-verification
+4. Every review decision must be traceable by a third party
+5. Ship fast, iterate on feedback — do not over-engineer before pilots
+
+## What this roadmap deliberately excludes
+
+- Enterprise SSO / multi-tenant (post-revenue)
+- AI auto-verification (post-moat)
+- Mobile app (desktop-first for reviewers)
+- Non-Article 6 methodologies (stay focused)
+- Blockchain provenance (nice-to-have, not required for $5K)

--- a/docs/roadmaps/verifiable-review-record/phase-status.json
+++ b/docs/roadmaps/verifiable-review-record/phase-status.json
@@ -1,0 +1,89 @@
+{
+  "roadmap": "verifiable-review-record",
+  "goal": "Ship paid verification service — traceable review records, not clickable checklists.",
+  "last_updated_at": "2026-04-15T00:00:00Z",
+  "status": "active",
+  "pricing": {
+    "pilot_rate": "$1,500-2,500 per methodology verification",
+    "scale_rate": "$5,000 after 3 case studies with 60-70% time savings",
+    "target_pilots": 5
+  },
+  "current_focus": ["VRR-1: Rule Review Surface"],
+  "phases": [
+    {
+      "id": "vrr-1-rule-review-surface",
+      "name": "Rule Review Surface",
+      "week": 1,
+      "status": "active",
+      "depends_on": []
+    },
+    {
+      "id": "vrr-2-defensibility-layer",
+      "name": "Defensibility Layer",
+      "week": 2,
+      "status": "planned",
+      "depends_on": ["vrr-1-rule-review-surface"]
+    },
+    {
+      "id": "vrr-3-full-coverage-export",
+      "name": "Full Methodology Coverage + Export",
+      "week": 3,
+      "status": "planned",
+      "depends_on": ["vrr-2-defensibility-layer"]
+    },
+    {
+      "id": "vrr-4-pilot-ready-mvp",
+      "name": "Pilot-Ready MVP",
+      "weeks": "4-5",
+      "status": "planned",
+      "depends_on": ["vrr-3-full-coverage-export"]
+    }
+  ],
+  "pr_evidence": {},
+  "pr_meta": {
+    "VRR-1": {
+      "title": "Rule Review Surface",
+      "summary": "Build the traceable review record: rule text, status, rationale, support reference, provenance. The monetizable object.",
+      "acceptance": [
+        "Rule text from rules.json displayed in full",
+        "Status selector: Pending/Verified/Not Verified/Needs Follow-up",
+        "Rationale required for non-pending",
+        "Support reference required for non-pending",
+        "Provenance footer with reviewer + timestamp",
+        "Reviews persist across reloads (localStorage)",
+        "Reserved evidence panel placeholder"
+      ]
+    },
+    "VRR-2": {
+      "title": "Defensibility Layer",
+      "summary": "Backend persistence, evidence attachment, STAC support for satellite rules, review audit trail, finalize gate.",
+      "acceptance": [
+        "Reviews persist server-side via API",
+        "File upload and URL evidence links work",
+        "STAC facts auto-populate for satellite rules",
+        "Audit trail records all status changes",
+        "Finalize blocked until all rules reviewed"
+      ]
+    },
+    "VRR-3": {
+      "title": "Full Methodology Coverage + Export",
+      "summary": "All AR-ACM0003 rules reviewable. PDF + JSON verification summary export. Document upload.",
+      "acceptance": [
+        "All AR-ACM0003 v02-0 rules visible and reviewable",
+        "PDF export with all review records",
+        "JSON export passes schema validation",
+        "Document upload + basic text extraction"
+      ]
+    },
+    "VRR-4": {
+      "title": "Pilot-Ready MVP",
+      "summary": "Project-level synthesis, workbook calculations, multi-methodology, observer access. First paid pilot.",
+      "acceptance": [
+        "Verification Opinion report covers all rules",
+        "Workbook calculations (baseline/removals/leakage)",
+        "At least 2 methodologies loadable",
+        "At least 1 external pilot completed"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Roadmap: traceable-rule-review-mvp
Roadmap-Phase: phase-1-rule-review-record
SSOT: docs/roadmaps/traceable-rule-review-mvp/phase-status.json

## WHAT

- Add `docs/roadmaps/traceable-rule-review-mvp/PLAN.md` — narrative roadmap
- Add `docs/roadmaps/traceable-rule-review-mvp/phase-status.json` — machine-readable SSOT
- SUMMARY.md regenerated by roadmap generator

## WHY

- Single source of truth for traceable rule review execution
- Consistent phase IDs across app and methodologies repos
- Clean repo boundary: app owns UI/workflow/persistence/export
- Generator-compatible phase-status format (phase_1_*, phase_2_*, etc.)

## Phases

- Phase 1 (active): Rule Review Record — review panel with status, rationale, evidence, provenance
- Phase 2: Defensible Verification — evidence attachment, audit trail, finalize gate
- Phase 3: STAC/AOI Support Facts — auto satellite support for eligible rules
- Phase 4: Document and Workbook Support — upload + extract structured facts
- Phase 5: Exportable Verification Output — PDF + JSON export with full traceability

Cross-repo: https://github.com/Fredilly/article6-methodologies/pull/388
