### PR TITLE
Add VVB draft workpaper export

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -106,8 +106,8 @@ Lane status: Active
 Commercial sales-readiness lane for project developer gap audits, VVB workpaper exports, public verification autopsies, white-label consultancy pilots, and rule encoding. `traceable-rule-review-mvp` remains the technical foundation.
 
 Current focus:
-- Phase 4 is complete: PR #555 upgraded VERIFICATION_REPORT.html into a structured Verification Readiness Review skeleton with explicit limits, traceability, and truthful missing-field handling
-- Next build: Phase 5 VVB Workpaper Export, reusing the same review data without overstating Article6 as a verifier or claiming registry approval
+- Phase 5 is active: a separate VVB-facing draft workpaper export now reuses review rows, readiness gaps, evidence references, and provenance without claiming verifier authority
+- Next build: deepen registry-aware workpaper coverage and provenance detail without overstating Article6 as a verifier or claiming registry approval
 - Keep `traceable-rule-review-mvp` as the technical foundation for review records and exports
 - Preserve app-vs-methodologies boundaries while preparing sellable verification outputs
 

--- a/docs/roadmaps/project-readiness-verification-output/phase-status.json
+++ b/docs/roadmaps/project-readiness-verification-output/phase-status.json
@@ -13,8 +13,8 @@
     "status": "active",
     "summary": "Commercial sales-readiness lane for project developer gap audits, VVB workpaper exports, public verification autopsies, white-label consultancy pilots, and rule encoding. `traceable-rule-review-mvp` remains the technical foundation.",
     "current_focus": [
-      "Phase 4 is complete: PR #555 upgraded VERIFICATION_REPORT.html into a structured Verification Readiness Review skeleton with explicit limits, traceability, and truthful missing-field handling",
-      "Next build: Phase 5 VVB Workpaper Export, reusing the same review data without overstating Article6 as a verifier or claiming registry approval",
+      "Phase 5 is active: a separate VVB-facing draft workpaper export now reuses review rows, readiness gaps, evidence references, and provenance without claiming verifier authority",
+      "Next build: deepen registry-aware workpaper coverage and provenance detail without overstating Article6 as a verifier or claiming registry approval",
       "Keep `traceable-rule-review-mvp` as the technical foundation for review records and exports",
       "Preserve app-vs-methodologies boundaries while preparing sellable verification outputs"
     ],
@@ -52,9 +52,9 @@
       "summary": "Completed via PR #555. `VERIFICATION_REPORT.html` now renders as a structured Verification Readiness Review skeleton with explicit limits, traceability, missing-field states, and no claims of formal validation, verification, certification, VVB approval, registry approval, or credit issuance."
     },
     "phase_5_vvb_workpaper_export": {
-      "status": "planned",
+      "status": "active",
       "title": "VVB Workpaper Export",
-      "summary": "Reuse the same review data for VVB-facing draft workpapers, provenance bundles, and truthful registry-aware report sections."
+      "summary": "Active. Export a VVB-facing draft workpaper artifact separate from the client readiness report, reusing rule reviews, readiness gaps, expected and missing evidence, reviewer artifact state, and provenance references. This remains draft workpaper support only and does not claim formal validation, verification, certification, VVB approval, registry approval, credit issuance, or credit eligibility."
     },
     "phase_6_public_autopsy_workflow": {
       "status": "planned",

--- a/src/app/api/exports/vvb-workpaper/route.ts
+++ b/src/app/api/exports/vvb-workpaper/route.ts
@@ -1,0 +1,43 @@
+import { buildVvbWorkpaperExport } from "@/lib/readiness/vvbWorkpaperExport";
+import type { VvbWorkpaperReport } from "@/lib/readiness/vvbWorkpaperReport";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asVvbWorkpaperReport(value: unknown): VvbWorkpaperReport | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  if (typeof record.reportId !== "string" || !record.reportId.trim()) return null;
+  if (typeof record.generatedAt !== "string" || !record.generatedAt.trim()) return null;
+  const context = asRecord(record.projectMethodVersionContext);
+  if (!context || typeof context.methodologyCode !== "string" || typeof context.methodologyVersion !== "string") return null;
+  return value as VvbWorkpaperReport;
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as unknown;
+    const record = asRecord(body) ?? {};
+    const report = asVvbWorkpaperReport(record.report);
+
+    if (!report) return new Response("Missing or invalid VVB workpaper report payload", { status: 400 });
+
+    const { zipBytes } = buildVvbWorkpaperExport({ report });
+    return new Response(new Uint8Array(zipBytes), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": 'attachment; filename="vvb-draft-workpaper.zip"',
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(`VVB workpaper export failed (500). ${message}`, { status: 500 });
+  }
+}

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -37,11 +37,12 @@ import { buildReviewSummaryPdf } from "@/lib/verify/reviewSummaryPdf";
 import { buildFinalizedExportKpis, buildSelectedStacExport, prepareChecklistExport } from "@/lib/verify/finalizedExport";
 import { buildStacSupportFactsState } from "@/lib/verify/stacSupportFacts";
 import { isStacEligible } from "@/lib/verify/stacEligibility";
-import { checkFinalizeGate, REVIEW_STORE_EVENT } from "@/lib/verify/reviewStore";
+import { checkFinalizeGate, getAllReviews, REVIEW_STORE_EVENT } from "@/lib/verify/reviewStore";
 import { buildRequirementCoverageRows, reconcileRequirement } from "@/app/m/_lib/requirementCoverage";
 import { EXPECTED_EVIDENCE_LABELS } from "@/app/m/_lib/requirementCoverage";
 import { deriveRuleReadinessGaps } from "@/lib/readiness/gapEngine";
 import { buildClientReadinessReport } from "@/lib/readiness/clientReadinessReport";
+import { buildVvbWorkpaperReport } from "@/lib/readiness/vvbWorkpaperReport";
 import { computeKpis, linkedRuleIdsFromPins } from "@/lib/kpis/computeKpis";
 import {
   buildEvidenceInventory,
@@ -228,6 +229,10 @@ function safeFilename(value: string): string {
 
 function clientReadinessReportId(methodCode: string, version: string, runId: string): string {
   return `CRR-${safeFilename(methodCode)}-${safeFilename(version)}-${safeFilename(runId)}`;
+}
+
+function vvbWorkpaperReportId(methodCode: string, version: string, runId: string): string {
+  return `VVB-WP-${safeFilename(methodCode)}-${safeFilename(version)}-${safeFilename(runId)}`;
 }
 
 function inventoryHaystack(item: EvidenceInventoryItem): string {
@@ -488,6 +493,8 @@ export default function ProofMapTab({
   const [reviewPdfError, setReviewPdfError] = useState<string | null>(null);
   const [clientReadinessExportBusy, setClientReadinessExportBusy] = useState(false);
   const [clientReadinessExportError, setClientReadinessExportError] = useState<string | null>(null);
+  const [vvbWorkpaperExportBusy, setVvbWorkpaperExportBusy] = useState(false);
+  const [vvbWorkpaperExportError, setVvbWorkpaperExportError] = useState<string | null>(null);
   const uploadAoiInputRef = useRef<HTMLInputElement | null>(null);
   const uploadPddInputRef = useRef<HTMLInputElement | null>(null);
   const [pddFragmentDrafts, setPddFragmentDrafts] = useState<Record<string, PddFragmentDraft>>({});
@@ -2909,13 +2916,13 @@ export default function ProofMapTab({
     downloadJson(artifact, filename);
   }, [activeReviewArtifact, buildFinalReviewArtifact, methodCode, verifierBundle, version]);
 
-  const buildClientReadinessReportPayload = useCallback(async () => {
+  const buildReadinessExportContext = useCallback(async () => {
     const generatedAt = verifierBundle.finalizedAt ?? verifierBundle.exportedAt;
     if (!generatedAt) {
-      throw new Error("Finalize the current Verify run before exporting a client readiness report.");
+      throw new Error("Finalize the current Verify run before exporting a readiness artifact.");
     }
     if (!ruleOptions.length) {
-      throw new Error("No method rules are available for client readiness export.");
+      throw new Error("No method rules are available for readiness export.");
     }
 
     const ruleContexts = await Promise.all(
@@ -2972,6 +2979,8 @@ export default function ProofMapTab({
       reviewerArtifactsByRuleId,
     });
 
+    const reviewsByRuleId = getAllReviews(methodCode, version);
+
     const suppliedDocuments = [...evidenceInventory]
       .filter((item) => item.kind !== "stac-item")
       .sort((a, b) => a.evidence_id.localeCompare(b.evidence_id))
@@ -2993,6 +3002,37 @@ export default function ProofMapTab({
         type: expectedType,
       }));
 
+    return {
+      generatedAt,
+      readinessGaps,
+      reviewerArtifactsByRuleId,
+      reviewsByRuleId,
+      suppliedDocuments,
+      missingDocuments,
+    };
+  }, [
+    evidenceInventory,
+    fetchSelectedRuleContext,
+    methodCode,
+    ruleOptions,
+    verifierBundle.exportedAt,
+    verifierBundle.finalizedAt,
+    verifierBundle.minutes,
+    verifierBundle.outcomeNote,
+    verifierBundle.runContext.runId,
+    verifierBundle.savedReviewerArtifactAt,
+    verifierBundle.savedReviewerArtifactContext,
+    version,
+  ]);
+
+  const buildClientReadinessReportPayload = useCallback(async () => {
+    const {
+      generatedAt,
+      readinessGaps,
+      suppliedDocuments,
+      missingDocuments,
+    } = await buildReadinessExportContext();
+
     const report = buildClientReadinessReport({
       reportId: clientReadinessReportId(methodCode, version, verifierBundle.runContext.runId),
       generatedAt,
@@ -3012,17 +3052,58 @@ export default function ProofMapTab({
     return { report, readinessGaps };
   }, [
     aoi?.name,
-    evidenceInventory,
-    fetchSelectedRuleContext,
+    buildReadinessExportContext,
     methodCode,
-    ruleOptions,
+    verifierBundle.runContext.runId,
+    version,
+  ]);
+
+  const buildVvbWorkpaperPayload = useCallback(async () => {
+    const {
+      generatedAt,
+      readinessGaps,
+      reviewerArtifactsByRuleId,
+      reviewsByRuleId,
+      suppliedDocuments,
+      missingDocuments,
+    } = await buildReadinessExportContext();
+
+    const reviewerArtifactsRecord = Object.fromEntries(reviewerArtifactsByRuleId.entries());
+    const report = buildVvbWorkpaperReport({
+      reportId: vvbWorkpaperReportId(methodCode, version, verifierBundle.runContext.runId),
+      generatedAt,
+      project: {
+        name: aoi?.name?.trim() || `VVB workspace ${methodCode}@${version}`,
+        description: `Draft VVB workpaper support generated from Verify run ${verifierBundle.runContext.runId}.`,
+      },
+      methodology: {
+        code: methodCode,
+        version,
+      },
+      suppliedDocuments,
+      missingDocuments,
+      readinessGaps,
+      reviewsByRuleId,
+      reviewerArtifactsByRuleId: reviewerArtifactsRecord,
+      provenance: {
+        sourceRunId: verifierBundle.runContext.runId,
+        artifactState: verifierBundle.finalizedAt ? "finalized" : verifierBundle.exportedAt ? "draft" : "unavailable",
+        snapshotExportedAt: verifierBundle.exportedAt ?? null,
+        finalizedAt: verifierBundle.finalizedAt ?? null,
+        auditPackReference: `audit-pack.${safeFilename(methodCode)}.${safeFilename(version)}.${safeFilename(verifierBundle.runContext.runId)}.zip`,
+        clientReadinessReference: clientReadinessReportId(methodCode, version, verifierBundle.runContext.runId),
+        traceBundleReference: `verify-run:${verifierBundle.runContext.runId}`,
+      },
+    });
+
+    return { report };
+  }, [
+    aoi?.name,
+    buildReadinessExportContext,
+    methodCode,
     verifierBundle.exportedAt,
     verifierBundle.finalizedAt,
-    verifierBundle.minutes,
-    verifierBundle.outcomeNote,
     verifierBundle.runContext.runId,
-    verifierBundle.savedReviewerArtifactAt,
-    verifierBundle.savedReviewerArtifactContext,
     version,
   ]);
 
@@ -3050,6 +3131,31 @@ export default function ProofMapTab({
       setClientReadinessExportBusy(false);
     }
   }, [buildClientReadinessReportPayload, methodCode, showToast, verifierBundle.runContext.runId, version]);
+
+  const handleExportVvbWorkpaper = useCallback(async () => {
+    setVvbWorkpaperExportBusy(true);
+    setVvbWorkpaperExportError(null);
+    try {
+      const payload = await buildVvbWorkpaperPayload();
+      const response = await fetch("/api/exports/vvb-workpaper", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      const filename = `vvb-draft-workpaper.${safeFilename(methodCode)}.${safeFilename(version)}.${safeFilename(verifierBundle.runContext.runId)}.zip`;
+      downloadBytes(bytes, filename, "application/zip");
+      showToast("VVB draft workpaper exported");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setVvbWorkpaperExportError(message);
+    } finally {
+      setVvbWorkpaperExportBusy(false);
+    }
+  }, [buildVvbWorkpaperPayload, methodCode, showToast, verifierBundle.runContext.runId, version]);
 
   const handleDownloadReviewSummaryPdf = useCallback(async () => {
     const finalizedAt = verifierBundle.finalizedAt ?? verifierBundle.exportedAt;
@@ -4515,6 +4621,9 @@ export default function ProofMapTab({
                 onExportClientReadinessReport={() => {
                   void handleExportClientReadinessReport();
                 }}
+                onExportVvbWorkpaper={() => {
+                  void handleExportVvbWorkpaper();
+                }}
                 onCopyLink={() => {
                   void handleCopyReviewSummaryLink();
                 }}
@@ -4524,6 +4633,8 @@ export default function ProofMapTab({
                 pdfError={reviewPdfError}
                 clientReadinessExportBusy={clientReadinessExportBusy}
                 clientReadinessExportError={clientReadinessExportError}
+                vvbWorkpaperExportBusy={vvbWorkpaperExportBusy}
+                vvbWorkpaperExportError={vvbWorkpaperExportError}
               />
             ) : (
               <EvidenceWorkflowStepper

--- a/src/components/verify/FinalReviewSummaryPanel.tsx
+++ b/src/components/verify/FinalReviewSummaryPanel.tsx
@@ -19,6 +19,7 @@ type FinalReviewSummaryPanelProps = {
   onDownloadJson: () => void;
   onDownloadPdf: () => void;
   onExportClientReadinessReport?: () => void;
+  onExportVvbWorkpaper?: () => void;
   onCopyLink?: () => void;
   onStartAnotherRun: () => void;
   onViewRunHistory: () => void;
@@ -26,6 +27,8 @@ type FinalReviewSummaryPanelProps = {
   pdfBusy?: boolean;
   clientReadinessExportBusy?: boolean;
   clientReadinessExportError?: string | null;
+  vvbWorkpaperExportBusy?: boolean;
+  vvbWorkpaperExportError?: string | null;
 };
 
 function formatDate(value: string | null | undefined): string | null {
@@ -66,6 +69,7 @@ export default function FinalReviewSummaryPanel({
   onDownloadJson,
   onDownloadPdf,
   onExportClientReadinessReport,
+  onExportVvbWorkpaper,
   onCopyLink,
   onStartAnotherRun,
   onViewRunHistory,
@@ -73,6 +77,8 @@ export default function FinalReviewSummaryPanel({
   pdfBusy = false,
   clientReadinessExportBusy = false,
   clientReadinessExportError = null,
+  vvbWorkpaperExportBusy = false,
+  vvbWorkpaperExportError = null,
 }: FinalReviewSummaryPanelProps) {
   const finalizedLabel = formatDate(finalizedAt);
   const completedSteps = wizard.steps.filter((step) => step.complete);
@@ -148,8 +154,21 @@ export default function FinalReviewSummaryPanel({
             {clientReadinessExportBusy ? "Preparing readiness report..." : "Export client readiness report"}
           </button>
         ) : null}
+        {onExportVvbWorkpaper ? (
+          <button
+            type="button"
+            className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-wait disabled:opacity-70"
+            onClick={() => {
+              onExportVvbWorkpaper();
+            }}
+            disabled={vvbWorkpaperExportBusy}
+          >
+            {vvbWorkpaperExportBusy ? "Preparing VVB workpaper..." : "Export VVB draft workpaper"}
+          </button>
+        ) : null}
       </div>
       {clientReadinessExportError ? <div className="text-xs text-rose-700">{clientReadinessExportError}</div> : null}
+      {vvbWorkpaperExportError ? <div className="text-xs text-rose-700">{vvbWorkpaperExportError}</div> : null}
 
       <details className="rounded-xl border border-slate-200 bg-white">
         <summary className="cursor-pointer list-none px-3 py-2 text-xs font-semibold text-slate-900">

--- a/src/lib/readiness/vvbWorkpaperExport.tsx
+++ b/src/lib/readiness/vvbWorkpaperExport.tsx
@@ -142,10 +142,12 @@ function renderRuleReviewRows(report: VvbWorkpaperReport): string {
         <tr>
           <td><strong>${escapeHtml(row.ruleId)}</strong><br /><span>${escapeHtml(row.ruleTitle)}</span></td>
           <td>${escapeHtml(row.reviewStatusLabel)}</td>
+          <td>${escapeHtml(row.reviewRecordScopeLabel)}</td>
           <td>${escapeHtml(row.reviewerRationale)}</td>
           <td>${escapeHtml(row.supportReference)}</td>
           <td>${joinOrFallback(row.linkedEvidenceRefs, "No linked evidence refs")}</td>
           <td>${joinOrFallback(row.candidateEvidenceRefs, "No candidate evidence refs")}</td>
+          <td>${joinOrFallback(row.attachmentRefs, "No attachment refs")}</td>
         </tr>`,
     )
     .join("");
@@ -208,6 +210,8 @@ function reportHtmlDocument(report: VvbWorkpaperReport): string {
         <p>${escapeHtml(report.executiveSummary.headline)}</p>
         <p>${escapeHtml(report.workpaperStatus.note)}</p>
         <dl>
+          <dt>Source run scope</dt><dd>${escapeHtml(report.workpaperStatus.sourceRunScope.replaceAll("_", " "))}</dd>
+          <dt>Review record scope</dt><dd>${escapeHtml(report.workpaperStatus.reviewRecordScope.replaceAll("_", " "))}</dd>
           <dt>Project ID</dt><dd>${escapeHtml(context.projectId)}</dd>
           <dt>Proponent</dt><dd>${escapeHtml(context.proponent)}</dd>
           <dt>Region</dt><dd>${escapeHtml(context.region)}</dd>
@@ -247,10 +251,10 @@ function reportHtmlDocument(report: VvbWorkpaperReport): string {
 
       <section>
         <h2>Rule review workpaper table</h2>
-        <p>Rows remain draft workpaper support unless a reviewer has explicitly recorded a non-pending judgment.</p>
+        <p>Rows remain draft workpaper support unless a reviewer has explicitly recorded a non-pending judgment. Review rows are workspace-level method/version records unless separately saved as run-bound reviewer artifact state.</p>
         <table>
           <thead>
-            <tr><th>Rule</th><th>Review status</th><th>Reviewer rationale</th><th>Support reference</th><th>Linked evidence refs</th><th>Candidate evidence refs</th></tr>
+            <tr><th>Rule</th><th>Review status</th><th>Record scope</th><th>Reviewer rationale</th><th>Support reference</th><th>Linked evidence refs</th><th>Candidate evidence refs</th><th>Attachment refs</th></tr>
           </thead>
           <tbody>${renderRuleReviewRows(report)}</tbody>
         </table>

--- a/src/lib/readiness/vvbWorkpaperExport.tsx
+++ b/src/lib/readiness/vvbWorkpaperExport.tsx
@@ -1,0 +1,420 @@
+import { zipSync } from "fflate";
+import { canonicalStringify, sha256Hex } from "@/integrity/artifacts";
+import type { VvbWorkpaperReport } from "@/lib/readiness/vvbWorkpaperReport";
+
+export type VvbWorkpaperAppendixArtifact = {
+  kind: "article6.vvb_workpaper_appendix";
+  version: 1;
+  reportId: string;
+  generatedAt: string;
+  methodology: {
+    code: string;
+    version: string;
+    name: string;
+    sector: string;
+  };
+  bundleReferences: VvbWorkpaperReport["evidenceProvenanceReferences"]["bundleReferences"];
+  traceability: {
+    ruleCount: number;
+    evidenceReferenceCount: number;
+    rules: Array<{
+      ruleId: string;
+      reviewStatus: string;
+      readinessState: string;
+      severity: string;
+      linkedEvidenceRefs: string[];
+      candidateEvidenceRefs: string[];
+      reviewerArtifactState: string;
+    }>;
+  };
+  limitations: string[];
+  nonClaims: string[];
+};
+
+export type VvbWorkpaperExportManifest = {
+  kind: "article6.vvb_workpaper_export";
+  version: 1;
+  generated_at: string;
+  report_id: string;
+  files: Array<{
+    path: string;
+    sha256: string;
+    bytes: number;
+  }>;
+};
+
+export type BuildVvbWorkpaperExportInput = {
+  report: VvbWorkpaperReport;
+};
+
+export type VvbWorkpaperExportResult = {
+  zipBytes: Buffer;
+  manifest: VvbWorkpaperExportManifest;
+  appendix: VvbWorkpaperAppendixArtifact;
+  html: string;
+};
+
+const FORBIDDEN_CLAIMS = [
+  "verification opinion",
+  "formal verification opinion",
+  "formal validation opinion",
+  "registry approval",
+  "registry approved",
+  "credit issuance",
+  "credit eligibility",
+  "verified credits",
+  "assurance opinion",
+  "vvb approval",
+] as const;
+
+function flattenForCanonicalJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isoForZip(iso: string): Date {
+  const parsed = new Date(iso);
+  if (!Number.isFinite(parsed.getTime())) return new Date("1980-01-01T00:00:00.000Z");
+  if (parsed.getUTCFullYear() < 1980) return new Date("1980-01-01T00:00:00.000Z");
+  if (parsed.getUTCFullYear() > 2099) return new Date("2099-12-31T23:59:58.000Z");
+  return parsed;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function listOrFallback(items: string[], fallback: string): string {
+  if (!items.length) return `<p>${escapeHtml(fallback)}</p>`;
+  return `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
+}
+
+function joinOrFallback(items: string[], fallback: string): string {
+  return items.length ? items.map(escapeHtml).join(", ") : escapeHtml(fallback);
+}
+
+function buildVvbWorkpaperAppendixArtifact(input: BuildVvbWorkpaperExportInput): VvbWorkpaperAppendixArtifact {
+  const report = input.report;
+  return {
+    kind: "article6.vvb_workpaper_appendix",
+    version: 1,
+    reportId: report.reportId,
+    generatedAt: report.generatedAt,
+    methodology: {
+      code: report.projectMethodVersionContext.methodologyCode,
+      version: report.projectMethodVersionContext.methodologyVersion,
+      name: report.projectMethodVersionContext.methodologyName,
+      sector: report.projectMethodVersionContext.sector,
+    },
+    bundleReferences: report.evidenceProvenanceReferences.bundleReferences,
+    traceability: {
+      ruleCount: report.ruleReviewWorkpaperTable.length,
+      evidenceReferenceCount: report.evidenceProvenanceReferences.evidenceReferenceIndex.length,
+      rules: report.ruleReviewWorkpaperTable.map((row) => {
+        const readiness = report.readinessGapStatus.find((item) => item.ruleId === row.ruleId);
+        const artifact = report.reviewerArtifactState.find((item) => item.ruleId === row.ruleId);
+        return {
+          ruleId: row.ruleId,
+          reviewStatus: row.reviewStatus,
+          readinessState: readiness?.readinessState ?? "not_available",
+          severity: readiness?.severity ?? "not_available",
+          linkedEvidenceRefs: row.linkedEvidenceRefs,
+          candidateEvidenceRefs: row.candidateEvidenceRefs,
+          reviewerArtifactState: artifact?.state ?? "missing",
+        };
+      }),
+    },
+    limitations: report.limitationsAndNonClaims.limitations,
+    nonClaims: report.limitationsAndNonClaims.nonClaims,
+  };
+}
+
+function renderRuleReviewRows(report: VvbWorkpaperReport): string {
+  return report.ruleReviewWorkpaperTable
+    .map(
+      (row) => `
+        <tr>
+          <td><strong>${escapeHtml(row.ruleId)}</strong><br /><span>${escapeHtml(row.ruleTitle)}</span></td>
+          <td>${escapeHtml(row.reviewStatusLabel)}</td>
+          <td>${escapeHtml(row.reviewerRationale)}</td>
+          <td>${escapeHtml(row.supportReference)}</td>
+          <td>${joinOrFallback(row.linkedEvidenceRefs, "No linked evidence refs")}</td>
+          <td>${joinOrFallback(row.candidateEvidenceRefs, "No candidate evidence refs")}</td>
+        </tr>`,
+    )
+    .join("");
+}
+
+function renderReadinessRows(report: VvbWorkpaperReport): string {
+  return report.readinessGapStatus
+    .map(
+      (row) => `
+        <tr>
+          <td><strong>${escapeHtml(row.ruleId)}</strong><br /><span>${escapeHtml(row.ruleTitle)}</span></td>
+          <td>${escapeHtml(row.readinessState.replaceAll("_", " "))}</td>
+          <td>${escapeHtml(row.severity)}</td>
+          <td>${joinOrFallback(row.expectedEvidence, "No encoded expectation")}</td>
+          <td>${joinOrFallback(row.missingEvidence, "No missing evidence listed")}</td>
+          <td>${joinOrFallback(row.nextActions, "No next action listed")}</td>
+        </tr>`,
+    )
+    .join("");
+}
+
+function renderArtifactRows(report: VvbWorkpaperReport): string {
+  return report.reviewerArtifactState
+    .map(
+      (row) => `
+        <tr>
+          <td><strong>${escapeHtml(row.ruleId)}</strong><br /><span>${escapeHtml(row.ruleTitle)}</span></td>
+          <td>${escapeHtml(row.state)}</td>
+          <td>${escapeHtml(row.savedAt)}</td>
+          <td>${escapeHtml(row.note)}</td>
+        </tr>`,
+    )
+    .join("");
+}
+
+function renderEvidenceRows(report: VvbWorkpaperReport): string {
+  return report.evidenceProvenanceReferences.evidenceReferenceIndex
+    .map(
+      (row) => `
+        <tr>
+          <td><strong>${escapeHtml(row.id)}</strong><br /><span>${escapeHtml(row.label)}</span></td>
+          <td>${escapeHtml(row.type)}</td>
+          <td>${escapeHtml(row.referenceState.replaceAll("_", " "))}</td>
+          <td>${joinOrFallback(row.linkedRuleIds, "No linked rules")}</td>
+          <td>${escapeHtml(row.note)}</td>
+        </tr>`,
+    )
+    .join("");
+}
+
+function reportHtmlDocument(report: VvbWorkpaperReport): string {
+  const context = report.projectMethodVersionContext;
+  const totals = report.executiveSummary.totals;
+  const body = `
+    <article>
+      <section>
+        <p><strong>VVB draft workpaper support</strong> · <strong>Draft export only</strong></p>
+        <h1>${escapeHtml(context.projectName)}</h1>
+        <p>${escapeHtml(context.methodologyCode)}@${escapeHtml(context.methodologyVersion)} · ${escapeHtml(report.workpaperStatus.label)}</p>
+        <p>${escapeHtml(report.executiveSummary.headline)}</p>
+        <p>${escapeHtml(report.workpaperStatus.note)}</p>
+        <dl>
+          <dt>Project ID</dt><dd>${escapeHtml(context.projectId)}</dd>
+          <dt>Proponent</dt><dd>${escapeHtml(context.proponent)}</dd>
+          <dt>Region</dt><dd>${escapeHtml(context.region)}</dd>
+          <dt>Methodology</dt><dd>${escapeHtml(context.methodologyCode)}@${escapeHtml(context.methodologyVersion)}</dd>
+          <dt>Generated</dt><dd>${escapeHtml(report.generatedAt)}</dd>
+          <dt>Report ID</dt><dd>${escapeHtml(report.reportId)}</dd>
+        </dl>
+      </section>
+
+      <section>
+        <h2>Project / method / version context</h2>
+        <p><strong>Methodology name:</strong> ${escapeHtml(context.methodologyName)}</p>
+        <p><strong>Sector:</strong> ${escapeHtml(context.sector)}</p>
+        <p><strong>Description:</strong> ${escapeHtml(context.projectDescription)}</p>
+      </section>
+
+      <section>
+        <h2>Registry and program context</h2>
+        <p><strong>Registry program:</strong> ${escapeHtml(report.registryAndProgramContext.registryProgram)}</p>
+        <p><strong>Registry project ID:</strong> ${escapeHtml(report.registryAndProgramContext.registryProjectId)}</p>
+        <p>${escapeHtml(report.registryAndProgramContext.note)}</p>
+      </section>
+
+      <section>
+        <h2>Executive Summary</h2>
+        <ul>
+          <li>Total rules: ${totals.rules}</li>
+          <li>Reviewed rules: ${totals.reviewed}</li>
+          <li>Pending or not reviewed: ${totals.pendingOrNotReviewed}</li>
+          <li>Needs follow-up: ${totals.needsFollowup}</li>
+          <li>Missing evidence / not started: ${totals.missingEvidence}</li>
+          <li>Unknown expectation: ${totals.unknownExpectation}</li>
+          <li>Saved reviewer artifact state: ${totals.reviewerArtifactSaved}</li>
+        </ul>
+        <p>${escapeHtml(report.executiveSummary.note)}</p>
+      </section>
+
+      <section>
+        <h2>Rule review workpaper table</h2>
+        <p>Rows remain draft workpaper support unless a reviewer has explicitly recorded a non-pending judgment.</p>
+        <table>
+          <thead>
+            <tr><th>Rule</th><th>Review status</th><th>Reviewer rationale</th><th>Support reference</th><th>Linked evidence refs</th><th>Candidate evidence refs</th></tr>
+          </thead>
+          <tbody>${renderRuleReviewRows(report)}</tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Readiness / gap status</h2>
+        <table>
+          <thead>
+            <tr><th>Rule</th><th>Readiness state</th><th>Severity</th><th>Expected evidence</th><th>Missing evidence</th><th>Next actions</th></tr>
+          </thead>
+          <tbody>${renderReadinessRows(report)}</tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Reviewer artifact state</h2>
+        <table>
+          <thead>
+            <tr><th>Rule</th><th>State</th><th>Saved at</th><th>Note</th></tr>
+          </thead>
+          <tbody>${renderArtifactRows(report)}</tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Evidence / provenance references</h2>
+        <h3>Supplied documents</h3>
+        ${
+          report.evidenceProvenanceReferences.suppliedDocuments.length
+            ? `<ul>${report.evidenceProvenanceReferences.suppliedDocuments
+                .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)}${item.note ? ` · ${escapeHtml(item.note)}` : ""}</li>`)
+                .join("")}</ul>`
+            : "<p>No supplied documents recorded.</p>"
+        }
+        <h3>Missing documents</h3>
+        ${
+          report.evidenceProvenanceReferences.missingDocuments.length
+            ? `<ul>${report.evidenceProvenanceReferences.missingDocuments
+                .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)}</li>`)
+                .join("")}</ul>`
+            : "<p>No missing documents recorded.</p>"
+        }
+        <h3>Evidence reference index</h3>
+        <table>
+          <thead>
+            <tr><th>Reference</th><th>Type</th><th>Reference state</th><th>Linked rules</th><th>Note</th></tr>
+          </thead>
+          <tbody>${renderEvidenceRows(report)}</tbody>
+        </table>
+        <h3>Bundle references</h3>
+        <ul>
+          ${report.evidenceProvenanceReferences.bundleReferences
+            .map((item) => `<li>${escapeHtml(item.label)}: ${escapeHtml(item.value)} (${escapeHtml(item.availability)})</li>`)
+            .join("")}
+        </ul>
+      </section>
+
+      <section>
+        <h2>Limitations and non-claims</h2>
+        <h3>Limitations</h3>
+        ${listOrFallback(report.limitationsAndNonClaims.limitations, "No limitations listed.")}
+        <h3>Non-claims</h3>
+        ${listOrFallback(report.limitationsAndNonClaims.nonClaims, "No non-claims listed.")}
+      </section>
+
+      <section>
+        <h2>Technical Appendix</h2>
+        <p><strong>Generated:</strong> ${escapeHtml(report.technicalAppendix.generatedAt)}</p>
+        <h3>State definitions</h3>
+        ${listOrFallback(
+          report.technicalAppendix.stateDefinitions.map(
+            (item) => `${item.state.replaceAll("_", " ")} · ${item.description}`,
+          ),
+          "No state definitions listed.",
+        )}
+      </section>
+    </article>`;
+
+  return [
+    "<!DOCTYPE html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charSet="utf-8" />',
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />',
+    `<title>${escapeHtml(context.projectName)} VVB draft workpaper support</title>`,
+    "<style>",
+    "body{margin:0;background:#f8fafc;color:#0f172a;font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;}",
+    ".report-shell{max-width:1120px;margin:0 auto;padding:24px;}",
+    "table{width:100%;border-collapse:collapse;margin-top:12px;}",
+    "th,td{border:1px solid #cbd5e1;padding:8px;vertical-align:top;text-align:left;font-size:12px;}",
+    "th{background:#e2e8f0;}",
+    "section{margin-bottom:24px;}",
+    "</style>",
+    "</head>",
+    "<body>",
+    `<div class="report-shell">${body}</div>`,
+    "</body>",
+    "</html>",
+  ].join("");
+}
+
+function assertNoForbiddenClaims(serialized: string): void {
+  const haystack = serialized.toLowerCase();
+  const found = FORBIDDEN_CLAIMS.find((claim) => haystack.includes(claim));
+  if (found) {
+    throw new Error(`VVB workpaper export contains forbidden claim language: ${found}`);
+  }
+}
+
+export function buildVvbWorkpaperExport(input: BuildVvbWorkpaperExportInput): VvbWorkpaperExportResult {
+  const appendix = buildVvbWorkpaperAppendixArtifact(input);
+  const reportJson = canonicalStringify(flattenForCanonicalJson(input.report));
+  const appendixJson = canonicalStringify(flattenForCanonicalJson(appendix));
+  const evidenceIndexJson = canonicalStringify(
+    flattenForCanonicalJson(input.report.evidenceProvenanceReferences.evidenceReferenceIndex),
+  );
+  const html = reportHtmlDocument(input.report);
+
+  assertNoForbiddenClaims([reportJson, appendixJson, evidenceIndexJson, html].join("\n"));
+
+  const fileEntries = [
+    {
+      path: "vvb-draft-workpaper/workpaper.json",
+      bytes: Buffer.from(reportJson, "utf8"),
+    },
+    {
+      path: "vvb-draft-workpaper/workpaper.html",
+      bytes: Buffer.from(html, "utf8"),
+    },
+    {
+      path: "vvb-draft-workpaper/appendix/workpaper-traceability.json",
+      bytes: Buffer.from(appendixJson, "utf8"),
+    },
+    {
+      path: "vvb-draft-workpaper/appendix/evidence-reference-index.json",
+      bytes: Buffer.from(evidenceIndexJson, "utf8"),
+    },
+  ].sort((a, b) => a.path.localeCompare(b.path));
+
+  const manifest: VvbWorkpaperExportManifest = {
+    kind: "article6.vvb_workpaper_export",
+    version: 1,
+    generated_at: input.report.generatedAt,
+    report_id: input.report.reportId,
+    files: fileEntries.map((entry) => ({
+      path: entry.path,
+      sha256: sha256Hex(entry.bytes),
+      bytes: entry.bytes.length,
+    })),
+  };
+
+  const manifestBytes = Buffer.from(canonicalStringify(flattenForCanonicalJson(manifest)), "utf8");
+  const mtime = isoForZip(input.report.generatedAt);
+  const zipEntries: Record<string, Uint8Array | [Uint8Array, { mtime: Date }]> = {
+    "manifest.json": [new Uint8Array(manifestBytes), { mtime }],
+  };
+
+  for (const entry of fileEntries) {
+    zipEntries[entry.path] = [new Uint8Array(entry.bytes), { mtime }];
+  }
+
+  return {
+    zipBytes: Buffer.from(zipSync(zipEntries, { level: 0 })),
+    manifest,
+    appendix,
+    html,
+  };
+}

--- a/src/lib/readiness/vvbWorkpaperExport.tsx
+++ b/src/lib/readiness/vvbWorkpaperExport.tsx
@@ -67,6 +67,8 @@ const FORBIDDEN_CLAIMS = [
   "vvb approval",
 ] as const;
 
+const SAFE_NON_CLAIM_SENTENCE = /\b(?:not|no|without|does not|doesn't|avoid|avoids|avoiding|prevent|prevents|preventing)\b/;
+
 function flattenForCanonicalJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
@@ -353,7 +355,24 @@ function reportHtmlDocument(report: VvbWorkpaperReport): string {
 
 function assertNoForbiddenClaims(serialized: string): void {
   const haystack = serialized.toLowerCase();
-  const found = FORBIDDEN_CLAIMS.find((claim) => haystack.includes(claim));
+  const found = FORBIDDEN_CLAIMS.find((claim) => {
+    let startIndex = 0;
+    while (startIndex < haystack.length) {
+      const index = haystack.indexOf(claim, startIndex);
+      if (index === -1) return false;
+      const sentenceStart = Math.max(
+        haystack.lastIndexOf(".", index - 1),
+        haystack.lastIndexOf("!", index - 1),
+        haystack.lastIndexOf("?", index - 1),
+        haystack.lastIndexOf("\n", index - 1),
+      );
+      const sentenceFragment = haystack.slice(Math.max(0, sentenceStart + 1), index);
+      const negated = SAFE_NON_CLAIM_SENTENCE.test(sentenceFragment);
+      if (!negated) return true;
+      startIndex = index + claim.length;
+    }
+    return false;
+  });
   if (found) {
     throw new Error(`VVB workpaper export contains forbidden claim language: ${found}`);
   }

--- a/src/lib/readiness/vvbWorkpaperReport.ts
+++ b/src/lib/readiness/vvbWorkpaperReport.ts
@@ -60,6 +60,8 @@ export type VvbWorkpaperReport = {
   workpaperStatus: {
     label: "Draft workpaper support";
     sourceRunId: string;
+    sourceRunScope: "active_verify_run" | "unavailable";
+    reviewRecordScope: "workspace_method_version";
     artifactState: string;
     generatedAt: string;
     note: string;
@@ -82,6 +84,7 @@ export type VvbWorkpaperReport = {
     ruleTitle: string;
     reviewStatus: ReviewStatus | "not_reviewed";
     reviewStatusLabel: string;
+    reviewRecordScopeLabel: string;
     reviewerRationale: string;
     supportReference: string;
     evidenceLink: string;
@@ -161,6 +164,8 @@ export type BuildVvbWorkpaperReportInput = {
     traceBundleReference?: string | null;
   };
 };
+
+const WORKSPACE_REVIEW_SCOPE_LABEL = "Workspace-local method/version review state";
 
 function expectedEvidenceLabel(type: RequirementCoverageExpectedEvidenceType): string {
   return EXPECTED_EVIDENCE_LABELS[type] ?? type;
@@ -354,10 +359,12 @@ export function buildVvbWorkpaperReport(input: BuildVvbWorkpaperReportInput): Vv
     workpaperStatus: {
       label: "Draft workpaper support",
       sourceRunId: input.provenance?.sourceRunId?.trim() || "Unavailable",
+      sourceRunScope: input.provenance?.sourceRunId?.trim() ? "active_verify_run" : "unavailable",
+      reviewRecordScope: "workspace_method_version",
       artifactState: input.provenance?.artifactState?.trim() || "Unavailable",
       generatedAt: input.generatedAt,
       note:
-        "This export supports VVB-style workpaper preparation. It does not express a verifier conclusion and does not convert pending rows into satisfied review results.",
+        "This export supports VVB-style workpaper preparation. Active Verify run references stay tied to the current run, while local review rows remain workspace-level method/version records unless separately saved as run-bound reviewer artifact state.",
     },
     executiveSummary: {
       headline: workpaperHeadline,
@@ -381,12 +388,13 @@ export function buildVvbWorkpaperReport(input: BuildVvbWorkpaperReportInput): Vv
         ruleTitle: gap.title,
         reviewStatus,
         reviewStatusLabel: statusLabel(reviewStatus),
+        reviewRecordScopeLabel: WORKSPACE_REVIEW_SCOPE_LABEL,
         reviewerRationale: review?.rationale?.trim() || "Not reviewed.",
         supportReference: review?.supportReference?.trim() || "Not provided.",
         evidenceLink: review?.evidenceLink?.trim() || "Not provided.",
         linkedEvidenceRefs: sortedUnique(gap.linkedEvidence.map((item) => item.id)),
         candidateEvidenceRefs: sortedUnique(gap.candidateEvidence.map((item) => item.id)),
-        attachmentRefs: sortedUnique((review?.evidenceAttachments ?? []).map((item) => item.id)),
+        attachmentRefs: sortedUnique((review?.evidenceAttachments ?? []).map((item) => `${gap.ruleId}:${item.id}`)),
       };
     }),
     readinessGapStatus: readinessGaps.map((gap) => ({
@@ -423,6 +431,11 @@ export function buildVvbWorkpaperReport(input: BuildVvbWorkpaperReportInput): Vv
           availability: input.provenance?.sourceRunId?.trim() ? "available" : "unavailable",
         },
         {
+          label: "Review record scope",
+          value: WORKSPACE_REVIEW_SCOPE_LABEL,
+          availability: "available",
+        },
+        {
           label: "Snapshot exported at",
           value: input.provenance?.snapshotExportedAt?.trim() || "Unavailable",
           availability: input.provenance?.snapshotExportedAt?.trim() ? "available" : "unavailable",
@@ -452,6 +465,7 @@ export function buildVvbWorkpaperReport(input: BuildVvbWorkpaperReportInput): Vv
     limitationsAndNonClaims: {
       limitations: [
         "Derived from local Article6 review state, evidence inventory, and readiness logic available at export time.",
+        "Local review rows are scoped to the current method/version workspace, not automatically to the active Verify run.",
         "Missing evidence, missing reviewer artifact state, and not-reviewed rows remain unresolved at export time.",
         "Included references are traceability aids only unless separately packaged through another export path.",
       ],

--- a/src/lib/readiness/vvbWorkpaperReport.ts
+++ b/src/lib/readiness/vvbWorkpaperReport.ts
@@ -173,11 +173,11 @@ function evidenceLabel(item: RuleReadinessGap["linkedEvidence"][number]): string
 function statusLabel(status: ReviewStatus | "not_reviewed"): string {
   switch (status) {
     case "verified":
-      return "Verified";
+      return "Reviewer marked supported";
     case "not_verified":
-      return "Not verified";
+      return "Reviewer marked not supported";
     case "needs_followup":
-      return "Needs follow-up";
+      return "Reviewer requested follow-up";
     case "pending":
       return "Pending reviewer confirmation";
     case "not_reviewed":

--- a/src/lib/readiness/vvbWorkpaperReport.ts
+++ b/src/lib/readiness/vvbWorkpaperReport.ts
@@ -1,0 +1,477 @@
+import { EXPECTED_EVIDENCE_LABELS } from "@/app/m/_lib/requirementCoverage";
+import type { RequirementCoverageExpectedEvidenceType } from "@/app/m/_lib/requirementCoverage";
+import type { ClientReadinessDocument } from "@/lib/readiness/clientReadinessReport";
+import type { ReadinessGapSeverity, ReadinessGapState, RuleReadinessGap } from "@/lib/readiness/gapEngine";
+import type { EvidenceAttachment, ReviewStatus } from "@/lib/verify/reviewStore";
+
+export type VvbWorkpaperReviewInput = {
+  status: ReviewStatus;
+  rationale?: string | null;
+  supportReference?: string | null;
+  evidenceLink?: string | null;
+  evidenceAttachments?: EvidenceAttachment[];
+  reviewedBy?: string | null;
+  reviewedAt?: string | null;
+  updatedAt?: string | null;
+};
+
+export type VvbReviewerArtifactInput = {
+  savedAt?: string | null;
+  minutes?: string | null;
+  outcomeNote?: string | null;
+};
+
+export type VvbWorkpaperEvidenceReference = {
+  id: string;
+  label: string;
+  type: string;
+  source: string;
+  linkedRuleIds: string[];
+  referenceState: "linked_evidence" | "candidate_evidence" | "review_attachment" | "supplied_document";
+  includedInExport: false;
+  note: string;
+};
+
+export type VvbWorkpaperBundleReference = {
+  label: string;
+  value: string;
+  availability: "available" | "unavailable";
+};
+
+export type VvbWorkpaperReport = {
+  reportId: string;
+  generatedAt: string;
+  projectMethodVersionContext: {
+    projectName: string;
+    projectId: string;
+    proponent: string;
+    region: string;
+    projectDescription: string;
+    methodologyCode: string;
+    methodologyVersion: string;
+    methodologyName: string;
+    sector: string;
+  };
+  registryAndProgramContext: {
+    registryProgram: string;
+    registryProjectId: string;
+    note: string;
+  };
+  workpaperStatus: {
+    label: "Draft workpaper support";
+    sourceRunId: string;
+    artifactState: string;
+    generatedAt: string;
+    note: string;
+  };
+  executiveSummary: {
+    headline: string;
+    totals: {
+      rules: number;
+      reviewed: number;
+      pendingOrNotReviewed: number;
+      needsFollowup: number;
+      missingEvidence: number;
+      unknownExpectation: number;
+      reviewerArtifactSaved: number;
+    };
+    note: string;
+  };
+  ruleReviewWorkpaperTable: Array<{
+    ruleId: string;
+    ruleTitle: string;
+    reviewStatus: ReviewStatus | "not_reviewed";
+    reviewStatusLabel: string;
+    reviewerRationale: string;
+    supportReference: string;
+    evidenceLink: string;
+    linkedEvidenceRefs: string[];
+    candidateEvidenceRefs: string[];
+    attachmentRefs: string[];
+  }>;
+  readinessGapStatus: Array<{
+    ruleId: string;
+    ruleTitle: string;
+    readinessState: ReadinessGapState;
+    severity: ReadinessGapSeverity;
+    summary: string;
+    expectedEvidence: string[];
+    missingEvidence: string[];
+    nextActions: string[];
+  }>;
+  reviewerArtifactState: Array<{
+    ruleId: string;
+    ruleTitle: string;
+    state: "saved" | "missing";
+    savedAt: string;
+    note: string;
+  }>;
+  evidenceProvenanceReferences: {
+    suppliedDocuments: ClientReadinessDocument[];
+    missingDocuments: ClientReadinessDocument[];
+    evidenceReferenceIndex: VvbWorkpaperEvidenceReference[];
+    bundleReferences: VvbWorkpaperBundleReference[];
+  };
+  limitationsAndNonClaims: {
+    limitations: string[];
+    nonClaims: string[];
+  };
+  technicalAppendix: {
+    generatedAt: string;
+    stateDefinitions: Array<{
+      state: ReadinessGapState;
+      description: string;
+    }>;
+  };
+};
+
+export type BuildVvbWorkpaperReportInput = {
+  reportId: string;
+  generatedAt: string;
+  project: {
+    name: string;
+    projectId?: string;
+    proponent?: string;
+    region?: string;
+    description?: string;
+  };
+  methodology: {
+    code: string;
+    version: string;
+    name?: string;
+    sector?: string;
+  };
+  registry?: {
+    program?: string | null;
+    projectId?: string | null;
+    note?: string | null;
+  };
+  suppliedDocuments?: ClientReadinessDocument[];
+  missingDocuments?: ClientReadinessDocument[];
+  readinessGaps: RuleReadinessGap[];
+  reviewsByRuleId?: Record<string, VvbWorkpaperReviewInput>;
+  reviewerArtifactsByRuleId?: Record<string, VvbReviewerArtifactInput>;
+  provenance?: {
+    sourceRunId?: string | null;
+    artifactState?: string | null;
+    snapshotExportedAt?: string | null;
+    finalizedAt?: string | null;
+    auditPackReference?: string | null;
+    clientReadinessReference?: string | null;
+    traceBundleReference?: string | null;
+  };
+};
+
+function expectedEvidenceLabel(type: RequirementCoverageExpectedEvidenceType): string {
+  return EXPECTED_EVIDENCE_LABELS[type] ?? type;
+}
+
+function evidenceLabel(item: RuleReadinessGap["linkedEvidence"][number]): string {
+  return item.title?.trim() || item.fragmentLabel?.trim() || item.documentLabel?.trim() || item.id;
+}
+
+function statusLabel(status: ReviewStatus | "not_reviewed"): string {
+  switch (status) {
+    case "verified":
+      return "Verified";
+    case "not_verified":
+      return "Not verified";
+    case "needs_followup":
+      return "Needs follow-up";
+    case "pending":
+      return "Pending reviewer confirmation";
+    case "not_reviewed":
+      return "Not reviewed";
+  }
+}
+
+function stateDescription(state: ReadinessGapState): string {
+  switch (state) {
+    case "ready":
+      return "Expected evidence is linked and reviewer artifact state is saved for readiness support.";
+    case "needs_review":
+      return "Evidence is linked, but reviewer clarification is still needed before the row is stable.";
+    case "missing_evidence":
+      return "Expected evidence is partly or wholly missing.";
+    case "missing_reviewer_record":
+      return "Evidence is linked, but reviewer artifact state is not saved.";
+    case "not_started":
+      return "No linked evidence has been assembled against the expected evidence set.";
+    case "unknown_expectation":
+      return "Methodology-owned expectation metadata is not specific enough to assess the rule consistently.";
+  }
+}
+
+function reviewerArtifactSaved(artifact?: VvbReviewerArtifactInput | null): boolean {
+  if (!artifact) return false;
+  return Boolean(artifact.savedAt?.trim() || artifact.minutes?.trim() || artifact.outcomeNote?.trim());
+}
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+function referenceStatePriority(state: VvbWorkpaperEvidenceReference["referenceState"]): number {
+  switch (state) {
+    case "linked_evidence":
+      return 4;
+    case "review_attachment":
+      return 3;
+    case "candidate_evidence":
+      return 2;
+    case "supplied_document":
+      return 1;
+  }
+}
+
+function upsertEvidenceReference(
+  byId: Map<string, VvbWorkpaperEvidenceReference>,
+  next: VvbWorkpaperEvidenceReference,
+): void {
+  const current = byId.get(next.id);
+  if (!current) {
+    byId.set(next.id, {
+      ...next,
+      linkedRuleIds: sortedUnique(next.linkedRuleIds),
+    });
+    return;
+  }
+  byId.set(next.id, {
+    ...current,
+    label: current.label || next.label,
+    type: current.type || next.type,
+    source: current.source || next.source,
+    linkedRuleIds: sortedUnique([...current.linkedRuleIds, ...next.linkedRuleIds]),
+    referenceState:
+      referenceStatePriority(next.referenceState) > referenceStatePriority(current.referenceState)
+        ? next.referenceState
+        : current.referenceState,
+    note:
+      referenceStatePriority(next.referenceState) > referenceStatePriority(current.referenceState)
+        ? next.note
+        : current.note,
+  });
+}
+
+function buildEvidenceReferenceIndex(input: BuildVvbWorkpaperReportInput): VvbWorkpaperEvidenceReference[] {
+  const byId = new Map<string, VvbWorkpaperEvidenceReference>();
+
+  for (const document of input.suppliedDocuments ?? []) {
+    upsertEvidenceReference(byId, {
+      id: document.id,
+      label: document.label,
+      type: document.type,
+      source: document.note?.trim() || "Supplied document record",
+      linkedRuleIds: [],
+      referenceState: "supplied_document",
+      includedInExport: false,
+      note: document.note?.trim() || "Supplied document record only. File packaging is not implied here.",
+    });
+  }
+
+  for (const gap of input.readinessGaps) {
+    for (const item of gap.linkedEvidence) {
+      upsertEvidenceReference(byId, {
+        id: item.id,
+        label: evidenceLabel(item),
+        type: item.type,
+        source: item.source,
+        linkedRuleIds: [gap.ruleId],
+        referenceState: "linked_evidence",
+        includedInExport: false,
+        note: "Linked workspace evidence reference.",
+      });
+    }
+    for (const item of gap.candidateEvidence) {
+      upsertEvidenceReference(byId, {
+        id: item.id,
+        label: evidenceLabel(item),
+        type: item.type,
+        source: item.source,
+        linkedRuleIds: [gap.ruleId],
+        referenceState: "candidate_evidence",
+        includedInExport: false,
+        note: "Candidate evidence suggestion only. This is not treated as accepted support.",
+      });
+    }
+  }
+
+  for (const [ruleId, review] of Object.entries(input.reviewsByRuleId ?? {})) {
+    for (const attachment of review.evidenceAttachments ?? []) {
+      upsertEvidenceReference(byId, {
+        id: `${ruleId}:${attachment.id}`,
+        label: attachment.label,
+        type: attachment.type,
+        source: attachment.url?.trim() || "Local reviewer attachment reference",
+        linkedRuleIds: [ruleId],
+        referenceState: "review_attachment",
+        includedInExport: false,
+        note:
+          attachment.type === "url" && attachment.url?.trim()
+            ? `Reviewer attachment reference: ${attachment.url.trim()}`
+            : "Reviewer attachment reference only.",
+      });
+    }
+  }
+
+  return Array.from(byId.values()).sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function buildVvbWorkpaperReport(input: BuildVvbWorkpaperReportInput): VvbWorkpaperReport {
+  const readinessGaps = [...input.readinessGaps].sort((a, b) => a.ruleId.localeCompare(b.ruleId));
+  const reviewedCount = readinessGaps.filter((gap) => {
+    const status = input.reviewsByRuleId?.[gap.ruleId]?.status;
+    return status && status !== "pending";
+  }).length;
+  const reviewerArtifactSavedCount = readinessGaps.filter((gap) => reviewerArtifactSaved(input.reviewerArtifactsByRuleId?.[gap.ruleId])).length;
+  const evidenceReferenceIndex = buildEvidenceReferenceIndex(input);
+  const workpaperHeadline =
+    reviewedCount > 0
+      ? "Draft VVB workpaper support assembled from local rule reviews, readiness gaps, and evidence references."
+      : "Draft VVB workpaper support assembled from readiness gaps and evidence references. Reviewer judgments remain largely unrecorded.";
+
+  return {
+    reportId: input.reportId,
+    generatedAt: input.generatedAt,
+    projectMethodVersionContext: {
+      projectName: input.project.name.trim() || "Not provided",
+      projectId: input.project.projectId?.trim() || "Not provided",
+      proponent: input.project.proponent?.trim() || "Not provided",
+      region: input.project.region?.trim() || "Not provided",
+      projectDescription: input.project.description?.trim() || "Not provided",
+      methodologyCode: input.methodology.code.trim(),
+      methodologyVersion: input.methodology.version.trim(),
+      methodologyName: input.methodology.name?.trim() || "Not provided",
+      sector: input.methodology.sector?.trim() || "Not provided",
+    },
+    registryAndProgramContext: {
+      registryProgram: input.registry?.program?.trim() || "Not provided",
+      registryProjectId: input.registry?.projectId?.trim() || "Not provided",
+      note:
+        input.registry?.note?.trim() ||
+        "Registry-specific context is not carried in the current workspace unless it is entered explicitly.",
+    },
+    workpaperStatus: {
+      label: "Draft workpaper support",
+      sourceRunId: input.provenance?.sourceRunId?.trim() || "Unavailable",
+      artifactState: input.provenance?.artifactState?.trim() || "Unavailable",
+      generatedAt: input.generatedAt,
+      note:
+        "This export supports VVB-style workpaper preparation. It does not express a verifier conclusion and does not convert pending rows into satisfied review results.",
+    },
+    executiveSummary: {
+      headline: workpaperHeadline,
+      totals: {
+        rules: readinessGaps.length,
+        reviewed: reviewedCount,
+        pendingOrNotReviewed: readinessGaps.length - reviewedCount,
+        needsFollowup: readinessGaps.filter((gap) => input.reviewsByRuleId?.[gap.ruleId]?.status === "needs_followup").length,
+        missingEvidence: readinessGaps.filter((gap) => gap.state === "missing_evidence" || gap.state === "not_started").length,
+        unknownExpectation: readinessGaps.filter((gap) => gap.state === "unknown_expectation").length,
+        reviewerArtifactSaved: reviewerArtifactSavedCount,
+      },
+      note:
+        "Pending and not-reviewed rows remain draft review records only. Candidate evidence remains suggestion-only until a reviewer explicitly records a judgment.",
+    },
+    ruleReviewWorkpaperTable: readinessGaps.map((gap) => {
+      const review = input.reviewsByRuleId?.[gap.ruleId];
+      const reviewStatus = review?.status ?? "not_reviewed";
+      return {
+        ruleId: gap.ruleId,
+        ruleTitle: gap.title,
+        reviewStatus,
+        reviewStatusLabel: statusLabel(reviewStatus),
+        reviewerRationale: review?.rationale?.trim() || "Not reviewed.",
+        supportReference: review?.supportReference?.trim() || "Not provided.",
+        evidenceLink: review?.evidenceLink?.trim() || "Not provided.",
+        linkedEvidenceRefs: sortedUnique(gap.linkedEvidence.map((item) => item.id)),
+        candidateEvidenceRefs: sortedUnique(gap.candidateEvidence.map((item) => item.id)),
+        attachmentRefs: sortedUnique((review?.evidenceAttachments ?? []).map((item) => item.id)),
+      };
+    }),
+    readinessGapStatus: readinessGaps.map((gap) => ({
+      ruleId: gap.ruleId,
+      ruleTitle: gap.title,
+      readinessState: gap.state,
+      severity: gap.severity,
+      summary: gap.summary,
+      expectedEvidence: gap.expectedEvidenceTypes.map(expectedEvidenceLabel),
+      missingEvidence: gap.missingExpectedEvidenceTypes.map(expectedEvidenceLabel),
+      nextActions: gap.recommendations.map((item) => item.label),
+    })),
+    reviewerArtifactState: readinessGaps.map((gap) => {
+      const artifact = input.reviewerArtifactsByRuleId?.[gap.ruleId];
+      const saved = reviewerArtifactSaved(artifact);
+      return {
+        ruleId: gap.ruleId,
+        ruleTitle: gap.title,
+        state: saved ? "saved" : "missing",
+        savedAt: artifact?.savedAt?.trim() || "Not saved",
+        note: saved
+          ? "Reviewer artifact state is saved for this rule."
+          : "No saved reviewer artifact state is recorded for this rule yet.",
+      };
+    }),
+    evidenceProvenanceReferences: {
+      suppliedDocuments: [...(input.suppliedDocuments ?? [])].sort((a, b) => a.id.localeCompare(b.id)),
+      missingDocuments: [...(input.missingDocuments ?? [])].sort((a, b) => a.id.localeCompare(b.id)),
+      evidenceReferenceIndex,
+      bundleReferences: [
+        {
+          label: "Source Verify run",
+          value: input.provenance?.sourceRunId?.trim() || "Unavailable",
+          availability: input.provenance?.sourceRunId?.trim() ? "available" : "unavailable",
+        },
+        {
+          label: "Snapshot exported at",
+          value: input.provenance?.snapshotExportedAt?.trim() || "Unavailable",
+          availability: input.provenance?.snapshotExportedAt?.trim() ? "available" : "unavailable",
+        },
+        {
+          label: "Finalized at",
+          value: input.provenance?.finalizedAt?.trim() || "Unavailable",
+          availability: input.provenance?.finalizedAt?.trim() ? "available" : "unavailable",
+        },
+        {
+          label: "Audit-pack reference",
+          value: input.provenance?.auditPackReference?.trim() || "Unavailable",
+          availability: input.provenance?.auditPackReference?.trim() ? "available" : "unavailable",
+        },
+        {
+          label: "Client readiness reference",
+          value: input.provenance?.clientReadinessReference?.trim() || "Unavailable",
+          availability: input.provenance?.clientReadinessReference?.trim() ? "available" : "unavailable",
+        },
+        {
+          label: "Trace bundle reference",
+          value: input.provenance?.traceBundleReference?.trim() || "Unavailable",
+          availability: input.provenance?.traceBundleReference?.trim() ? "available" : "unavailable",
+        },
+      ],
+    },
+    limitationsAndNonClaims: {
+      limitations: [
+        "Derived from local Article6 review state, evidence inventory, and readiness logic available at export time.",
+        "Missing evidence, missing reviewer artifact state, and not-reviewed rows remain unresolved at export time.",
+        "Included references are traceability aids only unless separately packaged through another export path.",
+      ],
+      nonClaims: [
+        "This export does not express a verifier conclusion.",
+        "This export does not indicate registry acceptance or project approval.",
+        "This export does not indicate issuance or eligibility of credits.",
+        "This export does not convert pending or candidate-only material into accepted support.",
+      ],
+    },
+    technicalAppendix: {
+      generatedAt: input.generatedAt,
+      stateDefinitions: [
+        { state: "ready", description: stateDescription("ready") },
+        { state: "needs_review", description: stateDescription("needs_review") },
+        { state: "missing_evidence", description: stateDescription("missing_evidence") },
+        { state: "missing_reviewer_record", description: stateDescription("missing_reviewer_record") },
+        { state: "not_started", description: stateDescription("not_started") },
+        { state: "unknown_expectation", description: stateDescription("unknown_expectation") },
+      ],
+    },
+  };
+}

--- a/tests/app/api/exports/vvb-workpaper.route.test.ts
+++ b/tests/app/api/exports/vvb-workpaper.route.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "@jest/globals";
+import type { RequirementCoverageRow } from "@/app/m/_lib/requirementCoverage";
+import { POST } from "@/app/api/exports/vvb-workpaper/route";
+import { deriveRuleReadinessGaps } from "@/lib/readiness/gapEngine";
+import { buildVvbWorkpaperReport } from "@/lib/readiness/vvbWorkpaperReport";
+
+function makeRow(overrides: Partial<RequirementCoverageRow> = {}): RequirementCoverageRow {
+  return {
+    ruleId: "R-1",
+    ruleSummary: {
+      title: "Monitoring frequency",
+      snippet: "Maintain a monitoring report.",
+      when: [],
+      tags: [],
+    },
+    provenance: {
+      tools: [],
+      citations: [],
+    },
+    expectedEvidenceTypes: [],
+    linkedEvidence: [],
+    candidateEvidence: [],
+    status: "missing",
+    ...overrides,
+  };
+}
+
+function makePayload() {
+  const readinessGaps = deriveRuleReadinessGaps({
+    rows: [
+      makeRow({
+        ruleId: "R-1",
+        expectedEvidenceTypes: ["monitoring-report"],
+        linkedEvidence: [{ id: "ev-1", title: "Monitoring report", type: "monitoring-report", source: "inventory" }],
+        status: "partial",
+      }),
+    ],
+    reviewerArtifactsByRuleId: new Map([
+      ["R-1", { savedAt: "2026-05-05T00:00:00Z", outcomeNote: "Saved reviewer artifact." }],
+    ]),
+  });
+
+  const report = buildVvbWorkpaperReport({
+    reportId: "VVB-WP-ROUTE-001",
+    generatedAt: "2026-05-05T00:00:00Z",
+    project: { name: "Delta Mangrove Restoration" },
+    methodology: { code: "AR-ACM0003", version: "v02-0" },
+    readinessGaps,
+    provenance: {
+      sourceRunId: "run-1234",
+      artifactState: "finalized",
+    },
+  });
+
+  return { report };
+}
+
+describe("/api/exports/vvb-workpaper route", () => {
+  it("rejects missing payload pieces", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/exports/vvb-workpaper", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("Missing or invalid VVB workpaper report payload");
+  });
+
+  it("returns a zip attachment for valid report export input", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/exports/vvb-workpaper", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(makePayload()),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+    expect(response.headers.get("Content-Disposition")).toContain('attachment; filename="vvb-draft-workpaper.zip"');
+  });
+});

--- a/tests/components/finalReviewSummaryPanel.test.tsx
+++ b/tests/components/finalReviewSummaryPanel.test.tsx
@@ -182,6 +182,105 @@ describe("FinalReviewSummaryPanel", () => {
     expect(withExport).toContain("Export client readiness report");
   });
 
+  test("shows the VVB draft workpaper export action only when export wiring is provided", () => {
+    const withoutExport = renderToStaticMarkup(
+      <FinalReviewSummaryPanel
+        summary={{
+          methodCode: "AR-ACM0003",
+          version: "v02-0",
+          ruleId: "R-1",
+          ruleSection: "Monitoring period",
+          ruleText: "Evidence must fall inside the monitoring period.",
+          selectedEvidenceId: "stac-1",
+          selectedEvidenceDatetime: "2026-03-25T00:00:00Z",
+          cloudCover: 4.5,
+          aoiLabel: "Project AOI",
+          reviewState: "finalized",
+          generatedAt: "2026-03-25T00:10:00Z",
+          outcomeNote: "Stable result.",
+          stacSearchResultCount: 3,
+          linkedRuleCount: 1,
+          selectedEvidenceLinkedRules: ["R-1"],
+          stacSupportFactsStatus: null,
+          linkedStacSupportFactCount: null,
+          unlinkedStacSupportFactCount: null,
+          checklistStatus: "unused",
+          reconciliationStatus: "Supported",
+          reconciliationReason: "All expected evidence is linked.",
+          narrative: "Finalized verify review.",
+        }}
+        artifact={null}
+        currentRunLabel="run-1234"
+        finalizedAt="2026-03-25T00:10:00Z"
+        reviewedRuleCount={1}
+        linkedEvidenceCount={2}
+        wizard={getVerifyWizardStepDetails({
+          selectedRuleId: "R-1",
+          aoiHash: "aoi",
+          stacItemIds: ["item-1"],
+          selectedStacItemId: "item-1",
+          linkedRuleIds: ["R-1"],
+          reviewerArtifactSavedAt: "2026-03-25T00:05:00Z",
+          finalizedAt: "2026-03-25T00:10:00Z",
+        })}
+        onDownloadJson={() => {}}
+        onDownloadPdf={() => {}}
+        onStartAnotherRun={() => {}}
+        onViewRunHistory={() => {}}
+      />,
+    );
+    expect(withoutExport).not.toContain("Export VVB draft workpaper");
+
+    const withExport = renderToStaticMarkup(
+      <FinalReviewSummaryPanel
+        summary={{
+          methodCode: "AR-ACM0003",
+          version: "v02-0",
+          ruleId: "R-1",
+          ruleSection: "Monitoring period",
+          ruleText: "Evidence must fall inside the monitoring period.",
+          selectedEvidenceId: "stac-1",
+          selectedEvidenceDatetime: "2026-03-25T00:00:00Z",
+          cloudCover: 4.5,
+          aoiLabel: "Project AOI",
+          reviewState: "finalized",
+          generatedAt: "2026-03-25T00:10:00Z",
+          outcomeNote: "Stable result.",
+          stacSearchResultCount: 3,
+          linkedRuleCount: 1,
+          selectedEvidenceLinkedRules: ["R-1"],
+          stacSupportFactsStatus: null,
+          linkedStacSupportFactCount: null,
+          unlinkedStacSupportFactCount: null,
+          checklistStatus: "unused",
+          reconciliationStatus: "Supported",
+          reconciliationReason: "All expected evidence is linked.",
+          narrative: "Finalized verify review.",
+        }}
+        artifact={null}
+        currentRunLabel="run-1234"
+        finalizedAt="2026-03-25T00:10:00Z"
+        reviewedRuleCount={1}
+        linkedEvidenceCount={2}
+        wizard={getVerifyWizardStepDetails({
+          selectedRuleId: "R-1",
+          aoiHash: "aoi",
+          stacItemIds: ["item-1"],
+          selectedStacItemId: "item-1",
+          linkedRuleIds: ["R-1"],
+          reviewerArtifactSavedAt: "2026-03-25T00:05:00Z",
+          finalizedAt: "2026-03-25T00:10:00Z",
+        })}
+        onDownloadJson={() => {}}
+        onDownloadPdf={() => {}}
+        onExportVvbWorkpaper={() => {}}
+        onStartAnotherRun={() => {}}
+        onViewRunHistory={() => {}}
+      />,
+    );
+    expect(withExport).toContain("Export VVB draft workpaper");
+  });
+
   test("keeps reviewer minutes and outcome note in the finalized audit-pack POST body", async () => {
     const artifact: EvidenceSnapshot = {
       method: { code: "AR-ACM0003", version: "v02-0" },

--- a/tests/lib/readiness/vvbWorkpaperExport.test.ts
+++ b/tests/lib/readiness/vvbWorkpaperExport.test.ts
@@ -174,4 +174,27 @@ describe("buildVvbWorkpaperExport", () => {
     expect(reportHtml).toContain("Candidate evidence refs");
     expect(reportHtml).toContain("cand-1");
   });
+
+  test("uses softened buyer-facing review status labels in the exported workpaper", async () => {
+    const result = buildVvbWorkpaperExport({ report: buildSampleReport() });
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const reportRaw = await zip.file("vvb-draft-workpaper/workpaper.json")?.async("string");
+    const reportHtml = (await zip.file("vvb-draft-workpaper/workpaper.html")?.async("string")) ?? "";
+
+    expect(reportRaw).toBeTruthy();
+    const report = JSON.parse(reportRaw ?? "{}") as {
+      ruleReviewWorkpaperTable: Array<{ ruleId: string; reviewStatusLabel: string }>;
+    };
+
+    expect(report.ruleReviewWorkpaperTable.find((row) => row.ruleId === "R-1")?.reviewStatusLabel).toBe(
+      "Reviewer marked supported",
+    );
+    expect(report.ruleReviewWorkpaperTable.find((row) => row.ruleId === "R-2")?.reviewStatusLabel).toBe(
+      "Pending reviewer confirmation",
+    );
+    expect(reportHtml).toContain("Reviewer marked supported");
+    expect(reportHtml).not.toContain(">Verified<");
+    expect(reportHtml).not.toContain(">Not verified<");
+    expect(reportHtml).not.toContain(">Needs follow-up<");
+  });
 });

--- a/tests/lib/readiness/vvbWorkpaperExport.test.ts
+++ b/tests/lib/readiness/vvbWorkpaperExport.test.ts
@@ -197,4 +197,26 @@ describe("buildVvbWorkpaperExport", () => {
     expect(reportHtml).not.toContain(">Not verified<");
     expect(reportHtml).not.toContain(">Needs follow-up<");
   });
+
+  test("allows explicit non-claim language even when it references blocked concepts", () => {
+    const report = buildSampleReport();
+    report.limitationsAndNonClaims.nonClaims = [
+      "This draft workpaper is not a verification opinion.",
+      "This draft workpaper is not registry approval or VVB approval.",
+      "This draft workpaper is not credit issuance or credit eligibility.",
+    ];
+
+    expect(() => buildVvbWorkpaperExport({ report })).not.toThrow();
+  });
+
+  test("still rejects affirmative forbidden claim language", () => {
+    const report = buildSampleReport();
+    report.limitationsAndNonClaims.nonClaims = [
+      "This draft workpaper is a verification opinion.",
+    ];
+
+    expect(() => buildVvbWorkpaperExport({ report })).toThrow(
+      "VVB workpaper export contains forbidden claim language: verification opinion",
+    );
+  });
 });

--- a/tests/lib/readiness/vvbWorkpaperExport.test.ts
+++ b/tests/lib/readiness/vvbWorkpaperExport.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "@jest/globals";
+import JSZip from "jszip";
+import type { RequirementCoverageRow } from "@/app/m/_lib/requirementCoverage";
+import { deriveRuleReadinessGaps } from "@/lib/readiness/gapEngine";
+import { buildVvbWorkpaperExport } from "@/lib/readiness/vvbWorkpaperExport";
+import { buildVvbWorkpaperReport } from "@/lib/readiness/vvbWorkpaperReport";
+
+function makeRow(overrides: Partial<RequirementCoverageRow> = {}): RequirementCoverageRow {
+  return {
+    ruleId: "R-1",
+    ruleSummary: {
+      title: "Monitoring frequency",
+      snippet: "Maintain a monitoring report.",
+      when: [],
+      tags: [],
+    },
+    provenance: {
+      tools: [],
+      citations: [],
+    },
+    expectedEvidenceTypes: [],
+    linkedEvidence: [],
+    candidateEvidence: [],
+    status: "missing",
+    ...overrides,
+  };
+}
+
+function buildSampleReport() {
+  const readinessGaps = deriveRuleReadinessGaps({
+    rows: [
+      makeRow({
+        ruleId: "R-1",
+        expectedEvidenceTypes: ["monitoring-report"],
+        linkedEvidence: [{ id: "ev-1", title: "Monitoring report", type: "monitoring-report", source: "inventory" }],
+        candidateEvidence: [{ id: "cand-1", title: "Candidate workbook", type: "spreadsheet-workbook", source: "inventory" }],
+        status: "partial",
+      }),
+      makeRow({
+        ruleId: "R-2",
+        ruleSummary: {
+          title: "Boundary reconciliation",
+          snippet: "Boundary inputs must reconcile with project records.",
+          when: [],
+          tags: [],
+        },
+        expectedEvidenceTypes: ["pdd", "gis"],
+        status: "missing",
+      }),
+    ],
+    reviewerArtifactsByRuleId: new Map([
+      ["R-1", { savedAt: "2026-05-05T00:00:00Z", outcomeNote: "Saved reviewer artifact." }],
+    ]),
+  });
+
+  return buildVvbWorkpaperReport({
+    reportId: "VVB-WP-001",
+    generatedAt: "2026-05-05T00:00:00Z",
+    project: {
+      name: "Delta Mangrove Restoration",
+      projectId: "Not provided",
+      proponent: "Project Dev Ltd",
+      region: "Indonesia",
+    },
+    methodology: {
+      code: "AR-ACM0003",
+      version: "v02-0",
+      name: "Afforestation and reforestation",
+    },
+    suppliedDocuments: [{ id: "doc-1", label: "Project Design Document", type: "pdd" }],
+    missingDocuments: [{ id: "missing-gis", label: "GIS / map evidence", type: "gis" }],
+    readinessGaps,
+    reviewsByRuleId: {
+      "R-1": {
+        status: "verified",
+        rationale: "Monitoring report covers the period.",
+        supportReference: "PDD section 3 and linked monitoring report.",
+        evidenceAttachments: [{ id: "att-1", type: "url", label: "Monitoring report URL", url: "https://example.test/report", addedAt: "2026-05-05T00:00:00Z" }],
+        reviewedBy: "local-reviewer",
+        reviewedAt: "2026-05-05T00:00:00Z",
+        updatedAt: "2026-05-05T00:00:00Z",
+      },
+      "R-2": {
+        status: "pending",
+        rationale: "",
+        supportReference: "",
+        evidenceAttachments: [],
+        reviewedBy: "",
+        reviewedAt: "",
+        updatedAt: "2026-05-05T00:00:00Z",
+      },
+    },
+    reviewerArtifactsByRuleId: {
+      "R-1": { savedAt: "2026-05-05T00:00:00Z", outcomeNote: "Saved reviewer artifact." },
+    },
+    provenance: {
+      sourceRunId: "run-1234",
+      artifactState: "finalized",
+      snapshotExportedAt: "2026-05-05T00:00:00Z",
+      finalizedAt: "2026-05-05T00:00:00Z",
+      auditPackReference: "audit-pack.AR-ACM0003.v02-0.run-1234.zip",
+      clientReadinessReference: "CRR-AR-ACM0003-v02-0-run-1234",
+      traceBundleReference: "verify-run:run-1234",
+    },
+  });
+}
+
+describe("buildVvbWorkpaperExport", () => {
+  test("packages the workpaper report, appendix, and evidence index into a deterministic zip", async () => {
+    const first = buildVvbWorkpaperExport({ report: buildSampleReport() });
+    const second = buildVvbWorkpaperExport({ report: buildSampleReport() });
+
+    expect(first.zipBytes.equals(second.zipBytes)).toBe(true);
+
+    const zip = await JSZip.loadAsync(first.zipBytes);
+    const paths = Object.keys(zip.files).sort();
+    expect(paths).toEqual([
+      "manifest.json",
+      "vvb-draft-workpaper/appendix/evidence-reference-index.json",
+      "vvb-draft-workpaper/appendix/workpaper-traceability.json",
+      "vvb-draft-workpaper/workpaper.html",
+      "vvb-draft-workpaper/workpaper.json",
+    ]);
+  });
+
+  test("keeps forbidden verifier, registry, and issuance claims out of exported artifacts", async () => {
+    const result = buildVvbWorkpaperExport({ report: buildSampleReport() });
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const html = (await zip.file("vvb-draft-workpaper/workpaper.html")?.async("string")) ?? "";
+    const appendix = (await zip.file("vvb-draft-workpaper/appendix/workpaper-traceability.json")?.async("string")) ?? "";
+    const serialized = `${html}\n${appendix}`.toLowerCase();
+
+    expect(serialized).not.toContain("verification opinion");
+    expect(serialized).not.toContain("formal verification opinion");
+    expect(serialized).not.toContain("registry approval");
+    expect(serialized).not.toContain("credit issuance");
+    expect(serialized).not.toContain("credit eligibility");
+    expect(serialized).not.toContain("vvb approval");
+  });
+
+  test("keeps candidate evidence distinct from linked support and preserves traceability", async () => {
+    const result = buildVvbWorkpaperExport({ report: buildSampleReport() });
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const appendixRaw = await zip.file("vvb-draft-workpaper/appendix/workpaper-traceability.json")?.async("string");
+    const evidenceIndexRaw = await zip.file("vvb-draft-workpaper/appendix/evidence-reference-index.json")?.async("string");
+    const reportHtml = (await zip.file("vvb-draft-workpaper/workpaper.html")?.async("string")) ?? "";
+
+    expect(appendixRaw).toBeTruthy();
+    expect(evidenceIndexRaw).toBeTruthy();
+
+    const appendix = JSON.parse(appendixRaw ?? "{}") as {
+      reportId: string;
+      traceability: {
+        rules: Array<{
+          ruleId: string;
+          candidateEvidenceRefs: string[];
+        }>;
+      };
+    };
+    const evidenceIndex = JSON.parse(evidenceIndexRaw ?? "[]") as Array<{
+      id: string;
+      referenceState: string;
+      note: string;
+    }>;
+
+    expect(appendix.reportId).toBe("VVB-WP-001");
+    expect(appendix.traceability.rules.find((rule) => rule.ruleId === "R-1")?.candidateEvidenceRefs).toEqual(["cand-1"]);
+    expect(evidenceIndex.find((item) => item.id === "cand-1")).toEqual(
+      expect.objectContaining({
+        referenceState: "candidate_evidence",
+        note: expect.stringContaining("Candidate evidence suggestion only"),
+      }),
+    );
+    expect(reportHtml).toContain("Candidate evidence refs");
+    expect(reportHtml).toContain("cand-1");
+  });
+});

--- a/tests/lib/readiness/vvbWorkpaperExport.test.ts
+++ b/tests/lib/readiness/vvbWorkpaperExport.test.ts
@@ -175,6 +175,62 @@ describe("buildVvbWorkpaperExport", () => {
     expect(reportHtml).toContain("cand-1");
   });
 
+  test("distinguishes active-run provenance from workspace-local review state", async () => {
+    const result = buildVvbWorkpaperExport({ report: buildSampleReport() });
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const reportRaw = await zip.file("vvb-draft-workpaper/workpaper.json")?.async("string");
+    expect(reportRaw).toBeTruthy();
+
+    const report = JSON.parse(reportRaw ?? "{}") as {
+      workpaperStatus: {
+        sourceRunId: string;
+        sourceRunScope: string;
+        reviewRecordScope: string;
+        note: string;
+      };
+      evidenceProvenanceReferences: {
+        bundleReferences: Array<{ label: string; value: string }>;
+      };
+      ruleReviewWorkpaperTable: Array<{ ruleId: string; reviewRecordScopeLabel: string }>;
+    };
+
+    expect(report.workpaperStatus.sourceRunId).toBe("run-1234");
+    expect(report.workpaperStatus.sourceRunScope).toBe("active_verify_run");
+    expect(report.workpaperStatus.reviewRecordScope).toBe("workspace_method_version");
+    expect(report.workpaperStatus.note).toContain("workspace-level method/version records");
+    expect(report.evidenceProvenanceReferences.bundleReferences).toContainEqual(
+      expect.objectContaining({
+        label: "Review record scope",
+        value: "Workspace-local method/version review state",
+      }),
+    );
+    expect(report.ruleReviewWorkpaperTable.find((row) => row.ruleId === "R-1")?.reviewRecordScopeLabel).toBe(
+      "Workspace-local method/version review state",
+    );
+  });
+
+  test("makes attachment refs resolvable against the evidence reference index", async () => {
+    const result = buildVvbWorkpaperExport({ report: buildSampleReport() });
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const reportRaw = await zip.file("vvb-draft-workpaper/workpaper.json")?.async("string");
+    const evidenceIndexRaw = await zip.file("vvb-draft-workpaper/appendix/evidence-reference-index.json")?.async("string");
+    expect(reportRaw).toBeTruthy();
+    expect(evidenceIndexRaw).toBeTruthy();
+
+    const report = JSON.parse(reportRaw ?? "{}") as {
+      ruleReviewWorkpaperTable: Array<{ ruleId: string; attachmentRefs: string[] }>;
+    };
+    const evidenceIndex = JSON.parse(evidenceIndexRaw ?? "[]") as Array<{ id: string; referenceState: string }>;
+
+    const attachmentRefs = report.ruleReviewWorkpaperTable.find((row) => row.ruleId === "R-1")?.attachmentRefs ?? [];
+    expect(attachmentRefs).toEqual(["R-1:att-1"]);
+    for (const ref of attachmentRefs) {
+      expect(evidenceIndex.find((item) => item.id === ref)).toEqual(
+        expect.objectContaining({ id: ref, referenceState: "review_attachment" }),
+      );
+    }
+  });
+
   test("uses softened buyer-facing review status labels in the exported workpaper", async () => {
     const result = buildVvbWorkpaperExport({ report: buildSampleReport() });
     const zip = await JSZip.loadAsync(result.zipBytes);


### PR DESCRIPTION
Roadmap: commercial sales-readiness lane
Roadmap-Item: phase_5_vvb_workpaper_export
SSOT: docs/roadmaps/project-readiness-verification-output/phase-status.json

### Roadmap-Update
- slug: project-readiness-verification-output
- items:
  - RC5: active

## WHAT

- Add a VVB-facing draft workpaper export using existing review, evidence, readiness, and provenance data
- Keep the export explicitly limited to workpaper support and readiness evidence
- Preserve truthful missing-field handling and non-claim language

## WHY

- Phase 4 completed the client readiness report
- Phase 5 is the next roadmap step for sellable VVB-facing outputs
- VVB workpapers are commercially useful without claiming Article6 performs formal verification

**Signed-off-by:** Fred E <fredilly@article6.org>