### PR TITLE
fix: carry saved reviewer artifact into rule review modal

### DIFF
--- a/src/app/m/_components/RuleDetailModal.tsx
+++ b/src/app/m/_components/RuleDetailModal.tsx
@@ -16,6 +16,11 @@ import {
   requirementProvenanceHint,
   type RequirementCoverageRow,
 } from "@/app/m/_lib/requirementCoverage";
+import {
+  createReviewerArtifactContext,
+  readVerifierRunBundle,
+  reviewerArtifactContextMatches,
+} from "@/lib/verify/runState";
 
 type RuleDetailModalProps = {
   open: boolean;
@@ -116,6 +121,58 @@ function evidencePrimaryLabel(item: RequirementCoverageRow["linkedEvidence"][num
 function evidenceSecondaryLabel(item: RequirementCoverageRow["linkedEvidence"][number]): string | null {
   if (item.documentLabel && item.title !== item.documentLabel) return item.title;
   return null;
+}
+
+function resolveRuleReviewReviewerArtifact(input: {
+  rowRuleId: string;
+  canonicalRuleId?: string | null;
+  reviewMethodology?: string | null;
+  reviewVersion?: string | null;
+  reviewerMinutes?: string | null;
+  reviewerOutcomeNote?: string | null;
+}): { reviewerMinutes: string | null; reviewerOutcomeNote: string | null } {
+  const explicitReviewerArtifactProvided = input.reviewerMinutes != null || input.reviewerOutcomeNote != null;
+  if (explicitReviewerArtifactProvided) {
+    return {
+      reviewerMinutes: input.reviewerMinutes ?? null,
+      reviewerOutcomeNote: input.reviewerOutcomeNote ?? null,
+    };
+  }
+
+  const methodCode = input.reviewMethodology?.trim() ?? "";
+  const version = input.reviewVersion?.trim() ?? "";
+  if (!methodCode || !version) {
+    return { reviewerMinutes: null, reviewerOutcomeNote: null };
+  }
+
+  const bundle = readVerifierRunBundle(methodCode, version);
+  if (!bundle.savedReviewerArtifactAt || !bundle.savedReviewerArtifactContext) {
+    return { reviewerMinutes: null, reviewerOutcomeNote: null };
+  }
+
+  const candidateRuleIds = Array.from(
+    new Set([input.canonicalRuleId?.trim() ?? "", input.rowRuleId.trim()].filter(Boolean)),
+  );
+  const matchesCurrentRule = candidateRuleIds.some((ruleId) =>
+    reviewerArtifactContextMatches(
+      bundle.savedReviewerArtifactContext,
+      createReviewerArtifactContext({
+        methodCode,
+        version,
+        ruleId,
+        runId: bundle.runContext.runId,
+      }),
+    ),
+  );
+
+  if (!matchesCurrentRule) {
+    return { reviewerMinutes: null, reviewerOutcomeNote: null };
+  }
+
+  return {
+    reviewerMinutes: bundle.minutes,
+    reviewerOutcomeNote: bundle.outcomeNote,
+  };
 }
 
 export default function RuleDetailModal({
@@ -248,11 +305,19 @@ export default function RuleDetailModal({
         : reviewStatus === "needs_followup"
           ? "Follow-up is still needed before a final judgment."
           : "No judgment recorded yet.";
+  const resolvedReviewerArtifact = resolveRuleReviewReviewerArtifact({
+    rowRuleId: row.ruleId,
+    canonicalRuleId,
+    reviewMethodology,
+    reviewVersion,
+    reviewerMinutes,
+    reviewerOutcomeNote,
+  });
   const reconciliation = reconcileRequirement({
     linkedEvidence: row.linkedEvidence,
     expectedEvidenceTypes: row.expectedEvidenceTypes,
-    reviewerMinutes,
-    reviewerOutcomeNote,
+    reviewerMinutes: resolvedReviewerArtifact.reviewerMinutes,
+    reviewerOutcomeNote: resolvedReviewerArtifact.reviewerOutcomeNote,
   });
   const reconciliationMeta = REQUIREMENT_RECONCILIATION_META[reconciliation.status];
 

--- a/tests/components/ruleDetailModal.test.tsx
+++ b/tests/components/ruleDetailModal.test.tsx
@@ -364,4 +364,4 @@ describe("RuleDetailModal", () => {
     expect(draftOnlyHtml).toContain("Linked evidence is present, but no reviewer artifact is saved yet.");
     expect(draftOnlyHtml).not.toContain("Linked evidence is present and reviewer artifact is saved.");
   });
-}
+});

--- a/tests/components/ruleDetailModal.test.tsx
+++ b/tests/components/ruleDetailModal.test.tsx
@@ -2,6 +2,11 @@ import { describe, expect, it } from "@jest/globals";
 import { renderToStaticMarkup } from "react-dom/server";
 import RuleDetailModal from "@/app/m/_components/RuleDetailModal";
 import type { RequirementCoverageRow } from "@/app/m/_lib/requirementCoverage";
+import {
+  createReviewerArtifactContext,
+  createVerifierRunBundle,
+  persistVerifierRunBundle,
+} from "@/lib/verify/runState";
 
 const linkedRow: RequirementCoverageRow = {
   ruleId: "R-1",
@@ -79,6 +84,35 @@ const missingExpectedEvidenceRow: RequirementCoverageRow = {
   ruleId: "R-3",
   expectedEvidenceTypes: [],
 };
+
+const linkedNoExpectedEvidenceRow: RequirementCoverageRow = {
+  ...missingExpectedEvidenceRow,
+  linkedEvidence: [{ id: "ev-stac-1", title: "Boundary map", type: "STAC item", source: "inventory" }],
+  status: "linked",
+};
+
+function ensureLocalStorage(): Storage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  let store: Record<string, string> = {};
+  const memoryStorage = {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  } as Storage;
+  (globalThis as unknown as { localStorage: Storage }).localStorage = memoryStorage;
+  return memoryStorage;
+}
 
 describe("RuleDetailModal", () => {
   it("renders rich rule detail with methodology metadata", () => {
@@ -209,4 +243,125 @@ describe("RuleDetailModal", () => {
     expect(html).toContain("Next: link eligibility proof.");
     expect(html).toContain("S-4");
   });
-});
+
+  it("shows reviewer artifact saved in the current support picture when the saved verify bundle matches the current rule context", () => {
+    const storage = ensureLocalStorage();
+    storage.clear();
+    const bundle = createVerifierRunBundle("AR-ACM0003", "v02-0");
+    const reviewerContext = createReviewerArtifactContext({
+      methodCode: "AR-ACM0003",
+      version: "v02-0",
+      ruleId: "UNFCCC.Forestry.AR-ACM0003.v02-0.R-3",
+      runId: bundle.runContext.runId,
+    });
+    persistVerifierRunBundle("AR-ACM0003", "v02-0", {
+      ...bundle,
+      reviewerContext,
+      savedReviewerArtifactContext: reviewerContext,
+      savedReviewerArtifactAt: "2026-04-26T01:02:03Z",
+      minutes: "Saved reviewer minutes.",
+      outcomeNote: "Saved reviewer outcome.",
+      draftMinutes: "Saved reviewer minutes.",
+      draftOutcomeNote: "Saved reviewer outcome.",
+    });
+
+    const html = renderToStaticMarkup(
+      <RuleDetailModal
+        open
+        row={linkedNoExpectedEvidenceRow}
+        canonicalRuleId="UNFCCC.Forestry.AR-ACM0003.v02-0.R-3"
+        ruleText="Document the eligibility boundary for review."
+        methodologyLabel="UNFCCC Forestry · AR-ACM0003 · v02-0"
+        reviewMethodology="AR-ACM0003"
+        reviewVersion="v02-0"
+        sourcePath={null}
+        sha256={null}
+        traceSections={[]}
+        onClose={() => {}}
+        onOpenSourceContext={() => {}}
+      />,
+    );
+
+    expect(html).toContain("Current support picture");
+    expect(html).toContain("Linked evidence is present and reviewer artifact is saved.");
+    expect(html).not.toContain("Linked evidence is present, but no reviewer artifact is saved yet.");
+  });
+
+  it("keeps the no-reviewer-artifact message for wrong-rule or unsaved-draft state", () => {
+    const storage = ensureLocalStorage();
+    storage.clear();
+    const bundle = createVerifierRunBundle("AR-ACM0003", "v02-0");
+    const wrongRuleContext = createReviewerArtifactContext({
+      methodCode: "AR-ACM0003",
+      version: "v02-0",
+      ruleId: "UNFCCC.Forestry.AR-ACM0003.v02-0.R-999",
+      runId: bundle.runContext.runId,
+    });
+    persistVerifierRunBundle("AR-ACM0003", "v02-0", {
+      ...bundle,
+      reviewerContext: wrongRuleContext,
+      savedReviewerArtifactContext: wrongRuleContext,
+      savedReviewerArtifactAt: "2026-04-26T01:02:03Z",
+      minutes: "Saved reviewer minutes.",
+      outcomeNote: "Saved reviewer outcome.",
+      draftMinutes: "Saved reviewer minutes.",
+      draftOutcomeNote: "Saved reviewer outcome.",
+    });
+
+    const wrongRuleHtml = renderToStaticMarkup(
+      <RuleDetailModal
+        open
+        row={linkedNoExpectedEvidenceRow}
+        canonicalRuleId="UNFCCC.Forestry.AR-ACM0003.v02-0.R-3"
+        ruleText="Document the eligibility boundary for review."
+        methodologyLabel="UNFCCC Forestry · AR-ACM0003 · v02-0"
+        reviewMethodology="AR-ACM0003"
+        reviewVersion="v02-0"
+        sourcePath={null}
+        sha256={null}
+        traceSections={[]}
+        onClose={() => {}}
+        onOpenSourceContext={() => {}}
+      />,
+    );
+
+    expect(wrongRuleHtml).toContain("Linked evidence is present, but no reviewer artifact is saved yet.");
+
+    const draftOnlyContext = createReviewerArtifactContext({
+      methodCode: "AR-ACM0003",
+      version: "v02-0",
+      ruleId: "UNFCCC.Forestry.AR-ACM0003.v02-0.R-3",
+      runId: bundle.runContext.runId,
+    });
+    persistVerifierRunBundle("AR-ACM0003", "v02-0", {
+      ...bundle,
+      reviewerContext: draftOnlyContext,
+      savedReviewerArtifactContext: null,
+      savedReviewerArtifactAt: null,
+      minutes: "",
+      outcomeNote: "",
+      draftMinutes: "Unsaved draft reviewer minutes.",
+      draftOutcomeNote: "Unsaved draft reviewer outcome.",
+    });
+
+    const draftOnlyHtml = renderToStaticMarkup(
+      <RuleDetailModal
+        open
+        row={linkedNoExpectedEvidenceRow}
+        canonicalRuleId="UNFCCC.Forestry.AR-ACM0003.v02-0.R-3"
+        ruleText="Document the eligibility boundary for review."
+        methodologyLabel="UNFCCC Forestry · AR-ACM0003 · v02-0"
+        reviewMethodology="AR-ACM0003"
+        reviewVersion="v02-0"
+        sourcePath={null}
+        sha256={null}
+        traceSections={[]}
+        onClose={() => {}}
+        onOpenSourceContext={() => {}}
+      />,
+    );
+
+    expect(draftOnlyHtml).toContain("Linked evidence is present, but no reviewer artifact is saved yet.");
+    expect(draftOnlyHtml).not.toContain("Linked evidence is present and reviewer artifact is saved.");
+  });
+}


### PR DESCRIPTION
## WHAT

- resolve the Rule Review modal support-picture handoff from saved verifier state
- read the persisted verify bundle when the modal does not receive reviewer minutes/outcome note directly
- only treat a reviewer artifact as present when the saved artifact context matches the current method, version, rule, and run
- add regression coverage for matching saved artifact, wrong-rule mismatch, and unsaved draft-only state

## WHY

- the false message in Rule Review came from `RuleDetailModal`, not the finalized summary/export path
- PR #535 fixed stale finalized artifact guards, but this modal still computed reconciliation from empty `reviewerMinutes` / `reviewerOutcomeNote` props
- `MethodDetailPane` opens the richer Rule Review modal without passing reviewer artifact fields, so the support picture fell back to "Linked evidence is present, but no reviewer artifact is saved yet." even when the current verify run had a saved reviewer artifact
- the modal now pulls the saved reviewer artifact from the persisted verify bundle for the same method/version/rule/run context, without weakening wrong-rule or draft-only behavior

Validation:
- `npx jest tests/components/ruleDetailModal.test.tsx --runInBand`
- `npm run typecheck`
- `npm run lint`

**Signed-off-by:** Fred E <fredilly@article6.org>