### PR TITLE
Update roadmap status for readiness gap engine core

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -182,8 +182,10 @@ Lane status: Active
 Turn per-rule verification into a traceable rule review workspace. The product center is the review record, not the checklist. 8-phase path to paid VVB pilots.
 
 Current focus:
-- Phase 1 + 2 + 3 + 4 complete — review panel, audit trail, finalize gate, AOI/STAC support, document/workbook support
-- Phase 5 next: method completeness (target methods)
+- Phases 1-4 are complete: review panel, audit trail, finalize gate, AOI/STAC support, and document/workbook support are in place
+- Phase 5 is now in progress for method completeness across the target demo methods
+- PR #546 added the readiness-gap engine core as backend derivation only, with no visible Verify UI change yet
+- Next work: wire derived readiness facts into Verify and reviewer-facing export surfaces
 
 Not active now:
 - STAC auto-verification (support facts only, not auto-verify)

--- a/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
+++ b/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
@@ -3,15 +3,17 @@
     "status": "active",
     "summary": "Turn per-rule verification into a traceable rule review workspace. The product center is the review record, not the checklist. 8-phase path to paid VVB pilots.",
     "current_focus": [
-      "Phase 1 + 2 + 3 + 4 complete — review panel, audit trail, finalize gate, AOI/STAC support, document/workbook support",
-      "Phase 5 next: method completeness (target methods)"
+      "Phases 1-4 are complete: review panel, audit trail, finalize gate, AOI/STAC support, and document/workbook support are in place",
+      "Phase 5 is now in progress for method completeness across the target demo methods",
+      "PR #546 added the readiness-gap engine core as backend derivation only, with no visible Verify UI change yet",
+      "Next work: wire derived readiness facts into Verify and reviewer-facing export surfaces"
     ],
     "not_active_now": [
       "STAC auto-verification (support facts only, not auto-verify)",
       "AI-assisted review (post-moat)",
       "Multi-methodology cross-referencing (Phase 5+)"
     ],
-    "last_updated_at": "2026-04-16T15:00:00Z"
+    "last_updated_at": "2026-05-03T21:50:01Z"
   },
   "phase_0_roadmap_contract_freeze": {
     "status": "done",
@@ -39,9 +41,9 @@
     "summary": "PDD excerpts and workbook previews surface in rule review panel. Document/workbook support lane with provenance. STAC excluded from this lane."
   },
   "phase_5_method_completeness_target_methods": {
-    "status": "next",
+    "status": "in_progress",
     "title": "Method Completeness (Target Methods)",
-    "summary": "Ensure enough methodologies are encoded and complete for pilot demos. AR-ACM0003 + at least one agriculture method fully reviewable."
+    "summary": "Ensure enough methodologies are encoded and complete for pilot demos. AR-ACM0003 + at least one agriculture method remain the target demo methods. The readiness-gap engine core now exists, but reviewer-facing Verify UI wiring is still pending."
   },
   "phase_6_exportable_verification_output": {
     "status": "planned",
@@ -53,6 +55,10 @@
     "title": "Pilot-Ready VVB Workflow",
     "summary": "First paid pilot. Verification opinion, workbook calculations, multi-methodology, observer access. $1,500-2,500 per verification."
   },
-  "pr_evidence": {},
-  "pr_notes": {}
+  "pr_evidence": {
+    "pr_546": "Readiness gap engine core only. No UI visuals. Derives per-rule state, severity, missing expected evidence, recommendations, and reviewer override handling."
+  },
+  "pr_notes": {
+    "pr_546": "Backend derivation only. No visible Verify UI change. Follow-up required to surface readiness gaps in reviewer workflow."
+  }
 }


### PR DESCRIPTION
Roadmap: traceable-rule-review-mvp
Roadmap-Item: phase_5_method_completeness_target_methods
SSOT: docs/roadmaps/traceable-rule-review-mvp/phase-status.json

This status-only PR updates the traceable rule review roadmap after PR #546. It marks Phase 5 as in progress, records the readiness-gap engine core as backend derivation evidence, and keeps the roadmap explicit that reviewer-facing Verify UI wiring is still pending.

## WHAT

- Updated roadmap status JSON to mark Phase 5 as in progress
- Recorded PR #546 as readiness-gap engine core evidence
- Clarified that PR #546 has no visible Verify UI changes

## WHY

- Keep roadmap status truthful after backend readiness-gap work
- Avoid implying reviewer-facing visuals or export readiness before they exist
- Make the next high-signal task clear: surface readiness facts in Verify

**Signed-off-by:** Fred E <fredilly@article6.org>