### PR TITLE
feat: add registry-aware verification report export

### DIFF
--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { createProject } from '@/lib/projects/storage';
+import { projectRegistryFromMethodProgram } from '@/lib/projects/verificationReport';
 
 type MethodOption = {
   code: string;
@@ -51,6 +52,7 @@ export default function NewProjectForm() {
         name,
         methodCode: code,
         methodVersion: version,
+        registry: projectRegistryFromMethodProgram(methods.find((method) => `${method.code}@${method.version}` === selectedMethod)?.program),
         aoiLabel: aoiLabel || undefined,
         description: description || undefined,
         ruleIds: rules.map((r: { id: string; title: string; sectionId?: string }) => ({

--- a/src/lib/projects/exportPdf.ts
+++ b/src/lib/projects/exportPdf.ts
@@ -1,4 +1,5 @@
-import type { Project, RuleReview, ProjectCoverage } from '@/lib/projects/types';
+import type { Project, ProjectCoverage, RuleReview } from '@/lib/projects/types';
+import { composeVerificationReport } from '@/lib/projects/verificationReport';
 
 function esc(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
@@ -32,17 +33,6 @@ function statusLabel(s: string): string {
   return s.toUpperCase();
 }
 
-function sectionTitle(sectionId: string): string {
-  const titles: Record<string, string> = {
-    'S-1': 'Scope and Boundary',
-    'S-2': 'Baseline',
-    'S-3': 'Monitoring',
-    'S-4': 'Leakage',
-    'S-5': 'Permanence',
-  };
-  return titles[sectionId] ?? sectionId;
-}
-
 function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 3) + '...' : s;
 }
@@ -54,6 +44,7 @@ function safeDate(iso: string | undefined): string {
 }
 
 export function buildProjectExportPdf(project: Project, coverage: ProjectCoverage): Buffer {
+  const report = composeVerificationReport(project, coverage);
   const now = new Date().toISOString().replace('T', ' ').slice(0, 16);
   const W = 612;
   const PAGE_H = 792;
@@ -108,6 +99,12 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
     y -= 28;
   }
 
+  function bodyLine(text: string, font: 'F1' | 'FB' = 'F1', size = 8, color = '0.2 0.2 0.2 rg'): void {
+    need(14);
+    ln.push(...TXT(L, y, font, size, truncate(text, 96), color));
+    y -= 12;
+  }
+
   function cols(): void {
     need(20);
     ln.push(
@@ -120,21 +117,22 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
   }
 
   ln.push(
-    ...TXT(L, y + 20, 'F1', 8, 'VERIFICATION PACK', '0.5 0.5 0.5 rg'),
-    ...TXT(L, y + 4, 'FB', 18, project.name, '0.1 0.1 0.1 rg'),
-    ...TXT(L, y - 14, 'F1', 9, `${project.methodCode} @ ${project.methodVersion}`, '0.35 0.35 0.35 rg'),
+    ...TXT(L, y + 20, 'F1', 8, 'VERIFICATION REPORT', '0.5 0.5 0.5 rg'),
+    ...TXT(L, y + 4, 'FB', 18, report.title, '0.1 0.1 0.1 rg'),
+    ...TXT(L, y - 14, 'F1', 9, truncate(report.subtitle, 84), '0.35 0.35 0.35 rg'),
   );
   let metaX = L;
-  const metaItems = [
-    `Status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}`,
-    project.aoiLabel ? `Area: ${project.aoiLabel}` : null,
-    `${coverage.verified + coverage.gap} of ${coverage.total} rules reviewed`,
-  ].filter(Boolean);
-  for (const item of metaItems) {
-    ln.push(...TXT(metaX, y - 30, 'F1', 8, String(item), '0.45 0.45 0.45 rg'));
+  for (const item of report.summaryItems.slice(0, 3)) {
+    ln.push(...TXT(metaX, y - 34, 'F1', 8, truncate(item, 26), '0.45 0.45 0.45 rg'));
     metaX += 160;
   }
-  y -= 64;
+  y -= 68;
+
+  sec('REPORT STATUS');
+  bodyLine(`Registry: ${report.registry}.`, 'FB', 8, '0.25 0.25 0.25 rg');
+  bodyLine(`Render state: ${report.status}.`);
+  bodyLine(`Project status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}.`);
+  y -= 4;
 
   sec('COVERAGE SUMMARY');
   const items = [
@@ -161,87 +159,77 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
   );
   y -= 24;
 
-  const grouped = project.reviews.reduce((acc, r) => {
-    if (!acc[r.sectionId]) acc[r.sectionId] = [];
-    acc[r.sectionId].push(r);
-    return acc;
-  }, {} as Record<string, RuleReview[]>);
-
-  for (const [sid, reviews] of Object.entries(grouped)) {
-    sec(sectionTitle(sid));
-    cols();
-    for (const [index, r] of reviews.entries()) {
-      const t = truncate(r.ruleTitle, 55);
-      const statusColor = r.status === 'verified'
-        ? '0.2 0.55 0.3 rg'
-        : r.status === 'gap'
-          ? '0.75 0.2 0.2 rg'
-          : '0.45 0.45 0.45 rg';
-      const detailText = r.note?.trim() || '';
-      const hasDetails = detailText.length > 0 && r.status !== 'not-started';
-      const rowHeight = hasDetails ? 30 : 16;
-      need(rowHeight);
-      if (index % 2 === 1) ln.push(RC(L, y - 2, R - L, rowHeight - 2, 0.97));
-      ln.push(
-        ...TXT(L, y, 'F1', 8, r.ruleId, '0.4 0.4 0.4 rg'),
-        ...TXT(L + 110, y, 'F1', 8, t, '0.15 0.15 0.15 rg'),
-        ...TXT(L + 390, y, 'F1', 8, sym(r.status), statusColor),
-        ...TXT(L + 402, y, 'FB', 7, statusLabel(r.status), statusColor),
-      );
-      if (hasDetails) {
-        // Keep note text short enough to stay readable in the PDF row layout.
-        ln.push(...TXT(L + 110, y - 12, 'F1', 7, truncate(detailText, 80), '0.5 0.5 0.5 rg'));
-      }
-      y -= rowHeight;
-    }
-    y -= 8;
+  for (const section of report.sections) {
+    sec(section.title);
+    for (const line of section.lines) bodyLine(line);
+    y -= 4;
   }
 
-  const gaps = project.reviews.filter(r => r.status === 'gap' || r.status === 'not-started');
-  if (gaps.length > 0) {
-    sec(`OPEN GAPS (${gaps.length})`);
-    for (const r of gaps) {
-      const t = truncate(r.ruleTitle, 55);
-      const note = r.note?.trim() || (r.status === 'not-started' ? 'Not yet reviewed' : '');
+  if (report.groupedReviews.length > 0) {
+    sec('REQUIREMENT REVIEW SUMMARY');
+    y -= 2;
+    for (const group of report.groupedReviews) {
+      sec(group.title);
+      cols();
+      for (const [index, review] of group.reviews.entries()) {
+        const t = truncate(review.ruleTitle, 55);
+        const statusColor = review.status === 'verified'
+          ? '0.2 0.55 0.3 rg'
+          : review.status === 'gap'
+            ? '0.75 0.2 0.2 rg'
+            : '0.45 0.45 0.45 rg';
+        const detailText = review.note?.trim() || '';
+        const evidenceText = review.evidenceIds.length > 0 ? `Evidence refs: ${review.evidenceIds.length}.` : '';
+        const detailLine = [detailText, evidenceText].filter(Boolean).join(' ');
+        const hasDetails = detailLine.length > 0 && review.status !== 'not-started';
+        const rowHeight = hasDetails ? 30 : 16;
+        need(rowHeight);
+        if (index % 2 === 1) ln.push(RC(L, y - 2, R - L, rowHeight - 2, 0.97));
+        ln.push(
+          ...TXT(L, y, 'F1', 8, review.ruleId, '0.4 0.4 0.4 rg'),
+          ...TXT(L + 110, y, 'F1', 8, t, '0.15 0.15 0.15 rg'),
+          ...TXT(L + 390, y, 'F1', 8, sym(review.status), statusColor),
+          ...TXT(L + 402, y, 'FB', 7, statusLabel(review.status), statusColor),
+        );
+        if (hasDetails) ln.push(...TXT(L + 110, y - 12, 'F1', 7, truncate(detailLine, 80), '0.5 0.5 0.5 rg'));
+        y -= rowHeight;
+      }
+      y -= 8;
+    }
+  }
+
+  if (report.openFindings.length > 0) {
+    sec(`OPEN FINDINGS (${report.openFindings.length})`);
+    for (const review of report.openFindings) {
+      const t = truncate(review.ruleTitle, 55);
+      const note = review.note?.trim() || (review.status === 'not-started' ? 'Not yet reviewed.' : review.status === 'in-progress' ? 'Review in progress.' : '');
       const gapHeight = note ? 30 : 16;
       need(gapHeight);
       ln.push(
-        ...TXT(L, y, 'F1', 8, r.ruleId, '0.4 0.4 0.4 rg'),
+        ...TXT(L, y, 'F1', 8, review.ruleId, '0.4 0.4 0.4 rg'),
         ...TXT(L + 110, y, 'F1', 8, t, '0.15 0.15 0.15 rg'),
-        ...TXT(L + 390, y, 'FB', 7, statusLabel(r.status), '0.75 0.2 0.2 rg'),
+        ...TXT(L + 390, y, 'FB', 7, statusLabel(review.status), '0.75 0.2 0.2 rg'),
       );
-      if (note) {
-        ln.push(...TXT(L + 110, y - 12, 'F1', 7, truncate(note, 80), '0.5 0.5 0.5 rg'));
-      }
+      if (note) ln.push(...TXT(L + 110, y - 12, 'F1', 7, truncate(note, 80), '0.5 0.5 0.5 rg'));
       y -= gapHeight;
     }
     y -= 8;
   }
 
   sec('PROVENANCE');
-  const provenanceItems: [string, string][] = [
-    ['Project ID', project.id],
-    ['Methodology', `${project.methodCode} @ ${project.methodVersion}`],
-    ['Created', safeDate(project.createdAt)],
-    ['Status', project.status === 'locked' ? 'Locked' : 'In Progress'],
-    ['Rules Reviewed', `${coverage.verified + coverage.gap} of ${coverage.total}`],
-    ['Export Time', now],
-  ];
-  if (project.lockedAt) {
-    provenanceItems.splice(4, 0, ['Locked', safeDate(project.lockedAt)]);
-  }
-  for (const [k, v] of provenanceItems) {
+  for (const [label, value] of report.provenance) {
     need(18);
     ln.push(
-      ...TXT(L, y, 'FB', 8, String(k), '0.4 0.4 0.4 rg'),
-      ...TXT(L + 140, y, 'F1', 8, String(v), '0.15 0.15 0.15 rg'),
+      ...TXT(L, y, 'FB', 8, truncate(label, 18), '0.4 0.4 0.4 rg'),
+      ...TXT(L + 140, y, 'F1', 8, truncate(value || 'n/a', 52), '0.15 0.15 0.15 rg'),
     );
     y -= 16;
   }
   need(30);
   ln.push(
     LN(y),
-    ...TXT(L, y - 12, 'F1', 7, 'This document is generated from reviewer-entered data. It is not a formal certification opinion.', '0.7 0.7 0.7 rg'),
+    ...TXT(L, y - 12, 'F1', 7, truncate(report.limitation, 110), '0.7 0.7 0.7 rg'),
+    ...TXT(L, y - 24, 'F1', 7, `Export time ${safeDate(now)}.`, '0.7 0.7 0.7 rg'),
   );
   flush();
 

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -33,6 +33,7 @@ export function createProject(input: {
   name: string;
   methodCode: string;
   methodVersion: string;
+  registry?: Project['registry'];
   aoiLabel?: string;
   description?: string;
   ruleIds: Array<{ id: string; title: string; sectionId: string }>;
@@ -42,6 +43,7 @@ export function createProject(input: {
     name: input.name,
     methodCode: input.methodCode,
     methodVersion: input.methodVersion,
+    registry: input.registry,
     status: 'in-progress',
     createdAt: new Date().toISOString(),
     aoiLabel: input.aoiLabel,

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -2,6 +2,8 @@ export type ProjectStatus = 'in-progress' | 'locked';
 
 export type RuleReviewStatus = 'not-started' | 'in-progress' | 'verified' | 'gap' | 'not-applicable';
 
+export type ProjectRegistry = 'UNFCCC' | 'Verra' | 'Gold Standard' | 'Unknown';
+
 export type RuleReview = {
   ruleId: string;
   ruleTitle: string;
@@ -18,6 +20,7 @@ export type Project = {
   name: string;
   methodCode: string;
   methodVersion: string;
+  registry?: ProjectRegistry;
   status: ProjectStatus;
   createdAt: string;
   lockedAt?: string;

--- a/src/lib/projects/verificationReport.ts
+++ b/src/lib/projects/verificationReport.ts
@@ -1,0 +1,256 @@
+import type { Project, ProjectCoverage, ProjectRegistry, RuleReview } from '@/lib/projects/types';
+
+export type VerificationReportStatus = 'ready' | 'registry_not_fully_supported' | 'insufficient_source_content';
+
+export type VerificationReportSection = {
+  title: string;
+  lines: string[];
+};
+
+export type VerificationReportRuleGroup = {
+  title: string;
+  reviews: RuleReview[];
+};
+
+export type VerificationReportComposition = {
+  registry: ProjectRegistry;
+  status: VerificationReportStatus;
+  title: string;
+  subtitle: string;
+  summaryItems: string[];
+  sections: VerificationReportSection[];
+  groupedReviews: VerificationReportRuleGroup[];
+  openFindings: RuleReview[];
+  provenance: Array<[string, string]>;
+  limitation: string;
+};
+
+function sectionTitle(sectionId: string): string {
+  const titles: Record<string, string> = {
+    'S-1': 'Scope and Boundary',
+    'S-2': 'Baseline',
+    'S-3': 'Monitoring',
+    'S-4': 'Leakage',
+    'S-5': 'Permanence',
+  };
+  return titles[sectionId] ?? sectionId;
+}
+
+function normalizeRegistry(value: string | undefined): ProjectRegistry {
+  const raw = value?.trim().toLowerCase() ?? '';
+  if (!raw) return 'Unknown';
+  if (raw.startsWith('unfccc') || raw === 'cdm') return 'UNFCCC';
+  if (raw.startsWith('verra') || raw.includes('verified carbon standard') || raw === 'vcs') return 'Verra';
+  if (raw.startsWith('gold standard') || raw === 'gold-standard' || raw === 'gs') return 'Gold Standard';
+  return 'Unknown';
+}
+
+export function resolveProjectRegistry(project: Pick<Project, 'methodCode' | 'registry'>): ProjectRegistry {
+  const explicit = normalizeRegistry(project.registry);
+  if (explicit !== 'Unknown') return explicit;
+
+  const code = project.methodCode.trim().toUpperCase();
+  if (!code) return 'Unknown';
+  if (code.startsWith('UNFCCC.') || code.includes('UNFCCC')) return 'UNFCCC';
+  if (code.startsWith('VM') || code.startsWith('VMR') || code.includes('VERRA')) return 'Verra';
+  if (code.startsWith('GS') || code.includes('GOLD STANDARD')) return 'Gold Standard';
+  if (/^(AR|AM|ACM|SSC|TOOL)/.test(code)) return 'UNFCCC';
+  return 'Unknown';
+}
+
+function groupReviews(project: Project): VerificationReportRuleGroup[] {
+  const grouped = project.reviews.reduce((acc, review) => {
+    const key = sectionTitle(review.sectionId || 'Requirements');
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(review);
+    return acc;
+  }, {} as Record<string, RuleReview[]>);
+
+  return Object.entries(grouped).map(([title, reviews]) => ({ title, reviews }));
+}
+
+function buildProvenance(project: Project, coverage: ProjectCoverage, registry: ProjectRegistry, status: VerificationReportStatus): Array<[string, string]> {
+  return [
+    ['Registry', registry],
+    ['Report status', status],
+    ['Project ID', project.id],
+    ['Methodology', `${project.methodCode} @ ${project.methodVersion}`],
+    ['Created', project.createdAt || 'n/a'],
+    ['Rules reviewed', `${coverage.verified + coverage.gap} of ${coverage.total}`],
+  ];
+}
+
+function buildOpenFindings(project: Project): RuleReview[] {
+  return project.reviews.filter((review) => review.status === 'gap' || review.status === 'not-started' || review.status === 'in-progress');
+}
+
+function buildSummaryItems(project: Project, coverage: ProjectCoverage, registry: ProjectRegistry): string[] {
+  const items = [
+    `Registry: ${registry}`,
+    `Methodology: ${project.methodCode} @ ${project.methodVersion}`,
+    `Reviewed: ${coverage.verified + coverage.gap} of ${coverage.total} rules`,
+  ];
+  if (project.aoiLabel) items.push(`Area: ${project.aoiLabel}`);
+  return items;
+}
+
+function buildEvidenceSummary(project: Project): string[] {
+  const linkedEvidenceCount = project.reviews.reduce((sum, review) => sum + review.evidenceIds.length, 0);
+  const notedRules = project.reviews.filter((review) => Boolean(review.note?.trim())).length;
+  return [
+    `Linked evidence references recorded: ${linkedEvidenceCount}.`,
+    `Reviewer rationale notes recorded: ${notedRules}.`,
+    'No certification opinion, quantified impacts, or unsupported findings are added beyond reviewer-entered project data.',
+  ];
+}
+
+export function composeUnfcccVerificationReport(project: Project, coverage: ProjectCoverage): VerificationReportComposition {
+  const registry = 'UNFCCC' as const;
+  const reviewedCount = coverage.verified + coverage.gap;
+  const groupedReviews = groupReviews(project);
+  const openFindings = buildOpenFindings(project);
+
+  if (reviewedCount === 0) {
+    return {
+      registry,
+      status: 'insufficient_source_content',
+      title: 'UNFCCC VERIFICATION REPORT',
+      subtitle: 'Truthful fallback: reviewed rule content is not yet sufficient to render a full UNFCCC-facing report.',
+      summaryItems: buildSummaryItems(project, coverage, registry),
+      sections: [
+        {
+          title: 'SOURCE CONTENT STATUS',
+          lines: [
+            'UNFCCC registry detected for this project.',
+            'A full UNFCCC report requires at least one completed rule review marked verified or gap.',
+            `Current completed reviews: ${reviewedCount} of ${coverage.total}.`,
+          ],
+        },
+        {
+          title: 'AVAILABLE PROJECT CONTEXT',
+          lines: [
+            `Project: ${project.name}.`,
+            `Methodology: ${project.methodCode} @ ${project.methodVersion}.`,
+            project.aoiLabel ? `Area label: ${project.aoiLabel}.` : 'Area label: not provided.',
+          ],
+        },
+      ],
+      groupedReviews: [],
+      openFindings: [],
+      provenance: buildProvenance(project, coverage, registry, 'insufficient_source_content'),
+      limitation: 'This export is a truthful fallback only. It does not represent a completed UNFCCC verification report.',
+    };
+  }
+
+  return {
+    registry,
+    status: 'ready',
+    title: 'UNFCCC VERIFICATION REPORT',
+    subtitle: 'Rendered from current project, review, and evidence-link data without adding unsupported registry conclusions.',
+    summaryItems: buildSummaryItems(project, coverage, registry),
+    sections: [
+      {
+        title: 'ENGAGEMENT CONTEXT',
+        lines: [
+          `Project: ${project.name}.`,
+          `Methodology: ${project.methodCode} @ ${project.methodVersion}.`,
+          project.aoiLabel ? `Area label: ${project.aoiLabel}.` : 'Area label: not provided.',
+          `Review status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}.`,
+        ],
+      },
+      {
+        title: 'REVIEW STATUS SUMMARY',
+        lines: [
+          `Verified rules: ${coverage.verified}.`,
+          `Gap rules: ${coverage.gap}.`,
+          `In-progress rules: ${coverage.inProgress}. Pending rules: ${coverage.notStarted}. Not-applicable rules: ${coverage.notApplicable}.`,
+          `Percent complete across actionable rules: ${coverage.percentComplete}%.`,
+        ],
+      },
+      {
+        title: 'EVIDENCE TRACEABILITY',
+        lines: buildEvidenceSummary(project),
+      },
+    ],
+    groupedReviews,
+    openFindings,
+    provenance: buildProvenance(project, coverage, registry, 'ready'),
+    limitation: 'This report summarizes reviewer-entered verification data. It is not a formal certification or issuance opinion.',
+  };
+}
+
+function composeRecognizedFallbackReport(
+  registry: 'Verra' | 'Gold Standard',
+  project: Project,
+  coverage: ProjectCoverage,
+): VerificationReportComposition {
+  return {
+    registry,
+    status: 'registry_not_fully_supported',
+    title: `${registry.toUpperCase()} VERIFICATION REPORT`,
+    subtitle: `Truthful fallback: ${registry} is recognized in the export pipeline, but a full ${registry}-specific renderer is not shipped in v1.`,
+    summaryItems: buildSummaryItems(project, coverage, registry),
+    sections: [
+      {
+        title: 'REGISTRY SUPPORT STATUS',
+        lines: [
+          `${registry} registry detected for this project.`,
+          `${registry} full renderer not yet implemented in v1.`,
+          'The system therefore emits a fallback report state instead of pretending a full registry-shaped report exists.',
+        ],
+      },
+      {
+        title: 'AVAILABLE REVIEW DATA',
+        lines: [
+          `Project: ${project.name}.`,
+          `Methodology: ${project.methodCode} @ ${project.methodVersion}.`,
+          `Completed reviews captured so far: ${coverage.verified + coverage.gap} of ${coverage.total}.`,
+        ],
+      },
+    ],
+    groupedReviews: [],
+    openFindings: [],
+    provenance: buildProvenance(project, coverage, registry, 'registry_not_fully_supported'),
+    limitation: `This export is not a full ${registry} verification report. It is a truthful fallback summary only.`,
+  };
+}
+
+export function composeVerraVerificationReport(project: Project, coverage: ProjectCoverage): VerificationReportComposition {
+  return composeRecognizedFallbackReport('Verra', project, coverage);
+}
+
+export function composeGoldStandardVerificationReport(project: Project, coverage: ProjectCoverage): VerificationReportComposition {
+  return composeRecognizedFallbackReport('Gold Standard', project, coverage);
+}
+
+export function composeVerificationReport(project: Project, coverage: ProjectCoverage): VerificationReportComposition {
+  const registry = resolveProjectRegistry(project);
+  if (registry === 'UNFCCC') return composeUnfcccVerificationReport(project, coverage);
+  if (registry === 'Verra') return composeVerraVerificationReport(project, coverage);
+  if (registry === 'Gold Standard') return composeGoldStandardVerificationReport(project, coverage);
+
+  return {
+    registry: 'Unknown',
+    status: 'registry_not_fully_supported',
+    title: 'VERIFICATION REPORT',
+    subtitle: 'Truthful fallback: registry could not be resolved confidently from current project data.',
+    summaryItems: buildSummaryItems(project, coverage, 'Unknown'),
+    sections: [
+      {
+        title: 'REGISTRY STATUS',
+        lines: [
+          'The export pipeline could not confidently map this project to UNFCCC, Verra, or Gold Standard.',
+          'No registry-specific report renderer was used.',
+        ],
+      },
+    ],
+    groupedReviews: [],
+    openFindings: [],
+    provenance: buildProvenance(project, coverage, 'Unknown', 'registry_not_fully_supported'),
+    limitation: 'This export is a generic truthful fallback only.',
+  };
+}
+
+export function projectRegistryFromMethodProgram(program: string | undefined): ProjectRegistry {
+  return normalizeRegistry(program?.split('/')[0]);
+}

--- a/tests/api/project.export-pdf.route.test.ts
+++ b/tests/api/project.export-pdf.route.test.ts
@@ -10,6 +10,7 @@ function makeProject(reviewCount = 6): Project {
     name: 'Malawi Verification Project',
     methodCode: 'AR-AMS0007',
     methodVersion: 'v03-1',
+    registry: 'UNFCCC',
     status: 'locked',
     createdAt: '2026-04-15T00:00:00Z',
     aoiLabel: 'Machinga District',
@@ -42,6 +43,7 @@ describe('/api/projects/[id]/export-pdf route', () => {
     const parsed = await extractPdfTextWithPdfParse({ bytes });
 
     expect(parsed.text).toContain('Malawi Verification Project');
+    expect(parsed.text).toContain('UNFCCC VERIFICATION REPORT');
     expect(parsed.text).toContain('COVERAGE SUMMARY');
     expect(parsed.text).toContain('Verification requirement 1');
     expect(parsed.text).toContain('PROVENANCE');
@@ -62,13 +64,13 @@ describe('/api/projects/[id]/export-pdf route', () => {
     const raw = pdf.toString('utf8');
 
     expect(parsed.text).toContain('Verification requirement 90');
-    expect(parsed.text).toContain('OPEN GAPS');
+    expect(parsed.text).toContain('OPEN FINDINGS');
     expect(raw).toMatch(/\/Kids \[(\d+ 0 R\s*)+\] \/Count \d+/);
     expect(raw).toContain('BT');
     expect(raw).toContain('ET');
   }, 15000);
 
-  it('uses ARTICLE6 branding and VERIFICATION PACK title', async () => {
+  it('uses ARTICLE6 branding and the UNFCCC report title', async () => {
     const project = makeProject();
     const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {
       method: 'POST',
@@ -80,8 +82,30 @@ describe('/api/projects/[id]/export-pdf route', () => {
     const parsed = await extractPdfTextWithPdfParse({ bytes });
 
     expect(parsed.text).toContain('ARTICLE6');
-    expect(parsed.text).toContain('VERIFICATION PACK');
+    expect(parsed.text).toContain('UNFCCC VERIFICATION REPORT');
+    expect(parsed.text).toContain('REQUIREMENT REVIEW SUMMARY');
     expect(parsed.text).not.toContain('app.article6');
+  }, 15000);
+
+  it('renders a truthful Verra fallback instead of a fake full report', async () => {
+    const project = {
+      ...makeProject(),
+      methodCode: 'VM0007',
+      registry: 'Verra' as const,
+    };
+    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ project }),
+    });
+    const res = await POST(req);
+    const bytes = await res.arrayBuffer();
+    const parsed = await extractPdfTextWithPdfParse({ bytes });
+
+    expect(parsed.text).toContain('VERRA VERIFICATION REPORT');
+    expect(parsed.text).toContain('REGISTRY SUPPORT STATUS');
+    expect(parsed.text).toContain('full renderer not yet implemented');
+    expect(parsed.text).not.toContain('REQUIREMENT REVIEW SUMMARY');
   }, 15000);
 
   it('renders reviewer rationale under rules that have notes', async () => {

--- a/tests/lib/projects/verificationReport.test.ts
+++ b/tests/lib/projects/verificationReport.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from '@jest/globals';
+import type { Project, ProjectCoverage } from '@/lib/projects/types';
+import {
+  composeGoldStandardVerificationReport,
+  composeUnfcccVerificationReport,
+  composeVerificationReport,
+  composeVerraVerificationReport,
+} from '@/lib/projects/verificationReport';
+
+function makeCoverage(overrides: Partial<ProjectCoverage> = {}): ProjectCoverage {
+  return {
+    total: 3,
+    verified: 1,
+    gap: 1,
+    notStarted: 1,
+    notApplicable: 0,
+    inProgress: 0,
+    percentComplete: 67,
+    ...overrides,
+  };
+}
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'proj_123',
+    name: 'Demo Forestry Project',
+    methodCode: 'AR-ACM0003',
+    methodVersion: 'v02-0',
+    registry: 'UNFCCC',
+    status: 'locked',
+    createdAt: '2026-04-23T00:00:00.000Z',
+    reviews: [
+      {
+        ruleId: 'R-1',
+        ruleTitle: 'Submit a monitoring report.',
+        sectionId: 'S-1',
+        status: 'verified',
+        evidenceIds: ['evidence-1'],
+        note: 'Monitoring report reviewed.',
+      },
+      {
+        ruleId: 'R-2',
+        ruleTitle: 'Provide baseline calculations.',
+        sectionId: 'S-2',
+        status: 'gap',
+        evidenceIds: [],
+        note: 'Baseline workbook missing.',
+      },
+      {
+        ruleId: 'R-3',
+        ruleTitle: 'Maintain project boundary records.',
+        sectionId: 'S-3',
+        status: 'not-started',
+        evidenceIds: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('verification report composition', () => {
+  it('routes UNFCCC projects to the full renderer path', () => {
+    const report = composeVerificationReport(makeProject(), makeCoverage());
+
+    expect(report.registry).toBe('UNFCCC');
+    expect(report.status).toBe('ready');
+    expect(report.title).toBe('UNFCCC VERIFICATION REPORT');
+    expect(report.sections.map((section) => section.title)).toEqual(
+      expect.arrayContaining(['ENGAGEMENT CONTEXT', 'REVIEW STATUS SUMMARY', 'EVIDENCE TRACEABILITY']),
+    );
+    expect(report.groupedReviews).toHaveLength(3);
+  });
+
+  it('returns an insufficient-source fallback for UNFCCC when no completed reviews exist', () => {
+    const project = makeProject({
+      reviews: makeProject().reviews.map((review) => ({ ...review, status: 'not-started', note: undefined })),
+    });
+    const coverage = makeCoverage({ verified: 0, gap: 0, notStarted: 3, percentComplete: 0 });
+
+    const report = composeUnfcccVerificationReport(project, coverage);
+
+    expect(report.status).toBe('insufficient_source_content');
+    expect(report.groupedReviews).toEqual([]);
+    expect(report.sections[0]?.title).toBe('SOURCE CONTENT STATUS');
+  });
+
+  it('routes Verra through a registry-specific fallback path', () => {
+    const report = composeVerraVerificationReport(
+      makeProject({ methodCode: 'VM0007', registry: 'Verra' }),
+      makeCoverage(),
+    );
+
+    expect(report.registry).toBe('Verra');
+    expect(report.status).toBe('registry_not_fully_supported');
+    expect(report.title).toBe('VERRA VERIFICATION REPORT');
+    expect(report.sections[0]?.lines.join(' ')).toMatch(/not yet implemented/i);
+  });
+
+  it('routes Gold Standard through a registry-specific fallback path', () => {
+    const report = composeGoldStandardVerificationReport(
+      makeProject({ methodCode: 'GS TPDDTEC', registry: 'Gold Standard' }),
+      makeCoverage(),
+    );
+
+    expect(report.registry).toBe('Gold Standard');
+    expect(report.status).toBe('registry_not_fully_supported');
+    expect(report.title).toBe('GOLD STANDARD VERIFICATION REPORT');
+    expect(report.sections[0]?.lines.join(' ')).toMatch(/fallback/i);
+  });
+
+  it('does not masquerade registry fallback as a successful full render', () => {
+    const report = composeVerificationReport(
+      makeProject({ methodCode: 'VM0047', registry: 'Verra' }),
+      makeCoverage(),
+    );
+
+    expect(report.status).not.toBe('ready');
+    expect(report.groupedReviews).toEqual([]);
+    expect(report.limitation).toMatch(/not a full Verra verification report/i);
+  });
+});


### PR DESCRIPTION
## What
- add a shared `composeVerificationReport(...)` entry point that routes report composition by registry instead of hardcoding a single generic project PDF
- fully implement the UNFCCC report path with registry-specific title, section order, review summary, evidence traceability, and truthful insufficient-source fallback behavior
- add first-class Verra and Gold Standard composition paths that return explicit registry-aware fallback report states instead of masquerading as fully supported renders
- capture project registry at creation time for new project verifications while preserving safe inference for existing projects
- add focused tests for registry routing, fallback truthfulness, and rendered PDF text

## Why
The app already spans multiple registries, so the verification report export path cannot stay structurally UNFCCC-only without forcing a rewrite later. v1 should ship one production-ready renderer for UNFCCC, but it also needs real registry routing now so Verra and Gold Standard are recognized as first-class registries and fail truthfully when full registry-specific report composition is not yet available.

Visible UI changes to look for:
- UNFCCC project exports now read as `UNFCCC VERIFICATION REPORT` and include registry-shaped report sections like `ENGAGEMENT CONTEXT`, `REVIEW STATUS SUMMARY`, `EVIDENCE TRACEABILITY`, and `REQUIREMENT REVIEW SUMMARY`
- Verra exports no longer fall through the generic path; they render a truthful fallback state that says the Verra renderer is recognized but not yet fully implemented
- Gold Standard projects are recognized by the composition layer and return the same explicit fallback state instead of pretending to be fully supported

## Validation
- `npx jest tests/lib/projects/verificationReport.test.ts --runInBand`
- `npx jest tests/api/project.export-pdf.route.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`

Signed-off-by: Fredilly <fredilly@article6.org>
