### PR TITLE
Add client readiness report export

### DIFF
--- a/src/app/api/exports/client-readiness-report/route.ts
+++ b/src/app/api/exports/client-readiness-report/route.ts
@@ -1,0 +1,54 @@
+import { buildClientReadinessReportExport } from "@/lib/readiness/clientReadinessExport";
+import type { ClientReadinessReport } from "@/lib/readiness/clientReadinessReport";
+import type { RuleReadinessGap } from "@/lib/readiness/gapEngine";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asClientReadinessReport(value: unknown): ClientReadinessReport | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  if (typeof record.reportId !== "string" || !record.reportId.trim()) return null;
+  const appendix = asRecord(record.technicalAppendix);
+  if (!appendix || typeof appendix.generatedAt !== "string" || !appendix.generatedAt.trim()) return null;
+  return value as ClientReadinessReport;
+}
+
+function asReadinessGaps(value: unknown): RuleReadinessGap[] | null {
+  if (!Array.isArray(value)) return null;
+  const valid = value.every((item) => {
+    const record = asRecord(item);
+    return Boolean(record && typeof record.ruleId === "string" && typeof record.state === "string" && typeof record.severity === "string");
+  });
+  return valid ? (value as RuleReadinessGap[]) : null;
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as unknown;
+    const record = asRecord(body) ?? {};
+    const report = asClientReadinessReport(record.report);
+    const readinessGaps = asReadinessGaps(record.readinessGaps);
+
+    if (!report) return new Response("Missing or invalid report payload", { status: 400 });
+    if (!readinessGaps) return new Response("Missing or invalid readinessGaps payload", { status: 400 });
+
+    const { zipBytes } = buildClientReadinessReportExport({ report, readinessGaps });
+    return new Response(new Uint8Array(zipBytes), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": 'attachment; filename="client-readiness-report.zip"',
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(`Client readiness report export failed (500). ${message}`, { status: 500 });
+  }
+}

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -39,7 +39,9 @@ import { buildStacSupportFactsState } from "@/lib/verify/stacSupportFacts";
 import { isStacEligible } from "@/lib/verify/stacEligibility";
 import { checkFinalizeGate, REVIEW_STORE_EVENT } from "@/lib/verify/reviewStore";
 import { buildRequirementCoverageRows, reconcileRequirement } from "@/app/m/_lib/requirementCoverage";
+import { EXPECTED_EVIDENCE_LABELS } from "@/app/m/_lib/requirementCoverage";
 import { deriveRuleReadinessGaps } from "@/lib/readiness/gapEngine";
+import { buildClientReadinessReport } from "@/lib/readiness/clientReadinessReport";
 import { computeKpis, linkedRuleIdsFromPins } from "@/lib/kpis/computeKpis";
 import {
   buildEvidenceInventory,
@@ -48,6 +50,7 @@ import {
   formatEvidenceInventoryId,
   linkEvidencePinToRequirement,
   linkPddFragmentToRequirement,
+  type EvidenceInventoryItem,
   unlinkPddFragmentFromRequirement,
   unlinkEvidencePinFromRequirement,
   upsertPddFragmentOnEvidencePin,
@@ -221,6 +224,40 @@ function downloadBytes(bytes: Uint8Array, filename: string, mimeType: string) {
 function safeFilename(value: string): string {
   const trimmed = (value ?? "").trim() || "unknown";
   return trimmed.replace(/[^\w.\-]+/g, "_").slice(0, 64) || "unknown";
+}
+
+function clientReadinessReportId(methodCode: string, version: string, runId: string): string {
+  return `CRR-${safeFilename(methodCode)}-${safeFilename(version)}-${safeFilename(runId)}`;
+}
+
+function inventoryHaystack(item: EvidenceInventoryItem): string {
+  return [
+    item.type,
+    item.kind,
+    item.display_name,
+    item.source_summary,
+    item.provenance_summary,
+    item.pdd_document?.file_name,
+    ...(item.workbook_assets ?? []).flatMap((asset) => [asset.file_name, asset.file_kind]),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function inventoryMatchesExpectedEvidence(
+  item: EvidenceInventoryItem,
+  expectedType: keyof typeof EXPECTED_EVIDENCE_LABELS,
+): boolean {
+  const haystack = inventoryHaystack(item);
+  if (expectedType === "monitoring-report") return haystack.includes("monitoring report") || haystack.includes("monitoring-report");
+  if (expectedType === "spreadsheet-workbook") return haystack.includes("spreadsheet") || haystack.includes("workbook") || haystack.includes(".xlsx") || haystack.includes(".csv");
+  if (expectedType === "pdd") return haystack.includes("pdd") || haystack.includes("project design document");
+  if (expectedType === "gis") return haystack.includes("gis") || haystack.includes("satellite") || haystack.includes("stac") || haystack.includes("map evidence");
+  if (expectedType === "qa-qc-record") return haystack.includes("qa/qc") || haystack.includes("qa qc") || haystack.includes("qa-qc");
+  if (expectedType === "eligibility-proof") return haystack.includes("eligibility");
+  if (expectedType === "calculation-support") return haystack.includes("calculation") || haystack.includes("parameter") || haystack.includes("support");
+  return item.link_state === "linked" || item.kind !== "stac-item";
 }
 
 function hostnamePathFromUrl(value: string): string {
@@ -449,6 +486,8 @@ export default function ProofMapTab({
   const [reviewArtifact, setReviewArtifact] = useState<EvidenceSnapshot | null>(null);
   const [reviewPdfBusy, setReviewPdfBusy] = useState(false);
   const [reviewPdfError, setReviewPdfError] = useState<string | null>(null);
+  const [clientReadinessExportBusy, setClientReadinessExportBusy] = useState(false);
+  const [clientReadinessExportError, setClientReadinessExportError] = useState<string | null>(null);
   const uploadAoiInputRef = useRef<HTMLInputElement | null>(null);
   const uploadPddInputRef = useRef<HTMLInputElement | null>(null);
   const [pddFragmentDrafts, setPddFragmentDrafts] = useState<Record<string, PddFragmentDraft>>({});
@@ -2870,6 +2909,148 @@ export default function ProofMapTab({
     downloadJson(artifact, filename);
   }, [activeReviewArtifact, buildFinalReviewArtifact, methodCode, verifierBundle, version]);
 
+  const buildClientReadinessReportPayload = useCallback(async () => {
+    const generatedAt = verifierBundle.finalizedAt ?? verifierBundle.exportedAt;
+    if (!generatedAt) {
+      throw new Error("Finalize the current Verify run before exporting a client readiness report.");
+    }
+    if (!ruleOptions.length) {
+      throw new Error("No method rules are available for client readiness export.");
+    }
+
+    const ruleContexts = await Promise.all(
+      ruleOptions.map(async (rule) => ({
+        rule,
+        context: await fetchSelectedRuleContext(rule.id),
+      })),
+    );
+
+    const rows = buildRequirementCoverageRows({
+      rules: ruleContexts.map(({ rule, context }) => ({
+        id: rule.id,
+        title: context?.id ?? rule.title ?? rule.id,
+        snippet: context?.text ?? rule.title ?? rule.id,
+        text: context?.text ?? undefined,
+        expectedEvidence: context?.expectedEvidence ?? [],
+        tags: context?.tags ?? [],
+        sectionId: context?.sectionId ?? undefined,
+      })),
+      inventoryItems: evidenceInventory,
+    });
+
+    const reviewerArtifactsByRuleId = new Map<
+      string,
+      {
+        savedAt?: string | null;
+        minutes?: string | null;
+        outcomeNote?: string | null;
+      }
+    >();
+    const savedReviewerRuleId = verifierBundle.savedReviewerArtifactContext?.ruleId ?? null;
+    if (
+      verifierBundle.savedReviewerArtifactAt &&
+      savedReviewerRuleId &&
+      reviewerArtifactContextMatches(
+        verifierBundle.savedReviewerArtifactContext,
+        createReviewerArtifactContext({
+          methodCode,
+          version,
+          ruleId: savedReviewerRuleId,
+          runId: verifierBundle.runContext.runId,
+        }),
+      )
+    ) {
+      reviewerArtifactsByRuleId.set(savedReviewerRuleId, {
+        savedAt: verifierBundle.savedReviewerArtifactAt,
+        minutes: verifierBundle.minutes,
+        outcomeNote: verifierBundle.outcomeNote,
+      });
+    }
+
+    const readinessGaps = deriveRuleReadinessGaps({
+      rows,
+      reviewerArtifactsByRuleId,
+    });
+
+    const suppliedDocuments = [...evidenceInventory]
+      .filter((item) => item.kind !== "stac-item")
+      .sort((a, b) => a.evidence_id.localeCompare(b.evidence_id))
+      .map((item) => ({
+        id: item.evidence_id,
+        label: item.display_name,
+        type: item.type,
+        note: item.source_summary,
+      }));
+
+    const missingDocuments = Array.from(
+      new Set(readinessGaps.flatMap((gap) => gap.missingExpectedEvidenceTypes)),
+    )
+      .filter((expectedType) => !evidenceInventory.some((item) => inventoryMatchesExpectedEvidence(item, expectedType)))
+      .sort((a, b) => a.localeCompare(b))
+      .map((expectedType) => ({
+        id: `missing-${expectedType}`,
+        label: EXPECTED_EVIDENCE_LABELS[expectedType] ?? expectedType,
+        type: expectedType,
+      }));
+
+    const report = buildClientReadinessReport({
+      reportId: clientReadinessReportId(methodCode, version, verifierBundle.runContext.runId),
+      generatedAt,
+      project: {
+        name: aoi?.name?.trim() || `Client readiness workspace ${methodCode}@${version}`,
+        description: `Pre-verification readiness export generated from finalized Verify run ${verifierBundle.runContext.runId}.`,
+      },
+      methodology: {
+        code: methodCode,
+        version,
+      },
+      suppliedDocuments,
+      missingDocuments,
+      readinessGaps,
+    });
+
+    return { report, readinessGaps };
+  }, [
+    aoi?.name,
+    evidenceInventory,
+    fetchSelectedRuleContext,
+    methodCode,
+    ruleOptions,
+    verifierBundle.exportedAt,
+    verifierBundle.finalizedAt,
+    verifierBundle.minutes,
+    verifierBundle.outcomeNote,
+    verifierBundle.runContext.runId,
+    verifierBundle.savedReviewerArtifactAt,
+    verifierBundle.savedReviewerArtifactContext,
+    version,
+  ]);
+
+  const handleExportClientReadinessReport = useCallback(async () => {
+    setClientReadinessExportBusy(true);
+    setClientReadinessExportError(null);
+    try {
+      const payload = await buildClientReadinessReportPayload();
+      const response = await fetch("/api/exports/client-readiness-report", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      const filename = `client-readiness-report.${safeFilename(methodCode)}.${safeFilename(version)}.${safeFilename(verifierBundle.runContext.runId)}.zip`;
+      downloadBytes(bytes, filename, "application/zip");
+      showToast("Client readiness report exported");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setClientReadinessExportError(message);
+    } finally {
+      setClientReadinessExportBusy(false);
+    }
+  }, [buildClientReadinessReportPayload, methodCode, showToast, verifierBundle.runContext.runId, version]);
+
   const handleDownloadReviewSummaryPdf = useCallback(async () => {
     const finalizedAt = verifierBundle.finalizedAt ?? verifierBundle.exportedAt;
     if (!finalizedAt) return;
@@ -4331,6 +4512,9 @@ export default function ProofMapTab({
                 onDownloadPdf={() => {
                   void handleDownloadReviewSummaryPdf();
                 }}
+                onExportClientReadinessReport={() => {
+                  void handleExportClientReadinessReport();
+                }}
                 onCopyLink={() => {
                   void handleCopyReviewSummaryLink();
                 }}
@@ -4338,6 +4522,8 @@ export default function ProofMapTab({
                 onViewRunHistory={handleViewRunHistory}
                 pdfBusy={reviewPdfBusy}
                 pdfError={reviewPdfError}
+                clientReadinessExportBusy={clientReadinessExportBusy}
+                clientReadinessExportError={clientReadinessExportError}
               />
             ) : (
               <EvidenceWorkflowStepper

--- a/src/components/verify/FinalReviewSummaryPanel.tsx
+++ b/src/components/verify/FinalReviewSummaryPanel.tsx
@@ -18,11 +18,14 @@ type FinalReviewSummaryPanelProps = {
   wizard: VerifyWizardStepDetails;
   onDownloadJson: () => void;
   onDownloadPdf: () => void;
+  onExportClientReadinessReport?: () => void;
   onCopyLink?: () => void;
   onStartAnotherRun: () => void;
   onViewRunHistory: () => void;
   pdfError?: string | null;
   pdfBusy?: boolean;
+  clientReadinessExportBusy?: boolean;
+  clientReadinessExportError?: string | null;
 };
 
 function formatDate(value: string | null | undefined): string | null {
@@ -62,11 +65,14 @@ export default function FinalReviewSummaryPanel({
   wizard,
   onDownloadJson,
   onDownloadPdf,
+  onExportClientReadinessReport,
   onCopyLink,
   onStartAnotherRun,
   onViewRunHistory,
   pdfError = null,
   pdfBusy = false,
+  clientReadinessExportBusy = false,
+  clientReadinessExportError = null,
 }: FinalReviewSummaryPanelProps) {
   const finalizedLabel = formatDate(finalizedAt);
   const completedSteps = wizard.steps.filter((step) => step.complete);
@@ -130,7 +136,20 @@ export default function FinalReviewSummaryPanel({
             Download audit pack
           </button>
         ) : null}
+        {onExportClientReadinessReport ? (
+          <button
+            type="button"
+            className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-wait disabled:opacity-70"
+            onClick={() => {
+              onExportClientReadinessReport();
+            }}
+            disabled={clientReadinessExportBusy}
+          >
+            {clientReadinessExportBusy ? "Preparing readiness report..." : "Export client readiness report"}
+          </button>
+        ) : null}
       </div>
+      {clientReadinessExportError ? <div className="text-xs text-rose-700">{clientReadinessExportError}</div> : null}
 
       <details className="rounded-xl border border-slate-200 bg-white">
         <summary className="cursor-pointer list-none px-3 py-2 text-xs font-semibold text-slate-900">

--- a/src/lib/readiness/clientReadinessExport.tsx
+++ b/src/lib/readiness/clientReadinessExport.tsx
@@ -1,6 +1,4 @@
 import { zipSync } from "fflate";
-import { renderToStaticMarkup } from "react-dom/server";
-import ClientReadinessReportView from "@/components/readiness/ClientReadinessReportView";
 import { EXPECTED_EVIDENCE_LABELS } from "@/app/m/_lib/requirementCoverage";
 import type { RequirementCoverageExpectedEvidenceType } from "@/app/m/_lib/requirementCoverage";
 import { canonicalStringify, sha256Hex } from "@/integrity/artifacts";
@@ -105,8 +103,227 @@ function evidenceLabel(item: RuleReadinessGap["linkedEvidence"][number]): string
   return item.title?.trim() || item.fragmentLabel?.trim() || item.documentLabel?.trim() || item.id;
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function joinEscaped(values: string[], fallback: string): string {
+  return values.length ? values.map(escapeHtml).join(", ") : escapeHtml(fallback);
+}
+
+function renderList(items: string[], empty: string): string {
+  if (!items.length) return `<p>${escapeHtml(empty)}</p>`;
+  return `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
+}
+
+function renderRuleRows(report: ClientReadinessReport): string {
+  return report.ruleFindingsMatrix
+    .map(
+      (item) => `
+        <tr>
+          <td><strong>${escapeHtml(item.ruleId)}</strong><br /><span>${escapeHtml(item.ruleTitle)}</span></td>
+          <td>${escapeHtml(item.category.replaceAll("_", " "))}</td>
+          <td>${escapeHtml(item.severity)}</td>
+          <td>${escapeHtml(item.assessment)}${
+            item.missingExpectedEvidence.length
+              ? `<br /><span>Missing: ${joinEscaped(item.missingExpectedEvidence, "")}</span>`
+              : ""
+          }</td>
+          <td>${joinEscaped(item.nextActions, "No next action listed yet.")}</td>
+        </tr>`,
+    )
+    .join("");
+}
+
+function renderEvidenceChecklistRows(report: ClientReadinessReport): string {
+  return report.evidenceChecklist.items
+    .map(
+      (item) => `
+        <tr>
+          <td><strong>${escapeHtml(item.ruleId)}</strong><br /><span>${escapeHtml(item.ruleTitle)}</span></td>
+          <td>${joinEscaped(item.expectedEvidence, "No encoded expectation listed.")}</td>
+          <td>${joinEscaped(item.linkedEvidence, "No linked evidence yet.")}</td>
+          <td>${joinEscaped(item.missingEvidence, "No missing evidence listed.")}</td>
+          <td>${escapeHtml(item.status.replaceAll("_", " "))}</td>
+        </tr>`,
+    )
+    .join("");
+}
+
+function renderOpenFindingsGroup(title: string, description: string, items: ClientReadinessReport["openFindings"]["missingEvidence"]): string {
+  return `
+    <section>
+      <h3>${escapeHtml(title)}</h3>
+      <p>${escapeHtml(description)}</p>
+      ${
+        items.length
+          ? `<ul>${items
+              .map(
+                (item) => `<li><strong>${escapeHtml(item.ruleId)}</strong> ${escapeHtml(item.ruleTitle)} · ${escapeHtml(item.severity)} · ${escapeHtml(item.assessment)} · Next: ${joinEscaped(item.nextActions, "Reviewer follow-up still needs to be defined.")}</li>`,
+              )
+              .join("")}</ul>`
+          : "<p>No items in this group right now.</p>"
+      }
+    </section>`
+}
+
 function reportHtmlDocument(report: ClientReadinessReport): string {
-  const body = renderToStaticMarkup(<ClientReadinessReportView report={report} />);
+  const context = report.projectAndMethodologyContext;
+  const totals = report.executiveReadinessSummary.totals;
+  const body = `
+    <article>
+      <section>
+        <p><strong>Client readiness report</strong> · <strong>Pre-verification readiness assessment</strong></p>
+        <h1>${escapeHtml(context.projectName)}</h1>
+        <p>${escapeHtml(context.methodologyCode)}@${escapeHtml(context.methodologyVersion)}${context.methodologyName ? ` · ${escapeHtml(context.methodologyName)}` : ""}</p>
+        <p>${escapeHtml(report.executiveReadinessSummary.headline)}</p>
+        <p>This readiness report is a client-facing preparation tool. It is not a verifier decision and does not determine registration, issuance, or quantified carbon outcomes.</p>
+        <dl>
+          ${context.projectId ? `<dt>Project ID</dt><dd>${escapeHtml(context.projectId)}</dd>` : ""}
+          ${context.proponent ? `<dt>Proponent</dt><dd>${escapeHtml(context.proponent)}</dd>` : ""}
+          ${context.region ? `<dt>Region</dt><dd>${escapeHtml(context.region)}</dd>` : ""}
+          ${context.sector ? `<dt>Sector</dt><dd>${escapeHtml(context.sector)}</dd>` : ""}
+          <dt>Report ID</dt><dd>${escapeHtml(report.reportId)}</dd>
+          <dt>Generated</dt><dd>${escapeHtml(report.technicalAppendix.generatedAt)}</dd>
+        </dl>
+      </section>
+
+      <section>
+        <h2>Executive Readiness Summary</h2>
+        <p>Totals are readiness categories, not a formal assurance score. Missing evidence may include rules that are also not started.</p>
+        <ul>
+          <li>Position: ${escapeHtml(report.executiveReadinessSummary.readinessPosition)}</li>
+          <li>Ready: ${totals.ready}</li>
+          <li>Missing evidence / not started: ${totals.missingEvidence} (includes ${totals.notStarted} not-started items)</li>
+          <li>Clarification needed: ${totals.clarificationNeeded}</li>
+          <li>Reviewer judgment needed: ${totals.reviewerJudgmentNeeded}</li>
+          <li>Unknown / not assessable: ${totals.unknownOrNotAssessable}</li>
+        </ul>
+        ${renderList(report.executiveReadinessSummary.highlights, "No highlights listed.")}
+      </section>
+
+      <section>
+        <h2>Scope, Criteria, and Limits</h2>
+        <p>${escapeHtml(report.scopeCriteriaAndLimits.reportPurpose)}</p>
+        <p>${escapeHtml(report.scopeCriteriaAndLimits.scopeSummary)}</p>
+        ${renderList(report.scopeCriteriaAndLimits.criteriaBasis, "No criteria basis listed.")}
+      </section>
+
+      <section>
+        <h2>Project and Methodology Context</h2>
+        ${context.projectDescription ? `<p>${escapeHtml(context.projectDescription)}</p>` : ""}
+        <p>${escapeHtml(context.methodologyCode)}@${escapeHtml(context.methodologyVersion)}</p>
+      </section>
+
+      <section>
+        <h2>Documents Reviewed</h2>
+        <h3>Supplied documents</h3>
+        ${
+          report.documentsReviewed.suppliedDocuments.length
+            ? `<ul>${report.documentsReviewed.suppliedDocuments
+                .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)}${item.note ? ` · ${escapeHtml(item.note)}` : ""}</li>`)
+                .join("")}</ul>`
+            : "<p>No supplied documents are listed yet.</p>"
+        }
+        <h3>Reviewed evidence</h3>
+        ${
+          report.documentsReviewed.reviewedEvidence.length
+            ? `<ul>${report.documentsReviewed.reviewedEvidence
+                .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)} · linked to ${joinEscaped(item.linkedRuleIds, "")}</li>`)
+                .join("")}</ul>`
+            : "<p>No reviewed evidence is linked yet.</p>"
+        }
+      </section>
+
+      <section>
+        <h2>Missing Documents</h2>
+        ${
+          report.documentsReviewed.missingDocuments.length
+            ? `<ul>${report.documentsReviewed.missingDocuments
+                .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)}${item.note ? ` · ${escapeHtml(item.note)}` : ""}</li>`)
+                .join("")}</ul>`
+            : "<p>No missing documents are listed right now.</p>"
+        }
+      </section>
+
+      <section>
+        <h2>Readiness Assessment Approach</h2>
+        <p>${escapeHtml(report.readinessAssessmentApproach.approachSummary)}</p>
+        <p><strong>Evidence policy:</strong> ${escapeHtml(report.readinessAssessmentApproach.evidencePolicy)}</p>
+        <p><strong>Reviewer judgment policy:</strong> ${escapeHtml(report.readinessAssessmentApproach.reviewerJudgmentPolicy)}</p>
+      </section>
+
+      <section>
+        <h2>Rule Findings Matrix</h2>
+        <p>VVB-shaped rule findings for readiness review only. These rows summarize readiness conditions, not a verifier conclusion.</p>
+        <table>
+          <thead>
+            <tr><th>Rule</th><th>Category</th><th>Severity</th><th>Assessment</th><th>Next actions</th></tr>
+          </thead>
+          <tbody>
+            ${renderRuleRows(report)}
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Open Findings</h2>
+        ${renderOpenFindingsGroup("Open Findings: Missing Evidence", "Rules that still need expected evidence or have not yet started from a readiness standpoint.", report.openFindings.missingEvidence)}
+        ${renderOpenFindingsGroup("Open Findings: Clarification Needed", "Rules that still need reviewer clarification before the readiness record is stable.", report.openFindings.clarificationNeeded)}
+        ${renderOpenFindingsGroup("Open Findings: Reviewer Judgment Needed", "Rules with linked evidence but without a sufficiently recorded reviewer judgment.", report.openFindings.reviewerJudgmentNeeded)}
+        ${renderOpenFindingsGroup("Open Findings: Unknown or Not Assessable", "Rules where encoded expectations are still incomplete or not yet assessable.", report.openFindings.unknownOrNotAssessable)}
+      </section>
+
+      <section>
+        <h2>Evidence Checklist</h2>
+        <p>Expected, linked, and still-missing evidence are shown rule by rule.</p>
+        <table>
+          <thead>
+            <tr><th>Rule</th><th>Expected</th><th>Linked</th><th>Missing</th><th>State</th></tr>
+          </thead>
+          <tbody>
+            ${renderEvidenceChecklistRows(report)}
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Recommended Corrective Actions</h2>
+        ${
+          report.recommendedCorrectiveActions.items.length
+            ? `<ul>${report.recommendedCorrectiveActions.items
+                .map((item) => `<li><strong>${escapeHtml(item.ruleId)}</strong> ${escapeHtml(item.ruleTitle)} · ${escapeHtml(item.priority)} priority · ${escapeHtml(item.action)} · ${escapeHtml(item.basis)}</li>`)
+                .join("")}</ul>`
+            : "<p>No corrective actions are currently listed because all assessed rules are marked ready for readiness review.</p>"
+        }
+      </section>
+
+      <section>
+        <h2>Limitations</h2>
+        ${renderList([...report.executiveReadinessSummary.limitations, ...report.scopeCriteriaAndLimits.limitations], "No limitations listed.")}
+      </section>
+
+      <section>
+        <h2>Technical Appendix</h2>
+        <p>Appendix material is included for HTML/PDF export readiness and reviewer traceability.</p>
+        ${renderList(report.technicalAppendix.disclaimers, "No appendix disclaimers listed.")}
+        <h3>State definitions</h3>
+        ${renderList(report.technicalAppendix.stateDefinitions.map((item) => `${item.state.replaceAll("_", " ")} · ${item.description}`), "No state definitions listed.")}
+        <h3>Evidence reference index</h3>
+        ${
+          report.technicalAppendix.evidenceReferenceIndex.length
+            ? `<ul>${report.technicalAppendix.evidenceReferenceIndex
+                .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)} · linked to ${joinEscaped(item.linkedRuleIds, "")}</li>`)
+                .join("")}</ul>`
+            : "<p>No evidence references are indexed yet.</p>"
+        }
+      </section>
+    </article>`;
   return [
     "<!DOCTYPE html>",
     '<html lang="en">',

--- a/src/lib/readiness/clientReadinessExport.tsx
+++ b/src/lib/readiness/clientReadinessExport.tsx
@@ -1,0 +1,252 @@
+import { zipSync } from "fflate";
+import { renderToStaticMarkup } from "react-dom/server";
+import ClientReadinessReportView from "@/components/readiness/ClientReadinessReportView";
+import { EXPECTED_EVIDENCE_LABELS } from "@/app/m/_lib/requirementCoverage";
+import type { RequirementCoverageExpectedEvidenceType } from "@/app/m/_lib/requirementCoverage";
+import { canonicalStringify, sha256Hex } from "@/integrity/artifacts";
+import type { ClientReadinessReport } from "@/lib/readiness/clientReadinessReport";
+import type { RuleReadinessGap } from "@/lib/readiness/gapEngine";
+
+export type ClientReadinessAppendixArtifact = {
+  kind: "article6.client_readiness_appendix";
+  version: 1;
+  reportId: string;
+  generatedAt: string;
+  project: ClientReadinessReport["projectAndMethodologyContext"];
+  methodology: {
+    code: string;
+    version: string;
+    name?: string;
+    sector?: string;
+  };
+  limitations: string[];
+  traceability: {
+    ruleCount: number;
+    evidenceCount: number;
+    rules: Array<{
+      ruleId: string;
+      ruleTitle: string;
+      state: RuleReadinessGap["state"];
+      severity: RuleReadinessGap["severity"];
+      baseState: RuleReadinessGap["baseState"];
+      baseSeverity: RuleReadinessGap["baseSeverity"];
+      missingExpectedEvidence: string[];
+      recommendations: string[];
+      linkedEvidence: Array<{
+        id: string;
+        label: string;
+        type: string;
+        source: string;
+      }>;
+      override:
+        | {
+            state: RuleReadinessGap["state"] | null;
+            severity: RuleReadinessGap["severity"] | null;
+            reason: string;
+            reviewer: string | null;
+            updatedAt: string | null;
+          }
+        | null;
+    }>;
+  };
+  evidenceReferenceIndex: ClientReadinessReport["technicalAppendix"]["evidenceReferenceIndex"];
+};
+
+export type ClientReadinessExportManifest = {
+  kind: "article6.client_readiness_export";
+  version: 1;
+  generated_at: string;
+  report_id: string;
+  files: Array<{
+    path: string;
+    sha256: string;
+    bytes: number;
+  }>;
+};
+
+export type BuildClientReadinessReportExportInput = {
+  report: ClientReadinessReport;
+  readinessGaps: RuleReadinessGap[];
+};
+
+export type ClientReadinessReportExportResult = {
+  zipBytes: Buffer;
+  manifest: ClientReadinessExportManifest;
+  appendix: ClientReadinessAppendixArtifact;
+  html: string;
+};
+
+const FORBIDDEN_CLAIMS = [
+  "verification opinion",
+  "registry approval",
+  "registry approved",
+  "credit issuance",
+  "verified credits",
+  "assurance opinion",
+] as const;
+
+function flattenForCanonicalJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isoForZip(iso: string): Date {
+  const parsed = new Date(iso);
+  if (!Number.isFinite(parsed.getTime())) return new Date("1980-01-01T00:00:00.000Z");
+  if (parsed.getUTCFullYear() < 1980) return new Date("1980-01-01T00:00:00.000Z");
+  if (parsed.getUTCFullYear() > 2099) return new Date("2099-12-31T23:59:58.000Z");
+  return parsed;
+}
+
+function expectedEvidenceLabel(type: RequirementCoverageExpectedEvidenceType): string {
+  return EXPECTED_EVIDENCE_LABELS[type] ?? type;
+}
+
+function evidenceLabel(item: RuleReadinessGap["linkedEvidence"][number]): string {
+  return item.title?.trim() || item.fragmentLabel?.trim() || item.documentLabel?.trim() || item.id;
+}
+
+function reportHtmlDocument(report: ClientReadinessReport): string {
+  const body = renderToStaticMarkup(<ClientReadinessReportView report={report} />);
+  return [
+    "<!DOCTYPE html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charSet="utf-8" />',
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />',
+    `<title>${report.projectAndMethodologyContext.projectName} client readiness report</title>`,
+    "<style>",
+    "body{margin:0;background:#f8fafc;color:#0f172a;font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;}",
+    ".report-shell{max-width:1040px;margin:0 auto;padding:24px;}",
+    "</style>",
+    "</head>",
+    "<body>",
+    `<div class="report-shell">${body}</div>`,
+    "</body>",
+    "</html>",
+  ].join("");
+}
+
+function assertNoForbiddenClaims(serialized: string): void {
+  const haystack = serialized.toLowerCase();
+  const found = FORBIDDEN_CLAIMS.find((claim) => haystack.includes(claim));
+  if (found) {
+    throw new Error(`Client readiness export contains forbidden claim language: ${found}`);
+  }
+}
+
+export function buildClientReadinessAppendixArtifact(input: BuildClientReadinessReportExportInput): ClientReadinessAppendixArtifact {
+  const readinessGaps = [...input.readinessGaps].sort((a, b) => a.ruleId.localeCompare(b.ruleId));
+  const evidenceReferenceIndex = [...input.report.technicalAppendix.evidenceReferenceIndex].sort((a, b) => a.id.localeCompare(b.id));
+
+  return {
+    kind: "article6.client_readiness_appendix",
+    version: 1,
+    reportId: input.report.reportId,
+    generatedAt: input.report.technicalAppendix.generatedAt,
+    project: input.report.projectAndMethodologyContext,
+    methodology: {
+      code: input.report.projectAndMethodologyContext.methodologyCode,
+      version: input.report.projectAndMethodologyContext.methodologyVersion,
+      name: input.report.projectAndMethodologyContext.methodologyName,
+      sector: input.report.projectAndMethodologyContext.sector,
+    },
+    limitations: [
+      ...input.report.executiveReadinessSummary.limitations,
+      ...input.report.scopeCriteriaAndLimits.limitations,
+      ...input.report.technicalAppendix.disclaimers,
+    ],
+    traceability: {
+      ruleCount: readinessGaps.length,
+      evidenceCount: evidenceReferenceIndex.length,
+      rules: readinessGaps.map((gap) => ({
+        ruleId: gap.ruleId,
+        ruleTitle: gap.title,
+        state: gap.state,
+        severity: gap.severity,
+        baseState: gap.baseState,
+        baseSeverity: gap.baseSeverity,
+        missingExpectedEvidence: gap.missingExpectedEvidenceTypes.map(expectedEvidenceLabel),
+        recommendations: gap.recommendations.map((item) => item.label),
+        linkedEvidence: [...gap.linkedEvidence]
+          .map((item) => ({
+            id: item.id,
+            label: evidenceLabel(item),
+            type: item.type,
+            source: item.source,
+          }))
+          .sort((a, b) => a.id.localeCompare(b.id)),
+        override: gap.override
+          ? {
+              state: gap.override.state ?? null,
+              severity: gap.override.severity ?? null,
+              reason: gap.override.reason,
+              reviewer: gap.override.reviewer ?? null,
+              updatedAt: gap.override.updatedAt ?? null,
+            }
+          : null,
+      })),
+    },
+    evidenceReferenceIndex,
+  };
+}
+
+export function buildClientReadinessReportExport(
+  input: BuildClientReadinessReportExportInput,
+): ClientReadinessReportExportResult {
+  const appendix = buildClientReadinessAppendixArtifact(input);
+  const reportJson = canonicalStringify(flattenForCanonicalJson(input.report));
+  const appendixJson = canonicalStringify(flattenForCanonicalJson(appendix));
+  const evidenceIndexJson = canonicalStringify(flattenForCanonicalJson(appendix.evidenceReferenceIndex));
+  const html = reportHtmlDocument(input.report);
+
+  assertNoForbiddenClaims([reportJson, appendixJson, evidenceIndexJson, html].join("\n"));
+
+  const fileEntries = [
+    {
+      path: "client-readiness-report/report.json",
+      bytes: Buffer.from(reportJson, "utf8"),
+    },
+    {
+      path: "client-readiness-report/report.html",
+      bytes: Buffer.from(html, "utf8"),
+    },
+    {
+      path: "client-readiness-report/appendix/audit-pack-appendix.json",
+      bytes: Buffer.from(appendixJson, "utf8"),
+    },
+    {
+      path: "client-readiness-report/appendix/evidence-reference-index.json",
+      bytes: Buffer.from(evidenceIndexJson, "utf8"),
+    },
+  ].sort((a, b) => a.path.localeCompare(b.path));
+
+  const manifest: ClientReadinessExportManifest = {
+    kind: "article6.client_readiness_export",
+    version: 1,
+    generated_at: input.report.technicalAppendix.generatedAt,
+    report_id: input.report.reportId,
+    files: fileEntries.map((entry) => ({
+      path: entry.path,
+      sha256: sha256Hex(entry.bytes),
+      bytes: entry.bytes.length,
+    })),
+  };
+
+  const manifestBytes = Buffer.from(canonicalStringify(flattenForCanonicalJson(manifest)), "utf8");
+  const mtime = isoForZip(input.report.technicalAppendix.generatedAt);
+  const zipEntries: Record<string, Uint8Array | [Uint8Array, { mtime: Date }]> = {
+    "manifest.json": [new Uint8Array(manifestBytes), { mtime }],
+  };
+
+  for (const entry of fileEntries) {
+    zipEntries[entry.path] = [new Uint8Array(entry.bytes), { mtime }];
+  }
+
+  const zipBytes = Buffer.from(zipSync(zipEntries, { level: 0 }));
+  return {
+    zipBytes,
+    manifest,
+    appendix,
+    html,
+  };
+}

--- a/src/lib/readiness/clientReadinessExport.tsx
+++ b/src/lib/readiness/clientReadinessExport.tsx
@@ -428,7 +428,7 @@ export function buildClientReadinessReportExport(
       bytes: Buffer.from(html, "utf8"),
     },
     {
-      path: "client-readiness-report/appendix/audit-pack-appendix.json",
+      path: "client-readiness-report/appendix/readiness-traceability-appendix.json",
       bytes: Buffer.from(appendixJson, "utf8"),
     },
     {

--- a/tests/app/api/exports/client-readiness-report.route.test.ts
+++ b/tests/app/api/exports/client-readiness-report.route.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "@jest/globals";
+import { POST } from "@/app/api/exports/client-readiness-report/route";
+import { buildClientReadinessReport } from "@/lib/readiness/clientReadinessReport";
+import { deriveRuleReadinessGaps } from "@/lib/readiness/gapEngine";
+import type { RequirementCoverageRow } from "@/app/m/_lib/requirementCoverage";
+
+function makeRow(overrides: Partial<RequirementCoverageRow> = {}): RequirementCoverageRow {
+  return {
+    ruleId: "R-1",
+    ruleSummary: {
+      title: "Monitoring frequency",
+      snippet: "Maintain a monitoring report.",
+      when: [],
+      tags: [],
+    },
+    provenance: {
+      tools: [],
+      citations: [],
+    },
+    expectedEvidenceTypes: [],
+    linkedEvidence: [],
+    candidateEvidence: [],
+    status: "missing",
+    ...overrides,
+  };
+}
+
+function makePayload() {
+  const readinessGaps = deriveRuleReadinessGaps({
+    rows: [
+      makeRow({
+        ruleId: "R-1",
+        expectedEvidenceTypes: ["monitoring-report"],
+        linkedEvidence: [{ id: "ev-1", title: "Monitoring report", type: "monitoring-report", source: "inventory" }],
+        status: "partial",
+      }),
+    ],
+    reviewerArtifactsByRuleId: new Map([
+      ["R-1", { savedAt: "2026-05-04T00:00:00Z", outcomeNote: "Support recorded." }],
+    ]),
+  });
+
+  const report = buildClientReadinessReport({
+    reportId: "CRR-ROUTE-001",
+    generatedAt: "2026-05-04T00:00:00Z",
+    project: { name: "Delta Mangrove Restoration" },
+    methodology: { code: "AR-ACM0003", version: "v02-0" },
+    readinessGaps,
+  });
+
+  return { report, readinessGaps };
+}
+
+describe("/api/exports/client-readiness-report route", () => {
+  it("rejects missing payload pieces", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/exports/client-readiness-report", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("Missing or invalid report payload");
+  });
+
+  it("returns a zip attachment for valid report export input", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/exports/client-readiness-report", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(makePayload()),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+    expect(response.headers.get("Content-Disposition")).toContain('attachment; filename="client-readiness-report.zip"');
+  });
+});

--- a/tests/components/finalReviewSummaryPanel.test.tsx
+++ b/tests/components/finalReviewSummaryPanel.test.tsx
@@ -83,6 +83,105 @@ describe("FinalReviewSummaryPanel", () => {
     expect(html).not.toContain("Next required action");
   });
 
+  test("shows the client readiness export action only when export wiring is provided", () => {
+    const withoutExport = renderToStaticMarkup(
+      <FinalReviewSummaryPanel
+        summary={{
+          methodCode: "AR-ACM0003",
+          version: "v02-0",
+          ruleId: "R-1",
+          ruleSection: "Monitoring period",
+          ruleText: "Evidence must fall inside the monitoring period.",
+          selectedEvidenceId: "stac-1",
+          selectedEvidenceDatetime: "2026-03-25T00:00:00Z",
+          cloudCover: 4.5,
+          aoiLabel: "Project AOI",
+          reviewState: "finalized",
+          generatedAt: "2026-03-25T00:10:00Z",
+          outcomeNote: "Stable result.",
+          stacSearchResultCount: 3,
+          linkedRuleCount: 1,
+          selectedEvidenceLinkedRules: ["R-1"],
+          stacSupportFactsStatus: null,
+          linkedStacSupportFactCount: null,
+          unlinkedStacSupportFactCount: null,
+          checklistStatus: "unused",
+          reconciliationStatus: "Supported",
+          reconciliationReason: "All expected evidence is linked.",
+          narrative: "Finalized verify review.",
+        }}
+        artifact={null}
+        currentRunLabel="run-1234"
+        finalizedAt="2026-03-25T00:10:00Z"
+        reviewedRuleCount={1}
+        linkedEvidenceCount={2}
+        wizard={getVerifyWizardStepDetails({
+          selectedRuleId: "R-1",
+          aoiHash: "aoi",
+          stacItemIds: ["item-1"],
+          selectedStacItemId: "item-1",
+          linkedRuleIds: ["R-1"],
+          reviewerArtifactSavedAt: "2026-03-25T00:05:00Z",
+          finalizedAt: "2026-03-25T00:10:00Z",
+        })}
+        onDownloadJson={() => {}}
+        onDownloadPdf={() => {}}
+        onStartAnotherRun={() => {}}
+        onViewRunHistory={() => {}}
+      />,
+    );
+    expect(withoutExport).not.toContain("Export client readiness report");
+
+    const withExport = renderToStaticMarkup(
+      <FinalReviewSummaryPanel
+        summary={{
+          methodCode: "AR-ACM0003",
+          version: "v02-0",
+          ruleId: "R-1",
+          ruleSection: "Monitoring period",
+          ruleText: "Evidence must fall inside the monitoring period.",
+          selectedEvidenceId: "stac-1",
+          selectedEvidenceDatetime: "2026-03-25T00:00:00Z",
+          cloudCover: 4.5,
+          aoiLabel: "Project AOI",
+          reviewState: "finalized",
+          generatedAt: "2026-03-25T00:10:00Z",
+          outcomeNote: "Stable result.",
+          stacSearchResultCount: 3,
+          linkedRuleCount: 1,
+          selectedEvidenceLinkedRules: ["R-1"],
+          stacSupportFactsStatus: null,
+          linkedStacSupportFactCount: null,
+          unlinkedStacSupportFactCount: null,
+          checklistStatus: "unused",
+          reconciliationStatus: "Supported",
+          reconciliationReason: "All expected evidence is linked.",
+          narrative: "Finalized verify review.",
+        }}
+        artifact={null}
+        currentRunLabel="run-1234"
+        finalizedAt="2026-03-25T00:10:00Z"
+        reviewedRuleCount={1}
+        linkedEvidenceCount={2}
+        wizard={getVerifyWizardStepDetails({
+          selectedRuleId: "R-1",
+          aoiHash: "aoi",
+          stacItemIds: ["item-1"],
+          selectedStacItemId: "item-1",
+          linkedRuleIds: ["R-1"],
+          reviewerArtifactSavedAt: "2026-03-25T00:05:00Z",
+          finalizedAt: "2026-03-25T00:10:00Z",
+        })}
+        onDownloadJson={() => {}}
+        onDownloadPdf={() => {}}
+        onExportClientReadinessReport={() => {}}
+        onStartAnotherRun={() => {}}
+        onViewRunHistory={() => {}}
+      />,
+    );
+    expect(withExport).toContain("Export client readiness report");
+  });
+
   test("keeps reviewer minutes and outcome note in the finalized audit-pack POST body", async () => {
     const artifact: EvidenceSnapshot = {
       method: { code: "AR-ACM0003", version: "v02-0" },

--- a/tests/lib/readiness/clientReadinessReportExport.test.ts
+++ b/tests/lib/readiness/clientReadinessReportExport.test.ts
@@ -84,8 +84,8 @@ describe("buildClientReadinessReportExport", () => {
     const zip = await JSZip.loadAsync(first.zipBytes);
     const paths = Object.keys(zip.files).sort();
     expect(paths).toEqual([
-      "client-readiness-report/appendix/audit-pack-appendix.json",
       "client-readiness-report/appendix/evidence-reference-index.json",
+      "client-readiness-report/appendix/readiness-traceability-appendix.json",
       "client-readiness-report/report.html",
       "client-readiness-report/report.json",
       "manifest.json",
@@ -96,7 +96,7 @@ describe("buildClientReadinessReportExport", () => {
     const result = buildSampleExport();
     const zip = await JSZip.loadAsync(result.zipBytes);
     const html = (await zip.file("client-readiness-report/report.html")?.async("string")) ?? "";
-    const appendix = (await zip.file("client-readiness-report/appendix/audit-pack-appendix.json")?.async("string")) ?? "";
+    const appendix = (await zip.file("client-readiness-report/appendix/readiness-traceability-appendix.json")?.async("string")) ?? "";
     const serialized = `${html}\n${appendix}`.toLowerCase();
 
     expect(serialized).not.toContain("verification opinion");
@@ -109,7 +109,7 @@ describe("buildClientReadinessReportExport", () => {
   test("includes traceable appendix fields for report id, timestamp, rules, and evidence ids", async () => {
     const result = buildSampleExport();
     const zip = await JSZip.loadAsync(result.zipBytes);
-    const appendixRaw = await zip.file("client-readiness-report/appendix/audit-pack-appendix.json")?.async("string");
+    const appendixRaw = await zip.file("client-readiness-report/appendix/readiness-traceability-appendix.json")?.async("string");
     expect(appendixRaw).toBeTruthy();
     const appendix = JSON.parse(appendixRaw ?? "{}") as {
       reportId: string;

--- a/tests/lib/readiness/clientReadinessReportExport.test.ts
+++ b/tests/lib/readiness/clientReadinessReportExport.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "@jest/globals";
+import JSZip from "jszip";
+import type { RequirementCoverageRow } from "@/app/m/_lib/requirementCoverage";
+import { buildClientReadinessReportExport } from "@/lib/readiness/clientReadinessExport";
+import { buildClientReadinessReport } from "@/lib/readiness/clientReadinessReport";
+import { deriveRuleReadinessGaps } from "@/lib/readiness/gapEngine";
+
+function makeRow(overrides: Partial<RequirementCoverageRow> = {}): RequirementCoverageRow {
+  return {
+    ruleId: "R-1",
+    ruleSummary: {
+      title: "Monitoring frequency",
+      snippet: "Maintain a monitoring report.",
+      when: [],
+      tags: [],
+    },
+    provenance: {
+      tools: [],
+      citations: [],
+    },
+    expectedEvidenceTypes: [],
+    linkedEvidence: [],
+    candidateEvidence: [],
+    status: "missing",
+    ...overrides,
+  };
+}
+
+function buildSampleExport() {
+  const readinessGaps = deriveRuleReadinessGaps({
+    rows: [
+      makeRow({
+        ruleId: "R-1",
+        expectedEvidenceTypes: ["monitoring-report"],
+        linkedEvidence: [{ id: "ev-1", title: "Monitoring report", type: "monitoring-report", source: "inventory" }],
+        status: "partial",
+      }),
+      makeRow({
+        ruleId: "R-2",
+        expectedEvidenceTypes: ["spreadsheet-workbook"],
+        status: "missing",
+      }),
+    ],
+    reviewerArtifactsByRuleId: new Map([
+      [
+        "R-1",
+        {
+          savedAt: "2026-05-04T00:00:00Z",
+          outcomeNote: "Readiness support documented.",
+        },
+      ],
+    ]),
+  });
+
+  const report = buildClientReadinessReport({
+    reportId: "CRR-EXPORT-001",
+    generatedAt: "2026-05-04T00:00:00Z",
+    project: {
+      name: "Delta Mangrove Restoration",
+      projectId: "P-001",
+      proponent: "Project Dev Ltd",
+      region: "Indonesia",
+    },
+    methodology: {
+      code: "AR-ACM0003",
+      version: "v02-0",
+      name: "Afforestation and reforestation",
+    },
+    suppliedDocuments: [{ id: "doc-1", label: "Project Design Document", type: "pdd" }],
+    missingDocuments: [{ id: "missing-spreadsheet-workbook", label: "Spreadsheet workbook", type: "spreadsheet-workbook" }],
+    readinessGaps,
+  });
+
+  return buildClientReadinessReportExport({ report, readinessGaps });
+}
+
+describe("buildClientReadinessReportExport", () => {
+  test("packages the readiness report, appendix, and evidence index into a deterministic zip", async () => {
+    const first = buildSampleExport();
+    const second = buildSampleExport();
+
+    expect(first.zipBytes.equals(second.zipBytes)).toBe(true);
+
+    const zip = await JSZip.loadAsync(first.zipBytes);
+    const paths = Object.keys(zip.files).sort();
+    expect(paths).toEqual([
+      "client-readiness-report/appendix/audit-pack-appendix.json",
+      "client-readiness-report/appendix/evidence-reference-index.json",
+      "client-readiness-report/report.html",
+      "client-readiness-report/report.json",
+      "manifest.json",
+    ]);
+  });
+
+  test("keeps forbidden verifier and registry claims out of exported artifacts", async () => {
+    const result = buildSampleExport();
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const html = (await zip.file("client-readiness-report/report.html")?.async("string")) ?? "";
+    const appendix = (await zip.file("client-readiness-report/appendix/audit-pack-appendix.json")?.async("string")) ?? "";
+    const serialized = `${html}\n${appendix}`.toLowerCase();
+
+    expect(serialized).not.toContain("verification opinion");
+    expect(serialized).not.toContain("registry approval");
+    expect(serialized).not.toContain("credit issuance");
+    expect(serialized).not.toContain("verified credits");
+    expect(serialized).not.toContain("assurance opinion");
+  });
+
+  test("includes traceable appendix fields for report id, timestamp, rules, and evidence ids", async () => {
+    const result = buildSampleExport();
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const appendixRaw = await zip.file("client-readiness-report/appendix/audit-pack-appendix.json")?.async("string");
+    expect(appendixRaw).toBeTruthy();
+    const appendix = JSON.parse(appendixRaw ?? "{}") as {
+      reportId: string;
+      generatedAt: string;
+      traceability: {
+        rules: Array<{
+          ruleId: string;
+          linkedEvidence: Array<{ id: string }>;
+        }>;
+      };
+    };
+
+    expect(appendix.reportId).toBe("CRR-EXPORT-001");
+    expect(appendix.generatedAt).toBe("2026-05-04T00:00:00Z");
+    expect(appendix.traceability.rules.map((rule) => rule.ruleId)).toEqual(["R-1", "R-2"]);
+    expect(appendix.traceability.rules[0]?.linkedEvidence.map((item) => item.id)).toEqual(["ev-1"]);
+  });
+});


### PR DESCRIPTION
## WHAT

- Added deterministic client readiness report ZIP export
- Added finalized Verify summary action for exporting the client readiness report
- Packaged report JSON, report HTML, evidence reference index, manifest, and readiness traceability appendix
- Kept export language bounded to pre-verification readiness, not verifier/registry/issuance claims

## WHY

- Gives Article6 a client-facing paid readiness deliverable
- Preserves traceability from report findings back to rules and evidence
- Completes the smallest safe Phase 4 export path without expanding into VVB workpaper or registry-facing output

**Signed-off-by:** Fred E <fredilly@article6.org>**