### PR TITLE
chore: replace jargon with plain English in demo components

### DIFF
--- a/src/app/api/stac/search/route.ts
+++ b/src/app/api/stac/search/route.ts
@@ -115,7 +115,7 @@ export async function POST(req: Request) {
   const geometry = extractPolygonGeometry(parsedBody.data.aoi_geojson);
   if (!geometry) {
     return NextResponse.json(
-      { ok: false, code: "BAD_REQUEST", request_id, message: "AOI must be a Polygon or MultiPolygon GeoJSON." },
+      { ok: false, code: "BAD_REQUEST", request_id, message: "Area must be a Polygon or MultiPolygon GeoJSON." },
       { status: 400 },
     );
   }

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -1614,7 +1614,7 @@ export default function ProofMapTab({
 
   const baselineMissing = useMemo(() => {
     const missing: string[] = [];
-    if (!currentAoiFingerprint) missing.push("AOI");
+    if (!currentAoiFingerprint) missing.push("Area");
     if (!currentBaselineProvenance.methodId || !currentBaselineProvenance.versionId) missing.push("method/version");
     if (!currentBaselineProvenance.harnessVersion) missing.push("harness version");
     if (!currentBaselineProvenance.datasetHash) missing.push("dataset hash");
@@ -1816,11 +1816,11 @@ export default function ProofMapTab({
       case 1:
         return { title: "Pick rule", instruction: "Choose the rule you are verifying before building evidence context.", stepLabel: "Step 1 of 7" };
       case 2:
-        return { title: "Confirm AOI", instruction: "Upload or confirm the AOI so the evidence search has a clear scope.", stepLabel: "Step 2 of 7" };
+        return { title: "Confirm Area", instruction: "Upload or confirm the Area so the evidence search has a clear scope.", stepLabel: "Step 2 of 7" };
       case 3:
-        return { title: "Search STAC", instruction: "Run the evidence search and inspect the returned context in the left pane.", stepLabel: "Step 3 of 7" };
+        return { title: "Search Satellite", instruction: "Run the evidence search and inspect the returned context in the left pane.", stepLabel: "Step 3 of 7" };
       case 4:
-        return { title: "Select item", instruction: "Pick the most relevant STAC item from the returned evidence set.", stepLabel: "Step 4 of 7" };
+        return { title: "Select item", instruction: "Pick the most relevant satellite result from the returned evidence set.", stepLabel: "Step 4 of 7" };
       case 5:
         return {
           title: "Evidence inventory",
@@ -3179,10 +3179,10 @@ export default function ProofMapTab({
                                     }),
                                   ),
                                 );
-                                showToast("STAC item attached");
+                                showToast("Satellite result attached");
                               }}
                             >
-                              Attach STAC item
+                              Attach satellite result
                             </button>
                           ) : null}
                         </div>

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -113,7 +113,7 @@ export default function NewProjectForm() {
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-semibold text-slate-700">AOI Label (optional)</label>
+          <label className="mb-1 block text-sm font-semibold text-slate-700">Area Label (optional)</label>
           <input
             type="text"
             value={aoiLabel}

--- a/src/components/verify/EvidenceWorkflowStepper.tsx
+++ b/src/components/verify/EvidenceWorkflowStepper.tsx
@@ -533,7 +533,7 @@ export default function EvidenceWorkflowStepper({
 
       <div className={`${stepShellClass} rounded-lg border px-3 py-2 ${stepStateClass(step2)}`} data-testid="wizard-step-2">
         <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Step 2</div>
-        <div className="mt-1 text-xs font-semibold text-slate-900">Confirm AOI</div>
+        <div className="mt-1 text-xs font-semibold text-slate-900">Confirm Area</div>
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <button
             type="button"
@@ -543,32 +543,32 @@ export default function EvidenceWorkflowStepper({
             onClick={onUploadAoi}
             disabled={step2.disabled}
           >
-            Upload AOI
+            Upload Area
           </button>
           {!selectedRuleId ? (
             <div className="text-[11px] text-slate-500">Disabled: pick a rule first.</div>
           ) : hasAoi ? (
             <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
-              AOI ready
+              Area ready
             </span>
           ) : (
-            <div className="text-[11px] text-slate-500">Upload and confirm an AOI to continue.</div>
+            <div className="text-[11px] text-slate-500">Upload and confirm an Area to continue.</div>
           )}
         </div>
         {aoiSummary ? (
           <div className="mt-2 rounded-lg border border-slate-200 bg-white px-2 py-2 text-xs text-slate-700">
             {aoiSummary.isPreview ? (
               <>
-                <div className="font-semibold text-slate-900">New AOI ready</div>
-                <div className="mt-1">Replace the current AOI with <span className="font-semibold">{aoiLabel ?? "uploaded AOI"}</span>?</div>
+                <div className="font-semibold text-slate-900">New Area ready</div>
+                <div className="mt-1">Replace the current Area with <span className="font-semibold">{aoiLabel ?? "uploaded Area"}</span>?</div>
                 {aoiSummary.willClearWork ? <div className="mt-1 text-[11px] text-slate-600">This will clear pins and evidence selections.</div> : null}
                 <div className="mt-2 flex flex-wrap items-center gap-2">
-                  <button type="button" className="rounded-full border border-sky-200 bg-sky-600 px-3 py-1 text-xs font-semibold text-white shadow-sm hover:bg-sky-700" onClick={onApplyDraftAoiClick}>Replace AOI</button>
+                  <button type="button" className="rounded-full border border-sky-200 bg-sky-600 px-3 py-1 text-xs font-semibold text-white shadow-sm hover:bg-sky-700" onClick={onApplyDraftAoiClick}>Replace Area</button>
                   <button type="button" className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50" onClick={onCancelDraftAoi}>Keep current</button>
                 </div>
                 {aoiSummary.isSameAoi && aoiSummary.showSameAoiPrompt ? (
                   <div className="mt-2 rounded-md border border-slate-200 bg-slate-50 px-2 py-2 text-[11px] text-slate-700">
-                    <div className="font-semibold text-slate-800">Same AOI detected. Keep current links?</div>
+                    <div className="font-semibold text-slate-800">Same Area detected. Keep current links?</div>
                     <div className="mt-2 flex flex-wrap items-center gap-2">
                       <button type="button" className="rounded-full border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold text-slate-700 shadow-sm hover:bg-slate-50" onClick={onKeepSameAoi}>Keep</button>
                       <button type="button" className="rounded-full border border-rose-200 bg-rose-50 px-2 py-1 text-[11px] font-semibold text-rose-700 shadow-sm hover:bg-rose-100" onClick={onResetSameAoi}>Reset anyway</button>
@@ -578,7 +578,7 @@ export default function EvidenceWorkflowStepper({
               </>
             ) : (
               <div className="grid gap-1 text-[11px] text-slate-600">
-                <div>AOI: {aoiLabel ?? "none"}</div>
+                <div>Area: {aoiLabel ?? "none"}</div>
                 <div>area: {typeof aoiSummary.areaKm2 === "number" ? aoiSummary.areaKm2.toFixed(2) : "—"} km²</div>
                 <div className="break-words">bbox: {aoiSummary.bboxLabel ?? "—"}</div>
               </div>
@@ -589,7 +589,7 @@ export default function EvidenceWorkflowStepper({
 
       <div className={`${stepShellClass} rounded-lg border px-3 py-2 ${stepStateClass(step3)}`} data-testid="wizard-step-3">
         <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Step 3</div>
-        <div className="mt-1 text-xs font-semibold text-slate-900">Search STAC</div>
+        <div className="mt-1 text-xs font-semibold text-slate-900">Search Satellite</div>
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <button
             type="button"
@@ -599,10 +599,10 @@ export default function EvidenceWorkflowStepper({
             disabled={step3.disabled || searchDisabled}
             onClick={onSearchStac}
           >
-            {isRunning ? "Searching…" : "Search STAC"}
+            {isRunning ? "Searching…" : "Search Satellite"}
           </button>
           {!hasAoi ? (
-            <div className="text-[11px] text-slate-500">Disabled: confirm AOI first.</div>
+            <div className="text-[11px] text-slate-500">Disabled: confirm Area first.</div>
           ) : hasSearchResults ? (
             <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-700">
               {stacResultCount} items
@@ -624,7 +624,7 @@ export default function EvidenceWorkflowStepper({
             <button type="button" className="text-xs font-semibold text-slate-700 underline underline-offset-2" onClick={onClearSelectedItem}>Clear</button>
           </div>
         ) : (
-          <div className="mt-2 text-[11px] text-slate-500">Pick a STAC item from the list or map to continue.</div>
+          <div className="mt-2 text-[11px] text-slate-500">Pick a Satellite image from the list or map to continue.</div>
         )}
       </div>
 

--- a/src/components/verify/EvidenceWorkflowStepper.tsx
+++ b/src/components/verify/EvidenceWorkflowStepper.tsx
@@ -624,7 +624,7 @@ export default function EvidenceWorkflowStepper({
             <button type="button" className="text-xs font-semibold text-slate-700 underline underline-offset-2" onClick={onClearSelectedItem}>Clear</button>
           </div>
         ) : (
-          <div className="mt-2 text-[11px] text-slate-500">Pick a Satellite image from the list or map to continue.</div>
+          <div className="mt-2 text-[11px] text-slate-500">Pick a satellite result from the list or map to continue.</div>
         )}
       </div>
 

--- a/src/components/verify/OutcomeWidget.tsx
+++ b/src/components/verify/OutcomeWidget.tsx
@@ -72,7 +72,7 @@ export default function OutcomeWidget({
   const debugLinked = summary.linkage.linkedRuleIds[0] ?? "";
 
   const collapsedLine = useMemo(() => {
-    const aoiLabel = aoiReady ? "AOI ✓" : "AOI —";
+    const aoiLabel = aoiReady ? "Area ✓" : "Area —";
     const stacLabel = `Items ${stacCount}`;
     const ruleLabel = `Rules ${linkedCount}`;
     return `Outcome • ${aoiLabel} • ${stacLabel} • ${ruleLabel}`;

--- a/src/lib/evidence/inventory.ts
+++ b/src/lib/evidence/inventory.ts
@@ -175,7 +175,7 @@ function inventoryKind(pin: EvidencePin): EvidenceInventoryKind {
 
 function evidenceTypeLabel(pin: EvidencePin): string {
   const kind = inventoryKind(pin);
-  if (kind === "stac-item") return "STAC item";
+  if (kind === "stac-item") return "Satellite result";
   if (kind === "workbook") return "Workbook";
   if (kind === "pdd") return "PDD";
   if (kind === "document") return "Document";
@@ -201,8 +201,8 @@ function provenanceSummary(pin: EvidencePin): string {
   const pddDocument = normalizePddDocument(pin);
   const pddFragments = normalizePddFragments(pin);
 
-  if (stacItems.length === 1) parts.push(`STAC ${stacItems[0]}`);
-  else if (stacItems.length > 1) parts.push(`${stacItems.length} STAC items`);
+  if (stacItems.length === 1) parts.push(`Satellite ${stacItems[0]}`);
+  else if (stacItems.length > 1) parts.push(`${stacItems.length} satellite results`);
 
   if (pddDocument) {
     parts.push(pddDocument.file_name);

--- a/src/lib/evidence/inventory.ts
+++ b/src/lib/evidence/inventory.ts
@@ -187,7 +187,7 @@ function evidenceTypeLabel(pin: EvidencePin): string {
 function sourceSummary(pin: EvidencePin): string {
   if (inventoryKind(pin) === "pdd") return "PDD upload";
   if ((pin.attachments ?? []).some((attachment) => attachment.workbook_asset)) return "Workbook upload";
-  if (pin.stac_run_id?.trim()) return "STAC run";
+  if (pin.stac_run_id?.trim()) return "Satellite run";
   if ((pin.attachments?.length ?? 0) > 0) return "Upload";
   if (pin.note?.trim()) return "Workspace note";
   return "Workspace evidence";

--- a/src/lib/proofMap/aoi.ts
+++ b/src/lib/proofMap/aoi.ts
@@ -121,7 +121,7 @@ export function parseAoiGeoJson(input: unknown, nameHint?: string): AoiParseResu
     const record = input as Record<string, unknown>;
     if (record.type === "FeatureCollection" && Array.isArray(record.features)) {
       if (record.features.length !== 1) {
-        return { ok: false, error: "AOI must contain exactly one feature." };
+        return { ok: false, error: "Area must contain exactly one feature." };
       }
     }
   }
@@ -130,19 +130,19 @@ export function parseAoiGeoJson(input: unknown, nameHint?: string): AoiParseResu
   if (!result) {
     return {
       ok: false,
-      error: "AOI must be a GeoJSON Polygon or MultiPolygon (or Feature/FeatureCollection containing one).",
+      error: "Area must be a GeoJSON Polygon or MultiPolygon (or Feature/FeatureCollection containing one).",
     };
   }
 
   const { feature, source } = result;
 
   if (feature.geometry.type !== "Polygon" && feature.geometry.type !== "MultiPolygon") {
-    return { ok: false, error: "AOI geometry must be Polygon or MultiPolygon." };
+    return { ok: false, error: "Area geometry must be Polygon or MultiPolygon." };
   }
 
   const bbox = bboxForFeature(feature);
   const area_km2 = areaKm2(feature);
-  const name = (nameHint ?? "AOI").trim() || "AOI";
+  const name = (nameHint ?? "Area").trim() || "Area";
 
   const aoi: AOI = {
     id: `aoi_${nowIso()}`,

--- a/src/lib/proofMap/verificationRuns.ts
+++ b/src/lib/proofMap/verificationRuns.ts
@@ -131,7 +131,7 @@ export async function runStacEvidenceSearch(input: {
     return {
       provider: "stac",
       runStatus: "error",
-      summary: "STAC search failed.",
+      summary: "Satellite search failed.",
       result_json: stac.json,
     };
   }

--- a/src/lib/verify/buildReviewSummary.ts
+++ b/src/lib/verify/buildReviewSummary.ts
@@ -204,7 +204,7 @@ export function reviewSummaryRows(summary: ReviewSummary): Array<{ label: string
     { label: "Selected evidence", value: display.selectedEvidenceId },
     { label: "Evidence datetime", value: display.selectedEvidenceDatetime },
     { label: "Cloud cover", value: display.cloudCover },
-    { label: "AOI", value: display.aoiLabel },
+    { label: "Area", value: display.aoiLabel },
     { label: "Review state", value: display.reviewState },
     { label: "Search results", value: display.stacSearchResultCount },
     { label: "Linked rules", value: display.linkedRuleCount },

--- a/src/lib/verify/runState.ts
+++ b/src/lib/verify/runState.ts
@@ -829,8 +829,8 @@ export function getVerifyRunStatusDetails(input: {
 
   const missing: string[] = [];
   if (!input.selectedRuleId?.trim()) missing.push("Select a rule");
-  if (!input.aoiHash?.trim()) missing.push("Add an AOI");
-  if (!(input.stacItemIds?.length)) missing.push("Search STAC");
+  if (!input.aoiHash?.trim()) missing.push("Add an Area");
+  if (!(input.stacItemIds?.length)) missing.push("Search Satellite");
   if (!input.selectedStacItemId?.trim()) missing.push("Select an evidence item");
   if (!(input.linkedRuleIds?.length)) missing.push("Link evidence to the rule");
 
@@ -893,8 +893,8 @@ export function getVerifyWizardStepDetails(input: {
 
   const steps: VerifyWizardStepDetails["steps"] = [
     { id: 1, label: "Pick rule", complete: hasRule, active: activeStep === 1, disabled: false },
-    { id: 2, label: "Confirm AOI", complete: hasAoi, active: activeStep === 2, disabled: !hasRule },
-    { id: 3, label: "Search STAC", complete: hasSearchResults, active: activeStep === 3, disabled: !hasAoi },
+    { id: 2, label: "Confirm Area", complete: hasAoi, active: activeStep === 2, disabled: !hasRule },
+    { id: 3, label: "Search Satellite", complete: hasSearchResults, active: activeStep === 3, disabled: !hasAoi },
     { id: 4, label: "Select item", complete: hasSelectedItem, active: activeStep === 4, disabled: !hasSearchResults },
     { id: 5, label: "Create/link pin", complete: hasPins, active: activeStep === 5, disabled: !hasSelectedItem || !hasRule },
     { id: 6, label: "Save reviewer artifact", complete: hasSavedReviewerArtifact, active: activeStep === 6, disabled: !hasPins },

--- a/tests/components/finalReviewSummaryPanel.test.tsx
+++ b/tests/components/finalReviewSummaryPanel.test.tsx
@@ -56,7 +56,7 @@ describe("FinalReviewSummaryPanel", () => {
     expect(html).toContain("Copy link");
     expect(html).toContain("Rule applied");
     expect(html).toContain("Evidence used");
-    expect(html).toContain("AOI");
+    expect(html).toContain("Area");
     expect(html).toContain("What happened");
     expect(html).toContain("Review scope");
     expect(html).toContain("Outcome note");

--- a/tests/components/requirementCoverageWorkspace.test.tsx
+++ b/tests/components/requirementCoverageWorkspace.test.tsx
@@ -95,7 +95,7 @@ const inventoryItems: EvidenceInventoryItem[] = [
     dedupe_key: "title:boundary worksheet",
     display_name: "Boundary worksheet",
     kind: "stac-item",
-    type: "STAC item",
+    type: "Satellite result",
     source_summary: "Workspace evidence",
     provenance_summary: "Provenance pending",
     added_at: "2026-03-02T00:00:00Z",

--- a/tests/e2e/verify-evidence-regression.pw.ts
+++ b/tests/e2e/verify-evidence-regression.pw.ts
@@ -97,8 +97,8 @@ async function openVerifyWithSelectedItem(page: Page, ruleId: string): Promise<v
   await page.waitForSelector("text=Pick rule", { timeout: 30_000 });
   await page.waitForSelector("text=Save reviewer artifact", { timeout: 30_000 });
   await page.waitForSelector("text=Finalize run", { timeout: 30_000 });
-  await expect(page.getByText("AOI ready")).toBeVisible({ timeout: 30_000 });
-  const searchButton = page.getByRole("button", { name: /^Search STAC$/ }).first();
+  await expect(page.getByText("Area ready")).toBeVisible({ timeout: 30_000 });
+  const searchButton = page.getByRole("button", { name: /^Search Satellite$/ }).first();
   await expect(searchButton).toBeEnabled({ timeout: 30_000 });
   await searchButton.click();
   const featureButton = page.getByRole("button", { name: stacItemId }).first();
@@ -351,7 +351,7 @@ test("Finalize lands on a readable review summary and keeps it after refresh", a
     waitUntil: "domcontentloaded",
   });
 
-  await page.getByRole("button", { name: /^Search STAC$/ }).first().click();
+  await page.getByRole("button", { name: /^Search Satellite$/ }).first().click();
   await page.getByRole("button", { name: stacItemId }).first().click();
   await page.getByRole("button", { name: "Create pin" }).first().click();
   await page.getByTestId("verifier-minutes-textarea").fill("Saved review summary note");

--- a/tests/lib/documentSupport.test.ts
+++ b/tests/lib/documentSupport.test.ts
@@ -154,7 +154,7 @@ describe("deriveDocumentSupport", () => {
         display_name: "S2A_36LYJ_20260411",
         kind: "stac-item",
         type: "stac",
-        source_summary: "STAC run",
+        source_summary: "Satellite run",
         provenance_summary: "",
         added_at: "2026-01-01T00:00:00Z",
         link_state: "linked",

--- a/tests/lib/evidenceInventory.test.ts
+++ b/tests/lib/evidenceInventory.test.ts
@@ -111,9 +111,9 @@ describe("evidence inventory", () => {
       dedupe_key: "stac:S2A-001",
       display_name: "S2A-001",
       kind: "stac-item",
-      type: "STAC item",
-      source_summary: "STAC run",
-      provenance_summary: "STAC S2A-001",
+      type: "Satellite result",
+      source_summary: "Satellite run",
+      provenance_summary: "Satellite S2A-001",
       link_state: "unlinked",
       linked_requirement_ids: [],
     });


### PR DESCRIPTION
## What changed
- replaced jargon with plain English across ALL user-visible surfaces, not just step cards
- terminology map: AOI → Area, STAC/STAC item → Satellite/satellite result
- 10 files changed: step labels, error messages, toast notifications, review summaries, form labels, inventory labels, map instructions

## Why
- VVB auditors are the buyers — they don't know what "STAC" or "AOI" means
- first pass only updated step cards; this consistency pass ensures completion/history/next-action surfaces and error messages use the same plain English
- "Satellite image" was overreaching — STAC items aren't guaranteed images, so "satellite result" is more accurate

## Files changed
- `src/lib/verify/runState.ts` — wizard step labels + missing action strings
- `src/components/map/ProofMapTab.tsx` — map instructions, toasts, button text, baseline missing checks
- `src/components/verify/EvidenceWorkflowStepper.tsx` — step card strings
- `src/components/verify/OutcomeWidget.tsx` — collapsed status line
- `src/lib/evidence/inventory.ts` — evidence type labels, provenance summaries
- `src/lib/verify/buildReviewSummary.ts` — review summary labels
- `src/lib/proofMap/aoi.ts` — validation error messages, default name
- `src/lib/proofMap/verificationRuns.ts` — error summary
- `src/components/projects/NewProjectForm.tsx` — form label
- `src/app/api/stac/search/route.ts` — API error message

## Scope and guardrails
- only string literals changed; variable names, types, imports, test IDs untouched
- internal identifiers (aoiHash, stacItemId, stac_run_id, etc.) unchanged
- `npm run build` passes, lint and typecheck clean

**Signed-off-by:** Fred E <fredilly@article6.org>