### PR TITLE
Fix/audit pack stale finalized artifact

### DIFF
--- a/src/app/api/exports/audit-pack/route.ts
+++ b/src/app/api/exports/audit-pack/route.ts
@@ -6,6 +6,10 @@ import { ZodError } from "zod";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+function asTrimmedOrEmpty(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const method = url.searchParams.get("method") || "";
@@ -45,6 +49,19 @@ export async function POST(req: Request) {
       }
       throw error;
     }
+
+    if (artifact) {
+      if (asTrimmedOrEmpty(artifact.method.code) !== asTrimmedOrEmpty(method)) {
+        return new Response("Artifact method does not match request method", { status: 400 });
+      }
+      if (asTrimmedOrEmpty(artifact.method.version) !== asTrimmedOrEmpty(version)) {
+        return new Response("Artifact version does not match request version", { status: 400 });
+      }
+      if (artifact.verifier?.finalizedState !== "finalized" || !asTrimmedOrEmpty(artifact.verifier.finalizedAt)) {
+        return new Response("Artifact must be explicitly finalized", { status: 400 });
+      }
+    }
+
     const evidencePins = Array.isArray(record.evidencePins) ? (record.evidencePins as EvidencePin[]) : [];
     const zip = buildAuditPackZip(method, version, {
       finalizedReview: artifact ? { artifact, evidencePins } : null,

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -154,6 +154,39 @@ function shortSha(value: string): string {
   return `${trimmed.slice(0, 10)}…${trimmed.slice(-2)}`;
 }
 
+function asTrimmedOrNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function finalizedArtifactRuleId(artifact: EvidenceSnapshot | null): string | null {
+  return (
+    asTrimmedOrNull(artifact?.summary?.ruleId) ??
+    asTrimmedOrNull(artifact?.outcome?.linkage.selectedRuleId) ??
+    asTrimmedOrNull(artifact?.outcome?.linkage.linkedRuleIds?.[0]) ??
+    null
+  );
+}
+
+export function finalizedArtifactMatchesContext(input: {
+  artifact: EvidenceSnapshot | null;
+  methodCode: string;
+  version: string;
+  selectedRuleId: string | null;
+  runId: string;
+  finalizedAt: string | null;
+}): boolean {
+  const { artifact } = input;
+  if (!artifact) return false;
+  if (artifact.verifier?.finalizedState !== "finalized") return false;
+  if (asTrimmedOrNull(artifact.verifier?.finalizedAt) !== asTrimmedOrNull(input.finalizedAt)) return false;
+  if (asTrimmedOrNull(artifact.verifier?.runId) !== asTrimmedOrNull(input.runId)) return false;
+  if (asTrimmedOrNull(artifact.method.code) !== asTrimmedOrNull(input.methodCode)) return false;
+  if (asTrimmedOrNull(artifact.method.version) !== asTrimmedOrNull(input.version)) return false;
+  if (finalizedArtifactRuleId(artifact) !== asTrimmedOrNull(input.selectedRuleId)) return false;
+  return true;
+}
+
 function downloadJson(value: unknown, filename: string) {
   const text = canonicalJsonStringify(value);
   const blob = new Blob([text], { type: "application/json" });
@@ -1855,6 +1888,26 @@ export default function ProofMapTab({
     setReviewPdfBusy(false);
   }, [currentWorkspaceIsFinal]);
 
+  const reviewArtifactMatchesCurrentContext = useMemo(
+    () =>
+      finalizedArtifactMatchesContext({
+        artifact: reviewArtifact,
+        methodCode,
+        version,
+        selectedRuleId,
+        runId: verifierBundle.runContext.runId,
+        finalizedAt: verifierBundle.finalizedAt,
+      }),
+    [methodCode, reviewArtifact, selectedRuleId, verifierBundle.finalizedAt, verifierBundle.runContext.runId, version],
+  );
+  const activeReviewArtifact = reviewArtifactMatchesCurrentContext ? reviewArtifact : null;
+
+  useEffect(() => {
+    if (!reviewArtifact) return;
+    if (reviewArtifactMatchesCurrentContext) return;
+    setReviewArtifact(null);
+  }, [reviewArtifact, reviewArtifactMatchesCurrentContext]);
+
   const buildStacItemsJson = useCallback(() => {
     if (!latestStacRun || latestStacRun.status !== "ok") return { items: [] as Array<Record<string, unknown>> };
     if (!latestStacRun.result_json) return { items: [] as Array<Record<string, unknown>> };
@@ -2066,7 +2119,7 @@ export default function ProofMapTab({
   );
 
   useEffect(() => {
-    if (!currentWorkspaceIsFinal || reviewArtifact || !verifierBundle.finalizedAt) return;
+    if (!currentWorkspaceIsFinal || activeReviewArtifact || !verifierBundle.finalizedAt) return;
     let active = true;
     void buildFinalReviewArtifact({
       finalizedAt: verifierBundle.finalizedAt,
@@ -2084,7 +2137,7 @@ export default function ProofMapTab({
     return () => {
       active = false;
     };
-  }, [buildFinalReviewArtifact, currentWorkspaceIsFinal, reviewArtifact, verifierBundle]);
+  }, [activeReviewArtifact, buildFinalReviewArtifact, currentWorkspaceIsFinal, verifierBundle]);
 
   const handleFinalizeRun = useCallback(() => {
     if (finalizeGate && !finalizeGate.canFinalize) return;
@@ -2572,7 +2625,7 @@ export default function ProofMapTab({
     const finalizedAt = verifierBundle.finalizedAt ?? verifierBundle.exportedAt;
     if (!finalizedAt) return;
     const artifact =
-      reviewArtifact ??
+      activeReviewArtifact ??
       (
         await buildFinalReviewArtifact({
           finalizedAt,
@@ -2585,7 +2638,7 @@ export default function ProofMapTab({
     setReviewArtifact(artifact);
     const filename = `verify-final.${safeFilename(methodCode)}.${safeFilename(version)}.${safeFilename(verifierBundle.runContext.runId)}.json`;
     downloadJson(artifact, filename);
-  }, [buildFinalReviewArtifact, methodCode, reviewArtifact, verifierBundle, version]);
+  }, [activeReviewArtifact, buildFinalReviewArtifact, methodCode, verifierBundle, version]);
 
   const handleDownloadReviewSummaryPdf = useCallback(async () => {
     const finalizedAt = verifierBundle.finalizedAt ?? verifierBundle.exportedAt;
@@ -2594,7 +2647,7 @@ export default function ProofMapTab({
     setReviewPdfError(null);
     try {
       const artifact =
-        reviewArtifact ??
+        activeReviewArtifact ??
         (
           await buildFinalReviewArtifact({
             finalizedAt,
@@ -2613,7 +2666,7 @@ export default function ProofMapTab({
     } finally {
       setReviewPdfBusy(false);
     }
-  }, [buildFinalReviewArtifact, methodCode, reviewArtifact, reviewSummary, verifierBundle, version]);
+  }, [activeReviewArtifact, buildFinalReviewArtifact, methodCode, reviewSummary, verifierBundle, version]);
 
   const handleCopyReviewSummaryLink = useCallback(async () => {
     if (typeof window === "undefined") return;
@@ -3979,8 +4032,8 @@ export default function ProofMapTab({
           <div className="transition">
             {currentWorkspaceIsFinal ? (
               <FinalReviewSummaryPanel
-                summary={reviewArtifact?.summary ?? reviewSummary}
-                artifact={reviewArtifact}
+                summary={activeReviewArtifact?.summary ?? reviewSummary}
+                artifact={activeReviewArtifact}
           evidencePins={evidencePins}
                 currentRunLabel={currentRunLabel}
                 loadedFromRunLabel={loadedFromRunLabel}
@@ -4072,8 +4125,8 @@ export default function ProofMapTab({
                 }
                 finalizedResult={
                   <ReviewSummaryCard
-                    summary={reviewArtifact?.summary ?? reviewSummary}
-                    artifact={reviewArtifact}
+                    summary={activeReviewArtifact?.summary ?? reviewSummary}
+                    artifact={activeReviewArtifact}
                     onDownloadJson={() => {
                       void handleDownloadReviewSummaryJson();
                     }}

--- a/tests/app/api/exports/audit-pack.route.test.ts
+++ b/tests/app/api/exports/audit-pack.route.test.ts
@@ -1,115 +1,231 @@
-import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { GET, POST } from "@/app/api/exports/audit-pack/route";
 import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
 
-const buildAuditPackZip = jest.fn();
+function buildArtifact(overrides?: Partial<EvidenceSnapshot>): EvidenceSnapshot {
+  const artifact: EvidenceSnapshot = {
+    method: { code: "AR-ACM0003", version: "v02-0" },
+    evidence_source: { type: "stac_url", ref: "https://stac.example.test" },
+    selected: {
+      id: "scene-1",
+      item: {
+        id: "scene-1",
+        datetime: "2026-03-25T00:00:00Z",
+        collection: "sentinel-2",
+        cloud_cover: 4,
+        linked_rules: ["R-1"],
+      },
+    },
+    outcome: {
+      aoi: { hash: "aoi", bbox: [0, 0, 1, 1], areaKm2: 1 },
+      stac: { query: { source: "https://stac.example.test" }, itemIds: ["scene-1"] },
+      linkage: { selectedRuleId: "R-1", linkedRuleIds: ["R-1"] },
+      exportState: { snapshotExportedAt: "2026-03-25T00:10:00Z" },
+      provenance: {
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        generatedAt: "2026-03-25T00:10:00Z",
+        snapshotSchemaVersion: "evidence-snapshot/v2",
+      },
+    },
+    verifier: {
+      runId: "run-1234",
+      createdAt: "2026-03-25T00:05:00Z",
+      minutes: "minutes",
+      outcomeNote: "note",
+      finalizedAt: "2026-03-25T00:10:00Z",
+      finalizedState: "finalized",
+      delta: "",
+      impact: "",
+      checklistStatus: "1/1 completed",
+      checklist: [],
+      tasks: [],
+    },
+    kpis: {
+      stacSearchResultCount: 1,
+      selectedEvidenceCount: 1,
+      linkedRuleCount: 1,
+      coverage: { numerator: 1, denominator: 1 },
+      snapshotExportedAt: "2026-03-25T00:10:00Z",
+    },
+    summary: {
+      methodCode: "AR-ACM0003",
+      version: "v02-0",
+      ruleId: "R-1",
+      ruleSection: "Monitoring period",
+      ruleText: "Evidence must fall inside the monitoring period.",
+      selectedEvidenceId: "scene-1",
+      selectedEvidenceDatetime: "2026-03-25T00:00:00Z",
+      cloudCover: 4,
+      aoiLabel: "Project AOI",
+      reviewState: "finalized",
+      generatedAt: "2026-03-25T00:10:00Z",
+      outcomeNote: "Stable result.",
+      stacSearchResultCount: 1,
+      linkedRuleCount: 1,
+      selectedEvidenceLinkedRules: ["R-1"],
+      checklistStatus: "1/1 completed",
+      reconciliationStatus: "Supported",
+      reconciliationReason: "All expected evidence is linked.",
+      narrative: "Finalized verify review.",
+    },
+  };
+  return { ...artifact, ...overrides };
+}
 
-jest.mock("@/exports/auditPack", () => ({
-  buildAuditPackZip: (...args: unknown[]) => buildAuditPackZip(...args),
-}));
+const rulesJson = {
+  rules: [{ id: "R-1", text: "Evidence must fall inside the monitoring period." }],
+};
 
-describe("audit-pack route", () => {
+const sectionsJson = {
+  sections: [{ id: "S-1", title: "Monitoring", anchor: "#S-1" }],
+};
+
+function withTemporaryMethodologyCheckout<T>(callback: () => Promise<T> | T): Promise<T> | T {
+  const previousCwd = process.cwd();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "article6-audit-pack-route-"));
+  const methodDir = path.join(root, "public", "methodologies", "UNFCCC", "Forestry", "AR-ACM0003", "v02-0");
+
+  fs.mkdirSync(methodDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(methodDir, "META.json"),
+    JSON.stringify({ code: "AR-ACM0003", version: "v02-0", title: "Temporary test methodology" }),
+  );
+  fs.writeFileSync(path.join(methodDir, "rules.json"), JSON.stringify(rulesJson));
+  fs.writeFileSync(path.join(methodDir, "sections.json"), JSON.stringify(sectionsJson));
+  fs.writeFileSync(path.join(methodDir, "rules.rich.json"), JSON.stringify(rulesJson));
+  fs.writeFileSync(path.join(methodDir, "sections.rich.json"), JSON.stringify(sectionsJson));
+
+  try {
+    process.chdir(root);
+    return callback();
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("/api/exports/audit-pack route", () => {
   beforeEach(() => {
-    buildAuditPackZip.mockReset();
-    buildAuditPackZip.mockReturnValue(new Uint8Array([0x50, 0x4b, 0x03, 0x04]));
+    jest.clearAllMocks();
   });
 
-  test("POST returns 400 when method/version is missing", async () => {
-    const { POST } = await import("@/app/api/exports/audit-pack/route");
-    const res = await POST(
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("GET rejects missing method/version", async () => {
+    const response = await GET(new Request("http://localhost/api/exports/audit-pack"));
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("Missing ?method=AR-XXXX&version=vYY-Y");
+  });
+
+  it("POST rejects missing method/version", async () => {
+    const response = await POST(
       new Request("http://localhost/api/exports/audit-pack", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ method: "AR-ACM0003" }),
+        body: JSON.stringify({}),
       }),
     );
 
-    expect(res.status).toBe(400);
-    await expect(res.text()).resolves.toContain("Missing method/version");
-    expect(buildAuditPackZip).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("Missing method/version in request body");
   });
 
-  test("POST returns 400 for malformed artifact payloads", async () => {
-    const { POST } = await import("@/app/api/exports/audit-pack/route");
-    const res = await POST(
-      new Request("http://localhost/api/exports/audit-pack", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          method: "AR-ACM0003",
-          version: "v02-0",
-          artifact: { method: { code: "", version: "v02-0" } },
-        }),
-      }),
-    );
-
-    expect(res.status).toBe(400);
-    await expect(res.text()).resolves.toContain("Invalid artifact payload");
-    expect(buildAuditPackZip).not.toHaveBeenCalled();
-  });
-
-  test("POST exports zip for valid finalized payloads", async () => {
-    const artifact: EvidenceSnapshot = {
-      method: { code: "AR-ACM0003", version: "v02-0" },
-      evidence_source: { type: "stac_url", ref: "https://stac.example.test" },
-      verifier: {
-        runId: "run-1",
-        createdAt: "2026-04-24T11:50:00.000Z",
-        minutes: "Reviewed.",
-        outcomeNote: "Ready.",
-        finalizedAt: "2026-04-24T12:00:00.000Z",
-        finalizedState: "finalized",
-        delta: "",
-        impact: "",
-        tasks: [],
-      },
-    };
-
-    const { POST } = await import("@/app/api/exports/audit-pack/route");
-    const res = await POST(
+  it("POST rejects malformed artifact payloads", async () => {
+    const response = await POST(
       new Request("http://localhost/api/exports/audit-pack", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           method: "AR-ACM0003",
           version: "v02-0",
-          artifact,
-          evidencePins: [{ id: "pin-1", kind: "note", title: "scene-1", created_at: "2026-04-24T11:54:00.000Z" }],
+          artifact: { invalid: true },
         }),
       }),
     );
 
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toBe("application/zip");
-    expect(buildAuditPackZip).toHaveBeenCalledWith("AR-ACM0003", "v02-0", {
-      finalizedReview: {
-        artifact,
-        evidencePins: [{ id: "pin-1", kind: "note", title: "scene-1", created_at: "2026-04-24T11:54:00.000Z" }],
-      },
-    });
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("Invalid artifact payload");
   });
 
-  test("POST keeps unexpected export failures as 500", async () => {
-    buildAuditPackZip.mockImplementation(() => {
-      throw new Error("zip failed");
-    });
-    const { POST } = await import("@/app/api/exports/audit-pack/route");
-    const res = await POST(
+  it("POST rejects wrong method and wrong version artifacts", async () => {
+    const wrongMethod = await POST(
       new Request("http://localhost/api/exports/audit-pack", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ method: "AR-ACM0003", version: "v02-0" }),
+        body: JSON.stringify({
+          method: "AR-OTHER",
+          version: "v02-0",
+          artifact: buildArtifact(),
+        }),
+      }),
+    );
+    expect(wrongMethod.status).toBe(400);
+    expect(await wrongMethod.text()).toContain("Artifact method does not match request method");
+
+    const wrongVersion = await POST(
+      new Request("http://localhost/api/exports/audit-pack", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          method: "AR-ACM0003",
+          version: "v99-9",
+          artifact: buildArtifact(),
+        }),
+      }),
+    );
+    expect(wrongVersion.status).toBe(400);
+    expect(await wrongVersion.text()).toContain("Artifact version does not match request version");
+  });
+
+  it("POST rejects draft artifacts", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/exports/audit-pack", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          method: "AR-ACM0003",
+          version: "v02-0",
+          artifact: buildArtifact({
+            verifier: {
+              ...buildArtifact().verifier,
+              finalizedState: "draft",
+              finalizedAt: null,
+            },
+          }),
+        }),
       }),
     );
 
-    expect(res.status).toBe(500);
-    await expect(res.text()).resolves.toContain("zip failed");
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("Artifact must be explicitly finalized");
   });
 
-  test("GET still returns 400 when method/version is missing", async () => {
-    const { GET } = await import("@/app/api/exports/audit-pack/route");
-    const res = await GET(new Request("http://localhost/api/exports/audit-pack"));
+  it("POST exports matching finalized artifacts", async () => {
+    const artifact = buildArtifact();
+    const evidencePins = [{ id: "pin-1", kind: "note", title: "scene-1", cited_ids: [], created_at: "2026-03-25T00:00:00Z" }];
+    const response = await withTemporaryMethodologyCheckout(() =>
+      POST(
+        new Request("http://localhost/api/exports/audit-pack", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            method: "AR-ACM0003",
+            version: "v02-0",
+            artifact,
+            evidencePins,
+          }),
+        }),
+      ),
+    );
 
-    expect(res.status).toBe(400);
-    await expect(res.text()).resolves.toContain("Missing ?method");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
   });
 });

--- a/tests/app/api/exports/audit-pack.route.test.ts
+++ b/tests/app/api/exports/audit-pack.route.test.ts
@@ -84,7 +84,7 @@ const sectionsJson = {
   sections: [{ id: "S-1", title: "Monitoring", anchor: "#S-1" }],
 };
 
-function withTemporaryMethodologyCheckout<T>(callback: () => Promise<T> | T): Promise<T> | T {
+async function withTemporaryMethodologyCheckout<T>(callback: () => Promise<T> | T): Promise<T> {
   const previousCwd = process.cwd();
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "article6-audit-pack-route-"));
   const methodDir = path.join(root, "public", "methodologies", "UNFCCC", "Forestry", "AR-ACM0003", "v02-0");
@@ -101,7 +101,7 @@ function withTemporaryMethodologyCheckout<T>(callback: () => Promise<T> | T): Pr
 
   try {
     process.chdir(root);
-    return callback();
+    return await callback();
   } finally {
     process.chdir(previousCwd);
     fs.rmSync(root, { recursive: true, force: true });

--- a/tests/components/proofMapTab.reviewArtifact.test.ts
+++ b/tests/components/proofMapTab.reviewArtifact.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "@jest/globals";
+import { finalizedArtifactMatchesContext, finalizedArtifactRuleId } from "@/components/map/ProofMapTab";
+import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
+
+function buildArtifact(overrides?: Partial<EvidenceSnapshot>): EvidenceSnapshot {
+  const artifact: EvidenceSnapshot = {
+    method: { code: "AR-ACM0003", version: "v02-0" },
+    evidence_source: { type: "stac_url", ref: "https://stac.example.test" },
+    selected: {
+      id: "scene-1",
+      item: {
+        id: "scene-1",
+        datetime: "2026-03-25T00:00:00Z",
+        collection: "sentinel-2",
+        cloud_cover: 4,
+        linked_rules: ["R-1"],
+      },
+    },
+    outcome: {
+      aoi: { hash: "aoi", bbox: [0, 0, 1, 1], areaKm2: 1 },
+      stac: { query: { source: "https://stac.example.test" }, itemIds: ["scene-1"] },
+      linkage: { selectedRuleId: "R-1", linkedRuleIds: ["R-1"] },
+      exportState: { snapshotExportedAt: "2026-03-25T00:10:00Z" },
+      provenance: {
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        generatedAt: "2026-03-25T00:10:00Z",
+        snapshotSchemaVersion: "evidence-snapshot/v2",
+      },
+    },
+    verifier: {
+      runId: "run-1234",
+      createdAt: "2026-03-25T00:05:00Z",
+      minutes: "minutes",
+      outcomeNote: "note",
+      finalizedAt: "2026-03-25T00:10:00Z",
+      finalizedState: "finalized",
+      delta: "",
+      impact: "",
+      checklistStatus: "1/1 completed",
+      checklist: [],
+      tasks: [],
+    },
+    kpis: {
+      stacSearchResultCount: 1,
+      selectedEvidenceCount: 1,
+      linkedRuleCount: 1,
+      coverage: { numerator: 1, denominator: 1 },
+      snapshotExportedAt: "2026-03-25T00:10:00Z",
+    },
+    summary: {
+      methodCode: "AR-ACM0003",
+      version: "v02-0",
+      ruleId: "R-1",
+      ruleSection: "Monitoring period",
+      ruleText: "Evidence must fall inside the monitoring period.",
+      selectedEvidenceId: "scene-1",
+      selectedEvidenceDatetime: "2026-03-25T00:00:00Z",
+      cloudCover: 4,
+      aoiLabel: "Project AOI",
+      reviewState: "finalized",
+      generatedAt: "2026-03-25T00:10:00Z",
+      outcomeNote: "Stable result.",
+      stacSearchResultCount: 1,
+      linkedRuleCount: 1,
+      selectedEvidenceLinkedRules: ["R-1"],
+      checklistStatus: "1/1 completed",
+      reconciliationStatus: "Supported",
+      reconciliationReason: "All expected evidence is linked.",
+      narrative: "Finalized verify review.",
+    },
+  };
+  return { ...artifact, ...overrides };
+}
+
+describe("ProofMapTab finalized review artifact guard", () => {
+  test("extracts the finalized rule id from the strongest available context", () => {
+    expect(finalizedArtifactRuleId(buildArtifact())).toBe("R-1");
+    expect(
+      finalizedArtifactRuleId(
+        buildArtifact({
+          summary: undefined,
+          outcome: {
+            aoi: { hash: "aoi", bbox: [0, 0, 1, 1], areaKm2: 1 },
+            stac: { query: { source: "https://stac.example.test" }, itemIds: ["scene-1"] },
+            linkage: { selectedRuleId: "R-2", linkedRuleIds: ["R-2"] },
+            exportState: { snapshotExportedAt: "2026-03-25T00:10:00Z" },
+            provenance: {
+              methodCode: "AR-ACM0003",
+              version: "v02-0",
+              generatedAt: "2026-03-25T00:10:00Z",
+              snapshotSchemaVersion: "evidence-snapshot/v2",
+            },
+          },
+        }),
+      ),
+    ).toBe("R-2");
+  });
+
+  test("matches only the current finalized method/version/rule/run/timestamp context", () => {
+    const artifact = buildArtifact();
+    expect(
+      finalizedArtifactMatchesContext({
+        artifact,
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        selectedRuleId: "R-1",
+        runId: "run-1234",
+        finalizedAt: "2026-03-25T00:10:00Z",
+      }),
+    ).toBe(true);
+
+    expect(
+      finalizedArtifactMatchesContext({
+        artifact,
+        methodCode: "AR-ACM9999",
+        version: "v02-0",
+        selectedRuleId: "R-1",
+        runId: "run-1234",
+        finalizedAt: "2026-03-25T00:10:00Z",
+      }),
+    ).toBe(false);
+    expect(
+      finalizedArtifactMatchesContext({
+        artifact,
+        methodCode: "AR-ACM0003",
+        version: "v99-9",
+        selectedRuleId: "R-1",
+        runId: "run-1234",
+        finalizedAt: "2026-03-25T00:10:00Z",
+      }),
+    ).toBe(false);
+    expect(
+      finalizedArtifactMatchesContext({
+        artifact,
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        selectedRuleId: "R-2",
+        runId: "run-1234",
+        finalizedAt: "2026-03-25T00:10:00Z",
+      }),
+    ).toBe(false);
+    expect(
+      finalizedArtifactMatchesContext({
+        artifact,
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        selectedRuleId: "R-1",
+        runId: "run-9999",
+        finalizedAt: "2026-03-25T00:10:00Z",
+      }),
+    ).toBe(false);
+    expect(
+      finalizedArtifactMatchesContext({
+        artifact,
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        selectedRuleId: "R-1",
+        runId: "run-1234",
+        finalizedAt: "2026-03-26T00:10:00Z",
+      }),
+    ).toBe(false);
+    expect(
+      finalizedArtifactMatchesContext({
+        artifact: buildArtifact({
+          verifier: {
+            ...artifact.verifier,
+            finalizedState: "draft",
+          },
+        }),
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        selectedRuleId: "R-1",
+        runId: "run-1234",
+        finalizedAt: "2026-03-25T00:10:00Z",
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

  - invalidate finalized `reviewArtifact` whenever it no longer matches the
  current method, version, rule, run, or finalized timestamp
  - regenerate the finalized artifact for the new finalized context instead of
  reusing stale state
  - reject audit-pack POST artifacts when method or version do not match the
  request
  - reject audit-pack POST artifacts unless they are explicitly finalized
  - add route and panel coverage for finalized artifact validation

  ## Why

  Audit-pack export must never use a stale finalized review artifact. The export
  has to match the exact method/version/rule/run context shown in the UI,
  otherwise a VVB-facing package can contain mismatched finalized review state.

  ## Validation

  - `npx jest tests/app/api/exports/audit-pack.route.test.ts --runInBand`
  - `npx jest tests/components/finalReviewSummaryPanel.test.tsx --runInBand`
  - `npx jest tests/exports/auditPack.contract.test.ts --runInBand`
  - `npm run typecheck`
  - `npm run lint`

  Signed-off-by: Fred E <fredilly@article6.org>

