### PR TITLE
Clean Verify UI hierarchy with existing Article6 palette

### DIFF
--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -1986,15 +1986,15 @@ export default function ProofMapTab({
       {
         key: "stac",
         label: "STAC",
-        value: stacStatus,
+        value: stacStatus === "results found" ? "found" : stacStatus,
         detail: stacDetail,
         tone: stacStatus === "results found" ? "ok" : stacStatus === "failed" ? "blocked" : "warn",
         onClick: () => scrollToSection(stacSectionRef),
       },
       {
         key: "support-facts",
-        label: "Support facts",
-        value: supportFactsStatus,
+        label: "Support",
+        value: supportFactsStatus === "select rule" ? "select rule" : supportFactsStatus,
         detail: supportFactsDetail,
         tone:
           supportFactsStatus === "linked"
@@ -2007,7 +2007,7 @@ export default function ProofMapTab({
       },
       {
         key: "reviewer-record",
-        label: "Reviewer record",
+        label: "Reviewer",
         value: reviewerRecordStatus,
         detail: verifierBundle.savedReviewerArtifactAt
           ? `Saved ${formatLocalDateTime(verifierBundle.savedReviewerArtifactAt)}`
@@ -2020,7 +2020,7 @@ export default function ProofMapTab({
       {
         key: "export",
         label: "Export",
-        value: exportStatus,
+        value: exportStatus === "draft available" ? "draft" : exportStatus,
         detail: exportDetail,
         tone: currentWorkspaceIsFinal || finalizeReady ? "ok" : hasDraftExport ? "warn" : "blocked",
         onClick: () => scrollToSection(finalSummarySectionRef),
@@ -4086,17 +4086,23 @@ export default function ProofMapTab({
               </button>
             </div>
           ) : null}
-          <VerifyReadinessStrip
-            ruleId={selectedRuleId}
-            chips={verifyReadinessChips}
-          />
-          <div ref={ruleSectionRef}>
-            <RuleReadinessFacts
+          <div className="overflow-hidden rounded-2xl border border-slate-200/70 bg-white/95 shadow-sm shadow-slate-200/30">
+            <VerifyReadinessStrip
               ruleId={selectedRuleId}
-              ruleTitle={selectedRuleCoverageRow?.ruleSummary.title ?? null}
-              gap={selectedRuleReadinessGap}
-              unavailableReason={selectedRuleReadinessUnavailableReason}
+              chips={verifyReadinessChips}
+              embedded
+              showRuleLabel={false}
+              helperText={selectedRuleId ? "Current status for this review path." : "Select a rule to inspect rule-specific readiness."}
             />
+            <div ref={ruleSectionRef}>
+              <RuleReadinessFacts
+                ruleId={selectedRuleId}
+                ruleTitle={selectedRuleCoverageRow?.ruleSummary.title ?? null}
+                gap={selectedRuleReadinessGap}
+                unavailableReason={selectedRuleReadinessUnavailableReason}
+                embedded
+              />
+            </div>
           </div>
           <div
             data-testid="left-pane-step-focus"

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -1924,16 +1924,16 @@ export default function ProofMapTab({
           : latestRun.status === "warn" && stacFeatureIds.length > 0
             ? "results found"
             : "failed";
-    const stacDetail =
+    const satelliteDetail =
       !hasAoiLoaded
-        ? "Load an AOI before running STAC search."
+        ? "Upload an area before running satellite search."
         : !latestRun
-          ? "No STAC search has been run for the active AOI."
+          ? "No satellite search has been run for the current area."
           : stacStatus === "results found"
-            ? `${stacFeatureIds.length} STAC result${stacFeatureIds.length === 1 ? "" : "s"} found for the active AOI.`
+            ? `${stacFeatureIds.length} satellite result${stacFeatureIds.length === 1 ? "" : "s"} found for the current area.`
             : stacStatus === "no results"
-              ? "STAC search completed but returned no results for the active AOI."
-              : latestRun.summary?.trim() || "STAC search failed for the active AOI.";
+              ? "Satellite search completed but returned no results for the current area."
+              : latestRun.summary?.trim() || "Satellite search failed for the current area.";
     const supportFactsStatus = !selectedRuleId
       ? "select rule"
       : stacSupportFacts.linkedFacts.length > 0
@@ -1944,13 +1944,13 @@ export default function ProofMapTab({
             ? "optional"
             : "unlinked";
     const supportFactsDetail = !selectedRuleId
-      ? "Select a rule to assess AOI/STAC support facts."
+      ? "Select a rule to assess area/satellite support facts."
       : stacSupportFacts.linkedFacts.length > 0
         ? stacSupportFacts.lookupMessage
         : stacSupportFacts.staleFacts.length > 0
           ? stacSupportFacts.lookupMessage
           : !selectedRuleStacEligible
-            ? "AOI/STAC support facts are optional for this rule. Link them only if they materially support the review."
+            ? "Area/satellite support facts are optional for this rule. Link them only if they materially support the review."
             : stacSupportFacts.lookupMessage;
     const reviewerRecordStatus = verifierBundle.savedReviewerArtifactAt
       ? "saved"
@@ -1977,17 +1977,17 @@ export default function ProofMapTab({
     return [
       {
         key: "aoi",
-        label: "AOI",
-        value: hasAoiLoaded ? "loaded" : "missing",
-        detail: hasAoiLoaded ? aoi?.name ?? bboxLabel ?? "AOI loaded." : "Upload or confirm an AOI to scope the review.",
+        label: "Area",
+        value: hasAoiLoaded ? "ready" : "missing",
+        detail: hasAoiLoaded ? aoi?.name ?? bboxLabel ?? "Area ready." : "Upload or confirm an area to scope the review.",
         tone: hasAoiLoaded ? "ok" : "blocked",
         onClick: () => scrollToSection(aoiSectionRef),
       },
       {
         key: "stac",
-        label: "STAC",
+        label: "Satellite",
         value: stacStatus === "results found" ? "found" : stacStatus,
-        detail: stacDetail,
+        detail: satelliteDetail,
         tone: stacStatus === "results found" ? "ok" : stacStatus === "failed" ? "blocked" : "warn",
         onClick: () => scrollToSection(stacSectionRef),
       },
@@ -4092,7 +4092,7 @@ export default function ProofMapTab({
               chips={verifyReadinessChips}
               embedded
               showRuleLabel={false}
-              helperText={selectedRuleId ? "Current status for this review path." : "Select a rule to inspect rule-specific readiness."}
+              helperText={selectedRuleId ? "Current review status." : "Select a rule to inspect rule-specific readiness."}
             />
             <div ref={ruleSectionRef}>
               <RuleReadinessFacts
@@ -4269,18 +4269,14 @@ export default function ProofMapTab({
               <div className="text-sm font-semibold text-slate-900">
                 {currentWorkspaceIsFinal ? "Final Review Summary" : "Evidence workflow"}
               </div>
-              {!currentWorkspaceIsFinal ? (
-                <div className="mt-1 text-xs text-slate-500">
-                  Single path: rule -&gt; AOI -&gt; STAC -&gt; item -&gt; pin -&gt; reviewer save -&gt; finalize.
-                </div>
-              ) : (
+              {currentWorkspaceIsFinal ? (
                 <div className="mt-1 text-xs text-slate-500">
                   Finalized result, exports, and summary are now the primary right-panel surface.
                 </div>
-              )}
+              ) : null}
             </div>
             {!currentWorkspaceIsFinal ? (
-              <div className="flex flex-wrap items-center justify-end gap-2">
+              <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 sm:flex-nowrap">
                 <button
                   type="button"
                   className="rounded-full border border-rose-200 bg-white px-3 py-1 text-xs font-semibold text-rose-700 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -4090,17 +4090,20 @@ export default function ProofMapTab({
             ruleId={selectedRuleId}
             chips={verifyReadinessChips}
           />
-          <RuleReadinessFacts
-            ruleId={selectedRuleId}
-            gap={selectedRuleReadinessGap}
-            unavailableReason={selectedRuleReadinessUnavailableReason}
-          />
+          <div ref={ruleSectionRef}>
+            <RuleReadinessFacts
+              ruleId={selectedRuleId}
+              ruleTitle={selectedRuleCoverageRow?.ruleSummary.title ?? null}
+              gap={selectedRuleReadinessGap}
+              unavailableReason={selectedRuleReadinessUnavailableReason}
+            />
+          </div>
           <div
             data-testid="left-pane-step-focus"
-            className={`sticky top-0 z-10 rounded-xl border px-4 py-3 text-sm shadow-sm transition ${
+            className={`sticky top-0 z-10 rounded-2xl border px-4 py-3 text-sm transition ${
               currentWorkspaceIsFinal
-                ? "border-slate-200/70 bg-slate-50/90 text-slate-500 shadow-none"
-                : "border-slate-200 bg-white"
+                ? "border-slate-200/70 bg-slate-50/90 text-slate-500"
+                : "border-slate-200/70 bg-white/95 shadow-sm shadow-slate-200/30"
             }`}
           >
             <div className="flex items-center justify-between gap-2">
@@ -4109,87 +4112,92 @@ export default function ProofMapTab({
             </div>
             <div className="mt-1 text-xs text-slate-600">{leftPaneHeader.instruction}</div>
           </div>
-          <div className={`grid gap-2 transition ${currentWorkspaceIsFinal ? "opacity-55" : ""}`}>
-            <div
-              ref={ruleSectionRef}
-              data-testid="left-section-rule"
-              className={`rounded-xl border bg-white px-3 py-2 transition ${activeLeftSection === "rule" ? "border-sky-300 shadow-sm" : "border-slate-200 opacity-70"}`}
-            >
-              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Rule context</div>
-              <div className="mt-1 text-sm font-semibold text-slate-900">{selectedRuleId ?? "No rule selected"}</div>
-            </div>
-            <div
-              ref={aoiSectionRef}
-              data-testid="left-section-aoi"
-              className={`rounded-xl border bg-white px-3 py-2 transition ${activeLeftSection === "aoi" ? "border-sky-300 shadow-sm" : "border-slate-200 opacity-70"}`}
-            >
-              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">AOI summary</div>
-              <div className="mt-1 text-sm font-semibold text-slate-900">{aoi?.name ?? "No AOI loaded"}</div>
-              <div className="mt-1 text-[11px] text-slate-500">{bboxLabel ?? "Upload an AOI to continue."}</div>
-            </div>
-            <div
-              ref={stacSectionRef}
-              data-testid="left-section-stac"
-              className={`rounded-xl border bg-white px-3 py-2 transition ${activeLeftSection === "stac" ? "border-sky-300 shadow-sm" : "border-slate-200 opacity-70"}`}
-            >
-              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">STAC evidence</div>
-              <div className="mt-1 text-sm font-semibold text-slate-900">{stacFeatureIds.length} item{stacFeatureIds.length === 1 ? "" : "s"}</div>
-              <div className="mt-1 text-[11px] text-slate-500">{stacQuery.source ?? "Run a STAC search to load evidence context."}</div>
-            </div>
-            <div
-              ref={selectedItemSectionRef}
-              data-testid="left-section-selected"
-              className={`rounded-xl border bg-white px-3 py-2 transition ${activeLeftSection === "selected" ? "border-sky-300 shadow-sm" : "border-slate-200 opacity-70"}`}
-            >
-              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Selected item</div>
-              <div className="mt-1 text-sm font-semibold text-slate-900">{selectedStacItemId ?? "No item selected"}</div>
-            </div>
-            <div
-              ref={pinsSectionRef}
-              data-testid="left-section-pins"
-              className={`rounded-xl border bg-white px-3 py-2 transition ${activeLeftSection === "pins" ? "border-sky-300 shadow-sm" : "border-slate-200 opacity-70"}`}
-            >
-              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Evidence inventory</div>
-              <div className="mt-1 text-sm font-semibold text-slate-900">
-                {evidenceInventory.length} item{evidenceInventory.length === 1 ? "" : "s"}
+          <details className={`rounded-2xl border border-slate-200/70 bg-white/90 transition ${currentWorkspaceIsFinal ? "opacity-60" : ""}`}>
+            <summary className="cursor-pointer list-none px-4 py-3" data-testid="verify-technical-context-toggle">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Technical context</div>
+                  <div className="mt-1 text-sm font-medium text-slate-700">
+                    AOI, STAC, selected item, inventory, reviewer artifact, and finalization metadata
+                  </div>
+                </div>
+                <span className="text-xs font-semibold text-slate-500">Show</span>
+              </div>
+            </summary>
+            <div className="grid gap-2 border-t border-slate-100 px-4 pb-4 pt-3">
+              <div
+                ref={aoiSectionRef}
+                data-testid="left-section-aoi"
+                className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "aoi" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
+              >
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">AOI summary</div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">{aoi?.name ?? "No AOI loaded"}</div>
+                <div className="mt-1 text-[11px] text-slate-500">{bboxLabel ?? "Upload an AOI to continue."}</div>
+              </div>
+              <div
+                ref={stacSectionRef}
+                data-testid="left-section-stac"
+                className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "stac" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
+              >
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">STAC evidence</div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">{stacFeatureIds.length} item{stacFeatureIds.length === 1 ? "" : "s"}</div>
+                <div className="mt-1 text-[11px] text-slate-500">{stacQuery.source ?? "Run a STAC search to load evidence context."}</div>
+              </div>
+              <div
+                ref={selectedItemSectionRef}
+                data-testid="left-section-selected"
+                className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "selected" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
+              >
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Selected item</div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">{selectedStacItemId ?? "No item selected"}</div>
+              </div>
+              <div
+                ref={pinsSectionRef}
+                data-testid="left-section-pins"
+                className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "pins" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
+              >
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Evidence inventory</div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">
+                  {evidenceInventory.length} item{evidenceInventory.length === 1 ? "" : "s"}
+                </div>
+              </div>
+              <div
+                ref={reviewerSectionRef}
+                data-testid="left-section-reviewer"
+                className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "reviewer" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
+              >
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Reviewer artifact</div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">
+                  {verifierBundle.savedReviewerArtifactAt ? "Saved reviewer artifact" : "Draft reviewer artifact"}
+                </div>
+                <div className="mt-1 line-clamp-2 text-[11px] text-slate-500">
+                  {(verifierBundle.savedReviewerArtifactAt ? verifierBundle.minutes || verifierBundle.outcomeNote : verifierBundle.draftMinutes || verifierBundle.draftOutcomeNote) || "No reviewer notes yet."}
+                </div>
+              </div>
+              <div
+                ref={finalSummarySectionRef}
+                data-testid="left-section-summary"
+                className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "summary" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
+              >
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Final summary</div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">{currentWorkspaceIsFinal ? "Final artifact written" : "Not finalized yet"}</div>
+                <div className="mt-1 text-[11px] text-slate-500">
+                  {currentWorkspaceIsFinal ? `Finalized ${formatLocalDateTime(verifierBundle.finalizedAt ?? "")}` : "Finalize run to export the single immutable artifact."}
+                </div>
               </div>
             </div>
-            <div
-              ref={reviewerSectionRef}
-              data-testid="left-section-reviewer"
-              className={`rounded-xl border bg-white px-3 py-2 transition ${activeLeftSection === "reviewer" ? "border-sky-300 shadow-sm" : "border-slate-200 opacity-70"}`}
-            >
-              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Reviewer artifact</div>
-              <div className="mt-1 text-sm font-semibold text-slate-900">
-                {verifierBundle.savedReviewerArtifactAt ? "Saved reviewer artifact" : "Draft reviewer artifact"}
-              </div>
-              <div className="mt-1 line-clamp-2 text-[11px] text-slate-500">
-                {(verifierBundle.savedReviewerArtifactAt ? verifierBundle.minutes || verifierBundle.outcomeNote : verifierBundle.draftMinutes || verifierBundle.draftOutcomeNote) || "No reviewer notes yet."}
-              </div>
-            </div>
-            <div
-              ref={finalSummarySectionRef}
-              data-testid="left-section-summary"
-              className={`rounded-xl border bg-white px-3 py-2 transition ${activeLeftSection === "summary" ? "border-sky-300 shadow-sm" : "border-slate-200 opacity-70"}`}
-            >
-              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Final summary</div>
-              <div className="mt-1 text-sm font-semibold text-slate-900">{currentWorkspaceIsFinal ? "Final artifact written" : "Not finalized yet"}</div>
-              <div className="mt-1 text-[11px] text-slate-500">
-                {currentWorkspaceIsFinal ? `Finalized ${formatLocalDateTime(verifierBundle.finalizedAt ?? "")}` : "Finalize run to export the single immutable artifact."}
-              </div>
-            </div>
-          </div>
+          </details>
           <div
             className={
               isListMode
-                ? `grid gap-3 rounded-xl border bg-white p-4 transition ${
+                ? `grid gap-3 rounded-2xl border bg-white/95 p-4 transition ${
                     currentWorkspaceIsFinal
                       ? "border-slate-200/70 bg-slate-50/80 opacity-45 shadow-none"
                       : wizardDetails.activeStep === 4 || wizardDetails.activeStep === 5
-                      ? "border-sky-300 shadow-sm"
+                      ? "border-sky-300/80 shadow-sm shadow-sky-100/60"
                       : wizardDetails.activeStep === 3
-                        ? "border-amber-300 shadow-sm"
-                        : "border-slate-200"
+                        ? "border-amber-300/80 shadow-sm shadow-amber-100/60"
+                        : "border-slate-200/70 shadow-sm shadow-slate-200/30"
                   }`
                 : "hidden"
             }
@@ -4201,11 +4209,11 @@ export default function ProofMapTab({
               isListMode
                 ? "hidden"
                 : currentWorkspaceIsFinal
-                  ? "rounded-xl border border-slate-200/70 opacity-45 shadow-none"
+                  ? "rounded-2xl border border-slate-200/70 opacity-45 shadow-none"
                 : wizardDetails.activeStep === 4 || wizardDetails.activeStep === 5
-                  ? "rounded-xl border border-sky-300 shadow-sm"
-                  : wizardDetails.activeStep === 3
-                    ? "rounded-xl border border-amber-300 shadow-sm"
+                  ? "rounded-2xl border border-sky-300/80 shadow-sm shadow-sky-100/60"
+                : wizardDetails.activeStep === 3
+                    ? "rounded-2xl border border-amber-300/80 shadow-sm shadow-amber-100/60"
                     : undefined
             }
           >
@@ -4236,10 +4244,10 @@ export default function ProofMapTab({
         </div>
 
         <div
-          className={`grid min-w-0 w-full max-w-full gap-3 overflow-hidden rounded-xl border p-4 transition ${
+          className={`grid min-w-0 w-full max-w-full gap-3 overflow-hidden rounded-2xl border p-4 transition ${
             currentWorkspaceIsFinal
-              ? "border-emerald-200 bg-white/95 shadow-sm shadow-emerald-100"
-              : "border-slate-200 bg-white"
+              ? "border-emerald-200/80 bg-white/95 shadow-sm shadow-emerald-100/70"
+              : "border-slate-200/70 bg-white/95 shadow-sm shadow-slate-200/30"
           } ${panelCollapsed ? "lg:hidden" : ""}`}
         >
           <input
@@ -4250,7 +4258,7 @@ export default function ProofMapTab({
             onChange={handleUploadAoiChange}
           />
 
-          <div className={`flex items-start justify-between gap-2 ${currentWorkspaceIsFinal ? "opacity-70" : ""}`}>
+          <div className={`flex items-start justify-between gap-3 ${currentWorkspaceIsFinal ? "opacity-70" : ""}`}>
             <div>
               <div className="text-sm font-semibold text-slate-900">
                 {currentWorkspaceIsFinal ? "Final Review Summary" : "Evidence workflow"}
@@ -4269,7 +4277,7 @@ export default function ProofMapTab({
               <div className="flex flex-wrap items-center justify-end gap-2">
                 <button
                   type="button"
-                  className="rounded-full border border-rose-200 bg-rose-50 px-3 py-1 text-xs font-semibold text-rose-700 shadow-sm hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="rounded-full border border-rose-200 bg-white px-3 py-1 text-xs font-semibold text-rose-700 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
                   onClick={() => {
                     if (hasStartOverState) setStartOverOpen(true);
                     else showToast("Nothing to clear.");
@@ -4280,14 +4288,14 @@ export default function ProofMapTab({
                 </button>
                 <button
                   type="button"
-                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
+                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-50"
                   onClick={handleNewRun}
                 >
                   New run
                 </button>
                 <button
                   type="button"
-                  className="hidden items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50 lg:inline-flex"
+                  className="hidden items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-50 lg:inline-flex"
                   onClick={() => setPanelCollapsed(true)}
                   aria-label="Collapse Verify panel"
                 >
@@ -4421,7 +4429,7 @@ export default function ProofMapTab({
           <div className="rounded-xl border-t border-dashed border-slate-200 pt-3">
             <button
               type="button"
-              className="flex w-full items-center justify-between rounded-lg bg-slate-50 px-3 py-2 text-left"
+              className="flex w-full items-center justify-between rounded-xl bg-slate-50/70 px-3 py-2 text-left"
               onClick={() => setSecondarySectionOpen((value) => !value)}
               data-testid="secondary-context-toggle"
             >

--- a/src/components/verify/EvidenceWorkflowStepper.tsx
+++ b/src/components/verify/EvidenceWorkflowStepper.tsx
@@ -84,7 +84,7 @@ type EvidenceWorkflowStepperProps = {
 
 function stepStateClass(input: { active: boolean; complete: boolean; disabled: boolean }): string {
   if (input.active) return "border-slate-300 bg-white shadow-sm shadow-slate-200/30";
-  if (input.complete) return "border-slate-200/90 bg-white";
+  if (input.complete) return "border-emerald-200/80 bg-emerald-50/35";
   if (input.disabled) return "border-slate-200/80 bg-slate-50/60 opacity-80";
   return "border-slate-200/90 bg-white";
 }

--- a/src/components/verify/EvidenceWorkflowStepper.tsx
+++ b/src/components/verify/EvidenceWorkflowStepper.tsx
@@ -83,15 +83,15 @@ type EvidenceWorkflowStepperProps = {
 };
 
 function stepStateClass(input: { active: boolean; complete: boolean; disabled: boolean }): string {
-  if (input.active) return "border-slate-300 bg-slate-50";
-  if (input.complete) return "border-emerald-200/90 bg-emerald-50/65";
-  if (input.disabled) return "border-slate-200 bg-slate-50/60 opacity-80";
-  return "border-slate-200 bg-white";
+  if (input.active) return "border-slate-300 bg-white shadow-sm shadow-slate-200/30";
+  if (input.complete) return "border-slate-200/90 bg-white";
+  if (input.disabled) return "border-slate-200/80 bg-slate-50/60 opacity-80";
+  return "border-slate-200/90 bg-white";
 }
 
 function stepMarkerClass(input: { active: boolean; complete: boolean; disabled: boolean }): string {
   if (input.active) return "border-slate-900 bg-slate-900 text-white";
-  if (input.complete) return "border-emerald-300 bg-emerald-50 text-emerald-700";
+  if (input.complete) return "border-emerald-200 bg-white text-emerald-700";
   if (input.disabled) return "border-slate-200 bg-slate-50 text-slate-400";
   return "border-slate-200 bg-white text-slate-500";
 }
@@ -395,7 +395,6 @@ export default function EvidenceWorkflowStepper({
   const reviewerArtifactSaved = Boolean(savedReviewerArtifactAt);
   const readyToFinalize =
     !finalizeBlocked && (step7.active || (reviewerArtifactSaved && !currentWorkspaceIsFinal && !step7.disabled));
-  const inProgress = !currentWorkspaceIsFinal && !readyToFinalize;
   const stepShellClass = currentWorkspaceIsFinal ? "opacity-45 transition" : "transition";
   const [completedWorkflowExpanded, setCompletedWorkflowExpanded] = useState(false);
   const completedCounts = [
@@ -454,61 +453,21 @@ export default function EvidenceWorkflowStepper({
     );
   }
 
+  const searchAndSelectState = {
+    active: step3.active || step4.active,
+    complete: step4.complete,
+    disabled: step3.disabled,
+  };
+  const saveAndFinalizeState = {
+    active: step6.active || step7.active,
+    complete: false,
+    disabled: step6.disabled && step7.disabled,
+  };
+
   return (
     <div className="grid gap-3">
-      <div className="sticky top-0 z-10 rounded-xl border border-slate-200 bg-white px-3.5 py-3">
-        <div className="flex flex-wrap items-start justify-between gap-2">
-          <div>
-            <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Current workspace</div>
-            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-600">
-              <span>
-                <span className="font-semibold text-slate-900">Run:</span>{" "}
-                <span data-testid="current-run-indicator" className="font-mono">
-                  {currentRunLabel}
-                </span>
-              </span>
-              {loadedFromRunLabel ? (
-                <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-medium text-sky-700">
-                  Loaded from Run {loadedFromRunLabel}
-                </span>
-              ) : null}
-              {isEditedDraft ? (
-                <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
-                  Edited draft
-                </span>
-              ) : null}
-              {currentWorkspaceIsFinal ? (
-                <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
-                  Finalized
-                </span>
-              ) : null}
-              {inProgress ? (
-                <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-700">
-                  In progress
-                </span>
-              ) : null}
-              {reviewerArtifactSaved && !currentWorkspaceIsFinal ? (
-                <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-medium text-sky-700">
-                  Reviewer artifact saved
-                </span>
-              ) : null}
-              {readyToFinalize ? (
-                <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
-                  Ready to finalize
-                </span>
-              ) : null}
-              {hasUnsavedWorkspaceEdits ? (
-                <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
-                  Unsaved edits
-                </span>
-              ) : null}
-            </div>
-          </div>
-          <div className="text-right text-[11px] text-slate-500" data-testid="wizard-next-action">
-            <div className="font-semibold uppercase tracking-wide text-slate-400">Next required action</div>
-            <div className="mt-1 text-slate-700">{nextActionText}</div>
-          </div>
-        </div>
+      <div className="rounded-xl border border-slate-200/80 bg-slate-50/50 px-3.5 py-2.5 text-[11px] text-slate-600" data-testid="wizard-next-action">
+        <span className="font-semibold text-slate-900">Next:</span> {nextActionText}
       </div>
 
       <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step1)}`} data-testid="wizard-step-1">
@@ -522,32 +481,32 @@ export default function EvidenceWorkflowStepper({
               <div className={`text-sm font-semibold ${stepTextTone(step1)}`}>Pick rule</div>
             </div>
             <div className="mt-2 flex flex-wrap items-center gap-2">
-          <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1">
-            <span className="text-xs font-semibold text-slate-600">Rule</span>
-            <select
-              className="max-w-[220px] bg-transparent text-xs text-slate-700 outline-none"
-              value={selectedRuleId ?? ""}
-              onChange={(event) => onSelectRuleId?.(event.target.value.trim() || null)}
-            >
-              <option value="">Select rule…</option>
-              {ruleOptions.map((rule) => (
-                <option key={rule.id} value={rule.id} title={rule.id}>
-                  {formatRuleOptionLabel(rule)}
-                </option>
-              ))}
-            </select>
-          </div>
-          {selectedRuleId ? (
-            <button
-              type="button"
-              className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
-              onClick={() => onViewRule?.(selectedRuleId)}
-            >
-              View rule
-            </button>
-          ) : (
-            <div className="text-[11px] text-slate-500">Select a rule to unlock the rest of the workflow.</div>
-          )}
+              <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1">
+                <span className="text-xs font-semibold text-slate-600">Rule</span>
+                <select
+                  className="max-w-[220px] bg-transparent text-xs text-slate-700 outline-none"
+                  value={selectedRuleId ?? ""}
+                  onChange={(event) => onSelectRuleId?.(event.target.value.trim() || null)}
+                >
+                  <option value="">Select rule…</option>
+                  {ruleOptions.map((rule) => (
+                    <option key={rule.id} value={rule.id} title={rule.id}>
+                      {formatRuleOptionLabel(rule)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {selectedRuleId ? (
+                <button
+                  type="button"
+                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+                  onClick={() => onViewRule?.(selectedRuleId)}
+                >
+                  View rule
+                </button>
+              ) : (
+                <div className="text-[11px] text-slate-500">Select a rule to unlock the rest of the workflow.</div>
+              )}
             </div>
           </div>
         </div>
@@ -561,118 +520,107 @@ export default function EvidenceWorkflowStepper({
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 2</div>
-              <div className={`text-sm font-semibold ${stepTextTone(step2)}`}>Confirm Area</div>
+              <div className={`text-sm font-semibold ${stepTextTone(step2)}`}>Confirm area</div>
             </div>
             <div className="mt-2 flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${
-              step2.active ? "border-slate-900 bg-slate-900 text-white hover:bg-slate-800" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
-            }`}
-            onClick={onUploadAoi}
-            disabled={step2.disabled}
-          >
-            Upload Area
-          </button>
-          {!selectedRuleId ? (
-            <div className="text-[11px] text-slate-500">Disabled: pick a rule first.</div>
-          ) : hasAoi ? (
-            <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
-              Area ready
-            </span>
-          ) : (
-            <div className="text-[11px] text-slate-500">Upload and confirm an Area to continue.</div>
-          )}
+              <button
+                type="button"
+                className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${
+                  step2.active ? "border-slate-900 bg-slate-900 text-white hover:bg-slate-800" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+                }`}
+                onClick={onUploadAoi}
+                disabled={step2.disabled}
+              >
+                Upload Area
+              </button>
+              {!selectedRuleId ? (
+                <div className="text-[11px] text-slate-500">Disabled: pick a rule first.</div>
+              ) : hasAoi ? (
+                <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+                  Area ready
+                </span>
+              ) : (
+                <div className="text-[11px] text-slate-500">Upload and confirm an Area to continue.</div>
+              )}
             </div>
-        {aoiSummary ? (
-          <div className="mt-2 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-xs text-slate-700">
-            {aoiSummary.isPreview ? (
-              <>
-                <div className="font-semibold text-slate-900">New Area ready</div>
-                <div className="mt-1">Replace the current Area with <span className="font-semibold">{aoiLabel ?? "uploaded Area"}</span>?</div>
-                {aoiSummary.willClearWork ? <div className="mt-1 text-[11px] text-slate-600">This will clear pins and evidence selections.</div> : null}
-                <div className="mt-2 flex flex-wrap items-center gap-2">
-                  <button type="button" className="rounded-full border border-sky-200 bg-sky-600 px-3 py-1 text-xs font-semibold text-white shadow-sm hover:bg-sky-700" onClick={onApplyDraftAoiClick}>Replace Area</button>
-                  <button type="button" className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50" onClick={onCancelDraftAoi}>Keep current</button>
-                </div>
-                {aoiSummary.isSameAoi && aoiSummary.showSameAoiPrompt ? (
-                  <div className="mt-2 rounded-md border border-slate-200 bg-slate-50 px-2 py-2 text-[11px] text-slate-700">
-                    <div className="font-semibold text-slate-800">Same Area detected. Keep current links?</div>
+            {aoiSummary ? (
+              <div className="mt-2 rounded-lg border border-slate-200 bg-slate-50/60 px-2.5 py-2 text-xs text-slate-700">
+                {aoiSummary.isPreview ? (
+                  <>
+                    <div className="font-semibold text-slate-900">New Area ready</div>
+                    <div className="mt-1">Replace the current Area with <span className="font-semibold">{aoiLabel ?? "uploaded Area"}</span>?</div>
+                    {aoiSummary.willClearWork ? <div className="mt-1 text-[11px] text-slate-600">This will clear pins and evidence selections.</div> : null}
                     <div className="mt-2 flex flex-wrap items-center gap-2">
-                      <button type="button" className="rounded-full border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold text-slate-700 shadow-sm hover:bg-slate-50" onClick={onKeepSameAoi}>Keep</button>
-                      <button type="button" className="rounded-full border border-rose-200 bg-rose-50 px-2 py-1 text-[11px] font-semibold text-rose-700 shadow-sm hover:bg-rose-100" onClick={onResetSameAoi}>Reset anyway</button>
+                      <button type="button" className="rounded-full border border-sky-200 bg-sky-600 px-3 py-1 text-xs font-semibold text-white hover:bg-sky-700" onClick={onApplyDraftAoiClick}>Replace Area</button>
+                      <button type="button" className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-50" onClick={onCancelDraftAoi}>Keep current</button>
                     </div>
+                    {aoiSummary.isSameAoi && aoiSummary.showSameAoiPrompt ? (
+                      <div className="mt-2 rounded-md border border-slate-200 bg-white px-2 py-2 text-[11px] text-slate-700">
+                        <div className="font-semibold text-slate-800">Same Area detected. Keep current links?</div>
+                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                          <button type="button" className="rounded-full border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold text-slate-700 hover:bg-slate-50" onClick={onKeepSameAoi}>Keep</button>
+                          <button type="button" className="rounded-full border border-rose-200 bg-rose-50 px-2 py-1 text-[11px] font-semibold text-rose-700 hover:bg-rose-100" onClick={onResetSameAoi}>Reset anyway</button>
+                        </div>
+                      </div>
+                    ) : null}
+                  </>
+                ) : (
+                  <div className="grid gap-1 text-[11px] text-slate-600">
+                    <div>Area: {aoiLabel ?? "none"}</div>
+                    <div>area: {typeof aoiSummary.areaKm2 === "number" ? aoiSummary.areaKm2.toFixed(2) : "—"} km²</div>
+                    <div className="break-words">bbox: {aoiSummary.bboxLabel ?? "—"}</div>
                   </div>
-                ) : null}
-              </>
-            ) : (
-              <div className="grid gap-1 text-[11px] text-slate-600">
-                <div>Area: {aoiLabel ?? "none"}</div>
-                <div>area: {typeof aoiSummary.areaKm2 === "number" ? aoiSummary.areaKm2.toFixed(2) : "—"} km²</div>
-                <div className="break-words">bbox: {aoiSummary.bboxLabel ?? "—"}</div>
+                )}
               </div>
-            )}
-          </div>
-        ) : null}
+            ) : null}
           </div>
         </div>
       </div>
 
-      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step3)}`} data-testid="wizard-step-3">
+      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(searchAndSelectState)}`} data-testid="wizard-step-3">
         <div className="flex items-start gap-3">
-          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step3)}`}>
-            {step3.complete ? "✓" : "3"}
+          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(searchAndSelectState)}`}>
+            {searchAndSelectState.complete ? "✓" : "3"}
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 3</div>
-              <div className={`text-sm font-semibold ${stepTextTone(step3)}`}>Search Satellite</div>
+              <div className={`text-sm font-semibold ${stepTextTone(searchAndSelectState)}`}>Search satellite</div>
             </div>
             <div className="mt-2 flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            className={`rounded-full border px-3 py-1.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60 ${
-              step3.active ? "border-slate-900 bg-slate-900 text-white hover:bg-slate-800" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
-            }`}
-            disabled={step3.disabled || searchDisabled}
-            onClick={onSearchStac}
-          >
-            {isRunning ? "Searching…" : "Search Satellite"}
-          </button>
-          {!hasAoi ? (
-            <div className="text-[11px] text-slate-500">Disabled: confirm Area first.</div>
-          ) : hasSearchResults ? (
-            <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-700">
-              {stacResultCount} items
-            </span>
-          ) : (
-            <div className="text-[11px] text-slate-500">Run search to load candidate evidence.</div>
-          )}
+              <button
+                type="button"
+                className={`rounded-full border px-3 py-1.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60 ${
+                  searchAndSelectState.active ? "border-slate-900 bg-slate-900 text-white hover:bg-slate-800" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+                }`}
+                disabled={step3.disabled || searchDisabled}
+                onClick={onSearchStac}
+              >
+                {isRunning ? "Searching…" : "Search Satellite"}
+              </button>
+              {!hasAoi ? (
+                <div className="text-[11px] text-slate-500">Disabled: confirm Area first.</div>
+              ) : hasSearchResults ? (
+                <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-700">
+                  {stacResultCount} result{stacResultCount === 1 ? "" : "s"}
+                </span>
+              ) : (
+                <div className="text-[11px] text-slate-500">Run search to load candidate evidence.</div>
+              )}
             </div>
-          </div>
-        </div>
-      </div>
-
-      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step4)}`} data-testid="wizard-step-4">
-        <div className="flex items-start gap-3">
-          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step4)}`}>
-            {step4.complete ? "✓" : "4"}
-          </div>
-          <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 4</div>
-          <div className={`text-sm font-semibold ${stepTextTone(step4)}`}>Select item</div>
-        </div>
-        {selectedStacItemId ? (
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-700">
-              <span className="font-mono">{selectedStacItemId}</span>
-            </span>
-            <button type="button" className="text-xs font-semibold text-slate-700 underline underline-offset-2" onClick={onClearSelectedItem}>Clear</button>
-          </div>
-        ) : (
-          <div className="mt-2 text-[11px] text-slate-500">Pick a satellite result from the list or map to continue.</div>
-        )}
+            <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50/55 px-3 py-2" data-testid="wizard-step-4">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Selected item</div>
+              {selectedStacItemId ? (
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-700">
+                    <span className="font-mono">{selectedStacItemId}</span>
+                  </span>
+                  <button type="button" className="text-xs font-semibold text-slate-700 underline underline-offset-2" onClick={onClearSelectedItem}>Clear</button>
+                </div>
+              ) : (
+                <div className="mt-2 text-[11px] text-slate-500">Pick a satellite result from the list or map to continue.</div>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -680,128 +628,124 @@ export default function EvidenceWorkflowStepper({
       <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step5)}`} data-testid="wizard-step-5">
         <div className="flex items-start gap-3">
           <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step5)}`}>
-            {step5.complete ? "✓" : "5"}
+            {step5.complete ? "✓" : "4"}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 4</div>
+              <div className={`text-sm font-semibold ${stepTextTone(step5)}`}>Evidence inventory</div>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <Tooltip content={createPinDisabledReason}>
+                <button
+                  type="button"
+                  className={`rounded-full border px-3 py-1.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60 ${
+                    step5.active ? "border-slate-900 bg-slate-900 text-white hover:bg-slate-800" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+                  }`}
+                  onClick={onCreatePin}
+                  disabled={!canCreatePin}
+                >
+                  Create pin
+                </button>
+              </Tooltip>
+              {pinsCount > 0 ? (
+                <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+                  {pinsCount} link{pinsCount === 1 ? "" : "s"} ready
+                </span>
+              ) : (
+                <div className="text-[11px] text-slate-500">Create and link evidence for the selected rule.</div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(saveAndFinalizeState)}`} data-testid="wizard-step-6">
+        <div className="flex items-start gap-3">
+          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(saveAndFinalizeState)}`}>
+            {step7.complete ? "✓" : "5"}
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 5</div>
-              <div className={`text-sm font-semibold ${stepTextTone(step5)}`}>Create/link pin</div>
+              <div className={`text-sm font-semibold ${stepTextTone(saveAndFinalizeState)}`}>Save &amp; finalize</div>
             </div>
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-          <Tooltip content={createPinDisabledReason}>
-            <button
-              type="button"
-              className={`rounded-full border px-3 py-1.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60 ${
-                step5.active ? "border-slate-900 bg-slate-900 text-white hover:bg-slate-800" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
-              }`}
-              onClick={onCreatePin}
-              disabled={!canCreatePin}
-            >
-              Create pin
-            </button>
-          </Tooltip>
-          {pinsCount > 0 ? (
-            <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
-              {pinsCount} link{pinsCount === 1 ? "" : "s"} ready
-            </span>
-          ) : null}
+            <div className="mt-2 grid gap-3">
+              <div className="text-[11px] text-slate-500">Type concise minutes or an outcome note, save it explicitly, then finalize the run.</div>
+              <textarea
+                data-testid="verifier-minutes-textarea"
+                className="min-h-[92px] w-full resize-none rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-800 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-200 disabled:opacity-60"
+                placeholder="Verifier minutes: what you checked, what you assume, what remains uncertain."
+                value={draftMinutes}
+                disabled={currentWorkspaceIsFinal}
+                onChange={(event) => onReviewerMinutesChange(event.target.value)}
+              />
+              <textarea
+                className="min-h-[72px] w-full resize-none rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-800 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-200 disabled:opacity-60"
+                placeholder="Outcome note: one concise sentence if minutes are unnecessary."
+                value={draftOutcomeNote}
+                disabled={currentWorkspaceIsFinal}
+                onChange={(event) => onReviewerOutcomeNoteChange(event.target.value)}
+              />
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  onClick={onSaveReviewerArtifact}
+                  disabled={step6.disabled || currentWorkspaceIsFinal || !hasDraftArtifactChanges}
+                >
+                  Save reviewer artifact
+                </button>
+                {savedReviewerArtifactAt ? (
+                  <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+                    Saved {formatDate(savedReviewerArtifactAt)}
+                  </span>
+                ) : null}
+                {hasUnsavedWorkspaceEdits ? (
+                  <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                    Unsaved edits
+                  </span>
+                ) : null}
+                {loadedFromRunLabel ? (
+                  <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-medium text-sky-700">
+                    Loaded from Run {loadedFromRunLabel}
+                  </span>
+                ) : null}
+                {isEditedDraft ? (
+                  <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                    Edited draft
+                  </span>
+                ) : null}
+              </div>
+              <div className="rounded-lg border border-slate-200 bg-slate-50/55 px-3 py-3" data-testid="wizard-step-7">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Finalize run</div>
+                <div className="mt-1 text-[11px] text-slate-500">Finalization writes the immutable run artifact with evidence and reviewer notes.</div>
+                {finalizeGateBanner ? <div className="mt-2">{finalizeGateBanner}</div> : null}
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    className="rounded-full border border-slate-900 bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+                    onClick={onFinalizeRun}
+                    disabled={step7.disabled || currentWorkspaceIsFinal || finalizeBlocked}
+                  >
+                    Finalize run
+                  </button>
+                  {reviewerArtifactSaved ? (
+                    <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-medium text-sky-700">
+                      Reviewer artifact saved
+                    </span>
+                  ) : null}
+                  {readyToFinalize ? (
+                    <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                      Ready to finalize
+                    </span>
+                  ) : null}
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-
-      <div className={`${stepShellClass} rounded-xl border px-3.5 py-3 ${stepStateClass(step6)}`} data-testid="wizard-step-6">
-        <div className="flex items-start gap-3">
-          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step6)}`}>
-            {step6.complete ? "✓" : "6"}
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 6</div>
-              <div className={`text-sm font-semibold ${stepTextTone(step6)}`}>Save reviewer artifact</div>
-            </div>
-        <div className="mt-2 grid gap-3">
-          <div className="text-[11px] text-slate-500">Type concise minutes or an outcome note, then save it explicitly before finalization.</div>
-          <textarea
-            data-testid="verifier-minutes-textarea"
-            className="min-h-[92px] w-full resize-none rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-800 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-200 disabled:opacity-60"
-            placeholder="Verifier minutes: what you checked, what you assume, what remains uncertain."
-            value={draftMinutes}
-            disabled={currentWorkspaceIsFinal}
-            onChange={(event) => onReviewerMinutesChange(event.target.value)}
-          />
-          <textarea
-            className="min-h-[72px] w-full resize-none rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-800 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-200 disabled:opacity-60"
-            placeholder="Outcome note: one concise sentence if minutes are unnecessary."
-            value={draftOutcomeNote}
-            disabled={currentWorkspaceIsFinal}
-            onChange={(event) => onReviewerOutcomeNoteChange(event.target.value)}
-          />
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-              onClick={onSaveReviewerArtifact}
-              disabled={step6.disabled || currentWorkspaceIsFinal || !hasDraftArtifactChanges}
-            >
-              Save reviewer artifact
-            </button>
-            {savedReviewerArtifactAt ? (
-              <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
-                Saved {formatDate(savedReviewerArtifactAt)}
-              </span>
-            ) : null}
-          </div>
-        </div>
-          </div>
-        </div>
-      </div>
-
-      <div className={`${currentWorkspaceIsFinal ? "opacity-70 transition" : "transition"} rounded-xl border px-3.5 py-3 ${stepStateClass(step7)}`} data-testid="wizard-step-7">
-        <div className="flex items-start gap-3">
-          <div className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${stepMarkerClass(step7)}`}>
-            {step7.complete ? "✓" : "7"}
-          </div>
-          <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">Step 7</div>
-          <div className={`text-sm font-semibold ${stepTextTone(step7)}`}>Finalize run</div>
-        </div>
-        <div className="mt-1 text-[11px] text-slate-500">This is the single completion/export action. Finalization writes the immutable run artifact with evidence and reviewer notes.</div>
-        {finalizeGateBanner ? <div className="mt-2">{finalizeGateBanner}</div> : null}
-        <div className="mt-2 flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            className="rounded-full border border-slate-900 bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
-            onClick={onFinalizeRun}
-            disabled={step7.disabled || currentWorkspaceIsFinal || finalizeBlocked}
-          >
-            Finalize run
-          </button>
-          {finalizedAt ? (
-            <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
-              Finalized {formatDate(finalizedAt)}
-            </span>
-          ) : null}
-        </div>
-          </div>
-        </div>
-      </div>
-
-      {wizard.isComplete ? (
-        <div className="rounded-2xl border border-emerald-200 bg-gradient-to-br from-emerald-50 via-white to-slate-50 px-4 py-4 shadow-sm shadow-emerald-100" data-testid="wizard-completion-card">
-          <div className="text-sm font-semibold text-emerald-900">Run complete</div>
-          <div className="mt-1 text-xs text-emerald-800">Locked artifacts: finalized workspace state and the saved reviewer artifact.</div>
-          {finalizedResult ? <div className="mt-4">{finalizedResult}</div> : null}
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <button type="button" className="rounded-full border border-emerald-700 bg-emerald-700 px-3 py-1 text-xs font-semibold text-white shadow-sm hover:bg-emerald-800" onClick={onStartAnotherRun}>Start another run</button>
-            {onViewOutcome ? (
-              <button type="button" className="rounded-full border border-emerald-200 bg-white px-3 py-1 text-xs font-semibold text-emerald-800 shadow-sm hover:bg-emerald-100" onClick={onViewOutcome}>View outcome</button>
-            ) : null}
-            <button type="button" className="rounded-full border border-emerald-200 bg-white px-3 py-1 text-xs font-semibold text-emerald-800 shadow-sm hover:bg-emerald-100" onClick={onViewRunHistory}>View run history</button>
-          </div>
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/src/components/verify/RuleReadinessFacts.tsx
+++ b/src/components/verify/RuleReadinessFacts.tsx
@@ -3,6 +3,7 @@ import type { RuleReadinessGap } from "@/lib/readiness/gapEngine";
 
 type RuleReadinessFactsProps = {
   ruleId: string | null;
+  ruleTitle?: string | null;
   gap: RuleReadinessGap | null;
   unavailableReason?: string | null;
 };
@@ -38,10 +39,10 @@ function missingEvidenceLabels(gap: RuleReadinessGap): string {
     .join(", ");
 }
 
-export default function RuleReadinessFacts({ ruleId, gap, unavailableReason = null }: RuleReadinessFactsProps) {
+export default function RuleReadinessFacts({ ruleId, ruleTitle = null, gap, unavailableReason = null }: RuleReadinessFactsProps) {
   if (!ruleId) {
     return (
-      <div className="rounded-xl border border-slate-200 bg-white px-4 py-3" data-testid="rule-readiness-facts">
+      <div className="rounded-2xl border border-slate-200/70 bg-white/95 px-4 py-3.5 shadow-sm shadow-slate-200/30" data-testid="rule-readiness-facts">
         <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
         <div className="mt-1 text-sm font-medium text-slate-700">Not assessed</div>
         <div className="mt-2 text-xs text-slate-500">Select a rule to inspect rule-specific readiness facts.</div>
@@ -51,8 +52,14 @@ export default function RuleReadinessFacts({ ruleId, gap, unavailableReason = nu
 
   if (!gap) {
     return (
-      <div className="rounded-xl border border-slate-200 bg-white px-4 py-3" data-testid="rule-readiness-facts">
-        <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
+      <div className="rounded-2xl border border-slate-200/70 bg-white/95 px-4 py-3.5 shadow-sm shadow-slate-200/30" data-testid="rule-readiness-facts">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
+            <div className="mt-1 text-sm font-semibold text-slate-900">{ruleTitle ?? ruleId}</div>
+            {ruleTitle && ruleTitle !== ruleId ? <div className="mt-1 text-xs text-slate-500">{ruleId}</div> : null}
+          </div>
+        </div>
         <div className="mt-1 flex flex-wrap items-center gap-2">
           <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${stateTone("not_available")}`}>
             Not available
@@ -70,17 +77,23 @@ export default function RuleReadinessFacts({ ruleId, gap, unavailableReason = nu
       : null;
 
   return (
-    <div className="rounded-xl border border-slate-200 bg-white px-4 py-3" data-testid="rule-readiness-facts">
-      <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
-      <div className="mt-2 flex flex-wrap items-center gap-2">
-        <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${stateTone(gap.state)}`}>
-          {titleCase(gap.state)}
-        </span>
-        <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${severityTone(gap.severity)}`}>
-          Severity: {titleCase(gap.severity)}
-        </span>
+    <div className="rounded-2xl border border-slate-200/70 bg-white/95 px-4 py-3.5 shadow-sm shadow-slate-200/30" data-testid="rule-readiness-facts">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
+          <div className="mt-1 text-sm font-semibold text-slate-900">{ruleTitle ?? gap.title ?? ruleId}</div>
+          <div className="mt-1 text-xs text-slate-500">{ruleId}</div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${stateTone(gap.state)}`}>
+            {titleCase(gap.state)}
+          </span>
+          <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${severityTone(gap.severity)}`}>
+            Severity: {titleCase(gap.severity)}
+          </span>
+        </div>
       </div>
-      <div className="mt-2 grid gap-1 text-xs text-slate-600">
+      <div className="mt-3 grid gap-2 rounded-xl bg-slate-50/70 px-3 py-3 text-xs text-slate-600">
         {gap.missingExpectedEvidenceTypes.length ? (
           <div>
             <span className="font-semibold text-slate-900">Missing:</span> {missingEvidenceLabels(gap)}
@@ -95,7 +108,7 @@ export default function RuleReadinessFacts({ ruleId, gap, unavailableReason = nu
           </div>
         ) : null}
       </div>
-      <div className="mt-2 text-xs text-slate-500">{gap.summary}</div>
+      <div className="mt-3 text-xs text-slate-500">{gap.summary}</div>
     </div>
   );
 }

--- a/src/components/verify/RuleReadinessFacts.tsx
+++ b/src/components/verify/RuleReadinessFacts.tsx
@@ -68,7 +68,6 @@ export default function RuleReadinessFacts({
           <div className="min-w-0">
             <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
             <div className="mt-1 text-sm font-semibold text-slate-900">{ruleTitle ?? ruleId}</div>
-            {ruleTitle && ruleTitle !== ruleId ? <div className="mt-1 text-xs text-slate-500">{ruleId}</div> : null}
           </div>
         </div>
         <div className="mt-1 flex flex-wrap items-center gap-2">
@@ -92,8 +91,14 @@ export default function RuleReadinessFacts({
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0">
           <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
-          <div className="mt-1 text-sm font-semibold text-slate-900">{ruleTitle ?? gap.title ?? ruleId}</div>
-          <div className="mt-1 text-xs text-slate-500">{ruleId}</div>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-sm font-semibold text-slate-900">
+            <span>{ruleTitle ?? gap.title ?? ruleId}</span>
+            {ruleTitle && ruleTitle !== ruleId ? (
+              <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-600">
+                {ruleId}
+              </span>
+            ) : null}
+          </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${stateTone(gap.state)}`}>
@@ -105,9 +110,11 @@ export default function RuleReadinessFacts({
         </div>
       </div>
       <div className="mt-3 grid gap-2 rounded-xl bg-slate-50/55 px-3 py-3 text-xs text-slate-600">
-        <div>
-          <span className="font-semibold text-slate-900">Next:</span> {nextAction}
-        </div>
+        {nextAction !== "Not available" ? (
+          <div>
+            <span className="font-semibold text-slate-900">Next step:</span> {nextAction}
+          </div>
+        ) : null}
         {gap.missingExpectedEvidenceTypes.length ? (
           <div>
             <span className="font-semibold text-slate-900">Missing:</span> {missingEvidenceLabels(gap)}
@@ -119,9 +126,7 @@ export default function RuleReadinessFacts({
           </div>
         ) : null}
       </div>
-      <div className="mt-3 text-xs text-slate-500">
-        <span className="font-semibold text-slate-700">Why this matters:</span> {gap.summary}
-      </div>
+      <div className="mt-3 text-xs text-slate-500">{gap.summary}</div>
     </div>
   );
 }

--- a/src/components/verify/RuleReadinessFacts.tsx
+++ b/src/components/verify/RuleReadinessFacts.tsx
@@ -6,6 +6,7 @@ type RuleReadinessFactsProps = {
   ruleTitle?: string | null;
   gap: RuleReadinessGap | null;
   unavailableReason?: string | null;
+  embedded?: boolean;
 };
 
 function titleCase(value: string): string {
@@ -39,10 +40,20 @@ function missingEvidenceLabels(gap: RuleReadinessGap): string {
     .join(", ");
 }
 
-export default function RuleReadinessFacts({ ruleId, ruleTitle = null, gap, unavailableReason = null }: RuleReadinessFactsProps) {
+export default function RuleReadinessFacts({
+  ruleId,
+  ruleTitle = null,
+  gap,
+  unavailableReason = null,
+  embedded = false,
+}: RuleReadinessFactsProps) {
+  const shellClass = embedded
+    ? "px-4 py-3.5"
+    : "rounded-2xl border border-slate-200/70 bg-white/95 px-4 py-3.5 shadow-sm shadow-slate-200/30";
+
   if (!ruleId) {
     return (
-      <div className="rounded-2xl border border-slate-200/70 bg-white/95 px-4 py-3.5 shadow-sm shadow-slate-200/30" data-testid="rule-readiness-facts">
+      <div className={shellClass} data-testid="rule-readiness-facts">
         <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
         <div className="mt-1 text-sm font-medium text-slate-700">Not assessed</div>
         <div className="mt-2 text-xs text-slate-500">Select a rule to inspect rule-specific readiness facts.</div>
@@ -52,7 +63,7 @@ export default function RuleReadinessFacts({ ruleId, ruleTitle = null, gap, unav
 
   if (!gap) {
     return (
-      <div className="rounded-2xl border border-slate-200/70 bg-white/95 px-4 py-3.5 shadow-sm shadow-slate-200/30" data-testid="rule-readiness-facts">
+      <div className={shellClass} data-testid="rule-readiness-facts">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
@@ -77,7 +88,7 @@ export default function RuleReadinessFacts({ ruleId, ruleTitle = null, gap, unav
       : null;
 
   return (
-    <div className="rounded-2xl border border-slate-200/70 bg-white/95 px-4 py-3.5 shadow-sm shadow-slate-200/30" data-testid="rule-readiness-facts">
+    <div className={shellClass} data-testid="rule-readiness-facts">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0">
           <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Rule readiness</div>
@@ -93,22 +104,24 @@ export default function RuleReadinessFacts({ ruleId, ruleTitle = null, gap, unav
           </span>
         </div>
       </div>
-      <div className="mt-3 grid gap-2 rounded-xl bg-slate-50/70 px-3 py-3 text-xs text-slate-600">
+      <div className="mt-3 grid gap-2 rounded-xl bg-slate-50/55 px-3 py-3 text-xs text-slate-600">
+        <div>
+          <span className="font-semibold text-slate-900">Next:</span> {nextAction}
+        </div>
         {gap.missingExpectedEvidenceTypes.length ? (
           <div>
             <span className="font-semibold text-slate-900">Missing:</span> {missingEvidenceLabels(gap)}
           </div>
         ) : null}
-        <div>
-          <span className="font-semibold text-slate-900">Next:</span> {nextAction}
-        </div>
         {overrideNote ? (
           <div>
             <span className="font-semibold text-slate-900">Reviewer override:</span> {overrideNote}
           </div>
         ) : null}
       </div>
-      <div className="mt-3 text-xs text-slate-500">{gap.summary}</div>
+      <div className="mt-3 text-xs text-slate-500">
+        <span className="font-semibold text-slate-700">Why this matters:</span> {gap.summary}
+      </div>
     </div>
   );
 }

--- a/src/components/verify/VerifyReadinessStrip.tsx
+++ b/src/components/verify/VerifyReadinessStrip.tsx
@@ -12,6 +12,9 @@ export type VerifyReadinessChip = {
 type VerifyReadinessStripProps = {
   ruleId?: string | null;
   chips: VerifyReadinessChip[];
+  embedded?: boolean;
+  showRuleLabel?: boolean;
+  helperText?: string | null;
 };
 
 function chipClasses(tone: VerifyReadinessChip["tone"], clickable: boolean): string {
@@ -29,23 +32,35 @@ function chipClasses(tone: VerifyReadinessChip["tone"], clickable: boolean): str
   return `${base} ${toneClass} ${interactive}`;
 }
 
-export default function VerifyReadinessStrip({ ruleId, chips }: VerifyReadinessStripProps) {
+export default function VerifyReadinessStrip({
+  ruleId,
+  chips,
+  embedded = false,
+  showRuleLabel = true,
+  helperText = "Current readiness for the selected rule.",
+}: VerifyReadinessStripProps) {
+  const shellClass = embedded
+    ? "border-b border-slate-100 px-4 py-3"
+    : "rounded-2xl border border-slate-200/70 bg-white/95 px-4 py-3.5 shadow-sm shadow-slate-200/30";
+
   return (
-    <div className="rounded-2xl border border-slate-200/70 bg-white/95 px-4 py-3.5 shadow-sm shadow-slate-200/30">
+    <div className={shellClass}>
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-1.5 lg:flex-row lg:items-end lg:justify-between">
           <div className="min-w-0">
             <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">
               Verify readiness
             </div>
-            <div className="mt-1 text-sm font-medium leading-5 text-slate-700">
-              {ruleId ? `Active rule ${ruleId}` : "Select a rule to inspect rule-specific readiness."}
-            </div>
+            {showRuleLabel ? (
+              <div className="mt-1 text-sm font-medium leading-5 text-slate-700">
+                {ruleId ? `Active rule ${ruleId}` : "Select a rule to inspect rule-specific readiness."}
+              </div>
+            ) : null}
           </div>
-          <div className="text-xs text-slate-500">Current readiness for the selected rule.</div>
+          {helperText ? <div className="text-xs text-slate-500">{helperText}</div> : null}
         </div>
 
-        <div className="rounded-xl bg-slate-50/70 px-2 py-2">
+        <div className={`rounded-xl ${embedded ? "bg-slate-50/55" : "bg-slate-50/70"} px-2 py-2`}>
           <div className="flex flex-wrap gap-1.5 lg:justify-start">
             {chips.map((chip) => {
               const content = (

--- a/src/components/verify/VerifyReadinessStrip.tsx
+++ b/src/components/verify/VerifyReadinessStrip.tsx
@@ -16,69 +16,76 @@ type VerifyReadinessStripProps = {
 
 function chipClasses(tone: VerifyReadinessChip["tone"], clickable: boolean): string {
   const base =
-    "inline-flex h-8 items-center gap-1 rounded-full border px-2.5 text-[11px] font-medium transition";
+    "inline-flex min-h-8 items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-medium transition";
   const toneClass =
     tone === "ok"
-      ? "border-emerald-200/90 bg-emerald-50/70 text-emerald-800"
+      ? "border-emerald-200/80 bg-emerald-50/55 text-emerald-800"
       : tone === "warn"
-        ? "border-amber-200/90 bg-amber-50/80 text-amber-800"
+        ? "border-amber-200/80 bg-amber-50/65 text-amber-800"
         : tone === "blocked"
-          ? "border-rose-200/90 bg-rose-50/70 text-rose-800"
-          : "border-slate-200 bg-slate-50 text-slate-600";
+          ? "border-rose-200/80 bg-rose-50/55 text-rose-800"
+          : "border-slate-200/80 bg-slate-50/80 text-slate-600";
   const interactive = clickable ? "cursor-pointer hover:border-slate-300 hover:bg-white" : "cursor-default";
   return `${base} ${toneClass} ${interactive}`;
 }
 
 export default function VerifyReadinessStrip({ ruleId, chips }: VerifyReadinessStripProps) {
   return (
-    <div className="rounded-xl border border-slate-200/80 bg-white px-4 py-3">
-      <div className="flex flex-col gap-2.5 lg:flex-row lg:items-center lg:justify-between">
-        <div className="min-w-0">
-          <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">
-            Verify readiness
+    <div className="rounded-2xl border border-slate-200/70 bg-white/95 px-4 py-3.5 shadow-sm shadow-slate-200/30">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5 lg:flex-row lg:items-end lg:justify-between">
+          <div className="min-w-0">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+              Verify readiness
+            </div>
+            <div className="mt-1 text-sm font-medium leading-5 text-slate-700">
+              {ruleId ? `Active rule ${ruleId}` : "Select a rule to inspect rule-specific readiness."}
+            </div>
           </div>
-          <div className="mt-1 text-sm font-medium leading-5 text-slate-700">
-            {ruleId ? `Active rule ${ruleId}` : "Select a rule to inspect rule-specific readiness."}
+          <div className="text-xs text-slate-500">
+            Review status stays descriptive only. No verification opinion or export readiness is implied here.
           </div>
         </div>
 
-        <div className="flex flex-wrap gap-1.5 lg:justify-end">
-          {chips.map((chip) => {
-            const content = (
-              <>
-                <span className="text-current/65">{chip.label}:</span>
-                <span>{chip.value}</span>
-              </>
-            );
+        <div className="rounded-xl bg-slate-50/70 px-2 py-2">
+          <div className="flex flex-wrap gap-1.5 lg:justify-start">
+            {chips.map((chip) => {
+              const content = (
+                <>
+                  <span className="text-current/65">{chip.label}:</span>
+                  <span>{chip.value}</span>
+                </>
+              );
 
-            if (chip.onClick) {
+              if (chip.onClick) {
+                return (
+                  <button
+                    key={chip.key}
+                    type="button"
+                    title={chip.detail}
+                    aria-label={`${chip.label}: ${chip.value}. ${chip.detail}`}
+                    data-testid={`verify-readiness-chip-${chip.key}`}
+                    className={chipClasses(chip.tone, true)}
+                    onClick={chip.onClick}
+                  >
+                    {content}
+                  </button>
+                );
+              }
+
               return (
-                <button
+                <span
                   key={chip.key}
-                  type="button"
                   title={chip.detail}
                   aria-label={`${chip.label}: ${chip.value}. ${chip.detail}`}
                   data-testid={`verify-readiness-chip-${chip.key}`}
-                  className={chipClasses(chip.tone, true)}
-                  onClick={chip.onClick}
+                  className={chipClasses(chip.tone, false)}
                 >
                   {content}
-                </button>
+                </span>
               );
-            }
-
-            return (
-              <span
-                key={chip.key}
-                title={chip.detail}
-                aria-label={`${chip.label}: ${chip.value}. ${chip.detail}`}
-                data-testid={`verify-readiness-chip-${chip.key}`}
-                className={chipClasses(chip.tone, false)}
-              >
-                {content}
-              </span>
-            );
-          })}
+            })}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/verify/VerifyReadinessStrip.tsx
+++ b/src/components/verify/VerifyReadinessStrip.tsx
@@ -42,9 +42,7 @@ export default function VerifyReadinessStrip({ ruleId, chips }: VerifyReadinessS
               {ruleId ? `Active rule ${ruleId}` : "Select a rule to inspect rule-specific readiness."}
             </div>
           </div>
-          <div className="text-xs text-slate-500">
-            Review status stays descriptive only. No verification opinion or export readiness is implied here.
-          </div>
+          <div className="text-xs text-slate-500">Current readiness for the selected rule.</div>
         </div>
 
         <div className="rounded-xl bg-slate-50/70 px-2 py-2">

--- a/tests/components/evidenceWorkflowStepper.test.tsx
+++ b/tests/components/evidenceWorkflowStepper.test.tsx
@@ -54,9 +54,9 @@ describe("EvidenceWorkflowStepper", () => {
       />,
     );
 
-    expect(html).toContain("Step 6");
+    expect(html).toContain("Step 5");
+    expect(html).toContain("Save &amp; finalize");
     expect(html).toContain("Save reviewer artifact");
-    expect(html).toContain("Step 7");
     expect(html).toContain("Finalize run");
     expect(html).toContain("Reviewer artifact saved");
     expect(html).toContain("Ready to finalize");

--- a/tests/components/ruleReadinessFacts.test.tsx
+++ b/tests/components/ruleReadinessFacts.test.tsx
@@ -45,7 +45,7 @@ describe("RuleReadinessFacts", () => {
     expect(html).toContain("Severity: High");
     expect(html).toContain("Missing:");
     expect(html).toContain("Monitoring report");
-    expect(html).toContain("Next:");
+    expect(html).toContain("Next step:");
     expect(html).toContain("Link expected evidence");
     expect(html).toContain("Reviewer override:");
     expect(html).toContain("Needs Review (Medium) — Expectation encoding still needs clarification.");

--- a/tests/components/verifyReadinessStrip.test.tsx
+++ b/tests/components/verifyReadinessStrip.test.tsx
@@ -12,7 +12,7 @@ describe("VerifyReadinessStrip", () => {
             key: "support-facts",
             label: "Support facts",
             value: "select rule",
-            detail: "Select a rule to assess AOI/STAC support facts.",
+            detail: "Select a rule to assess area/satellite support facts.",
             tone: "blocked",
           },
         ]}
@@ -22,7 +22,7 @@ describe("VerifyReadinessStrip", () => {
     expect(html).toContain("Select a rule to inspect rule-specific readiness.");
     expect(html).toContain("Support facts:");
     expect(html).toContain("select rule");
-    expect(html).toContain("Select a rule to assess AOI/STAC support facts.");
+    expect(html).toContain("Select a rule to assess area/satellite support facts.");
     expect(html).not.toContain("not applicable");
   });
 
@@ -33,28 +33,28 @@ describe("VerifyReadinessStrip", () => {
         chips={[
           {
             key: "aoi",
-            label: "AOI",
-            value: "loaded",
-            detail: "Project AOI loaded.",
+            label: "Area",
+            value: "ready",
+            detail: "Project area ready.",
             tone: "ok",
           },
           {
             key: "stac",
-            label: "STAC",
-            value: "results found",
-            detail: "2 STAC results found for the active AOI.",
+            label: "Satellite",
+            value: "found",
+            detail: "2 satellite results found for the current area.",
             tone: "ok",
           },
           {
             key: "support-facts",
-            label: "Support facts",
+            label: "Support",
             value: "optional",
-            detail: "AOI/STAC support facts are optional for this rule. Link them only if they materially support the review.",
+            detail: "Area/satellite support facts are optional for this rule. Link them only if they materially support the review.",
             tone: "neutral",
           },
           {
             key: "reviewer-record",
-            label: "Reviewer record",
+            label: "Reviewer",
             value: "draft",
             detail: "Draft reviewer notes exist but are not saved yet.",
             tone: "warn",
@@ -62,7 +62,7 @@ describe("VerifyReadinessStrip", () => {
           {
             key: "export",
             label: "Export",
-            value: "draft available",
+            value: "draft",
             detail: "Draft snapshot exported 2026-03-25 00:10:00. Final export still needs finalize requirements to pass.",
             tone: "warn",
           },
@@ -72,17 +72,17 @@ describe("VerifyReadinessStrip", () => {
 
     expect(html).toContain("Verify readiness");
     expect(html).toContain("Active rule R-1-0001");
-    expect(html).toContain("AOI:");
-    expect(html).toContain("loaded");
-    expect(html).toContain("STAC:");
-    expect(html).toContain("results found");
-    expect(html).toContain("Support facts:");
+    expect(html).toContain("Area:");
+    expect(html).toContain("ready");
+    expect(html).toContain("Satellite:");
+    expect(html).toContain("found");
+    expect(html).toContain("Support:");
     expect(html).toContain("optional");
-    expect(html).toContain("Reviewer record:");
+    expect(html).toContain("Reviewer:");
     expect(html).toContain("draft");
     expect(html).toContain("Export:");
-    expect(html).toContain("draft available");
-    expect(html).toContain("AOI/STAC support facts are optional for this rule. Link them only if they materially support the review.");
+    expect(html).toContain("draft");
+    expect(html).toContain("Area/satellite support facts are optional for this rule. Link them only if they materially support the review.");
     expect(html).toContain("Draft snapshot exported 2026-03-25 00:10:00. Final export still needs finalize requirements to pass.");
   });
 });


### PR DESCRIPTION
## WHAT

- cleaned up the Verify screen hierarchy using existing Article6 palette classes
- made completed readiness states read consistently with calmer success styling
- reduced duplicate rule/status copy and simplified next-step messaging
- switched primary UI wording toward user-facing `Area` / `Satellite` language while keeping technical terms subordinate
- restored subtle completion highlighting in the workflow and kept utility actions compact

## WHY

- makes the reviewer path easier to scan and act on
- reduces noisy dev-facing language and duplicated metadata
- keeps the interface truthful while making it more consistent and usable
- preserves current behavior and status semantics without introducing a new design system

**Signed-off-by:** Fred E <fredilly@article6.org>