### PR TITLE
Update readiness roadmap Phase 3 status

### DIFF
--- a/docs/roadmaps/project-readiness-verification-output/phase-status.json
+++ b/docs/roadmaps/project-readiness-verification-output/phase-status.json
@@ -40,7 +40,7 @@
     "phase_3_readiness_gap_engine": {
       "status": "done",
       "title": "Readiness Gap Engine",
-      "summary": "Done. The Verify workflow now derives and surfaces rule-level readiness state, severity, missing expected evidence, recommendations, and saved reviewer artifact state from evidence inventory plus methodology expectations. Live reviewer override wiring remains separate follow-up work. Client report/export wiring remains separate Phase 4 work."
+      "summary": "Done. The Verify workflow now derives and surfaces rule-level readiness state, severity, missing expected evidence, recommendations / next action, and saved reviewer artifact state from evidence inventory plus methodology expectations. Live reviewer override wiring, client readiness report export, verification pack/report generation, and any registry approval, verification opinion, or credit issuance claims remain outside Phase 3."
     },
     "phase_4_client_readiness_report_export": {
       "status": "planned",


### PR DESCRIPTION
Roadmap: project-readiness-verification-output
Roadmap-Item: phase_3_readiness_gap_engine
SSOT: docs/roadmaps/project-readiness-verification-output/phase-status.json

## WHAT

- marked Phase 3 Readiness Gap Engine as done in the roadmap SSOT
- updated the phase summary to reflect Verify-visible readiness state, severity, missing evidence, recommendations, and saved reviewer artifact state
- kept live reviewer overrides and client readiness report/export work outside Phase 3

## WHY

- keeps the commercial readiness roadmap aligned with the verified PR #551 scope
- prevents Phase 3 from overstating unfinished override or export/report work
- gives Phase 4 a clean starting point for client-facing readiness outputs

**Signed-off-by:** Fred E <fredilly@article6.org>