### PR TITLE
feat: unify verify surface and inline coverage state

### DIFF
--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -9,21 +9,13 @@ import RequirementCoverageWorkspace from "@/app/m/_components/RequirementCoverag
 import RuleDetailModal from "@/app/m/_components/RuleDetailModal";
 import {
   buildRequirementCoverageRows,
-  requirementProvenanceHint,
-  summarizeExpectedEvidence,
-  summarizeLinkedEvidence,
   type RequirementCoverageStatus,
 } from "@/app/m/_lib/requirementCoverage";
 import TrustStrip from "@/components/TrustStrip";
 import ProofMapTab from "@/components/map/ProofMapTab";
-import ReviewProgressIndicator from "@/components/verify/ReviewProgressIndicator";
 import VerifyHeader from "@/app/m/_components/VerifyHeader";
 import { useMethodsLayout } from "@/app/m/_components/MethodsLayoutContext";
 import ShareLinkButton from "@/components/actions/ShareLinkButton";
-import CoveragePanel from "@/components/coverage/CoveragePanel";
-import CoverageDrawer from "@/components/coverage/CoverageDrawer";
-import { buildCoverageQueue } from "@/lib/coverage/queue";
-import { addCoverageTask } from "@/lib/coverage/tasks";
 import {
   buildEvidenceInventory,
   coalesceEvidencePins,
@@ -60,7 +52,7 @@ import type { ProofEvidenceItem } from "@/lib/proof/bundle";
 import { importProofBundleText } from "@/lib/proof/import";
 import { applyUrlUpdates, parseDetailTab, type DetailTab } from "@/lib/nav/urlState";
 import type { MethodVersionLineage } from "@/app/m/_lib/methodVersionMetadata";
-import { getReviewProgress, REVIEW_STORE_EVENT, type ReviewProgress } from "@/lib/verify/reviewStore";
+import { getAllReviews, getReviewProgress, REVIEW_STORE_EVENT, type ReviewProgress, type ReviewStatus } from "@/lib/verify/reviewStore";
 import { deriveDocumentSupport } from "@/lib/verify/documentSupport";
 
 type MethodDetail = {
@@ -116,13 +108,13 @@ export default function MethodDetailPane({
   const verifierMode = useMemo(() => isVerifierMode(searchParams), [searchParams]);
   const urlVerifyMode = useMemo(() => getVerifyView(new URLSearchParams(searchString)), [searchString]);
   const [verifyViewMode, setVerifyViewMode] = useState<"list" | "map">(urlVerifyMode);
-  const defaultTab: DetailTab = useMemo(() => (isEvidenceMode ? "verify" : "rules"), [isEvidenceMode]);
+  const defaultTab: DetailTab = "verify";
   const tab = useMemo(() => {
     if (isEvidenceMode) return "verify";
     const parsed = parseDetailTab(new URLSearchParams(searchString).get("tab"));
     return parsed ?? defaultTab;
   }, [defaultTab, isEvidenceMode, searchString]);
-  const surfaceTab: DetailTab = tab === "verify" ? "verify" : "rules";
+  const surfaceTab: DetailTab = "verify";
   const effectiveTab: DetailTab = isEvidenceMode ? "verify" : surfaceTab;
   const methodBasePath = useMemo(() => {
     const encodedCode = encodeURIComponent(method.code);
@@ -282,6 +274,7 @@ export default function MethodDetailPane({
   const [verificationRuns, setVerificationRuns] = useState<VerificationRun[]>([]);
   const [integrityDiffOpen, setIntegrityDiffOpen] = useState(false);
   const [reviewProgress, setReviewProgress] = useState<ReviewProgress | null>(null);
+  const [reviewStatusByRuleId, setReviewStatusByRuleId] = useState<Map<string, ReviewStatus>>(new Map());
   type WorkspaceSnapshot = {
     currentAoi: AOI | null;
     evidencePins: EvidencePin[];
@@ -300,7 +293,6 @@ export default function MethodDetailPane({
   };
   const [stacEvidenceByKey, setStacEvidenceByKey] = useState<Record<string, StacEvidenceState>>({});
   const [selectedStacItemId, setSelectedStacItemId] = useState<string | null>(null);
-  const [coverageDrawerOpen, setCoverageDrawerOpen] = useState(false);
 
   const lineageVersions = method.lineage?.lineage?.length ? method.lineage.lineage : method.versions;
   const versionBadges = [
@@ -319,30 +311,7 @@ export default function MethodDetailPane({
 
   const stacEvidenceState = evidenceKey ? stacEvidenceByKey[evidenceKey] ?? null : null;
 
-  const tabBase =
-    "inline-flex items-center justify-center rounded-full px-3 py-1.5 text-xs font-semibold transition";
-  const tabActive = "bg-slate-900 text-white";
-  const tabIdle = "bg-slate-100 text-slate-700 hover:bg-slate-200";
-
-  const coverageRules = useMemo(
-    () => rules.map((rule) => ({ id: rule.id, title: rule.title, tags: rule.tags ?? [] })),
-    [rules],
-  );
   const coverageLinkedRuleIds = useMemo(() => linkedRuleIdsFromPins(evidencePins), [evidencePins]);
-  const coverageRulesWithStatus = useMemo(() => {
-    const linked = new Set(coverageLinkedRuleIds);
-    return coverageRules.map((rule) => ({
-      ...rule,
-      status: linked.has(rule.id) ? ("covered" as const) : ("uncovered" as const),
-    }));
-  }, [coverageLinkedRuleIds, coverageRules]);
-  const coverageSummary = useMemo(() => {
-    return buildCoverageQueue({
-      rules: coverageRules,
-      coveredRuleIds: new Set(coverageLinkedRuleIds),
-      limit: 10,
-    });
-  }, [coverageLinkedRuleIds, coverageRules]);
   const sectionTitleById = useMemo(
     () => new Map(sections.map((section) => [section.id, section.title])),
     [sections],
@@ -421,10 +390,13 @@ export default function MethodDetailPane({
   useEffect(() => {
     if (!activeVersion) {
       setReviewProgress(null);
+      setReviewStatusByRuleId(new Map());
       return;
     }
     const updateProgress = () => {
       setReviewProgress(getReviewProgress(method.code, activeVersion, requirementRows.length));
+      const reviews = getAllReviews(method.code, activeVersion);
+      setReviewStatusByRuleId(new Map(Object.values(reviews).map((review) => [review.ruleId, review.status])));
     };
     updateProgress();
     const handleReviewStoreChange = () => updateProgress();
@@ -462,8 +434,8 @@ export default function MethodDetailPane({
       return;
     }
     const urlTab = parseDetailTab(new URLSearchParams(searchString).get("tab"));
-    if (urlTab && urlTab !== "verify") {
-      const next = applyUrlUpdates(new URLSearchParams(searchString), { tab: "rules" });
+    if (urlTab === "rules") {
+      const next = applyUrlUpdates(new URLSearchParams(searchString), { tab: "verify" });
       if (next !== searchString) {
         router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
       }
@@ -845,7 +817,7 @@ export default function MethodDetailPane({
     (ruleId: string) => {
       const origin = typeof window !== "undefined" ? window.location.origin : "";
       const path = `/m/${encodeURIComponent(method.code)}/v/${encodeURIComponent(activeVersion ?? "")}`;
-      const { tab, rule, section, hash } = encodeShareState({ tab: "rules", rule: ruleId });
+      const { tab, rule, section, hash } = encodeShareState({ tab: "verify", rule: ruleId });
       const params = new URLSearchParams();
       if (tab) params.set("tab", tab);
       if (rule) params.set("rule", rule);
@@ -1061,11 +1033,11 @@ export default function MethodDetailPane({
   }, [activeVersion, method.code, traceIndex, traceLoading]);
 
   useEffect(() => {
-    if (effectiveTab === "rules") void ensureRulesLoaded();
+    if (effectiveTab === "verify") void ensureRulesLoaded();
   }, [effectiveTab, ensureRulesLoaded]);
 
   useEffect(() => {
-    if (effectiveTab !== "rules") return;
+    if (effectiveTab !== "verify") return;
     void ensureSectionsLoaded();
   }, [effectiveTab, ensureSectionsLoaded]);
 
@@ -1091,7 +1063,7 @@ export default function MethodDetailPane({
   }, [activeRuleId, ensureSectionsLoaded]);
 
   const openRule = useCallback(async (ruleId: string) => {
-    setTabParam("rules");
+    setTabParam("verify");
     setRulesDeeplinkWarning(null);
     const list = await ensureRulesLoaded();
     if (list.length === 0) return false;
@@ -1160,11 +1132,11 @@ export default function MethodDetailPane({
   const sectionsById = useMemo(() => new Map(sections.map((section) => [section.id, section])), [sections]);
 
   useEffect(() => {
-    if (tab !== "rules") return;
+    if (surfaceTab !== "verify") return;
     if (!activeRuleId) return;
     const el = document.getElementById(`r-${activeRuleId}`) ?? document.getElementById(activeRuleId);
     el?.scrollIntoView({ block: "nearest" });
-  }, [activeRuleId, tab]);
+  }, [activeRuleId, surfaceTab]);
 
   const navigateToRule = useCallback(
     async (ruleId: string) => {
@@ -1212,14 +1184,6 @@ export default function MethodDetailPane({
       appendAuditEvent({ kind: "rule.jump", payload: { rule_id: ruleId } });
     },
     [appendAuditEvent, router],
-  );
-
-  const handleCoverageTask = useCallback(
-    (ruleId: string) => {
-      if (!activeVersion) return { storedIn: "coverage", action: "added" as const };
-      return addCoverageTask({ methodCode: method.code, version: activeVersion, ruleId });
-    },
-    [activeVersion, method.code],
   );
 
   const handleExportAuditTrail = useCallback(() => {
@@ -1321,8 +1285,39 @@ export default function MethodDetailPane({
         if (type === "section") return await navigateToSection(id);
         return false;
       }}
-      onOpenCoverageDrawer={() => setCoverageDrawerOpen(true)}
     />
+  );
+
+  const verifyUtilitySurface = (
+    <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-1">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Utilities</div>
+          <h3 className="text-base font-semibold text-slate-900">Evidence, map, share, and export stay in context</h3>
+          <p className="text-sm text-slate-600">
+            Supporting tools stay attached to the active requirement instead of sending the reviewer to a separate coverage destination.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <ShareLinkButton
+            tab="verify"
+            view={verifyViewMode}
+            ruleId={activeRuleId}
+            sectionId={sectionPreview?.id ?? null}
+          />
+          {methodsLayout?.isVerifyTab ? (
+            <button
+              type="button"
+              onClick={() => methodsLayout.setMethodsCollapsed(!methodsLayout.methodsCollapsed)}
+              className="hidden items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50 lg:inline-flex"
+            >
+              {methodsLayout.methodsCollapsed ? "Show methods" : "Hide methods"}
+            </button>
+          ) : null}
+        </div>
+      </div>
+      <div className="mt-4">{proofMapSurface}</div>
+    </section>
   );
 
   const verifySurface = (
@@ -1333,7 +1328,73 @@ export default function MethodDetailPane({
         onChangeMode={handleHeaderViewModeChange}
         onToggleVerifierMode={handleToggleVerifierMode}
       />
-      {proofMapSurface}
+      {rulesDeeplinkWarning ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          {rulesDeeplinkWarning}
+        </div>
+      ) : null}
+      {rulesError ? (
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          {rulesError}
+        </div>
+      ) : null}
+      {ruleDetailError ? (
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          Failed to load selected requirement detail: {ruleDetailError}
+        </div>
+      ) : null}
+      {rulesLoading ? (
+        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+          Loading verification requirements…
+        </div>
+      ) : null}
+      {!rulesLoading && !rulesError && requirementRows.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-200 bg-white p-10 text-center text-sm text-slate-500">
+          No requirements found for this version.
+        </div>
+      ) : null}
+      {!rulesLoading && !rulesError && requirementRows.length ? (
+        <RequirementCoverageWorkspace
+          rows={requirementRows}
+          activeRuleId={activeRuleId}
+          selectedRequirementText={
+            ruleDetailLoading && activeRuleId && ruleDetail?.id !== activeRuleId
+              ? "Loading requirement details…"
+              : (ruleDetail?.summary ?? null)
+          }
+          selectedRequirementSourcePath={ruleDetail?.sourcePath ?? null}
+          selectedRequirementSha256={ruleDetail?.sha256 ?? null}
+          selectedTraceSections={linkedTraceSections.map((link) => {
+            const section = sectionsById.get(link.section_id);
+            return {
+              sectionId: link.section_id,
+              title: section?.title ?? link.title ?? null,
+              textSnippet: section?.textSnippet ?? null,
+              match: link.match,
+            };
+          })}
+          onSelectRule={(ruleId) => {
+            void openRule(ruleId);
+          }}
+          onOpenSourceContext={(sectionId) => {
+            void navigateToSection(sectionId);
+          }}
+          onCopyRequirementLink={async (ruleId) => {
+            if (!activeVersion) return;
+            try {
+              await navigator.clipboard.writeText(buildRuleLink(ruleId));
+            } catch {
+              // ignore
+            }
+          }}
+          inventoryItems={evidenceInventory}
+          onLinkInventoryItem={handleLinkInventoryItem}
+          onUnlinkInventoryItem={handleUnlinkInventoryItem}
+          reviewStatusByRuleId={reviewStatusByRuleId}
+          reviewProgress={reviewProgress}
+          supportingEvidence={verifyUtilitySurface}
+        />
+      ) : null}
     </div>
   );
 
@@ -1487,254 +1548,7 @@ export default function MethodDetailPane({
         </div>
       ) : null}
 
-      {isEvidenceMode ? null : (
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            onClick={() => setTabParam("rules")}
-            className={`${tabBase} ${surfaceTab === "rules" ? tabActive : tabIdle}`}
-            aria-pressed={surfaceTab === "rules"}
-          >
-            Coverage
-          </button>
-          <button
-            type="button"
-            onClick={() => setTabParam("verify")}
-            className={`${tabBase} ${surfaceTab === "verify" ? tabActive : tabIdle}`}
-            aria-pressed={surfaceTab === "verify"}
-          >
-            Verify
-          </button>
-          {methodsLayout?.isVerifyTab && surfaceTab === "verify" ? (
-            <button
-              type="button"
-              onClick={() => methodsLayout.setMethodsCollapsed(!methodsLayout.methodsCollapsed)}
-              className="hidden items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50 lg:inline-flex"
-            >
-              {methodsLayout.methodsCollapsed ? "Show methods" : "Hide methods"}
-            </button>
-          ) : null}
-        </div>
-      )}
-
-      {isEvidenceMode ? (
-        verifySurface
-      ) : surfaceTab === "verify" ? (
-        verifySurface
-      ) : (
-        <div className="mt-4 grid gap-3">
-          {activeVersion ? (
-            <CoveragePanel
-              summary={coverageSummary}
-              onView={() => setCoverageDrawerOpen(true)}
-            />
-          ) : null}
-
-          {activeVersion ? (
-            <CoverageDrawer
-              open={coverageDrawerOpen}
-              title={`${coverageSummary.uncovered} unresolved requirements`}
-              rules={coverageRulesWithStatus}
-              activeRuleId={activeRuleId}
-              onClose={() => setCoverageDrawerOpen(false)}
-              onOpenRule={openRule}
-              onAddTask={handleCoverageTask}
-            />
-          ) : null}
-
-          {rulesDeeplinkWarning ? (
-            <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
-              {rulesDeeplinkWarning}
-            </div>
-          ) : null}
-
-          {rulesError ? (
-            <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-              {rulesError}
-            </div>
-          ) : null}
-
-          {ruleDetailError ? (
-            <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-              Failed to load selected requirement detail: {ruleDetailError}
-            </div>
-          ) : null}
-
-          {rulesLoading ? (
-            <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-              Loading requirement coverage…
-            </div>
-          ) : null}
-
-          {!rulesLoading && !rulesError && requirementRows.length === 0 ? (
-            <div className="rounded-2xl border border-dashed border-slate-200 bg-white p-10 text-center text-sm text-slate-500">
-              No requirements found for this version.
-            </div>
-          ) : null}
-
-          {!rulesLoading && !rulesError && requirementRows.length ? (
-            <>
-              {activeVersion && reviewProgress ? (
-                <ReviewProgressIndicator progress={reviewProgress} />
-              ) : null}
-
-              <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                  <div className="space-y-2">
-                    <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-                      Methodology detail
-                    </div>
-                    <h3 className="text-lg font-semibold text-slate-900">
-                      Keep the workflow simple and open richer methodology detail only when needed.
-                    </h3>
-                    <p className="text-sm text-slate-600">
-                      View rule now opens a richer modal from the existing verification flow without sending the reviewer to a separate workspace.
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap gap-2 text-xs font-semibold text-slate-700">
-                    <span className="rounded-full bg-slate-100 px-3 py-1">Rules {requirementRows.length}</span>
-                    <span className="rounded-full bg-amber-50 px-3 py-1 text-amber-800">
-                      Unresolved {requirementRows.filter((row) => row.status === "missing" || row.status === "partial").length}
-                    </span>
-                  </div>
-                </div>
-
-                {activeRequirementRow ? (
-                  <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
-                    <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                      <div className="flex flex-wrap items-start justify-between gap-3">
-                        <div>
-                          <div className="font-mono text-xs font-semibold text-slate-700">{activeRequirementRow.ruleId}</div>
-                          <h4 className="mt-2 text-base font-semibold text-slate-900">
-                            {ruleDetail?.title ?? activeRequirementRow.ruleSummary.title}
-                          </h4>
-                        </div>
-                        <button
-                          type="button"
-                          className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
-                          onClick={() => setRuleDetailModalOpen(true)}
-                        >
-                          View rule
-                        </button>
-                      </div>
-                      <p className="mt-3 text-sm leading-6 text-slate-700">
-                        {ruleDetailLoading && activeRuleId && ruleDetail?.id !== activeRuleId
-                          ? "Loading requirement details…"
-                          : (ruleDetail?.summary ?? activeRequirementRow.ruleSummary.summary ?? activeRequirementRow.ruleSummary.snippet)}
-                      </p>
-                    </div>
-
-                    <div className="grid gap-3">
-                      <div className="rounded-2xl border border-slate-200 bg-white p-4">
-                        <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Provenance</div>
-                        <div className="mt-2 text-sm text-slate-700">
-                          {requirementProvenanceHint(activeRequirementRow)}
-                        </div>
-                      </div>
-                      <div className="rounded-2xl border border-slate-200 bg-white p-4">
-                        <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Expected evidence</div>
-                        <div className="mt-2 text-sm text-slate-700">
-                          {summarizeExpectedEvidence(activeRequirementRow.expectedEvidenceTypes)}
-                        </div>
-                      </div>
-                      <div className="rounded-2xl border border-slate-200 bg-white p-4">
-                        <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Linked evidence</div>
-                        <div className="mt-2 text-sm text-slate-700">
-                          {summarizeLinkedEvidence(activeRequirementRow.linkedEvidence)}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="mt-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500">
-                    Select a rule from the verification workflow to inspect richer methodology detail.
-                  </div>
-                )}
-              </section>
-
-              <details className="rounded-2xl border border-slate-200 bg-white shadow-sm">
-                <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-slate-900">
-                  Requirement coverage workspace
-                  <span className="ml-2 text-xs font-normal text-slate-500">Secondary review surface</span>
-                </summary>
-                <div className="border-t border-slate-100 px-4 py-4">
-                  <RequirementCoverageWorkspace
-                    rows={requirementRows}
-                    activeRuleId={activeRuleId}
-                    selectedRequirementText={
-                      ruleDetailLoading && activeRuleId && ruleDetail?.id !== activeRuleId
-                        ? "Loading requirement details…"
-                        : (ruleDetail?.summary ?? null)
-                    }
-                    selectedRequirementSourcePath={ruleDetail?.sourcePath ?? null}
-                    selectedRequirementSha256={ruleDetail?.sha256 ?? null}
-                    selectedTraceSections={linkedTraceSections.map((link) => {
-                      const section = sectionsById.get(link.section_id);
-                      return {
-                        sectionId: link.section_id,
-                        title: section?.title ?? link.title ?? null,
-                        textSnippet: section?.textSnippet ?? null,
-                        match: link.match,
-                      };
-                    })}
-                    onSelectRule={(ruleId) => {
-                      void openRule(ruleId);
-                    }}
-                    onOpenSourceContext={(sectionId) => {
-                      void navigateToSection(sectionId);
-                    }}
-                    onCopyRequirementLink={async (ruleId) => {
-                      if (!activeVersion) return;
-                      try {
-                        await navigator.clipboard.writeText(buildRuleLink(ruleId));
-                      } catch {
-                        // ignore
-                      }
-                    }}
-                    inventoryItems={evidenceInventory}
-                    onLinkInventoryItem={handleLinkInventoryItem}
-                    onUnlinkInventoryItem={handleUnlinkInventoryItem}
-                    supportingEvidence={
-                      <div className="grid gap-3">
-                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                          <div className="text-sm text-slate-600">
-                            Supporting views stay attached to the selected requirement while verify, finalize, and export stay available.
-                          </div>
-                          <div className="flex flex-wrap items-center gap-2">
-                            <div className="inline-flex rounded-full border border-slate-200 bg-slate-50 p-1 text-xs font-semibold text-slate-600">
-                              {(["list", "map"] as const).map((modeOption) => (
-                                <button
-                                  key={modeOption}
-                                  type="button"
-                                  className={`rounded-full px-3 py-1 ${
-                                    verifyViewMode === modeOption ? "bg-white text-slate-900 shadow-sm" : ""
-                                  }`}
-                                  onClick={() => setVerifyViewMode(modeOption)}
-                                  aria-pressed={verifyViewMode === modeOption}
-                                >
-                                  {modeOption === "list" ? "Evidence" : "Map"}
-                                </button>
-                              ))}
-                            </div>
-                            <button
-                              type="button"
-                              onClick={() => navigateToVerify(verifyViewMode)}
-                              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
-                            >
-                              Open full verify workspace
-                            </button>
-                          </div>
-                        </div>
-                        {proofMapSurface}
-                      </div>
-                    }
-                  />
-                </div>
-              </details>
-            </>
-          ) : null}
-        </div>
-      )}
+      {verifySurface}
     </div>
   );
 }

--- a/src/app/m/_components/RequirementCoverageWorkspace.tsx
+++ b/src/app/m/_components/RequirementCoverageWorkspace.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { formatEvidenceInventoryId, type EvidenceInventoryItem } from "@/lib/evidence/inventory";
+import ReviewProgressIndicator from "@/components/verify/ReviewProgressIndicator";
+import type { ReviewProgress, ReviewStatus } from "@/lib/verify/reviewStore";
 import {
   EXPECTED_EVIDENCE_LABELS,
   REQUIREMENT_COVERAGE_STATUS_META,
@@ -11,7 +13,7 @@ import {
   type RequirementCoverageRow,
 } from "@/app/m/_lib/requirementCoverage";
 
-export type RequirementCoverageFilter = "all" | "unresolved" | "linked" | "needs-review";
+export type RequirementCoverageFilter = "all" | "pending" | "verified" | "gaps";
 
 type RequirementCoverageWorkspaceProps = {
   rows: RequirementCoverageRow[];
@@ -31,6 +33,8 @@ type RequirementCoverageWorkspaceProps = {
   inventoryItems?: EvidenceInventoryItem[];
   onLinkInventoryItem?: (evidenceId: string, ruleId: string, fragmentId?: string) => void;
   onUnlinkInventoryItem?: (evidenceId: string, ruleId: string, fragmentId?: string) => void;
+  reviewStatusByRuleId?: Map<string, ReviewStatus>;
+  reviewProgress?: ReviewProgress | null;
   supportingEvidence?: ReactNode;
 };
 
@@ -67,11 +71,10 @@ function linkedEvidenceProvenance(item: RequirementCoverageRow["linkedEvidence"]
   return ([item.documentLabel, item.fragmentLabel, section, pageLabel].filter(Boolean).join(" • ") || item.provenanceSummary) ?? null;
 }
 
-function matchesFilter(row: RequirementCoverageRow, filter: RequirementCoverageFilter): boolean {
-  if (filter === "all") return true;
-  if (filter === "unresolved") return row.status === "missing" || row.status === "partial";
-  if (filter === "linked") return row.status === "linked";
-  return row.status === "needs-review";
+function reviewFilterBucket(status: ReviewStatus | null | undefined): RequirementCoverageFilter {
+  if (status === "verified") return "verified";
+  if (status === "not_verified" || status === "needs_followup") return "gaps";
+  return "pending";
 }
 
 export default function RequirementCoverageWorkspace({
@@ -87,6 +90,8 @@ export default function RequirementCoverageWorkspace({
   inventoryItems = [],
   onLinkInventoryItem,
   onUnlinkInventoryItem,
+  reviewStatusByRuleId = new Map<string, ReviewStatus>(),
+  reviewProgress = null,
   supportingEvidence = null,
 }: RequirementCoverageWorkspaceProps) {
   const [filter, setFilter] = useState<RequirementCoverageFilter>("all");
@@ -95,20 +100,21 @@ export default function RequirementCoverageWorkspace({
   const counts = useMemo(() => {
     return rows.reduce(
       (acc, row) => {
+        const bucket = reviewFilterBucket(reviewStatusByRuleId.get(row.ruleId));
         acc.total += 1;
-        if (row.status === "missing" || row.status === "partial") acc.unresolved += 1;
-        if (row.status === "linked") acc.linked += 1;
-        if (row.status === "needs-review") acc.needsReview += 1;
+        if (bucket === "pending") acc.pending += 1;
+        if (bucket === "verified") acc.verified += 1;
+        if (bucket === "gaps") acc.gaps += 1;
         return acc;
       },
-      { total: 0, unresolved: 0, linked: 0, needsReview: 0 },
+      { total: 0, pending: 0, verified: 0, gaps: 0 },
     );
-  }, [rows]);
+  }, [reviewStatusByRuleId, rows]);
 
   const filteredRows = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     return rows.filter((row) => {
-      if (!matchesFilter(row, filter)) return false;
+      if (filter !== "all" && reviewFilterBucket(reviewStatusByRuleId.get(row.ruleId)) !== filter) return false;
       if (!normalizedQuery) return true;
       const haystack = [
         row.ruleId,
@@ -122,7 +128,7 @@ export default function RequirementCoverageWorkspace({
         .toLowerCase();
       return haystack.includes(normalizedQuery);
     });
-  }, [filter, query, rows]);
+  }, [filter, query, reviewStatusByRuleId, rows]);
 
   const selectedRow = useMemo(() => {
     const inFiltered = filteredRows.find((row) => row.ruleId === activeRuleId);
@@ -155,29 +161,28 @@ export default function RequirementCoverageWorkspace({
 
   return (
     <div className="grid gap-4">
+      {reviewProgress ? <ReviewProgressIndicator progress={reviewProgress} /> : null}
       <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-2">
-            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-              Requirement coverage workspace
-            </div>
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Requirement review</div>
             <h3 className="text-lg font-semibold text-slate-900">
               Review methodology requirements row by row with provenance and evidence context.
             </h3>
-            <div className="flex flex-wrap gap-2 text-xs font-semibold text-slate-700">
-              <span className="rounded-full bg-slate-100 px-3 py-1">Total {counts.total}</span>
-              <span className="rounded-full bg-amber-50 px-3 py-1 text-amber-800">Unresolved {counts.unresolved}</span>
-              <span className="rounded-full bg-emerald-50 px-3 py-1 text-emerald-800">Complete {counts.linked}</span>
-              <span className="rounded-full bg-rose-50 px-3 py-1 text-rose-800">Needs review {counts.needsReview}</span>
+            <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">Rules {counts.total}</span>
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+                Reviewed {counts.verified + counts.gaps}
+              </span>
             </div>
           </div>
           <div className="flex w-full flex-col gap-2 sm:w-auto sm:min-w-80">
             <div className="inline-flex w-full flex-wrap rounded-full border border-slate-200 bg-slate-50 p-1 text-xs font-semibold text-slate-600">
               {([
                 ["all", `All (${counts.total})`],
-                ["unresolved", `Unresolved (${counts.unresolved})`],
-                ["linked", `Linked (${counts.linked})`],
-                ["needs-review", `Needs review (${counts.needsReview})`],
+                ["pending", `Pending (${counts.pending})`],
+                ["verified", `Verified (${counts.verified})`],
+                ["gaps", `Gaps (${counts.gaps})`],
               ] as Array<[RequirementCoverageFilter, string]>).map(([value, label]) => (
                 <button
                   key={value}

--- a/src/app/m/_components/VerifyHeader.tsx
+++ b/src/app/m/_components/VerifyHeader.tsx
@@ -19,11 +19,11 @@ export default function VerifyHeader({
   return (
     <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Requirement coverage</h1>
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Verify requirements</h1>
         <p className="text-sm text-slate-600">
           Reconcile methodology requirements against linked evidence before validation, verification, or diligence.
         </p>
-        <span className="sr-only">List Map Upload AOI Search STAC evidence Requirement coverage</span>
+        <span className="sr-only">List Map Upload AOI Search STAC evidence Verify requirements</span>
       </div>
       <div className="flex flex-wrap items-center gap-2">
         <button

--- a/tests/components/requirementCoverageWorkspace.test.tsx
+++ b/tests/components/requirementCoverageWorkspace.test.tsx
@@ -8,6 +8,7 @@ import { useMemo, useState } from "react";
 import RequirementCoverageWorkspace from "@/app/m/_components/RequirementCoverageWorkspace";
 import type { RequirementCoverageRow } from "@/app/m/_lib/requirementCoverage";
 import type { EvidenceInventoryItem } from "@/lib/evidence/inventory";
+import type { ReviewProgress } from "@/lib/verify/reviewStore";
 
 const rows: RequirementCoverageRow[] = [
   {
@@ -137,6 +138,16 @@ const inventoryItems: EvidenceInventoryItem[] = [
   },
 ];
 
+const reviewProgress: ReviewProgress = {
+  total: 2,
+  reviewed: 1,
+  verified: 1,
+  notVerified: 0,
+  needsFollowup: 0,
+  pending: 1,
+  percentReviewed: 50,
+};
+
 describe("RequirementCoverageWorkspace", () => {
   it("renders requirement row metadata and empty expected-evidence state", () => {
     const html = renderToStaticMarkup(
@@ -150,11 +161,12 @@ describe("RequirementCoverageWorkspace", () => {
         onSelectRule={() => {}}
         onOpenSourceContext={() => {}}
         inventoryItems={inventoryItems}
+        reviewProgress={reviewProgress}
         supportingEvidence={<div>supporting evidence marker</div>}
       />,
     );
 
-    expect(html).toContain("Requirement coverage workspace");
+    expect(html).toContain("Requirement review");
     expect(html).toContain("Maintain a monitoring report and spreadsheet workbook.");
     expect(html).toContain("Monitoring");
     expect(html).toContain("Monitoring report");
@@ -172,6 +184,11 @@ describe("RequirementCoverageWorkspace", () => {
     expect(html).toContain("Boundary worksheet");
     expect(html).toContain("PDD: project-design.pdf");
     expect(html).toContain("Provenance pending");
+    expect(html).toContain("1 of 2 rules reviewed");
+    expect(html).toContain("All (2)");
+    expect(html).toContain("Pending (2)");
+    expect(html).toContain("Verified (0)");
+    expect(html).toContain("Gaps (0)");
     expect(html).toContain("EV-EV1");
     expect(html).toContain("Unlinked");
     expect(html).toContain("Not linked yet");
@@ -320,6 +337,118 @@ describe("RequirementCoverageWorkspace", () => {
     });
 
     expect(container.textContent).toContain("Requirement is unresolved. No linked evidence yet.");
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+  it("filters the verify list by pending, verified, and gaps review state", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const rowsWithGap: RequirementCoverageRow[] = [
+      ...rows,
+      {
+        ruleId: "R-3",
+        ruleSummary: {
+          title: "Leakage deduction check",
+          snippet: "Document leakage deductions and follow-up evidence.",
+          type: undefined,
+          tags: [],
+        },
+        provenance: {
+          sectionId: "S-30",
+          sectionTitle: "Leakage",
+          page: undefined,
+          anchor: "#S-30",
+          primarySection: "S-30",
+          sectionAnchor: "#S-30",
+          sectionStableId: "S-30",
+          tools: [],
+          citations: [{ sectionId: "S-30", label: "Section 30" }],
+        },
+        expectedEvidenceTypes: [],
+        linkedEvidence: [],
+        candidateEvidence: [],
+        status: "needs-review",
+      },
+    ];
+
+    await act(async () => {
+      root.render(
+        <RequirementCoverageWorkspace
+          rows={rowsWithGap}
+          activeRuleId="R-2"
+          onSelectRule={() => {}}
+          onOpenSourceContext={() => {}}
+          reviewStatusByRuleId={
+            new Map([
+              ["R-1", "verified"],
+              ["R-2", "pending"],
+              ["R-3", "needs_followup"],
+            ])
+          }
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Pending (1)");
+    expect(container.textContent).toContain("Verified (1)");
+    expect(container.textContent).toContain("Gaps (1)");
+    expect(container.textContent).toContain("Document the eligibility boundary for review.");
+    expect(container.textContent).not.toContain("Monitoring frequency");
+    expect(container.textContent).not.toContain("Leakage deduction check");
+
+    await act(async () => {
+      (Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Verified (1)")) as HTMLButtonElement).click();
+    });
+
+    expect(container.textContent).toContain("Monitoring frequency");
+    expect(container.textContent).not.toContain("Eligibility boundary");
+    expect(container.textContent).not.toContain("Leakage deduction check");
+
+    await act(async () => {
+      (Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Gaps (1)")) as HTMLButtonElement).click();
+    });
+
+    expect(container.textContent).toContain("Leakage deduction check");
+    expect(container.textContent).not.toContain("Monitoring frequency");
+    expect(container.textContent).not.toContain("Eligibility boundary");
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("keeps a preselected reviewed rule visible on initial render", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <RequirementCoverageWorkspace
+          rows={rows}
+          activeRuleId="R-1"
+          onSelectRule={() => {}}
+          onOpenSourceContext={() => {}}
+          reviewStatusByRuleId={
+            new Map([
+              ["R-1", "verified"],
+              ["R-2", "pending"],
+            ])
+          }
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("All (2)");
+    expect(container.textContent).toContain("Monitoring frequency");
+    expect(container.textContent).toContain("Document the eligibility boundary for review.");
+    expect(container.querySelector("#r-R-1")?.getAttribute("aria-pressed")).toBe("true");
 
     await act(async () => {
       root.unmount();


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- - RC5: in_progress -->
  <!-- - PR12: done -->
  <!-- - PR13: in_progress -->

Allowed statuses: planned | next | in_progress | done | blocked

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

## What
- remove `Coverage` as a top-level methods destination
- default the methods review surface to `Verify`
- inline review progress, reviewed count, and `All / Pending / Verified / Gaps` chips into the verify workspace
- preserve the existing rule review and evidence-linking flow while keeping supporting evidence/map tools in-context
- add focused regression coverage for filter behavior and preselected reviewed-rule visibility

## Why
- reviewers should work in one verification surface instead of choosing between `Coverage` and `Verify`
- progress is supporting context for verification and belongs in the active review workspace
- the safe default filter must not hide a specifically selected reviewed rule on initial load
- this keeps the PR narrowly scoped to the methods review surface and avoids the unrelated Quick Check changes mixed into PR #522

Visible UI changes to look for:
- the methods page no longer exposes Coverage as a separate top-level destination
- Verify is the default review surface
- progress and review filters are embedded directly in-context inside Verify
- filter chips show All / Pending / Verified / Gaps
- existing review flow still behaves normally

**Signed-off-by**: Fred E <fredilly@article6.org>