### PR TITLE
PR #533 adds the first VVB-style UNFCCC draft verification workpaper export. It does not create a final VVB verification opinion.

### DIFF
--- a/src/lib/projects/exportPdf.ts
+++ b/src/lib/projects/exportPdf.ts
@@ -17,22 +17,6 @@ export function getProjectCoverage(reviews: RuleReview[]): ProjectCoverage {
   return { total, verified, gap, notStarted, notApplicable, inProgress, percentComplete };
 }
 
-function sym(s: string): string {
-  if (s === 'verified') return '\u2713';
-  if (s === 'gap') return '\u2717';
-  if (s === 'not-applicable') return '\u2014';
-  return '\u25CB';
-}
-
-function statusLabel(s: string): string {
-  if (s === 'verified') return 'VERIFIED';
-  if (s === 'gap') return 'GAP';
-  if (s === 'not-started') return 'PENDING';
-  if (s === 'not-applicable') return 'N/A';
-  if (s === 'in-progress') return 'IN PROGRESS';
-  return s.toUpperCase();
-}
-
 function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 3) + '...' : s;
 }
@@ -44,8 +28,8 @@ function safeDate(iso: string | undefined): string {
 }
 
 export function buildProjectExportPdf(project: Project, coverage: ProjectCoverage): Buffer {
-  const report = composeVerificationReport(project, coverage);
   const now = new Date().toISOString().replace('T', ' ').slice(0, 16);
+  const report = composeVerificationReport(project, coverage, now);
   const W = 612;
   const PAGE_H = 792;
   const L = 56;
@@ -105,17 +89,6 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
     y -= 12;
   }
 
-  function cols(): void {
-    need(20);
-    ln.push(
-      LN(y + 4),
-      ...TXT(L, y, 'FB', 7, 'RULE', '0.55 0.55 0.55 rg'),
-      ...TXT(L + 110, y, 'FB', 7, 'TITLE', '0.55 0.55 0.55 rg'),
-      ...TXT(L + 390, y, 'FB', 7, 'STATUS', '0.55 0.55 0.55 rg'),
-    );
-    y -= 18;
-  }
-
   ln.push(
     ...TXT(L, y + 20, 'F1', 8, 'VERIFICATION REPORT', '0.5 0.5 0.5 rg'),
     ...TXT(L, y + 4, 'FB', 18, report.title, '0.1 0.1 0.1 rg'),
@@ -128,103 +101,12 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
   }
   y -= 68;
 
-  sec('REPORT STATUS');
-  bodyLine(`Registry: ${report.registry}.`, 'FB', 8, '0.25 0.25 0.25 rg');
-  bodyLine(`Render state: ${report.status}.`);
-  bodyLine(`Project status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}.`);
-  y -= 4;
-
-  sec('COVERAGE SUMMARY');
-  const items = [
-    ['Verified', coverage.verified, '0.2 0.55 0.3'],
-    ['Gaps', coverage.gap, '0.8 0.2 0.2'],
-    ['In Progress', coverage.inProgress, '0.8 0.6 0.1'],
-    ['Pending', coverage.notStarted, '0.6 0.6 0.6'],
-    ['N/A', coverage.notApplicable, '0.8 0.8 0.8'],
-  ];
-  let cx = L;
-  for (const [label, val, color] of items) {
-    ln.push(
-      ...TXT(cx, y, 'FB', 18, String(val), `${color} rg`),
-      ...TXT(cx, y - 14, 'F1', 7, String(label), '0.45 0.45 0.45 rg'),
-    );
-    cx += 96;
-  }
-  y -= 40;
-  const fillW = Math.max(4, (R - L) * coverage.percentComplete / 100);
-  ln.push(
-    RC(L, y, R - L, 6, 0.93),
-    RC(L, y, fillW, 6, 0.22),
-    ...TXT(R - 36, y + 10, 'FB', 9, `${coverage.percentComplete}%`, '0.25 0.25 0.25 rg'),
-  );
-  y -= 24;
-
   for (const section of report.sections) {
     sec(section.title);
     for (const line of section.lines) bodyLine(line);
     y -= 4;
   }
 
-  if (report.groupedReviews.length > 0) {
-    sec('REQUIREMENT REVIEW SUMMARY');
-    y -= 2;
-    for (const group of report.groupedReviews) {
-      sec(group.title);
-      cols();
-      for (const [index, review] of group.reviews.entries()) {
-        const t = truncate(review.ruleTitle, 55);
-        const statusColor = review.status === 'verified'
-          ? '0.2 0.55 0.3 rg'
-          : review.status === 'gap'
-            ? '0.75 0.2 0.2 rg'
-            : '0.45 0.45 0.45 rg';
-        const detailText = review.note?.trim() || '';
-        const evidenceText = review.evidenceIds.length > 0 ? `Evidence refs: ${review.evidenceIds.length}.` : '';
-        const detailLine = [detailText, evidenceText].filter(Boolean).join(' ');
-        const hasDetails = detailLine.length > 0 && review.status !== 'not-started';
-        const rowHeight = hasDetails ? 30 : 16;
-        need(rowHeight);
-        if (index % 2 === 1) ln.push(RC(L, y - 2, R - L, rowHeight - 2, 0.97));
-        ln.push(
-          ...TXT(L, y, 'F1', 8, review.ruleId, '0.4 0.4 0.4 rg'),
-          ...TXT(L + 110, y, 'F1', 8, t, '0.15 0.15 0.15 rg'),
-          ...TXT(L + 390, y, 'F1', 8, sym(review.status), statusColor),
-          ...TXT(L + 402, y, 'FB', 7, statusLabel(review.status), statusColor),
-        );
-        if (hasDetails) ln.push(...TXT(L + 110, y - 12, 'F1', 7, truncate(detailLine, 80), '0.5 0.5 0.5 rg'));
-        y -= rowHeight;
-      }
-      y -= 8;
-    }
-  }
-
-  if (report.openFindings.length > 0) {
-    sec(`OPEN FINDINGS (${report.openFindings.length})`);
-    for (const review of report.openFindings) {
-      const t = truncate(review.ruleTitle, 55);
-      const note = review.note?.trim() || (review.status === 'not-started' ? 'Not yet reviewed.' : review.status === 'in-progress' ? 'Review in progress.' : '');
-      const gapHeight = note ? 30 : 16;
-      need(gapHeight);
-      ln.push(
-        ...TXT(L, y, 'F1', 8, review.ruleId, '0.4 0.4 0.4 rg'),
-        ...TXT(L + 110, y, 'F1', 8, t, '0.15 0.15 0.15 rg'),
-        ...TXT(L + 390, y, 'FB', 7, statusLabel(review.status), '0.75 0.2 0.2 rg'),
-      );
-      if (note) ln.push(...TXT(L + 110, y - 12, 'F1', 7, truncate(note, 80), '0.5 0.5 0.5 rg'));
-      y -= gapHeight;
-    }
-    y -= 8;
-  }
-
-  sec('PROVENANCE');
-  for (const [label, value] of report.provenance) {
-    need(18);
-    ln.push(
-      ...TXT(L, y, 'FB', 8, truncate(label, 18), '0.4 0.4 0.4 rg'),
-      ...TXT(L + 140, y, 'F1', 8, truncate(value || 'n/a', 52), '0.15 0.15 0.15 rg'),
-    );
-    y -= 16;
-  }
   need(30);
   ln.push(
     LN(y),

--- a/src/lib/projects/exportPdf.ts
+++ b/src/lib/projects/exportPdf.ts
@@ -17,14 +17,41 @@ export function getProjectCoverage(reviews: RuleReview[]): ProjectCoverage {
   return { total, verified, gap, notStarted, notApplicable, inProgress, percentComplete };
 }
 
-function truncate(s: string, max: number): string {
-  return s.length > max ? s.slice(0, max - 3) + '...' : s;
-}
-
 function safeDate(iso: string | undefined): string {
   if (!iso) return 'n/a';
   const d = iso.slice(0, 10);
   return /^\d{4}-\d{2}-\d{2}$/.test(d) ? d : iso.slice(0, 16);
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 3) + '...' : s;
+}
+
+function splitLongToken(token: string, max: number): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < token.length; i += max) chunks.push(token.slice(i, i + max));
+  return chunks;
+}
+
+function wrapText(text: string, max = 96): string[] {
+  const words = text.split(/\s+/).filter(Boolean).flatMap((word) => (
+    word.length > max ? splitLongToken(word, max) : [word]
+  ));
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= max) {
+      current = next;
+    } else {
+      if (current) lines.push(current);
+      current = word;
+    }
+  }
+
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [''];
 }
 
 export function buildProjectExportPdf(project: Project, coverage: ProjectCoverage): Buffer {
@@ -84,9 +111,11 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
   }
 
   function bodyLine(text: string, font: 'F1' | 'FB' = 'F1', size = 8, color = '0.2 0.2 0.2 rg'): void {
-    need(14);
-    ln.push(...TXT(L, y, font, size, truncate(text, 96), color));
-    y -= 12;
+    for (const line of wrapText(text)) {
+      need(14);
+      ln.push(...TXT(L, y, font, size, line, color));
+      y -= 12;
+    }
   }
 
   ln.push(

--- a/src/lib/projects/reportFindings.ts
+++ b/src/lib/projects/reportFindings.ts
@@ -1,0 +1,58 @@
+import type { RuleReview } from '@/lib/projects/types';
+
+export type ReportFindingCode = 'OK' | 'CL' | 'NC' | 'FAR' | 'PENDING' | 'NA';
+
+export type ReportFinding = {
+  findingId: string;
+  ruleId: string;
+  ruleTitle: string;
+  sectionId: string;
+  sectionTitle: string;
+  code: ReportFindingCode;
+  sourceStatus: RuleReview['status'];
+  rationale: string;
+  evidenceIds: string[];
+  limitation?: string;
+};
+
+export function reportFindingCodeFromReviewStatus(status: RuleReview['status']): ReportFindingCode {
+  if (status === 'verified') return 'OK';
+  if (status === 'gap') return 'NC';
+  if (status === 'in-progress') return 'CL';
+  if (status === 'not-started') return 'PENDING';
+  if (status === 'not-applicable') return 'NA';
+  return 'PENDING';
+}
+
+export function buildReportFinding(
+  review: RuleReview,
+  index: number,
+  sectionTitle: string,
+): ReportFinding {
+  const code = reportFindingCodeFromReviewStatus(review.status);
+  const note = review.note?.trim();
+  const defaultRationale = code === 'OK'
+    ? 'Reviewer marked this requirement as verified; no additional rationale was recorded.'
+    : code === 'NC'
+      ? 'Reviewer marked this requirement as a gap; no additional rationale was recorded.'
+      : code === 'CL'
+        ? 'Review is in progress; conclusion is not final.'
+        : code === 'NA'
+          ? 'Reviewer marked this requirement as not applicable.'
+          : 'Requirement has not yet been assessed.';
+
+  return {
+    findingId: `F-${String(index + 1).padStart(3, '0')}`,
+    ruleId: review.ruleId,
+    ruleTitle: review.ruleTitle,
+    sectionId: review.sectionId,
+    sectionTitle,
+    code,
+    sourceStatus: review.status,
+    rationale: note || defaultRationale,
+    evidenceIds: review.evidenceIds,
+    limitation: code === 'PENDING' || code === 'CL'
+      ? 'Finding is not a completed verification conclusion.'
+      : undefined,
+  };
+}

--- a/src/lib/projects/reportFindings.ts
+++ b/src/lib/projects/reportFindings.ts
@@ -31,8 +31,11 @@ export function buildReportFinding(
 ): ReportFinding {
   const code = reportFindingCodeFromReviewStatus(review.status);
   const note = review.note?.trim();
+  const lacksSupport = code === 'OK' && !note && review.evidenceIds.length === 0;
   const defaultRationale = code === 'OK'
-    ? 'Reviewer marked this requirement as verified; no additional rationale was recorded.'
+    ? lacksSupport
+      ? 'Reviewer marked this requirement as verified, but no reviewer rationale or linked evidence reference is recorded.'
+      : 'Reviewer marked this requirement as verified; no additional rationale was recorded.'
     : code === 'NC'
       ? 'Reviewer marked this requirement as a gap; no additional rationale was recorded.'
       : code === 'CL'
@@ -51,8 +54,10 @@ export function buildReportFinding(
     sourceStatus: review.status,
     rationale: note || defaultRationale,
     evidenceIds: review.evidenceIds,
-    limitation: code === 'PENDING' || code === 'CL'
-      ? 'Finding is not a completed verification conclusion.'
-      : undefined,
+    limitation: lacksSupport
+      ? 'Draft OK is support-limited: no linked evidence reference or reviewer rationale is available.'
+      : code === 'PENDING' || code === 'CL'
+        ? 'Finding is not a completed verification conclusion.'
+        : undefined,
   };
 }

--- a/src/lib/projects/verificationReport.ts
+++ b/src/lib/projects/verificationReport.ts
@@ -1,15 +1,11 @@
-import type { Project, ProjectCoverage, ProjectRegistry, RuleReview } from '@/lib/projects/types';
+import { buildReportFinding, type ReportFinding, type ReportFindingCode } from '@/lib/projects/reportFindings';
+import type { Project, ProjectCoverage, ProjectRegistry } from '@/lib/projects/types';
 
 export type VerificationReportStatus = 'ready' | 'registry_not_fully_supported' | 'insufficient_source_content';
 
 export type VerificationReportSection = {
   title: string;
   lines: string[];
-};
-
-export type VerificationReportRuleGroup = {
-  title: string;
-  reviews: RuleReview[];
 };
 
 export type VerificationReportComposition = {
@@ -19,11 +15,22 @@ export type VerificationReportComposition = {
   subtitle: string;
   summaryItems: string[];
   sections: VerificationReportSection[];
-  groupedReviews: VerificationReportRuleGroup[];
-  openFindings: RuleReview[];
+  findings: ReportFinding[];
   provenance: Array<[string, string]>;
   limitation: string;
 };
+
+const UNFCCC_SECTION_ORDER = [
+  'REPORT STATUS',
+  'PROJECT AND METHODOLOGY IDENTIFICATION',
+  'VERIFICATION SCOPE',
+  'MEANS OF VERIFICATION',
+  'FINDINGS SUMMARY',
+  'REQUIREMENT FINDINGS',
+  'EVIDENCE APPENDIX',
+  'LIMITATIONS',
+  'PROVENANCE',
+] as const;
 
 function sectionTitle(sectionId: string): string {
   const titles: Record<string, string> = {
@@ -58,30 +65,25 @@ export function resolveProjectRegistry(project: Pick<Project, 'methodCode' | 're
   return 'Unknown';
 }
 
-function groupReviews(project: Project): VerificationReportRuleGroup[] {
-  const grouped = project.reviews.reduce((acc, review) => {
-    const key = sectionTitle(review.sectionId || 'Requirements');
-    if (!acc[key]) acc[key] = [];
-    acc[key].push(review);
-    return acc;
-  }, {} as Record<string, RuleReview[]>);
-
-  return Object.entries(grouped).map(([title, reviews]) => ({ title, reviews }));
-}
-
-function buildProvenance(project: Project, coverage: ProjectCoverage, registry: ProjectRegistry, status: VerificationReportStatus): Array<[string, string]> {
-  return [
+function buildProvenance(
+  project: Project,
+  coverage: ProjectCoverage,
+  registry: ProjectRegistry,
+  status: VerificationReportStatus,
+  exportTime = 'generated during export',
+): Array<[string, string]> {
+  const items: Array<[string, string]> = [
     ['Registry', registry],
     ['Report status', status],
     ['Project ID', project.id],
     ['Methodology', `${project.methodCode} @ ${project.methodVersion}`],
     ['Created', project.createdAt || 'n/a'],
     ['Rules reviewed', `${coverage.verified + coverage.gap} of ${coverage.total}`],
+    ['Export time', exportTime],
   ];
-}
 
-function buildOpenFindings(project: Project): RuleReview[] {
-  return project.reviews.filter((review) => review.status === 'gap' || review.status === 'not-started' || review.status === 'in-progress');
+  if (project.lockedAt) items.splice(5, 0, ['Locked', project.lockedAt]);
+  return items;
 }
 
 function buildSummaryItems(project: Project, coverage: ProjectCoverage, registry: ProjectRegistry): string[] {
@@ -104,11 +106,55 @@ function buildEvidenceSummary(project: Project): string[] {
   ];
 }
 
-export function composeUnfcccVerificationReport(project: Project, coverage: ProjectCoverage): VerificationReportComposition {
+function buildFindings(project: Project): ReportFinding[] {
+  return project.reviews.map((review, index) => buildReportFinding(
+    review,
+    index,
+    sectionTitle(review.sectionId || 'Requirements'),
+  ));
+}
+
+function countFindings(findings: ReportFinding[]): Record<ReportFindingCode, number> {
+  return findings.reduce((acc, finding) => {
+    acc[finding.code] += 1;
+    return acc;
+  }, { OK: 0, CL: 0, NC: 0, FAR: 0, PENDING: 0, NA: 0 } as Record<ReportFindingCode, number>);
+}
+
+function linesFromProvenance(provenance: Array<[string, string]>): string[] {
+  return provenance.map(([label, value]) => `${label}: ${value || 'n/a'}.`);
+}
+
+function buildRequirementFindingLines(findings: ReportFinding[]): string[] {
+  if (findings.length === 0) return ['No requirement findings are available from current project review data.'];
+  return findings.flatMap((finding) => [
+    `${finding.findingId} [${finding.code}] ${finding.ruleId}: ${finding.ruleTitle}.`,
+    `Section: ${finding.sectionTitle}.`,
+    `Rationale: ${finding.rationale}`,
+    `Evidence references: ${finding.evidenceIds.length}.`,
+  ]);
+}
+
+function buildEvidenceAppendixLines(findings: ReportFinding[]): string[] {
+  const lines = findings.flatMap((finding) => {
+    if (finding.evidenceIds.length === 0) return [`${finding.findingId}: No linked evidence references recorded.`];
+    return finding.evidenceIds.map((id) => `${finding.findingId}: Evidence reference: ${id}.`);
+  });
+
+  return lines.length > 0 ? lines : ['No linked evidence references recorded.'];
+}
+
+export function composeUnfcccVerificationReport(
+  project: Project,
+  coverage: ProjectCoverage,
+  exportTime?: string,
+): VerificationReportComposition {
   const registry = 'UNFCCC' as const;
   const reviewedCount = coverage.verified + coverage.gap;
-  const groupedReviews = groupReviews(project);
-  const openFindings = buildOpenFindings(project);
+  const findings = buildFindings(project);
+  const findingCounts = countFindings(findings);
+  const provenance = buildProvenance(project, coverage, registry, reviewedCount === 0 ? 'insufficient_source_content' : 'ready', exportTime);
+  const limitation = 'This draft report summarizes reviewer-entered Article6 project review data. It is not a formal certification, validation, verification opinion, issuance approval, or registry decision.';
 
   if (reviewedCount === 0) {
     return {
@@ -118,27 +164,39 @@ export function composeUnfcccVerificationReport(project: Project, coverage: Proj
       subtitle: 'Truthful fallback: reviewed rule content is not yet sufficient to render a full UNFCCC-facing report.',
       summaryItems: buildSummaryItems(project, coverage, registry),
       sections: [
-        {
-          title: 'SOURCE CONTENT STATUS',
-          lines: [
-            'UNFCCC registry detected for this project.',
-            'A full UNFCCC report requires at least one completed rule review marked verified or gap.',
-            `Current completed reviews: ${reviewedCount} of ${coverage.total}.`,
-          ],
-        },
-        {
-          title: 'AVAILABLE PROJECT CONTEXT',
-          lines: [
-            `Project: ${project.name}.`,
-            `Methodology: ${project.methodCode} @ ${project.methodVersion}.`,
-            project.aoiLabel ? `Area label: ${project.aoiLabel}.` : 'Area label: not provided.',
-          ],
-        },
+        { title: UNFCCC_SECTION_ORDER[0], lines: [
+          `Registry: ${registry}.`,
+          'Report status: insufficient_source_content.',
+          `Project status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}.`,
+          `Methodology: ${project.methodCode} @ ${project.methodVersion}.`,
+          `Completion summary: ${reviewedCount} of ${coverage.total} rules completed.`,
+          'Draft limitation: completed reviewer source content is not yet sufficient for a full UNFCCC draft report.',
+        ] },
+        { title: UNFCCC_SECTION_ORDER[1], lines: [
+          `Project name: ${project.name}.`,
+          `Project ID: ${project.id}.`,
+          `Methodology: ${project.methodCode} @ ${project.methodVersion}.`,
+          project.aoiLabel ? `AOI label: ${project.aoiLabel}.` : 'AOI label: not provided.',
+          `Created date: ${project.createdAt || 'n/a'}.`,
+          project.lockedAt ? `Locked date: ${project.lockedAt}.` : 'Locked date: not locked.',
+        ] },
+        { title: UNFCCC_SECTION_ORDER[2], lines: [
+          `Total rules: ${coverage.total}. Reviewed rules: ${reviewedCount}. Pending rules: ${coverage.notStarted}. Gap rules: ${coverage.gap}.`,
+          'No certification, registry approval, or issuance conclusion is made by this draft report.',
+        ] },
+        { title: UNFCCC_SECTION_ORDER[3], lines: buildEvidenceSummary(project) },
+        { title: UNFCCC_SECTION_ORDER[4], lines: [
+          `OK: ${findingCounts.OK}. CL: ${findingCounts.CL}. NC: ${findingCounts.NC}. PENDING: ${findingCounts.PENDING}. NA: ${findingCounts.NA}.`,
+          findingCounts.FAR > 0 ? `FAR: ${findingCounts.FAR}.` : 'FAR: 0; no forward action requests are generated without explicit project data.',
+        ] },
+        { title: UNFCCC_SECTION_ORDER[5], lines: buildRequirementFindingLines(findings) },
+        { title: UNFCCC_SECTION_ORDER[6], lines: buildEvidenceAppendixLines(findings) },
+        { title: UNFCCC_SECTION_ORDER[7], lines: [limitation] },
+        { title: UNFCCC_SECTION_ORDER[8], lines: linesFromProvenance(provenance) },
       ],
-      groupedReviews: [],
-      openFindings: [],
-      provenance: buildProvenance(project, coverage, registry, 'insufficient_source_content'),
-      limitation: 'This export is a truthful fallback only. It does not represent a completed UNFCCC verification report.',
+      findings,
+      provenance,
+      limitation,
     };
   }
 
@@ -150,32 +208,55 @@ export function composeUnfcccVerificationReport(project: Project, coverage: Proj
     summaryItems: buildSummaryItems(project, coverage, registry),
     sections: [
       {
-        title: 'ENGAGEMENT CONTEXT',
+        title: UNFCCC_SECTION_ORDER[0],
         lines: [
-          `Project: ${project.name}.`,
+          `Registry: ${registry}.`,
+          'Report status: ready.',
+          `Project status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}.`,
           `Methodology: ${project.methodCode} @ ${project.methodVersion}.`,
-          project.aoiLabel ? `Area label: ${project.aoiLabel}.` : 'Area label: not provided.',
-          `Review status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}.`,
+          `Completion summary: ${reviewedCount} of ${coverage.total} rules completed.`,
+          'Draft limitation: this is a structured VVB-style draft workpaper, not a registry decision.',
         ],
       },
       {
-        title: 'REVIEW STATUS SUMMARY',
+        title: UNFCCC_SECTION_ORDER[1],
         lines: [
-          `Verified rules: ${coverage.verified}.`,
-          `Gap rules: ${coverage.gap}.`,
-          `In-progress rules: ${coverage.inProgress}. Pending rules: ${coverage.notStarted}. Not-applicable rules: ${coverage.notApplicable}.`,
-          `Percent complete across actionable rules: ${coverage.percentComplete}%.`,
+          `Project name: ${project.name}.`,
+          `Project ID: ${project.id}.`,
+          `Methodology: ${project.methodCode} @ ${project.methodVersion}.`,
+          project.aoiLabel ? `AOI label: ${project.aoiLabel}.` : 'AOI label: not provided.',
+          `Created date: ${project.createdAt || 'n/a'}.`,
+          project.lockedAt ? `Locked date: ${project.lockedAt}.` : 'Locked date: not locked.',
         ],
       },
       {
-        title: 'EVIDENCE TRACEABILITY',
+        title: UNFCCC_SECTION_ORDER[2],
+        lines: [
+          `Total rules: ${coverage.total}. Reviewed rules: ${reviewedCount}. Pending rules: ${coverage.notStarted}. Gap rules: ${coverage.gap}.`,
+          `In-progress rules: ${coverage.inProgress}. Not-applicable rules: ${coverage.notApplicable}.`,
+          `Percent complete across actionable rules: ${coverage.percentComplete}%.`,
+          'No certification, registry approval, or issuance conclusion is made by this draft report.',
+        ],
+      },
+      {
+        title: UNFCCC_SECTION_ORDER[3],
         lines: buildEvidenceSummary(project),
       },
+      {
+        title: UNFCCC_SECTION_ORDER[4],
+        lines: [
+          `OK: ${findingCounts.OK}. CL: ${findingCounts.CL}. NC: ${findingCounts.NC}. PENDING: ${findingCounts.PENDING}. NA: ${findingCounts.NA}.`,
+          findingCounts.FAR > 0 ? `FAR: ${findingCounts.FAR}.` : 'FAR: 0; no forward action requests are generated without explicit project data.',
+        ],
+      },
+      { title: UNFCCC_SECTION_ORDER[5], lines: buildRequirementFindingLines(findings) },
+      { title: UNFCCC_SECTION_ORDER[6], lines: buildEvidenceAppendixLines(findings) },
+      { title: UNFCCC_SECTION_ORDER[7], lines: [limitation] },
+      { title: UNFCCC_SECTION_ORDER[8], lines: linesFromProvenance(provenance) },
     ],
-    groupedReviews,
-    openFindings,
-    provenance: buildProvenance(project, coverage, registry, 'ready'),
-    limitation: 'This report summarizes reviewer-entered verification data. It is not a formal certification or issuance opinion.',
+    findings,
+    provenance,
+    limitation,
   };
 }
 
@@ -208,8 +289,7 @@ function composeRecognizedFallbackReport(
         ],
       },
     ],
-    groupedReviews: [],
-    openFindings: [],
+    findings: [],
     provenance: buildProvenance(project, coverage, registry, 'registry_not_fully_supported'),
     limitation: `This export is not a full ${registry} verification report. It is a truthful fallback summary only.`,
   };
@@ -223,9 +303,13 @@ export function composeGoldStandardVerificationReport(project: Project, coverage
   return composeRecognizedFallbackReport('Gold Standard', project, coverage);
 }
 
-export function composeVerificationReport(project: Project, coverage: ProjectCoverage): VerificationReportComposition {
+export function composeVerificationReport(
+  project: Project,
+  coverage: ProjectCoverage,
+  exportTime?: string,
+): VerificationReportComposition {
   const registry = resolveProjectRegistry(project);
-  if (registry === 'UNFCCC') return composeUnfcccVerificationReport(project, coverage);
+  if (registry === 'UNFCCC') return composeUnfcccVerificationReport(project, coverage, exportTime);
   if (registry === 'Verra') return composeVerraVerificationReport(project, coverage);
   if (registry === 'Gold Standard') return composeGoldStandardVerificationReport(project, coverage);
 
@@ -244,8 +328,7 @@ export function composeVerificationReport(project: Project, coverage: ProjectCov
         ],
       },
     ],
-    groupedReviews: [],
-    openFindings: [],
+    findings: [],
     provenance: buildProvenance(project, coverage, 'Unknown', 'registry_not_fully_supported'),
     limitation: 'This export is a generic truthful fallback only.',
   };

--- a/src/lib/projects/verificationReport.ts
+++ b/src/lib/projects/verificationReport.ts
@@ -131,6 +131,7 @@ function buildRequirementFindingLines(findings: ReportFinding[]): string[] {
     `${finding.findingId} [${finding.code}] ${finding.ruleId}: ${finding.ruleTitle}.`,
     `Section: ${finding.sectionTitle}.`,
     `Rationale: ${finding.rationale}`,
+    ...(finding.limitation ? [`Limitation: ${finding.limitation}`] : []),
     `Evidence references: ${finding.evidenceIds.length}.`,
   ]);
 }

--- a/tests/api/project.export-pdf.route.test.ts
+++ b/tests/api/project.export-pdf.route.test.ts
@@ -4,6 +4,15 @@ import { extractPdfTextWithPdfParse } from '@/lib/chat/quickCheckPdfExtractor';
 import { buildProjectExportPdf } from '@/lib/projects/exportPdf';
 import type { Project } from '@/lib/projects/types';
 
+const UNSUPPORTED_CERTIFICATION_PHRASES = [
+  'certified emission reductions are approved',
+  'verification opinion: positive',
+  'VCUs issued',
+  'registry approved',
+  'validated successfully',
+  'verified successfully',
+];
+
 function makeProject(reviewCount = 6): Project {
   return {
     id: 'project-12345678',
@@ -44,7 +53,14 @@ describe('/api/projects/[id]/export-pdf route', () => {
 
     expect(parsed.text).toContain('Malawi Verification Project');
     expect(parsed.text).toContain('UNFCCC VERIFICATION REPORT');
-    expect(parsed.text).toContain('COVERAGE SUMMARY');
+    expect(parsed.text).toContain('REPORT STATUS');
+    expect(parsed.text).toContain('PROJECT AND METHODOLOGY IDENTIFICATION');
+    expect(parsed.text).toContain('VERIFICATION SCOPE');
+    expect(parsed.text).toContain('MEANS OF VERIFICATION');
+    expect(parsed.text).toContain('FINDINGS SUMMARY');
+    expect(parsed.text).toContain('REQUIREMENT FINDINGS');
+    expect(parsed.text).toContain('EVIDENCE APPENDIX');
+    expect(parsed.text).toContain('LIMITATIONS');
     expect(parsed.text).toContain('Verification requirement 1');
     expect(parsed.text).toContain('PROVENANCE');
   }, 15000);
@@ -64,7 +80,8 @@ describe('/api/projects/[id]/export-pdf route', () => {
     const raw = pdf.toString('utf8');
 
     expect(parsed.text).toContain('Verification requirement 90');
-    expect(parsed.text).toContain('OPEN FINDINGS');
+    expect(parsed.text).toContain('REQUIREMENT FINDINGS');
+    expect(parsed.text).toContain('EVIDENCE APPENDIX');
     expect(raw).toMatch(/\/Kids \[(\d+ 0 R\s*)+\] \/Count \d+/);
     expect(raw).toContain('BT');
     expect(raw).toContain('ET');
@@ -83,7 +100,7 @@ describe('/api/projects/[id]/export-pdf route', () => {
 
     expect(parsed.text).toContain('ARTICLE6');
     expect(parsed.text).toContain('UNFCCC VERIFICATION REPORT');
-    expect(parsed.text).toContain('REQUIREMENT REVIEW SUMMARY');
+    expect(parsed.text).toContain('REQUIREMENT FINDINGS');
     expect(parsed.text).not.toContain('app.article6');
   }, 15000);
 
@@ -105,7 +122,7 @@ describe('/api/projects/[id]/export-pdf route', () => {
     expect(parsed.text).toContain('VERRA VERIFICATION REPORT');
     expect(parsed.text).toContain('REGISTRY SUPPORT STATUS');
     expect(parsed.text).toContain('full renderer not yet implemented');
-    expect(parsed.text).not.toContain('REQUIREMENT REVIEW SUMMARY');
+    expect(parsed.text).not.toContain('REQUIREMENT FINDINGS');
   }, 15000);
 
   it('renders reviewer rationale under rules that have notes', async () => {
@@ -133,7 +150,7 @@ describe('/api/projects/[id]/export-pdf route', () => {
     expect(parsed.text).toContain('Boundary worksheet not provided');
   }, 15000);
 
-  it('shows percentage complete in coverage summary', async () => {
+  it('shows percentage complete in verification scope', async () => {
     const project = makeProject();
     const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {
       method: 'POST',
@@ -145,6 +162,25 @@ describe('/api/projects/[id]/export-pdf route', () => {
     const parsed = await extractPdfTextWithPdfParse({ bytes });
 
     expect(parsed.text).toMatch(/\d+%/);
+  }, 15000);
+
+  it('does not render unsupported certification or issuance phrases', async () => {
+    const project = makeProject();
+    const pdf = buildProjectExportPdf(project, {
+      total: 6,
+      verified: 4,
+      gap: 1,
+      notStarted: 1,
+      notApplicable: 0,
+      inProgress: 0,
+      percentComplete: 83,
+    });
+    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);
+    const parsed = await extractPdfTextWithPdfParse({ bytes });
+
+    for (const phrase of UNSUPPORTED_CERTIFICATION_PHRASES) {
+      expect(parsed.text).not.toContain(phrase);
+    }
   }, 15000);
 
   it('handles missing timestamps without crashing', async () => {

--- a/tests/api/project.export-pdf.route.test.ts
+++ b/tests/api/project.export-pdf.route.test.ts
@@ -150,6 +150,56 @@ describe('/api/projects/[id]/export-pdf route', () => {
     expect(parsed.text).toContain('Boundary worksheet not provided');
   }, 15000);
 
+  it('wraps long reviewer rationale and long evidence references without dropping audit text', async () => {
+    const longEvidenceId = 'evidence-' + '0123456789abcdef'.repeat(10);
+    const project = makeProject(1);
+    project.reviews[0] = {
+      ...project.reviews[0],
+      status: 'verified',
+      note: 'This unusually detailed reviewer rationale should remain visible in the exported PDF because it explains the sampled invoices, monitoring workbook cross-check, and boundary reconciliation used for the draft assessment.',
+      evidenceIds: [longEvidenceId],
+    };
+    const pdf = buildProjectExportPdf(project, {
+      total: 1,
+      verified: 1,
+      gap: 0,
+      notStarted: 0,
+      notApplicable: 0,
+      inProgress: 0,
+      percentComplete: 100,
+    });
+    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);
+    const parsed = await extractPdfTextWithPdfParse({ bytes });
+
+    expect(parsed.text).toContain('sampled invoices, monitoring workbook cross-check');
+    expect(parsed.text).toContain('boundary reconciliation used for the draft assessment');
+    expect(parsed.text).toContain('0123456789abcdef0123456789abcdef');
+  }, 15000);
+
+  it('shows a visible limitation for verified rules that lack evidence and rationale', async () => {
+    const project = makeProject(1);
+    project.reviews[0] = {
+      ...project.reviews[0],
+      status: 'verified',
+      note: undefined,
+      evidenceIds: [],
+    };
+    const pdf = buildProjectExportPdf(project, {
+      total: 1,
+      verified: 1,
+      gap: 0,
+      notStarted: 0,
+      notApplicable: 0,
+      inProgress: 0,
+      percentComplete: 100,
+    });
+    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);
+    const parsed = await extractPdfTextWithPdfParse({ bytes });
+
+    expect(parsed.text).toContain('no reviewer rationale or linked evidence reference');
+    expect(parsed.text).toContain('Draft OK is support-limited');
+  }, 15000);
+
   it('shows percentage complete in verification scope', async () => {
     const project = makeProject();
     const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {

--- a/tests/lib/projects/reportFindings.test.ts
+++ b/tests/lib/projects/reportFindings.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from '@jest/globals';
+import type { RuleReview } from '@/lib/projects/types';
+import { reportFindingCodeFromReviewStatus } from '@/lib/projects/reportFindings';
+
+describe('report finding mapping', () => {
+  it.each([
+    ['verified', 'OK'],
+    ['gap', 'NC'],
+    ['in-progress', 'CL'],
+    ['not-started', 'PENDING'],
+    ['not-applicable', 'NA'],
+  ] as const)('maps %s to %s', (status, code) => {
+    expect(reportFindingCodeFromReviewStatus(status)).toBe(code);
+  });
+
+  it('does not map any current review status to FAR by default', () => {
+    const statuses: RuleReview['status'][] = ['verified', 'gap', 'in-progress', 'not-started', 'not-applicable'];
+
+    expect(statuses.map(reportFindingCodeFromReviewStatus)).not.toContain('FAR');
+  });
+});

--- a/tests/lib/projects/reportFindings.test.ts
+++ b/tests/lib/projects/reportFindings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import type { RuleReview } from '@/lib/projects/types';
-import { reportFindingCodeFromReviewStatus } from '@/lib/projects/reportFindings';
+import { buildReportFinding, reportFindingCodeFromReviewStatus } from '@/lib/projects/reportFindings';
 
 describe('report finding mapping', () => {
   it.each([
@@ -17,5 +17,19 @@ describe('report finding mapping', () => {
     const statuses: RuleReview['status'][] = ['verified', 'gap', 'in-progress', 'not-started', 'not-applicable'];
 
     expect(statuses.map(reportFindingCodeFromReviewStatus)).not.toContain('FAR');
+  });
+
+  it('qualifies verified findings that have no evidence references or reviewer rationale', () => {
+    const finding = buildReportFinding({
+      ruleId: 'R-weak',
+      ruleTitle: 'Confirm monitoring evidence exists.',
+      sectionId: 'S-3',
+      status: 'verified',
+      evidenceIds: [],
+    }, 0, 'Monitoring');
+
+    expect(finding.code).toBe('OK');
+    expect(finding.rationale).toMatch(/no reviewer rationale or linked evidence reference/i);
+    expect(finding.limitation).toMatch(/support-limited/i);
   });
 });

--- a/tests/lib/projects/verificationReport.test.ts
+++ b/tests/lib/projects/verificationReport.test.ts
@@ -113,6 +113,32 @@ describe('verification report composition', () => {
     expect(summary).toContain('FAR: 0');
   });
 
+  it('renders support limitations for verified findings without evidence or rationale', () => {
+    const project = makeProject({
+      reviews: [
+        {
+          ruleId: 'R-weak',
+          ruleTitle: 'Confirm monitoring evidence exists.',
+          sectionId: 'S-3',
+          status: 'verified',
+          evidenceIds: [],
+        },
+      ],
+    });
+    const report = composeVerificationReport(project, makeCoverage({
+      total: 1,
+      verified: 1,
+      gap: 0,
+      notStarted: 0,
+      percentComplete: 100,
+    }));
+    const requirementFindings = report.sections.find((section) => section.title === 'REQUIREMENT FINDINGS')?.lines.join(' ');
+
+    expect(report.findings[0]?.code).toBe('OK');
+    expect(requirementFindings).toContain('no reviewer rationale or linked evidence reference');
+    expect(requirementFindings).toContain('Draft OK is support-limited');
+  });
+
   it('returns an insufficient-source fallback for UNFCCC when no completed reviews exist', () => {
     const project = makeProject({
       reviews: makeProject().reviews.map((review) => ({ ...review, status: 'not-started', note: undefined })),

--- a/tests/lib/projects/verificationReport.test.ts
+++ b/tests/lib/projects/verificationReport.test.ts
@@ -7,6 +7,38 @@ import {
   composeVerraVerificationReport,
 } from '@/lib/projects/verificationReport';
 
+const FORMAL_UNFCCC_SECTION_ORDER = [
+  'REPORT STATUS',
+  'PROJECT AND METHODOLOGY IDENTIFICATION',
+  'VERIFICATION SCOPE',
+  'MEANS OF VERIFICATION',
+  'FINDINGS SUMMARY',
+  'REQUIREMENT FINDINGS',
+  'EVIDENCE APPENDIX',
+  'LIMITATIONS',
+  'PROVENANCE',
+];
+
+const UNSUPPORTED_CERTIFICATION_PHRASES = [
+  'certified emission reductions are approved',
+  'verification opinion: positive',
+  'VCUs issued',
+  'registry approved',
+  'validated successfully',
+  'verified successfully',
+];
+
+function reportText(report: ReturnType<typeof composeVerificationReport>): string {
+  return [
+    report.title,
+    report.subtitle,
+    ...report.summaryItems,
+    ...report.sections.flatMap((section) => [section.title, ...section.lines]),
+    ...report.provenance.flat(),
+    report.limitation,
+  ].join('\n');
+}
+
 function makeCoverage(overrides: Partial<ProjectCoverage> = {}): ProjectCoverage {
   return {
     total: 3,
@@ -59,16 +91,26 @@ function makeProject(overrides: Partial<Project> = {}): Project {
 }
 
 describe('verification report composition', () => {
-  it('routes UNFCCC projects to the full renderer path', () => {
+  it('routes UNFCCC projects to the formal full renderer path', () => {
     const report = composeVerificationReport(makeProject(), makeCoverage());
 
     expect(report.registry).toBe('UNFCCC');
     expect(report.status).toBe('ready');
     expect(report.title).toBe('UNFCCC VERIFICATION REPORT');
-    expect(report.sections.map((section) => section.title)).toEqual(
-      expect.arrayContaining(['ENGAGEMENT CONTEXT', 'REVIEW STATUS SUMMARY', 'EVIDENCE TRACEABILITY']),
-    );
-    expect(report.groupedReviews).toHaveLength(3);
+    expect(report.sections.map((section) => section.title)).toEqual(FORMAL_UNFCCC_SECTION_ORDER);
+    expect(report.findings.map((finding) => finding.code)).toEqual(['OK', 'NC', 'PENDING']);
+  });
+
+  it('emits deterministic finding summary counts for UNFCCC reports', () => {
+    const report = composeVerificationReport(makeProject(), makeCoverage());
+    const summary = report.sections.find((section) => section.title === 'FINDINGS SUMMARY')?.lines.join(' ');
+
+    expect(summary).toContain('OK: 1');
+    expect(summary).toContain('NC: 1');
+    expect(summary).toContain('PENDING: 1');
+    expect(summary).toContain('CL: 0');
+    expect(summary).toContain('NA: 0');
+    expect(summary).toContain('FAR: 0');
   });
 
   it('returns an insufficient-source fallback for UNFCCC when no completed reviews exist', () => {
@@ -80,8 +122,8 @@ describe('verification report composition', () => {
     const report = composeUnfcccVerificationReport(project, coverage);
 
     expect(report.status).toBe('insufficient_source_content');
-    expect(report.groupedReviews).toEqual([]);
-    expect(report.sections[0]?.title).toBe('SOURCE CONTENT STATUS');
+    expect(report.sections.map((section) => section.title)).toEqual(FORMAL_UNFCCC_SECTION_ORDER);
+    expect(report.findings.every((finding) => finding.code === 'PENDING')).toBe(true);
   });
 
   it('routes Verra through a registry-specific fallback path', () => {
@@ -115,7 +157,28 @@ describe('verification report composition', () => {
     );
 
     expect(report.status).not.toBe('ready');
-    expect(report.groupedReviews).toEqual([]);
+    expect(report.findings).toEqual([]);
     expect(report.limitation).toMatch(/not a full Verra verification report/i);
+  });
+
+  it('keeps Verra and Gold Standard on truthful fallback paths without full report sections', () => {
+    const verra = composeVerificationReport(makeProject({ methodCode: 'VM0007', registry: 'Verra' }), makeCoverage());
+    const gold = composeVerificationReport(makeProject({ methodCode: 'GS TPDDTEC', registry: 'Gold Standard' }), makeCoverage());
+
+    expect(verra.status).toBe('registry_not_fully_supported');
+    expect(gold.status).toBe('registry_not_fully_supported');
+    expect(verra.sections.map((section) => section.title)).not.toContain('REQUIREMENT FINDINGS');
+    expect(gold.sections.map((section) => section.title)).not.toContain('REQUIREMENT FINDINGS');
+    expect(verra.findings).toEqual([]);
+    expect(gold.findings).toEqual([]);
+  });
+
+  it('does not emit unsupported certification or issuance phrases', () => {
+    const report = composeVerificationReport(makeProject(), makeCoverage());
+    const text = reportText(report);
+
+    for (const phrase of UNSUPPORTED_CERTIFICATION_PHRASES) {
+      expect(text).not.toContain(phrase);
+    }
   });
 });


### PR DESCRIPTION
## What
- adds a formal VVB-style UNFCCC draft report contract on top of the registry-aware export work from #532
- derives deterministic report findings from existing rule reviews using OK/CL/NC/PENDING/NA mappings, with FAR reserved but not emitted without explicit data
- renders required UNFCCC draft sections in deterministic order, including verification scope, means of verification, findings summary, requirement findings, evidence appendix, limitations, and provenance
- keeps Verra, Gold Standard, and Unknown registries as truthful fallback states without full renderer sections
- adds evals that prevent unsupported certification, issuance, or registry-approval language

## Validation
- `npx jest tests/lib/projects/reportFindings.test.ts tests/lib/projects/verificationReport.test.ts tests/api/project.export-pdf.route.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`

## Notes
This remains a draft/workpaper-style report contract. It intentionally does not render final certification, validation, verification-opinion, issuance, site-visit, verifier-identity, or registry-decision claims unless future explicit project data and tests support them.