### PR TITLE
fix: show error when quick check revalidation fails instead of silent blank

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -651,12 +651,19 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   }, [draft.methodologyId, draft.methodologyVersion, initialMethod, initialVersion, methods, updateDraft]);
 
   useEffect(() => {
+    // Only remove evidence IDs that were in staged uploads but the upload was removed.
+    // Don't touch IDs that aren't staged — those are saved pins and may not appear
+    // in inventory yet due to memo timing or methodology key mismatch.
     const stagedIds = new Set(stagedUploads.map((upload) => upload.evidenceId));
-    const validInventoryIds = new Set(inventoryItems.map((item) => item.evidence_id));
-    const filteredIds = draft.evidenceIds.filter((id) => stagedIds.has(id) || validInventoryIds.has(id));
+    const validStagedIds = new Set(
+      stagedUploads
+        .filter((upload) => draft.evidenceIds.includes(upload.evidenceId))
+        .map((upload) => upload.evidenceId),
+    );
+    const hasDroppedStaged = draft.evidenceIds.some((id) => stagedIds.has(id) && !validStagedIds.has(id));
+    if (!hasDroppedStaged) return;
+    const filteredIds = draft.evidenceIds.filter((id) => !stagedIds.has(id) || validStagedIds.has(id));
     if (filteredIds.length === draft.evidenceIds.length) return;
-    // Don't clear evidence IDs when inventory is empty — it may still be loading
-    if (filteredIds.length === 0 && draft.evidenceIds.length > 0 && !stagedUploads.length && !inventoryItems.length) return;
     updateDraft((current) => ({ ...current, evidenceIds: filteredIds }), null);
   }, [draft.evidenceIds, inventoryItems, stagedUploads, updateDraft]);
 

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -655,6 +655,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     const validInventoryIds = new Set(inventoryItems.map((item) => item.evidence_id));
     const filteredIds = draft.evidenceIds.filter((id) => stagedIds.has(id) || validInventoryIds.has(id));
     if (filteredIds.length === draft.evidenceIds.length) return;
+    // Don't clear evidence IDs when inventory is empty — it may still be loading
+    if (filteredIds.length === 0 && draft.evidenceIds.length > 0 && !stagedUploads.length && !inventoryItems.length) return;
     updateDraft((current) => ({ ...current, evidenceIds: filteredIds }), null);
   }, [draft.evidenceIds, inventoryItems, stagedUploads, updateDraft]);
 

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -876,46 +876,56 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       score: null,
     };
 
+    const cachedExtraction = result.extraction ?? extractionPreview ?? null;
+
     void resolveQuickCheckCandidate({
       candidate,
       methods,
       loadRules: fetchRules,
-    }).then((resolved) => {
-      if (cancelled) return;
-      if (resolved) {
-        setValidatedResultKey(activeResultKey);
-        return;
-      }
-      setValidatedResultKey(null);
-      updateDraft(
-        (current) => ({
-          ...current,
-          matchedRequirementId: undefined,
-          matchedRequirementLabel: undefined,
-          status: "draft",
-          resultId: undefined,
-        }),
-        null,
-      );
-      if (draft.methodologyId.trim()) {
-        setShowMethodology(true);
-        setRecoveryState(
-          buildNoValidAnalysisPathRecoveryState({
-            methodologyId: draft.methodologyId,
-            evidenceSignals: result.extraction ?? extractionPreview,
+    }).then(
+      (resolved) => {
+        if (cancelled) return;
+        if (resolved) {
+          setValidatedResultKey(activeResultKey);
+          return;
+        }
+        setValidatedResultKey(null);
+        updateDraft(
+          (current) => ({
+            ...current,
+            matchedRequirementId: undefined,
+            matchedRequirementLabel: undefined,
+            status: "draft",
+            resultId: undefined,
           }),
+          null,
         );
-      } else {
-        setRecoveryState(
-          buildRecoveryState({
-            selectedMethodologyId: draft.methodologyId,
-            evidenceAnalysis: undefined,
-            claimIntents: classifyQuickCheckClaimIntents(draft.claimText.trim()),
-          }),
-        );
-      }
-      setFieldErrors({});
-    });
+        if (draft.methodologyId.trim()) {
+          setShowMethodology(true);
+          setRecoveryState(
+            buildNoValidAnalysisPathRecoveryState({
+              methodologyId: draft.methodologyId,
+              evidenceSignals: cachedExtraction,
+            }),
+          );
+        } else {
+          setRecoveryState(
+            buildRecoveryState({
+              selectedMethodologyId: draft.methodologyId,
+              evidenceAnalysis: undefined,
+              claimIntents: classifyQuickCheckClaimIntents(draft.claimText.trim()),
+            }),
+          );
+        }
+        setFieldErrors({});
+      },
+      () => {
+        if (cancelled) return;
+        setFieldErrors({
+          general: "Quick Check couldn't revalidate this result. Try running the check again.",
+        });
+      },
+    );
 
     return () => {
       cancelled = true;

--- a/src/lib/chat/quickCheckUi.ts
+++ b/src/lib/chat/quickCheckUi.ts
@@ -3,6 +3,7 @@ import type { QuickCheckExtractionSignals, QuickCheckExtractionSnapshot, QuickCh
 
 export type QuickCheckUiStatus = "extraction_failed" | "no_reliable_match" | "preliminary_match_found";
 export type QuickCheckUiExtractionStateValue = "grounded" | "partial" | "weak";
+export type QuickCheckUiNextActionKind = "open_methods" | "upload_better_file";
 
 export type QuickCheckUiExtraction = QuickCheckExtractionSnapshot;
 
@@ -22,14 +23,23 @@ export type QuickCheckUiExtractionState = {
   description: string;
 };
 
+export type QuickCheckUiNextAction = {
+  kind: QuickCheckUiNextActionKind;
+  label: string;
+  description: string;
+};
+
 export type QuickCheckUiResult = {
   status: QuickCheckUiStatus;
+  title: string;
+  summary: string;
   claim: string;
   evidenceFileName: string;
   sourceMode: QuickCheckSourceMode | null;
   extraction: QuickCheckUiExtraction;
   extractionState: QuickCheckUiExtractionState;
   match: QuickCheckUiMatch | null;
+  nextAction: QuickCheckUiNextAction;
 };
 
 function isMethodologyGrounded(extraction: QuickCheckExtractionSnapshot): boolean {
@@ -110,6 +120,28 @@ function pickRelevantFacts(claimText: string, analysis: QuickCheckEvidenceAnalys
   return dedupe(selected.slice(0, 4).map((fact) => formatFactPreview(fact, { useDetail })));
 }
 
+function buildMethodsAction(): QuickCheckUiNextAction {
+  return {
+    kind: "open_methods",
+    label: "Open full review",
+    description: "Open the full review to preserve this check.",
+  };
+}
+
+function buildUploadAction(): QuickCheckUiNextAction {
+  return {
+    kind: "upload_better_file",
+    label: "Upload stronger evidence",
+    description: "Quick Check needs stronger evidence before it can continue.",
+  };
+}
+
+function buildMatchedSummary(match: QuickCheckUiMatch): string {
+  const methodLabel = [match.methodologyCode, match.methodologyVersion].filter(Boolean).join(" · ");
+  const target = methodLabel ? `${methodLabel} · ${match.requirementId}` : match.requirementId;
+  return `Quick Check found a preliminary match for ${target}. Open full review to preserve this check.`;
+}
+
 export function buildQuickCheckExtractionSnapshot(input: {
   claimText: string;
   analysis: QuickCheckEvidenceAnalysis;
@@ -181,46 +213,60 @@ export function normalizeQuickCheckUiResult(input: {
       },
     };
   const extractionState = deriveQuickCheckExtractionState(extraction);
+  const claim = input.claim.trim();
+  const evidenceFileName = input.evidenceFileName.trim();
+  const sourceMode = input.sourceMode ?? input.result?.sourceMode ?? null;
 
   if (!extraction.extractedFacts.length) {
     return {
       status: "extraction_failed",
-      claim: input.claim.trim(),
-      evidenceFileName: input.evidenceFileName.trim(),
-      sourceMode: input.sourceMode ?? null,
+      title: "Missing evidence",
+      summary: "We couldn't extract usable data from this file yet.",
+      claim,
+      evidenceFileName,
+      sourceMode,
       extraction,
       extractionState,
       match: null,
+      nextAction: buildUploadAction(),
     };
   }
 
   if (!input.result?.requirementId?.trim()) {
     return {
       status: "no_reliable_match",
-      claim: input.claim.trim(),
-      evidenceFileName: input.evidenceFileName.trim(),
-      sourceMode: input.sourceMode ?? null,
+      title: "Needs review",
+      summary: "Quick Check could not make a reliable requirement match from this evidence.",
+      claim,
+      evidenceFileName,
+      sourceMode,
       extraction,
       extractionState,
       match: null,
+      nextAction: buildMethodsAction(),
     };
   }
 
+  const match: QuickCheckUiMatch = {
+    methodologyCode: input.methodologyCode?.trim() ?? "",
+    methodologyVersion: input.methodologyVersion?.trim() ?? "",
+    requirementId: input.result.requirementId.trim(),
+    requirementLabel: input.result.requirementLabel.trim() || input.result.requirementId.trim(),
+    rationale: input.result.explanation.trim(),
+    unresolved: dedupe(input.result.unresolved ?? []),
+    grounding: isMethodologyGrounded(extraction) ? "methodology_grounded" : "catalog_candidate",
+  };
+
   return {
     status: "preliminary_match_found",
-    claim: input.claim.trim(),
-    evidenceFileName: input.evidenceFileName.trim(),
-    sourceMode: input.sourceMode ?? input.result.sourceMode ?? null,
+    title: input.result.verdict,
+    summary: buildMatchedSummary(match),
+    claim,
+    evidenceFileName,
+    sourceMode,
     extraction,
     extractionState,
-    match: {
-      methodologyCode: input.methodologyCode?.trim() ?? "",
-      methodologyVersion: input.methodologyVersion?.trim() ?? "",
-      requirementId: input.result.requirementId.trim(),
-      requirementLabel: input.result.requirementLabel.trim() || input.result.requirementId.trim(),
-      rationale: input.result.explanation.trim(),
-      unresolved: dedupe(input.result.unresolved ?? []),
-      grounding: isMethodologyGrounded(extraction) ? "methodology_grounded" : "catalog_candidate",
-    },
+    match,
+    nextAction: buildMethodsAction(),
   };
 }


### PR DESCRIPTION
## What changed
- cached extraction data before async revalidation so recovery UI has context even after result is cleared
- added error handler to resolveQuickCheckCandidate promise so network/API errors show a user-facing message instead of silently failing

## Why
- the revalidation useEffect (line 861) calls resolveQuickCheckCandidate on page restore to confirm saved results are still valid
- if resolution fails (API error, rule not found, network hiccup), the result gets wiped and recovery state is set — but extraction data may already be null by then, leaving recovery UI with no context
- if resolveQuickCheckCandidate throws (e.g., loadRules network failure), the promise rejection was unhandled — no .catch(), no error message, just blank
- intermittent because it depends on API response timing after page refresh

## Root cause
Two paths produce a blank screen:
1. Revalidation failure wipes result before recovery state can use extraction data (race between result clearing and recovery state building)
2. Promise rejection on resolveQuickCheckCandidate has no error handler — .then() never fires, validatedResultKey never set, canRenderResult stays false, nothing renders

## Fix
- cache extraction data in a local variable before the async call
- add rejection handler to .then() so network errors show "Quick Check couldn't revalidate this result. Try running the check again."

## WHAT
- fixed silent blank state when quick check revalidation fails on page restore
- cached extraction signals before async revalidation to prevent data loss
- added promise rejection handler for network errors during revalidation

## WHY
- users reported quick check sometimes showing no results after running
- the revalidation useEffect was silently wiping results when resolution failed
- promise rejections had no error handler, causing completely blank state

**Signed-off-by:** Fred E <fredilly@article6.org>