### PR TITLE
[codex] Add verify readiness strip

### DIFF
--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -1508,8 +1508,18 @@ export default function MethodDetailPane({
             <button
               type="button"
               onClick={() => methodsLayout.setMethodsCollapsed(!methodsLayout.methodsCollapsed)}
-              className="hidden items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50 lg:inline-flex"
+              className={`hidden items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold transition lg:inline-flex ${
+                methodsLayout.methodsCollapsed
+                  ? "border-slate-300 bg-slate-900 text-white hover:bg-slate-800"
+                  : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+              }`}
             >
+              <span
+                className={`h-2 w-2 rounded-full ${
+                  methodsLayout.methodsCollapsed ? "bg-white" : "bg-slate-300"
+                }`}
+                aria-hidden="true"
+              />
               {methodsLayout.methodsCollapsed ? "Show methods" : "Hide methods"}
             </button>
           ) : null}

--- a/src/app/m/_components/MethodsFinder.tsx
+++ b/src/app/m/_components/MethodsFinder.tsx
@@ -122,31 +122,50 @@ export default async function MethodsFinder({
         >
           <MethodsFinderShell
             left={
-              <div className="rounded-xl border border-slate-200 bg-white p-4">
-                <div className="mb-3 flex items-center justify-between gap-3">
-                  <h2 className="text-sm font-semibold text-slate-900">Methods</h2>
-                  <span className="text-xs text-slate-500">{methods.length} items</span>
+              <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+                <div className="border-b border-slate-100 px-4 py-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Methods</div>
+                      <h2 className="mt-1 text-sm font-semibold text-slate-900">Available methodology sets</h2>
+                    </div>
+                    <span className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] font-medium text-slate-500">{methods.length}</span>
+                  </div>
                 </div>
-                <ul className="flex flex-col gap-2">
+                <ul className="flex max-h-[calc(100vh-14rem)] flex-col gap-2 overflow-y-auto p-3">
                   {methods.map((method) => {
                     const active = selectedMethod?.code === method.code;
                     return (
                       <li key={method.code}>
                         <Link
                           href={`/m/${encodeURIComponent(method.code)}`}
-                          className={`flex items-center justify-between rounded-lg border px-3 py-2 text-left transition-colors ${
+                          className={`flex items-center justify-between gap-3 rounded-2xl border px-3.5 py-3 text-left transition-colors ${
                             active
                               ? "border-slate-300 bg-slate-50"
-                              : "border-slate-200 bg-white hover:bg-slate-50"
+                              : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/80"
                           }`}
                         >
-                          <div className="flex flex-col">
-                            <span className="font-mono text-sm text-slate-900">{method.code}</span>
-                            <span className="text-xs text-slate-500">
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2">
+                              <span className="truncate font-mono text-sm text-slate-900">{method.code}</span>
+                              <span className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[10px] font-medium text-slate-500">
+                                {method.versionCount} version{method.versionCount === 1 ? "" : "s"}
+                              </span>
+                            </div>
+                            <span className="mt-1 block truncate text-xs text-slate-500">
                               {method.program} • {method.sector}
                             </span>
                           </div>
-                          <span className="text-xs text-slate-400">{method.versionCount} v</span>
+                          <span
+                            className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${
+                              active
+                                ? "border-slate-900 bg-slate-900 text-white"
+                                : "border-slate-300 bg-white text-slate-400"
+                            }`}
+                            aria-hidden="true"
+                          >
+                            {active ? "✓" : ""}
+                          </span>
                         </Link>
                       </li>
                     );

--- a/src/app/m/_components/MethodsFinderShell.tsx
+++ b/src/app/m/_components/MethodsFinderShell.tsx
@@ -99,7 +99,7 @@ export default function MethodsFinderShell({ left, right }: MethodsFinderShellPr
   const layoutClass = useMemo(
     () =>
       `grid gap-4 ${
-        collapsed ? "lg:grid-cols-[minmax(0,1fr)]" : "lg:grid-cols-[360px_minmax(0,1fr)]"
+        collapsed ? "lg:grid-cols-[minmax(0,1fr)]" : "lg:grid-cols-[320px_minmax(0,1fr)] xl:grid-cols-[336px_minmax(0,1fr)]"
       }`,
     [collapsed],
   );
@@ -107,7 +107,7 @@ export default function MethodsFinderShell({ left, right }: MethodsFinderShellPr
   return (
     <MethodsLayoutProvider value={{ isVerifyTab, methodsCollapsed: collapsed, setMethodsCollapsed: setMethodsCollapsedWithUrl }}>
       <div className={layoutClass}>
-        <section className={`w-full ${collapsed ? "lg:hidden" : ""}`}>{left}</section>
+        <section className={`w-full ${collapsed ? "lg:hidden" : "lg:sticky lg:top-4 lg:self-start"}`}>{left}</section>
         <section className="w-full">{right}</section>
       </div>
     </MethodsLayoutProvider>

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -248,6 +248,14 @@ function formatLocalDateTime(iso: string): string {
   return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`;
 }
 
+function formatSnapshotSummaryTime(value: string | null | undefined): { label: string; title?: string } {
+  if (!value) return { label: "Not exported" };
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return { label: "Exported", title: value };
+  const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return { label: `Exported ${time}`, title: date.toISOString() };
+}
+
 function inventoryLinkStateLabel(linkedRequirementIds: string[]): string {
   if (!linkedRequirementIds.length) return "Unlinked";
   if (linkedRequirementIds.length === 1) return "Linked to 1 requirement";
@@ -1890,35 +1898,43 @@ export default function ProofMapTab({
               : latestRun.summary?.trim() || "STAC search failed for the active AOI.";
     const supportFactsStatus = !selectedRuleId
       ? "select rule"
-      : !selectedRuleStacEligible
-        ? "not applicable"
-        : stacSupportFacts.linkedFacts.length > 0
-          ? "linked"
-          : stacSupportFacts.staleFacts.length > 0
-            ? "stale"
+      : stacSupportFacts.linkedFacts.length > 0
+        ? "linked"
+        : stacSupportFacts.staleFacts.length > 0
+          ? "stale"
+          : !selectedRuleStacEligible
+            ? "optional"
             : "unlinked";
     const supportFactsDetail = !selectedRuleId
       ? "Select a rule to assess AOI/STAC support facts."
-      : !selectedRuleStacEligible
-        ? "AOI/STAC support facts are not expected for this rule."
-        : stacSupportFacts.lookupMessage;
+      : stacSupportFacts.linkedFacts.length > 0
+        ? stacSupportFacts.lookupMessage
+        : stacSupportFacts.staleFacts.length > 0
+          ? stacSupportFacts.lookupMessage
+          : !selectedRuleStacEligible
+            ? "AOI/STAC support facts are optional for this rule. Link them only if they materially support the review."
+            : stacSupportFacts.lookupMessage;
     const reviewerRecordStatus = verifierBundle.savedReviewerArtifactAt
       ? "saved"
       : hasReviewerDraft
         ? "draft"
         : "missing";
-    const exportReady =
-      currentWorkspaceIsFinal ||
-      Boolean(finalizeGate?.canFinalize && linkedRuleIds.length > 0 && verifierBundle.savedReviewerArtifactAt);
+    const finalizeReady = Boolean(finalizeGate?.canFinalize && linkedRuleIds.length > 0 && verifierBundle.savedReviewerArtifactAt);
+    const hasDraftExport = Boolean(verifierBundle.exportedAt);
+    const exportStatus = currentWorkspaceIsFinal ? "finalized" : finalizeReady ? "ready" : hasDraftExport ? "draft available" : "not ready";
     const exportDetail = currentWorkspaceIsFinal
       ? `Finalized ${formatLocalDateTime(verifierBundle.finalizedAt ?? "")}`
-      : finalizeGate && !finalizeGate.canFinalize
-        ? finalizeGate.reasons[0] ?? "Finalize gate is blocked."
-        : !linkedRuleIds.length
-          ? "Link evidence to at least one rule before finalizing or exporting."
-          : !verifierBundle.savedReviewerArtifactAt
-            ? "Save reviewer artifact before finalizing or exporting."
-            : "Finalize gate is clear for export.";
+      : finalizeReady
+        ? "Finalize gate is clear. Final review export is ready."
+        : hasDraftExport
+          ? `Draft snapshot exported ${formatLocalDateTime(verifierBundle.exportedAt ?? "")}. Final export still needs finalize requirements to pass.`
+          : finalizeGate && !finalizeGate.canFinalize
+            ? finalizeGate.reasons[0] ?? "Finalize gate is blocked."
+            : !linkedRuleIds.length
+              ? "Link evidence to at least one rule before finalizing the export."
+              : !verifierBundle.savedReviewerArtifactAt
+                ? "Save reviewer artifact before finalizing the export."
+                : "Finalize requirements are not yet met.";
 
     return [
       {
@@ -1945,7 +1961,7 @@ export default function ProofMapTab({
         tone:
           supportFactsStatus === "linked"
             ? "ok"
-            : supportFactsStatus === "not applicable"
+            : supportFactsStatus === "optional"
               ? "neutral"
               : supportFactsStatus === "stale"
                 ? "warn"
@@ -1966,9 +1982,9 @@ export default function ProofMapTab({
       {
         key: "export",
         label: "Export",
-        value: exportReady ? "ready" : "blocked",
+        value: exportStatus,
         detail: exportDetail,
-        tone: exportReady ? "ok" : "blocked",
+        tone: currentWorkspaceIsFinal || finalizeReady ? "ok" : hasDraftExport ? "warn" : "blocked",
         onClick: () => scrollToSection(finalSummarySectionRef),
       },
     ];
@@ -1988,6 +2004,7 @@ export default function ProofMapTab({
     stacSupportFacts.linkedFacts.length,
     stacSupportFacts.lookupMessage,
     stacSupportFacts.staleFacts.length,
+    verifierBundle.exportedAt,
     verifierBundle.finalizedAt,
     verifierBundle.savedReviewerArtifactAt,
   ]);
@@ -3762,25 +3779,30 @@ export default function ProofMapTab({
     </>
   );
 
+  const summarySnapshot = formatSnapshotSummaryTime(runKpis.snapshotExportedAt ?? null);
+
   return (
     <div className="mt-4 grid gap-4">
       <div className="rounded-xl border border-slate-200 bg-white px-4 py-3">
         <div className="flex flex-col gap-2.5 lg:flex-row lg:items-start lg:justify-between">
           <div className="min-w-0">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Review workspace</div>
+            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Review summary</div>
             <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
-              <span className="font-mono text-sm font-semibold text-slate-900">{methodCode}@{version}</span>
               <span className="text-xs text-slate-500">
-                {selectedRuleId ? `Rule ${selectedRuleId}` : "No rule selected"}
+                method: <span className="font-mono font-semibold text-slate-900">{methodCode}@{version}</span>
               </span>
               <span className="text-xs text-slate-500">
-                Run <span className="font-mono">{currentRunLabel}</span>
+                Items: <span className="font-semibold text-slate-900">{runKpis.itemsCount}</span>
+              </span>
+              <span className="text-xs text-slate-500">
+                Linked: <span className="font-semibold text-slate-900">{runKpis.linkedRulesCount}</span>
+              </span>
+              <span className="text-xs text-slate-500" title={summarySnapshot.title}>
+                Snapshot: <span className="font-semibold text-slate-900">{summarySnapshot.label}</span>
               </span>
             </div>
           </div>
-          <div className="text-xs text-slate-500">
-            Review first. Open technical metadata only when needed.
-          </div>
+          <div className="text-xs text-slate-500">Keep reviewer-useful state visible. Open technical metadata only when needed.</div>
         </div>
       </div>
 

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -3996,6 +3996,10 @@ export default function ProofMapTab({
               </button>
             </div>
           ) : null}
+          <VerifyReadinessStrip
+            ruleId={selectedRuleId}
+            chips={verifyReadinessChips}
+          />
           <div
             data-testid="left-pane-step-focus"
             className={`sticky top-0 z-10 rounded-xl border px-4 py-3 text-sm shadow-sm transition ${
@@ -4203,11 +4207,6 @@ export default function ProofMapTab({
               {error}
             </div>
           ) : null}
-
-          <VerifyReadinessStrip
-            ruleId={selectedRuleId}
-            chips={verifyReadinessChips}
-          />
 
           <div className="transition">
             {currentWorkspaceIsFinal ? (

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -1888,13 +1888,15 @@ export default function ProofMapTab({
             : stacStatus === "no results"
               ? "STAC search completed but returned no results for the active AOI."
               : latestRun.summary?.trim() || "STAC search failed for the active AOI.";
-    const supportFactsStatus = !selectedRuleId || !selectedRuleStacEligible
-      ? "not applicable"
-      : stacSupportFacts.linkedFacts.length > 0
-        ? "linked"
-        : stacSupportFacts.staleFacts.length > 0
-          ? "stale"
-          : "unlinked";
+    const supportFactsStatus = !selectedRuleId
+      ? "select rule"
+      : !selectedRuleStacEligible
+        ? "not applicable"
+        : stacSupportFacts.linkedFacts.length > 0
+          ? "linked"
+          : stacSupportFacts.staleFacts.length > 0
+            ? "stale"
+            : "unlinked";
     const supportFactsDetail = !selectedRuleId
       ? "Select a rule to assess AOI/STAC support facts."
       : !selectedRuleStacEligible

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -3765,111 +3765,141 @@ export default function ProofMapTab({
   return (
     <div className="mt-4 grid gap-4">
       <div className="rounded-xl border border-slate-200 bg-white px-4 py-3">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex min-w-0 flex-wrap items-center gap-2">
-            <button
-              type="button"
-              className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50"
-              onClick={async () => {
-                const text = `${methodCode}@${version}`;
-                await copyToClipboard(text);
-              }}
-              title={`Copy method ${methodCode}@${version}`}
-            >
-              <span className="text-slate-500">method:</span>
-              <span className="font-mono">{methodCode}@{version}</span>
-            </button>
-
-            {appCommit ? (
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50"
-                onClick={async () => {
-                  const full = (process.env.NEXT_PUBLIC_GIT_SHA || "").trim();
-                  await copyToClipboard(full || appCommit);
-                }}
-                title="Copy app commit"
-              >
-                <span className="text-slate-500">app:</span>
-                <span className="font-mono">{appCommit}</span>
-              </button>
-            ) : null}
-
-            {evidenceChip ? (
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50"
-                onClick={async () => {
-                  await copyToClipboard(evidenceChip.value);
-                }}
-                title="Copy evidence layer ref"
-              >
-                <span className="text-slate-500">{evidenceChip.label}:</span>
-                <span className="font-mono">{evidenceChip.display}</span>
-              </button>
-            ) : localEvidenceHashInputs ? (
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50"
-                onClick={async () => {
-                  const snapshot = await buildOutcomeSnapshot({
-                    method: { code: methodCode, version },
-                    evidence_source: { type: "upload", ref: "local_pins", hash_inputs: localEvidenceHashInputs },
-                  });
-                  if (snapshot.evidence_source.hash) await copyToClipboard(snapshot.evidence_source.hash);
-                }}
-                title="Copy local evidence hash"
-              >
-                <span className="text-slate-500">evidence:</span>
-                <span className="font-mono">local:{localEvidenceHashInputs.length}</span>
-              </button>
-            ) : (
-              <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-500">
-                evidence: none
+        <div className="flex flex-col gap-2.5 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Review workspace</div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+              <span className="font-mono text-sm font-semibold text-slate-900">{methodCode}@{version}</span>
+              <span className="text-xs text-slate-500">
+                {selectedRuleId ? `Rule ${selectedRuleId}` : "No rule selected"}
               </span>
-            )}
-
-            {auditHashes?.rules ? (
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50"
-                onClick={async () => copyToClipboard(auditHashes.rules ?? "")}
-                title="Copy rules_sha256"
-              >
-                <span className="text-slate-500">rules:</span>
-                <span className="font-mono">{shortSha(auditHashes.rules)}</span>
-              </button>
-            ) : null}
-            {auditHashes?.sections ? (
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50"
-                onClick={async () => copyToClipboard(auditHashes.sections ?? "")}
-                title="Copy sections_sha256"
-              >
-                <span className="text-slate-500">sections:</span>
-                <span className="font-mono">{shortSha(auditHashes.sections)}</span>
-              </button>
-            ) : null}
+              <span className="text-xs text-slate-500">
+                Run <span className="font-mono">{currentRunLabel}</span>
+              </span>
+            </div>
           </div>
-
-          <div className="flex min-w-0 flex-wrap items-center gap-2">
-            <ProofCoverageChip
-              kpis={runKpis}
-              onViewCoverage={onOpenCoverageDrawer}
-            />
-            <button
-              type="button"
-              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
-              onClick={() => {
-                document.getElementById("verify-outcome")?.scrollIntoView({ behavior: "smooth", block: "start" });
-              }}
-            >
-              Outcome
-            </button>
+          <div className="text-xs text-slate-500">
+            Review first. Open technical metadata only when needed.
           </div>
         </div>
       </div>
+
+      <details className="group rounded-xl border border-slate-200 bg-white" data-testid="verify-technical-metadata">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-left marker:hidden">
+          <div>
+            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Technical metadata</div>
+            <div className="mt-1 text-sm font-medium text-slate-700">Export context, hashes, and debug details</div>
+          </div>
+          <span className="text-xs font-semibold text-slate-500 group-open:hidden">Show</span>
+          <span className="hidden text-xs font-semibold text-slate-500 group-open:inline">Hide</span>
+        </summary>
+        <div className="border-t border-slate-100 px-4 py-3">
+          <div className="flex flex-col gap-3">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+                onClick={async () => {
+                  const text = `${methodCode}@${version}`;
+                  await copyToClipboard(text);
+                }}
+                title={`Copy method ${methodCode}@${version}`}
+              >
+                <span className="text-slate-500">method:</span>
+                <span className="font-mono">{methodCode}@{version}</span>
+              </button>
+
+              {appCommit ? (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+                  onClick={async () => {
+                    const full = (process.env.NEXT_PUBLIC_GIT_SHA || "").trim();
+                    await copyToClipboard(full || appCommit);
+                  }}
+                  title="Copy app commit"
+                >
+                  <span className="text-slate-500">app:</span>
+                  <span className="font-mono">{appCommit}</span>
+                </button>
+              ) : null}
+
+              {evidenceChip ? (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+                  onClick={async () => {
+                    await copyToClipboard(evidenceChip.value);
+                  }}
+                  title="Copy evidence layer ref"
+                >
+                  <span className="text-slate-500">{evidenceChip.label}:</span>
+                  <span className="font-mono">{evidenceChip.display}</span>
+                </button>
+              ) : localEvidenceHashInputs ? (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+                  onClick={async () => {
+                    const snapshot = await buildOutcomeSnapshot({
+                      method: { code: methodCode, version },
+                      evidence_source: { type: "upload", ref: "local_pins", hash_inputs: localEvidenceHashInputs },
+                    });
+                    if (snapshot.evidence_source.hash) await copyToClipboard(snapshot.evidence_source.hash);
+                  }}
+                  title="Copy local evidence hash"
+                >
+                  <span className="text-slate-500">evidence:</span>
+                  <span className="font-mono">local:{localEvidenceHashInputs.length}</span>
+                </button>
+              ) : (
+                <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-500">
+                  evidence: none
+                </span>
+              )}
+
+              {auditHashes?.rules ? (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+                  onClick={async () => copyToClipboard(auditHashes.rules ?? "")}
+                  title="Copy rules_sha256"
+                >
+                  <span className="text-slate-500">rules:</span>
+                  <span className="font-mono">{shortSha(auditHashes.rules)}</span>
+                </button>
+              ) : null}
+              {auditHashes?.sections ? (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+                  onClick={async () => copyToClipboard(auditHashes.sections ?? "")}
+                  title="Copy sections_sha256"
+                >
+                  <span className="text-slate-500">sections:</span>
+                  <span className="font-mono">{shortSha(auditHashes.sections)}</span>
+                </button>
+              ) : null}
+            </div>
+
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <ProofCoverageChip
+                kpis={runKpis}
+                onViewCoverage={onOpenCoverageDrawer}
+              />
+              <button
+                type="button"
+                className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+                onClick={() => {
+                  document.getElementById("verify-outcome")?.scrollIntoView({ behavior: "smooth", block: "start" });
+                }}
+              >
+                Outcome
+              </button>
+            </div>
+          </div>
+        </div>
+      </details>
 
       {undoVisible ? (
         <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow">

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -10,6 +10,7 @@ import FinalizeGateBanner from "@/components/verify/FinalizeGateBanner";
 import ReviewSummaryCard from "@/components/verify/ReviewSummaryCard";
 import RunHistoryPanel from "@/components/verify/RunHistoryPanel";
 import EvidenceWorkflowStepper from "@/components/verify/EvidenceWorkflowStepper";
+import VerifyReadinessStrip, { type VerifyReadinessChip } from "@/components/verify/VerifyReadinessStrip";
 import type { AOI, EvidencePin, VerificationRun } from "@/lib/proofMap/types";
 import { parseAoiGeoJson } from "@/lib/proofMap/aoi";
 import type { ProofEvidenceItem } from "@/lib/proof/bundle";
@@ -34,6 +35,7 @@ import { buildReviewSummary, type ReviewSummary } from "@/lib/verify/buildReview
 import { buildReviewSummaryPdf } from "@/lib/verify/reviewSummaryPdf";
 import { buildFinalizedExportKpis, buildSelectedStacExport, prepareChecklistExport } from "@/lib/verify/finalizedExport";
 import { buildStacSupportFactsState } from "@/lib/verify/stacSupportFacts";
+import { isStacEligible } from "@/lib/verify/stacEligibility";
 import { checkFinalizeGate, REVIEW_STORE_EVENT } from "@/lib/verify/reviewStore";
 import { buildRequirementCoverageRows, reconcileRequirement } from "@/app/m/_lib/requirementCoverage";
 import { computeKpis, linkedRuleIdsFromPins } from "@/lib/kpis/computeKpis";
@@ -432,6 +434,7 @@ export default function ProofMapTab({
     sectionId: string | null;
     sectionTitle: string | null;
     expectedEvidence: string[];
+    tags: string[];
   } | null>(null);
   const [reviewArtifact, setReviewArtifact] = useState<EvidenceSnapshot | null>(null);
   const [reviewPdfBusy, setReviewPdfBusy] = useState(false);
@@ -513,6 +516,7 @@ export default function ProofMapTab({
         sectionId: null,
         sectionTitle: null,
         expectedEvidence: [],
+        tags: [],
       };
       try {
         const ruleResponse = await fetch(
@@ -552,6 +556,13 @@ export default function ProofMapTab({
             ? ruleRecord.expectedEvidence.filter((value): value is string => typeof value === "string")
             : Array.isArray((ruleRecord.requirement_coverage as { expected_evidence?: unknown } | undefined)?.expected_evidence)
               ? ((ruleRecord.requirement_coverage as { expected_evidence?: unknown[] }).expected_evidence ?? []).filter(
+                  (value): value is string => typeof value === "string",
+                )
+              : [],
+          tags: Array.isArray(ruleRecord.tags)
+            ? ruleRecord.tags.filter((value): value is string => typeof value === "string")
+            : Array.isArray((ruleRecord.requirement_coverage as { tags?: unknown } | undefined)?.tags)
+              ? ((ruleRecord.requirement_coverage as { tags?: unknown[] }).tags ?? []).filter(
                   (value): value is string => typeof value === "string",
                 )
               : [],
@@ -1754,7 +1765,7 @@ export default function ProofMapTab({
             snippet: selectedRuleContext?.text ?? selectedRuleId,
             text: selectedRuleContext?.text ?? undefined,
             expectedEvidence: selectedRuleContext?.expectedEvidence ?? [],
-            tags: [],
+            tags: selectedRuleContext?.tags ?? [],
             sectionId: selectedRuleContext?.sectionId ?? undefined,
           },
         ],
@@ -1847,6 +1858,137 @@ export default function ProofMapTab({
   const pinsSectionRef = useRef<HTMLDivElement | null>(null);
   const reviewerSectionRef = useRef<HTMLDivElement | null>(null);
   const finalSummarySectionRef = useRef<HTMLDivElement | null>(null);
+  const scrollToSection = useCallback((ref: { current: HTMLDivElement | null }) => {
+    ref.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+  const selectedRuleStacEligible = useMemo(
+    () => isStacEligible(selectedRuleContext?.tags ?? []),
+    [selectedRuleContext?.tags],
+  );
+  const hasReviewerDraft = Boolean(verifierBundle.draftMinutes.trim() || verifierBundle.draftOutcomeNote.trim());
+  const verifyReadinessChips = useMemo<VerifyReadinessChip[]>(() => {
+    const hasAoiLoaded = Boolean(aoi?.geojson);
+    const stacStatus =
+      !hasAoiLoaded || !latestRun
+        ? "not run"
+        : latestRun.status === "ok"
+          ? stacFeatureIds.length > 0
+            ? "results found"
+            : "no results"
+          : latestRun.status === "warn" && stacFeatureIds.length > 0
+            ? "results found"
+            : "failed";
+    const stacDetail =
+      !hasAoiLoaded
+        ? "Load an AOI before running STAC search."
+        : !latestRun
+          ? "No STAC search has been run for the active AOI."
+          : stacStatus === "results found"
+            ? `${stacFeatureIds.length} STAC result${stacFeatureIds.length === 1 ? "" : "s"} found for the active AOI.`
+            : stacStatus === "no results"
+              ? "STAC search completed but returned no results for the active AOI."
+              : latestRun.summary?.trim() || "STAC search failed for the active AOI.";
+    const supportFactsStatus = !selectedRuleId || !selectedRuleStacEligible
+      ? "not applicable"
+      : stacSupportFacts.linkedFacts.length > 0
+        ? "linked"
+        : stacSupportFacts.staleFacts.length > 0
+          ? "stale"
+          : "unlinked";
+    const supportFactsDetail = !selectedRuleId
+      ? "Select a rule to assess AOI/STAC support facts."
+      : !selectedRuleStacEligible
+        ? "AOI/STAC support facts are not expected for this rule."
+        : stacSupportFacts.lookupMessage;
+    const reviewerRecordStatus = verifierBundle.savedReviewerArtifactAt
+      ? "saved"
+      : hasReviewerDraft
+        ? "draft"
+        : "missing";
+    const exportReady =
+      currentWorkspaceIsFinal ||
+      Boolean(finalizeGate?.canFinalize && linkedRuleIds.length > 0 && verifierBundle.savedReviewerArtifactAt);
+    const exportDetail = currentWorkspaceIsFinal
+      ? `Finalized ${formatLocalDateTime(verifierBundle.finalizedAt ?? "")}`
+      : finalizeGate && !finalizeGate.canFinalize
+        ? finalizeGate.reasons[0] ?? "Finalize gate is blocked."
+        : !linkedRuleIds.length
+          ? "Link evidence to at least one rule before finalizing or exporting."
+          : !verifierBundle.savedReviewerArtifactAt
+            ? "Save reviewer artifact before finalizing or exporting."
+            : "Finalize gate is clear for export.";
+
+    return [
+      {
+        key: "aoi",
+        label: "AOI",
+        value: hasAoiLoaded ? "loaded" : "missing",
+        detail: hasAoiLoaded ? aoi?.name ?? bboxLabel ?? "AOI loaded." : "Upload or confirm an AOI to scope the review.",
+        tone: hasAoiLoaded ? "ok" : "blocked",
+        onClick: () => scrollToSection(aoiSectionRef),
+      },
+      {
+        key: "stac",
+        label: "STAC",
+        value: stacStatus,
+        detail: stacDetail,
+        tone: stacStatus === "results found" ? "ok" : stacStatus === "failed" ? "blocked" : "warn",
+        onClick: () => scrollToSection(stacSectionRef),
+      },
+      {
+        key: "support-facts",
+        label: "Support facts",
+        value: supportFactsStatus,
+        detail: supportFactsDetail,
+        tone:
+          supportFactsStatus === "linked"
+            ? "ok"
+            : supportFactsStatus === "not applicable"
+              ? "neutral"
+              : supportFactsStatus === "stale"
+                ? "warn"
+                : "blocked",
+      },
+      {
+        key: "reviewer-record",
+        label: "Reviewer record",
+        value: reviewerRecordStatus,
+        detail: verifierBundle.savedReviewerArtifactAt
+          ? `Saved ${formatLocalDateTime(verifierBundle.savedReviewerArtifactAt)}`
+          : hasReviewerDraft
+            ? "Draft reviewer notes exist but are not saved yet."
+            : "No reviewer artifact is saved for the active rule and run.",
+        tone: reviewerRecordStatus === "saved" ? "ok" : reviewerRecordStatus === "draft" ? "warn" : "blocked",
+        onClick: () => scrollToSection(reviewerSectionRef),
+      },
+      {
+        key: "export",
+        label: "Export",
+        value: exportReady ? "ready" : "blocked",
+        detail: exportDetail,
+        tone: exportReady ? "ok" : "blocked",
+        onClick: () => scrollToSection(finalSummarySectionRef),
+      },
+    ];
+  }, [
+    aoi?.geojson,
+    aoi?.name,
+    bboxLabel,
+    currentWorkspaceIsFinal,
+    finalizeGate,
+    hasReviewerDraft,
+    latestRun,
+    linkedRuleIds.length,
+    scrollToSection,
+    selectedRuleId,
+    selectedRuleStacEligible,
+    stacFeatureIds.length,
+    stacSupportFacts.linkedFacts.length,
+    stacSupportFacts.lookupMessage,
+    stacSupportFacts.staleFacts.length,
+    verifierBundle.finalizedAt,
+    verifierBundle.savedReviewerArtifactAt,
+  ]);
   const activeLeftSection = useMemo(() => {
     switch (wizardDetails.activeStep) {
       case 1:
@@ -2317,7 +2459,6 @@ export default function ProofMapTab({
     const hasEvidence = (currentStacEvidence?.fc?.features?.length ?? 0) > 0;
     const hasRuns = verificationRuns.length > 0;
     const hasSnapshots = (evidenceSnapshots ?? []).length > 0;
-    const hasReviewerDraft = Boolean(verifierBundle.draftMinutes.trim() || verifierBundle.draftOutcomeNote.trim());
     const hasComparisonNotes = Boolean(verifierBundle.delta.trim() || verifierBundle.impact.trim() || verifierBundle.tasks.length);
     const hasWorkspaceRunState = Boolean(
       verifierBundle.exportedAt ||
@@ -2334,10 +2475,9 @@ export default function ProofMapTab({
     evidenceSnapshots,
     selectedStacItemId,
     verificationRuns.length,
+    hasReviewerDraft,
     verifierBundle.delta,
     verifierBundle.derivedFromRunId,
-    verifierBundle.draftMinutes,
-    verifierBundle.draftOutcomeNote,
     verifierBundle.exportedAt,
     verifierBundle.finalizedAt,
     verifierBundle.impact,
@@ -4062,12 +4202,17 @@ export default function ProofMapTab({
             </div>
           ) : null}
 
+          <VerifyReadinessStrip
+            ruleId={selectedRuleId}
+            chips={verifyReadinessChips}
+          />
+
           <div className="transition">
             {currentWorkspaceIsFinal ? (
               <FinalReviewSummaryPanel
                 summary={activeReviewArtifact?.summary ?? reviewSummary}
                 artifact={activeReviewArtifact}
-          evidencePins={evidencePins}
+                evidencePins={evidencePins}
                 currentRunLabel={currentRunLabel}
                 loadedFromRunLabel={loadedFromRunLabel}
                 finalizedAt={verifierBundle.finalizedAt}

--- a/src/components/verify/EvidenceWorkflowStepper.tsx
+++ b/src/components/verify/EvidenceWorkflowStepper.tsx
@@ -83,10 +83,23 @@ type EvidenceWorkflowStepperProps = {
 };
 
 function stepStateClass(input: { active: boolean; complete: boolean; disabled: boolean }): string {
-  if (input.active) return "border-slate-900 bg-slate-50 shadow-sm";
-  if (input.complete) return "border-emerald-200 bg-emerald-50";
-  if (input.disabled) return "border-slate-200 bg-slate-50/70 opacity-75";
+  if (input.active) return "border-slate-300 bg-slate-50";
+  if (input.complete) return "border-emerald-200/90 bg-emerald-50/65";
+  if (input.disabled) return "border-slate-200 bg-slate-50/60 opacity-80";
   return "border-slate-200 bg-white";
+}
+
+function stepMarkerClass(input: { active: boolean; complete: boolean; disabled: boolean }): string {
+  if (input.active) return "border-slate-900 bg-slate-900 text-white";
+  if (input.complete) return "border-emerald-300 bg-emerald-50 text-emerald-700";
+  if (input.disabled) return "border-slate-200 bg-slate-50 text-slate-400";
+  return "border-slate-200 bg-white text-slate-500";
+}
+
+function stepTextTone(input: { active: boolean; complete: boolean; disabled: boolean }): string {
+  if (input.active) return "text-slate-900";
+  if (input.disabled) return "text-slate-500";
+  return "text-slate-700";
 }
 
 function formatDate(value: string | null | undefined): string | null {
@@ -109,13 +122,13 @@ function CompletedWorkflowSummary(props: {
 
   return (
     <div
-      className="rounded-xl border border-emerald-200 bg-gradient-to-r from-emerald-50 via-white to-slate-50 px-4 py-3 shadow-sm shadow-emerald-100"
+      className="rounded-xl border border-emerald-200/90 bg-white px-4 py-3"
       data-testid="wizard-completed-summary"
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-emerald-200 bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-emerald-800">
+            <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-700">
               Finalized
             </span>
             {methodCode && version ? (
@@ -136,7 +149,7 @@ function CompletedWorkflowSummary(props: {
           {onViewOutcome ? (
             <button
               type="button"
-              className="rounded-full border border-emerald-700 bg-emerald-700 px-3 py-1 text-xs font-semibold text-white shadow-sm hover:bg-emerald-800"
+            className="rounded-full border border-slate-900 bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-800"
               onClick={onViewOutcome}
             >
               View outcome
@@ -144,14 +157,14 @@ function CompletedWorkflowSummary(props: {
           ) : null}
           <button
             type="button"
-            className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
+            className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
             onClick={onStartAnotherRun}
           >
             Start another run
           </button>
           <button
             type="button"
-            className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
+            className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-500 hover:bg-slate-50 hover:text-slate-700"
             onClick={onExpand}
           >
             Expand workflow
@@ -208,18 +221,18 @@ function CompletedWorkflowDetail(props: {
       <div className="flex justify-end">
         <button
           type="button"
-          className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
+          className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-500 hover:bg-slate-50 hover:text-slate-700"
           onClick={onCollapse}
         >
           Collapse workflow
         </button>
       </div>
 
-      <div className="rounded-xl border border-emerald-200 bg-white px-4 py-4 shadow-sm">
+      <div className="rounded-xl border border-emerald-200 bg-white px-4 py-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full border border-emerald-200 bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-emerald-800">
+              <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-700">
                 Completed workflow
               </span>
               {methodCode && version ? (
@@ -237,7 +250,7 @@ function CompletedWorkflowDetail(props: {
             {onViewOutcome ? (
               <button
                 type="button"
-                className="rounded-full border border-emerald-700 bg-emerald-700 px-3 py-1 text-xs font-semibold text-white shadow-sm hover:bg-emerald-800"
+                className="rounded-full border border-slate-900 bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-800"
                 onClick={onViewOutcome}
               >
                 View outcome
@@ -245,14 +258,14 @@ function CompletedWorkflowDetail(props: {
             ) : null}
             <button
               type="button"
-              className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
+              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
               onClick={onStartAnotherRun}
             >
               Start another run
             </button>
             <button
               type="button"
-              className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
+              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
               onClick={onViewRunHistory}
             >
               View run history
@@ -443,7 +456,7 @@ export default function EvidenceWorkflowStepper({
 
   return (
     <div className="grid gap-3">
-      <div className="sticky top-0 z-10 rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-sm">
+      <div className="sticky top-0 z-10 rounded-xl border border-slate-200 bg-white px-3.5 py-3">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div>
             <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Current workspace</div>
@@ -455,12 +468,12 @@ export default function EvidenceWorkflowStepper({
                 </span>
               </span>
               {loadedFromRunLabel ? (
-                <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-700">
+                <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-medium text-sky-700">
                   Loaded from Run {loadedFromRunLabel}
                 </span>
               ) : null}
               {isEditedDraft ? (
-                <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-700">
+                <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
                   Edited draft
                 </span>
               ) : null}
@@ -470,22 +483,22 @@ export default function EvidenceWorkflowStepper({
                 </span>
               ) : null}
               {inProgress ? (
-                <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-semibold text-slate-700">
+                <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-700">
                   In progress
                 </span>
               ) : null}
               {reviewerArtifactSaved && !currentWorkspaceIsFinal ? (
-                <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-700">
+                <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-medium text-sky-700">
                   Reviewer artifact saved
                 </span>
               ) : null}
               {readyToFinalize ? (
-                <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-700">
+                <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
                   Ready to finalize
                 </span>
               ) : null}
               {hasUnsavedWorkspaceEdits ? (
-                <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-700">
+                <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
                   Unsaved edits
                 </span>
               ) : null}
@@ -498,10 +511,17 @@ export default function EvidenceWorkflowStepper({
         </div>
       </div>
 
-      <div className={`${stepShellClass} rounded-lg border px-3 py-2 ${stepStateClass(step1)}`} data-testid="wizard-step-1">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Step 1</div>
-        <div className="mt-1 text-xs font-semibold text-slate-900">Pick rule</div>
-        <div className="mt-2 flex flex-wrap items-center gap-2">
+      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step1)}`} data-testid="wizard-step-1">
+        <div className="flex items-start gap-3">
+          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step1)}`}>
+            {step1.complete ? "✓" : "1"}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 1</div>
+              <div className={`text-sm font-semibold ${stepTextTone(step1)}`}>Pick rule</div>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
           <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1">
             <span className="text-xs font-semibold text-slate-600">Rule</span>
             <select
@@ -528,16 +548,25 @@ export default function EvidenceWorkflowStepper({
           ) : (
             <div className="text-[11px] text-slate-500">Select a rule to unlock the rest of the workflow.</div>
           )}
+            </div>
+          </div>
         </div>
       </div>
 
-      <div className={`${stepShellClass} rounded-lg border px-3 py-2 ${stepStateClass(step2)}`} data-testid="wizard-step-2">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Step 2</div>
-        <div className="mt-1 text-xs font-semibold text-slate-900">Confirm Area</div>
-        <div className="mt-2 flex flex-wrap items-center gap-2">
+      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step2)}`} data-testid="wizard-step-2">
+        <div className="flex items-start gap-3">
+          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step2)}`}>
+            {step2.complete ? "✓" : "2"}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 2</div>
+              <div className={`text-sm font-semibold ${stepTextTone(step2)}`}>Confirm Area</div>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
           <button
             type="button"
-            className={`rounded-full border px-3 py-1 text-xs font-semibold shadow-sm ${
+            className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${
               step2.active ? "border-slate-900 bg-slate-900 text-white hover:bg-slate-800" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
             }`}
             onClick={onUploadAoi}
@@ -554,9 +583,9 @@ export default function EvidenceWorkflowStepper({
           ) : (
             <div className="text-[11px] text-slate-500">Upload and confirm an Area to continue.</div>
           )}
-        </div>
+            </div>
         {aoiSummary ? (
-          <div className="mt-2 rounded-lg border border-slate-200 bg-white px-2 py-2 text-xs text-slate-700">
+          <div className="mt-2 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-xs text-slate-700">
             {aoiSummary.isPreview ? (
               <>
                 <div className="font-semibold text-slate-900">New Area ready</div>
@@ -585,15 +614,24 @@ export default function EvidenceWorkflowStepper({
             )}
           </div>
         ) : null}
+          </div>
+        </div>
       </div>
 
-      <div className={`${stepShellClass} rounded-lg border px-3 py-2 ${stepStateClass(step3)}`} data-testid="wizard-step-3">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Step 3</div>
-        <div className="mt-1 text-xs font-semibold text-slate-900">Search Satellite</div>
-        <div className="mt-2 flex flex-wrap items-center gap-2">
+      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step3)}`} data-testid="wizard-step-3">
+        <div className="flex items-start gap-3">
+          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step3)}`}>
+            {step3.complete ? "✓" : "3"}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 3</div>
+              <div className={`text-sm font-semibold ${stepTextTone(step3)}`}>Search Satellite</div>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
           <button
             type="button"
-            className={`rounded-full border px-3 py-1 text-xs font-semibold shadow-sm disabled:cursor-not-allowed disabled:opacity-60 ${
+            className={`rounded-full border px-3 py-1.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60 ${
               step3.active ? "border-slate-900 bg-slate-900 text-white hover:bg-slate-800" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
             }`}
             disabled={step3.disabled || searchDisabled}
@@ -610,12 +648,21 @@ export default function EvidenceWorkflowStepper({
           ) : (
             <div className="text-[11px] text-slate-500">Run search to load candidate evidence.</div>
           )}
+            </div>
+          </div>
         </div>
       </div>
 
-      <div className={`${stepShellClass} rounded-lg border px-3 py-2 ${stepStateClass(step4)}`} data-testid="wizard-step-4">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Step 4</div>
-        <div className="mt-1 text-xs font-semibold text-slate-900">Select item</div>
+      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step4)}`} data-testid="wizard-step-4">
+        <div className="flex items-start gap-3">
+          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step4)}`}>
+            {step4.complete ? "✓" : "4"}
+          </div>
+          <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 4</div>
+          <div className={`text-sm font-semibold ${stepTextTone(step4)}`}>Select item</div>
+        </div>
         {selectedStacItemId ? (
           <div className="mt-2 flex flex-wrap items-center gap-2">
             <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-700">
@@ -626,16 +673,25 @@ export default function EvidenceWorkflowStepper({
         ) : (
           <div className="mt-2 text-[11px] text-slate-500">Pick a satellite result from the list or map to continue.</div>
         )}
+          </div>
+        </div>
       </div>
 
-      <div className={`${stepShellClass} rounded-lg border px-3 py-2 ${stepStateClass(step5)}`} data-testid="wizard-step-5">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Step 5</div>
-        <div className="mt-1 text-xs font-semibold text-slate-900">Create/link pin</div>
-        <div className="mt-2 flex flex-wrap items-center gap-2">
+      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step5)}`} data-testid="wizard-step-5">
+        <div className="flex items-start gap-3">
+          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step5)}`}>
+            {step5.complete ? "✓" : "5"}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 5</div>
+              <div className={`text-sm font-semibold ${stepTextTone(step5)}`}>Create/link pin</div>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
           <Tooltip content={createPinDisabledReason}>
             <button
               type="button"
-              className={`rounded-full border px-3 py-1 text-xs font-semibold shadow-sm disabled:cursor-not-allowed disabled:opacity-60 ${
+              className={`rounded-full border px-3 py-1.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60 ${
                 step5.active ? "border-slate-900 bg-slate-900 text-white hover:bg-slate-800" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
               }`}
               onClick={onCreatePin}
@@ -649,24 +705,33 @@ export default function EvidenceWorkflowStepper({
               {pinsCount} link{pinsCount === 1 ? "" : "s"} ready
             </span>
           ) : null}
+            </div>
+          </div>
         </div>
       </div>
 
-      <div className={`${stepShellClass} rounded-lg border px-3 py-2 ${stepStateClass(step6)}`} data-testid="wizard-step-6">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Step 6</div>
-        <div className="mt-1 text-xs font-semibold text-slate-900">Save reviewer artifact</div>
+      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step6)}`} data-testid="wizard-step-6">
+        <div className="flex items-start gap-3">
+          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step6)}`}>
+            {step6.complete ? "✓" : "6"}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 6</div>
+              <div className={`text-sm font-semibold ${stepTextTone(step6)}`}>Save reviewer artifact</div>
+            </div>
         <div className="mt-2 grid gap-3">
           <div className="text-[11px] text-slate-500">Type concise minutes or an outcome note, then save it explicitly before finalization.</div>
           <textarea
             data-testid="verifier-minutes-textarea"
-            className="min-h-[96px] w-full resize-none rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-200 disabled:opacity-60"
+            className="min-h-[92px] w-full resize-none rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-800 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-200 disabled:opacity-60"
             placeholder="Verifier minutes: what you checked, what you assume, what remains uncertain."
             value={draftMinutes}
             disabled={currentWorkspaceIsFinal}
             onChange={(event) => onReviewerMinutesChange(event.target.value)}
           />
           <textarea
-            className="min-h-[72px] w-full resize-none rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-200 disabled:opacity-60"
+            className="min-h-[72px] w-full resize-none rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-800 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-200 disabled:opacity-60"
             placeholder="Outcome note: one concise sentence if minutes are unnecessary."
             value={draftOutcomeNote}
             disabled={currentWorkspaceIsFinal}
@@ -675,7 +740,7 @@ export default function EvidenceWorkflowStepper({
           <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
               onClick={onSaveReviewerArtifact}
               disabled={step6.disabled || currentWorkspaceIsFinal || !hasDraftArtifactChanges}
             >
@@ -688,17 +753,26 @@ export default function EvidenceWorkflowStepper({
             ) : null}
           </div>
         </div>
+          </div>
+        </div>
       </div>
 
-      <div className={`${currentWorkspaceIsFinal ? "opacity-70 transition" : "transition"} rounded-lg border px-3 py-2 ${stepStateClass(step7)}`} data-testid="wizard-step-7">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Step 7</div>
-        <div className="mt-1 text-xs font-semibold text-slate-900">Finalize run</div>
+      <div className={`${currentWorkspaceIsFinal ? "opacity-70 transition" : "transition"} rounded-xl border px-3.5 py-3 ${stepStateClass(step7)}`} data-testid="wizard-step-7">
+        <div className="flex items-start gap-3">
+          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step7)}`}>
+            {step7.complete ? "✓" : "7"}
+          </div>
+          <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 7</div>
+          <div className={`text-sm font-semibold ${stepTextTone(step7)}`}>Finalize run</div>
+        </div>
         <div className="mt-1 text-[11px] text-slate-500">This is the single completion/export action. Finalization writes the immutable run artifact with evidence and reviewer notes.</div>
         {finalizeGateBanner ? <div className="mt-2">{finalizeGateBanner}</div> : null}
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <button
             type="button"
-            className="rounded-full border border-emerald-700 bg-emerald-700 px-3 py-1 text-xs font-semibold text-white shadow-sm hover:bg-emerald-800 disabled:cursor-not-allowed disabled:opacity-60"
+            className="rounded-full border border-slate-900 bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
             onClick={onFinalizeRun}
             disabled={step7.disabled || currentWorkspaceIsFinal || finalizeBlocked}
           >
@@ -709,6 +783,8 @@ export default function EvidenceWorkflowStepper({
               Finalized {formatDate(finalizedAt)}
             </span>
           ) : null}
+        </div>
+          </div>
         </div>
       </div>
 

--- a/src/components/verify/VerifyReadinessStrip.tsx
+++ b/src/components/verify/VerifyReadinessStrip.tsx
@@ -16,37 +16,37 @@ type VerifyReadinessStripProps = {
 
 function chipClasses(tone: VerifyReadinessChip["tone"], clickable: boolean): string {
   const base =
-    "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-semibold transition";
+    "inline-flex h-8 items-center gap-1 rounded-full border px-2.5 text-[11px] font-medium transition";
   const toneClass =
     tone === "ok"
-      ? "border-emerald-200 bg-emerald-50/70 text-emerald-900"
+      ? "border-emerald-200/90 bg-emerald-50/70 text-emerald-800"
       : tone === "warn"
-        ? "border-amber-200 bg-amber-50/80 text-amber-900"
+        ? "border-amber-200/90 bg-amber-50/80 text-amber-800"
         : tone === "blocked"
-          ? "border-rose-200 bg-rose-50/70 text-rose-900"
-          : "border-slate-200 bg-slate-50 text-slate-700";
+          ? "border-rose-200/90 bg-rose-50/70 text-rose-800"
+          : "border-slate-200 bg-slate-50 text-slate-600";
   const interactive = clickable ? "cursor-pointer hover:border-slate-300 hover:bg-white" : "cursor-default";
   return `${base} ${toneClass} ${interactive}`;
 }
 
 export default function VerifyReadinessStrip({ ruleId, chips }: VerifyReadinessStripProps) {
   return (
-    <div className="rounded-xl border border-slate-200/80 bg-white/80 px-4 py-3.5">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <div className="rounded-xl border border-slate-200/80 bg-white px-4 py-3">
+      <div className="flex flex-col gap-2.5 lg:flex-row lg:items-center lg:justify-between">
         <div className="min-w-0">
-          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">
             Verify readiness
           </div>
-          <div className="mt-1 text-xs leading-5 text-slate-500">
+          <div className="mt-1 text-sm font-medium leading-5 text-slate-700">
             {ruleId ? `Active rule ${ruleId}` : "Select a rule to inspect rule-specific readiness."}
           </div>
         </div>
 
-        <div className="flex flex-wrap gap-1.5">
+        <div className="flex flex-wrap gap-1.5 lg:justify-end">
           {chips.map((chip) => {
             const content = (
               <>
-                <span className="text-current/70">{chip.label}:</span>
+                <span className="text-current/65">{chip.label}:</span>
                 <span>{chip.value}</span>
               </>
             );

--- a/src/components/verify/VerifyReadinessStrip.tsx
+++ b/src/components/verify/VerifyReadinessStrip.tsx
@@ -31,18 +31,18 @@ function chipClasses(tone: VerifyReadinessChip["tone"], clickable: boolean): str
 
 export default function VerifyReadinessStrip({ ruleId, chips }: VerifyReadinessStripProps) {
   return (
-    <div className="rounded-xl border border-slate-200 bg-white px-4 py-3">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+    <div className="rounded-xl border border-slate-200/80 bg-white/80 px-4 py-3.5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
             Verify readiness
           </div>
-          <div className="mt-1 text-xs text-slate-500">
+          <div className="mt-1 text-xs leading-5 text-slate-500">
             {ruleId ? `Active rule ${ruleId}` : "Select a rule to inspect rule-specific readiness."}
           </div>
         </div>
 
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-1.5">
           {chips.map((chip) => {
             const content = (
               <>

--- a/src/components/verify/VerifyReadinessStrip.tsx
+++ b/src/components/verify/VerifyReadinessStrip.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+export type VerifyReadinessChip = {
+  key: string;
+  label: string;
+  value: string;
+  detail: string;
+  tone: "ok" | "warn" | "blocked" | "neutral";
+  onClick?: () => void;
+};
+
+type VerifyReadinessStripProps = {
+  ruleId?: string | null;
+  chips: VerifyReadinessChip[];
+};
+
+function chipClasses(tone: VerifyReadinessChip["tone"], clickable: boolean): string {
+  const base =
+    "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-semibold transition";
+  const toneClass =
+    tone === "ok"
+      ? "border-emerald-200 bg-emerald-50/70 text-emerald-900"
+      : tone === "warn"
+        ? "border-amber-200 bg-amber-50/80 text-amber-900"
+        : tone === "blocked"
+          ? "border-rose-200 bg-rose-50/70 text-rose-900"
+          : "border-slate-200 bg-slate-50 text-slate-700";
+  const interactive = clickable ? "cursor-pointer hover:border-slate-300 hover:bg-white" : "cursor-default";
+  return `${base} ${toneClass} ${interactive}`;
+}
+
+export default function VerifyReadinessStrip({ ruleId, chips }: VerifyReadinessStripProps) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white px-4 py-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Verify readiness
+          </div>
+          <div className="mt-1 text-xs text-slate-500">
+            {ruleId ? `Active rule ${ruleId}` : "Select a rule to inspect rule-specific readiness."}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {chips.map((chip) => {
+            const content = (
+              <>
+                <span className="text-current/70">{chip.label}:</span>
+                <span>{chip.value}</span>
+              </>
+            );
+
+            if (chip.onClick) {
+              return (
+                <button
+                  key={chip.key}
+                  type="button"
+                  title={chip.detail}
+                  aria-label={`${chip.label}: ${chip.value}. ${chip.detail}`}
+                  data-testid={`verify-readiness-chip-${chip.key}`}
+                  className={chipClasses(chip.tone, true)}
+                  onClick={chip.onClick}
+                >
+                  {content}
+                </button>
+              );
+            }
+
+            return (
+              <span
+                key={chip.key}
+                title={chip.detail}
+                aria-label={`${chip.label}: ${chip.value}. ${chip.detail}`}
+                data-testid={`verify-readiness-chip-${chip.key}`}
+                className={chipClasses(chip.tone, false)}
+              >
+                {content}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/components/verifyReadinessStrip.test.tsx
+++ b/tests/components/verifyReadinessStrip.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "@jest/globals";
+import { renderToStaticMarkup } from "react-dom/server";
+import VerifyReadinessStrip from "@/components/verify/VerifyReadinessStrip";
+
+describe("VerifyReadinessStrip", () => {
+  test("renders compact truthful readiness chips", () => {
+    const html = renderToStaticMarkup(
+      <VerifyReadinessStrip
+        ruleId="R-1-0001"
+        chips={[
+          {
+            key: "aoi",
+            label: "AOI",
+            value: "loaded",
+            detail: "Project AOI loaded.",
+            tone: "ok",
+          },
+          {
+            key: "stac",
+            label: "STAC",
+            value: "results found",
+            detail: "2 STAC results found for the active AOI.",
+            tone: "ok",
+          },
+          {
+            key: "support-facts",
+            label: "Support facts",
+            value: "not applicable",
+            detail: "AOI/STAC support facts are not expected for this rule.",
+            tone: "neutral",
+          },
+          {
+            key: "reviewer-record",
+            label: "Reviewer record",
+            value: "draft",
+            detail: "Draft reviewer notes exist but are not saved yet.",
+            tone: "warn",
+          },
+          {
+            key: "export",
+            label: "Export",
+            value: "blocked",
+            detail: "Save reviewer artifact before finalizing or exporting.",
+            tone: "blocked",
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("Verify readiness");
+    expect(html).toContain("Active rule R-1-0001");
+    expect(html).toContain("AOI:");
+    expect(html).toContain("loaded");
+    expect(html).toContain("STAC:");
+    expect(html).toContain("results found");
+    expect(html).toContain("Support facts:");
+    expect(html).toContain("not applicable");
+    expect(html).toContain("Reviewer record:");
+    expect(html).toContain("draft");
+    expect(html).toContain("Export:");
+    expect(html).toContain("blocked");
+    expect(html).toContain("AOI/STAC support facts are not expected for this rule.");
+  });
+});

--- a/tests/components/verifyReadinessStrip.test.tsx
+++ b/tests/components/verifyReadinessStrip.test.tsx
@@ -48,8 +48,8 @@ describe("VerifyReadinessStrip", () => {
           {
             key: "support-facts",
             label: "Support facts",
-            value: "not applicable",
-            detail: "AOI/STAC support facts are not expected for this rule.",
+            value: "optional",
+            detail: "AOI/STAC support facts are optional for this rule. Link them only if they materially support the review.",
             tone: "neutral",
           },
           {
@@ -62,9 +62,9 @@ describe("VerifyReadinessStrip", () => {
           {
             key: "export",
             label: "Export",
-            value: "blocked",
-            detail: "Save reviewer artifact before finalizing or exporting.",
-            tone: "blocked",
+            value: "draft available",
+            detail: "Draft snapshot exported 2026-03-25 00:10:00. Final export still needs finalize requirements to pass.",
+            tone: "warn",
           },
         ]}
       />,
@@ -77,11 +77,12 @@ describe("VerifyReadinessStrip", () => {
     expect(html).toContain("STAC:");
     expect(html).toContain("results found");
     expect(html).toContain("Support facts:");
-    expect(html).toContain("not applicable");
+    expect(html).toContain("optional");
     expect(html).toContain("Reviewer record:");
     expect(html).toContain("draft");
     expect(html).toContain("Export:");
-    expect(html).toContain("blocked");
-    expect(html).toContain("AOI/STAC support facts are not expected for this rule.");
+    expect(html).toContain("draft available");
+    expect(html).toContain("AOI/STAC support facts are optional for this rule. Link them only if they materially support the review.");
+    expect(html).toContain("Draft snapshot exported 2026-03-25 00:10:00. Final export still needs finalize requirements to pass.");
   });
 });

--- a/tests/components/verifyReadinessStrip.test.tsx
+++ b/tests/components/verifyReadinessStrip.test.tsx
@@ -3,6 +3,29 @@ import { renderToStaticMarkup } from "react-dom/server";
 import VerifyReadinessStrip from "@/components/verify/VerifyReadinessStrip";
 
 describe("VerifyReadinessStrip", () => {
+  test("keeps no selected rule distinct from not applicable", () => {
+    const html = renderToStaticMarkup(
+      <VerifyReadinessStrip
+        ruleId={null}
+        chips={[
+          {
+            key: "support-facts",
+            label: "Support facts",
+            value: "select rule",
+            detail: "Select a rule to assess AOI/STAC support facts.",
+            tone: "blocked",
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("Select a rule to inspect rule-specific readiness.");
+    expect(html).toContain("Support facts:");
+    expect(html).toContain("select rule");
+    expect(html).toContain("Select a rule to assess AOI/STAC support facts.");
+    expect(html).not.toContain("not applicable");
+  });
+
   test("renders compact truthful readiness chips", () => {
     const html = renderToStaticMarkup(
       <VerifyReadinessStrip


### PR DESCRIPTION
## What changed

Final polish for the Verify-page readiness surface on top of `feat/verify-readiness-strip`.

This keeps the design intact but fixes the remaining product-level wording and hierarchy issues:
- the always-visible top row is now a compact reviewer summary instead of generic workspace metadata
- `Support facts` no longer says `not applicable` for non-STAC-tagged rules when STAC support can still be linked optionally
- `Export` no longer says `blocked` after a draft snapshot has already been exported

Current readiness chips are now truthful to the underlying state:
- `AOI`: `loaded` / `missing`
- `STAC`: `not run` / `no results` / `results found` / `failed`
- `Support facts`: `select rule` / `linked` / `unlinked` / `stale` / `optional`
- `Reviewer record`: `missing` / `draft` / `saved`
- `Export`: `not ready` / `draft available` / `ready` / `finalized`

Always visible summary row:
- `method: AR-ACM0003@v02-0`
- `Items: …`
- `Linked: …`
- `Snapshot: Exported …`

Technical hashes, export context, and debug metadata remain behind the existing disclosure.

## Why

PR #542 was functionally green, but the Verify page still overstated two states and surfaced the wrong metadata by default.

Priority here is truthfulness first:
- reviewers should see method/items/linked/snapshot immediately
- optional STAC support should not be described as absolutely inapplicable
- a downloadable draft snapshot should not be described as fully blocked export

## User impact

- Reviewer-useful state is visible immediately without opening technical metadata
- Non-required STAC support is presented as optional rather than impossible
- Draft export availability is distinguished from final export readiness
- Final export still stays gated on the existing finalize requirements

## Root cause

The first pass summarized the correct underlying state, but some labels were framed around implementation gates instead of reviewer truth:
- visible metadata favored workspace context over reviewer scan value
- non-STAC-tagged rules collapsed optional support into `not applicable`
- export status collapsed draft-exportable and truly blocked states together

## Validation

- `npx jest tests/components/verifyReadinessStrip.test.tsx --runInBand`
- `npm run typecheck`

**Signed-off-by:** Fred E <fredilly@article6.org>