### PR TITLE
refactor: simplify methods review surface

### DIFF
--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -9,9 +9,6 @@ import RequirementCoverageWorkspace from "@/app/m/_components/RequirementCoverag
 import RuleDetailModal from "@/app/m/_components/RuleDetailModal";
 import {
   buildRequirementCoverageRows,
-  requirementProvenanceHint,
-  summarizeExpectedEvidence,
-  summarizeLinkedEvidence,
   type RequirementCoverageStatus,
 } from "@/app/m/_lib/requirementCoverage";
 import TrustStrip from "@/components/TrustStrip";
@@ -35,7 +32,7 @@ import { linkedRuleIdsFromPins } from "@/lib/kpis/computeKpis";
 import { useAuditTrail, type AuditTrailEventInput } from "@/lib/auditTrail/store";
 import { getVerifyView, isVerifierMode } from "@/lib/mode";
 import { jumpToRule } from "@/lib/ruleJump";
-import { decodeShareState, encodeShareState } from "@/lib/shareLink";
+import { decodeShareState } from "@/lib/shareLink";
 import { shouldResetDerivedState } from "@/lib/proofMap/aoiApply";
 import {
   clearProofMapStorage,
@@ -840,22 +837,6 @@ export default function MethodDetailPane({
     }
   }, [activeVersion, method.code, rules, rulesLoading]);
 
-  const buildRuleLink = useCallback(
-    (ruleId: string) => {
-      const origin = typeof window !== "undefined" ? window.location.origin : "";
-      const path = `/m/${encodeURIComponent(method.code)}/v/${encodeURIComponent(activeVersion ?? "")}`;
-      const { tab, rule, section, hash } = encodeShareState({ tab: "rules", rule: ruleId });
-      const params = new URLSearchParams();
-      if (tab) params.set("tab", tab);
-      if (rule) params.set("rule", rule);
-      if (section) params.set("section", section);
-      const query = params.toString();
-      const suffix = `${query ? `?${query}` : ""}${hash ? `#${hash}` : ""}`;
-      return `${origin}${path}${suffix}`;
-    },
-    [activeVersion, method.code],
-  );
-
   const loadRuleDetail = useCallback(async (ruleId: string) => {
     if (!activeVersion) return;
     setRuleDetailLoading(true);
@@ -1563,160 +1544,53 @@ export default function MethodDetailPane({
               {activeVersion && reviewProgress ? (
                 <ReviewProgressIndicator progress={reviewProgress} />
               ) : null}
-
-              <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                  <div className="space-y-2">
-                    <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-                      Methodology detail
-                    </div>
-                    <h3 className="text-lg font-semibold text-slate-900">
-                      Keep the workflow simple and open richer methodology detail only when needed.
-                    </h3>
-                    <p className="text-sm text-slate-600">
-                      View rule now opens a richer modal from the existing verification flow without sending the reviewer to a separate workspace.
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap gap-2 text-xs font-semibold text-slate-700">
-                    <span className="rounded-full bg-slate-100 px-3 py-1">Rules {requirementRows.length}</span>
-                    <span className="rounded-full bg-amber-50 px-3 py-1 text-amber-800">
-                      Unresolved {requirementRows.filter((row) => row.status === "missing" || row.status === "partial").length}
-                    </span>
-                  </div>
-                </div>
-
-                {activeRequirementRow ? (
-                  <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
-                    <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                      <div className="flex flex-wrap items-start justify-between gap-3">
-                        <div>
-                          <div className="font-mono text-xs font-semibold text-slate-700">{activeRequirementRow.ruleId}</div>
-                          <h4 className="mt-2 text-base font-semibold text-slate-900">
-                            {ruleDetail?.title ?? activeRequirementRow.ruleSummary.title}
-                          </h4>
+              <RequirementCoverageWorkspace
+                rows={requirementRows}
+                activeRuleId={activeRuleId}
+                selectedRequirementText={
+                  ruleDetailLoading && activeRuleId && ruleDetail?.id !== activeRuleId
+                    ? "Loading requirement details…"
+                    : (ruleDetail?.summary ?? null)
+                }
+                onSelectRule={(ruleId) => {
+                  void openRule(ruleId);
+                }}
+                inventoryItems={evidenceInventory}
+                onLinkInventoryItem={handleLinkInventoryItem}
+                onUnlinkInventoryItem={handleUnlinkInventoryItem}
+                supportingEvidence={
+                  <div className="grid gap-3">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="text-sm text-slate-600">Keep evidence and map context attached to the selected rule.</div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <div className="inline-flex rounded-full border border-slate-200 bg-slate-50 p-1 text-xs font-semibold text-slate-600">
+                          {(["list", "map"] as const).map((modeOption) => (
+                            <button
+                              key={modeOption}
+                              type="button"
+                              className={`rounded-full px-3 py-1 ${
+                                verifyViewMode === modeOption ? "bg-white text-slate-900 shadow-sm" : ""
+                              }`}
+                              onClick={() => setVerifyViewMode(modeOption)}
+                              aria-pressed={verifyViewMode === modeOption}
+                            >
+                              {modeOption === "list" ? "Evidence" : "Map"}
+                            </button>
+                          ))}
                         </div>
                         <button
                           type="button"
+                          onClick={() => navigateToVerify(verifyViewMode)}
                           className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
-                          onClick={() => setRuleDetailModalOpen(true)}
                         >
-                          View rule
+                          Open full review
                         </button>
                       </div>
-                      <p className="mt-3 text-sm leading-6 text-slate-700">
-                        {ruleDetailLoading && activeRuleId && ruleDetail?.id !== activeRuleId
-                          ? "Loading requirement details…"
-                          : (ruleDetail?.summary ?? activeRequirementRow.ruleSummary.summary ?? activeRequirementRow.ruleSummary.snippet)}
-                      </p>
                     </div>
-
-                    <div className="grid gap-3">
-                      <div className="rounded-2xl border border-slate-200 bg-white p-4">
-                        <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Provenance</div>
-                        <div className="mt-2 text-sm text-slate-700">
-                          {requirementProvenanceHint(activeRequirementRow)}
-                        </div>
-                      </div>
-                      <div className="rounded-2xl border border-slate-200 bg-white p-4">
-                        <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Expected evidence</div>
-                        <div className="mt-2 text-sm text-slate-700">
-                          {summarizeExpectedEvidence(activeRequirementRow.expectedEvidenceTypes)}
-                        </div>
-                      </div>
-                      <div className="rounded-2xl border border-slate-200 bg-white p-4">
-                        <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Linked evidence</div>
-                        <div className="mt-2 text-sm text-slate-700">
-                          {summarizeLinkedEvidence(activeRequirementRow.linkedEvidence)}
-                        </div>
-                      </div>
-                    </div>
+                    {proofMapSurface}
                   </div>
-                ) : (
-                  <div className="mt-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500">
-                    Select a rule from the verification workflow to inspect richer methodology detail.
-                  </div>
-                )}
-              </section>
-
-              <details className="rounded-2xl border border-slate-200 bg-white shadow-sm">
-                <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-slate-900">
-                  Requirement coverage workspace
-                  <span className="ml-2 text-xs font-normal text-slate-500">Secondary review surface</span>
-                </summary>
-                <div className="border-t border-slate-100 px-4 py-4">
-                  <RequirementCoverageWorkspace
-                    rows={requirementRows}
-                    activeRuleId={activeRuleId}
-                    selectedRequirementText={
-                      ruleDetailLoading && activeRuleId && ruleDetail?.id !== activeRuleId
-                        ? "Loading requirement details…"
-                        : (ruleDetail?.summary ?? null)
-                    }
-                    selectedRequirementSourcePath={ruleDetail?.sourcePath ?? null}
-                    selectedRequirementSha256={ruleDetail?.sha256 ?? null}
-                    selectedTraceSections={linkedTraceSections.map((link) => {
-                      const section = sectionsById.get(link.section_id);
-                      return {
-                        sectionId: link.section_id,
-                        title: section?.title ?? link.title ?? null,
-                        textSnippet: section?.textSnippet ?? null,
-                        match: link.match,
-                      };
-                    })}
-                    onSelectRule={(ruleId) => {
-                      void openRule(ruleId);
-                    }}
-                    onOpenSourceContext={(sectionId) => {
-                      void navigateToSection(sectionId);
-                    }}
-                    onCopyRequirementLink={async (ruleId) => {
-                      if (!activeVersion) return;
-                      try {
-                        await navigator.clipboard.writeText(buildRuleLink(ruleId));
-                      } catch {
-                        // ignore
-                      }
-                    }}
-                    inventoryItems={evidenceInventory}
-                    onLinkInventoryItem={handleLinkInventoryItem}
-                    onUnlinkInventoryItem={handleUnlinkInventoryItem}
-                    supportingEvidence={
-                      <div className="grid gap-3">
-                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                          <div className="text-sm text-slate-600">
-                            Supporting views stay attached to the selected requirement while verify, finalize, and export stay available.
-                          </div>
-                          <div className="flex flex-wrap items-center gap-2">
-                            <div className="inline-flex rounded-full border border-slate-200 bg-slate-50 p-1 text-xs font-semibold text-slate-600">
-                              {(["list", "map"] as const).map((modeOption) => (
-                                <button
-                                  key={modeOption}
-                                  type="button"
-                                  className={`rounded-full px-3 py-1 ${
-                                    verifyViewMode === modeOption ? "bg-white text-slate-900 shadow-sm" : ""
-                                  }`}
-                                  onClick={() => setVerifyViewMode(modeOption)}
-                                  aria-pressed={verifyViewMode === modeOption}
-                                >
-                                  {modeOption === "list" ? "Evidence" : "Map"}
-                                </button>
-                              ))}
-                            </div>
-                            <button
-                              type="button"
-                              onClick={() => navigateToVerify(verifyViewMode)}
-                              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
-                            >
-                              Open full verify workspace
-                            </button>
-                          </div>
-                        </div>
-                        {proofMapSurface}
-                      </div>
-                    }
-                  />
-                </div>
-              </details>
+                }
+              />
             </>
           ) : null}
         </div>

--- a/src/app/m/_components/RequirementCoverageWorkspace.tsx
+++ b/src/app/m/_components/RequirementCoverageWorkspace.tsx
@@ -5,9 +5,6 @@ import { formatEvidenceInventoryId, type EvidenceInventoryItem } from "@/lib/evi
 import {
   EXPECTED_EVIDENCE_LABELS,
   REQUIREMENT_COVERAGE_STATUS_META,
-  requirementProvenanceHint,
-  summarizeExpectedEvidence,
-  summarizeLinkedEvidence,
   type RequirementCoverageRow,
 } from "@/app/m/_lib/requirementCoverage";
 
@@ -17,17 +14,7 @@ type RequirementCoverageWorkspaceProps = {
   rows: RequirementCoverageRow[];
   activeRuleId: string | null;
   selectedRequirementText?: string | null;
-  selectedRequirementSourcePath?: string | null;
-  selectedRequirementSha256?: string | null;
-  selectedTraceSections?: Array<{
-    sectionId: string;
-    title?: string | null;
-    textSnippet?: string | null;
-    match?: "explicit" | "text";
-  }>;
   onSelectRule: (ruleId: string) => void;
-  onOpenSourceContext: (sectionId: string) => void;
-  onCopyRequirementLink?: (ruleId: string) => void;
   inventoryItems?: EvidenceInventoryItem[];
   onLinkInventoryItem?: (evidenceId: string, ruleId: string, fragmentId?: string) => void;
   onUnlinkInventoryItem?: (evidenceId: string, ruleId: string, fragmentId?: string) => void;
@@ -78,12 +65,7 @@ export default function RequirementCoverageWorkspace({
   rows,
   activeRuleId,
   selectedRequirementText,
-  selectedRequirementSourcePath,
-  selectedRequirementSha256,
-  selectedTraceSections = [],
   onSelectRule,
-  onOpenSourceContext,
-  onCopyRequirementLink,
   inventoryItems = [],
   onLinkInventoryItem,
   onUnlinkInventoryItem,
@@ -141,11 +123,6 @@ export default function RequirementCoverageWorkspace({
     selectedRequirementRef.current?.scrollIntoView({ block: "start", inline: "nearest" });
   }, [selectedRow?.ruleId]);
 
-  const primarySourceSectionId =
-    selectedRow?.provenance.sectionId ??
-    selectedRow?.provenance.citations.find((citation) => citation.sectionId)?.sectionId ??
-    selectedTraceSections[0]?.sectionId ??
-    null;
   const inventoryCounts = useMemo(() => {
     return inventoryItems.reduce(
       (acc, item) => {
@@ -163,26 +140,22 @@ export default function RequirementCoverageWorkspace({
       <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-2">
-            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-              Requirement coverage workspace
-            </div>
-            <h3 className="text-lg font-semibold text-slate-900">
-              Review methodology requirements row by row with provenance and evidence context.
-            </h3>
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Requirements</div>
+            <h3 className="text-lg font-semibold text-slate-900">Open a requirement and review it in one place.</h3>
             <div className="flex flex-wrap gap-2 text-xs font-semibold text-slate-700">
               <span className="rounded-full bg-slate-100 px-3 py-1">Total {counts.total}</span>
-              <span className="rounded-full bg-amber-50 px-3 py-1 text-amber-800">Unresolved {counts.unresolved}</span>
+              <span className="rounded-full bg-amber-50 px-3 py-1 text-amber-800">Open {counts.unresolved}</span>
               <span className="rounded-full bg-emerald-50 px-3 py-1 text-emerald-800">Complete {counts.linked}</span>
-              <span className="rounded-full bg-rose-50 px-3 py-1 text-rose-800">Needs review {counts.needsReview}</span>
+              <span className="rounded-full bg-rose-50 px-3 py-1 text-rose-800">Review {counts.needsReview}</span>
             </div>
           </div>
           <div className="flex w-full flex-col gap-2 sm:w-auto sm:min-w-80">
             <div className="inline-flex w-full flex-wrap rounded-full border border-slate-200 bg-slate-50 p-1 text-xs font-semibold text-slate-600">
               {([
                 ["all", `All (${counts.total})`],
-                ["unresolved", `Unresolved (${counts.unresolved})`],
+                ["unresolved", `Open (${counts.unresolved})`],
                 ["linked", `Linked (${counts.linked})`],
-                ["needs-review", `Needs review (${counts.needsReview})`],
+                ["needs-review", `Review (${counts.needsReview})`],
               ] as Array<[RequirementCoverageFilter, string]>).map(([value, label]) => (
                 <button
                   key={value}
@@ -234,23 +207,8 @@ export default function RequirementCoverageWorkspace({
                         {status.label}
                       </span>
                     </div>
-                    <span className="text-xs text-slate-500">{requirementProvenanceHint(row)}</span>
                   </div>
                   <div className="text-sm font-semibold leading-snug text-slate-900">{row.ruleSummary.snippet}</div>
-                  <div className="grid gap-2 text-xs text-slate-600 md:grid-cols-3">
-                    <div>
-                      <div className="font-semibold uppercase tracking-wide text-slate-400">Provenance</div>
-                      <div className="mt-1">{requirementProvenanceHint(row)}</div>
-                    </div>
-                    <div>
-                      <div className="font-semibold uppercase tracking-wide text-slate-400">Expected evidence</div>
-                      <div className="mt-1">{summarizeExpectedEvidence(row.expectedEvidenceTypes)}</div>
-                    </div>
-                    <div>
-                      <div className="font-semibold uppercase tracking-wide text-slate-400">Linked evidence</div>
-                      <div className="mt-1">{summarizeLinkedEvidence(row.linkedEvidence)}</div>
-                    </div>
-                  </div>
                 </button>
               );
             })
@@ -267,9 +225,7 @@ export default function RequirementCoverageWorkspace({
               <div className="space-y-4">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
-                    <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-                      Selected requirement
-                    </div>
+                    <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Selected rule</div>
                     <div className="mt-1 font-mono text-xs font-semibold text-slate-700">{selectedRow.ruleId}</div>
                   </div>
                   <span
@@ -287,71 +243,7 @@ export default function RequirementCoverageWorkspace({
                 </div>
 
                 <section className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Methodology provenance</div>
-                  <div className="mt-2 space-y-2 text-sm text-slate-700">
-                    <div>{requirementProvenanceHint(selectedRow)}</div>
-                    {selectedRow.provenance.tools.length ? (
-                      <ul className="grid gap-2">
-                        {selectedRow.provenance.tools.map((tool) => (
-                          <li key={tool} className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600">
-                            {tool}
-                          </li>
-                        ))}
-                      </ul>
-                    ) : null}
-                    {selectedRow.provenance.citations.length ? (
-                      <ul className="grid gap-2">
-                        {selectedRow.provenance.citations.slice(0, 4).map((citation, index) => (
-                          <li key={`${citation.sectionId ?? citation.anchor ?? "citation"}-${index}`} className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600">
-                            {citation.label ?? citation.sectionId ?? citation.anchor ?? "Methodology citation"}
-                          </li>
-                        ))}
-                      </ul>
-                    ) : null}
-                    {selectedTraceSections.length ? (
-                      <div className="grid gap-2">
-                        {selectedTraceSections.slice(0, 3).map((section) => (
-                          <button
-                            key={section.sectionId}
-                            type="button"
-                            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-left hover:border-slate-300"
-                            onClick={() => onOpenSourceContext(section.sectionId)}
-                          >
-                            <div className="font-mono text-[11px] text-slate-600">{section.sectionId}</div>
-                            <div className="mt-1 text-sm font-semibold text-slate-900">
-                              {section.title ?? "Methodology section"}
-                            </div>
-                            {section.textSnippet ? (
-                              <div className="mt-1 text-xs text-slate-600">{section.textSnippet}</div>
-                            ) : null}
-                          </button>
-                        ))}
-                      </div>
-                    ) : null}
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        type="button"
-                        onClick={() => primarySourceSectionId && onOpenSourceContext(primarySourceSectionId)}
-                        disabled={!primarySourceSectionId}
-                        className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        Open source context
-                      </button>
-                      {onCopyRequirementLink ? (
-                        <button
-                          type="button"
-                          onClick={() => onCopyRequirementLink(selectedRow.ruleId)}
-                          className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
-                        >
-                          Copy link
-                        </button>
-                      ) : null}
-                    </div>
-                  </div>
-                </section>
-
-                <section className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Expected evidence</div>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">What to look for</div>
                   <div className="mt-2 text-sm text-slate-700">
                     {selectedRow.expectedEvidenceTypes.length ? (
                       <ul className="grid gap-2">
@@ -368,24 +260,14 @@ export default function RequirementCoverageWorkspace({
                 </section>
 
                 <section className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Linked evidence</div>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Evidence found</div>
                   <div className="mt-2 text-sm text-slate-700">
                     {selectedRow.linkedEvidence.length ? (
                       <ul className="grid gap-2">
                         {selectedRow.linkedEvidence.map((item) => (
                           <li key={`${item.source}:${item.id}`} className="rounded-lg border border-slate-200 bg-white px-3 py-2">
                             <div className="font-semibold text-slate-900">{item.title}</div>
-                            <div className="mt-1 font-mono text-[11px] text-slate-600">
-                              {item.fragmentId ? item.fragmentId : formatEvidenceInventoryId(item.id)}
-                            </div>
-                            <div className="mt-1 text-xs text-slate-600">
-                              {item.type} • {item.source}
-                            </div>
-                            {item.documentLabel && item.fragmentLabel ? (
-                              <div className="mt-1 text-xs text-slate-600">
-                                {item.documentLabel}
-                              </div>
-                            ) : null}
+                            <div className="mt-1 text-xs text-slate-600">{item.type}</div>
                             {linkedEvidenceProvenance(item) ? (
                               <div className="mt-1 text-xs text-slate-600">{linkedEvidenceProvenance(item)}</div>
                             ) : null}
@@ -409,49 +291,16 @@ export default function RequirementCoverageWorkspace({
                         ))}
                       </ul>
                     ) : (
-                      <div>Requirement is unresolved. No linked evidence yet.</div>
+                      <div>No evidence linked yet.</div>
                     )}
-                  </div>
-                </section>
-
-                <section className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Workbook-derived candidates</div>
-                  <div className="mt-2 text-sm text-slate-700">
-                    {selectedRow.candidateEvidence.length ? (
-                      <ul className="grid gap-2">
-                        {selectedRow.candidateEvidence.map((item) => (
-                          <li key={`${item.source}:${item.id}`} className="rounded-lg border border-slate-200 bg-white px-3 py-2">
-                            <div className="font-semibold text-slate-900">{item.title}</div>
-                            <div className="mt-1 font-mono text-[11px] text-slate-600">{item.id}</div>
-                            <div className="mt-1 text-xs text-slate-600">{item.type} • candidate only</div>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <div>No workbook-derived candidates for this requirement yet.</div>
-                    )}
-                  </div>
-                </section>
-
-                <section className="grid gap-2 text-xs text-slate-600">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <span className="font-semibold text-slate-700">Source path</span>
-                    <span className="break-all font-mono text-slate-700">{selectedRequirementSourcePath ?? "—"}</span>
-                  </div>
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <span className="font-semibold text-slate-700">sha256</span>
-                    <span className="break-all font-mono text-slate-700">{selectedRequirementSha256 ?? "—"}</span>
-                  </div>
-                  <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600">
-                    {REQUIREMENT_COVERAGE_STATUS_META[selectedRow.status].description}
                   </div>
                 </section>
 
                 <section className="rounded-xl border border-slate-200 bg-slate-50 p-3" data-testid="evidence-inventory-panel">
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div>
-                      <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Evidence inventory</div>
-                      <div className="mt-1 text-sm font-semibold text-slate-900">Active workspace evidence</div>
+                      <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Files in review</div>
+                      <div className="mt-1 text-sm font-semibold text-slate-900">Current evidence</div>
                     </div>
                     <div className="flex flex-wrap gap-2 text-[11px] font-semibold text-slate-700">
                       <span className="rounded-full border border-slate-200 bg-white px-2 py-0.5">Total {inventoryCounts.total}</span>
@@ -501,7 +350,7 @@ export default function RequirementCoverageWorkspace({
                                       className="rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-700 hover:bg-sky-100"
                                       data-testid={`inventory-link-${item.evidence_id}`}
                                     >
-                                      Link
+                                      Add
                                     </button>
                                   )
                                 ) : null}
@@ -575,20 +424,12 @@ export default function RequirementCoverageWorkspace({
       </div>
 
       {selectedRow ? (
-        <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-          <div className="mb-3">
-            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-              Supporting evidence
-            </div>
-            <h3 className="mt-1 text-base font-semibold text-slate-900">
-              Evidence and map context for {selectedRow.ruleId}
-            </h3>
-            <p className="mt-1 text-sm text-slate-600">
-              These views follow the selected requirement while verify, finalize, and export stay available.
-            </p>
-          </div>
-          {supportingEvidence}
-        </section>
+        <details className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-slate-900">
+            Evidence
+          </summary>
+          <div className="border-t border-slate-100 px-4 py-4">{supportingEvidence}</div>
+        </details>
       ) : null}
     </div>
   );

--- a/tests/components/requirementCoverageWorkspace.test.tsx
+++ b/tests/components/requirementCoverageWorkspace.test.tsx
@@ -144,35 +144,26 @@ describe("RequirementCoverageWorkspace", () => {
         rows={rows}
         activeRuleId="R-1"
         selectedRequirementText="Maintain a monitoring report and spreadsheet workbook for each reporting period."
-        selectedRequirementSourcePath="methodologies/example/rules.json"
-        selectedRequirementSha256="abc123"
-        selectedTraceSections={[{ sectionId: "S-10", title: "Monitoring", textSnippet: "Monitoring context" }]}
         onSelectRule={() => {}}
-        onOpenSourceContext={() => {}}
         inventoryItems={inventoryItems}
         supportingEvidence={<div>supporting evidence marker</div>}
       />,
     );
 
-    expect(html).toContain("Requirement coverage workspace");
+    expect(html).toContain("Requirements");
     expect(html).toContain("Maintain a monitoring report and spreadsheet workbook.");
-    expect(html).toContain("Monitoring");
     expect(html).toContain("Monitoring report");
     expect(html).toContain("Q1 monitoring report");
     expect(html).toContain("project-design.pdf");
-    expect(html).toContain("Boundary overview");
     expect(html).toContain("Project boundary");
     expect(html).toContain("Pages 4-5");
     expect(html).toContain("The project boundary covers compartments 1 through 4.");
     expect(html).toContain("Complete");
-    expect(html).toContain("No expected evidence defined for this rule.");
-    expect(html).toContain("No linked evidence yet");
-    expect(html).toContain("No workbook-derived candidates for this requirement yet.");
-    expect(html).toContain("Evidence inventory");
+    expect(html).toContain("What to look for");
+    expect(html).toContain("Files in review");
     expect(html).toContain("Boundary worksheet");
     expect(html).toContain("PDD: project-design.pdf");
     expect(html).toContain("Provenance pending");
-    expect(html).toContain("EV-EV1");
     expect(html).toContain("Unlinked");
     expect(html).toContain("Not linked yet");
     expect(html).toContain("More");
@@ -260,11 +251,7 @@ describe("RequirementCoverageWorkspace", () => {
           rows={computedRows}
           activeRuleId={activeRuleId}
           selectedRequirementText={activeRow?.ruleId === "R-1" ? "Full monitoring requirement text." : "Full eligibility requirement text."}
-          selectedRequirementSourcePath="methodologies/example/rules.json"
-          selectedRequirementSha256="abc123"
-          selectedTraceSections={[{ sectionId: activeRow?.provenance.sectionId ?? "S-10", title: activeRow?.provenance.sectionTitle ?? "Section" }]}
           onSelectRule={setActiveRuleId}
-          onOpenSourceContext={() => {}}
           inventoryItems={inventory}
           onLinkInventoryItem={(evidenceId, ruleId) =>
             setInventory((current) =>
@@ -316,8 +303,8 @@ describe("RequirementCoverageWorkspace", () => {
     expect(container.querySelector("#requirement-detail-R-2")).not.toBeNull();
     expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "start", inline: "nearest" });
     expect(scrollTargets.at(-1)?.id).toBe("requirement-detail-R-2");
-    expect(container.textContent).toContain("Requirement is unresolved. No linked evidence yet.");
-    expect(container.textContent).toContain("Workbook-derived candidates");
+    expect(container.textContent).toContain("No evidence linked yet.");
+    expect(container.textContent).toContain("Files in review");
 
     await act(async () => {
       (container.querySelector('[data-testid="inventory-link-ev-2"]') as HTMLButtonElement).click();
@@ -330,7 +317,7 @@ describe("RequirementCoverageWorkspace", () => {
       (container.querySelector('[data-testid="inventory-unlink-ev-2"]') as HTMLButtonElement).click();
     });
 
-    expect(container.textContent).toContain("Requirement is unresolved. No linked evidence yet.");
+    expect(container.textContent).toContain("No evidence linked yet.");
 
     await act(async () => {
       root.unmount();


### PR DESCRIPTION
## What
- Remove the duplicate methodology-detail shell from the methods review page.
- Strip default provenance-heavy and jargon-heavy panels from the selected rule surface.
- Rename remaining sections into plain review language and collapse supporting evidence behind a simple disclosure.

## Why
The methods page still felt too noisy and internal. This change keeps the two-panel review flow but makes the default surface read like a reviewer workspace instead of a provenance console.

Signed-off-by: Fred E <fredilly@article6.org>