### PR TITLE
Roadmap cleanup: mark satisfied readiness foundations done

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -106,9 +106,8 @@ Lane status: Active
 Commercial sales-readiness lane for project developer gap audits, VVB workpaper exports, public verification autopsies, white-label consultancy pilots, and rule encoding. `traceable-rule-review-mvp` remains the technical foundation.
 
 Current focus:
-- Consolidate the commercial output around readiness gaps, traceable exports, and pilot sales
+- Readiness Gap Engine (RC3) — combine existing evidence inventory with methodology expectations into rule-level gap states
 - Keep `traceable-rule-review-mvp` as the technical foundation for review records and exports
-- Fold older overlapping lanes into this roadmap without erasing their history
 - Preserve app-vs-methodologies boundaries while preparing sellable verification outputs
 
 Not active now:
@@ -117,10 +116,10 @@ Not active now:
 - Credit issuance claims
 - Methodology-repo changes in this app repo
 
-1) RC0 — Roadmap consolidation: Next — Collapse the useful parts of old roadmaps into one commercial roadmap, preserve historical lanes as folded or superseded, and keep repo boundaries explicit.
-2) RC1 — PDD / Project Gap Intake: Planned — Ingest PDDs, monitoring reports, and workbooks into a project evidence inventory with page/section/fragment provenance and manual fragment-to-rule links.
-3) RC2 — Method Evidence Contracts: Planned — Define expected evidence per rule in the methodologies repo so the app can distinguish missing evidence from unknown expectations.
-4) RC3 — Readiness Gap Engine: Planned — Turn project evidence plus method expectations into rule-level gap states, severities, recommendations, and reviewer overrides.
+1) RC0 — Roadmap consolidation: Done — Collapse the useful parts of old roadmaps into one commercial roadmap, preserve historical lanes as folded or superseded, and keep repo boundaries explicit. Completed via PR #538.
+2) RC1 — PDD / Project Gap Intake: Done — Ingest PDDs, monitoring reports, and workbooks into a project evidence inventory with page/section/fragment provenance and manual fragment-to-rule links. Already satisfied by existing app.article6 evidence inventory and requirement-coverage work (Phase 4 Document/Workbook Support in traceable-rule-review-mvp).
+3) RC2 — Method Evidence Contracts: Done — Define expected evidence per rule in the methodologies repo so the app can distinguish missing evidence from unknown expectations. Completed upstream in article6-methodologies repo for current target methods.
+4) RC3 — Readiness Gap Engine: Next — Turn project evidence plus method expectations into rule-level gap states, severities, recommendations, and reviewer overrides. Next build: combine existing evidence inventory with methodology expected evidence.
 5) RC4 — Client Readiness Report Export: Planned — Produce the paid readiness report and audit pack appendix for project developers and consultancies with explicit limits and traceability.
 6) RC5 — VVB Workpaper Export: Planned — Reuse the same review data for VVB-facing draft workpapers, provenance bundles, and truthful registry-aware report sections.
 7) RC6 — Public Autopsy Workflow: Planned — Create a public-safe autopsy workflow using public project documents, redactions, and source-tied findings for marketing and proof.

--- a/docs/roadmaps/project-readiness-verification-output/phase-status.json
+++ b/docs/roadmaps/project-readiness-verification-output/phase-status.json
@@ -3,9 +3,8 @@
     "status": "active",
     "summary": "Commercial sales-readiness lane for project developer gap audits, VVB workpaper exports, public verification autopsies, white-label consultancy pilots, and rule encoding. `traceable-rule-review-mvp` remains the technical foundation.",
     "current_focus": [
-      "Consolidate the commercial output around readiness gaps, traceable exports, and pilot sales",
+      "Readiness Gap Engine (RC3) — combine existing evidence inventory with methodology expectations into rule-level gap states",
       "Keep `traceable-rule-review-mvp` as the technical foundation for review records and exports",
-      "Fold older overlapping lanes into this roadmap without erasing their history",
       "Preserve app-vs-methodologies boundaries while preparing sellable verification outputs"
     ],
     "not_active_now": [
@@ -17,24 +16,24 @@
   },
   "phases": {
     "phase_0_roadmap_consolidation": {
-      "status": "next",
+      "status": "done",
       "title": "Roadmap consolidation",
-      "summary": "Collapse the useful parts of old roadmaps into one commercial roadmap, preserve historical lanes as folded or superseded, and keep repo boundaries explicit."
+      "summary": "Collapse the useful parts of old roadmaps into one commercial roadmap, preserve historical lanes as folded or superseded, and keep repo boundaries explicit. Completed via PR #538."
     },
     "phase_1_pdd_project_gap_intake": {
-      "status": "planned",
+      "status": "done",
       "title": "PDD / Project Gap Intake",
-      "summary": "Ingest PDDs, monitoring reports, and workbooks into a project evidence inventory with page/section/fragment provenance and manual fragment-to-rule links."
+      "summary": "Ingest PDDs, monitoring reports, and workbooks into a project evidence inventory with page/section/fragment provenance and manual fragment-to-rule links. Already satisfied by existing app.article6 evidence inventory and requirement-coverage work (Phase 4 Document/Workbook Support in traceable-rule-review-mvp)."
     },
     "phase_2_method_evidence_contracts": {
-      "status": "planned",
+      "status": "done",
       "title": "Method Evidence Contracts",
-      "summary": "Define expected evidence per rule in the methodologies repo so the app can distinguish missing evidence from unknown expectations."
+      "summary": "Define expected evidence per rule in the methodologies repo so the app can distinguish missing evidence from unknown expectations. Completed upstream in article6-methodologies repo for current target methods."
     },
     "phase_3_readiness_gap_engine": {
-      "status": "planned",
+      "status": "next",
       "title": "Readiness Gap Engine",
-      "summary": "Turn project evidence plus method expectations into rule-level gap states, severities, recommendations, and reviewer overrides."
+      "summary": "Turn project evidence plus method expectations into rule-level gap states, severities, recommendations, and reviewer overrides. Next build: combine existing evidence inventory with methodology expected evidence."
     },
     "phase_4_client_readiness_report_export": {
       "status": "planned",


### PR DESCRIPTION
## WHAT

- Marked RC0, RC1, and RC2 as done based on existing roadmap/workstream evidence.
- Set RC3 Readiness Gap Engine as the next active commercial roadmap item.
- Regenerated the roadmap summary from the roadmap SSOT.

## WHY

- Prevent agents from rebuilding completed intake and methodology-contract foundations.
- Avoid falsely crediting closed duplicate PR #539 as completed work.
- Keep the next build focused on the missing sellable layer: rule-level readiness gap states.

Signed-off-by: Fred E <fredilly@article6.org>