### PR TITLE
feat(phase-4): surface extracted document and workbook support in rule review

### DIFF
--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -61,6 +61,7 @@ import { importProofBundleText } from "@/lib/proof/import";
 import { applyUrlUpdates, parseDetailTab, type DetailTab } from "@/lib/nav/urlState";
 import type { MethodVersionLineage } from "@/app/m/_lib/methodVersionMetadata";
 import { getReviewProgress, REVIEW_STORE_EVENT, type ReviewProgress } from "@/lib/verify/reviewStore";
+import { deriveDocumentSupport } from "@/lib/verify/documentSupport";
 
 type MethodDetail = {
   code: string;
@@ -411,6 +412,11 @@ export default function MethodDetailPane({
       };
     }).filter((item) => item.id);
   }, [stacEvidenceState]);
+
+  const documentSupportForPanel = useMemo(() => {
+    if (!activeRuleId) return [];
+    return deriveDocumentSupport(evidenceInventory, activeRuleId);
+  }, [activeRuleId, evidenceInventory]);
 
   useEffect(() => {
     if (!activeVersion) {
@@ -1430,6 +1436,7 @@ export default function MethodDetailPane({
         ruleTags={activeRequirementRow?.ruleSummary.tags ?? []}
         stacItems={stacItemsForPanel}
         hasAoi={!!effectiveAoi}
+        documentSupport={documentSupportForPanel}
         traceSections={linkedTraceSections.map((link) => {
           const section = sectionsById.get(link.section_id);
           return {

--- a/src/app/m/_components/RuleDetailModal.tsx
+++ b/src/app/m/_components/RuleDetailModal.tsx
@@ -7,6 +7,7 @@ import RuleReviewPanel from "@/components/verify/RuleReviewPanel";
 import { getReview, saveReview, type RuleReview } from "@/lib/verify/reviewStore";
 import { logAuditEvent } from "@/lib/verify/auditTrail";
 import { statusLabel } from "@/lib/verify/reviewValidation";
+import type { DocumentSupportEntry } from "@/lib/verify/documentSupport";
 import {
   EXPECTED_EVIDENCE_LABELS,
   REQUIREMENT_RECONCILIATION_META,
@@ -35,6 +36,7 @@ type RuleDetailModalProps = {
     bbox?: [number, number, number, number];
   }>;
   hasAoi?: boolean;
+  documentSupport?: DocumentSupportEntry[];
   methodologyLabel?: string | null;
   reviewMethodology?: string | null;
   reviewVersion?: string | null;
@@ -129,6 +131,7 @@ export default function RuleDetailModal({
   ruleTags = [],
   stacItems = [],
   hasAoi = false,
+  documentSupport = [],
   methodologyLabel,
   reviewMethodology,
   reviewVersion,
@@ -345,6 +348,7 @@ export default function RuleDetailModal({
               ruleTags={ruleTags}
               stacItems={stacItems}
               hasAoi={hasAoi}
+              documentSupport={documentSupport}
               onSave={handleSaveReview}
               onReviewChange={handleReviewChange}
             />

--- a/src/components/verify/DocumentSupportSection.tsx
+++ b/src/components/verify/DocumentSupportSection.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { DocumentSupportEntry } from "@/lib/verify/documentSupport";
+
+type DocumentSupportSectionProps = {
+  entries: DocumentSupportEntry[];
+};
+
+function kindLabel(kind: DocumentSupportEntry["kind"]): string {
+  switch (kind) {
+    case "pdd_excerpt":
+      return "PDD";
+    case "workbook_value":
+      return "Workbook";
+    case "document":
+      return "Document";
+  }
+}
+
+function kindTone(kind: DocumentSupportEntry["kind"]): string {
+  switch (kind) {
+    case "pdd_excerpt":
+      return "border-violet-200 bg-violet-50 text-violet-700";
+    case "workbook_value":
+      return "border-emerald-200 bg-emerald-50 text-emerald-700";
+    case "document":
+      return "border-slate-200 bg-slate-50 text-slate-600";
+  }
+}
+
+export default function DocumentSupportSection({ entries }: DocumentSupportSectionProps) {
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-4">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+        Document & workbook support
+      </div>
+      <div className="mt-3 space-y-3">
+        {entries.map((entry) => (
+          <div
+            key={entry.id}
+            className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-3"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="min-w-0 text-sm font-semibold text-slate-900 truncate">
+                {entry.title}
+              </div>
+              <span
+                className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${kindTone(entry.kind)}`}
+              >
+                {kindLabel(entry.kind)}
+              </span>
+            </div>
+            {entry.excerpt ? (
+              <div className="mt-2 rounded-lg border border-slate-200 bg-white px-2.5 py-2">
+                <pre className="whitespace-pre-wrap font-sans text-xs leading-5 text-slate-700">
+                  {entry.excerpt}
+                </pre>
+              </div>
+            ) : null}
+            <div className="mt-2 text-[11px] text-slate-500">{entry.provenance}</div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-[11px] text-slate-500">
+        Linked evidence support — reviewer must assess sufficiency.
+      </div>
+    </div>
+  );
+}

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -17,6 +17,8 @@ import { getAuditTrailForRule, logAuditEvent, type AuditEvent } from "@/lib/veri
 import { isStacEligible, stacEligibilityReason } from "@/lib/verify/stacEligibility";
 import { extractStacSupportFacts } from "@/lib/verify/stacSupportFacts";
 import StacSupportSection from "@/components/verify/StacSupportSection";
+import DocumentSupportSection from "@/components/verify/DocumentSupportSection";
+import type { DocumentSupportEntry } from "@/lib/verify/documentSupport";
 
 type RuleReviewPanelProps = {
   ruleId: string;
@@ -49,6 +51,7 @@ type RuleReviewPanelProps = {
     bbox?: [number, number, number, number];
   }>;
   hasAoi?: boolean;
+  documentSupport?: DocumentSupportEntry[];
   onSave: (review: RuleReview) => void;
   onReviewChange?: (review: RuleReview) => void;
 };
@@ -79,6 +82,7 @@ export default function RuleReviewPanel({
   ruleTags = [],
   stacItems = [],
   hasAoi = false,
+  documentSupport = [],
   onSave,
   onReviewChange,
 }: RuleReviewPanelProps) {
@@ -548,6 +552,8 @@ export default function RuleReviewPanel({
               </div>
             )}
           </section>
+
+          <DocumentSupportSection entries={documentSupport} />
 
           <StacSupportSection
             eligible={stacEligible}

--- a/src/lib/verify/documentSupport.ts
+++ b/src/lib/verify/documentSupport.ts
@@ -1,0 +1,113 @@
+/**
+ * Derive structured review support entries from evidence inventory items.
+ *
+ * These are support facts, not auto-verification.
+ * Provenance is always grounded to source file, section, sheet, or excerpt.
+ */
+
+import type { EvidenceInventoryItem, EvidenceInventoryWorkbookGroup } from "@/lib/evidence/inventory";
+
+export type DocumentSupportEntry = {
+  id: string;
+  kind: "pdd_excerpt" | "workbook_value" | "document";
+  source: string;
+  title: string;
+  excerpt?: string;
+  provenance: string;
+  ruleLinked: boolean;
+};
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return value.slice(0, max - 1) + "…";
+}
+
+function formatWorkbookPreview(group: EvidenceInventoryWorkbookGroup): string {
+  const headers = group.column_names.slice(0, 5);
+  const rows = group.rows.slice(0, 3);
+  if (!headers.length || !rows.length) return "";
+  const lines = rows.map((row) =>
+    headers.map((h) => truncate(String(row[h] ?? ""), 20)).join(" │ ")
+  );
+  return [headers.join(" │ "), ...lines].join("\n");
+}
+
+function groupProvenance(group: EvidenceInventoryWorkbookGroup): string {
+  const parts = [group.source_sheet, group.source_range ?? null].filter(Boolean);
+  return parts.join(" · ") || group.display_name;
+}
+
+/**
+ * Derive support entries for a specific rule from the evidence inventory.
+ */
+export function deriveDocumentSupport(
+  inventory: EvidenceInventoryItem[],
+  ruleId: string,
+): DocumentSupportEntry[] {
+  const entries: DocumentSupportEntry[] = [];
+
+  for (const item of inventory) {
+    // PDD fragments linked to this rule
+    if (item.kind === "pdd" && item.pdd_fragment_links?.length) {
+      for (const link of item.pdd_fragment_links) {
+        if (link.rule_id !== ruleId) continue;
+        const fragment = item.pdd_fragments?.find((f) => f.fragment_id === link.fragment_id);
+        if (!fragment) continue;
+        const sectionLabel = fragment.section_heading ?? fragment.section_label ?? fragment.fragment_id;
+        const pageLabel =
+          typeof fragment.page_start === "number"
+            ? `p. ${fragment.page_start}${fragment.page_end && fragment.page_end !== fragment.page_start ? `-${fragment.page_end}` : ""}`
+            : null;
+        const provenance = [item.display_name, sectionLabel, pageLabel].filter(Boolean).join(" · ");
+        entries.push({
+          id: fragment.fragment_id,
+          kind: "pdd_excerpt",
+          source: item.display_name,
+          title: sectionLabel,
+          excerpt: fragment.excerpt ?? undefined,
+          provenance,
+          ruleLinked: true,
+        });
+      }
+      continue;
+    }
+
+    // Non-PDD evidence linked to this rule
+    const isLinkedToRule = item.linked_requirement_ids?.includes(ruleId);
+    if (!isLinkedToRule) continue;
+
+    // Workbook groups — show structured data
+    // Check for workbook_record_groups regardless of kind label,
+    // since uploads may arrive as kind "document" or "upload"
+    if (item.workbook_record_groups?.length) {
+      for (const group of item.workbook_record_groups) {
+        const preview = formatWorkbookPreview(group);
+        entries.push({
+          id: group.group_id,
+          kind: "workbook_value",
+          source: item.display_name,
+          title: group.display_name,
+          excerpt: preview || undefined,
+          provenance: `${item.display_name} · ${groupProvenance(group)}`,
+          ruleLinked: true,
+        });
+      }
+      continue;
+    }
+
+    // Only document-like evidence in this lane — STAC, photos, notes have their own surfaces
+    if (item.kind === "stac-item" || item.kind === "photo" || item.kind === "note") continue;
+
+    // Documents / monitoring reports — just the document itself
+    entries.push({
+      id: item.evidence_id,
+      kind: "document",
+      source: item.display_name,
+      title: item.display_name,
+      provenance: [item.display_name, item.source_summary].filter(Boolean).join(" · ") || item.display_name,
+      ruleLinked: true,
+    });
+  }
+
+  return entries;
+}

--- a/tests/lib/documentSupport.test.ts
+++ b/tests/lib/documentSupport.test.ts
@@ -1,0 +1,207 @@
+import { deriveDocumentSupport } from "@/lib/verify/documentSupport";
+import type { EvidenceInventoryItem } from "@/lib/evidence/inventory";
+
+function makePddItem(overrides: Partial<EvidenceInventoryItem> = {}): EvidenceInventoryItem {
+  return {
+    evidence_id: "pdd-1",
+    dedupe_key: "pdd-1",
+    display_name: "Project Design Document v2.pdf",
+    kind: "pdd",
+    type: "pdd",
+    source_summary: "PDD upload",
+    provenance_summary: "",
+    added_at: "2026-01-01T00:00:00Z",
+    link_state: "linked",
+    linked_requirement_ids: [],
+    pdd_document: { evidence_id: "pdd-1", file_name: "PDD.pdf", mime: "application/pdf", added_at: "2026-01-01T00:00:00Z" },
+    pdd_fragments: [
+      {
+        fragment_id: "frag-1",
+        evidence_id: "pdd-1",
+        label: "Monitoring plan",
+        section_heading: "Section 4.2 — Monitoring",
+        section_label: "S-4-2",
+        page_start: 12,
+        page_end: 12,
+        excerpt: "Satellite imagery shall be used to monitor forest cover change on a quarterly basis.",
+      },
+    ],
+    pdd_fragment_links: [{ fragment_id: "frag-1", rule_id: "R-1" }],
+    ...overrides,
+  };
+}
+
+function makeWorkbookItem(overrides: Partial<EvidenceInventoryItem> = {}): EvidenceInventoryItem {
+  return {
+    evidence_id: "wb-1",
+    dedupe_key: "wb-1",
+    display_name: "Monitoring_Workbook_2024.xlsx",
+    kind: "workbook",
+    type: "spreadsheet-workbook",
+    source_summary: "Workbook upload",
+    provenance_summary: "",
+    added_at: "2026-01-01T00:00:00Z",
+    link_state: "linked",
+    linked_requirement_ids: ["R-2"],
+    workbook_assets: [],
+    workbook_record_groups: [
+      {
+        group_id: "grp-1",
+        group_type: "monitoring_period_table",
+        display_name: "Annual Monitoring Data",
+        workbook_id: "wb-1",
+        workbook_filename: "Monitoring_Workbook_2024.xlsx",
+        source_sheet: "Sheet1",
+        source_range: "A1:D10",
+        row_count: 9,
+        column_names: ["year", "area_ha", "emissions_tCO2", "method"],
+        rows: [
+          { year: "2022", area_ha: "1500", emissions_tCO2: "12500", method: "satellite" },
+          { year: "2023", area_ha: "1480", emissions_tCO2: "11800", method: "satellite" },
+          { year: "2024", area_ha: "1450", emissions_tCO2: "11200", method: "satellite" },
+        ],
+        provenance_summary: "Sheet1 A1:D10",
+        candidate_evidence_types: ["monitoring-report"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeDocumentItem(overrides: Partial<EvidenceInventoryItem> = {}): EvidenceInventoryItem {
+  return {
+    evidence_id: "doc-1",
+    dedupe_key: "doc-1",
+    display_name: "Monitoring Report 2024.pdf",
+    kind: "document",
+    type: "monitoring-report",
+    source_summary: "Document upload",
+    provenance_summary: "",
+    added_at: "2026-01-01T00:00:00Z",
+    link_state: "linked",
+    linked_requirement_ids: ["R-3"],
+    ...overrides,
+  };
+}
+
+describe("deriveDocumentSupport", () => {
+  describe("PDD excerpts", () => {
+    it("extracts linked PDD fragments with excerpt and provenance", () => {
+      const entries = deriveDocumentSupport([makePddItem()], "R-1");
+      expect(entries).toHaveLength(1);
+      expect(entries[0].kind).toBe("pdd_excerpt");
+      expect(entries[0].excerpt).toContain("Satellite imagery");
+      expect(entries[0].provenance).toContain("Project Design Document v2.pdf");
+      expect(entries[0].provenance).toContain("Section 4.2 — Monitoring");
+      expect(entries[0].provenance).toContain("p. 12");
+      expect(entries[0].ruleLinked).toBe(true);
+    });
+
+    it("returns empty for rules without linked PDD fragments", () => {
+      const entries = deriveDocumentSupport([makePddItem()], "R-99");
+      expect(entries).toHaveLength(0);
+    });
+  });
+
+  describe("workbook values", () => {
+    it("extracts workbook record groups with structured preview", () => {
+      const entries = deriveDocumentSupport([makeWorkbookItem()], "R-2");
+      expect(entries).toHaveLength(1);
+      expect(entries[0].kind).toBe("workbook_value");
+      expect(entries[0].title).toBe("Annual Monitoring Data");
+      expect(entries[0].excerpt).toContain("year");
+      expect(entries[0].excerpt).toContain("1500");
+      expect(entries[0].provenance).toContain("Sheet1");
+      expect(entries[0].provenance).toContain("A1:D10");
+    });
+
+    it("returns empty for rules without linked workbook evidence", () => {
+      const entries = deriveDocumentSupport([makeWorkbookItem()], "R-99");
+      expect(entries).toHaveLength(0);
+    });
+  });
+
+  describe("documents / monitoring reports", () => {
+    it("extracts linked documents with source provenance", () => {
+      const entries = deriveDocumentSupport([makeDocumentItem()], "R-3");
+      expect(entries).toHaveLength(1);
+      expect(entries[0].kind).toBe("document");
+      expect(entries[0].title).toBe("Monitoring Report 2024.pdf");
+      expect(entries[0].provenance).toContain("Monitoring Report 2024.pdf");
+      expect(entries[0].ruleLinked).toBe(true);
+    });
+  });
+
+  describe("blocked / empty states", () => {
+    it("returns empty for empty inventory", () => {
+      expect(deriveDocumentSupport([], "R-1")).toHaveLength(0);
+    });
+
+    it("returns empty for unrelated rules", () => {
+      const inv = [makePddItem(), makeWorkbookItem(), makeDocumentItem()];
+      expect(deriveDocumentSupport(inv, "R-999")).toHaveLength(0);
+    });
+
+    it("handles inventory items without linked rules", () => {
+      const item = makeWorkbookItem({ linked_requirement_ids: [] });
+      expect(deriveDocumentSupport([item], "R-2")).toHaveLength(0);
+    });
+
+    it("excludes STAC items from document support", () => {
+      const stacItem: EvidenceInventoryItem = {
+        evidence_id: "stac-1",
+        dedupe_key: "stac-1",
+        display_name: "S2A_36LYJ_20260411",
+        kind: "stac-item",
+        type: "stac",
+        source_summary: "STAC run",
+        provenance_summary: "",
+        added_at: "2026-01-01T00:00:00Z",
+        link_state: "linked",
+        linked_requirement_ids: ["R-1"],
+      };
+      expect(deriveDocumentSupport([stacItem], "R-1")).toHaveLength(0);
+    });
+
+    it("excludes photo evidence from document support", () => {
+      const photo: EvidenceInventoryItem = {
+        evidence_id: "photo-1",
+        dedupe_key: "photo-1",
+        display_name: "Field photo",
+        kind: "photo",
+        type: "photo",
+        source_summary: "Photo",
+        provenance_summary: "",
+        added_at: "2026-01-01T00:00:00Z",
+        link_state: "linked",
+        linked_requirement_ids: ["R-1"],
+      };
+      expect(deriveDocumentSupport([photo], "R-1")).toHaveLength(0);
+    });
+
+    it("excludes note evidence from document support", () => {
+      const note: EvidenceInventoryItem = {
+        evidence_id: "note-1",
+        dedupe_key: "note-1",
+        display_name: "Reviewer note",
+        kind: "note",
+        type: "note",
+        source_summary: "Note",
+        provenance_summary: "",
+        added_at: "2026-01-01T00:00:00Z",
+        link_state: "linked",
+        linked_requirement_ids: ["R-1"],
+      };
+      expect(deriveDocumentSupport([note], "R-1")).toHaveLength(0);
+    });
+
+    it("shows workbook data when record groups exist regardless of kind label", () => {
+      // Simulates a workbook uploaded as kind "document" but with parsed record groups
+      const item = makeWorkbookItem({ kind: "document" });
+      const entries = deriveDocumentSupport([item], "R-2");
+      expect(entries).toHaveLength(1);
+      expect(entries[0].kind).toBe("workbook_value");
+      expect(entries[0].excerpt).toContain("year");
+    });
+  });
+});


### PR DESCRIPTION
## What
- restrict document-support fallback to document-like evidence only
- exclude STAC, photo, and note items from Document & workbook support
- keep PDD fragment support and workbook preview support unchanged
- update tests to enforce the correct evidence-lane boundary

## Why
- prevent STAC duplication inside the review modal
- keep provenance lanes clean and easier to scan during verification
- preserve truthful support rendering by not mislabeling non-document evidence as documents

## What reviewers see
- **PDD excerpts** (purple badge): linked fragments show excerpt + section heading + page
- **Workbook previews** (green badge): linked workbook groups show column headers + first 3 data rows + sheet/range — detected by data (`workbook_record_groups`), not kind label
- **Generic documents** (grey badge): linked documents, uploads show filename + source
- **STAC excluded**: STAC items only appear in the dedicated STAC support facts section, not here
- Section stays hidden when no document/workbook support exists for a rule

## Files changed
- `src/lib/verify/documentSupport.ts` — exclude stac-item/photo/note in fallback branch
- `src/components/verify/DocumentSupportSection.tsx` — sidebar component (unchanged)
- `src/components/verify/RuleReviewPanel.tsx` — +6 lines, prop + render
- `src/app/m/_components/RuleDetailModal.tsx` — +4 lines, pass-through
- `src/app/m/_components/MethodDetailPane.tsx` — +7 lines, derive + pass
- `tests/lib/documentSupport.test.ts` — 12 tests (STAC/photo/note excluded, workbook kind-agnostic, PDD, empty states)

## Validation
- typecheck ✅
- lint ✅
- 12 documentSupport tests ✅

Signed-off-by: Fred E <fredilly@article6.org>