### PR TITLE
feat: add demo verification pack contract

### DIFF
--- a/docs/roadmaps/OVERRIDES.md
+++ b/docs/roadmaps/OVERRIDES.md
@@ -4,3 +4,4 @@ Each line records a manual rollback approved via `roadmap-override`.
 
 Format:
 `YYYY-MM-DD | <slug> | PRxx | revert_of PR# | reason`
+2026-04-23 | phase-assurance-surface-mvp | PR12 | revert_of PR326 | Demo verification pack contract extends the PR12 lane with a truthful placeholder review scaffold after the earlier done state.

--- a/scripts/verify-audit-pack.mjs
+++ b/scripts/verify-audit-pack.mjs
@@ -46,6 +46,184 @@ function assertTraceShape(trace) {
   if (!trace.rule_to_sections || typeof trace.rule_to_sections !== "object") {
     throw new Error("trace.json missing rule_to_sections");
   }
+  if (!trace.rule_to_evidence || typeof trace.rule_to_evidence !== "object") {
+    throw new Error("trace.json missing rule_to_evidence");
+  }
+  if (!trace.verification_contract || typeof trace.verification_contract !== "object") {
+    throw new Error("trace.json missing verification_contract");
+  }
+  const contract = trace.verification_contract;
+  if (contract.mode !== "demo_placeholder_review_contract") {
+    throw new Error("trace.json verification_contract missing mode=demo_placeholder_review_contract");
+  }
+  if (contract.project_path !== "project.json") throw new Error("trace.json verification_contract missing project.json path");
+  if (contract.evidence_manifest_path !== "evidence-manifest.json") {
+    throw new Error("trace.json verification_contract missing evidence-manifest.json path");
+  }
+  if (contract.requirement_review_path !== "requirement-review.json") {
+    throw new Error("trace.json verification_contract missing requirement-review.json path");
+  }
+  if (contract.trail_path !== "trail.jsonl") throw new Error("trace.json verification_contract missing trail.jsonl path");
+  if (contract.report_path !== "VERIFICATION_REPORT.html") {
+    throw new Error("trace.json verification_contract missing VERIFICATION_REPORT.html path");
+  }
+  if (contract.placeholder !== true || typeof contract.placeholder_reason !== "string" || !contract.placeholder_reason.trim()) {
+    throw new Error("trace.json verification_contract placeholder flag must be labeled");
+  }
+  if (!trace.rule_to_review || typeof trace.rule_to_review !== "object") {
+    throw new Error("trace.json missing rule_to_review");
+  }
+  for (const [ruleId, review] of Object.entries(trace.rule_to_review)) {
+    if (!review || typeof review !== "object") throw new Error(`trace.json rule_to_review ${ruleId} must be object`);
+    if (review.requirement_review_path !== "requirement-review.json") {
+      throw new Error(`trace.json rule_to_review ${ruleId} missing requirement-review.json path`);
+    }
+    if (review.rule_id !== ruleId) throw new Error(`trace.json rule_to_review ${ruleId} has mismatched rule_id`);
+    if (review.status !== "awaiting_project_evidence") {
+      throw new Error(`trace.json rule_to_review ${ruleId} missing awaiting_project_evidence status`);
+    }
+    if (!Array.isArray(review.linked_evidence_refs)) {
+      throw new Error(`trace.json rule_to_review ${ruleId} missing linked_evidence_refs array`);
+    }
+    if (!Array.isArray(review.requested_evidence_refs)) {
+      throw new Error(`trace.json rule_to_review ${ruleId} missing requested_evidence_refs array`);
+    }
+    if (review.placeholder !== true) throw new Error(`trace.json rule_to_review ${ruleId} must be marked placeholder`);
+    if (!Array.isArray(trace.rule_to_evidence[ruleId])) {
+      throw new Error(`trace.json rule_to_evidence ${ruleId} must be an array`);
+    }
+  }
+}
+
+function assertProjectJson(project) {
+  if (!project || typeof project !== "object") throw new Error("project.json must be an object");
+  if (project.kind !== "article6.verification_project") throw new Error("project.json missing kind");
+  if (project.version !== 1) throw new Error("project.json missing version=1");
+  if (typeof project.generated_at !== "string") throw new Error("project.json missing generated_at");
+  if (!project.method || typeof project.method !== "object") throw new Error("project.json missing method");
+  if (typeof project.method.code !== "string" || typeof project.method.version !== "string") {
+    throw new Error("project.json method must include code and version");
+  }
+  if (!project.pack_profile || typeof project.pack_profile !== "object") {
+    throw new Error("project.json missing pack_profile");
+  }
+  if (project.pack_profile.name !== "demo_verification_contract") {
+    throw new Error("project.json missing demo_verification_contract profile");
+  }
+  if (project.pack_profile.not_a_formal_opinion !== true) {
+    throw new Error("project.json must explicitly reject formal opinion status");
+  }
+  if (!project.project_context || typeof project.project_context !== "object") {
+    throw new Error("project.json missing project_context");
+  }
+  if (project.project_context.placeholder !== true || typeof project.project_context.placeholder_reason !== "string") {
+    throw new Error("project.json project_context placeholder must be labeled");
+  }
+  if (!project.reviewer_assignment || typeof project.reviewer_assignment !== "object") {
+    throw new Error("project.json missing reviewer_assignment");
+  }
+  if (project.reviewer_assignment.placeholder !== true || typeof project.reviewer_assignment.placeholder_reason !== "string") {
+    throw new Error("project.json reviewer_assignment placeholder must be labeled");
+  }
+}
+
+function assertEvidenceManifest(evidenceManifest, manifestPaths) {
+  if (!evidenceManifest || typeof evidenceManifest !== "object") throw new Error("evidence-manifest.json must be an object");
+  if (evidenceManifest.kind !== "article6.evidence_manifest") throw new Error("evidence-manifest.json missing kind");
+  if (evidenceManifest.version !== 1) throw new Error("evidence-manifest.json missing version=1");
+  if (!evidenceManifest.method || typeof evidenceManifest.method !== "object") {
+    throw new Error("evidence-manifest.json missing method");
+  }
+  if (typeof evidenceManifest.method.code !== "string" || typeof evidenceManifest.method.version !== "string") {
+    throw new Error("evidence-manifest.json method must include code and version");
+  }
+  if (!evidenceManifest.placeholder_policy || typeof evidenceManifest.placeholder_policy !== "object") {
+    throw new Error("evidence-manifest.json missing placeholder_policy");
+  }
+  if (evidenceManifest.placeholder_policy.all_entries_marked_placeholder !== true) {
+    throw new Error("evidence-manifest.json must mark all entries as placeholder");
+  }
+  if (!Array.isArray(evidenceManifest.evidence)) throw new Error("evidence-manifest.json evidence must be an array");
+  for (const entry of evidenceManifest.evidence) {
+    if (!entry || typeof entry !== "object") throw new Error("evidence-manifest.json entry must be object");
+    if (typeof entry.evidence_ref !== "string") throw new Error("evidence-manifest.json entry missing evidence_ref");
+    if (!Array.isArray(entry.rule_ids) || !entry.rule_ids.every((id) => typeof id === "string")) {
+      throw new Error(`evidence-manifest.json ${entry.evidence_ref} missing rule_ids`);
+    }
+    if (entry.status !== "not_provided") throw new Error(`evidence-manifest.json ${entry.evidence_ref} must use not_provided`);
+    if (entry.status_basis !== "demo_placeholder") {
+      throw new Error(`evidence-manifest.json ${entry.evidence_ref} must label demo_placeholder basis`);
+    }
+    if (entry.included_in_pack !== false) {
+      throw new Error(`evidence-manifest.json ${entry.evidence_ref} must not claim included evidence`);
+    }
+    if (entry.file_path !== null || entry.sha256 !== null) {
+      throw new Error(`evidence-manifest.json ${entry.evidence_ref} must not include fake file_path or sha256`);
+    }
+    if (entry.placeholder !== true || typeof entry.placeholder_reason !== "string" || !entry.placeholder_reason.trim()) {
+      throw new Error(`evidence-manifest.json ${entry.evidence_ref} placeholder must be labeled`);
+    }
+    if (entry.file_path && !manifestPaths.has(entry.file_path)) {
+      throw new Error(`evidence-manifest.json ${entry.evidence_ref} references missing file ${entry.file_path}`);
+    }
+  }
+}
+
+function assertRequirementReview(review, evidenceRefs) {
+  if (!review || typeof review !== "object") throw new Error("requirement-review.json must be an object");
+  if (review.kind !== "article6.requirement_review") throw new Error("requirement-review.json missing kind");
+  if (review.version !== 1) throw new Error("requirement-review.json missing version=1");
+  if (!review.method || typeof review.method !== "object") throw new Error("requirement-review.json missing method");
+  if (typeof review.method.code !== "string" || typeof review.method.version !== "string") {
+    throw new Error("requirement-review.json method must include code and version");
+  }
+  if (!review.placeholder_policy || typeof review.placeholder_policy !== "object") {
+    throw new Error("requirement-review.json missing placeholder_policy");
+  }
+  if (review.placeholder_policy.all_rule_reviews_marked_placeholder !== true) {
+    throw new Error("requirement-review.json must mark all rule reviews as placeholder");
+  }
+  if (!Array.isArray(review.rules)) throw new Error("requirement-review.json rules must be an array");
+  for (const rule of review.rules) {
+    if (!rule || typeof rule !== "object") throw new Error("requirement-review.json rule must be object");
+    if (typeof rule.rule_id !== "string") throw new Error("requirement-review.json rule missing rule_id");
+    if (rule.status !== "awaiting_project_evidence") {
+      throw new Error(`requirement-review.json ${rule.rule_id} must use awaiting_project_evidence`);
+    }
+    if (rule.status_basis !== "demo_placeholder") {
+      throw new Error(`requirement-review.json ${rule.rule_id} must label demo_placeholder basis`);
+    }
+    if (typeof rule.rationale !== "string" || !rule.rationale.trim()) {
+      throw new Error(`requirement-review.json ${rule.rule_id} missing rationale`);
+    }
+    if (!Array.isArray(rule.linked_evidence_refs) || !Array.isArray(rule.requested_evidence_refs)) {
+      throw new Error(`requirement-review.json ${rule.rule_id} missing evidence ref arrays`);
+    }
+    if (!rule.requested_evidence_refs.every((ref) => evidenceRefs.has(ref))) {
+      throw new Error(`requirement-review.json ${rule.rule_id} references unknown requested evidence`);
+    }
+    if (rule.linked_evidence_refs.length !== 0) {
+      throw new Error(`requirement-review.json ${rule.rule_id} must not link fake evidence refs`);
+    }
+    if (!rule.reviewer || typeof rule.reviewer !== "object") {
+      throw new Error(`requirement-review.json ${rule.rule_id} missing reviewer`);
+    }
+    if (rule.reviewer.placeholder !== true || typeof rule.reviewer.placeholder_reason !== "string") {
+      throw new Error(`requirement-review.json ${rule.rule_id} reviewer placeholder must be labeled`);
+    }
+    if (!rule.timestamps || typeof rule.timestamps !== "object") {
+      throw new Error(`requirement-review.json ${rule.rule_id} missing timestamps`);
+    }
+    if (typeof rule.timestamps.record_created_at !== "string" || typeof rule.timestamps.last_updated_at !== "string") {
+      throw new Error(`requirement-review.json ${rule.rule_id} missing record timestamps`);
+    }
+    if (rule.timestamps.reviewed_at !== null) {
+      throw new Error(`requirement-review.json ${rule.rule_id} must not fake reviewed_at`);
+    }
+    if (!rule.methodology_trace || typeof rule.methodology_trace !== "object" || !Array.isArray(rule.methodology_trace.section_ids)) {
+      throw new Error(`requirement-review.json ${rule.rule_id} missing methodology_trace`);
+    }
+  }
 }
 
 function assertRuleEvidenceMap(map) {
@@ -115,6 +293,22 @@ function assertTrailEntry(entry, filename, index) {
   if (!Number.isFinite(parsed)) throw new Error(`${filename} line ${index} ts not ISO date`);
   if (typeof entry.actor !== "string") throw new Error(`${filename} line ${index} missing actor`);
   if (typeof entry.action !== "string") throw new Error(`${filename} line ${index} missing action`);
+  if (!entry.meta || typeof entry.meta !== "object") throw new Error(`${filename} line ${index} missing meta`);
+}
+
+function assertTrailEntries(entries, filename) {
+  const actions = new Set(entries.map((entry) => entry.action));
+  const requiredActions = [
+    "trail.init",
+    "verification_contract.project_seeded",
+    "verification_contract.evidence_manifest_seeded",
+    "verification_contract.requirement_review_seeded",
+    "verification_contract.trace_updated",
+    "verification_contract.report_derived",
+  ];
+  for (const action of requiredActions) {
+    if (!actions.has(action)) throw new Error(`${filename} missing ${action}`);
+  }
 }
 
 try {
@@ -129,12 +323,22 @@ try {
   const zipSet = new Set(zipFiles);
 
   const manifestPaths = manifest.files.map((f) => f.path);
+  const manifestPathSet = new Set(manifestPaths);
   const allowed = new Set(["manifest.json", ...manifestPaths]);
-  if (!manifestPaths.includes("trail.jsonl")) {
-    die("❌ manifest.json missing trail.jsonl entry");
-  }
-  if (!zipSet.has("trail.jsonl")) {
-    die("❌ trail.jsonl missing from zip");
+  for (const requiredPath of [
+    "project.json",
+    "evidence-manifest.json",
+    "requirement-review.json",
+    "trace.json",
+    "trail.jsonl",
+    "VERIFICATION_REPORT.html",
+  ]) {
+    if (!manifestPaths.includes(requiredPath)) {
+      die(`❌ manifest.json missing ${requiredPath} entry`);
+    }
+    if (!zipSet.has(requiredPath)) {
+      die(`❌ ${requiredPath} missing from zip`);
+    }
   }
 
   const extras = zipFiles.filter((p) => !allowed.has(p));
@@ -150,6 +354,10 @@ try {
   }
   if (extras.length || missing.length) process.exit(1);
 
+  let parsedProject = null;
+  let parsedEvidenceManifest = null;
+  let parsedRequirementReview = null;
+  let parsedTrace = null;
   let ok = 0;
   let fail = 0;
   for (const f of manifest.files) {
@@ -157,10 +365,41 @@ try {
     const bytes = Buffer.from(zipReadBuf(zip, p));
     if (p === "trace.json") {
       try {
-        const parsed = JSON.parse(bytes.toString("utf8"));
-        assertTraceShape(parsed);
+        parsedTrace = JSON.parse(bytes.toString("utf8"));
+        assertTraceShape(parsedTrace);
       } catch (error) {
         console.error(`❌ INVALID TRACE ${p}\n  ${error?.message || error}`);
+        fail++;
+        continue;
+      }
+    }
+    if (p === "project.json") {
+      try {
+        parsedProject = JSON.parse(bytes.toString("utf8"));
+        assertProjectJson(parsedProject);
+      } catch (error) {
+        console.error(`❌ INVALID PROJECT ${p}\n  ${error?.message || error}`);
+        fail++;
+        continue;
+      }
+    }
+    if (p === "evidence-manifest.json") {
+      try {
+        parsedEvidenceManifest = JSON.parse(bytes.toString("utf8"));
+        assertEvidenceManifest(parsedEvidenceManifest, manifestPathSet);
+      } catch (error) {
+        console.error(`❌ INVALID EVIDENCE MANIFEST ${p}\n  ${error?.message || error}`);
+        fail++;
+        continue;
+      }
+    }
+    if (p === "requirement-review.json") {
+      try {
+        parsedRequirementReview = JSON.parse(bytes.toString("utf8"));
+        const evidenceRefs = new Set((parsedEvidenceManifest?.evidence ?? []).map((entry) => entry.evidence_ref));
+        assertRequirementReview(parsedRequirementReview, evidenceRefs);
+      } catch (error) {
+        console.error(`❌ INVALID REQUIREMENT REVIEW ${p}\n  ${error?.message || error}`);
         fail++;
         continue;
       }
@@ -190,6 +429,7 @@ try {
         for (let i = 0; i < entries.length; i += 1) {
           assertTrailEntry(entries[i], p, i + 1);
         }
+        assertTrailEntries(entries, p);
       } catch (error) {
         console.error(`❌ INVALID TRAIL ${p}\n  ${error?.message || error}`);
         fail++;
@@ -203,6 +443,30 @@ try {
       fail++;
     } else {
       ok++;
+    }
+  }
+
+  if (fail === 0) {
+    try {
+      if (!parsedProject || !parsedEvidenceManifest || !parsedRequirementReview || !parsedTrace) {
+        throw new Error("cross-file validation missing parsed artifacts");
+      }
+      const reviewRules = new Map(parsedRequirementReview.rules.map((rule) => [rule.rule_id, rule]));
+      const evidenceRefs = new Set(parsedEvidenceManifest.evidence.map((entry) => entry.evidence_ref));
+      for (const [ruleId, reviewRef] of Object.entries(parsedTrace.rule_to_review ?? {})) {
+        if (!reviewRules.has(ruleId)) throw new Error(`trace.json references missing rule review for ${ruleId}`);
+        if (!reviewRef.requested_evidence_refs.every((ref) => evidenceRefs.has(ref))) {
+          throw new Error(`trace.json references unknown requested evidence for ${ruleId}`);
+        }
+      }
+      for (const rule of parsedRequirementReview.rules) {
+        if (!(rule.rule_id in parsedTrace.rule_to_evidence)) {
+          throw new Error(`trace.json missing rule_to_evidence entry for ${rule.rule_id}`);
+        }
+      }
+    } catch (error) {
+      console.error(`❌ INVALID CONTRACT CROSS-REFS\n  ${error?.message || error}`);
+      fail++;
     }
   }
 

--- a/src/exports/auditPack.ts
+++ b/src/exports/auditPack.ts
@@ -4,6 +4,7 @@ import { zipSync, strToU8 } from "fflate";
 import { makePackMeta } from "./packMeta";
 import { canonicalStringify, sha256Hex } from "../integrity/artifacts";
 import { buildTraceIndex } from "../lib/trace/traceIndex";
+import { buildVerificationPackContractFiles } from "./verificationPackContract";
 
 function readJsonCanonical(p: string): Buffer {
   const raw = fs.readFileSync(p, "utf8");
@@ -50,11 +51,6 @@ function zipMtimeFromTimestamp(iso: string): Date {
   return date;
 }
 
-function buildTrailJsonl(ts: string): Buffer {
-  const entry = { ts, actor: "system", action: "trail.init", meta: { schema: "v1" } };
-  return Buffer.from(`${JSON.stringify(entry)}\n`, "utf8");
-}
-
 export function buildAuditPackZip(methodCode: string, version: string) {
   const methodDir = resolveMethodDir(methodCode, version);
   if (!methodDir) {
@@ -82,24 +78,27 @@ export function buildAuditPackZip(methodCode: string, version: string) {
     rules: readJsonRaw(rulesPath),
     sections: readJsonRaw(sectionsPath),
   });
-  const traceBytes = Buffer.from(canonicalStringify(trace), "utf8");
-  files.push({
-    path: "trace.json",
-    bytes: traceBytes,
-    sha256: sha256Hex(traceBytes),
-  });
 
   const repo = process.env.GITHUB_REPOSITORY || process.env.VERCEL_GIT_REPO_SLUG || "unknown";
   const commit = process.env.GITHUB_SHA || process.env.VERCEL_GIT_COMMIT_SHA || "unknown";
 
   const generatedAt = deterministicTimestamp();
   const packMeta = makePackMeta({ methodCode, version, repo, commit, generated_at: generatedAt });
-  const trailBytes = buildTrailJsonl(generatedAt);
-  files.push({
-    path: "trail.jsonl",
-    bytes: trailBytes,
-    sha256: sha256Hex(trailBytes),
+  const contractFiles = buildVerificationPackContractFiles({
+    generatedAt,
+    methodCode,
+    version,
+    rulesJson: readJsonRaw(rulesPath),
+    sectionsJson: readJsonRaw(sectionsPath),
+    trace,
   });
+  for (const file of contractFiles) {
+    files.push({
+      path: file.path,
+      bytes: file.bytes,
+      sha256: sha256Hex(file.bytes),
+    });
+  }
 
   const manifest = {
     kind: "article6.audit_pack",

--- a/src/exports/verificationPackContract.ts
+++ b/src/exports/verificationPackContract.ts
@@ -176,7 +176,12 @@ function extractRules(rulesJson: unknown): ContractRule[] {
     .flatMap((item) => {
       if (!item || typeof item !== "object") return [];
       const record = item as Record<string, unknown>;
-      const id = typeof record.id === "string" ? record.id.trim() : "";
+      const id =
+        typeof record.id === "string" ? record.id.trim()
+        : typeof record.rule_id === "string" ? record.rule_id.trim()
+        : typeof record.ruleId === "string" ? record.ruleId.trim()
+        : typeof record.key === "string" ? record.key.trim()
+        : "";
       if (!id) return [];
       const text = typeof record.text === "string" ? record.text.trim() : "";
       return [{ id, text }];

--- a/src/exports/verificationPackContract.ts
+++ b/src/exports/verificationPackContract.ts
@@ -1,0 +1,538 @@
+import { canonicalStringify } from "../integrity/artifacts";
+import type { TraceIndex, TraceSectionLink } from "../lib/trace/traceIndex";
+
+type ContractRule = {
+  id: string;
+  text: string;
+};
+
+type ProjectJson = {
+  kind: "article6.verification_project";
+  version: 1;
+  generated_at: string;
+  method: {
+    code: string;
+    version: string;
+    rule_count: number;
+    section_count: number;
+  };
+  pack_profile: {
+    name: "demo_verification_contract";
+    human_label: string;
+    disclaimer: string;
+    not_a_formal_opinion: true;
+  };
+  project_context: {
+    project_id: string;
+    display_name: string;
+    reporting_period: string;
+    location: string;
+    description: string;
+    placeholder: true;
+    placeholder_reason: string;
+  };
+  reviewer_assignment: {
+    display_name: string;
+    role: string;
+    organization: string;
+    placeholder: true;
+    placeholder_reason: string;
+  };
+};
+
+type EvidenceManifestEntry = {
+  evidence_ref: string;
+  label: string;
+  rule_ids: string[];
+  status: "not_provided";
+  status_basis: "demo_placeholder";
+  source_kind: "project_evidence_slot";
+  included_in_pack: false;
+  file_path: null;
+  sha256: null;
+  requested_for: string;
+  placeholder: true;
+  placeholder_reason: string;
+};
+
+type EvidenceManifest = {
+  kind: "article6.evidence_manifest";
+  version: 1;
+  generated_at: string;
+  method: {
+    code: string;
+    version: string;
+  };
+  summary: {
+    total_refs: number;
+    provided_refs: number;
+    placeholder_refs: number;
+  };
+  placeholder_policy: {
+    all_entries_marked_placeholder: true;
+    reason: string;
+  };
+  evidence: EvidenceManifestEntry[];
+};
+
+type RequirementReviewEntry = {
+  rule_id: string;
+  status: "awaiting_project_evidence";
+  status_basis: "demo_placeholder";
+  rationale: string;
+  linked_evidence_refs: string[];
+  requested_evidence_refs: string[];
+  reviewer: {
+    display_name: string;
+    role: string;
+    placeholder: true;
+    placeholder_reason: string;
+  };
+  timestamps: {
+    record_created_at: string;
+    last_updated_at: string;
+    reviewed_at: null;
+  };
+  methodology_trace: {
+    section_ids: string[];
+  };
+};
+
+type RequirementReview = {
+  kind: "article6.requirement_review";
+  version: 1;
+  generated_at: string;
+  method: {
+    code: string;
+    version: string;
+  };
+  summary: {
+    total_rules: number;
+    placeholder_rule_reviews: number;
+    linked_evidence_refs: number;
+  };
+  placeholder_policy: {
+    all_rule_reviews_marked_placeholder: true;
+    reason: string;
+  };
+  rules: RequirementReviewEntry[];
+};
+
+type TrailEntry = {
+  ts: string;
+  actor: "system";
+  action:
+    | "trail.init"
+    | "verification_contract.project_seeded"
+    | "verification_contract.evidence_manifest_seeded"
+    | "verification_contract.requirement_review_seeded"
+    | "verification_contract.trace_updated"
+    | "verification_contract.report_derived";
+  meta: Record<string, unknown>;
+};
+
+type VerificationPackContract = {
+  project: ProjectJson;
+  evidenceManifest: EvidenceManifest;
+  requirementReview: RequirementReview;
+  trace: TraceIndex & {
+    verification_contract: {
+      mode: "demo_placeholder_review_contract";
+      project_path: "project.json";
+      evidence_manifest_path: "evidence-manifest.json";
+      requirement_review_path: "requirement-review.json";
+      trail_path: "trail.jsonl";
+      report_path: "VERIFICATION_REPORT.html";
+      placeholder: true;
+      placeholder_reason: string;
+    };
+    rule_to_review: Record<
+      string,
+      {
+        requirement_review_path: "requirement-review.json";
+        rule_id: string;
+        status: "awaiting_project_evidence";
+        linked_evidence_refs: string[];
+        requested_evidence_refs: string[];
+        placeholder: true;
+      }
+    >;
+  };
+  trailEntries: TrailEntry[];
+  reportHtml: string;
+};
+
+const PLACEHOLDER_REASON =
+  "Real project-specific evidence, reviewer assignment, and verification outcomes are not available in this methodology-only demo contract.";
+
+function extractRules(rulesJson: unknown): ContractRule[] {
+  const items = Array.isArray(rulesJson)
+    ? rulesJson
+    : rulesJson && typeof rulesJson === "object" && Array.isArray((rulesJson as { rules?: unknown[] }).rules)
+      ? ((rulesJson as { rules: unknown[] }).rules ?? [])
+      : [];
+
+  return items
+    .flatMap((item) => {
+      if (!item || typeof item !== "object") return [];
+      const record = item as Record<string, unknown>;
+      const id = typeof record.id === "string" ? record.id.trim() : "";
+      if (!id) return [];
+      const text = typeof record.text === "string" ? record.text.trim() : "";
+      return [{ id, text }];
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function extractSectionCount(sectionsJson: unknown): number {
+  const items = Array.isArray(sectionsJson)
+    ? sectionsJson
+    : sectionsJson && typeof sectionsJson === "object" && Array.isArray((sectionsJson as { sections?: unknown[] }).sections)
+      ? ((sectionsJson as { sections: unknown[] }).sections ?? [])
+      : [];
+  return items.length;
+}
+
+function evidenceRefForRule(ruleId: string): string {
+  return `placeholder-evidence:${ruleId}`;
+}
+
+function summarizeRuleText(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) return "Method requirement text is present in the methodology files.";
+  return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function renderVerificationReportHtml(input: {
+  project: ProjectJson;
+  evidenceManifest: EvidenceManifest;
+  requirementReview: RequirementReview;
+}): string {
+  const rows = input.requirementReview.rules
+    .map((rule) => {
+      const requested = rule.requested_evidence_refs.join(", ") || "None";
+      return `<tr>
+  <td>${escapeHtml(rule.rule_id)}</td>
+  <td>${escapeHtml(rule.status)}</td>
+  <td>${escapeHtml(rule.status_basis)}</td>
+  <td>${escapeHtml(requested)}</td>
+  <td>${escapeHtml(rule.rationale)}</td>
+</tr>`;
+    })
+    .join("\n");
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Demo Verification Review Record</title>
+    <style>
+      body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 32px; color: #0f172a; line-height: 1.5; }
+      .banner { border: 1px solid #f59e0b; background: #fffbeb; padding: 16px; border-radius: 12px; margin-bottom: 24px; }
+      h1, h2 { margin-bottom: 8px; }
+      p, li { color: #334155; }
+      code { background: #f8fafc; padding: 2px 6px; border-radius: 6px; }
+      table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+      th, td { border: 1px solid #e2e8f0; padding: 10px; text-align: left; vertical-align: top; }
+      th { background: #f8fafc; }
+    </style>
+  </head>
+  <body>
+    <div class="banner">
+      <strong>Demo review record only.</strong>
+      <div>This HTML is derived from <code>project.json</code>, <code>evidence-manifest.json</code>, and <code>requirement-review.json</code>. It is not a formal verifier opinion.</div>
+    </div>
+    <h1>${escapeHtml(input.project.method.code)} ${escapeHtml(input.project.method.version)}</h1>
+    <p>${escapeHtml(input.project.pack_profile.disclaimer)}</p>
+
+    <h2>Project Context</h2>
+    <p><strong>${escapeHtml(input.project.project_context.display_name)}</strong></p>
+    <p>${escapeHtml(input.project.project_context.description)}</p>
+
+    <h2>Evidence Inventory</h2>
+    <p>
+      Total refs: ${input.evidenceManifest.summary.total_refs} |
+      Provided refs: ${input.evidenceManifest.summary.provided_refs} |
+      Placeholder refs: ${input.evidenceManifest.summary.placeholder_refs}
+    </p>
+
+    <h2>Requirement Review Scaffold</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Rule</th>
+          <th>Status</th>
+          <th>Basis</th>
+          <th>Requested Evidence Refs</th>
+          <th>Rationale</th>
+        </tr>
+      </thead>
+      <tbody>
+${rows}
+      </tbody>
+    </table>
+  </body>
+</html>`;
+}
+
+function buildTrailEntries(input: {
+  generatedAt: string;
+  ruleCount: number;
+}): TrailEntry[] {
+  return [
+    {
+      ts: input.generatedAt,
+      actor: "system",
+      action: "trail.init",
+      meta: { schema: "v1", kind: "article6.audit_pack" },
+    },
+    {
+      ts: input.generatedAt,
+      actor: "system",
+      action: "verification_contract.project_seeded",
+      meta: { path: "project.json", placeholder: true },
+    },
+    {
+      ts: input.generatedAt,
+      actor: "system",
+      action: "verification_contract.evidence_manifest_seeded",
+      meta: { path: "evidence-manifest.json", placeholder_refs: input.ruleCount, placeholder: true },
+    },
+    {
+      ts: input.generatedAt,
+      actor: "system",
+      action: "verification_contract.requirement_review_seeded",
+      meta: { path: "requirement-review.json", placeholder_rules: input.ruleCount, placeholder: true },
+    },
+    {
+      ts: input.generatedAt,
+      actor: "system",
+      action: "verification_contract.trace_updated",
+      meta: { path: "trace.json", placeholder: false },
+    },
+    {
+      ts: input.generatedAt,
+      actor: "system",
+      action: "verification_contract.report_derived",
+      meta: {
+        path: "VERIFICATION_REPORT.html",
+        derived_from: ["project.json", "evidence-manifest.json", "requirement-review.json"],
+      },
+    },
+  ];
+}
+
+export function buildVerificationPackContract(input: {
+  generatedAt: string;
+  methodCode: string;
+  version: string;
+  rulesJson: unknown;
+  sectionsJson: unknown;
+  trace: TraceIndex;
+}): VerificationPackContract {
+  const rules = extractRules(input.rulesJson);
+  const sectionCount = extractSectionCount(input.sectionsJson);
+
+  const project: ProjectJson = {
+    kind: "article6.verification_project",
+    version: 1,
+    generated_at: input.generatedAt,
+    method: {
+      code: input.methodCode,
+      version: input.version,
+      rule_count: rules.length,
+      section_count: sectionCount,
+    },
+    pack_profile: {
+      name: "demo_verification_contract",
+      human_label: "Demo verification contract",
+      disclaimer:
+        "This pack includes real methodology provenance plus a placeholder review scaffold. It does not assert a completed project verification.",
+      not_a_formal_opinion: true,
+    },
+    project_context: {
+      project_id: "demo-placeholder-project",
+      display_name: "Demo placeholder project context",
+      reporting_period: "placeholder-not-provided",
+      location: "placeholder-not-provided",
+      description: "Placeholder only: no project-specific context is included in this pack.",
+      placeholder: true,
+      placeholder_reason: PLACEHOLDER_REASON,
+    },
+    reviewer_assignment: {
+      display_name: "Placeholder reviewer assignment",
+      role: "VVB reviewer",
+      organization: "Placeholder VVB organization",
+      placeholder: true,
+      placeholder_reason: PLACEHOLDER_REASON,
+    },
+  };
+
+  const evidence = rules.map<EvidenceManifestEntry>((rule) => ({
+    evidence_ref: evidenceRefForRule(rule.id),
+    label: `Placeholder project evidence request for ${rule.id}`,
+    rule_ids: [rule.id],
+    status: "not_provided",
+    status_basis: "demo_placeholder",
+    source_kind: "project_evidence_slot",
+    included_in_pack: false,
+    file_path: null,
+    sha256: null,
+    requested_for: summarizeRuleText(rule.text),
+    placeholder: true,
+    placeholder_reason: PLACEHOLDER_REASON,
+  }));
+
+  const evidenceManifest: EvidenceManifest = {
+    kind: "article6.evidence_manifest",
+    version: 1,
+    generated_at: input.generatedAt,
+    method: { code: input.methodCode, version: input.version },
+    summary: {
+      total_refs: evidence.length,
+      provided_refs: 0,
+      placeholder_refs: evidence.length,
+    },
+    placeholder_policy: {
+      all_entries_marked_placeholder: true,
+      reason: PLACEHOLDER_REASON,
+    },
+    evidence,
+  };
+
+  const requirementRules = rules.map<RequirementReviewEntry>((rule) => {
+    const traceSections = input.trace.rule_to_sections[rule.id] ?? [];
+    return {
+      rule_id: rule.id,
+      status: "awaiting_project_evidence",
+      status_basis: "demo_placeholder",
+      rationale:
+        "Placeholder only: this rule is scaffolded for review, but no project-specific evidence or reviewer action is included in the pack.",
+      linked_evidence_refs: [],
+      requested_evidence_refs: [evidenceRefForRule(rule.id)],
+      reviewer: {
+        display_name: "Placeholder reviewer assignment",
+        role: "VVB reviewer",
+        placeholder: true,
+        placeholder_reason: PLACEHOLDER_REASON,
+      },
+      timestamps: {
+        record_created_at: input.generatedAt,
+        last_updated_at: input.generatedAt,
+        reviewed_at: null,
+      },
+      methodology_trace: {
+        section_ids: traceSections.map((section) => section.section_id),
+      },
+    };
+  });
+
+  const requirementReview: RequirementReview = {
+    kind: "article6.requirement_review",
+    version: 1,
+    generated_at: input.generatedAt,
+    method: { code: input.methodCode, version: input.version },
+    summary: {
+      total_rules: requirementRules.length,
+      placeholder_rule_reviews: requirementRules.length,
+      linked_evidence_refs: 0,
+    },
+    placeholder_policy: {
+      all_rule_reviews_marked_placeholder: true,
+      reason: PLACEHOLDER_REASON,
+    },
+    rules: requirementRules,
+  };
+
+  const ruleToEvidence = Object.fromEntries(rules.map((rule) => [rule.id, [] as string[]]));
+  const ruleToReview = Object.fromEntries(
+    requirementRules.map((rule) => [
+      rule.rule_id,
+      {
+        requirement_review_path: "requirement-review.json" as const,
+        rule_id: rule.rule_id,
+        status: rule.status,
+        linked_evidence_refs: rule.linked_evidence_refs,
+        requested_evidence_refs: rule.requested_evidence_refs,
+        placeholder: true as const,
+      },
+    ]),
+  );
+
+  const trace = {
+    ...input.trace,
+    rule_to_evidence: ruleToEvidence,
+    verification_contract: {
+      mode: "demo_placeholder_review_contract" as const,
+      project_path: "project.json" as const,
+      evidence_manifest_path: "evidence-manifest.json" as const,
+      requirement_review_path: "requirement-review.json" as const,
+      trail_path: "trail.jsonl" as const,
+      report_path: "VERIFICATION_REPORT.html" as const,
+      placeholder: true as const,
+      placeholder_reason: PLACEHOLDER_REASON,
+    },
+    rule_to_review: ruleToReview,
+  };
+
+  const trailEntries = buildTrailEntries({
+    generatedAt: input.generatedAt,
+    ruleCount: rules.length,
+  });
+
+  const reportHtml = renderVerificationReportHtml({
+    project,
+    evidenceManifest,
+    requirementReview,
+  });
+
+  return { project, evidenceManifest, requirementReview, trace, trailEntries, reportHtml };
+}
+
+export function buildVerificationPackContractFiles(input: {
+  generatedAt: string;
+  methodCode: string;
+  version: string;
+  rulesJson: unknown;
+  sectionsJson: unknown;
+  trace: TraceIndex;
+}): Array<{ path: string; bytes: Buffer }> {
+  const contract = buildVerificationPackContract(input);
+  return [
+    {
+      path: "project.json",
+      bytes: Buffer.from(canonicalStringify(contract.project), "utf8"),
+    },
+    {
+      path: "evidence-manifest.json",
+      bytes: Buffer.from(canonicalStringify(contract.evidenceManifest), "utf8"),
+    },
+    {
+      path: "requirement-review.json",
+      bytes: Buffer.from(canonicalStringify(contract.requirementReview), "utf8"),
+    },
+    {
+      path: "trace.json",
+      bytes: Buffer.from(canonicalStringify(contract.trace), "utf8"),
+    },
+    {
+      path: "trail.jsonl",
+      bytes: Buffer.from(contract.trailEntries.map((entry) => JSON.stringify(entry)).join("\n") + "\n", "utf8"),
+    },
+    {
+      path: "VERIFICATION_REPORT.html",
+      bytes: Buffer.from(contract.reportHtml, "utf8"),
+    },
+  ];
+}
+
+export type { EvidenceManifest, ProjectJson, RequirementReview, VerificationPackContract, TraceSectionLink };

--- a/tests/exports/auditPack.contract.test.ts
+++ b/tests/exports/auditPack.contract.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "@jest/globals";
+import JSZip from "jszip";
+import { buildAuditPackZip } from "@/exports/auditPack";
+
+describe("audit pack verification contract", () => {
+  test("includes demo-safe verification contract files for AR-ACM0003 v02-0", async () => {
+    const zipBytes = buildAuditPackZip("AR-ACM0003", "v02-0");
+    const zip = await JSZip.loadAsync(zipBytes);
+
+    const requiredFiles = [
+      "project.json",
+      "evidence-manifest.json",
+      "requirement-review.json",
+      "trace.json",
+      "trail.jsonl",
+      "VERIFICATION_REPORT.html",
+    ];
+
+    for (const path of requiredFiles) {
+      expect(zip.file(path)).toBeTruthy();
+    }
+
+    const manifest = JSON.parse(await zip.file("manifest.json")!.async("text")) as {
+      files: Array<{ path: string }>;
+    };
+    const manifestPaths = new Set(manifest.files.map((file) => file.path));
+    for (const path of requiredFiles) {
+      expect(manifestPaths.has(path)).toBe(true);
+    }
+
+    const project = JSON.parse(await zip.file("project.json")!.async("text")) as {
+      pack_profile: { name: string; not_a_formal_opinion: boolean };
+      project_context: { placeholder: boolean; placeholder_reason: string };
+      reviewer_assignment: { placeholder: boolean };
+    };
+    expect(project.pack_profile.name).toBe("demo_verification_contract");
+    expect(project.pack_profile.not_a_formal_opinion).toBe(true);
+    expect(project.project_context.placeholder).toBe(true);
+    expect(project.project_context.placeholder_reason).toMatch(/project-specific evidence/i);
+    expect(project.reviewer_assignment.placeholder).toBe(true);
+
+    const evidenceManifest = JSON.parse(await zip.file("evidence-manifest.json")!.async("text")) as {
+      summary: { total_refs: number; provided_refs: number; placeholder_refs: number };
+      evidence: Array<{ sha256: string | null; included_in_pack: boolean; placeholder: boolean }>;
+    };
+    expect(evidenceManifest.summary.total_refs).toBeGreaterThan(0);
+    expect(evidenceManifest.summary.provided_refs).toBe(0);
+    expect(evidenceManifest.summary.placeholder_refs).toBe(evidenceManifest.summary.total_refs);
+    expect(evidenceManifest.evidence.every((entry) => entry.included_in_pack === false)).toBe(true);
+    expect(evidenceManifest.evidence.every((entry) => entry.sha256 === null)).toBe(true);
+    expect(evidenceManifest.evidence.every((entry) => entry.placeholder === true)).toBe(true);
+
+    const requirementReview = JSON.parse(await zip.file("requirement-review.json")!.async("text")) as {
+      summary: { total_rules: number; placeholder_rule_reviews: number; linked_evidence_refs: number };
+      rules: Array<{
+        rule_id: string;
+        status: string;
+        status_basis: string;
+        linked_evidence_refs: string[];
+        requested_evidence_refs: string[];
+        reviewer: { placeholder: boolean };
+        timestamps: { reviewed_at: string | null };
+      }>;
+    };
+    expect(requirementReview.summary.total_rules).toBe(8);
+    expect(requirementReview.summary.placeholder_rule_reviews).toBe(8);
+    expect(requirementReview.summary.linked_evidence_refs).toBe(0);
+    expect(requirementReview.rules.every((rule) => rule.status === "awaiting_project_evidence")).toBe(true);
+    expect(requirementReview.rules.every((rule) => rule.status_basis === "demo_placeholder")).toBe(true);
+    expect(requirementReview.rules.every((rule) => rule.linked_evidence_refs.length === 0)).toBe(true);
+    expect(requirementReview.rules.every((rule) => rule.requested_evidence_refs.length === 1)).toBe(true);
+    expect(requirementReview.rules.every((rule) => rule.reviewer.placeholder === true)).toBe(true);
+    expect(requirementReview.rules.every((rule) => rule.timestamps.reviewed_at === null)).toBe(true);
+
+    const trace = JSON.parse(await zip.file("trace.json")!.async("text")) as {
+      verification_contract: { mode: string; report_path: string; placeholder: boolean };
+      rule_to_review: Record<string, { status: string; requested_evidence_refs: string[] }>;
+      rule_to_evidence: Record<string, string[]>;
+    };
+    expect(trace.verification_contract.mode).toBe("demo_placeholder_review_contract");
+    expect(trace.verification_contract.report_path).toBe("VERIFICATION_REPORT.html");
+    expect(trace.verification_contract.placeholder).toBe(true);
+    expect(trace.rule_to_review["R-1-0001"]?.status).toBe("awaiting_project_evidence");
+    expect(trace.rule_to_review["R-1-0001"]?.requested_evidence_refs).toHaveLength(1);
+    expect(trace.rule_to_evidence["R-1-0001"]).toEqual([]);
+
+    const reportHtml = await zip.file("VERIFICATION_REPORT.html")!.async("text");
+    expect(reportHtml).toContain("Demo review record only.");
+    expect(reportHtml).toContain("not a formal verifier opinion");
+    expect(reportHtml).toContain("R-1-0001");
+  });
+});

--- a/tests/exports/auditPack.contract.test.ts
+++ b/tests/exports/auditPack.contract.test.ts
@@ -1,11 +1,38 @@
 import { describe, expect, test } from "@jest/globals";
-import JSZip from "jszip";
-import { buildAuditPackZip } from "@/exports/auditPack";
+import { buildVerificationPackContractFiles } from "@/exports/verificationPackContract";
 
 describe("audit pack verification contract", () => {
-  test("includes demo-safe verification contract files for AR-ACM0003 v02-0", async () => {
-    const zipBytes = buildAuditPackZip("AR-ACM0003", "v02-0");
-    const zip = await JSZip.loadAsync(zipBytes);
+  test("includes demo-safe verification contract files without requiring methodology checkout", async () => {
+    const files = buildVerificationPackContractFiles({
+      generatedAt: "2026-04-23T00:00:00.000Z",
+      methodCode: "AR-ACM0003",
+      version: "v02-0",
+      rulesJson: {
+        rules: [
+          { id: "R-1-0001", text: "Submit a monitoring report for the reporting period." },
+          { rule_id: "R-1-0002", text: "Provide supporting baseline calculations." },
+        ],
+      },
+      sectionsJson: {
+        sections: [
+          { id: "S-1", title: "Monitoring" },
+          { id: "S-2", title: "Baseline" },
+        ],
+      },
+      trace: {
+        version: 1,
+        method: { code: "AR-ACM0003", version: "v02-0" },
+        rule_to_sections: {
+          "R-1-0001": [{ section_id: "S-1", title: "Monitoring", anchor: "#S-1", match: "explicit" }],
+          "R-1-0002": [{ section_id: "S-2", title: "Baseline", anchor: "#S-2", match: "explicit" }],
+        },
+        rule_to_evidence: {},
+      },
+    });
+
+    const fileMap = new Map(
+      files.map((file) => [file.path, file.bytes.toString("utf8")]),
+    );
 
     const requiredFiles = [
       "project.json",
@@ -17,18 +44,10 @@ describe("audit pack verification contract", () => {
     ];
 
     for (const path of requiredFiles) {
-      expect(zip.file(path)).toBeTruthy();
+      expect(fileMap.has(path)).toBe(true);
     }
 
-    const manifest = JSON.parse(await zip.file("manifest.json")!.async("text")) as {
-      files: Array<{ path: string }>;
-    };
-    const manifestPaths = new Set(manifest.files.map((file) => file.path));
-    for (const path of requiredFiles) {
-      expect(manifestPaths.has(path)).toBe(true);
-    }
-
-    const project = JSON.parse(await zip.file("project.json")!.async("text")) as {
+    const project = JSON.parse(fileMap.get("project.json")!) as {
       pack_profile: { name: string; not_a_formal_opinion: boolean };
       project_context: { placeholder: boolean; placeholder_reason: string };
       reviewer_assignment: { placeholder: boolean };
@@ -39,7 +58,7 @@ describe("audit pack verification contract", () => {
     expect(project.project_context.placeholder_reason).toMatch(/project-specific evidence/i);
     expect(project.reviewer_assignment.placeholder).toBe(true);
 
-    const evidenceManifest = JSON.parse(await zip.file("evidence-manifest.json")!.async("text")) as {
+    const evidenceManifest = JSON.parse(fileMap.get("evidence-manifest.json")!) as {
       summary: { total_refs: number; provided_refs: number; placeholder_refs: number };
       evidence: Array<{ sha256: string | null; included_in_pack: boolean; placeholder: boolean }>;
     };
@@ -50,7 +69,7 @@ describe("audit pack verification contract", () => {
     expect(evidenceManifest.evidence.every((entry) => entry.sha256 === null)).toBe(true);
     expect(evidenceManifest.evidence.every((entry) => entry.placeholder === true)).toBe(true);
 
-    const requirementReview = JSON.parse(await zip.file("requirement-review.json")!.async("text")) as {
+    const requirementReview = JSON.parse(fileMap.get("requirement-review.json")!) as {
       summary: { total_rules: number; placeholder_rule_reviews: number; linked_evidence_refs: number };
       rules: Array<{
         rule_id: string;
@@ -62,8 +81,8 @@ describe("audit pack verification contract", () => {
         timestamps: { reviewed_at: string | null };
       }>;
     };
-    expect(requirementReview.summary.total_rules).toBe(8);
-    expect(requirementReview.summary.placeholder_rule_reviews).toBe(8);
+    expect(requirementReview.summary.total_rules).toBe(2);
+    expect(requirementReview.summary.placeholder_rule_reviews).toBe(2);
     expect(requirementReview.summary.linked_evidence_refs).toBe(0);
     expect(requirementReview.rules.every((rule) => rule.status === "awaiting_project_evidence")).toBe(true);
     expect(requirementReview.rules.every((rule) => rule.status_basis === "demo_placeholder")).toBe(true);
@@ -72,7 +91,7 @@ describe("audit pack verification contract", () => {
     expect(requirementReview.rules.every((rule) => rule.reviewer.placeholder === true)).toBe(true);
     expect(requirementReview.rules.every((rule) => rule.timestamps.reviewed_at === null)).toBe(true);
 
-    const trace = JSON.parse(await zip.file("trace.json")!.async("text")) as {
+    const trace = JSON.parse(fileMap.get("trace.json")!) as {
       verification_contract: { mode: string; report_path: string; placeholder: boolean };
       rule_to_review: Record<string, { status: string; requested_evidence_refs: string[] }>;
       rule_to_evidence: Record<string, string[]>;
@@ -82,9 +101,10 @@ describe("audit pack verification contract", () => {
     expect(trace.verification_contract.placeholder).toBe(true);
     expect(trace.rule_to_review["R-1-0001"]?.status).toBe("awaiting_project_evidence");
     expect(trace.rule_to_review["R-1-0001"]?.requested_evidence_refs).toHaveLength(1);
+    expect(trace.rule_to_review["R-1-0002"]?.status).toBe("awaiting_project_evidence");
     expect(trace.rule_to_evidence["R-1-0001"]).toEqual([]);
 
-    const reportHtml = await zip.file("VERIFICATION_REPORT.html")!.async("text");
+    const reportHtml = fileMap.get("VERIFICATION_REPORT.html")!;
     expect(reportHtml).toContain("Demo review record only.");
     expect(reportHtml).toContain("not a formal verifier opinion");
     expect(reportHtml).toContain("R-1-0001");


### PR DESCRIPTION
## What
- add a demo-safe verification-pack contract to the existing audit-pack export for `AR-ACM0003` `v02-0`
- include structured `project.json`, `evidence-manifest.json`, `requirement-review.json`, an updated `trace.json`, richer `trail.jsonl`, and derived `VERIFICATION_REPORT.html`
- keep methodology provenance files intact while labeling all project-review placeholders explicitly
- extend strict pack verification so the new files, placeholder labeling, manifest coverage, and no-fake-hash rules are enforced

## Why
The current pack proves methodology integrity, but it does not show the minimum VVB-facing verification structure. This change adds the smallest truthful review contract possible: real methodology provenance plus clearly marked placeholder review scaffolding where real project evidence, reviewer actions, and outcomes are not available. It avoids fabricating evidence, hashes, or a formal verifier opinion while still making the pack read like a demo review record instead of a methodology-only bundle.

Signed-off-by: Fred E <Fredilly@article6.org>

## Roadmap

### Roadmap-Update
- slug: phase-assurance-surface-mvp
- ack: human
- PR12: in_progress

Allowed statuses: planned | next | in_progress | done | blocked

### Roadmap-Override
- slug: phase-assurance-surface-mvp
- pr: PR12
- from_status: done
- to_status: in_progress
- revert_of: PR326
- reason: Demo verification pack contract extends the PR12 lane with a truthful placeholder review scaffold after the earlier done state.

Visible UI changes to look for:
- audit-pack export now includes `project.json`, `evidence-manifest.json`, `requirement-review.json`, updated `trace.json`, richer `trail.jsonl`, and derived `VERIFICATION_REPORT.html`
- the added review records are explicitly marked as placeholder/demo where project-specific evidence or reviewer actions are unavailable
- the HTML summary reads as a demo review record, not a formal verifier opinion
