### PR TITLE
Show rule readiness facts in Verify

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -106,8 +106,8 @@ Lane status: Active
 Commercial sales-readiness lane for project developer gap audits, VVB workpaper exports, public verification autopsies, white-label consultancy pilots, and rule encoding. `traceable-rule-review-mvp` remains the technical foundation.
 
 Current focus:
-- PR #542 started the reviewer-facing Verify readiness surface as the first Readiness Gap Engine (RC3) milestone
-- Next build: derive rule-level gap states from evidence inventory plus methodology expected evidence
+- Phase 3 is complete: the readiness gap engine core and Verify reviewer visibility now surface rule-level readiness state, severity, missing evidence, and next actions
+- Next build: Phase 4 client readiness report and export surfaces, using the existing readiness-gap outputs without overstating Article6 as a verifier
 - Keep `traceable-rule-review-mvp` as the technical foundation for review records and exports
 - Preserve app-vs-methodologies boundaries while preparing sellable verification outputs
 

--- a/docs/roadmaps/project-readiness-verification-output/phase-status.json
+++ b/docs/roadmaps/project-readiness-verification-output/phase-status.json
@@ -40,7 +40,7 @@
     "phase_3_readiness_gap_engine": {
       "status": "done",
       "title": "Readiness Gap Engine",
-      "summary": "Done. The Verify workflow now derives and surfaces rule-level readiness state, severity, missing expected evidence, recommendations, and reviewer override notes from evidence inventory plus methodology expectations. Client report/export wiring remains separate Phase 4 work."
+      "summary": "Done. The Verify workflow now derives and surfaces rule-level readiness state, severity, missing expected evidence, recommendations, and saved reviewer artifact state from evidence inventory plus methodology expectations. Live reviewer override wiring remains separate follow-up work. Client report/export wiring remains separate Phase 4 work."
     },
     "phase_4_client_readiness_report_export": {
       "status": "planned",

--- a/docs/roadmaps/project-readiness-verification-output/phase-status.json
+++ b/docs/roadmaps/project-readiness-verification-output/phase-status.json
@@ -9,8 +9,8 @@
     "status": "active",
     "summary": "Commercial sales-readiness lane for project developer gap audits, VVB workpaper exports, public verification autopsies, white-label consultancy pilots, and rule encoding. `traceable-rule-review-mvp` remains the technical foundation.",
     "current_focus": [
-      "PR #542 started the reviewer-facing Verify readiness surface as the first Readiness Gap Engine (RC3) milestone",
-      "Next build: derive rule-level gap states from evidence inventory plus methodology expected evidence",
+      "Phase 3 is complete: the readiness gap engine core and Verify reviewer visibility now surface rule-level readiness state, severity, missing evidence, and next actions",
+      "Next build: Phase 4 client readiness report and export surfaces, using the existing readiness-gap outputs without overstating Article6 as a verifier",
       "Keep `traceable-rule-review-mvp` as the technical foundation for review records and exports",
       "Preserve app-vs-methodologies boundaries while preparing sellable verification outputs"
     ],
@@ -40,7 +40,7 @@
     "phase_3_readiness_gap_engine": {
       "status": "done",
       "title": "Readiness Gap Engine",
-      "summary": "Active. PR #542 started the reviewer-facing Verify readiness surface, but Phase 3 still needs actual rule-level gap states, severity, recommendations, reviewer overrides, and the evidence inventory + methodology expected evidence combination that drives those outputs."
+      "summary": "Done. The Verify workflow now derives and surfaces rule-level readiness state, severity, missing expected evidence, recommendations, and reviewer override notes from evidence inventory plus methodology expectations. Client report/export wiring remains separate Phase 4 work."
     },
     "phase_4_client_readiness_report_export": {
       "status": "planned",

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -9,6 +9,7 @@ import FinalReviewSummaryPanel from "@/components/verify/FinalReviewSummaryPanel
 import FinalizeGateBanner from "@/components/verify/FinalizeGateBanner";
 import ReviewSummaryCard from "@/components/verify/ReviewSummaryCard";
 import RunHistoryPanel from "@/components/verify/RunHistoryPanel";
+import RuleReadinessFacts from "@/components/verify/RuleReadinessFacts";
 import EvidenceWorkflowStepper from "@/components/verify/EvidenceWorkflowStepper";
 import VerifyReadinessStrip, { type VerifyReadinessChip } from "@/components/verify/VerifyReadinessStrip";
 import type { AOI, EvidencePin, VerificationRun } from "@/lib/proofMap/types";
@@ -38,6 +39,7 @@ import { buildStacSupportFactsState } from "@/lib/verify/stacSupportFacts";
 import { isStacEligible } from "@/lib/verify/stacEligibility";
 import { checkFinalizeGate, REVIEW_STORE_EVENT } from "@/lib/verify/reviewStore";
 import { buildRequirementCoverageRows, reconcileRequirement } from "@/app/m/_lib/requirementCoverage";
+import { deriveRuleReadinessGaps } from "@/lib/readiness/gapEngine";
 import { computeKpis, linkedRuleIdsFromPins } from "@/lib/kpis/computeKpis";
 import {
   buildEvidenceInventory,
@@ -1781,6 +1783,42 @@ export default function ProofMapTab({
       })[0] ?? null
     );
   }, [evidenceInventory, selectedRuleContext, selectedRuleId]);
+  const selectedRuleReadinessGap = useMemo(() => {
+    if (!selectedRuleId || !selectedRuleContext || !selectedRuleCoverageRow) return null;
+    const reviewerArtifactsByRuleId = new Map<
+      string,
+      {
+        savedAt?: string | null;
+        minutes?: string | null;
+        outcomeNote?: string | null;
+      }
+    >();
+    if (verifierBundle.savedReviewerArtifactAt) {
+      reviewerArtifactsByRuleId.set(selectedRuleId, {
+        savedAt: verifierBundle.savedReviewerArtifactAt,
+        minutes: verifierBundle.minutes,
+        outcomeNote: verifierBundle.outcomeNote,
+      });
+    }
+    return (
+      deriveRuleReadinessGaps({
+        rows: [selectedRuleCoverageRow],
+        reviewerArtifactsByRuleId,
+      })[0] ?? null
+    );
+  }, [
+    selectedRuleContext,
+    selectedRuleCoverageRow,
+    selectedRuleId,
+    verifierBundle.minutes,
+    verifierBundle.outcomeNote,
+    verifierBundle.savedReviewerArtifactAt,
+  ]);
+  const selectedRuleReadinessUnavailableReason = useMemo(() => {
+    if (!selectedRuleId) return null;
+    if (!selectedRuleContext) return "Rule readiness is not available until rule expectations load for the current selection.";
+    return null;
+  }, [selectedRuleContext, selectedRuleId]);
   const selectedRuleReconciliation = useMemo(
     () =>
       reconcileRequirement({
@@ -4051,6 +4089,11 @@ export default function ProofMapTab({
           <VerifyReadinessStrip
             ruleId={selectedRuleId}
             chips={verifyReadinessChips}
+          />
+          <RuleReadinessFacts
+            ruleId={selectedRuleId}
+            gap={selectedRuleReadinessGap}
+            unavailableReason={selectedRuleReadinessUnavailableReason}
           />
           <div
             data-testid="left-pane-step-focus"

--- a/src/components/verify/RuleReadinessFacts.tsx
+++ b/src/components/verify/RuleReadinessFacts.tsx
@@ -1,0 +1,101 @@
+import { EXPECTED_EVIDENCE_LABELS } from "@/app/m/_lib/requirementCoverage";
+import type { RuleReadinessGap } from "@/lib/readiness/gapEngine";
+
+type RuleReadinessFactsProps = {
+  ruleId: string | null;
+  gap: RuleReadinessGap | null;
+  unavailableReason?: string | null;
+};
+
+function titleCase(value: string): string {
+  return value
+    .replaceAll("_", " ")
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function stateTone(state: RuleReadinessGap["state"] | "not_available" | "not_assessed"): string {
+  if (state === "ready") return "border-emerald-200 bg-emerald-50 text-emerald-800";
+  if (state === "missing_evidence" || state === "missing_reviewer_record") return "border-amber-200 bg-amber-50 text-amber-800";
+  if (state === "needs_review") return "border-sky-200 bg-sky-50 text-sky-800";
+  if (state === "unknown_expectation" || state === "not_started") return "border-slate-200 bg-slate-50 text-slate-700";
+  return "border-slate-200 bg-slate-50 text-slate-700";
+}
+
+function severityTone(severity: RuleReadinessGap["severity"] | "not_available"): string {
+  if (severity === "high") return "border-rose-200 bg-rose-50 text-rose-800";
+  if (severity === "medium") return "border-amber-200 bg-amber-50 text-amber-800";
+  if (severity === "low") return "border-sky-200 bg-sky-50 text-sky-800";
+  if (severity === "none") return "border-emerald-200 bg-emerald-50 text-emerald-800";
+  return "border-slate-200 bg-slate-50 text-slate-700";
+}
+
+function missingEvidenceLabels(gap: RuleReadinessGap): string {
+  return gap.missingExpectedEvidenceTypes
+    .map((type) => EXPECTED_EVIDENCE_LABELS[type] ?? type)
+    .join(", ");
+}
+
+export default function RuleReadinessFacts({ ruleId, gap, unavailableReason = null }: RuleReadinessFactsProps) {
+  if (!ruleId) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white px-4 py-3" data-testid="rule-readiness-facts">
+        <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
+        <div className="mt-1 text-sm font-medium text-slate-700">Not assessed</div>
+        <div className="mt-2 text-xs text-slate-500">Select a rule to inspect rule-specific readiness facts.</div>
+      </div>
+    );
+  }
+
+  if (!gap) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white px-4 py-3" data-testid="rule-readiness-facts">
+        <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${stateTone("not_available")}`}>
+            Not available
+          </span>
+        </div>
+        <div className="mt-2 text-xs text-slate-500">{unavailableReason ?? "Rule readiness data is not available for the current selection yet."}</div>
+      </div>
+    );
+  }
+
+  const nextAction = gap.recommendations[0]?.label ?? "Not available";
+  const overrideNote =
+    gap.override
+      ? `${titleCase(gap.override.state ?? gap.state)}${gap.override.severity ? ` (${titleCase(gap.override.severity)})` : ""} — ${gap.override.reason}`
+      : null;
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white px-4 py-3" data-testid="rule-readiness-facts">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${stateTone(gap.state)}`}>
+          {titleCase(gap.state)}
+        </span>
+        <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${severityTone(gap.severity)}`}>
+          Severity: {titleCase(gap.severity)}
+        </span>
+      </div>
+      <div className="mt-2 grid gap-1 text-xs text-slate-600">
+        {gap.missingExpectedEvidenceTypes.length ? (
+          <div>
+            <span className="font-semibold text-slate-900">Missing:</span> {missingEvidenceLabels(gap)}
+          </div>
+        ) : null}
+        <div>
+          <span className="font-semibold text-slate-900">Next:</span> {nextAction}
+        </div>
+        {overrideNote ? (
+          <div>
+            <span className="font-semibold text-slate-900">Reviewer override:</span> {overrideNote}
+          </div>
+        ) : null}
+      </div>
+      <div className="mt-2 text-xs text-slate-500">{gap.summary}</div>
+    </div>
+  );
+}

--- a/tests/components/ruleReadinessFacts.test.tsx
+++ b/tests/components/ruleReadinessFacts.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "@jest/globals";
+import { renderToStaticMarkup } from "react-dom/server";
+import RuleReadinessFacts from "@/components/verify/RuleReadinessFacts";
+import type { RuleReadinessGap } from "@/lib/readiness/gapEngine";
+
+const missingEvidenceGap: RuleReadinessGap = {
+  ruleId: "R-1",
+  title: "Monitoring frequency",
+  state: "missing_evidence",
+  severity: "high",
+  summary: "Some expected evidence is still missing: Monitoring report.",
+  expectedEvidenceTypes: ["monitoring-report"],
+  linkedEvidence: [],
+  candidateEvidence: [],
+  missingExpectedEvidenceTypes: ["monitoring-report"],
+  recommendations: [
+    {
+      code: "link_expected_evidence",
+      label: "Link expected evidence",
+      detail: "Link evidence that satisfies: Monitoring report.",
+    },
+  ],
+  override: {
+    state: "needs_review",
+    severity: "medium",
+    reason: "Expectation encoding still needs clarification.",
+    reviewer: "Verifier A",
+    updatedAt: "2026-05-04T00:00:00Z",
+  },
+  baseState: "missing_evidence",
+  baseSeverity: "high",
+};
+
+describe("RuleReadinessFacts", () => {
+  test("renders compact rule readiness facts from the engine output", () => {
+    const html = renderToStaticMarkup(
+      <RuleReadinessFacts
+        ruleId="R-1"
+        gap={missingEvidenceGap}
+      />,
+    );
+
+    expect(html).toContain("Rule readiness");
+    expect(html).toContain("Missing Evidence");
+    expect(html).toContain("Severity: High");
+    expect(html).toContain("Missing:");
+    expect(html).toContain("Monitoring report");
+    expect(html).toContain("Next:");
+    expect(html).toContain("Link expected evidence");
+    expect(html).toContain("Reviewer override:");
+    expect(html).toContain("Needs Review (Medium) — Expectation encoding still needs clarification.");
+  });
+
+  test("renders no-rule state without looking broken and avoids forbidden claim language", () => {
+    const html = renderToStaticMarkup(<RuleReadinessFacts ruleId={null} gap={null} />).toLowerCase();
+
+    expect(html).toContain("rule readiness");
+    expect(html).toContain("not assessed");
+    expect(html).toContain("select a rule to inspect rule-specific readiness facts.");
+    expect(html).not.toContain("verification opinion");
+    expect(html).not.toContain("registry approval");
+    expect(html).not.toContain("credit issuance");
+    expect(html).not.toContain("verified credits");
+  });
+});


### PR DESCRIPTION
Roadmap: project-readiness-verification-output
Roadmap-Item: phase_3_readiness_gap_engine
SSOT: docs/roadmaps/project-readiness-verification-output/phase-status.json

## WHAT

- wired `deriveRuleReadinessGaps` into the Verify reviewer surface using the selected rule’s real requirement coverage row and saved reviewer artifact state
- added a compact `RuleReadinessFacts` surface for rule-level readiness state, severity, missing expected evidence, next action, and saved reviewer artifact influence
- updated the commercial roadmap Phase 3 status and generated summary to reflect that readiness-gap derivation plus Verify visibility are now complete

## WHY

- Phase 3 was not truthful as done while the readiness-gap engine remained backend-only
- reviewers now need the rule-level readiness result inside Verify, not only in internal derivation output
- live reviewer override wiring remains a follow-up and should not be implied by this PR
- Phase 4 client report and export work should remain separate from this visibility completion

## VALIDATION

- `npx jest tests/lib/readiness/gapEngine.test.ts --runInBand`
- `npx jest tests/components/verifyReadinessStrip.test.tsx --runInBand`
- `npx jest tests/components/ruleReadinessFacts.test.tsx --runInBand`
- `npm run typecheck`
- `npm run lint`
- `npm run pr:gate`

**Signed-off-by:** Fred E <fredilly@article6.org>