### PR TITLE
fix: scope compact trust strip to methods

### DIFF
--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -1368,6 +1368,7 @@ export default function MethodDetailPane({
           provenanceJson={provenanceJson}
           manifestRulesPath={manifestRulesPath}
           onOpenIntegrityDiff={() => setIntegrityDiffOpen(true)}
+          surface="methods"
         />
       </div>
 

--- a/src/components/trust/TrustStrip.tsx
+++ b/src/components/trust/TrustStrip.tsx
@@ -14,7 +14,7 @@ type TrustStripProps = {
   provenanceJson?: unknown | null;
   manifestRulesPath?: string | null;
   onOpenIntegrityDiff?: () => void;
-  demo?: boolean;
+  surface?: "default" | "methods";
 };
 
 type ExportArtifact = "provenance" | "META" | "rules" | "sections" | "rich";
@@ -187,7 +187,7 @@ export default function TrustStrip({
   provenanceJson,
   manifestRulesPath,
   onOpenIntegrityDiff,
-  demo = false,
+  surface = "default",
 }: TrustStripProps) {
   const router = useRouter();
   const provenancePicked = useMemo(() => pickProvenanceFields(provenanceJson), [provenanceJson]);
@@ -570,7 +570,7 @@ export default function TrustStrip({
 
   return (
     <div className="w-full">
-      {demo ? (
+      {surface === "methods" ? (
         <div className="flex items-center justify-between gap-4 border-y border-slate-100 bg-slate-50/50 px-4 py-2.5">
           <div className="flex items-center gap-3 min-w-0">
             <span className="inline-block h-2 w-2 rounded-full bg-emerald-500 ring-2 ring-emerald-100" />

--- a/tests/components/trustStrip.test.tsx
+++ b/tests/components/trustStrip.test.tsx
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+
+import { describe, expect, it, jest } from "@jest/globals";
+import { renderToStaticMarkup } from "react-dom/server";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+
+const TrustStrip = require("@/components/TrustStrip").default as typeof import("@/components/TrustStrip").default;
+
+const provenanceJson = {
+  generated_at: "2026-04-22T10:00:00Z",
+  generatedAt: "2026-04-22T10:00:00Z",
+  repo: "Fredilly/app.article6",
+  sha: "1234567890abcdef1234567890abcdef12345678",
+};
+
+describe("TrustStrip", () => {
+  it("renders a compact Methods surface when requested", () => {
+    const html = renderToStaticMarkup(
+      <TrustStrip
+        methodCode="UNFCCC.Forestry.AR-ACM0003"
+        version="02.0"
+        provenanceJson={provenanceJson}
+        surface="methods"
+      />,
+    );
+
+    expect(html).toContain("Download verification pack");
+    expect(html).toContain("Last reviewed");
+    expect(html).not.toContain("Trust strip");
+    expect(html).not.toContain("Derived");
+    expect(html).not.toContain("Advanced");
+  });
+
+  it("keeps the default trust surface unchanged elsewhere", () => {
+    const html = renderToStaticMarkup(
+      <TrustStrip
+        methodCode="UNFCCC.Forestry.AR-ACM0003"
+        version="02.0"
+        provenanceJson={provenanceJson}
+      />,
+    );
+
+    expect(html).toContain("Trust strip");
+    expect(html).toContain("Derived");
+    expect(html).toContain("Advanced");
+    expect(html).toContain("Download verification pack");
+  });
+});


### PR DESCRIPTION
## What
- replace the generic `demo` prop on `TrustStrip` with a route-scoped `surface` variant
- apply the compact trust-strip surface only from the Methods page callsite on `/m`
- add a focused component test covering the Methods variant and the default trust surface

## Why
PR #526 preserved the copy cleanup on main, but the Methods page no longer used the compact trust-strip presentation from the preview. This restores that quieter Methods surface without globally hiding advanced, import, or integrity controls on other trust-strip surfaces.

## Validation
- `npx jest tests/components/trustStrip.test.tsx --runInBand`
- `npm run typecheck`
- `npm run lint`

Signed-off-by: Codex <codex@openai.com>