### PR TITLE
Add Phase 3 readiness gap engine core

### DIFF
--- a/src/lib/readiness/gapEngine.ts
+++ b/src/lib/readiness/gapEngine.ts
@@ -1,0 +1,294 @@
+import type {
+  RequirementCoverageExpectedEvidenceType,
+  RequirementCoverageLinkedEvidence,
+  RequirementCoverageRow,
+} from "@/app/m/_lib/requirementCoverage";
+import { EXPECTED_EVIDENCE_LABELS } from "@/app/m/_lib/requirementCoverage";
+import { hasReviewerArtifact } from "@/lib/verify/runState";
+
+export type ReadinessGapState =
+  | "ready"
+  | "needs_review"
+  | "missing_evidence"
+  | "missing_reviewer_record"
+  | "not_started"
+  | "unknown_expectation";
+
+export type ReadinessGapSeverity = "none" | "low" | "medium" | "high";
+
+export type ReadinessGapOverride = {
+  state?: ReadinessGapState | null;
+  severity?: ReadinessGapSeverity | null;
+  reason: string;
+  reviewer?: string | null;
+  updatedAt?: string | null;
+};
+
+export type ReadinessGapRecommendationCode =
+  | "link_expected_evidence"
+  | "review_candidate_evidence"
+  | "save_reviewer_record"
+  | "define_expected_evidence"
+  | "review_override"
+  | "ready_for_review";
+
+export type ReadinessGapRecommendation = {
+  code: ReadinessGapRecommendationCode;
+  label: string;
+  detail: string;
+};
+
+export type RuleReadinessGap = {
+  ruleId: string;
+  title: string;
+  state: ReadinessGapState;
+  severity: ReadinessGapSeverity;
+  summary: string;
+  expectedEvidenceTypes: RequirementCoverageExpectedEvidenceType[];
+  linkedEvidence: RequirementCoverageLinkedEvidence[];
+  candidateEvidence: RequirementCoverageLinkedEvidence[];
+  missingExpectedEvidenceTypes: RequirementCoverageExpectedEvidenceType[];
+  recommendations: ReadinessGapRecommendation[];
+  override: ReadinessGapOverride | null;
+  baseState: ReadinessGapState;
+  baseSeverity: ReadinessGapSeverity;
+};
+
+export type DeriveRuleReadinessGapsInput = {
+  rows: RequirementCoverageRow[];
+  reviewerArtifactsByRuleId?: Map<
+    string,
+    {
+      savedAt?: string | null;
+      minutes?: string | null;
+      outcomeNote?: string | null;
+    }
+  >;
+  overridesByRuleId?: Map<string, ReadinessGapOverride>;
+};
+
+function linkedEvidenceTypesForGap(item: RequirementCoverageLinkedEvidence): RequirementCoverageExpectedEvidenceType[] {
+  const haystack = [
+    item.type,
+    item.title,
+    item.documentLabel,
+    item.provenanceSummary,
+    item.fragmentLabel,
+    item.sectionHeading,
+    item.sectionLabel,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  const matched = new Set<RequirementCoverageExpectedEvidenceType>();
+  if (haystack.includes("monitoring-report") || haystack.includes("monitoring report")) matched.add("monitoring-report");
+  if (haystack.includes("spreadsheet-workbook") || haystack.includes("spreadsheet workbook") || haystack.includes("workbook")) {
+    matched.add("spreadsheet-workbook");
+  }
+  if (haystack.includes("calculation-support") || haystack.includes("calculation support") || haystack.includes("calculation")) {
+    matched.add("calculation-support");
+  }
+  if (haystack.includes("pdd")) matched.add("pdd");
+  if (haystack.includes("gis") || haystack.includes("stac") || haystack.includes("map evidence")) matched.add("gis");
+  if (haystack.includes("qa/qc") || haystack.includes("qa-qc") || haystack.includes("qa qc")) matched.add("qa-qc-record");
+  if (haystack.includes("eligibility")) matched.add("eligibility-proof");
+  return Array.from(matched);
+}
+
+function missingExpectedEvidenceTypes(row: RequirementCoverageRow): RequirementCoverageExpectedEvidenceType[] {
+  if (!row.expectedEvidenceTypes.length) return [];
+  const satisfied = new Set<RequirementCoverageExpectedEvidenceType>();
+  for (const item of row.linkedEvidence) {
+    for (const matchedType of linkedEvidenceTypesForGap(item)) satisfied.add(matchedType);
+  }
+  return row.expectedEvidenceTypes.filter((type) => !satisfied.has(type));
+}
+
+function hasSavedReviewerRecord(input: {
+  savedAt?: string | null;
+  minutes?: string | null;
+  outcomeNote?: string | null;
+}): boolean {
+  if (input.savedAt?.trim()) return true;
+  return hasReviewerArtifact({ minutes: input.minutes, outcomeNote: input.outcomeNote });
+}
+
+function baseGapState(input: {
+  row: RequirementCoverageRow;
+  reviewerSaved: boolean;
+  missingExpected: RequirementCoverageExpectedEvidenceType[];
+}): ReadinessGapState {
+  const { row, reviewerSaved, missingExpected } = input;
+  if (!row.expectedEvidenceTypes.length) {
+    if (row.linkedEvidence.length > 0 || row.candidateEvidence.length > 0) return "unknown_expectation";
+    return "not_started";
+  }
+  if (!row.linkedEvidence.length) {
+    return "not_started";
+  }
+  if (row.expectedEvidenceTypes.length > 0 && missingExpected.length > 0) return "missing_evidence";
+  if (!reviewerSaved) {
+    return "missing_reviewer_record";
+  }
+  return "ready";
+}
+
+function baseGapSeverity(input: {
+  state: ReadinessGapState;
+  row: RequirementCoverageRow;
+  missingExpected: RequirementCoverageExpectedEvidenceType[];
+}): ReadinessGapSeverity {
+  const { state, row, missingExpected } = input;
+  if (state === "ready") return "none";
+  if (state === "unknown_expectation") return row.candidateEvidence.length > 0 || row.linkedEvidence.length > 0 ? "low" : "medium";
+  if (state === "needs_review") return "medium";
+  if (state === "missing_reviewer_record") return "medium";
+  if (state === "not_started") return row.expectedEvidenceTypes.length > 0 ? "high" : "medium";
+  if (missingExpected.length >= 2) return "high";
+  return "medium";
+}
+
+function formatExpectedEvidenceTypes(types: RequirementCoverageExpectedEvidenceType[]): string {
+  return types.map((type) => EXPECTED_EVIDENCE_LABELS[type] ?? type).join(", ");
+}
+
+function gapSummary(input: {
+  state: ReadinessGapState;
+  row: RequirementCoverageRow;
+  missingExpected: RequirementCoverageExpectedEvidenceType[];
+  reviewerSaved: boolean;
+}): string {
+  const { state, row, missingExpected, reviewerSaved } = input;
+  if (state === "ready") return "Expected evidence is linked and reviewer record is saved.";
+  if (state === "missing_reviewer_record") return "Expected evidence is linked, but the reviewer record is not saved yet.";
+  if (state === "needs_review") return "Evidence is linked, but the rule still needs reviewer judgment.";
+  if (state === "unknown_expectation") {
+    if (row.candidateEvidence.length > 0) {
+      return "Candidate evidence exists, but no methodology expectation is defined for this rule yet.";
+    }
+    return reviewerSaved
+      ? "Reviewer record is saved, but no methodology expectation is defined for this rule yet."
+      : "No methodology expectation is defined for this rule yet.";
+  }
+  if (state === "not_started") {
+    if (row.expectedEvidenceTypes.length > 0) {
+      return `No linked evidence yet. Expected: ${formatExpectedEvidenceTypes(row.expectedEvidenceTypes)}.`;
+    }
+    return "No linked evidence or reviewer record exists for this rule yet.";
+  }
+  const missingLabels = formatExpectedEvidenceTypes(missingExpected);
+  return reviewerSaved
+    ? `Some expected evidence is still missing: ${missingLabels}. Reviewer record is saved.`
+    : `Some expected evidence is still missing: ${missingLabels}.`;
+}
+
+function recommendation(
+  code: ReadinessGapRecommendationCode,
+  label: string,
+  detail: string,
+): ReadinessGapRecommendation {
+  return { code, label, detail };
+}
+
+function gapRecommendations(input: {
+  state: ReadinessGapState;
+  row: RequirementCoverageRow;
+  missingExpected: RequirementCoverageExpectedEvidenceType[];
+  override: ReadinessGapOverride | null;
+}): ReadinessGapRecommendation[] {
+  const { state, row, missingExpected, override } = input;
+  const next: ReadinessGapRecommendation[] = [];
+  if (state === "ready") {
+    next.push(recommendation("ready_for_review", "Ready for review", "Expected evidence is linked and reviewer record is saved."));
+  }
+  if (state === "not_started" || state === "missing_evidence") {
+    const detail = missingExpected.length
+      ? `Link evidence that satisfies: ${formatExpectedEvidenceTypes(missingExpected)}.`
+      : "Link evidence to start the rule review.";
+    next.push(recommendation("link_expected_evidence", "Link expected evidence", detail));
+  }
+  if (row.candidateEvidence.length > 0 && (state === "not_started" || state === "unknown_expectation" || state === "missing_evidence")) {
+    next.push(
+      recommendation(
+        "review_candidate_evidence",
+        "Review candidate evidence",
+        `${row.candidateEvidence.length} candidate evidence item${row.candidateEvidence.length === 1 ? "" : "s"} can be reviewed for linkage.`,
+      ),
+    );
+  }
+  if (state === "missing_reviewer_record" || state === "needs_review") {
+    next.push(
+      recommendation(
+        "save_reviewer_record",
+        "Save reviewer record",
+        "Add reviewer minutes or an outcome note to explain the current rule status.",
+      ),
+    );
+  }
+  if (state === "unknown_expectation") {
+    next.push(
+      recommendation(
+        "define_expected_evidence",
+        "Define expected evidence",
+        "Methodology expectations are not defined for this rule, so readiness can only be treated as reviewer judgment for now.",
+      ),
+    );
+  }
+  if (override) {
+    next.push(
+      recommendation(
+        "review_override",
+        "Review override",
+        `Reviewer override applied: ${override.reason.trim()}`,
+      ),
+    );
+  }
+  return next;
+}
+
+function normalizeOverride(override: ReadinessGapOverride | undefined): ReadinessGapOverride | null {
+  if (!override) return null;
+  const reason = override.reason?.trim();
+  if (!reason) return null;
+  return {
+    state: override.state ?? null,
+    severity: override.severity ?? null,
+    reason,
+    reviewer: override.reviewer?.trim() || null,
+    updatedAt: override.updatedAt?.trim() || null,
+  };
+}
+
+export function deriveRuleReadinessGaps(input: DeriveRuleReadinessGapsInput): RuleReadinessGap[] {
+  const reviewerArtifactsByRuleId = input.reviewerArtifactsByRuleId ?? new Map();
+  const overridesByRuleId = input.overridesByRuleId ?? new Map();
+
+  return [...input.rows]
+    .map((row) => {
+      const reviewer = reviewerArtifactsByRuleId.get(row.ruleId);
+      const reviewerSaved = hasSavedReviewerRecord(reviewer ?? {});
+      const missingExpected = missingExpectedEvidenceTypes(row);
+      const baseState = baseGapState({ row, reviewerSaved, missingExpected });
+      const baseSeverity = baseGapSeverity({ state: baseState, row, missingExpected });
+      const override = normalizeOverride(overridesByRuleId.get(row.ruleId));
+      const effectiveState = override?.state ?? baseState;
+      const effectiveSeverity = override?.severity ?? baseSeverity;
+
+      return {
+        ruleId: row.ruleId,
+        title: row.ruleSummary.title,
+        state: effectiveState,
+        severity: effectiveSeverity,
+        summary: gapSummary({ state: baseState, row, missingExpected, reviewerSaved }),
+        expectedEvidenceTypes: [...row.expectedEvidenceTypes],
+        linkedEvidence: [...row.linkedEvidence],
+        candidateEvidence: [...row.candidateEvidence],
+        missingExpectedEvidenceTypes: missingExpected,
+        recommendations: gapRecommendations({ state: effectiveState, row, missingExpected, override }),
+        override,
+        baseState,
+        baseSeverity,
+      } satisfies RuleReadinessGap;
+    })
+    .sort((a, b) => a.ruleId.localeCompare(b.ruleId));
+}

--- a/src/lib/readiness/gapEngine.ts
+++ b/src/lib/readiness/gapEngine.ts
@@ -98,6 +98,9 @@ function linkedEvidenceTypesForGap(item: RequirementCoverageLinkedEvidence): Req
 function missingExpectedEvidenceTypes(row: RequirementCoverageRow): RequirementCoverageExpectedEvidenceType[] {
   if (!row.expectedEvidenceTypes.length) return [];
   const satisfied = new Set<RequirementCoverageExpectedEvidenceType>();
+  if (row.linkedEvidence.length > 0 && row.expectedEvidenceTypes.includes("other")) {
+    satisfied.add("other");
+  }
   for (const item of row.linkedEvidence) {
     for (const matchedType of linkedEvidenceTypesForGap(item)) satisfied.add(matchedType);
   }
@@ -180,6 +183,51 @@ function gapSummary(input: {
   return reviewerSaved
     ? `Some expected evidence is still missing: ${missingLabels}. Reviewer record is saved.`
     : `Some expected evidence is still missing: ${missingLabels}.`;
+}
+
+function formatStateLabel(state: ReadinessGapState): string {
+  switch (state) {
+    case "ready":
+      return "ready";
+    case "needs_review":
+      return "needs review";
+    case "missing_evidence":
+      return "missing evidence";
+    case "missing_reviewer_record":
+      return "missing reviewer record";
+    case "not_started":
+      return "not started";
+    case "unknown_expectation":
+      return "unknown expectation";
+  }
+}
+
+function effectiveGapSummary(input: {
+  baseState: ReadinessGapState;
+  baseSeverity: ReadinessGapSeverity;
+  effectiveState: ReadinessGapState;
+  effectiveSeverity: ReadinessGapSeverity;
+  row: RequirementCoverageRow;
+  missingExpected: RequirementCoverageExpectedEvidenceType[];
+  reviewerSaved: boolean;
+  override: ReadinessGapOverride | null;
+}): string {
+  const { baseState, baseSeverity, effectiveState, effectiveSeverity, row, missingExpected, reviewerSaved, override } = input;
+  const baseSummary = gapSummary({ state: baseState, row, missingExpected, reviewerSaved });
+  if (!override) return baseSummary;
+
+  const parts: string[] = [];
+  if (effectiveState !== baseState) {
+    parts.push(`Reviewer override marks this rule as ${formatStateLabel(effectiveState)}.`);
+    parts.push(`Base assessment: ${baseSummary}`);
+  } else {
+    parts.push(baseSummary);
+  }
+  if (effectiveSeverity !== baseSeverity) {
+    parts.push(`Reviewer override sets severity to ${effectiveSeverity}.`);
+  }
+  parts.push(`Reason: ${override.reason}.`);
+  return parts.join(" ");
 }
 
 function recommendation(
@@ -279,7 +327,16 @@ export function deriveRuleReadinessGaps(input: DeriveRuleReadinessGapsInput): Ru
         title: row.ruleSummary.title,
         state: effectiveState,
         severity: effectiveSeverity,
-        summary: gapSummary({ state: baseState, row, missingExpected, reviewerSaved }),
+        summary: effectiveGapSummary({
+          baseState,
+          baseSeverity,
+          effectiveState,
+          effectiveSeverity,
+          row,
+          missingExpected,
+          reviewerSaved,
+          override,
+        }),
         expectedEvidenceTypes: [...row.expectedEvidenceTypes],
         linkedEvidence: [...row.linkedEvidence],
         candidateEvidence: [...row.candidateEvidence],

--- a/tests/lib/readiness/gapEngine.test.ts
+++ b/tests/lib/readiness/gapEngine.test.ts
@@ -183,6 +183,60 @@ describe("deriveRuleReadinessGaps", () => {
         reviewer: "Verifier A",
       },
     });
+    expect(gaps[0]?.summary).toContain("Reviewer override marks this rule as needs review.");
+    expect(gaps[0]?.summary).toContain("Reason: Reviewer wants to keep this open until expectations are confirmed.");
     expect(gaps[0]?.recommendations.map((item) => item.code)).toContain("review_override");
+  });
+
+  test("treats linked evidence as satisfying an other expectation", () => {
+    const gaps = deriveRuleReadinessGaps({
+      rows: [
+        makeRow({
+          ruleId: "R-4",
+          expectedEvidenceTypes: ["other"],
+          linkedEvidence: [{ id: "ev-1", title: "Field memo", type: "memo", source: "inventory" }],
+          status: "partial",
+        }),
+      ],
+      reviewerArtifactsByRuleId: new Map([
+        [
+          "R-4",
+          {
+            savedAt: "2026-05-04T00:00:00Z",
+            outcomeNote: "Accepted as method-specific support.",
+          },
+        ],
+      ]),
+    });
+
+    expect(gaps[0]).toMatchObject({
+      ruleId: "R-4",
+      state: "ready",
+      severity: "none",
+      missingExpectedEvidenceTypes: [],
+    });
+  });
+
+  test("does not satisfy an other expectation without linked evidence", () => {
+    const gaps = deriveRuleReadinessGaps({
+      rows: [
+        makeRow({
+          ruleId: "R-5",
+          expectedEvidenceTypes: ["other"],
+          candidateEvidence: [{ id: "cand-1", title: "Field memo", type: "memo", source: "inventory" }],
+        }),
+      ],
+    });
+
+    expect(gaps[0]).toMatchObject({
+      ruleId: "R-5",
+      state: "not_started",
+      severity: "high",
+      missingExpectedEvidenceTypes: ["other"],
+    });
+    expect(gaps[0]?.recommendations.map((item) => item.code)).toEqual([
+      "link_expected_evidence",
+      "review_candidate_evidence",
+    ]);
   });
 });

--- a/tests/lib/readiness/gapEngine.test.ts
+++ b/tests/lib/readiness/gapEngine.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "@jest/globals";
+import type { RequirementCoverageRow } from "@/app/m/_lib/requirementCoverage";
+import { deriveRuleReadinessGaps } from "@/lib/readiness/gapEngine";
+
+function makeRow(overrides: Partial<RequirementCoverageRow> = {}): RequirementCoverageRow {
+  return {
+    ruleId: "R-1",
+    ruleSummary: {
+      title: "Monitoring frequency",
+      snippet: "Maintain a monitoring report.",
+      when: [],
+      tags: [],
+    },
+    provenance: {
+      tools: [],
+      citations: [],
+    },
+    expectedEvidenceTypes: [],
+    linkedEvidence: [],
+    candidateEvidence: [],
+    status: "missing",
+    ...overrides,
+  };
+}
+
+describe("deriveRuleReadinessGaps", () => {
+  test("marks fully linked expected evidence with a saved reviewer record as ready", () => {
+    const gaps = deriveRuleReadinessGaps({
+      rows: [
+        makeRow({
+          expectedEvidenceTypes: ["monitoring-report", "spreadsheet-workbook"],
+          linkedEvidence: [
+            { id: "ev-1", title: "Q1 monitoring report", type: "monitoring-report", source: "inventory" },
+            { id: "ev-2", title: "Workbook tab A", type: "Workbook", source: "inventory" },
+          ],
+          status: "linked",
+        }),
+      ],
+      reviewerArtifactsByRuleId: new Map([
+        [
+          "R-1",
+          {
+            savedAt: "2026-05-04T00:00:00Z",
+            minutes: "Checked linked evidence.",
+          },
+        ],
+      ]),
+    });
+
+    expect(gaps[0]).toMatchObject({
+      ruleId: "R-1",
+      state: "ready",
+      severity: "none",
+      baseState: "ready",
+      baseSeverity: "none",
+      missingExpectedEvidenceTypes: [],
+    });
+    expect(gaps[0]?.recommendations.map((item) => item.code)).toEqual(["ready_for_review"]);
+  });
+
+  test("marks missing expected evidence as high severity when nothing is linked", () => {
+    const gaps = deriveRuleReadinessGaps({
+      rows: [
+        makeRow({
+          expectedEvidenceTypes: ["monitoring-report", "spreadsheet-workbook"],
+          candidateEvidence: [{ id: "cand-1", title: "Workbook group", type: "calculation_table", source: "inventory" }],
+        }),
+      ],
+    });
+
+    expect(gaps[0]).toMatchObject({
+      state: "not_started",
+      severity: "high",
+      missingExpectedEvidenceTypes: ["monitoring-report", "spreadsheet-workbook"],
+    });
+    expect(gaps[0]?.recommendations.map((item) => item.code)).toEqual([
+      "link_expected_evidence",
+      "review_candidate_evidence",
+    ]);
+  });
+
+  test("marks partially satisfied expectations as missing evidence", () => {
+    const gaps = deriveRuleReadinessGaps({
+      rows: [
+        makeRow({
+          expectedEvidenceTypes: ["monitoring-report", "spreadsheet-workbook"],
+          linkedEvidence: [{ id: "ev-1", title: "Q1 monitoring report", type: "monitoring-report", source: "inventory" }],
+          status: "partial",
+        }),
+      ],
+    });
+
+    expect(gaps[0]).toMatchObject({
+      state: "missing_evidence",
+      severity: "medium",
+      missingExpectedEvidenceTypes: ["spreadsheet-workbook"],
+    });
+    expect(gaps[0]?.summary).toContain("Spreadsheet workbook");
+  });
+
+  test("marks linked evidence without a reviewer record as missing reviewer record when expectations are satisfied", () => {
+    const gaps = deriveRuleReadinessGaps({
+      rows: [
+        makeRow({
+          expectedEvidenceTypes: ["monitoring-report"],
+          linkedEvidence: [{ id: "ev-1", title: "Q1 monitoring report", type: "monitoring-report", source: "inventory" }],
+          status: "partial",
+        }),
+      ],
+    });
+
+    expect(gaps[0]).toMatchObject({
+      state: "missing_reviewer_record",
+      severity: "medium",
+      missingExpectedEvidenceTypes: [],
+    });
+    expect(gaps[0]?.recommendations.map((item) => item.code)).toContain("save_reviewer_record");
+  });
+
+  test("treats linked evidence without methodology expectations as unknown expectation", () => {
+    const gaps = deriveRuleReadinessGaps({
+      rows: [
+        makeRow({
+          ruleId: "R-2",
+          linkedEvidence: [{ id: "ev-1", title: "Boundary map", type: "STAC item", source: "inventory" }],
+          candidateEvidence: [{ id: "cand-1", title: "Workbook group", type: "calculation_table", source: "inventory" }],
+          status: "partial",
+        }),
+      ],
+    });
+
+    expect(gaps[0]).toMatchObject({
+      ruleId: "R-2",
+      state: "unknown_expectation",
+      severity: "low",
+    });
+    expect(gaps[0]?.recommendations.map((item) => item.code)).toEqual([
+      "review_candidate_evidence",
+      "define_expected_evidence",
+    ]);
+  });
+
+  test("treats unsaved reviewer judgment on no-expectation rules as needs review", () => {
+    const gaps = deriveRuleReadinessGaps({
+      rows: [
+        makeRow({
+          ruleId: "R-3",
+          linkedEvidence: [{ id: "ev-1", title: "Boundary map", type: "STAC item", source: "inventory" }],
+          status: "partial",
+        }),
+      ],
+      reviewerArtifactsByRuleId: new Map([
+        [
+          "R-3",
+          {
+            minutes: "",
+            outcomeNote: "",
+          },
+        ],
+      ]),
+      overridesByRuleId: new Map([
+        [
+          "R-3",
+          {
+            state: "needs_review",
+            severity: "medium",
+            reason: "Reviewer wants to keep this open until expectations are confirmed.",
+            reviewer: "Verifier A",
+            updatedAt: "2026-05-04T00:00:00Z",
+          },
+        ],
+      ]),
+    });
+
+    expect(gaps[0]).toMatchObject({
+      state: "needs_review",
+      severity: "medium",
+      baseState: "unknown_expectation",
+      override: {
+        state: "needs_review",
+        severity: "medium",
+        reason: "Reviewer wants to keep this open until expectations are confirmed.",
+        reviewer: "Verifier A",
+      },
+    });
+    expect(gaps[0]?.recommendations.map((item) => item.code)).toContain("review_override");
+  });
+});


### PR DESCRIPTION
## Summary
- add a pure `src/lib/readiness/gapEngine.ts` derivation layer for Phase 3 readiness-gap facts
- derive per-rule readiness state, severity, missing expected evidence, recommendations, and optional reviewer overrides from existing coverage rows and reviewer artifacts
- add focused tests for ready, missing evidence, missing reviewer record, unknown expectation, and override flows

## Why
PR #542 started the reviewer-facing Verify readiness surface, but it did not yet derive rule-level gap facts from methodology expectations plus project evidence inventory. This PR adds the first real Phase 3 Readiness Gap Engine core without redesigning the UI.

## Scope
- pure derivation layer only
- no Verify UI changes
- no app-logic rewrites outside the new readiness module

## Validation
- `npx jest tests/lib/readiness/gapEngine.test.ts --runInBand`
- `npx jest src/app/m/_lib/requirementCoverage.test.ts --runInBand`
- `npx jest tests/lib/evidenceInventory.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`