### PR TITLE
feat(phase-2): evidence attachment, audit trail, finalize gate, progress

### DIFF
--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/app/m/_lib/requirementCoverage";
 import TrustStrip from "@/components/TrustStrip";
 import ProofMapTab from "@/components/map/ProofMapTab";
+import ReviewProgressIndicator from "@/components/verify/ReviewProgressIndicator";
 import VerifyHeader from "@/app/m/_components/VerifyHeader";
 import { useMethodsLayout } from "@/app/m/_components/MethodsLayoutContext";
 import ShareLinkButton from "@/components/actions/ShareLinkButton";
@@ -59,6 +60,7 @@ import type { ProofEvidenceItem } from "@/lib/proof/bundle";
 import { importProofBundleText } from "@/lib/proof/import";
 import { applyUrlUpdates, parseDetailTab, type DetailTab } from "@/lib/nav/urlState";
 import type { MethodVersionLineage } from "@/app/m/_lib/methodVersionMetadata";
+import { getReviewProgress, REVIEW_STORE_EVENT, type ReviewProgress } from "@/lib/verify/reviewStore";
 
 type MethodDetail = {
   code: string;
@@ -278,6 +280,7 @@ export default function MethodDetailPane({
   const [evidenceSnapshots, setEvidenceSnapshots] = useState<ProofEvidenceItem[]>([]);
   const [verificationRuns, setVerificationRuns] = useState<VerificationRun[]>([]);
   const [integrityDiffOpen, setIntegrityDiffOpen] = useState(false);
+  const [reviewProgress, setReviewProgress] = useState<ReviewProgress | null>(null);
   type WorkspaceSnapshot = {
     currentAoi: AOI | null;
     evidencePins: EvidencePin[];
@@ -386,6 +389,20 @@ export default function MethodDetailPane({
     () => requirementRows.find((row) => row.ruleId === activeRuleId) ?? null,
     [activeRuleId, requirementRows],
   );
+
+  useEffect(() => {
+    if (!activeVersion) {
+      setReviewProgress(null);
+      return;
+    }
+    const updateProgress = () => {
+      setReviewProgress(getReviewProgress(method.code, activeVersion, requirementRows.length));
+    };
+    updateProgress();
+    const handleReviewStoreChange = () => updateProgress();
+    window.addEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
+    return () => window.removeEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
+  }, [activeVersion, method.code, requirementRows.length]);
 
   useEffect(() => {
     setRules([]);
@@ -1525,6 +1542,10 @@ export default function MethodDetailPane({
 
           {!rulesLoading && !rulesError && requirementRows.length ? (
             <>
+              {activeVersion && reviewProgress ? (
+                <ReviewProgressIndicator progress={reviewProgress} />
+              ) : null}
+
               <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
                 <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                   <div className="space-y-2">

--- a/src/app/m/_components/RuleDetailModal.tsx
+++ b/src/app/m/_components/RuleDetailModal.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, CheckCircle2, ChevronDown, FileSearch, FileText, Link2, No
 import { formatEvidenceInventoryId } from "@/lib/evidence/inventory";
 import RuleReviewPanel from "@/components/verify/RuleReviewPanel";
 import { getReview, saveReview, type RuleReview } from "@/lib/verify/reviewStore";
+import { logAuditEvent } from "@/lib/verify/auditTrail";
 import { statusLabel } from "@/lib/verify/reviewValidation";
 import {
   EXPECTED_EVIDENCE_LABELS,
@@ -156,11 +157,38 @@ export default function RuleDetailModal({
 
   const handleSaveReview = useCallback(
     (review: RuleReview) => {
+      const actor = review.reviewedBy?.trim() || "local-reviewer";
+      if (!existingReview) {
+        logAuditEvent({
+          ruleId: review.ruleId,
+          methodology: review.methodology,
+          version: review.version,
+          action: "review_created",
+          newStatus: review.status,
+          actor,
+          note: `Created review with status ${review.status}`,
+        });
+      } else if (existingReview.status !== review.status) {
+        logAuditEvent({
+          ruleId: review.ruleId,
+          methodology: review.methodology,
+          version: review.version,
+          action: "status_change",
+          previousStatus: existingReview.status,
+          newStatus: review.status,
+          actor,
+          note: `Status changed from ${existingReview.status} to ${review.status}`,
+        });
+      }
       saveReview(review);
       setExistingReview(review);
     },
-    [],
+    [existingReview],
   );
+
+  const handleReviewChange = useCallback((review: RuleReview) => {
+    setExistingReview(review);
+  }, []);
 
   if (!open || !row) return null;
 
@@ -303,6 +331,7 @@ export default function RuleDetailModal({
               sourcePath={sourcePath ?? null}
               sha256={sha256 ?? null}
               onSave={handleSaveReview}
+              onReviewChange={handleReviewChange}
             />
           ) : (
             <div className="grid gap-4">

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -6,6 +6,7 @@ import AuditTrailPanel from "@/components/verifier/AuditTrailPanel";
 import DeltaImpactTasksPanel from "@/components/verify/DeltaImpactTasksPanel";
 import OutcomeWidget from "@/components/verify/OutcomeWidget";
 import FinalReviewSummaryPanel from "@/components/verify/FinalReviewSummaryPanel";
+import FinalizeGateBanner from "@/components/verify/FinalizeGateBanner";
 import ReviewSummaryCard from "@/components/verify/ReviewSummaryCard";
 import RunHistoryPanel from "@/components/verify/RunHistoryPanel";
 import EvidenceWorkflowStepper from "@/components/verify/EvidenceWorkflowStepper";
@@ -32,6 +33,7 @@ import { buildOutcomeSnapshot } from "@/lib/verify/snapshotExport";
 import { buildReviewSummary, type ReviewSummary } from "@/lib/verify/buildReviewSummary";
 import { buildReviewSummaryPdf } from "@/lib/verify/reviewSummaryPdf";
 import { buildFinalizedExportKpis, buildSelectedStacExport, prepareChecklistExport } from "@/lib/verify/finalizedExport";
+import { checkFinalizeGate, REVIEW_STORE_EVENT } from "@/lib/verify/reviewStore";
 import { buildRequirementCoverageRows, reconcileRequirement } from "@/app/m/_lib/requirementCoverage";
 import { computeKpis, linkedRuleIdsFromPins } from "@/lib/kpis/computeKpis";
 import {
@@ -1687,6 +1689,22 @@ export default function ProofMapTab({
     ],
   );
   const currentWorkspaceIsFinal = Boolean(verifierBundle.finalizedAt);
+  const [reviewGateVersion, setReviewGateVersion] = useState(0);
+  useEffect(() => {
+    if (!verifierMode) return;
+    const handleReviewStoreChange = () => setReviewGateVersion((current) => current + 1);
+    window.addEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
+    return () => window.removeEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
+  }, [verifierMode]);
+  const finalizeGate = useMemo(() => {
+    void reviewGateVersion;
+    if (!verifierMode) return null;
+    if (!methodCode.trim() || !version.trim()) return null;
+    if (!totalRules || totalRules < 1) {
+      return { canFinalize: false, reasons: ["Rule count unavailable for finalize gate."] };
+    }
+    return checkFinalizeGate(methodCode, version, totalRules);
+  }, [methodCode, reviewGateVersion, totalRules, verifierMode, version]);
   const selectedStacItemRecord = useMemo(() => {
     if (!selectedStacItemId) return null;
     const candidate = currentStacEvidence?.itemsById?.[selectedStacItemId];
@@ -2070,6 +2088,7 @@ export default function ProofMapTab({
   }, [buildFinalReviewArtifact, currentWorkspaceIsFinal, reviewArtifact, verifierBundle]);
 
   const handleFinalizeRun = useCallback(() => {
+    if (finalizeGate && !finalizeGate.canFinalize) return;
     if (!linkedRuleIds.length || !verifierBundle.savedReviewerArtifactAt) return;
     void (async () => {
       const finalizedAt = new Date().toISOString();
@@ -2113,6 +2132,7 @@ export default function ProofMapTab({
     buildFinalReviewArtifact,
     buildHistoryBundle,
     currentWorkspaceBundle,
+    finalizeGate,
     handleSaveRunHistory,
     linkedRuleIds,
     methodCode,
@@ -4109,6 +4129,10 @@ export default function ProofMapTab({
                 version={version}
                 reviewedRuleCount={linkedRuleIds.length}
                 linkedEvidenceCount={evidenceInventory.filter((item) => item.link_state === "linked").length}
+                finalizeBlocked={Boolean(finalizeGate && !finalizeGate.canFinalize)}
+                finalizeGateBanner={
+                  finalizeGate ? <FinalizeGateBanner gate={finalizeGate} onFinalize={handleFinalizeRun} showAction={false} /> : null
+                }
                 finalizedResult={
                   <ReviewSummaryCard
                     summary={reviewArtifact?.summary ?? reviewSummary}

--- a/src/components/verify/EvidenceWorkflowStepper.tsx
+++ b/src/components/verify/EvidenceWorkflowStepper.tsx
@@ -77,6 +77,8 @@ type EvidenceWorkflowStepperProps = {
   version?: string;
   reviewedRuleCount?: number | null;
   linkedEvidenceCount?: number | null;
+  finalizeBlocked?: boolean;
+  finalizeGateBanner?: ReactNode;
   finalizedResult?: ReactNode;
 };
 
@@ -364,6 +366,8 @@ export default function EvidenceWorkflowStepper({
   version,
   reviewedRuleCount = null,
   linkedEvidenceCount = null,
+  finalizeBlocked = false,
+  finalizeGateBanner = null,
   finalizedResult = null,
 }: EvidenceWorkflowStepperProps) {
   const stepMap = new Map(wizard.steps.map((step) => [step.id, step]));
@@ -376,7 +380,8 @@ export default function EvidenceWorkflowStepper({
   const step7 = stepMap.get(7)!;
   const hasDraftArtifactChanges = draftMinutes !== savedMinutes || draftOutcomeNote !== savedOutcomeNote;
   const reviewerArtifactSaved = Boolean(savedReviewerArtifactAt);
-  const readyToFinalize = step7.active || (reviewerArtifactSaved && !currentWorkspaceIsFinal && !step7.disabled);
+  const readyToFinalize =
+    !finalizeBlocked && (step7.active || (reviewerArtifactSaved && !currentWorkspaceIsFinal && !step7.disabled));
   const inProgress = !currentWorkspaceIsFinal && !readyToFinalize;
   const stepShellClass = currentWorkspaceIsFinal ? "opacity-45 transition" : "transition";
   const [completedWorkflowExpanded, setCompletedWorkflowExpanded] = useState(false);
@@ -389,6 +394,10 @@ export default function EvidenceWorkflowStepper({
       : null,
   ].filter(Boolean) as string[];
   const finalizedLabel = formatDate(finalizedAt);
+  const nextActionText =
+    finalizeBlocked && !currentWorkspaceIsFinal
+      ? "Complete all non-pending rule reviews with rationale and support before finalizing."
+      : (wizard.nextAction ?? "Run complete");
 
   useEffect(() => {
     setCompletedWorkflowExpanded(false);
@@ -484,7 +493,7 @@ export default function EvidenceWorkflowStepper({
           </div>
           <div className="text-right text-[11px] text-slate-500" data-testid="wizard-next-action">
             <div className="font-semibold uppercase tracking-wide text-slate-400">Next required action</div>
-            <div className="mt-1 text-slate-700">{wizard.nextAction ?? "Run complete"}</div>
+            <div className="mt-1 text-slate-700">{nextActionText}</div>
           </div>
         </div>
       </div>
@@ -685,12 +694,13 @@ export default function EvidenceWorkflowStepper({
         <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Step 7</div>
         <div className="mt-1 text-xs font-semibold text-slate-900">Finalize run</div>
         <div className="mt-1 text-[11px] text-slate-500">This is the single completion/export action. Finalization writes the immutable run artifact with evidence and reviewer notes.</div>
+        {finalizeGateBanner ? <div className="mt-2">{finalizeGateBanner}</div> : null}
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <button
             type="button"
             className="rounded-full border border-emerald-700 bg-emerald-700 px-3 py-1 text-xs font-semibold text-white shadow-sm hover:bg-emerald-800 disabled:cursor-not-allowed disabled:opacity-60"
             onClick={onFinalizeRun}
-            disabled={step7.disabled || currentWorkspaceIsFinal}
+            disabled={step7.disabled || currentWorkspaceIsFinal || finalizeBlocked}
           >
             Finalize run
           </button>

--- a/src/components/verify/FinalizeGateBanner.tsx
+++ b/src/components/verify/FinalizeGateBanner.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import type { FinalizeGate } from "@/lib/verify/reviewStore";
+
+type FinalizeGateBannerProps = {
+  gate: FinalizeGate;
+  onFinalize: () => void;
+};
+
+export default function FinalizeGateBanner({ gate, onFinalize }: FinalizeGateBannerProps) {
+  const [confirming, setConfirming] = useState(false);
+
+  if (gate.canFinalize) {
+    return (
+      <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className="text-sm font-semibold text-emerald-900">Ready to finalize</div>
+            <div className="mt-1 text-xs text-emerald-700">
+              All rules reviewed with rationale and support references.
+            </div>
+          </div>
+          {confirming ? (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onFinalize}
+                className="rounded-full bg-emerald-700 px-4 py-2 text-xs font-semibold text-white hover:bg-emerald-800"
+              >
+                Confirm finalize
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirming(false)}
+                className="rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 hover:bg-slate-50"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirming(true)}
+              className="rounded-full bg-emerald-700 px-4 py-2 text-xs font-semibold text-white hover:bg-emerald-800"
+            >
+              Finalize
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4">
+      <div className="text-sm font-semibold text-amber-900">Cannot finalize yet</div>
+      <ul className="mt-2 space-y-1">
+        {gate.reasons.slice(0, 5).map((reason, i) => (
+          <li key={i} className="text-xs text-amber-800">
+            · {reason}
+          </li>
+        ))}
+        {gate.reasons.length > 5 ? (
+          <li className="text-xs text-amber-600">
+            + {gate.reasons.length - 5} more
+          </li>
+        ) : null}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/verify/FinalizeGateBanner.tsx
+++ b/src/components/verify/FinalizeGateBanner.tsx
@@ -6,9 +6,10 @@ import type { FinalizeGate } from "@/lib/verify/reviewStore";
 type FinalizeGateBannerProps = {
   gate: FinalizeGate;
   onFinalize: () => void;
+  showAction?: boolean;
 };
 
-export default function FinalizeGateBanner({ gate, onFinalize }: FinalizeGateBannerProps) {
+export default function FinalizeGateBanner({ gate, onFinalize, showAction = true }: FinalizeGateBannerProps) {
   const [confirming, setConfirming] = useState(false);
 
   if (gate.canFinalize) {
@@ -21,7 +22,7 @@ export default function FinalizeGateBanner({ gate, onFinalize }: FinalizeGateBan
               All rules reviewed with rationale and support references.
             </div>
           </div>
-          {confirming ? (
+          {!showAction ? null : confirming ? (
             <div className="flex items-center gap-2">
               <button
                 type="button"

--- a/src/components/verify/ReviewProgressIndicator.tsx
+++ b/src/components/verify/ReviewProgressIndicator.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { ReviewProgress } from "@/lib/verify/reviewStore";
+
+type ReviewProgressIndicatorProps = {
+  progress: ReviewProgress;
+};
+
+export default function ReviewProgressIndicator({
+  progress,
+}: ReviewProgressIndicatorProps) {
+  const { total, reviewed, verified, notVerified, needsFollowup, pending, percentReviewed } =
+    progress;
+
+  if (total === 0) return null;
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-semibold text-slate-900">Review progress</div>
+        <div className="text-sm font-semibold text-slate-700">{percentReviewed}%</div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="mt-3 h-2 overflow-hidden rounded-full bg-slate-100">
+        <div
+          className="h-full rounded-full bg-emerald-500 transition-all"
+          style={{ width: `${percentReviewed}%` }}
+        />
+      </div>
+
+      {/* Counts */}
+      <div className="mt-3 flex flex-wrap gap-3 text-xs text-slate-600">
+        <span>
+          <span className="font-semibold text-emerald-700">{verified}</span> verified
+        </span>
+        <span>
+          <span className="font-semibold text-red-700">{notVerified}</span> not verified
+        </span>
+        <span>
+          <span className="font-semibold text-amber-700">{needsFollowup}</span> follow-up
+        </span>
+        <span>
+          <span className="font-semibold text-slate-500">{pending}</span> pending
+        </span>
+      </div>
+
+      <div className="mt-2 text-xs text-slate-500">
+        {reviewed} of {total} rules reviewed
+      </div>
+    </div>
+  );
+}

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -1,11 +1,19 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import type { ReviewStatus, RuleReview } from "@/lib/verify/reviewStore";
+import {
+  addEvidenceAttachment,
+  removeEvidenceAttachment,
+  saveReview,
+  type EvidenceAttachment,
+  type ReviewStatus,
+  type RuleReview,
+} from "@/lib/verify/reviewStore";
 import {
   validateReview,
   statusLabel,
 } from "@/lib/verify/reviewValidation";
+import { getAuditTrailForRule, logAuditEvent, type AuditEvent } from "@/lib/verify/auditTrail";
 
 type RuleReviewPanelProps = {
   ruleId: string;
@@ -30,6 +38,7 @@ type RuleReviewPanelProps = {
   sourcePath?: string | null;
   sha256?: string | null;
   onSave: (review: RuleReview) => void;
+  onReviewChange?: (review: RuleReview) => void;
 };
 
 const STATUSES: ReviewStatus[] = [
@@ -56,6 +65,7 @@ export default function RuleReviewPanel({
   sourcePath,
   sha256,
   onSave,
+  onReviewChange,
 }: RuleReviewPanelProps) {
   const [status, setStatus] = useState<ReviewStatus>(
     existingReview?.status ?? "pending",
@@ -68,6 +78,15 @@ export default function RuleReviewPanel({
   );
   const [evidenceLink, setEvidenceLink] = useState(
     existingReview?.evidenceLink ?? "",
+  );
+  const [attachments, setAttachments] = useState<EvidenceAttachment[]>(
+    existingReview?.evidenceAttachments ?? [],
+  );
+  const [attachmentType, setAttachmentType] = useState<EvidenceAttachment["type"]>("url");
+  const [attachmentLabel, setAttachmentLabel] = useState("");
+  const [attachmentUrl, setAttachmentUrl] = useState("");
+  const [auditEvents, setAuditEvents] = useState<AuditEvent[]>(
+    getAuditTrailForRule(ruleId, methodology, version).slice(-5).reverse(),
   );
   const [errors, setErrors] = useState<string[]>([]);
   const [saved, setSaved] = useState(false);
@@ -107,6 +126,19 @@ export default function RuleReviewPanel({
         };
     }
   }, [status]);
+  const actorLabel = existingReview?.reviewedBy?.trim() || "local-reviewer";
+
+  const refreshAuditEvents = useCallback(() => {
+    setAuditEvents(getAuditTrailForRule(ruleId, methodology, version).slice(-5).reverse());
+  }, [methodology, ruleId, version]);
+
+  const syncReview = useCallback(
+    (review: RuleReview) => {
+      setAttachments(review.evidenceAttachments ?? []);
+      onReviewChange?.(review);
+    },
+    [onReviewChange],
+  );
 
   const handleSave = useCallback(() => {
     const review: RuleReview = {
@@ -117,8 +149,8 @@ export default function RuleReviewPanel({
       rationale,
       supportReference,
       evidenceLink: evidenceLink || undefined,
-      evidenceAttachments: existingReview?.evidenceAttachments ?? [],
-      reviewedBy: existingReview?.reviewedBy ?? "reviewer",
+      evidenceAttachments: attachments,
+      reviewedBy: existingReview?.reviewedBy ?? "local-reviewer",
       reviewedAt: existingReview?.reviewedAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
@@ -131,6 +163,7 @@ export default function RuleReviewPanel({
 
     setErrors([]);
     onSave(review);
+    refreshAuditEvents();
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
   }, [
@@ -141,9 +174,105 @@ export default function RuleReviewPanel({
     rationale,
     supportReference,
     evidenceLink,
+    attachments,
     existingReview,
     onSave,
+    refreshAuditEvents,
   ]);
+
+  const handleAddAttachment = useCallback(() => {
+    const trimmedLabel = attachmentLabel.trim();
+    const trimmedUrl = attachmentUrl.trim();
+    if (!trimmedLabel) return;
+    if (attachmentType === "url" && !trimmedUrl) return;
+
+    if (!existingReview) {
+      const seededReview: RuleReview = {
+        ruleId,
+        methodology,
+        version,
+        status,
+        rationale,
+        supportReference,
+        evidenceLink: evidenceLink || undefined,
+        evidenceAttachments: attachments,
+        reviewedBy: actorLabel,
+        reviewedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      saveReview(seededReview);
+      syncReview(seededReview);
+    }
+
+    const review = addEvidenceAttachment(ruleId, methodology, version, {
+      type: attachmentType,
+      label: trimmedLabel,
+      url: attachmentType === "url" ? trimmedUrl : undefined,
+    });
+    if (!review) return;
+
+    logAuditEvent({
+      ruleId,
+      methodology,
+      version,
+      action: "evidence_added",
+      evidenceId: review.evidenceAttachments[review.evidenceAttachments.length - 1]?.id,
+      actor: actorLabel,
+      note:
+        attachmentType === "url"
+          ? `Added ${attachmentType} attachment: ${trimmedLabel} (${trimmedUrl})`
+          : `Added ${attachmentType} attachment: ${trimmedLabel}`,
+    });
+    setAttachmentLabel("");
+    setAttachmentUrl("");
+    syncReview(review);
+    refreshAuditEvents();
+  }, [
+    actorLabel,
+    attachmentLabel,
+    attachmentType,
+    attachmentUrl,
+    attachments,
+    evidenceLink,
+    existingReview,
+    methodology,
+    rationale,
+    refreshAuditEvents,
+    ruleId,
+    status,
+    supportReference,
+    syncReview,
+    version,
+  ]);
+
+  const handleFileSelected = useCallback(
+    (file: File | null) => {
+      if (!file) return;
+      setAttachmentType("file");
+      setAttachmentLabel(file.name);
+      setAttachmentUrl("");
+    },
+    [],
+  );
+
+  const handleRemoveAttachment = useCallback(
+    (attachment: EvidenceAttachment) => {
+      const review = removeEvidenceAttachment(ruleId, methodology, version, attachment.id);
+      if (!review) return;
+      logAuditEvent({
+        ruleId,
+        methodology,
+        version,
+        action: "evidence_removed",
+        evidenceId: attachment.id,
+        actor: actorLabel,
+        note: `Removed ${attachment.type} attachment: ${attachment.label}`,
+      });
+      syncReview(review);
+      refreshAuditEvents();
+    },
+    [actorLabel, methodology, refreshAuditEvents, ruleId, syncReview, version],
+  );
 
   return (
     <section className="rounded-[24px] border border-slate-200 bg-white shadow-sm">
@@ -257,6 +386,86 @@ export default function RuleReviewPanel({
                 className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-400"
               />
             </div>
+
+            <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <div>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Evidence attachments
+                </div>
+                <div className="mt-1 text-xs text-slate-500">
+                  Save URL, file-name, or reference attachments as supporting traces for this rule.
+                </div>
+              </div>
+
+              <div className="grid gap-2 sm:grid-cols-[120px_minmax(0,1fr)_minmax(0,1fr)_auto]">
+                <select
+                  value={attachmentType}
+                  onChange={(event) => setAttachmentType(event.target.value as EvidenceAttachment["type"])}
+                  className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-400"
+                >
+                  <option value="url">URL</option>
+                  <option value="file">File</option>
+                  <option value="reference">Reference</option>
+                </select>
+                {attachmentType === "file" ? (
+                  <input
+                    type="file"
+                    onChange={(event) => handleFileSelected(event.target.files?.[0] ?? null)}
+                    className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 file:mr-3 file:rounded-full file:border-0 file:bg-slate-900 file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white"
+                  />
+                ) : (
+                  <input
+                    type="text"
+                    value={attachmentLabel}
+                    onChange={(event) => setAttachmentLabel(event.target.value)}
+                    placeholder={attachmentType === "reference" ? "Reference label" : "Attachment label"}
+                    className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-400"
+                  />
+                )}
+                <input
+                  type="text"
+                  value={attachmentUrl}
+                  onChange={(event) => setAttachmentUrl(event.target.value)}
+                  disabled={attachmentType !== "url"}
+                  placeholder={attachmentType === "url" ? "https://…" : attachmentType === "file" ? "Stored as file name only" : "Optional location or note"}
+                  className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-400 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
+                />
+                <button
+                  type="button"
+                  onClick={handleAddAttachment}
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+                >
+                  Add
+                </button>
+              </div>
+
+              {attachments.length ? (
+                <ul className="grid gap-2">
+                  {attachments.map((attachment) => (
+                    <li key={attachment.id} className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-3 py-2.5">
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium text-slate-900">{attachment.label}</div>
+                        <div className="mt-1 text-xs text-slate-500">
+                          {attachment.type}
+                          {attachment.url ? ` · ${attachment.url}` : ""}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveAttachment(attachment)}
+                        className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="rounded-2xl border border-dashed border-slate-200 bg-white px-3 py-3 text-sm text-slate-500">
+                  No attachments saved yet.
+                </div>
+              )}
+            </div>
           </section>
         </div>
 
@@ -299,6 +508,28 @@ export default function RuleReviewPanel({
               Reviewed by {existingReview.reviewedBy} · {new Date(existingReview.updatedAt).toLocaleString()}
             </div>
           ) : null}
+
+          <section className="rounded-[20px] border border-slate-200 bg-white p-4">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+              Recent audit
+            </div>
+            {auditEvents.length ? (
+              <ul className="mt-3 grid gap-2">
+                {auditEvents.map((event, index) => (
+                  <li key={`${event.timestamp}:${index}`} className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2.5">
+                    <div className="text-xs font-semibold text-slate-700">{event.action.replaceAll("_", " ")}</div>
+                    <div className="mt-1 text-xs text-slate-600">
+                      {event.note ?? `${event.actor} · ${new Date(event.timestamp).toLocaleString()}`}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="mt-3 rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-500">
+                No audit events for this rule yet.
+              </div>
+            )}
+          </section>
         </aside>
       </div>
 

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -117,6 +117,7 @@ export default function RuleReviewPanel({
       rationale,
       supportReference,
       evidenceLink: evidenceLink || undefined,
+      evidenceAttachments: existingReview?.evidenceAttachments ?? [],
       reviewedBy: existingReview?.reviewedBy ?? "reviewer",
       reviewedAt: existingReview?.reviewedAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString(),

--- a/src/lib/verify/auditTrail.ts
+++ b/src/lib/verify/auditTrail.ts
@@ -1,0 +1,57 @@
+export type AuditEvent = {
+  ruleId: string;
+  methodology: string;
+  version: string;
+  action: "status_change" | "evidence_added" | "evidence_removed" | "review_created";
+  previousStatus?: string;
+  newStatus?: string;
+  evidenceId?: string;
+  actor: string;
+  timestamp: string;
+  note?: string;
+};
+
+const STORAGE_PREFIX = "article6:audit";
+
+function storageKey(methodology: string, version: string): string {
+  return `${STORAGE_PREFIX}:${methodology}:${version}`;
+}
+
+export function logAuditEvent(event: Omit<AuditEvent, "timestamp">): void {
+  const full: AuditEvent = {
+    ...event,
+    timestamp: new Date().toISOString(),
+  };
+  const key = storageKey(event.methodology, event.version);
+  try {
+    const raw = localStorage.getItem(key);
+    const events: AuditEvent[] = raw ? JSON.parse(raw) : [];
+    events.push(full);
+    localStorage.setItem(key, JSON.stringify(events));
+  } catch {
+    // Storage full or unavailable
+  }
+}
+
+export function getAuditTrail(
+  methodology: string,
+  version: string,
+  ruleId?: string,
+): AuditEvent[] {
+  try {
+    const raw = localStorage.getItem(storageKey(methodology, version));
+    const events: AuditEvent[] = raw ? JSON.parse(raw) : [];
+    if (ruleId) return events.filter((e) => e.ruleId === ruleId);
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function getAuditTrailForRule(
+  ruleId: string,
+  methodology: string,
+  version: string,
+): AuditEvent[] {
+  return getAuditTrail(methodology, version, ruleId);
+}

--- a/src/lib/verify/reviewStore.ts
+++ b/src/lib/verify/reviewStore.ts
@@ -1,5 +1,13 @@
 export type ReviewStatus = "pending" | "verified" | "not_verified" | "needs_followup";
 
+export type EvidenceAttachment = {
+  id: string;
+  type: "url" | "file" | "reference";
+  label: string;
+  url?: string;
+  addedAt: string;
+};
+
 export type RuleReview = {
   ruleId: string;
   methodology: string;
@@ -8,6 +16,7 @@ export type RuleReview = {
   rationale: string;
   supportReference: string;
   evidenceLink?: string;
+  evidenceAttachments: EvidenceAttachment[];
   reviewedBy: string;
   reviewedAt: string;
   updatedAt: string;
@@ -73,4 +82,118 @@ export function deleteReview(
   } catch {
     // ignore
   }
+}
+
+// --- Evidence attachment ---
+
+export function addEvidenceAttachment(
+  ruleId: string,
+  methodology: string,
+  version: string,
+  attachment: Omit<EvidenceAttachment, "id" | "addedAt">,
+): RuleReview | null {
+  const review = getReview(ruleId, methodology, version);
+  if (!review) return null;
+
+  const full: EvidenceAttachment = {
+    ...attachment,
+    id: `ev_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`,
+    addedAt: new Date().toISOString(),
+  };
+
+  review.evidenceAttachments = [...(review.evidenceAttachments ?? []), full];
+  saveReview(review);
+  return review;
+}
+
+export function removeEvidenceAttachment(
+  ruleId: string,
+  methodology: string,
+  version: string,
+  evidenceId: string,
+): RuleReview | null {
+  const review = getReview(ruleId, methodology, version);
+  if (!review) return null;
+
+  review.evidenceAttachments = (review.evidenceAttachments ?? []).filter(
+    (e) => e.id !== evidenceId,
+  );
+  saveReview(review);
+  return review;
+}
+
+// --- Review progress ---
+
+export type ReviewProgress = {
+  total: number;
+  reviewed: number;
+  verified: number;
+  notVerified: number;
+  needsFollowup: number;
+  pending: number;
+  percentReviewed: number;
+};
+
+export function getReviewProgress(
+  methodology: string,
+  version: string,
+  totalRules: number,
+): ReviewProgress {
+  const reviews = getAllReviews(methodology, version);
+  const entries = Object.values(reviews);
+  const reviewed = entries.filter((r) => r.status !== "pending").length;
+  const verified = entries.filter((r) => r.status === "verified").length;
+  const notVerified = entries.filter((r) => r.status === "not_verified").length;
+  const needsFollowup = entries.filter((r) => r.status === "needs_followup").length;
+  const pending = totalRules - reviewed;
+
+  return {
+    total: totalRules,
+    reviewed,
+    verified,
+    notVerified,
+    needsFollowup,
+    pending: Math.max(0, pending),
+    percentReviewed: totalRules > 0 ? Math.round((reviewed / totalRules) * 100) : 0,
+  };
+}
+
+// --- Finalize gate ---
+
+export type FinalizeGate = {
+  canFinalize: boolean;
+  reasons: string[];
+};
+
+export function checkFinalizeGate(
+  methodology: string,
+  version: string,
+  totalRules: number,
+): FinalizeGate {
+  const reviews = getAllReviews(methodology, version);
+  const entries = Object.values(reviews);
+  const reasons: string[] = [];
+
+  // Check all rules have a review
+  const reviewedRuleIds = new Set(entries.map((r) => r.ruleId));
+  if (reviewedRuleIds.size < totalRules) {
+    const missing = totalRules - reviewedRuleIds.size;
+    reasons.push(`${missing} rule${missing === 1 ? "" : "s"} not yet reviewed`);
+  }
+
+  // Check non-pending reviews have rationale + support
+  for (const review of entries) {
+    if (review.status === "pending") continue;
+    if (!review.rationale?.trim()) {
+      reasons.push(`Rule ${review.ruleId}: missing rationale`);
+    }
+    if (!review.supportReference?.trim()) {
+      reasons.push(`Rule ${review.ruleId}: missing support reference`);
+    }
+  }
+
+  return {
+    canFinalize: reasons.length === 0,
+    reasons,
+  };
 }

--- a/src/lib/verify/reviewStore.ts
+++ b/src/lib/verify/reviewStore.ts
@@ -23,9 +23,21 @@ export type RuleReview = {
 };
 
 const STORAGE_PREFIX = "article6:reviews";
+export const REVIEW_STORE_EVENT = "article6:review-store-changed";
+
+type ReviewStoreEventDetail = {
+  methodology: string;
+  version: string;
+  ruleId?: string;
+};
 
 function storageKey(methodology: string, version: string): string {
   return `${STORAGE_PREFIX}:${methodology}:${version}`;
+}
+
+function emitReviewStoreEvent(detail: ReviewStoreEventDetail): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(REVIEW_STORE_EVENT, { detail }));
 }
 
 export function getReview(
@@ -50,6 +62,11 @@ export function saveReview(review: RuleReview): void {
     const all: Record<string, RuleReview> = raw ? JSON.parse(raw) : {};
     all[review.ruleId] = { ...review, updatedAt: new Date().toISOString() };
     localStorage.setItem(key, JSON.stringify(all));
+    emitReviewStoreEvent({
+      methodology: review.methodology,
+      version: review.version,
+      ruleId: review.ruleId,
+    });
   } catch {
     // Storage full or unavailable — fail silently
   }
@@ -79,6 +96,7 @@ export function deleteReview(
     const all: Record<string, RuleReview> = JSON.parse(raw);
     delete all[ruleId];
     localStorage.setItem(key, JSON.stringify(all));
+    emitReviewStoreEvent({ methodology, version, ruleId });
   } catch {
     // ignore
   }
@@ -174,11 +192,13 @@ export function checkFinalizeGate(
   const entries = Object.values(reviews);
   const reasons: string[] = [];
 
-  // Check all rules have a review
-  const reviewedRuleIds = new Set(entries.map((r) => r.ruleId));
-  if (reviewedRuleIds.size < totalRules) {
-    const missing = totalRules - reviewedRuleIds.size;
-    reasons.push(`${missing} rule${missing === 1 ? "" : "s"} not yet reviewed`);
+  // Check all rules have a non-pending review
+  const completedRuleIds = new Set(
+    entries.filter((review) => review.status !== "pending").map((review) => review.ruleId),
+  );
+  if (completedRuleIds.size < totalRules) {
+    const missing = totalRules - completedRuleIds.size;
+    reasons.push(`${missing} rule${missing === 1 ? "" : "s"} still pending review`);
   }
 
   // Check non-pending reviews have rationale + support

--- a/tests/lib/reviewStore.test.ts
+++ b/tests/lib/reviewStore.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import {
+  addEvidenceAttachment,
+  checkFinalizeGate,
+  getReview,
+  getReviewProgress,
+  saveReview,
+  removeEvidenceAttachment,
+  type RuleReview,
+} from "@/lib/verify/reviewStore";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+const baseReview: RuleReview = {
+  ruleId: "R-1",
+  methodology: "AR-ACM0003",
+  version: "v02-0",
+  status: "verified",
+  rationale: "Rule is satisfied by the saved monitoring evidence.",
+  supportReference: "Monitoring report section 3.2",
+  evidenceLink: undefined,
+  evidenceAttachments: [],
+  reviewedBy: "local-reviewer",
+  reviewedAt: "2026-04-16T00:00:00.000Z",
+  updatedAt: "2026-04-16T00:00:00.000Z",
+};
+
+describe("reviewStore phase 2 helpers", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "localStorage", {
+      value: localStorageMock,
+      configurable: true,
+      writable: true,
+    });
+    globalThis.localStorage.clear();
+  });
+
+  it("adds and removes evidence attachments on saved reviews", () => {
+    saveReview(baseReview);
+
+    const withAttachment = addEvidenceAttachment("R-1", "AR-ACM0003", "v02-0", {
+      type: "reference",
+      label: "Workbook tab A",
+    });
+
+    expect(withAttachment?.evidenceAttachments).toHaveLength(1);
+    expect(withAttachment?.evidenceAttachments[0]?.label).toBe("Workbook tab A");
+
+    const removed = removeEvidenceAttachment(
+      "R-1",
+      "AR-ACM0003",
+      "v02-0",
+      withAttachment?.evidenceAttachments[0]?.id ?? "",
+    );
+
+    expect(removed?.evidenceAttachments).toHaveLength(0);
+  });
+
+  it("calculates progress from non-pending reviews only", () => {
+    saveReview(baseReview);
+    saveReview({
+      ...baseReview,
+      ruleId: "R-2",
+      status: "needs_followup",
+      rationale: "Need more source support.",
+      supportReference: "Open monitoring issue",
+    });
+    saveReview({
+      ...baseReview,
+      ruleId: "R-3",
+      status: "pending",
+      rationale: "",
+      supportReference: "",
+    });
+
+    expect(getReview("R-3", "AR-ACM0003", "v02-0")?.status).toBe("pending");
+
+    expect(getReviewProgress("AR-ACM0003", "v02-0", 4)).toEqual({
+      total: 4,
+      reviewed: 2,
+      verified: 1,
+      notVerified: 0,
+      needsFollowup: 1,
+      pending: 2,
+      percentReviewed: 50,
+    });
+  });
+
+  it("blocks finalize until every rule is non-pending and supported", () => {
+    saveReview(baseReview);
+    saveReview({
+      ...baseReview,
+      ruleId: "R-2",
+      status: "pending",
+      rationale: "",
+      supportReference: "",
+    });
+    saveReview({
+      ...baseReview,
+      ruleId: "R-3",
+      status: "not_verified",
+      rationale: "",
+      supportReference: "",
+    });
+
+    expect(checkFinalizeGate("AR-ACM0003", "v02-0", 3)).toEqual({
+      canFinalize: false,
+      reasons: [
+        "1 rule still pending review",
+        "Rule R-3: missing rationale",
+        "Rule R-3: missing support reference",
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Roadmap: traceable-rule-review-mvp
Roadmap-Phase: phase-2-defensible-verification
SSOT: docs/roadmaps/traceable-rule-review-mvp/phase-status.json

## WHAT

- `src/lib/verify/reviewStore.ts` — evidenceAttachments type, add/remove functions, review progress calculation, finalize gate check
- `src/lib/verify/auditTrail.ts` — append-only event log for status changes and evidence additions
- `src/components/verify/ReviewProgressIndicator.tsx` — progress bar with verified/not-verified/follow-up/pending counts
- `src/components/verify/FinalizeGateBanner.tsx` — blocks finalize when reviews incomplete, shows specific reasons
- `src/components/verify/RuleReviewPanel.tsx` — includes evidenceAttachments in review object

## WHY

- Phase 2 of traceable-rule-review-mvp: every review decision traceable by a third party
- Evidence attachment: link supporting documents to each rule review
- Audit trail: who changed what, when
- Finalize gate: can't lock project until all rules reviewed with rationale + support
- Progress indicator: visibility into review completion

## Next steps (Codex)

- Wire ReviewProgressIndicator into the Methods surface (/m/[code])
- Wire FinalizeGateBanner into the project finalize flow
- Add evidence attachment UI to RuleReviewPanel
- Connect audit trail logging to saveReview calls
