### PR TITLE
Project evidence intake foundation

### DIFF
--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -74,7 +74,7 @@ export default function NewProjectForm() {
       <div>
         <h1 className="text-2xl font-bold text-slate-900">New Project</h1>
         <p className="mt-1 text-sm text-slate-500">
-          Create a verification project tied to a methodology
+          Create a verification project tied to a methodology. Core evidence intake starts with explicit PDD, monitoring report, and workbook source states.
         </p>
       </div>
 

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -2,11 +2,23 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import type { Project, RuleReview, ProjectCoverage } from '@/lib/projects/types';
-import { getProject, updateRuleReview, lockProject, getProjectCoverage } from '@/lib/projects/storage';
+import type {
+  Project,
+  RuleReview,
+  ProjectCoverage,
+  ProjectEvidenceIntakeItem,
+  ProjectEvidenceIntakeStatus,
+} from '@/lib/projects/types';
+import { getProject, updateRuleReview, lockProject, getProjectCoverage, updateProjectEvidenceIntake } from '@/lib/projects/storage';
 
 type ProjectDetailProps = {
   projectId: string;
+};
+
+const INTAKE_STATUS_LABELS: Record<ProjectEvidenceIntakeStatus, string> = {
+  'source-not-supplied': 'Source not supplied',
+  supplied: 'Supplied',
+  linked: 'Linked to rules',
 };
 
 export default function ProjectDetail({ projectId }: ProjectDetailProps) {
@@ -45,6 +57,17 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
     const locked = lockProject(projectId);
     if (locked) {
       setProject(locked);
+    }
+  };
+
+  const handleEvidenceIntakeChange = (
+    type: ProjectEvidenceIntakeItem['type'],
+    update: Partial<Pick<ProjectEvidenceIntakeItem, 'status' | 'sourceName' | 'provenanceNote'>>,
+  ) => {
+    const updated = updateProjectEvidenceIntake(projectId, type, update);
+    if (updated) {
+      setProject(updated);
+      setCoverage(getProjectCoverage(updated));
     }
   };
 
@@ -153,6 +176,70 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
           <p className="mt-1 text-right text-xs text-slate-500">{coverage.percentComplete}% complete</p>
         </div>
       )}
+
+      <div className="rounded-lg border border-slate-200 bg-white">
+        <div className="border-b border-slate-100 px-4 py-3">
+          <h2 className="text-sm font-bold text-slate-700">Project evidence intake</h2>
+          <p className="mt-1 text-xs text-slate-500">
+            Record whether the project supplied the core evidence sources needed for readiness review.
+          </p>
+        </div>
+        <div className="divide-y divide-slate-100">
+          {project.evidenceIntake.map((item) => (
+            <div key={item.type} className="grid gap-3 px-4 py-4 md:grid-cols-[180px_180px_minmax(0,1fr)_minmax(0,1fr)] md:items-start">
+              <div>
+                <div className="text-sm font-semibold text-slate-800">{item.label}</div>
+                <div className="mt-1 text-xs text-slate-400">
+                  {item.updatedAt ? `Updated ${new Date(item.updatedAt).toLocaleDateString()}` : 'No source logged yet'}
+                </div>
+              </div>
+              <label className="grid gap-1 text-xs font-semibold text-slate-500">
+                Intake status
+                <select
+                  value={item.status}
+                  disabled={project.status === 'locked'}
+                  onChange={(event) =>
+                    handleEvidenceIntakeChange(item.type, {
+                      status: event.target.value as ProjectEvidenceIntakeStatus,
+                    })
+                  }
+                  className="rounded border border-slate-200 px-2 py-2 text-sm text-slate-700 disabled:bg-slate-50 disabled:text-slate-400"
+                >
+                  {Object.entries(INTAKE_STATUS_LABELS).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="grid gap-1 text-xs font-semibold text-slate-500">
+                Source / file name
+                <input
+                  value={item.sourceName ?? ''}
+                  disabled={project.status === 'locked'}
+                  onChange={(event) => handleEvidenceIntakeChange(item.type, { sourceName: event.target.value })}
+                  placeholder={item.status === 'source-not-supplied' ? 'Leave blank if not supplied' : 'project-design.pdf'}
+                  className="rounded border border-slate-200 px-3 py-2 text-sm text-slate-700 placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-400"
+                />
+              </label>
+              <label className="grid gap-1 text-xs font-semibold text-slate-500">
+                Provenance / intake note
+                <input
+                  value={item.provenanceNote ?? ''}
+                  disabled={project.status === 'locked'}
+                  onChange={(event) => handleEvidenceIntakeChange(item.type, { provenanceNote: event.target.value })}
+                  placeholder={
+                    item.status === 'source-not-supplied'
+                      ? 'Say source not supplied or note expected follow-up'
+                      : 'Page/section scope, intake note, or provenance summary'
+                  }
+                  className="rounded border border-slate-200 px-3 py-2 text-sm text-slate-700 placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-400"
+                />
+              </label>
+            </div>
+          ))}
+        </div>
+      </div>
 
       {Object.entries(grouped).map(([sectionId, reviews]) => (
         <div key={sectionId} className="rounded-lg border border-slate-200 bg-white">

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -1,16 +1,69 @@
-import type { Project, RuleReview, ProjectCoverage, RuleReviewStatus } from './types';
+import type {
+  Project,
+  RuleReview,
+  ProjectCoverage,
+  RuleReviewStatus,
+  ProjectEvidenceIntakeItem,
+  ProjectEvidenceIntakeStatus,
+  ProjectEvidenceIntakeType,
+} from './types';
 
 const STORAGE_KEY = 'article6_projects';
+const EVIDENCE_INTAKE_BLUEPRINT: Array<{ type: ProjectEvidenceIntakeType; label: string }> = [
+  { type: 'pdd', label: 'PDD' },
+  { type: 'monitoring-report', label: 'Monitoring report' },
+  { type: 'workbook', label: 'Workbook' },
+];
 
 function generateId(): string {
   return 'proj_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+function normalizeProjectEvidenceIntake(items: unknown): ProjectEvidenceIntakeItem[] {
+  const byType = new Map<ProjectEvidenceIntakeType, ProjectEvidenceIntakeItem>();
+  const source = Array.isArray(items) ? items : [];
+
+  for (const raw of source) {
+    if (!raw || typeof raw !== 'object') continue;
+    const candidate = raw as Partial<ProjectEvidenceIntakeItem>;
+    if (!candidate.type || !EVIDENCE_INTAKE_BLUEPRINT.some((item) => item.type === candidate.type)) continue;
+    const type = candidate.type as ProjectEvidenceIntakeType;
+    const blueprint = EVIDENCE_INTAKE_BLUEPRINT.find((item) => item.type === type)!;
+    const status: ProjectEvidenceIntakeStatus =
+      candidate.status === 'supplied' || candidate.status === 'linked' ? candidate.status : 'source-not-supplied';
+    byType.set(type, {
+      type,
+      label: typeof candidate.label === 'string' && candidate.label.trim() ? candidate.label.trim() : blueprint.label,
+      status,
+      sourceName: typeof candidate.sourceName === 'string' && candidate.sourceName.trim() ? candidate.sourceName.trim() : undefined,
+      provenanceNote:
+        typeof candidate.provenanceNote === 'string' && candidate.provenanceNote.trim() ? candidate.provenanceNote.trim() : undefined,
+      updatedAt: typeof candidate.updatedAt === 'string' && candidate.updatedAt.trim() ? candidate.updatedAt : undefined,
+    });
+  }
+
+  return EVIDENCE_INTAKE_BLUEPRINT.map(({ type, label }) => (
+    byType.get(type) ?? {
+      type,
+      label,
+      status: 'source-not-supplied',
+    }
+  ));
+}
+
+function normalizeProject(project: Project): Project {
+  return {
+    ...project,
+    evidenceIntake: normalizeProjectEvidenceIntake((project as Partial<Project>).evidenceIntake),
+  };
 }
 
 function loadAll(): Project[] {
   if (typeof window === 'undefined') return [];
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : [];
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.map((item) => normalizeProject(item as Project)) : [];
   } catch {
     return [];
   }
@@ -48,6 +101,7 @@ export function createProject(input: {
     createdAt: new Date().toISOString(),
     aoiLabel: input.aoiLabel,
     description: input.description,
+    evidenceIntake: normalizeProjectEvidenceIntake(undefined),
     reviews: input.ruleIds.map(r => ({
       ruleId: r.id,
       ruleTitle: r.title,
@@ -100,6 +154,32 @@ export function lockProject(projectId: string): Project | undefined {
 export function deleteProject(projectId: string): void {
   const projects = loadAll().filter(p => p.id !== projectId);
   saveAll(projects);
+}
+
+export function updateProjectEvidenceIntake(
+  projectId: string,
+  type: ProjectEvidenceIntakeType,
+  update: Partial<Pick<ProjectEvidenceIntakeItem, 'status' | 'sourceName' | 'provenanceNote'>>,
+): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find((p) => p.id === projectId);
+  if (!project) return undefined;
+  if (project.status === 'locked') return undefined;
+
+  const nextEvidenceIntake = normalizeProjectEvidenceIntake(project.evidenceIntake).map((item) => {
+    if (item.type !== type) return item;
+    return {
+      ...item,
+      status: update.status ?? item.status,
+      sourceName: update.sourceName?.trim() ? update.sourceName.trim() : undefined,
+      provenanceNote: update.provenanceNote?.trim() ? update.provenanceNote.trim() : undefined,
+      updatedAt: new Date().toISOString(),
+    };
+  });
+
+  project.evidenceIntake = nextEvidenceIntake;
+  saveAll(projects);
+  return project;
 }
 
 export function getProjectCoverage(project: Project): ProjectCoverage {

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -4,6 +4,19 @@ export type RuleReviewStatus = 'not-started' | 'in-progress' | 'verified' | 'gap
 
 export type ProjectRegistry = 'UNFCCC' | 'Verra' | 'Gold Standard' | 'Unknown';
 
+export type ProjectEvidenceIntakeType = 'pdd' | 'monitoring-report' | 'workbook';
+
+export type ProjectEvidenceIntakeStatus = 'source-not-supplied' | 'supplied' | 'linked';
+
+export type ProjectEvidenceIntakeItem = {
+  type: ProjectEvidenceIntakeType;
+  label: string;
+  status: ProjectEvidenceIntakeStatus;
+  sourceName?: string;
+  provenanceNote?: string;
+  updatedAt?: string;
+};
+
 export type RuleReview = {
   ruleId: string;
   ruleTitle: string;
@@ -26,6 +39,7 @@ export type Project = {
   lockedAt?: string;
   aoiLabel?: string;
   description?: string;
+  evidenceIntake: ProjectEvidenceIntakeItem[];
   reviews: RuleReview[];
 };
 

--- a/tests/lib/projects.storage.test.ts
+++ b/tests/lib/projects.storage.test.ts
@@ -1,0 +1,73 @@
+/** @jest-environment jsdom */
+
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { createProject, getProject, listProjects, updateProjectEvidenceIntake } from "@/lib/projects/storage";
+
+describe("project storage evidence intake foundation", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("initializes each new project with the three core evidence intake sources marked as not supplied", () => {
+    const project = createProject({
+      name: "Malawi grouped activity",
+      methodCode: "AR-ACM0003",
+      methodVersion: "v02-0",
+      ruleIds: [{ id: "R-1", title: "Rule 1", sectionId: "S-1" }],
+    });
+
+    expect(project.evidenceIntake).toEqual([
+      { type: "pdd", label: "PDD", status: "source-not-supplied" },
+      { type: "monitoring-report", label: "Monitoring report", status: "source-not-supplied" },
+      { type: "workbook", label: "Workbook", status: "source-not-supplied" },
+    ]);
+  });
+
+  it("updates evidence intake source status and provenance for an in-progress project", () => {
+    const project = createProject({
+      name: "Malawi grouped activity",
+      methodCode: "AR-ACM0003",
+      methodVersion: "v02-0",
+      ruleIds: [{ id: "R-1", title: "Rule 1", sectionId: "S-1" }],
+    });
+
+    const updated = updateProjectEvidenceIntake(project.id, "pdd", {
+      status: "supplied",
+      sourceName: "project-design.pdf",
+      provenanceNote: "Boundary description and coordinates expected from uploaded PDD.",
+    });
+
+    expect(updated?.evidenceIntake.find((item) => item.type === "pdd")).toMatchObject({
+      type: "pdd",
+      label: "PDD",
+      status: "supplied",
+      sourceName: "project-design.pdf",
+      provenanceNote: "Boundary description and coordinates expected from uploaded PDD.",
+    });
+  });
+
+  it("normalizes older stored projects that predate the evidence intake register", () => {
+    window.localStorage.setItem(
+      "article6_projects",
+      JSON.stringify([
+        {
+          id: "proj_legacy",
+          name: "Legacy project",
+          methodCode: "AR-ACM0003",
+          methodVersion: "v02-0",
+          status: "in-progress",
+          createdAt: "2026-04-29T00:00:00.000Z",
+          reviews: [{ ruleId: "R-1", ruleTitle: "Rule 1", sectionId: "S-1", status: "not-started", evidenceIds: [] }],
+        },
+      ]),
+    );
+
+    const project = getProject("proj_legacy");
+    expect(project?.evidenceIntake).toEqual([
+      { type: "pdd", label: "PDD", status: "source-not-supplied" },
+      { type: "monitoring-report", label: "Monitoring report", status: "source-not-supplied" },
+      { type: "workbook", label: "Workbook", status: "source-not-supplied" },
+    ]);
+    expect(listProjects()[0]?.evidenceIntake[0]?.type).toBe("pdd");
+  });
+});


### PR DESCRIPTION
## WHAT

- add a project-level evidence intake register for the three core Phase 1 sources: `PDD`, `monitoring report`, and `workbook`
- initialize each new project with explicit `source-not-supplied` intake states instead of implying evidence exists
- let the project detail screen record intake status, source/file name, and provenance note for each core source
- normalize older locally stored projects so they gain the intake register without migration breakage

## WHY

- the app already has evidence inventory and requirement-linking primitives, but project records still had no truthful way to say whether the core source documents were supplied yet
- Phase 1 needs an app-owned foundation for project evidence intake before parser, gap-engine, or export work grows further
- this keeps readiness language honest by making missing sources explicit instead of hidden behind review rows

## Validation

- `npx jest tests/lib/projects.storage.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`

### Roadmap-Update
- slug: project-readiness-verification-output
- items:
  - RC1: in_progress

**Signed-off-by:** Fred E <fredilly@article6.org>