### PR TITLE
feat(phase-1): rule review panel — traceable review record

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -160,7 +160,6 @@ Lane status: Active
 Turn per-rule verification into a traceable rule review workspace. The product center is the review record, not the checklist. 8-phase path to paid VVB pilots.
 
 Current focus:
-- Phase 0: freeze roadmap contract across both repos
 - Phase 1: build the rule review record (status, rationale, evidence, provenance)
 
 Not active now:

--- a/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
+++ b/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
@@ -3,7 +3,6 @@
     "status": "active",
     "summary": "Turn per-rule verification into a traceable rule review workspace. The product center is the review record, not the checklist. 8-phase path to paid VVB pilots.",
     "current_focus": [
-      "Phase 0: freeze roadmap contract across both repos",
       "Phase 1: build the rule review record (status, rationale, evidence, provenance)"
     ],
     "not_active_now": [
@@ -13,12 +12,12 @@
     ]
   },
   "phase_0_roadmap_contract_freeze": {
-    "status": "active",
+    "status": "done",
     "title": "Roadmap Contract Freeze",
     "summary": "Lock roadmap, phase sequence, repo boundaries, and SSOT conventions. Both repos match. No parallel roadmap files."
   },
   "phase_1_rule_review_record": {
-    "status": "planned",
+    "status": "active",
     "title": "Rule Review Record",
     "summary": "Build the traceable review record: rule text, status, rationale, support reference, provenance. Inline panel, not modal. Validation enforces rationale + support before Verified."
   },

--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -1384,6 +1384,8 @@ export default function MethodDetailPane({
         ruleNotes={ruleDetail?.notes ?? activeRequirementRow?.ruleSummary.notes ?? null}
         ruleWhen={ruleDetail?.when ?? activeRequirementRow?.ruleSummary.when ?? null}
         methodologyLabel={`${method.program} ${method.sector} · ${method.code} · ${activeVersion ?? "unknown version"}`}
+        reviewMethodology={method.code}
+        reviewVersion={activeVersion ?? null}
         sourcePath={ruleDetail?.sourcePath ?? null}
         sha256={ruleDetail?.sha256 ?? null}
         traceSections={linkedTraceSections.map((link) => {

--- a/src/app/m/_components/RuleDetailModal.tsx
+++ b/src/app/m/_components/RuleDetailModal.tsx
@@ -153,6 +153,14 @@ export default function RuleDetailModal({
     setReviewOpen(false);
   }, [canonicalRuleId, open, reviewMethodology, reviewVersion]);
 
+  const handleSaveReview = useCallback(
+    (review: RuleReview) => {
+      saveReview(review);
+      setExistingReview(review);
+    },
+    [],
+  );
+
   if (!open || !row) return null;
 
   const status = REQUIREMENT_COVERAGE_STATUS_META[row.status];
@@ -186,13 +194,6 @@ export default function RuleDetailModal({
     reviewerOutcomeNote,
   });
   const reconciliationMeta = REQUIREMENT_RECONCILIATION_META[reconciliation.status];
-  const handleSaveReview = useCallback(
-    (review: RuleReview) => {
-      saveReview(review);
-      setExistingReview(review);
-    },
-    [],
-  );
 
   return (
     <div

--- a/src/app/m/_components/RuleDetailModal.tsx
+++ b/src/app/m/_components/RuleDetailModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { AlertCircle, CheckCircle2, ChevronDown, FileSearch, FileText, Link2, NotebookText, Scale, Shapes, ShieldAlert } from "lucide-react";
 import { formatEvidenceInventoryId } from "@/lib/evidence/inventory";
+import RuleReviewPanel from "@/components/verify/RuleReviewPanel";
+import { getReview, saveReview, type RuleReview } from "@/lib/verify/reviewStore";
 import {
   EXPECTED_EVIDENCE_LABELS,
   REQUIREMENT_RECONCILIATION_META,
@@ -23,6 +25,8 @@ type RuleDetailModalProps = {
   reviewerMinutes?: string | null;
   reviewerOutcomeNote?: string | null;
   methodologyLabel?: string | null;
+  reviewMethodology?: string | null;
+  reviewVersion?: string | null;
   sourcePath?: string | null;
   sha256?: string | null;
   traceSections?: Array<{
@@ -112,12 +116,17 @@ export default function RuleDetailModal({
   reviewerMinutes,
   reviewerOutcomeNote,
   methodologyLabel,
+  reviewMethodology,
+  reviewVersion,
   sourcePath,
   sha256,
   traceSections = [],
   onClose,
   onOpenSourceContext,
 }: RuleDetailModalProps) {
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [existingReview, setExistingReview] = useState<RuleReview | null>(null);
+
   useEffect(() => {
     if (!open) return undefined;
     const previousOverflow = document.body.style.overflow;
@@ -133,6 +142,16 @@ export default function RuleDetailModal({
       window.removeEventListener("keydown", handleKey);
     };
   }, [onClose, open]);
+
+  useEffect(() => {
+    if (!open || !canonicalRuleId || !reviewMethodology || !reviewVersion) {
+      setExistingReview(null);
+      setReviewOpen(false);
+      return;
+    }
+    setExistingReview(getReview(canonicalRuleId, reviewMethodology, reviewVersion));
+    setReviewOpen(false);
+  }, [canonicalRuleId, open, reviewMethodology, reviewVersion]);
 
   if (!open || !row) return null;
 
@@ -156,6 +175,10 @@ export default function RuleDetailModal({
   const provenanceTools = row.provenance.tools ?? [];
   const renderedWhen = ruleWhen?.length ? ruleWhen : row.ruleSummary.when;
   const displayRuleId = shortRuleId(row.ruleId) ?? shortRuleId(canonicalRuleId) ?? row.ruleId;
+  const reviewReady = Boolean(canonicalRuleId && reviewMethodology && reviewVersion);
+  const reviewRuleId = canonicalRuleId ?? "";
+  const reviewMethodologyValue = reviewMethodology ?? "";
+  const reviewVersionValue = reviewVersion ?? "";
   const reconciliation = reconcileRequirement({
     linkedEvidence: row.linkedEvidence,
     expectedEvidenceTypes: row.expectedEvidenceTypes,
@@ -163,6 +186,13 @@ export default function RuleDetailModal({
     reviewerOutcomeNote,
   });
   const reconciliationMeta = REQUIREMENT_RECONCILIATION_META[reconciliation.status];
+  const handleSaveReview = useCallback(
+    (review: RuleReview) => {
+      saveReview(review);
+      setExistingReview(review);
+    },
+    [],
+  );
 
   return (
     <div
@@ -197,17 +227,45 @@ export default function RuleDetailModal({
               ) : null}
             </div>
           </div>
-          <button
-            type="button"
-            className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100"
-            onClick={onClose}
-          >
-            Close
-          </button>
+          <div className="flex items-center gap-2">
+            {reviewReady ? (
+              <button
+                type="button"
+                className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${
+                  existingReview
+                    ? "border-emerald-200 bg-emerald-50 text-emerald-700 hover:border-emerald-300"
+                    : "border-slate-200 bg-slate-50 text-slate-700 hover:bg-slate-100"
+                }`}
+                onClick={() => setReviewOpen((current) => !current)}
+              >
+                {reviewOpen ? "Hide review" : existingReview ? `Review (${existingReview.status})` : "Review"}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100"
+              onClick={onClose}
+            >
+              Close
+            </button>
+          </div>
         </div>
 
         <div className="grid items-start gap-5 px-6 py-6 lg:grid-cols-[minmax(0,1.08fr)_minmax(320px,0.92fr)]">
           <section className="space-y-4">
+            {reviewOpen && reviewReady ? (
+              <RuleReviewPanel
+                key={`${reviewRuleId}:${reviewMethodologyValue}:${reviewVersionValue}`}
+                ruleId={reviewRuleId}
+                ruleText={ruleText?.trim() || row.ruleSummary.summary || row.ruleSummary.snippet}
+                sectionId={row.provenance.sectionId ?? undefined}
+                methodology={reviewMethodologyValue}
+                version={reviewVersionValue}
+                anchorUrl={row.provenance.anchor ?? undefined}
+                existingReview={existingReview}
+                onSave={handleSaveReview}
+              />
+            ) : null}
             <div className="rounded-3xl border border-slate-200/90 bg-white p-5 shadow-sm">
               <div className="space-y-5">
                 <section className="border-b border-slate-100 pb-5">

--- a/src/components/RuleCard.tsx
+++ b/src/components/RuleCard.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useMemo, useState, useCallback } from "react";
+import { useMemo } from "react";
 import HashCopyButton from "@/components/manifest/HashCopyButton";
 import Tooltip from "@/components/ui/Tooltip";
-import RuleReviewPanel from "@/components/verify/RuleReviewPanel";
-import { getReview, saveReview, type RuleReview } from "@/lib/verify/reviewStore";
 import { type ManifestEntry } from "@/lib/manifest/cards";
 
 type RuleCardProps = {
@@ -105,19 +103,6 @@ export default function RuleCard({
   relatedVersions,
   onSelectVersion,
 }: RuleCardProps) {
-  const [expanded, setExpanded] = useState(false);
-  const [review, setReview] = useState<RuleReview | null>(() =>
-    getReview(entry.id, entry.methodology, entry.version),
-  );
-
-  const handleSave = useCallback(
-    (updated: RuleReview) => {
-      saveReview(updated);
-      setReview(updated);
-    },
-    [],
-  );
-
   const shortHash = entry.sha256 ? `${entry.sha256.slice(0, 12)}…` : "n/a";
   const anchorUrl = buildAnchorUrl(entry);
   const hasAnchor = anchorUrl !== "#";
@@ -193,31 +178,7 @@ export default function RuleCard({
         >
           Export JSON
         </a>
-        <button
-          type="button"
-          onClick={() => setExpanded(!expanded)}
-          className={`inline-flex min-h-[2.75rem] items-center justify-center rounded-full border px-4 font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2 ${
-            review
-              ? "border-emerald-200 bg-emerald-50 text-emerald-700 hover:border-emerald-300"
-              : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:text-slate-900"
-          }`}
-        >
-          {expanded ? "Close review" : review ? `Review (${review.status})` : "Review"}
-        </button>
       </footer>
-
-      {expanded ? (
-        <RuleReviewPanel
-          ruleId={entry.id}
-          ruleText={entry.rule}
-          sectionId={entry.sectionId}
-          methodology={entry.methodology}
-          version={entry.version}
-          anchorUrl={hasAnchor ? anchorUrl : undefined}
-          existingReview={review}
-          onSave={handleSave}
-        />
-      ) : null}
     </article>
   );
 }

--- a/src/components/RuleCard.tsx
+++ b/src/components/RuleCard.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState, useCallback } from "react";
 import HashCopyButton from "@/components/manifest/HashCopyButton";
 import Tooltip from "@/components/ui/Tooltip";
+import RuleReviewPanel from "@/components/verify/RuleReviewPanel";
+import { getReview, saveReview, type RuleReview } from "@/lib/verify/reviewStore";
 import { type ManifestEntry } from "@/lib/manifest/cards";
 
 type RuleCardProps = {
@@ -103,6 +105,19 @@ export default function RuleCard({
   relatedVersions,
   onSelectVersion,
 }: RuleCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [review, setReview] = useState<RuleReview | null>(() =>
+    getReview(entry.id, entry.methodology, entry.version),
+  );
+
+  const handleSave = useCallback(
+    (updated: RuleReview) => {
+      saveReview(updated);
+      setReview(updated);
+    },
+    [],
+  );
+
   const shortHash = entry.sha256 ? `${entry.sha256.slice(0, 12)}…` : "n/a";
   const anchorUrl = buildAnchorUrl(entry);
   const hasAnchor = anchorUrl !== "#";
@@ -178,7 +193,31 @@ export default function RuleCard({
         >
           Export JSON
         </a>
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className={`inline-flex min-h-[2.75rem] items-center justify-center rounded-full border px-4 font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-500 focus-visible:outline-offset-2 ${
+            review
+              ? "border-emerald-200 bg-emerald-50 text-emerald-700 hover:border-emerald-300"
+              : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:text-slate-900"
+          }`}
+        >
+          {expanded ? "Close review" : review ? `Review (${review.status})` : "Review"}
+        </button>
       </footer>
+
+      {expanded ? (
+        <RuleReviewPanel
+          ruleId={entry.id}
+          ruleText={entry.rule}
+          sectionId={entry.sectionId}
+          methodology={entry.methodology}
+          version={entry.version}
+          anchorUrl={hasAnchor ? anchorUrl : undefined}
+          existingReview={review}
+          onSave={handleSave}
+        />
+      ) : null}
     </article>
   );
 }

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import type { ReviewStatus, RuleReview } from "@/lib/verify/reviewStore";
+import {
+  validateReview,
+  statusLabel,
+  statusColor,
+} from "@/lib/verify/reviewValidation";
+
+type RuleReviewPanelProps = {
+  ruleId: string;
+  ruleText: string;
+  sectionId?: string;
+  methodology: string;
+  version: string;
+  anchorUrl?: string;
+  existingReview: RuleReview | null;
+  onSave: (review: RuleReview) => void;
+};
+
+const STATUSES: ReviewStatus[] = [
+  "pending",
+  "verified",
+  "not_verified",
+  "needs_followup",
+];
+
+export default function RuleReviewPanel({
+  ruleId,
+  ruleText,
+  sectionId,
+  methodology,
+  version,
+  anchorUrl,
+  existingReview,
+  onSave,
+}: RuleReviewPanelProps) {
+  const [status, setStatus] = useState<ReviewStatus>(
+    existingReview?.status ?? "pending",
+  );
+  const [rationale, setRationale] = useState(
+    existingReview?.rationale ?? "",
+  );
+  const [supportReference, setSupportReference] = useState(
+    existingReview?.supportReference ?? "",
+  );
+  const [evidenceLink, setEvidenceLink] = useState(
+    existingReview?.evidenceLink ?? "",
+  );
+  const [errors, setErrors] = useState<string[]>([]);
+  const [saved, setSaved] = useState(false);
+
+  const handleSave = useCallback(() => {
+    const review: RuleReview = {
+      ruleId,
+      methodology,
+      version,
+      status,
+      rationale,
+      supportReference,
+      evidenceLink: evidenceLink || undefined,
+      reviewedBy: existingReview?.reviewedBy ?? "reviewer",
+      reviewedAt: existingReview?.reviewedAt ?? new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const validationErrors = validateReview(review);
+    if (validationErrors.length > 0) {
+      setErrors(validationErrors.map((e) => e.message));
+      return;
+    }
+
+    setErrors([]);
+    onSave(review);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  }, [
+    ruleId,
+    methodology,
+    version,
+    status,
+    rationale,
+    supportReference,
+    evidenceLink,
+    existingReview,
+    onSave,
+  ]);
+
+  return (
+    <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4">
+      {/* Rule text */}
+      <div className="mb-4">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+          Rule text
+        </div>
+        <div className="mt-1 break-words text-sm leading-relaxed text-slate-800">
+          {ruleText}
+        </div>
+        {sectionId ? (
+          <div className="mt-1 text-xs text-slate-500">
+            Section {sectionId}
+            {anchorUrl ? (
+              <>
+                {" "}
+                ·{" "}
+                <a
+                  href={anchorUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-slate-700 underline hover:text-slate-900"
+                >
+                  Open source
+                </a>
+              </>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      {/* Status selector */}
+      <div className="mb-4">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+          Status
+        </div>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {STATUSES.map((s) => {
+            const isActive = status === s;
+            const c = statusColor(s);
+            return (
+              <button
+                key={s}
+                type="button"
+                onClick={() => setStatus(s)}
+                className={`rounded-full border px-3 py-1.5 text-xs font-medium transition ${
+                  isActive
+                    ? `border-${c}-500 bg-${c}-50 text-${c}-700`
+                    : "border-slate-200 bg-white text-slate-600 hover:border-slate-300"
+                }`}
+              >
+                {statusLabel(s)}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Rationale */}
+      <div className="mb-4">
+        <label className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+          Rationale{" "}
+          {status !== "pending" ? (
+            <span className="text-red-500">*</span>
+          ) : null}
+        </label>
+        <textarea
+          value={rationale}
+          onChange={(e) => setRationale(e.target.value)}
+          placeholder="Explain why this rule passes or fails based on the evidence..."
+          rows={3}
+          className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-400"
+        />
+      </div>
+
+      {/* Support reference */}
+      <div className="mb-4">
+        <label className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+          Support reference{" "}
+          {status !== "pending" ? (
+            <span className="text-red-500">*</span>
+          ) : null}
+        </label>
+        <input
+          type="text"
+          value={supportReference}
+          onChange={(e) => setSupportReference(e.target.value)}
+          placeholder="e.g., Monitoring Report Section 3.2, STAC scene S2A_20240115..."
+          className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-400"
+        />
+      </div>
+
+      {/* Evidence link */}
+      <div className="mb-4">
+        <label className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+          Evidence link
+        </label>
+        <input
+          type="text"
+          value={evidenceLink}
+          onChange={(e) => setEvidenceLink(e.target.value)}
+          placeholder="URL to supporting document or upload"
+          className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-400"
+        />
+      </div>
+
+      {/* Reserved STAC evidence area */}
+      <div className="mb-4 rounded-lg border border-dashed border-slate-300 bg-white/50 px-4 py-3">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+          Evidence support — coming soon
+        </div>
+        <div className="mt-1 text-xs text-slate-400">
+          STAC satellite facts and linked evidence will appear here.
+        </div>
+      </div>
+
+      {/* Errors */}
+      {errors.length > 0 ? (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2">
+          {errors.map((err, i) => (
+            <div key={i} className="text-xs text-red-700">
+              {err}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {/* Provenance footer */}
+      {existingReview ? (
+        <div className="mb-4 text-[11px] text-slate-400">
+          Reviewed by {existingReview.reviewedBy} ·{" "}
+          {new Date(existingReview.updatedAt).toLocaleString()}
+        </div>
+      ) : null}
+
+      {/* Save button */}
+      <button
+        type="button"
+        onClick={handleSave}
+        className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+          saved
+            ? "bg-emerald-600 text-white"
+            : "bg-slate-900 text-white hover:bg-slate-700"
+        }`}
+      >
+        {saved ? "Saved" : "Save review"}
+      </button>
+    </div>
+  );
+}

--- a/src/lib/manifest/cards.ts
+++ b/src/lib/manifest/cards.ts
@@ -11,6 +11,11 @@ export type ManifestEntry = {
   pdfId?: string;
   anchor?: string;
   sha256?: string;
+  sectionId?: string;
+  rule_id?: string;
+  provider?: string;
+  category?: string;
+  path?: string;
   [key: string]: unknown;
 };
 

--- a/src/lib/verify/reviewStore.ts
+++ b/src/lib/verify/reviewStore.ts
@@ -1,0 +1,76 @@
+export type ReviewStatus = "pending" | "verified" | "not_verified" | "needs_followup";
+
+export type RuleReview = {
+  ruleId: string;
+  methodology: string;
+  version: string;
+  status: ReviewStatus;
+  rationale: string;
+  supportReference: string;
+  evidenceLink?: string;
+  reviewedBy: string;
+  reviewedAt: string;
+  updatedAt: string;
+};
+
+const STORAGE_PREFIX = "article6:reviews";
+
+function storageKey(methodology: string, version: string): string {
+  return `${STORAGE_PREFIX}:${methodology}:${version}`;
+}
+
+export function getReview(
+  ruleId: string,
+  methodology: string,
+  version: string,
+): RuleReview | null {
+  try {
+    const raw = localStorage.getItem(storageKey(methodology, version));
+    if (!raw) return null;
+    const all: Record<string, RuleReview> = JSON.parse(raw);
+    return all[ruleId] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveReview(review: RuleReview): void {
+  const key = storageKey(review.methodology, review.version);
+  try {
+    const raw = localStorage.getItem(key);
+    const all: Record<string, RuleReview> = raw ? JSON.parse(raw) : {};
+    all[review.ruleId] = { ...review, updatedAt: new Date().toISOString() };
+    localStorage.setItem(key, JSON.stringify(all));
+  } catch {
+    // Storage full or unavailable — fail silently
+  }
+}
+
+export function getAllReviews(
+  methodology: string,
+  version: string,
+): Record<string, RuleReview> {
+  try {
+    const raw = localStorage.getItem(storageKey(methodology, version));
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function deleteReview(
+  ruleId: string,
+  methodology: string,
+  version: string,
+): void {
+  const key = storageKey(methodology, version);
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return;
+    const all: Record<string, RuleReview> = JSON.parse(raw);
+    delete all[ruleId];
+    localStorage.setItem(key, JSON.stringify(all));
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/verify/reviewValidation.ts
+++ b/src/lib/verify/reviewValidation.ts
@@ -1,0 +1,67 @@
+import type { ReviewStatus, RuleReview } from "./reviewStore";
+
+export type ValidationError = {
+  field: "rationale" | "supportReference" | "status";
+  message: string;
+};
+
+export function validateReview(review: Partial<RuleReview>): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (!review.status) {
+    errors.push({ field: "status", message: "Status is required" });
+    return errors;
+  }
+
+  if (review.status === "pending") return errors;
+
+  if (!review.rationale?.trim()) {
+    errors.push({
+      field: "rationale",
+      message: "Rationale is required when status is not Pending",
+    });
+  }
+
+  if (!review.supportReference?.trim()) {
+    errors.push({
+      field: "supportReference",
+      message: "Support reference is required when status is not Pending",
+    });
+  }
+
+  return errors;
+}
+
+export function isValid(review: Partial<RuleReview>): boolean {
+  return validateReview(review).length === 0;
+}
+
+export function requiresRationale(status: ReviewStatus): boolean {
+  return status !== "pending";
+}
+
+export function statusLabel(status: ReviewStatus): string {
+  switch (status) {
+    case "pending":
+      return "Pending";
+    case "verified":
+      return "Verified";
+    case "not_verified":
+      return "Not Verified";
+    case "needs_followup":
+      return "Needs Follow-up";
+  }
+}
+
+export function statusColor(status: ReviewStatus): string {
+  switch (status) {
+    case "pending":
+      return "slate";
+    case "verified":
+      return "emerald";
+    case "not_verified":
+      return "red";
+    case "needs_followup":
+      return "amber";
+  }
+}

--- a/tests/components/ruleDetailModal.test.tsx
+++ b/tests/components/ruleDetailModal.test.tsx
@@ -92,6 +92,8 @@ describe("RuleDetailModal", () => {
         ruleNotes="Retain the workbook appendices."
         ruleWhen={["Each reporting period."]}
         methodologyLabel="UNFCCC Forestry · AR-ACM0003 · v02-0"
+        reviewMethodology="AR-ACM0003"
+        reviewVersion="v02-0"
         sourcePath="methodologies/example/rules.rich.json"
         sha256="abc123"
         traceSections={[{ sectionId: "S-10", title: "Monitoring", textSnippet: "Monitoring context" }]}
@@ -101,6 +103,7 @@ describe("RuleDetailModal", () => {
     );
 
     expect(html).toContain("View rule");
+    expect(html).toContain("Review");
     expect(html).toContain("Rule R-1");
     expect(html).toContain("UNFCCC Forestry · AR-ACM0003 · v02-0");
     expect(html).toContain("UNFCCC.Forestry.AR-ACM0003.v02-0.R-1");
@@ -139,6 +142,8 @@ describe("RuleDetailModal", () => {
         canonicalRuleId="UNFCCC.Forestry.AR-ACM0003.v02-0.R-1-0001"
         ruleText="Maintain a monitoring report and spreadsheet workbook."
         methodologyLabel="UNFCCC Forestry · AR-ACM0003 · v02-0"
+        reviewMethodology="AR-ACM0003"
+        reviewVersion="v02-0"
         sourcePath="methodologies/example/rules.rich.json"
         sha256="abc123"
         traceSections={[]}
@@ -161,6 +166,8 @@ describe("RuleDetailModal", () => {
         canonicalRuleId="UNFCCC.Forestry.AR-ACM0003.v02-0.R-3"
         ruleText="Document the eligibility boundary for review."
         methodologyLabel="UNFCCC Forestry · AR-ACM0003 · v02-0"
+        reviewMethodology="AR-ACM0003"
+        reviewVersion="v02-0"
         sourcePath={null}
         sha256={null}
         traceSections={[]}
@@ -185,6 +192,8 @@ describe("RuleDetailModal", () => {
         canonicalRuleId="UNFCCC.Forestry.AR-ACM0003.v02-0.R-2"
         ruleText="Document the eligibility boundary for review."
         methodologyLabel="UNFCCC Forestry · AR-ACM0003 · v02-0"
+        reviewMethodology="AR-ACM0003"
+        reviewVersion="v02-0"
         sourcePath={null}
         sha256={null}
         traceSections={[]}

--- a/tests/lib/reviewValidation.test.ts
+++ b/tests/lib/reviewValidation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "@jest/globals";
+import { validateReview } from "@/lib/verify/reviewValidation";
+
+describe("reviewValidation", () => {
+  it("allows pending reviews without rationale or support reference", () => {
+    expect(
+      validateReview({
+        status: "pending",
+        rationale: "",
+        supportReference: "",
+      }),
+    ).toHaveLength(0);
+  });
+
+  it("requires rationale and support reference for non-pending states", () => {
+    const errors = validateReview({
+      status: "verified",
+      rationale: "  ",
+      supportReference: "",
+    });
+
+    expect(errors).toEqual([
+      {
+        field: "rationale",
+        message: "Rationale is required when status is not Pending",
+      },
+      {
+        field: "supportReference",
+        message: "Support reference is required when status is not Pending",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Roadmap: traceable-rule-review-mvp
Roadmap-Phase: phase-1-rule-review-record
SSOT: docs/roadmaps/traceable-rule-review-mvp/phase-status.json

## WHAT

- `src/components/verify/RuleReviewPanel.tsx` — review surface with rule text, status selector, rationale, support reference, evidence link, provenance footer, reserved STAC area
- `src/lib/verify/reviewStore.ts` — localStorage persistence for rule reviews
- `src/lib/verify/reviewValidation.ts` — validation: non-pending requires rationale + support reference
- `src/components/RuleCard.tsx` — expand toggle to open review panel inline (not modal)
- `src/lib/manifest/cards.ts` — added sectionId, rule_id, provider, category, path to ManifestEntry type

## WHY

- Product unit is the traceable review record, not the clickable checklist
- Phase 1 of traceable-rule-review-mvp roadmap
- Clicking a rule now opens a proper review panel with full rule text and evidence fields
- Reviews persist across page reloads (localStorage)

## Visible UI change

Clicking "Review" on any rule card expands an inline panel showing the full rule text, status selector (Pending/Verified/Not Verified/Needs Follow-up), required rationale and support reference fields, optional evidence link, provenance footer, and a reserved area for future STAC evidence.
