### PR TITLE
fix: sync rule selection with detail panel

### DIFF
--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -1158,13 +1158,6 @@ export default function MethodDetailPane({
 
   const sectionsById = useMemo(() => new Map(sections.map((section) => [section.id, section])), [sections]);
 
-  useEffect(() => {
-    if (tab !== "rules") return;
-    if (!activeRuleId) return;
-    const el = document.getElementById(`r-${activeRuleId}`) ?? document.getElementById(activeRuleId);
-    el?.scrollIntoView({ block: "nearest" });
-  }, [activeRuleId, tab]);
-
   const navigateToRule = useCallback(
     async (ruleId: string) => {
       const ok = await openRule(ruleId);

--- a/src/app/m/_components/RequirementCoverageWorkspace.tsx
+++ b/src/app/m/_components/RequirementCoverageWorkspace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { formatEvidenceInventoryId, type EvidenceInventoryItem } from "@/lib/evidence/inventory";
 import {
   EXPECTED_EVIDENCE_LABELS,
@@ -91,6 +91,7 @@ export default function RequirementCoverageWorkspace({
 }: RequirementCoverageWorkspaceProps) {
   const [filter, setFilter] = useState<RequirementCoverageFilter>("all");
   const [query, setQuery] = useState("");
+  const selectedRequirementRef = useRef<HTMLDivElement | null>(null);
 
   const counts = useMemo(() => {
     return rows.reduce(
@@ -135,6 +136,10 @@ export default function RequirementCoverageWorkspace({
     if (selectedRow.ruleId === activeRuleId) return;
     onSelectRule(selectedRow.ruleId);
   }, [activeRuleId, onSelectRule, selectedRow]);
+
+  useEffect(() => {
+    selectedRequirementRef.current?.scrollIntoView({ block: "start", inline: "nearest" });
+  }, [selectedRow?.ruleId]);
 
   const primarySourceSectionId =
     selectedRow?.provenance.sectionId ??
@@ -253,7 +258,11 @@ export default function RequirementCoverageWorkspace({
         </section>
 
         <aside className="xl:sticky xl:top-4 xl:self-start">
-          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div
+            ref={selectedRequirementRef}
+            id={selectedRow ? `requirement-detail-${selectedRow.ruleId}` : undefined}
+            className="scroll-mt-24 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+          >
             {selectedRow ? (
               <div className="space-y-4">
                 <div className="flex flex-wrap items-start justify-between gap-3">

--- a/tests/components/requirementCoverageWorkspace.test.tsx
+++ b/tests/components/requirementCoverageWorkspace.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -184,6 +184,12 @@ describe("RequirementCoverageWorkspace", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    const scrollTargets: Element[] = [];
+    const scrollIntoViewMock = jest.fn(function (this: Element) {
+      scrollTargets.push(this);
+    });
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
 
     function Harness() {
       const [activeRuleId, setActiveRuleId] = useState<string | null>("R-1");
@@ -298,6 +304,8 @@ describe("RequirementCoverageWorkspace", () => {
 
     expect(container.textContent).toContain("Full monitoring requirement text.");
     expect(container.querySelector("#r-R-1")?.getAttribute("aria-pressed")).toBe("true");
+    scrollIntoViewMock.mockClear();
+    scrollTargets.length = 0;
 
     await act(async () => {
       (container.querySelector("#r-R-2") as HTMLButtonElement).click();
@@ -305,6 +313,9 @@ describe("RequirementCoverageWorkspace", () => {
 
     expect(container.textContent).toContain("Full eligibility requirement text.");
     expect(container.querySelector("#r-R-2")?.getAttribute("aria-pressed")).toBe("true");
+    expect(container.querySelector("#requirement-detail-R-2")).not.toBeNull();
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "start", inline: "nearest" });
+    expect(scrollTargets.at(-1)?.id).toBe("requirement-detail-R-2");
     expect(container.textContent).toContain("Requirement is unresolved. No linked evidence yet.");
     expect(container.textContent).toContain("Workbook-derived candidates");
 
@@ -324,6 +335,7 @@ describe("RequirementCoverageWorkspace", () => {
     await act(async () => {
       root.unmount();
     });
+    Element.prototype.scrollIntoView = originalScrollIntoView;
     container.remove();
   });
 });


### PR DESCRIPTION
## What
- Scroll the right-side selected requirement panel into view when the active rule changes.
- Remove the old auto-scroll effect that was targeting the left rule list instead of the right detail target.
- Add a regression test covering left-panel selection updating the right-panel scroll target.

## Why
Review should feel like one connected workspace. Selecting a rule in the left panel should move the right panel to that exact requirement immediately and reliably, without forcing manual hunting.

Signed-off-by: Fred E <fredilly@article6.org>