### PR TITLE
Mark Phase 4 roadmap export done

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -106,8 +106,8 @@ Lane status: Active
 Commercial sales-readiness lane for project developer gap audits, VVB workpaper exports, public verification autopsies, white-label consultancy pilots, and rule encoding. `traceable-rule-review-mvp` remains the technical foundation.
 
 Current focus:
-- Phase 3 is complete: the readiness gap engine core and Verify reviewer visibility now surface rule-level readiness state, severity, missing evidence, and next actions
-- Next build: Phase 4 client readiness report and export surfaces, using the existing readiness-gap outputs without overstating Article6 as a verifier
+- Phase 4 is complete: PR #555 upgraded VERIFICATION_REPORT.html into a structured Verification Readiness Review skeleton with explicit limits, traceability, and truthful missing-field handling
+- Next build: Phase 5 VVB Workpaper Export, reusing the same review data without overstating Article6 as a verifier or claiming registry approval
 - Keep `traceable-rule-review-mvp` as the technical foundation for review records and exports
 - Preserve app-vs-methodologies boundaries while preparing sellable verification outputs
 
@@ -118,6 +118,7 @@ Not active now:
 - Methodology-repo changes in this app repo
 
 1) PR542: Done (PR #542)
+2) PR555: Done (PR #555)
 
 ## project-verification
 

--- a/docs/roadmaps/project-readiness-verification-output/phase-status.json
+++ b/docs/roadmaps/project-readiness-verification-output/phase-status.json
@@ -1,16 +1,20 @@
 {
   "PR542": "done",
+  "PR555": "done",
   "pr_evidence": {
     "PR542": [
       542
+    ],
+    "PR555": [
+      555
     ]
   },
   "phase_meta": {
     "status": "active",
     "summary": "Commercial sales-readiness lane for project developer gap audits, VVB workpaper exports, public verification autopsies, white-label consultancy pilots, and rule encoding. `traceable-rule-review-mvp` remains the technical foundation.",
     "current_focus": [
-      "Phase 3 is complete: the readiness gap engine core and Verify reviewer visibility now surface rule-level readiness state, severity, missing evidence, and next actions",
-      "Next build: Phase 4 client readiness report and export surfaces, using the existing readiness-gap outputs without overstating Article6 as a verifier",
+      "Phase 4 is complete: PR #555 upgraded VERIFICATION_REPORT.html into a structured Verification Readiness Review skeleton with explicit limits, traceability, and truthful missing-field handling",
+      "Next build: Phase 5 VVB Workpaper Export, reusing the same review data without overstating Article6 as a verifier or claiming registry approval",
       "Keep `traceable-rule-review-mvp` as the technical foundation for review records and exports",
       "Preserve app-vs-methodologies boundaries while preparing sellable verification outputs"
     ],
@@ -43,9 +47,9 @@
       "summary": "Done. The Verify workflow now derives and surfaces rule-level readiness state, severity, missing expected evidence, recommendations / next action, and saved reviewer artifact state from evidence inventory plus methodology expectations. Live reviewer override wiring, client readiness report export, verification pack/report generation, and any registry approval, verification opinion, or credit issuance claims remain outside Phase 3."
     },
     "phase_4_client_readiness_report_export": {
-      "status": "planned",
+      "status": "done",
       "title": "Client Readiness Report Export",
-      "summary": "Produce the paid readiness report and audit pack appendix for project developers and consultancies with explicit limits and traceability."
+      "summary": "Completed via PR #555. `VERIFICATION_REPORT.html` now renders as a structured Verification Readiness Review skeleton with explicit limits, traceability, missing-field states, and no claims of formal validation, verification, certification, VVB approval, registry approval, or credit issuance."
     },
     "phase_5_vvb_workpaper_export": {
       "status": "planned",


### PR DESCRIPTION
Roadmap: project-readiness-verification-output
Roadmap-Item: phase_4_client_readiness_report_export
SSOT: docs/roadmaps/project-readiness-verification-output/phase-status.json

### Roadmap-Update
- slug: project-readiness-verification-output
- ack: human
- PR555: done

## WHAT

- marked Phase 4 Client Readiness Report Export as done in the roadmap SSOT
- added PR #555 to the top-level PR status map and `pr_evidence`
- updated the Phase 4 summary to reflect the completed Verification Readiness Review skeleton export

## WHY

- keeps the commercial roadmap aligned with the completed PR #555 export work
- prevents the roadmap from implying Phase 4 is still planned after the new report skeleton shipped
- preserves the explicit limits around verification, certification, VVB approval, registry approval, and credit issuance

**Signed-off-by:** Fred E <fredilly@article6.org>