### PR TITLE
Docs/phase3 status after pr542

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -106,7 +106,8 @@ Lane status: Active
 Commercial sales-readiness lane for project developer gap audits, VVB workpaper exports, public verification autopsies, white-label consultancy pilots, and rule encoding. `traceable-rule-review-mvp` remains the technical foundation.
 
 Current focus:
-- Readiness Gap Engine (RC3) — combine existing evidence inventory with methodology expectations into rule-level gap states
+- PR #542 started the reviewer-facing Verify readiness surface as the first Readiness Gap Engine (RC3) milestone
+- Next build: derive rule-level gap states from evidence inventory plus methodology expected evidence
 - Keep `traceable-rule-review-mvp` as the technical foundation for review records and exports
 - Preserve app-vs-methodologies boundaries while preparing sellable verification outputs
 
@@ -119,7 +120,7 @@ Not active now:
 1) RC0 — Roadmap consolidation: Done — Collapse the useful parts of old roadmaps into one commercial roadmap, preserve historical lanes as folded or superseded, and keep repo boundaries explicit. Completed via PR #538.
 2) RC1 — PDD / Project Gap Intake: Done — Ingest PDDs, monitoring reports, and workbooks into a project evidence inventory with page/section/fragment provenance and manual fragment-to-rule links. Already satisfied by existing app.article6 evidence inventory and requirement-coverage work (Phase 4 Document/Workbook Support in traceable-rule-review-mvp).
 3) RC2 — Method Evidence Contracts: Done — Define expected evidence per rule in the methodologies repo so the app can distinguish missing evidence from unknown expectations. Completed upstream in article6-methodologies repo for current target methods.
-4) RC3 — Readiness Gap Engine: Next — Turn project evidence plus method expectations into rule-level gap states, severities, recommendations, and reviewer overrides. Next build: combine existing evidence inventory with methodology expected evidence.
+4) RC3 — Readiness Gap Engine: Active — Active. PR #542 started the reviewer-facing Verify readiness surface, but Phase 3 still needs actual rule-level gap states, severity, recommendations, reviewer overrides, and the evidence inventory + methodology expected evidence combination that drives those outputs.
 5) RC4 — Client Readiness Report Export: Planned — Produce the paid readiness report and audit pack appendix for project developers and consultancies with explicit limits and traceability.
 6) RC5 — VVB Workpaper Export: Planned — Reuse the same review data for VVB-facing draft workpapers, provenance bundles, and truthful registry-aware report sections.
 7) RC6 — Public Autopsy Workflow: Planned — Create a public-safe autopsy workflow using public project documents, redactions, and source-tied findings for marketing and proof.

--- a/docs/roadmaps/project-readiness-verification-output/phase-status.json
+++ b/docs/roadmaps/project-readiness-verification-output/phase-status.json
@@ -3,7 +3,8 @@
     "status": "active",
     "summary": "Commercial sales-readiness lane for project developer gap audits, VVB workpaper exports, public verification autopsies, white-label consultancy pilots, and rule encoding. `traceable-rule-review-mvp` remains the technical foundation.",
     "current_focus": [
-      "Readiness Gap Engine (RC3) — combine existing evidence inventory with methodology expectations into rule-level gap states",
+      "PR #542 started the reviewer-facing Verify readiness surface as the first Readiness Gap Engine (RC3) milestone",
+      "Next build: derive rule-level gap states from evidence inventory plus methodology expected evidence",
       "Keep `traceable-rule-review-mvp` as the technical foundation for review records and exports",
       "Preserve app-vs-methodologies boundaries while preparing sellable verification outputs"
     ],
@@ -31,9 +32,9 @@
       "summary": "Define expected evidence per rule in the methodologies repo so the app can distinguish missing evidence from unknown expectations. Completed upstream in article6-methodologies repo for current target methods."
     },
     "phase_3_readiness_gap_engine": {
-      "status": "next",
+      "status": "active",
       "title": "Readiness Gap Engine",
-      "summary": "Turn project evidence plus method expectations into rule-level gap states, severities, recommendations, and reviewer overrides. Next build: combine existing evidence inventory with methodology expected evidence."
+      "summary": "Active. PR #542 started the reviewer-facing Verify readiness surface, but Phase 3 still needs actual rule-level gap states, severity, recommendations, reviewer overrides, and the evidence inventory + methodology expected evidence combination that drives those outputs."
     },
     "phase_4_client_readiness_report_export": {
       "status": "planned",


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: project-readiness-verification-output
- ack: human
- items:
  - PR542: done
  - RC3: in_progress

Allowed statuses: planned | next | in_progress | done | blocked

## What changed

Updates the active commercial roadmap phase-status JSON after PR #542.

This marks `phase_3_readiness_gap_engine` as `active` instead of `next`, and records PR #542 as the start of the reviewer-facing Verify readiness surface rather than the completion of the phase.

It also updates `phase_meta.current_focus` so the roadmap clearly says:
- PR #542 started the readiness surface
- the next build is rule-level gap states derived from evidence inventory plus methodology expected evidence

## Why

PR #542 was an important milestone, but it did not finish the Readiness Gap Engine phase.

Phase 3 still needs the actual engine outputs and reviewer controls:
- rule-level gap states
- severity
- recommendations
- reviewer overrides
- evidence inventory + methodology expected evidence combination

The roadmap should reflect that partial progress truthfully so the commercial lane stays accurate.

## User impact

- The commercial roadmap now shows Phase 3 as in progress rather than still queued
- PR #542 is captured as the start of the readiness surface
- Remaining Readiness Gap Engine scope stays explicit for the next build
- No new formal VVB, registry, or credit-issuance claims are introduced

## Validation

- `git diff --name-only origin/main...HEAD`
- `node -e "JSON.parse(require('fs').readFileSync('docs/roadmaps/project-readiness-verification-output/phase-status.json','utf8')); console.log('valid json')"`

**Signed-off-by:** Fred E <fredilly@article6.org>