### PR TITLE
fix: export finalized project review data in audit pack

### DIFF
--- a/src/app/api/exports/audit-pack/route.ts
+++ b/src/app/api/exports/audit-pack/route.ts
@@ -1,4 +1,6 @@
 import { buildAuditPackZip } from "@/exports/auditPack";
+import { EvidenceSnapshotSchema } from "@/lib/proofMap/evidenceSnapshot";
+import type { EvidencePin } from "@/lib/proofMap/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -11,6 +13,33 @@ export async function GET(req: Request) {
 
   try {
     const zip = buildAuditPackZip(method, version);
+    return new Response(zip, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": 'attachment; filename="audit-pack.zip"',
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(`Audit pack export failed (500). ${message}`, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as unknown;
+    const record = body && typeof body === "object" && !Array.isArray(body) ? (body as Record<string, unknown>) : {};
+    const method = typeof record.method === "string" ? record.method : "";
+    const version = typeof record.version === "string" ? record.version : "";
+    if (!method || !version) return new Response("Missing method/version in request body", { status: 400 });
+
+    const artifact = record.artifact ? EvidenceSnapshotSchema.parse(record.artifact) : null;
+    const evidencePins = Array.isArray(record.evidencePins) ? (record.evidencePins as EvidencePin[]) : [];
+    const zip = buildAuditPackZip(method, version, {
+      finalizedReview: artifact ? { artifact, evidencePins } : null,
+    });
     return new Response(zip, {
       status: 200,
       headers: {

--- a/src/app/api/exports/audit-pack/route.ts
+++ b/src/app/api/exports/audit-pack/route.ts
@@ -1,6 +1,7 @@
 import { buildAuditPackZip } from "@/exports/auditPack";
 import { EvidenceSnapshotSchema } from "@/lib/proofMap/evidenceSnapshot";
 import type { EvidencePin } from "@/lib/proofMap/types";
+import { ZodError } from "zod";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -35,7 +36,15 @@ export async function POST(req: Request) {
     const version = typeof record.version === "string" ? record.version : "";
     if (!method || !version) return new Response("Missing method/version in request body", { status: 400 });
 
-    const artifact = record.artifact ? EvidenceSnapshotSchema.parse(record.artifact) : null;
+    let artifact = null;
+    try {
+      artifact = record.artifact ? EvidenceSnapshotSchema.parse(record.artifact) : null;
+    } catch (error: unknown) {
+      if (error instanceof ZodError) {
+        return new Response(`Invalid artifact payload. ${error.message}`, { status: 400 });
+      }
+      throw error;
+    }
     const evidencePins = Array.isArray(record.evidencePins) ? (record.evidencePins as EvidencePin[]) : [];
     const zip = buildAuditPackZip(method, version, {
       finalizedReview: artifact ? { artifact, evidencePins } : null,

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -3981,6 +3981,7 @@ export default function ProofMapTab({
               <FinalReviewSummaryPanel
                 summary={reviewArtifact?.summary ?? reviewSummary}
                 artifact={reviewArtifact}
+          evidencePins={evidencePins}
                 currentRunLabel={currentRunLabel}
                 loadedFromRunLabel={loadedFromRunLabel}
                 finalizedAt={verifierBundle.finalizedAt}

--- a/src/components/verify/FinalReviewSummaryPanel.tsx
+++ b/src/components/verify/FinalReviewSummaryPanel.tsx
@@ -30,6 +30,24 @@ function formatDate(value: string | null | undefined): string | null {
   return date.toLocaleString();
 }
 
+function safeFilename(value: string | null | undefined): string {
+  const trimmed = (value ?? "").trim() || "unknown";
+  return trimmed.replace(/[^\w.\-]+/g, "_").slice(0, 64) || "unknown";
+}
+
+function downloadBytes(bytes: Uint8Array, filename: string, mimeType: string) {
+  const blobPart = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  const blob = new Blob([blobPart], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
 export default function FinalReviewSummaryPanel({
   summary,
   artifact,
@@ -49,6 +67,20 @@ export default function FinalReviewSummaryPanel({
 }: FinalReviewSummaryPanelProps) {
   const finalizedLabel = formatDate(finalizedAt);
   const completedSteps = wizard.steps.filter((step) => step.complete);
+  const canDownloadAuditPack = Boolean(artifact?.verifier?.finalizedState === "finalized" || artifact?.verifier?.finalizedAt);
+  const handleDownloadAuditPack = async () => {
+    if (!artifact) return;
+    const method = artifact.method.code || summary.methodCode || "";
+    const version = artifact.method.version || summary.version || "";
+    const response = await fetch("/api/exports/audit-pack", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ method, version, artifact }),
+    });
+    if (!response.ok) throw new Error(await response.text());
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    downloadBytes(bytes, `audit-pack.${safeFilename(method)}.${safeFilename(version)}.${safeFilename(artifact.verifier?.runId)}.zip`, "application/zip");
+  };
 
   return (
     <section className="grid gap-3" data-testid="final-review-summary-panel">
@@ -84,6 +116,17 @@ export default function FinalReviewSummaryPanel({
         >
           View run history
         </button>
+        {canDownloadAuditPack ? (
+          <button
+            type="button"
+            className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
+            onClick={() => {
+              void handleDownloadAuditPack();
+            }}
+          >
+            Download audit pack
+          </button>
+        ) : null}
       </div>
 
       <details className="rounded-xl border border-slate-200 bg-white">

--- a/src/components/verify/FinalReviewSummaryPanel.tsx
+++ b/src/components/verify/FinalReviewSummaryPanel.tsx
@@ -2,6 +2,7 @@
 
 import ReviewSummaryCard from "@/components/verify/ReviewSummaryCard";
 import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
+import type { EvidencePin } from "@/lib/proofMap/types";
 import type { ReviewSummary } from "@/lib/verify/buildReviewSummary";
 import type { VerifyWizardStepDetails } from "@/lib/verify/runState";
 
@@ -13,6 +14,7 @@ type FinalReviewSummaryPanelProps = {
   finalizedAt?: string | null;
   reviewedRuleCount?: number | null;
   linkedEvidenceCount?: number | null;
+  evidencePins?: EvidencePin[];
   wizard: VerifyWizardStepDetails;
   onDownloadJson: () => void;
   onDownloadPdf: () => void;
@@ -56,6 +58,7 @@ export default function FinalReviewSummaryPanel({
   finalizedAt = null,
   reviewedRuleCount = null,
   linkedEvidenceCount = null,
+  evidencePins = [],
   wizard,
   onDownloadJson,
   onDownloadPdf,
@@ -75,7 +78,7 @@ export default function FinalReviewSummaryPanel({
     const response = await fetch("/api/exports/audit-pack", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ method, version, artifact }),
+      body: JSON.stringify({ method, version, artifact, evidencePins }),
     });
     if (!response.ok) throw new Error(await response.text());
     const bytes = new Uint8Array(await response.arrayBuffer());

--- a/src/exports/auditPack.ts
+++ b/src/exports/auditPack.ts
@@ -4,7 +4,7 @@ import { zipSync, strToU8 } from "fflate";
 import { makePackMeta } from "./packMeta";
 import { canonicalStringify, sha256Hex } from "../integrity/artifacts";
 import { buildTraceIndex } from "../lib/trace/traceIndex";
-import { buildVerificationPackContractFiles } from "./verificationPackContract";
+import { buildVerificationPackContractFiles, type FinalizedAuditPackReviewInput } from "./verificationPackContract";
 
 function readJsonCanonical(p: string): Buffer {
   const raw = fs.readFileSync(p, "utf8");
@@ -43,6 +43,19 @@ function deterministicTimestamp(): string {
   return "1970-01-01T00:00:00.000Z";
 }
 
+function generatedAtForAuditPack(finalizedReview?: FinalizedAuditPackReviewInput | null): string {
+  const artifact = finalizedReview?.artifact;
+  const finalizedAt =
+    artifact?.verifier?.finalizedAt?.trim() ||
+    artifact?.summary?.generatedAt?.trim() ||
+    artifact?.outcome?.exportState.snapshotExportedAt?.trim() ||
+    artifact?.outcome?.provenance.generatedAt?.trim() ||
+    null;
+  if (finalizedAt && Number.isFinite(new Date(finalizedAt).getTime())) return finalizedAt;
+  if (artifact) return new Date().toISOString();
+  return deterministicTimestamp();
+}
+
 function zipMtimeFromTimestamp(iso: string): Date {
   const date = new Date(iso);
   if (!Number.isFinite(date.getTime())) return new Date("1980-01-01T00:00:00.000Z");
@@ -51,7 +64,7 @@ function zipMtimeFromTimestamp(iso: string): Date {
   return date;
 }
 
-export function buildAuditPackZip(methodCode: string, version: string) {
+export function buildAuditPackZip(methodCode: string, version: string, options: { finalizedReview?: FinalizedAuditPackReviewInput | null } = {}) {
   const methodDir = resolveMethodDir(methodCode, version);
   if (!methodDir) {
     throw new Error(`Method/version not found on disk for ${methodCode}@${version} under public/methodologies`);
@@ -82,7 +95,7 @@ export function buildAuditPackZip(methodCode: string, version: string) {
   const repo = process.env.GITHUB_REPOSITORY || process.env.VERCEL_GIT_REPO_SLUG || "unknown";
   const commit = process.env.GITHUB_SHA || process.env.VERCEL_GIT_COMMIT_SHA || "unknown";
 
-  const generatedAt = deterministicTimestamp();
+  const generatedAt = generatedAtForAuditPack(options.finalizedReview);
   const packMeta = makePackMeta({ methodCode, version, repo, commit, generated_at: generatedAt });
   const contractFiles = buildVerificationPackContractFiles({
     generatedAt,
@@ -91,6 +104,7 @@ export function buildAuditPackZip(methodCode: string, version: string) {
     rulesJson: readJsonRaw(rulesPath),
     sectionsJson: readJsonRaw(sectionsPath),
     trace,
+    finalizedReview: options.finalizedReview ?? null,
   });
   for (const file of contractFiles) {
     files.push({

--- a/src/exports/verificationPackContract.ts
+++ b/src/exports/verificationPackContract.ts
@@ -1,4 +1,6 @@
 import { canonicalStringify } from "../integrity/artifacts";
+import type { EvidenceSnapshot } from "../lib/proofMap/evidenceSnapshot";
+import type { EvidencePin } from "../lib/proofMap/types";
 import type { TraceIndex, TraceSectionLink } from "../lib/trace/traceIndex";
 
 type ContractRule = {
@@ -28,14 +30,14 @@ type ProjectJson = {
     reporting_period: string;
     location: string;
     description: string;
-    placeholder: true;
+    placeholder: boolean;
     placeholder_reason: string;
   };
   reviewer_assignment: {
     display_name: string;
     role: string;
     organization: string;
-    placeholder: true;
+    placeholder: boolean;
     placeholder_reason: string;
   };
 };
@@ -44,15 +46,19 @@ type EvidenceManifestEntry = {
   evidence_ref: string;
   label: string;
   rule_ids: string[];
-  status: "not_provided";
-  status_basis: "demo_placeholder";
-  source_kind: "project_evidence_slot";
-  included_in_pack: false;
+  status: "not_provided" | "provided";
+  status_basis: "demo_placeholder" | "finalized_project_review";
+  source_kind: "project_evidence_slot" | "project_evidence_ref";
+  included_in_pack: boolean;
   file_path: null;
   sha256: null;
   requested_for: string;
-  placeholder: true;
+  placeholder: boolean;
   placeholder_reason: string;
+  fragment_id?: string;
+  source_pin_id?: string;
+  evidence_title?: string;
+  evidence_type?: string;
 };
 
 type EvidenceManifest = {
@@ -69,7 +75,7 @@ type EvidenceManifest = {
     placeholder_refs: number;
   };
   placeholder_policy: {
-    all_entries_marked_placeholder: true;
+    all_entries_marked_placeholder: boolean;
     reason: string;
   };
   evidence: EvidenceManifestEntry[];
@@ -77,24 +83,35 @@ type EvidenceManifest = {
 
 type RequirementReviewEntry = {
   rule_id: string;
-  status: "awaiting_project_evidence";
-  status_basis: "demo_placeholder";
+  status: "awaiting_project_evidence" | "finalized" | "finalized_review_data_missing";
+  status_basis: "demo_placeholder" | "finalized_project_review";
   rationale: string;
   linked_evidence_refs: string[];
   requested_evidence_refs: string[];
   reviewer: {
     display_name: string;
     role: string;
-    placeholder: true;
+    placeholder: boolean;
     placeholder_reason: string;
   };
   timestamps: {
     record_created_at: string;
     last_updated_at: string;
-    reviewed_at: null;
+    reviewed_at: string | null;
   };
   methodology_trace: {
     section_ids: string[];
+  };
+  reconciliation?: {
+    status: string | null;
+    reason: string | null;
+  };
+  reviewer_artifact?: {
+    run_id: string | null;
+    finalized_state: string | null;
+    finalized_at: string | null;
+    minutes_present: boolean;
+    outcome_note: string | null;
   };
 };
 
@@ -112,7 +129,7 @@ type RequirementReview = {
     linked_evidence_refs: number;
   };
   placeholder_policy: {
-    all_rule_reviews_marked_placeholder: true;
+    all_rule_reviews_marked_placeholder: boolean;
     reason: string;
   };
   rules: RequirementReviewEntry[];
@@ -137,13 +154,13 @@ type VerificationPackContract = {
   requirementReview: RequirementReview;
   trace: TraceIndex & {
     verification_contract: {
-      mode: "demo_placeholder_review_contract";
+      mode: "demo_placeholder_review_contract" | "finalized_project_review_contract";
       project_path: "project.json";
       evidence_manifest_path: "evidence-manifest.json";
       requirement_review_path: "requirement-review.json";
       trail_path: "trail.jsonl";
       report_path: "VERIFICATION_REPORT.html";
-      placeholder: true;
+      placeholder: boolean;
       placeholder_reason: string;
     };
     rule_to_review: Record<
@@ -151,10 +168,11 @@ type VerificationPackContract = {
       {
         requirement_review_path: "requirement-review.json";
         rule_id: string;
-        status: "awaiting_project_evidence";
+        status: RequirementReviewEntry["status"];
+        status_basis: string;
         linked_evidence_refs: string[];
         requested_evidence_refs: string[];
-        placeholder: true;
+        placeholder: boolean;
       }
     >;
   };
@@ -164,6 +182,14 @@ type VerificationPackContract = {
 
 const PLACEHOLDER_REASON =
   "Real project-specific evidence, reviewer assignment, and verification outcomes are not available in this methodology-only demo contract.";
+
+const FINALIZED_REVIEW_REASON =
+  "This audit pack was generated from a finalized local review artifact supplied by the export caller.";
+
+export type FinalizedAuditPackReviewInput = {
+  artifact?: EvidenceSnapshot | null;
+  evidencePins?: EvidencePin[] | null;
+};
 
 function extractRules(rulesJson: unknown): ContractRule[] {
   const items = Array.isArray(rulesJson)
@@ -200,6 +226,118 @@ function extractSectionCount(sectionsJson: unknown): number {
 
 function evidenceRefForRule(ruleId: string): string {
   return `placeholder-evidence:${ruleId}`;
+}
+
+function uniqueSorted(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.map((value) => value?.trim()).filter((value): value is string => Boolean(value)))).sort((a, b) =>
+    a.localeCompare(b),
+  );
+}
+
+function selectedRuleFromArtifact(artifact: EvidenceSnapshot | null | undefined): string | null {
+  return (
+    artifact?.summary?.ruleId?.trim() ||
+    artifact?.outcome?.linkage.selectedRuleId?.trim() ||
+    artifact?.outcome?.linkage.linkedRuleIds[0]?.trim() ||
+    null
+  );
+}
+
+function evidenceRefsForRule(input: {
+  ruleId: string | null;
+  artifact: EvidenceSnapshot | null | undefined;
+  evidencePins: EvidencePin[];
+}): EvidenceManifestEntry[] {
+  const entries: EvidenceManifestEntry[] = [];
+  const ruleId = input.ruleId;
+  const selectedEvidenceId =
+    input.artifact?.summary?.selectedEvidenceId?.trim() ||
+    input.artifact?.selected?.id?.trim() ||
+    input.artifact?.selected?.item?.id?.trim() ||
+    null;
+
+  for (const pin of input.evidencePins) {
+    const linkedRuleIds = uniqueSorted([pin.ruleId, ...(pin.cited_ids ?? []), ...(pin.pdd_fragment_links ?? []).map((link) => link.rule_id)]);
+    if (ruleId && linkedRuleIds.length && !linkedRuleIds.includes(ruleId)) continue;
+
+    const baseRuleIds = linkedRuleIds.length ? linkedRuleIds : ruleId ? [ruleId] : [];
+    const pinRefs = uniqueSorted([pin.itemId, ...(pin.stac_item_ids ?? []), pin.pdd_document?.evidence_id, pin.id]);
+    for (const ref of pinRefs) {
+      entries.push({
+        evidence_ref: ref,
+        label: pin.title || ref,
+        rule_ids: [...baseRuleIds],
+        status: "provided",
+        status_basis: "finalized_project_review",
+        source_kind: "project_evidence_ref",
+        included_in_pack: false,
+        file_path: null,
+        sha256: null,
+        requested_for: ruleId ? `Finalized review evidence linked to ${ruleId}` : "Finalized review evidence",
+        placeholder: false,
+        placeholder_reason: "",
+        source_pin_id: pin.id,
+        evidence_title: pin.title,
+        evidence_type: pin.kind,
+      });
+    }
+
+    for (const link of pin.pdd_fragment_links ?? []) {
+      if (ruleId && link.rule_id !== ruleId) continue;
+      const fragment = pin.pdd_fragments?.find((candidate) => candidate.fragment_id === link.fragment_id);
+      entries.push({
+        evidence_ref: link.fragment_id,
+        label: fragment?.label?.trim() || fragment?.section_heading?.trim() || link.fragment_id,
+        rule_ids: [link.rule_id],
+        status: "provided",
+        status_basis: "finalized_project_review",
+        source_kind: "project_evidence_ref",
+        included_in_pack: false,
+        file_path: null,
+        sha256: null,
+        requested_for: `Finalized review fragment linked to ${link.rule_id}`,
+        placeholder: false,
+        placeholder_reason: "",
+        fragment_id: link.fragment_id,
+        source_pin_id: pin.id,
+        evidence_title: pin.title,
+        evidence_type: pin.kind,
+      });
+    }
+  }
+
+  if (selectedEvidenceId && !entries.some((entry) => entry.evidence_ref === selectedEvidenceId)) {
+    entries.push({
+      evidence_ref: selectedEvidenceId,
+      label: selectedEvidenceId,
+      rule_ids: ruleId ? [ruleId] : [],
+      status: "provided",
+      status_basis: "finalized_project_review",
+      source_kind: "project_evidence_ref",
+      included_in_pack: false,
+      file_path: null,
+      sha256: null,
+      requested_for: ruleId ? `Finalized selected evidence for ${ruleId}` : "Finalized selected evidence",
+      placeholder: false,
+      placeholder_reason: "",
+      evidence_title: selectedEvidenceId,
+      evidence_type: "selected",
+    });
+  }
+
+  const byRef = new Map<string, EvidenceManifestEntry>();
+  for (const entry of entries) {
+    const current = byRef.get(entry.evidence_ref);
+    if (!current) {
+      byRef.set(entry.evidence_ref, entry);
+      continue;
+    }
+    byRef.set(entry.evidence_ref, {
+      ...current,
+      rule_ids: uniqueSorted([...current.rule_ids, ...entry.rule_ids]),
+    });
+  }
+  return Array.from(byRef.values()).sort((a, b) => a.evidence_ref.localeCompare(b.evidence_ref));
 }
 
 function summarizeRuleText(text: string): string {
@@ -270,7 +408,7 @@ function renderVerificationReportHtml(input: {
       Placeholder refs: ${input.evidenceManifest.summary.placeholder_refs}
     </p>
 
-    <h2>Requirement Review Scaffold</h2>
+    <h2>Requirement Review</h2>
     <table>
       <thead>
         <tr>
@@ -343,9 +481,19 @@ export function buildVerificationPackContract(input: {
   rulesJson: unknown;
   sectionsJson: unknown;
   trace: TraceIndex;
+  finalizedReview?: FinalizedAuditPackReviewInput | null;
 }): VerificationPackContract {
   const rules = extractRules(input.rulesJson);
   const sectionCount = extractSectionCount(input.sectionsJson);
+  const finalizedArtifact = input.finalizedReview?.artifact ?? null;
+  const finalizedPins = input.finalizedReview?.evidencePins ?? [];
+  const finalizedRuleId = selectedRuleFromArtifact(finalizedArtifact);
+  const finalizedEvidence = evidenceRefsForRule({
+    ruleId: finalizedRuleId,
+    artifact: finalizedArtifact,
+    evidencePins: finalizedPins,
+  });
+  const hasFinalizedReview = Boolean(finalizedArtifact?.verifier?.finalizedState === "finalized" || finalizedArtifact?.verifier?.finalizedAt);
 
   const project: ProjectJson = {
     kind: "article6.verification_project",
@@ -360,42 +508,47 @@ export function buildVerificationPackContract(input: {
     pack_profile: {
       name: "demo_verification_contract",
       human_label: "Demo verification contract",
-      disclaimer:
-        "This pack includes real methodology provenance plus a placeholder review scaffold. It does not assert a completed project verification.",
+      disclaimer: hasFinalizedReview
+        ? "This pack includes real methodology provenance plus finalized local review state supplied by the export caller. It is not a formal verifier opinion."
+        : "This pack includes real methodology provenance plus a placeholder review scaffold. It does not assert a completed project verification.",
       not_a_formal_opinion: true,
     },
     project_context: {
-      project_id: "demo-placeholder-project",
-      display_name: "Demo placeholder project context",
+      project_id: finalizedArtifact?.verifier?.runId ?? "demo-placeholder-project",
+      display_name: finalizedArtifact?.summary?.aoiLabel ?? "Demo placeholder project context",
       reporting_period: "placeholder-not-provided",
-      location: "placeholder-not-provided",
-      description: "Placeholder only: no project-specific context is included in this pack.",
-      placeholder: true,
-      placeholder_reason: PLACEHOLDER_REASON,
+      location: finalizedArtifact?.summary?.aoiLabel ?? "placeholder-not-provided",
+      description: hasFinalizedReview
+        ? "Finalized local review context is included where present; absent project fields remain explicitly unavailable."
+        : "Placeholder only: no project-specific context is included in this pack.",
+      placeholder: !hasFinalizedReview,
+      placeholder_reason: hasFinalizedReview ? "Project registry dossier fields were not supplied to the audit-pack export." : PLACEHOLDER_REASON,
     },
     reviewer_assignment: {
-      display_name: "Placeholder reviewer assignment",
-      role: "VVB reviewer",
+      display_name: hasFinalizedReview ? "Local reviewer artifact" : "Placeholder reviewer assignment",
+      role: hasFinalizedReview ? "Local review preparer" : "VVB reviewer",
       organization: "Placeholder VVB organization",
-      placeholder: true,
-      placeholder_reason: PLACEHOLDER_REASON,
+      placeholder: !hasFinalizedReview,
+      placeholder_reason: hasFinalizedReview ? "No verified reviewer identity was supplied to the audit-pack export." : PLACEHOLDER_REASON,
     },
   };
 
-  const evidence = rules.map<EvidenceManifestEntry>((rule) => ({
-    evidence_ref: evidenceRefForRule(rule.id),
-    label: `Placeholder project evidence request for ${rule.id}`,
-    rule_ids: [rule.id],
-    status: "not_provided",
-    status_basis: "demo_placeholder",
-    source_kind: "project_evidence_slot",
-    included_in_pack: false,
-    file_path: null,
-    sha256: null,
-    requested_for: summarizeRuleText(rule.text),
-    placeholder: true,
-    placeholder_reason: PLACEHOLDER_REASON,
-  }));
+  const evidence = hasFinalizedReview
+    ? finalizedEvidence
+    : rules.map<EvidenceManifestEntry>((rule) => ({
+        evidence_ref: evidenceRefForRule(rule.id),
+        label: `Placeholder project evidence request for ${rule.id}`,
+        rule_ids: [rule.id],
+        status: "not_provided",
+        status_basis: "demo_placeholder",
+        source_kind: "project_evidence_slot",
+        included_in_pack: false,
+        file_path: null,
+        sha256: null,
+        requested_for: summarizeRuleText(rule.text),
+        placeholder: true,
+        placeholder_reason: PLACEHOLDER_REASON,
+      }));
 
   const evidenceManifest: EvidenceManifest = {
     kind: "article6.evidence_manifest",
@@ -404,17 +557,17 @@ export function buildVerificationPackContract(input: {
     method: { code: input.methodCode, version: input.version },
     summary: {
       total_refs: evidence.length,
-      provided_refs: 0,
-      placeholder_refs: evidence.length,
+      provided_refs: evidence.filter((entry) => entry.status === "provided").length,
+      placeholder_refs: evidence.filter((entry) => entry.placeholder).length,
     },
     placeholder_policy: {
-      all_entries_marked_placeholder: true,
-      reason: PLACEHOLDER_REASON,
+      all_entries_marked_placeholder: !hasFinalizedReview,
+      reason: hasFinalizedReview ? FINALIZED_REVIEW_REASON : PLACEHOLDER_REASON,
     },
     evidence,
   };
 
-  const requirementRules = rules.map<RequirementReviewEntry>((rule) => {
+  const placeholderRequirementRules = rules.map<RequirementReviewEntry>((rule) => {
     const traceSections = input.trace.rule_to_sections[rule.id] ?? [];
     return {
       rule_id: rule.id,
@@ -441,6 +594,49 @@ export function buildVerificationPackContract(input: {
     };
   });
 
+  const finalizedRequirementRules: RequirementReviewEntry[] = hasFinalizedReview
+    ? [
+        {
+          rule_id: finalizedRuleId ?? "missing-finalized-rule-id",
+          status: finalizedRuleId && finalizedEvidence.length ? "finalized" : "finalized_review_data_missing",
+          status_basis: "finalized_project_review",
+          rationale:
+            finalizedArtifact?.summary?.narrative?.trim() ||
+            finalizedArtifact?.verifier?.outcomeNote?.trim() ||
+            "Finalized review artifact supplied, but no narrative or reviewer outcome note was available.",
+          linked_evidence_refs: finalizedEvidence.map((entry) => entry.evidence_ref),
+          requested_evidence_refs: [],
+          reviewer: {
+            display_name: "Local reviewer artifact",
+            role: "Local review preparer",
+            placeholder: false,
+            placeholder_reason: "",
+          },
+          timestamps: {
+            record_created_at: finalizedArtifact?.verifier?.createdAt ?? input.generatedAt,
+            last_updated_at: finalizedArtifact?.verifier?.finalizedAt ?? input.generatedAt,
+            reviewed_at: finalizedArtifact?.verifier?.finalizedAt ?? null,
+          },
+          methodology_trace: {
+            section_ids: uniqueSorted([finalizedArtifact?.summary?.ruleSection ?? null]),
+          },
+          reconciliation: {
+            status: finalizedArtifact?.summary?.reconciliationStatus ?? null,
+            reason: finalizedArtifact?.summary?.reconciliationReason ?? null,
+          },
+          reviewer_artifact: {
+            run_id: finalizedArtifact?.verifier?.runId ?? null,
+            finalized_state: finalizedArtifact?.verifier?.finalizedState ?? null,
+            finalized_at: finalizedArtifact?.verifier?.finalizedAt ?? null,
+            minutes_present: Boolean(finalizedArtifact?.verifier?.minutes?.trim()),
+            outcome_note: finalizedArtifact?.verifier?.outcomeNote?.trim() || finalizedArtifact?.summary?.outcomeNote || null,
+          },
+        },
+      ]
+    : [];
+
+  const requirementRules = hasFinalizedReview ? finalizedRequirementRules : placeholderRequirementRules;
+
   const requirementReview: RequirementReview = {
     kind: "article6.requirement_review",
     version: 1,
@@ -448,17 +644,19 @@ export function buildVerificationPackContract(input: {
     method: { code: input.methodCode, version: input.version },
     summary: {
       total_rules: requirementRules.length,
-      placeholder_rule_reviews: requirementRules.length,
-      linked_evidence_refs: 0,
+      placeholder_rule_reviews: requirementRules.filter((rule) => rule.status_basis === "demo_placeholder").length,
+      linked_evidence_refs: requirementRules.reduce((sum, rule) => sum + rule.linked_evidence_refs.length, 0),
     },
     placeholder_policy: {
-      all_rule_reviews_marked_placeholder: true,
-      reason: PLACEHOLDER_REASON,
+      all_rule_reviews_marked_placeholder: !hasFinalizedReview,
+      reason: hasFinalizedReview ? FINALIZED_REVIEW_REASON : PLACEHOLDER_REASON,
     },
     rules: requirementRules,
   };
 
-  const ruleToEvidence = Object.fromEntries(rules.map((rule) => [rule.id, [] as string[]]));
+  const ruleToEvidence = hasFinalizedReview
+    ? Object.fromEntries(requirementRules.map((rule) => [rule.rule_id, [...rule.linked_evidence_refs]]))
+    : Object.fromEntries(rules.map((rule) => [rule.id, [] as string[]]));
   const ruleToReview = Object.fromEntries(
     requirementRules.map((rule) => [
       rule.rule_id,
@@ -466,9 +664,10 @@ export function buildVerificationPackContract(input: {
         requirement_review_path: "requirement-review.json" as const,
         rule_id: rule.rule_id,
         status: rule.status,
-        linked_evidence_refs: rule.linked_evidence_refs,
-        requested_evidence_refs: rule.requested_evidence_refs,
-        placeholder: true as const,
+        status_basis: rule.status_basis,
+        linked_evidence_refs: [...rule.linked_evidence_refs],
+        requested_evidence_refs: [...rule.requested_evidence_refs],
+        placeholder: rule.status_basis === "demo_placeholder",
       },
     ]),
   );
@@ -477,14 +676,14 @@ export function buildVerificationPackContract(input: {
     ...input.trace,
     rule_to_evidence: ruleToEvidence,
     verification_contract: {
-      mode: "demo_placeholder_review_contract" as const,
+      mode: hasFinalizedReview ? "finalized_project_review_contract" as const : "demo_placeholder_review_contract" as const,
       project_path: "project.json" as const,
       evidence_manifest_path: "evidence-manifest.json" as const,
       requirement_review_path: "requirement-review.json" as const,
       trail_path: "trail.jsonl" as const,
       report_path: "VERIFICATION_REPORT.html" as const,
-      placeholder: true as const,
-      placeholder_reason: PLACEHOLDER_REASON,
+      placeholder: !hasFinalizedReview,
+      placeholder_reason: hasFinalizedReview ? FINALIZED_REVIEW_REASON : PLACEHOLDER_REASON,
     },
     rule_to_review: ruleToReview,
   };
@@ -510,6 +709,7 @@ export function buildVerificationPackContractFiles(input: {
   rulesJson: unknown;
   sectionsJson: unknown;
   trace: TraceIndex;
+  finalizedReview?: FinalizedAuditPackReviewInput | null;
 }): Array<{ path: string; bytes: Buffer }> {
   const contract = buildVerificationPackContract(input);
   return [

--- a/tests/app/api/exports/audit-pack.route.test.ts
+++ b/tests/app/api/exports/audit-pack.route.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
+
+const buildAuditPackZip = jest.fn();
+
+jest.mock("@/exports/auditPack", () => ({
+  buildAuditPackZip: (...args: unknown[]) => buildAuditPackZip(...args),
+}));
+
+describe("audit-pack route", () => {
+  beforeEach(() => {
+    buildAuditPackZip.mockReset();
+    buildAuditPackZip.mockReturnValue(new Uint8Array([0x50, 0x4b, 0x03, 0x04]));
+  });
+
+  test("POST returns 400 when method/version is missing", async () => {
+    const { POST } = await import("@/app/api/exports/audit-pack/route");
+    const res = await POST(
+      new Request("http://localhost/api/exports/audit-pack", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ method: "AR-ACM0003" }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.text()).resolves.toContain("Missing method/version");
+    expect(buildAuditPackZip).not.toHaveBeenCalled();
+  });
+
+  test("POST returns 400 for malformed artifact payloads", async () => {
+    const { POST } = await import("@/app/api/exports/audit-pack/route");
+    const res = await POST(
+      new Request("http://localhost/api/exports/audit-pack", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          method: "AR-ACM0003",
+          version: "v02-0",
+          artifact: { method: { code: "", version: "v02-0" } },
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.text()).resolves.toContain("Invalid artifact payload");
+    expect(buildAuditPackZip).not.toHaveBeenCalled();
+  });
+
+  test("POST exports zip for valid finalized payloads", async () => {
+    const artifact: EvidenceSnapshot = {
+      method: { code: "AR-ACM0003", version: "v02-0" },
+      evidence_source: { type: "stac_url", ref: "https://stac.example.test" },
+      verifier: {
+        runId: "run-1",
+        createdAt: "2026-04-24T11:50:00.000Z",
+        minutes: "Reviewed.",
+        outcomeNote: "Ready.",
+        finalizedAt: "2026-04-24T12:00:00.000Z",
+        finalizedState: "finalized",
+        delta: "",
+        impact: "",
+        tasks: [],
+      },
+    };
+
+    const { POST } = await import("@/app/api/exports/audit-pack/route");
+    const res = await POST(
+      new Request("http://localhost/api/exports/audit-pack", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          method: "AR-ACM0003",
+          version: "v02-0",
+          artifact,
+          evidencePins: [{ id: "pin-1", kind: "note", title: "scene-1", created_at: "2026-04-24T11:54:00.000Z" }],
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/zip");
+    expect(buildAuditPackZip).toHaveBeenCalledWith("AR-ACM0003", "v02-0", {
+      finalizedReview: {
+        artifact,
+        evidencePins: [{ id: "pin-1", kind: "note", title: "scene-1", created_at: "2026-04-24T11:54:00.000Z" }],
+      },
+    });
+  });
+
+  test("POST keeps unexpected export failures as 500", async () => {
+    buildAuditPackZip.mockImplementation(() => {
+      throw new Error("zip failed");
+    });
+    const { POST } = await import("@/app/api/exports/audit-pack/route");
+    const res = await POST(
+      new Request("http://localhost/api/exports/audit-pack", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ method: "AR-ACM0003", version: "v02-0" }),
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    await expect(res.text()).resolves.toContain("zip failed");
+  });
+
+  test("GET still returns 400 when method/version is missing", async () => {
+    const { GET } = await import("@/app/api/exports/audit-pack/route");
+    const res = await GET(new Request("http://localhost/api/exports/audit-pack"));
+
+    expect(res.status).toBe(400);
+    await expect(res.text()).resolves.toContain("Missing ?method");
+  });
+});

--- a/tests/components/finalReviewSummaryPanel.test.tsx
+++ b/tests/components/finalReviewSummaryPanel.test.tsx
@@ -1,9 +1,20 @@
-import { describe, expect, test } from "@jest/globals";
+/** @jest-environment jsdom */
+
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import FinalReviewSummaryPanel from "@/components/verify/FinalReviewSummaryPanel";
+import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
+import type { EvidencePin } from "@/lib/proofMap/types";
 import { getVerifyWizardStepDetails } from "@/lib/verify/runState";
 
 describe("FinalReviewSummaryPanel", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
   test("renders the finalized right-panel summary with blocks and actions", () => {
     const html = renderToStaticMarkup(
       <FinalReviewSummaryPanel
@@ -67,5 +78,147 @@ describe("FinalReviewSummaryPanel", () => {
     expect(html).toContain("Completed workflow history");
     expect(html).not.toContain("Current workspace");
     expect(html).not.toContain("Next required action");
+  });
+
+  test("includes evidencePins in finalized audit-pack POST body", async () => {
+    const artifact: EvidenceSnapshot = {
+      method: { code: "AR-ACM0003", version: "v02-0" },
+      evidence_source: { type: "stac_url", ref: "https://stac.example.test" },
+      selected: {
+        id: "sentinel-scene-1",
+        item: {
+          id: "sentinel-scene-1",
+          datetime: "2026-03-25T00:00:00Z",
+          collection: "sentinel-2",
+          cloud_cover: 4,
+          linked_rules: ["R-1"],
+        },
+      },
+      outcome: {
+        aoi: { hash: "aoi", bbox: [0, 0, 1, 1], areaKm2: 1 },
+        stac: { query: { source: "https://stac.example.test" }, itemIds: ["sentinel-scene-1"] },
+        linkage: { selectedRuleId: "R-1", linkedRuleIds: ["R-1"] },
+        exportState: { snapshotExportedAt: "2026-03-25T00:10:00Z" },
+        provenance: {
+          methodCode: "AR-ACM0003",
+          version: "v02-0",
+          generatedAt: "2026-03-25T00:10:00Z",
+          snapshotSchemaVersion: "evidence-snapshot/v2",
+        },
+      },
+      verifier: {
+        runId: "run-1234",
+        createdAt: "2026-03-25T00:05:00Z",
+        minutes: "Reviewer linked selected evidence and PDD fragment.",
+        outcomeNote: "Stable result.",
+        finalizedAt: "2026-03-25T00:10:00Z",
+        finalizedState: "finalized",
+        delta: "",
+        impact: "",
+        checklistStatus: "1/1 completed",
+        checklist: [],
+        tasks: [],
+      },
+      kpis: {
+        stacSearchResultCount: 1,
+        selectedEvidenceCount: 1,
+        linkedRuleCount: 1,
+        coverage: { numerator: 1, denominator: 1 },
+        snapshotExportedAt: "2026-03-25T00:10:00Z",
+      },
+      summary: {
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        ruleId: "R-1",
+        ruleSection: "Monitoring period",
+        ruleText: "Evidence must fall inside the monitoring period.",
+        selectedEvidenceId: "sentinel-scene-1",
+        selectedEvidenceDatetime: "2026-03-25T00:00:00Z",
+        cloudCover: 4,
+        aoiLabel: "Project AOI",
+        reviewState: "finalized",
+        generatedAt: "2026-03-25T00:10:00Z",
+        outcomeNote: "Stable result.",
+        stacSearchResultCount: 1,
+        linkedRuleCount: 1,
+        selectedEvidenceLinkedRules: ["R-1"],
+        checklistStatus: "1/1 completed",
+        reconciliationStatus: "Supported",
+        reconciliationReason: "All expected evidence is linked.",
+        narrative: "Finalized verify review.",
+      },
+    };
+    const evidencePins: EvidencePin[] = [
+      {
+        id: "pin-pdd-1",
+        kind: "pdd",
+        title: "PDD.pdf",
+        cited_ids: [],
+        created_at: "2026-03-25T00:00:00Z",
+        pdd_fragments: [{ evidence_id: "pin-pdd-1", fragment_id: "frag-monitoring-period", label: "Monitoring period" }],
+        pdd_fragment_links: [{ fragment_id: "frag-monitoring-period", rule_id: "R-1", linked_at: "2026-03-25T00:01:00Z" }],
+      },
+    ];
+    const fetchMock = jest.fn(async () => new Response(new Uint8Array([1, 2, 3]), { status: 200 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: jest.fn(() => "blob:audit-pack") });
+    Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: jest.fn() });
+    jest.spyOn(URL, "createObjectURL").mockReturnValue("blob:audit-pack");
+    jest.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <FinalReviewSummaryPanel
+          summary={artifact.summary}
+          artifact={artifact}
+          currentRunLabel="run-1234"
+          finalizedAt="2026-03-25T00:10:00Z"
+          reviewedRuleCount={1}
+          linkedEvidenceCount={1}
+          evidencePins={evidencePins}
+          wizard={getVerifyWizardStepDetails({
+            selectedRuleId: "R-1",
+            aoiHash: "aoi",
+            stacItemIds: ["item-1"],
+            selectedStacItemId: "item-1",
+            linkedRuleIds: ["R-1"],
+            reviewerArtifactSavedAt: "2026-03-25T00:05:00Z",
+            finalizedAt: "2026-03-25T00:10:00Z",
+          })}
+          onDownloadJson={() => {}}
+          onDownloadPdf={() => {}}
+          onStartAnotherRun={() => {}}
+          onViewRunHistory={() => {}}
+        />,
+      );
+    });
+
+    await act(async () => {
+      const auditPackButton = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find((button) =>
+        button.textContent?.includes("Download audit pack"),
+      );
+      auditPackButton?.click();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/exports/audit-pack",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(String),
+      }),
+    );
+    const requestBody = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string) as {
+      evidencePins?: EvidencePin[];
+    };
+    expect(requestBody.evidencePins).toEqual(evidencePins);
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/tests/exports/auditPack.contract.test.ts
+++ b/tests/exports/auditPack.contract.test.ts
@@ -1,117 +1,97 @@
 import { describe, expect, test } from "@jest/globals";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { strFromU8, unzipSync } from "fflate";
 import { buildAuditPackZip } from "@/exports/auditPack";
 import { buildVerificationPackContractFiles } from "@/exports/verificationPackContract";
 import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
 import type { EvidencePin } from "@/lib/proofMap/types";
 
+const rulesJson = {
+  rules: [
+    { id: "R-1-0001", text: "Submit a monitoring report for the reporting period." },
+    { id: "R-1-0002", text: "Provide supporting baseline calculations." },
+  ],
+};
+
+const sectionsJson = {
+  sections: [
+    { id: "S-1", title: "Monitoring", anchor: "#S-1" },
+    { id: "S-2", title: "Baseline", anchor: "#S-2" },
+  ],
+};
+
+const trace = {
+  version: 1,
+  method: { code: "AR-ACM0003", version: "v02-0" },
+  rule_to_sections: {
+    "R-1-0001": [{ section_id: "S-1", title: "Monitoring", anchor: "#S-1", match: "explicit" }],
+    "R-1-0002": [{ section_id: "S-2", title: "Baseline", anchor: "#S-2", match: "explicit" }],
+  },
+  rule_to_evidence: {},
+} as const;
+
+function withTemporaryMethodologyCheckout<T>(callback: () => T): T {
+  const previousCwd = process.cwd();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "article6-audit-pack-"));
+  const methodDir = path.join(root, "public", "methodologies", "UNFCCC", "Forestry", "AR-ACM0003", "v02-0");
+
+  fs.mkdirSync(methodDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(methodDir, "META.json"),
+    JSON.stringify({ code: "AR-ACM0003", version: "v02-0", title: "Temporary test methodology" }),
+  );
+  fs.writeFileSync(path.join(methodDir, "rules.json"), JSON.stringify(rulesJson));
+  fs.writeFileSync(path.join(methodDir, "sections.json"), JSON.stringify(sectionsJson));
+  fs.writeFileSync(path.join(methodDir, "rules.rich.json"), JSON.stringify(rulesJson));
+  fs.writeFileSync(path.join(methodDir, "sections.rich.json"), JSON.stringify(sectionsJson));
+
+  try {
+    process.chdir(root);
+    return callback();
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
 describe("audit pack verification contract", () => {
-  test("includes demo-safe verification contract files without requiring methodology checkout", async () => {
+  test("includes truthful demo-safe fallback contract files", () => {
     const files = buildVerificationPackContractFiles({
       generatedAt: "2026-04-23T00:00:00.000Z",
       methodCode: "AR-ACM0003",
       version: "v02-0",
-      rulesJson: {
-        rules: [
-          { id: "R-1-0001", text: "Submit a monitoring report for the reporting period." },
-          { rule_id: "R-1-0002", text: "Provide supporting baseline calculations." },
-        ],
-      },
-      sectionsJson: {
-        sections: [
-          { id: "S-1", title: "Monitoring" },
-          { id: "S-2", title: "Baseline" },
-        ],
-      },
-      trace: {
-        version: 1,
-        method: { code: "AR-ACM0003", version: "v02-0" },
-        rule_to_sections: {
-          "R-1-0001": [{ section_id: "S-1", title: "Monitoring", anchor: "#S-1", match: "explicit" }],
-          "R-1-0002": [{ section_id: "S-2", title: "Baseline", anchor: "#S-2", match: "explicit" }],
-        },
-        rule_to_evidence: {},
-      },
+      rulesJson,
+      sectionsJson,
+      trace,
     });
+    const fileMap = new Map(files.map((file) => [file.path, file.bytes.toString("utf8")]));
 
-    const fileMap = new Map(
-      files.map((file) => [file.path, file.bytes.toString("utf8")]),
-    );
-
-    const requiredFiles = [
-      "project.json",
-      "evidence-manifest.json",
-      "requirement-review.json",
-      "trace.json",
-      "trail.jsonl",
-      "VERIFICATION_REPORT.html",
-    ];
-
-    for (const path of requiredFiles) {
-      expect(fileMap.has(path)).toBe(true);
+    for (const required of ["project.json", "evidence-manifest.json", "requirement-review.json", "trace.json", "trail.jsonl", "VERIFICATION_REPORT.html"]) {
+      expect(fileMap.has(required)).toBe(true);
     }
-
-    const project = JSON.parse(fileMap.get("project.json")!) as {
-      pack_profile: { name: string; not_a_formal_opinion: boolean };
-      project_context: { placeholder: boolean; placeholder_reason: string };
-      reviewer_assignment: { placeholder: boolean };
-    };
-    expect(project.pack_profile.name).toBe("demo_verification_contract");
-    expect(project.pack_profile.not_a_formal_opinion).toBe(true);
-    expect(project.project_context.placeholder).toBe(true);
-    expect(project.project_context.placeholder_reason).toMatch(/project-specific evidence/i);
-    expect(project.reviewer_assignment.placeholder).toBe(true);
-
-    const evidenceManifest = JSON.parse(fileMap.get("evidence-manifest.json")!) as {
-      summary: { total_refs: number; provided_refs: number; placeholder_refs: number };
-      evidence: Array<{ sha256: string | null; included_in_pack: boolean; placeholder: boolean }>;
-    };
-    expect(evidenceManifest.summary.total_refs).toBeGreaterThan(0);
-    expect(evidenceManifest.summary.provided_refs).toBe(0);
-    expect(evidenceManifest.summary.placeholder_refs).toBe(evidenceManifest.summary.total_refs);
-    expect(evidenceManifest.evidence.every((entry) => entry.included_in_pack === false)).toBe(true);
-    expect(evidenceManifest.evidence.every((entry) => entry.sha256 === null)).toBe(true);
-    expect(evidenceManifest.evidence.every((entry) => entry.placeholder === true)).toBe(true);
 
     const requirementReview = JSON.parse(fileMap.get("requirement-review.json")!) as {
       summary: { total_rules: number; placeholder_rule_reviews: number; linked_evidence_refs: number };
-      rules: Array<{
-        rule_id: string;
-        status: string;
-        status_basis: string;
-        linked_evidence_refs: string[];
-        requested_evidence_refs: string[];
-        reviewer: { placeholder: boolean };
-        timestamps: { reviewed_at: string | null };
-      }>;
+      rules: Array<{ status: string; status_basis: string; linked_evidence_refs: string[] }>;
     };
-    expect(requirementReview.summary.total_rules).toBe(2);
-    expect(requirementReview.summary.placeholder_rule_reviews).toBe(2);
-    expect(requirementReview.summary.linked_evidence_refs).toBe(0);
+    expect(requirementReview.summary).toMatchObject({
+      total_rules: 2,
+      placeholder_rule_reviews: 2,
+      linked_evidence_refs: 0,
+    });
     expect(requirementReview.rules.every((rule) => rule.status === "awaiting_project_evidence")).toBe(true);
     expect(requirementReview.rules.every((rule) => rule.status_basis === "demo_placeholder")).toBe(true);
     expect(requirementReview.rules.every((rule) => rule.linked_evidence_refs.length === 0)).toBe(true);
-    expect(requirementReview.rules.every((rule) => rule.requested_evidence_refs.length === 1)).toBe(true);
-    expect(requirementReview.rules.every((rule) => rule.reviewer.placeholder === true)).toBe(true);
-    expect(requirementReview.rules.every((rule) => rule.timestamps.reviewed_at === null)).toBe(true);
 
-    const trace = JSON.parse(fileMap.get("trace.json")!) as {
-      verification_contract: { mode: string; report_path: string; placeholder: boolean };
-      rule_to_review: Record<string, { status: string; requested_evidence_refs: string[] }>;
-      rule_to_evidence: Record<string, string[]>;
+    const evidenceManifest = JSON.parse(fileMap.get("evidence-manifest.json")!) as {
+      summary: { provided_refs: number; placeholder_refs: number };
     };
-    expect(trace.verification_contract.mode).toBe("demo_placeholder_review_contract");
-    expect(trace.verification_contract.report_path).toBe("VERIFICATION_REPORT.html");
-    expect(trace.verification_contract.placeholder).toBe(true);
-    expect(trace.rule_to_review["R-1-0001"]?.status).toBe("awaiting_project_evidence");
-    expect(trace.rule_to_review["R-1-0001"]?.requested_evidence_refs).toHaveLength(1);
-    expect(trace.rule_to_review["R-1-0002"]?.status).toBe("awaiting_project_evidence");
-    expect(trace.rule_to_evidence["R-1-0001"]).toEqual([]);
+    expect(evidenceManifest.summary.provided_refs).toBe(0);
+    expect(evidenceManifest.summary.placeholder_refs).toBe(2);
 
-    const reportHtml = fileMap.get("VERIFICATION_REPORT.html")!;
-    expect(reportHtml).toContain("Demo review record only.");
-    expect(reportHtml).toContain("not a formal verifier opinion");
-    expect(reportHtml).toContain("R-1-0001");
+    expect(fileMap.get("VERIFICATION_REPORT.html")).toContain("not a formal verifier opinion");
   });
 
   test("uses finalized review artifact and linked evidence in audit-pack zip when supplied", () => {
@@ -150,9 +130,7 @@ describe("audit pack verification contract", () => {
         delta: "",
         impact: "",
         checklistStatus: "2/2 completed",
-        checklist: [
-          { id: "read-overview", label: "Read method overview", checked: true, updatedAt: "2026-04-24T11:55:00.000Z" },
-        ],
+        checklist: [{ id: "read-overview", label: "Read method overview", checked: true, updatedAt: "2026-04-24T11:55:00.000Z" }],
         tasks: [],
       },
       kpis: {
@@ -201,94 +179,43 @@ describe("audit pack verification contract", () => {
         title: "PDD.pdf",
         cited_ids: [],
         created_at: "2026-04-24T11:56:00.000Z",
-        pdd_fragments: [
-          {
-            evidence_id: "pin-pdd-1",
-            fragment_id: "frag-monitoring-period",
-            label: "Monitoring period",
-            page_start: 12,
-            excerpt: "Monitoring period evidence.",
-          },
-        ],
-        pdd_fragment_links: [
-          {
-            fragment_id: "frag-monitoring-period",
-            rule_id: "R-1-0001",
-            linked_at: "2026-04-24T11:57:00.000Z",
-          },
-        ],
+        pdd_fragments: [{ evidence_id: "pin-pdd-1", fragment_id: "frag-monitoring-period", label: "Monitoring period", page_start: 12 }],
+        pdd_fragment_links: [{ fragment_id: "frag-monitoring-period", rule_id: "R-1-0001", linked_at: "2026-04-24T11:57:00.000Z" }],
       },
     ];
 
-    const zip = buildAuditPackZip("AR-ACM0003", "v02-0", { finalizedReview: { artifact, evidencePins } });
+    const zip = withTemporaryMethodologyCheckout(() =>
+      buildAuditPackZip("AR-ACM0003", "v02-0", { finalizedReview: { artifact, evidencePins } }),
+    );
     const entries = unzipSync(new Uint8Array(zip));
-    const readJson = (path: string) => JSON.parse(strFromU8(entries[path]));
+    const readJson = (entry: string) => JSON.parse(strFromU8(entries[entry]));
 
     const manifest = readJson("manifest.json") as { generated_at: string };
     expect(manifest.generated_at).toBe("2026-04-24T12:00:00.000Z");
     expect(manifest.generated_at).not.toBe("1970-01-01T00:00:00.000Z");
 
-    const trace = readJson("trace.json") as {
-      verification_contract: { mode: string; placeholder: boolean };
-      rule_to_review: Record<string, { status: string; status_basis: string; linked_evidence_refs: string[] }>;
-    };
-    expect(trace.verification_contract).toMatchObject({
-      mode: "finalized_project_review_contract",
-      placeholder: false,
-    });
-    expect(trace.rule_to_review["R-1-0001"]).toMatchObject({
-      status: "finalized",
-      status_basis: "finalized_project_review",
-      linked_evidence_refs: expect.arrayContaining(["sentinel-scene-1", "frag-monitoring-period"]),
-    });
-
     const requirementReview = readJson("requirement-review.json") as {
       summary: { placeholder_rule_reviews: number; linked_evidence_refs: number };
-      rules: Array<{
-        rule_id: string;
-        status: string;
-        status_basis: string;
-        linked_evidence_refs: string[];
-        reconciliation?: { status: string | null; reason: string | null };
-        reviewer_artifact?: { finalized_state: string | null; outcome_note: string | null };
-      }>;
+      rules: Array<{ linked_evidence_refs: string[]; reconciliation?: { status: string | null }; reviewer_artifact?: { outcome_note: string | null } }>;
     };
     expect(requirementReview.summary.placeholder_rule_reviews).toBe(0);
     expect(requirementReview.summary.linked_evidence_refs).toBeGreaterThanOrEqual(2);
     expect(requirementReview.rules).toHaveLength(1);
-    expect(requirementReview.rules[0]).toMatchObject({
-      rule_id: "R-1-0001",
-      status: "finalized",
-      status_basis: "finalized_project_review",
-      reconciliation: {
-        status: "Supported",
-        reason: "All expected evidence is linked and reviewer artifact is saved.",
-      },
-      reviewer_artifact: {
-        finalized_state: "finalized",
-        outcome_note: "Ready for external review.",
-      },
-    });
-    expect(requirementReview.rules[0].linked_evidence_refs).toEqual(
-      expect.arrayContaining(["sentinel-scene-1", "frag-monitoring-period"]),
-    );
+    expect(requirementReview.rules[0].linked_evidence_refs).toEqual(expect.arrayContaining(["sentinel-scene-1", "frag-monitoring-period"]));
+    expect(requirementReview.rules[0].reconciliation?.status).toBe("Supported");
+    expect(requirementReview.rules[0].reviewer_artifact?.outcome_note).toBe("Ready for external review.");
     expect(JSON.stringify(requirementReview)).not.toContain("awaiting_project_evidence");
 
     const evidenceManifest = readJson("evidence-manifest.json") as {
       summary: { provided_refs: number; placeholder_refs: number };
-      evidence: Array<{ evidence_ref: string; status: string; fragment_id?: string; placeholder: boolean }>;
+      evidence: Array<{ evidence_ref: string; status: string; placeholder: boolean }>;
     };
     expect(evidenceManifest.summary.provided_refs).toBeGreaterThanOrEqual(2);
     expect(evidenceManifest.summary.placeholder_refs).toBe(0);
     expect(evidenceManifest.evidence).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ evidence_ref: "sentinel-scene-1", status: "provided", placeholder: false }),
-        expect.objectContaining({
-          evidence_ref: "frag-monitoring-period",
-          status: "provided",
-          fragment_id: "frag-monitoring-period",
-          placeholder: false,
-        }),
+        expect.objectContaining({ evidence_ref: "frag-monitoring-period", status: "provided", placeholder: false }),
       ]),
     );
     expect(JSON.stringify(evidenceManifest)).not.toContain("awaiting_project_evidence");

--- a/tests/exports/auditPack.contract.test.ts
+++ b/tests/exports/auditPack.contract.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "@jest/globals";
+import { strFromU8, unzipSync } from "fflate";
+import { buildAuditPackZip } from "@/exports/auditPack";
 import { buildVerificationPackContractFiles } from "@/exports/verificationPackContract";
+import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
+import type { EvidencePin } from "@/lib/proofMap/types";
 
 describe("audit pack verification contract", () => {
   test("includes demo-safe verification contract files without requiring methodology checkout", async () => {
@@ -108,5 +112,185 @@ describe("audit pack verification contract", () => {
     expect(reportHtml).toContain("Demo review record only.");
     expect(reportHtml).toContain("not a formal verifier opinion");
     expect(reportHtml).toContain("R-1-0001");
+  });
+
+  test("uses finalized review artifact and linked evidence in audit-pack zip when supplied", () => {
+    const artifact: EvidenceSnapshot = {
+      method: { code: "AR-ACM0003", version: "v02-0" },
+      evidence_source: { type: "stac_url", ref: "https://stac.example.test" },
+      selected: {
+        id: "sentinel-scene-1",
+        item: {
+          id: "sentinel-scene-1",
+          datetime: "2026-04-20T00:00:00Z",
+          collection: "sentinel-2",
+          cloud_cover: 3,
+          linked_rules: ["R-1-0001"],
+        },
+      },
+      outcome: {
+        aoi: { hash: "aoi-hash", bbox: [1, 2, 3, 4], areaKm2: 12 },
+        stac: { query: { source: "https://stac.example.test" }, itemIds: ["sentinel-scene-1"] },
+        linkage: { selectedRuleId: "R-1-0001", linkedRuleIds: ["R-1-0001"] },
+        exportState: { snapshotExportedAt: "2026-04-24T12:00:00.000Z" },
+        provenance: {
+          methodCode: "AR-ACM0003",
+          version: "v02-0",
+          generatedAt: "2026-04-24T12:00:00.000Z",
+          snapshotSchemaVersion: "evidence-snapshot/v2",
+        },
+      },
+      verifier: {
+        runId: "run-final-1",
+        createdAt: "2026-04-24T11:50:00.000Z",
+        minutes: "Reviewer checked selected satellite evidence and PDD fragment.",
+        outcomeNote: "Ready for external review.",
+        finalizedAt: "2026-04-24T12:00:00.000Z",
+        finalizedState: "finalized",
+        delta: "",
+        impact: "",
+        checklistStatus: "2/2 completed",
+        checklist: [
+          { id: "read-overview", label: "Read method overview", checked: true, updatedAt: "2026-04-24T11:55:00.000Z" },
+        ],
+        tasks: [],
+      },
+      kpis: {
+        stacSearchResultCount: 1,
+        selectedEvidenceCount: 1,
+        linkedRuleCount: 1,
+        coverage: { numerator: 1, denominator: 2 },
+        snapshotExportedAt: "2026-04-24T12:00:00.000Z",
+      },
+      summary: {
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        ruleId: "R-1-0001",
+        ruleSection: "Monitoring",
+        ruleText: "Submit a monitoring report for the reporting period.",
+        selectedEvidenceId: "sentinel-scene-1",
+        selectedEvidenceDatetime: "2026-04-20T00:00:00Z",
+        cloudCover: 3,
+        aoiLabel: "Demo AOI",
+        reviewState: "finalized",
+        generatedAt: "2026-04-24T12:00:00.000Z",
+        outcomeNote: "Ready for external review.",
+        stacSearchResultCount: 1,
+        linkedRuleCount: 1,
+        selectedEvidenceLinkedRules: ["R-1-0001"],
+        checklistStatus: "2/2 completed",
+        reconciliationStatus: "Supported",
+        reconciliationReason: "All expected evidence is linked and reviewer artifact is saved.",
+        narrative: "Finalized verify review. Rule R-1-0001. Selected evidence sentinel-scene-1 linked to R-1-0001.",
+      },
+    };
+    const evidencePins: EvidencePin[] = [
+      {
+        id: "pin-scene-1",
+        kind: "note",
+        title: "sentinel-scene-1",
+        ruleId: "R-1-0001",
+        itemId: "sentinel-scene-1",
+        cited_ids: ["R-1-0001"],
+        stac_item_ids: ["sentinel-scene-1"],
+        created_at: "2026-04-24T11:54:00.000Z",
+      },
+      {
+        id: "pin-pdd-1",
+        kind: "pdd",
+        title: "PDD.pdf",
+        cited_ids: [],
+        created_at: "2026-04-24T11:56:00.000Z",
+        pdd_fragments: [
+          {
+            evidence_id: "pin-pdd-1",
+            fragment_id: "frag-monitoring-period",
+            label: "Monitoring period",
+            page_start: 12,
+            excerpt: "Monitoring period evidence.",
+          },
+        ],
+        pdd_fragment_links: [
+          {
+            fragment_id: "frag-monitoring-period",
+            rule_id: "R-1-0001",
+            linked_at: "2026-04-24T11:57:00.000Z",
+          },
+        ],
+      },
+    ];
+
+    const zip = buildAuditPackZip("AR-ACM0003", "v02-0", { finalizedReview: { artifact, evidencePins } });
+    const entries = unzipSync(new Uint8Array(zip));
+    const readJson = (path: string) => JSON.parse(strFromU8(entries[path]));
+
+    const manifest = readJson("manifest.json") as { generated_at: string };
+    expect(manifest.generated_at).toBe("2026-04-24T12:00:00.000Z");
+    expect(manifest.generated_at).not.toBe("1970-01-01T00:00:00.000Z");
+
+    const trace = readJson("trace.json") as {
+      verification_contract: { mode: string; placeholder: boolean };
+      rule_to_review: Record<string, { status: string; status_basis: string; linked_evidence_refs: string[] }>;
+    };
+    expect(trace.verification_contract).toMatchObject({
+      mode: "finalized_project_review_contract",
+      placeholder: false,
+    });
+    expect(trace.rule_to_review["R-1-0001"]).toMatchObject({
+      status: "finalized",
+      status_basis: "finalized_project_review",
+      linked_evidence_refs: expect.arrayContaining(["sentinel-scene-1", "frag-monitoring-period"]),
+    });
+
+    const requirementReview = readJson("requirement-review.json") as {
+      summary: { placeholder_rule_reviews: number; linked_evidence_refs: number };
+      rules: Array<{
+        rule_id: string;
+        status: string;
+        status_basis: string;
+        linked_evidence_refs: string[];
+        reconciliation?: { status: string | null; reason: string | null };
+        reviewer_artifact?: { finalized_state: string | null; outcome_note: string | null };
+      }>;
+    };
+    expect(requirementReview.summary.placeholder_rule_reviews).toBe(0);
+    expect(requirementReview.summary.linked_evidence_refs).toBeGreaterThanOrEqual(2);
+    expect(requirementReview.rules).toHaveLength(1);
+    expect(requirementReview.rules[0]).toMatchObject({
+      rule_id: "R-1-0001",
+      status: "finalized",
+      status_basis: "finalized_project_review",
+      reconciliation: {
+        status: "Supported",
+        reason: "All expected evidence is linked and reviewer artifact is saved.",
+      },
+      reviewer_artifact: {
+        finalized_state: "finalized",
+        outcome_note: "Ready for external review.",
+      },
+    });
+    expect(requirementReview.rules[0].linked_evidence_refs).toEqual(
+      expect.arrayContaining(["sentinel-scene-1", "frag-monitoring-period"]),
+    );
+    expect(JSON.stringify(requirementReview)).not.toContain("awaiting_project_evidence");
+
+    const evidenceManifest = readJson("evidence-manifest.json") as {
+      summary: { provided_refs: number; placeholder_refs: number };
+      evidence: Array<{ evidence_ref: string; status: string; fragment_id?: string; placeholder: boolean }>;
+    };
+    expect(evidenceManifest.summary.provided_refs).toBeGreaterThanOrEqual(2);
+    expect(evidenceManifest.summary.placeholder_refs).toBe(0);
+    expect(evidenceManifest.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ evidence_ref: "sentinel-scene-1", status: "provided", placeholder: false }),
+        expect.objectContaining({
+          evidence_ref: "frag-monitoring-period",
+          status: "provided",
+          fragment_id: "frag-monitoring-period",
+          placeholder: false,
+        }),
+      ]),
+    );
+    expect(JSON.stringify(evidenceManifest)).not.toContain("awaiting_project_evidence");
   });
 });


### PR DESCRIPTION
## What
- Adds finalized-review support to audit-pack zip export via POST payload.
- Uses finalized rule/review/evidence/reconciliation/reviewer-note data when present.
- Keeps the method-only GET scaffold fallback truthful when finalized review data is missing.

## Validation
- `npx jest tests/exports/auditPack.contract.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`
- `node scripts/build-audit-pack.mjs AR-ACM0003 v02-0 /tmp/audit-pack-finalized-branch-scaffold.zip && npm run verify:audit-pack -- /tmp/audit-pack-finalized-branch-scaffold.zip`