### PR TITLE
Upgrade exported HTML reports with premium Article6 styling

### DIFF
--- a/src/lib/readiness/clientReadinessExport.tsx
+++ b/src/lib/readiness/clientReadinessExport.tsx
@@ -4,6 +4,13 @@ import type { RequirementCoverageExpectedEvidenceType } from "@/app/m/_lib/requi
 import { canonicalStringify, sha256Hex } from "@/integrity/artifacts";
 import type { ClientReadinessReport } from "@/lib/readiness/clientReadinessReport";
 import type { RuleReadinessGap } from "@/lib/readiness/gapEngine";
+import {
+  escapeHtml,
+  joinEscaped,
+  renderList,
+  renderMetricCard,
+  renderReportHtmlDocument,
+} from "@/lib/readiness/reportHtmlTheme";
 
 export type ClientReadinessAppendixArtifact = {
   kind: "article6.client_readiness_appendix";
@@ -103,30 +110,12 @@ function evidenceLabel(item: RuleReadinessGap["linkedEvidence"][number]): string
   return item.title?.trim() || item.fragmentLabel?.trim() || item.documentLabel?.trim() || item.id;
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-function joinEscaped(values: string[], fallback: string): string {
-  return values.length ? values.map(escapeHtml).join(", ") : escapeHtml(fallback);
-}
-
-function renderList(items: string[], empty: string): string {
-  if (!items.length) return `<p>${escapeHtml(empty)}</p>`;
-  return `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
-}
-
 function renderRuleRows(report: ClientReadinessReport): string {
   return report.ruleFindingsMatrix
     .map(
       (item) => `
         <tr>
-          <td><strong>${escapeHtml(item.ruleId)}</strong><br /><span>${escapeHtml(item.ruleTitle)}</span></td>
+          <td><span class="cell-title">${escapeHtml(item.ruleId)}</span><span class="cell-subtitle">${escapeHtml(item.ruleTitle)}</span></td>
           <td>${escapeHtml(item.category.replaceAll("_", " "))}</td>
           <td>${escapeHtml(item.severity)}</td>
           <td>${escapeHtml(item.assessment)}${
@@ -145,7 +134,7 @@ function renderEvidenceChecklistRows(report: ClientReadinessReport): string {
     .map(
       (item) => `
         <tr>
-          <td><strong>${escapeHtml(item.ruleId)}</strong><br /><span>${escapeHtml(item.ruleTitle)}</span></td>
+          <td><span class="cell-title">${escapeHtml(item.ruleId)}</span><span class="cell-subtitle">${escapeHtml(item.ruleTitle)}</span></td>
           <td>${joinEscaped(item.expectedEvidence, "No encoded expectation listed.")}</td>
           <td>${joinEscaped(item.linkedEvidence, "No linked evidence yet.")}</td>
           <td>${joinEscaped(item.missingEvidence, "No missing evidence listed.")}</td>
@@ -157,8 +146,10 @@ function renderEvidenceChecklistRows(report: ClientReadinessReport): string {
 
 function renderOpenFindingsGroup(title: string, description: string, items: ClientReadinessReport["openFindings"]["missingEvidence"]): string {
   return `
-    <section>
-      <h3>${escapeHtml(title)}</h3>
+    <section class="report-section">
+      <div class="section-kicker">Open findings</div>
+      <h3 class="section-title">${escapeHtml(title)}</h3>
+      <div class="section-body">
       <p>${escapeHtml(description)}</p>
       ${
         items.length
@@ -167,101 +158,108 @@ function renderOpenFindingsGroup(title: string, description: string, items: Clie
                 (item) => `<li><strong>${escapeHtml(item.ruleId)}</strong> ${escapeHtml(item.ruleTitle)} · ${escapeHtml(item.severity)} · ${escapeHtml(item.assessment)} · Next: ${joinEscaped(item.nextActions, "Reviewer follow-up still needs to be defined.")}</li>`,
               )
               .join("")}</ul>`
-          : "<p>No items in this group right now.</p>"
+          : '<p class="empty-note">No items in this group right now.</p>'
       }
+      </div>
     </section>`
 }
 
 function reportHtmlDocument(report: ClientReadinessReport): string {
   const context = report.projectAndMethodologyContext;
   const totals = report.executiveReadinessSummary.totals;
+  const executiveCards = [
+    renderMetricCard("Readiness position", report.executiveReadinessSummary.readinessPosition),
+    renderMetricCard("Ready", String(totals.ready), `${totals.rules} assessed rule${totals.rules === 1 ? "" : "s"}`),
+    renderMetricCard("Missing or not started", String(totals.missingEvidence), `${totals.notStarted} not-started item${totals.notStarted === 1 ? "" : "s"}`),
+    renderMetricCard("Reviewer judgment needed", String(totals.reviewerJudgmentNeeded), `${totals.clarificationNeeded} clarification item${totals.clarificationNeeded === 1 ? "" : "s"}`),
+  ].join("");
   const body = `
-    <article>
-      <section>
-        <p><strong>Client readiness report</strong> · <strong>Pre-verification readiness assessment</strong></p>
-        <h1>${escapeHtml(context.projectName)}</h1>
-        <p>${escapeHtml(context.methodologyCode)}@${escapeHtml(context.methodologyVersion)}${context.methodologyName ? ` · ${escapeHtml(context.methodologyName)}` : ""}</p>
-        <p>${escapeHtml(report.executiveReadinessSummary.headline)}</p>
-        <p>This readiness report is a client-facing preparation tool. It is not a verifier decision and does not determine registration, issuance, or quantified carbon outcomes.</p>
-        <dl>
-          ${context.projectId ? `<dt>Project ID</dt><dd>${escapeHtml(context.projectId)}</dd>` : ""}
-          ${context.proponent ? `<dt>Proponent</dt><dd>${escapeHtml(context.proponent)}</dd>` : ""}
-          ${context.region ? `<dt>Region</dt><dd>${escapeHtml(context.region)}</dd>` : ""}
-          ${context.sector ? `<dt>Sector</dt><dd>${escapeHtml(context.sector)}</dd>` : ""}
-          <dt>Report ID</dt><dd>${escapeHtml(report.reportId)}</dd>
-          <dt>Generated</dt><dd>${escapeHtml(report.technicalAppendix.generatedAt)}</dd>
-        </dl>
+      <section class="report-section">
+        <div class="section-kicker">Executive summary</div>
+        <h2 class="section-title">Readiness position</h2>
+        <div class="section-body">
+          <p>Totals are readiness categories, not a formal assurance score. Missing evidence may overlap with rules that are also not started.</p>
+          ${renderList(report.executiveReadinessSummary.highlights, "No highlights listed.")}
+        </div>
       </section>
 
-      <section>
-        <h2>Executive Readiness Summary</h2>
-        <p>Totals are readiness categories, not a formal assurance score. Missing evidence may include rules that are also not started.</p>
-        <ul>
-          <li>Position: ${escapeHtml(report.executiveReadinessSummary.readinessPosition)}</li>
-          <li>Ready: ${totals.ready}</li>
-          <li>Missing evidence / not started: ${totals.missingEvidence} (includes ${totals.notStarted} not-started items)</li>
-          <li>Clarification needed: ${totals.clarificationNeeded}</li>
-          <li>Reviewer judgment needed: ${totals.reviewerJudgmentNeeded}</li>
-          <li>Unknown / not assessable: ${totals.unknownOrNotAssessable}</li>
-        </ul>
-        ${renderList(report.executiveReadinessSummary.highlights, "No highlights listed.")}
+      <section class="report-section">
+        <div class="section-kicker">Scope</div>
+        <h2 class="section-title">Scope, criteria, and limits</h2>
+        <div class="section-body">
+          <p>${escapeHtml(report.scopeCriteriaAndLimits.reportPurpose)}</p>
+          <p>${escapeHtml(report.scopeCriteriaAndLimits.scopeSummary)}</p>
+          <h3 class="subsection-title">Criteria basis</h3>
+          ${renderList(report.scopeCriteriaAndLimits.criteriaBasis, "No criteria basis listed.")}
+        </div>
       </section>
 
-      <section>
-        <h2>Scope, Criteria, and Limits</h2>
-        <p>${escapeHtml(report.scopeCriteriaAndLimits.reportPurpose)}</p>
-        <p>${escapeHtml(report.scopeCriteriaAndLimits.scopeSummary)}</p>
-        ${renderList(report.scopeCriteriaAndLimits.criteriaBasis, "No criteria basis listed.")}
+      <section class="report-section">
+        <div class="section-kicker">Project context</div>
+        <h2 class="section-title">Project and methodology context</h2>
+        <div class="section-body">
+          ${context.projectDescription ? `<p>${escapeHtml(context.projectDescription)}</p>` : '<p class="empty-note">No project description provided.</p>'}
+          <div class="pill-row">
+            <span class="pill">${escapeHtml(context.methodologyCode)}@${escapeHtml(context.methodologyVersion)}</span>
+            ${context.methodologyName ? `<span class="pill">${escapeHtml(context.methodologyName)}</span>` : ""}
+            ${context.sector ? `<span class="pill">${escapeHtml(context.sector)}</span>` : ""}
+          </div>
+        </div>
       </section>
 
-      <section>
-        <h2>Project and Methodology Context</h2>
-        ${context.projectDescription ? `<p>${escapeHtml(context.projectDescription)}</p>` : ""}
-        <p>${escapeHtml(context.methodologyCode)}@${escapeHtml(context.methodologyVersion)}</p>
-      </section>
-
-      <section>
-        <h2>Documents Reviewed</h2>
-        <h3>Supplied documents</h3>
+      <section class="report-section">
+        <div class="section-kicker">Evidence base</div>
+        <h2 class="section-title">Documents reviewed</h2>
+        <div class="section-body">
+        <h3 class="subsection-title">Supplied documents</h3>
         ${
           report.documentsReviewed.suppliedDocuments.length
             ? `<ul>${report.documentsReviewed.suppliedDocuments
                 .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)}${item.note ? ` · ${escapeHtml(item.note)}` : ""}</li>`)
                 .join("")}</ul>`
-            : "<p>No supplied documents are listed yet.</p>"
+            : '<p class="empty-note">No supplied documents are listed yet.</p>'
         }
-        <h3>Reviewed evidence</h3>
+        <h3 class="subsection-title">Reviewed evidence</h3>
         ${
           report.documentsReviewed.reviewedEvidence.length
             ? `<ul>${report.documentsReviewed.reviewedEvidence
                 .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)} · linked to ${joinEscaped(item.linkedRuleIds, "")}</li>`)
                 .join("")}</ul>`
-            : "<p>No reviewed evidence is linked yet.</p>"
+            : '<p class="empty-note">No reviewed evidence is linked yet.</p>'
         }
+        </div>
       </section>
 
-      <section>
-        <h2>Missing Documents</h2>
+      <section class="report-section">
+        <div class="section-kicker">Missing inputs</div>
+        <h2 class="section-title">Missing documents</h2>
+        <div class="section-body">
         ${
           report.documentsReviewed.missingDocuments.length
             ? `<ul>${report.documentsReviewed.missingDocuments
                 .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)}${item.note ? ` · ${escapeHtml(item.note)}` : ""}</li>`)
                 .join("")}</ul>`
-            : "<p>No missing documents are listed right now.</p>"
+            : '<p class="empty-note">No missing documents are listed right now.</p>'
         }
+        </div>
       </section>
 
-      <section>
-        <h2>Readiness Assessment Approach</h2>
-        <p>${escapeHtml(report.readinessAssessmentApproach.approachSummary)}</p>
-        <p><strong>Evidence policy:</strong> ${escapeHtml(report.readinessAssessmentApproach.evidencePolicy)}</p>
-        <p><strong>Reviewer judgment policy:</strong> ${escapeHtml(report.readinessAssessmentApproach.reviewerJudgmentPolicy)}</p>
+      <section class="report-section">
+        <div class="section-kicker">Method</div>
+        <h2 class="section-title">Readiness assessment approach</h2>
+        <div class="section-body">
+          <p>${escapeHtml(report.readinessAssessmentApproach.approachSummary)}</p>
+          <p><strong>Evidence policy:</strong> ${escapeHtml(report.readinessAssessmentApproach.evidencePolicy)}</p>
+          <p><strong>Reviewer judgment policy:</strong> ${escapeHtml(report.readinessAssessmentApproach.reviewerJudgmentPolicy)}</p>
+        </div>
       </section>
 
-      <section>
-        <h2>Rule Findings Matrix</h2>
-        <p>VVB-shaped rule findings for readiness review only. These rows summarize readiness conditions, not a verifier conclusion.</p>
-        <table>
+      <section class="report-section">
+        <div class="section-kicker">Findings</div>
+        <h2 class="section-title">Rule findings matrix</h2>
+        <div class="section-body">
+        <p>These rows summarize readiness conditions, not a verifier conclusion.</p>
+        <table class="report-table">
           <thead>
             <tr><th>Rule</th><th>Category</th><th>Severity</th><th>Assessment</th><th>Next actions</th></tr>
           </thead>
@@ -269,20 +267,20 @@ function reportHtmlDocument(report: ClientReadinessReport): string {
             ${renderRuleRows(report)}
           </tbody>
         </table>
+        </div>
       </section>
 
-      <section>
-        <h2>Open Findings</h2>
         ${renderOpenFindingsGroup("Open Findings: Missing Evidence", "Rules that still need expected evidence or have not yet started from a readiness standpoint.", report.openFindings.missingEvidence)}
         ${renderOpenFindingsGroup("Open Findings: Clarification Needed", "Rules that still need reviewer clarification before the readiness record is stable.", report.openFindings.clarificationNeeded)}
         ${renderOpenFindingsGroup("Open Findings: Reviewer Judgment Needed", "Rules with linked evidence but without a sufficiently recorded reviewer judgment.", report.openFindings.reviewerJudgmentNeeded)}
         ${renderOpenFindingsGroup("Open Findings: Unknown or Not Assessable", "Rules where encoded expectations are still incomplete or not yet assessable.", report.openFindings.unknownOrNotAssessable)}
-      </section>
 
-      <section>
-        <h2>Evidence Checklist</h2>
+      <section class="report-section">
+        <div class="section-kicker">Checklist</div>
+        <h2 class="section-title">Evidence checklist</h2>
+        <div class="section-body">
         <p>Expected, linked, and still-missing evidence are shown rule by rule.</p>
-        <table>
+        <table class="report-table">
           <thead>
             <tr><th>Rule</th><th>Expected</th><th>Linked</th><th>Missing</th><th>State</th></tr>
           </thead>
@@ -290,57 +288,66 @@ function reportHtmlDocument(report: ClientReadinessReport): string {
             ${renderEvidenceChecklistRows(report)}
           </tbody>
         </table>
+        </div>
       </section>
 
-      <section>
-        <h2>Recommended Corrective Actions</h2>
+      <section class="report-section">
+        <div class="section-kicker">Actions</div>
+        <h2 class="section-title">Recommended corrective actions</h2>
+        <div class="section-body">
         ${
           report.recommendedCorrectiveActions.items.length
             ? `<ul>${report.recommendedCorrectiveActions.items
                 .map((item) => `<li><strong>${escapeHtml(item.ruleId)}</strong> ${escapeHtml(item.ruleTitle)} · ${escapeHtml(item.priority)} priority · ${escapeHtml(item.action)} · ${escapeHtml(item.basis)}</li>`)
                 .join("")}</ul>`
-            : "<p>No corrective actions are currently listed because all assessed rules are marked ready for readiness review.</p>"
+            : '<p class="empty-note">No corrective actions are currently listed because all assessed rules are marked ready for readiness review.</p>'
         }
+        </div>
       </section>
 
-      <section>
-        <h2>Limitations</h2>
+      <section class="report-section">
+        <div class="section-kicker">Limits</div>
+        <h2 class="section-title">Limitations</h2>
+        <div class="section-body">
         ${renderList([...report.executiveReadinessSummary.limitations, ...report.scopeCriteriaAndLimits.limitations], "No limitations listed.")}
+        </div>
       </section>
 
-      <section>
-        <h2>Technical Appendix</h2>
-        <p>Appendix material is included for HTML/PDF export readiness and reviewer traceability.</p>
+      <section class="report-section">
+        <div class="section-kicker">Appendix</div>
+        <h2 class="section-title">Technical appendix</h2>
+        <div class="section-body">
+        <p>Appendix material is included for HTML and PDF export readiness and reviewer traceability.</p>
+        <h3 class="subsection-title">Disclaimers</h3>
         ${renderList(report.technicalAppendix.disclaimers, "No appendix disclaimers listed.")}
-        <h3>State definitions</h3>
+        <h3 class="subsection-title">State definitions</h3>
         ${renderList(report.technicalAppendix.stateDefinitions.map((item) => `${item.state.replaceAll("_", " ")} · ${item.description}`), "No state definitions listed.")}
-        <h3>Evidence reference index</h3>
+        <h3 class="subsection-title">Evidence reference index</h3>
         ${
           report.technicalAppendix.evidenceReferenceIndex.length
             ? `<ul>${report.technicalAppendix.evidenceReferenceIndex
                 .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)} · linked to ${joinEscaped(item.linkedRuleIds, "")}</li>`)
                 .join("")}</ul>`
-            : "<p>No evidence references are indexed yet.</p>"
+            : '<p class="empty-note">No evidence references are indexed yet.</p>'
         }
-      </section>
-    </article>`;
-  return [
-    "<!DOCTYPE html>",
-    '<html lang="en">',
-    "<head>",
-    '<meta charSet="utf-8" />',
-    '<meta name="viewport" content="width=device-width, initial-scale=1" />',
-    `<title>${report.projectAndMethodologyContext.projectName} client readiness report</title>`,
-    "<style>",
-    "body{margin:0;background:#f8fafc;color:#0f172a;font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;}",
-    ".report-shell{max-width:1040px;margin:0 auto;padding:24px;}",
-    "</style>",
-    "</head>",
-    "<body>",
-    `<div class="report-shell">${body}</div>`,
-    "</body>",
-    "</html>",
-  ].join("");
+        </div>
+      </section>`;
+  return renderReportHtmlDocument({
+    title: report.executiveReadinessSummary.headline,
+    reportType: "Client Readiness Report",
+    scopeLabel: "Pre-verification readiness assessment",
+    reportId: report.reportId,
+    generatedAt: report.technicalAppendix.generatedAt,
+    methodologyLabel: `${context.methodologyCode}@${context.methodologyVersion}`,
+    contextLabel: context.methodologyName || context.projectName,
+    bannerTitle: "Scope and non-claim notice",
+    bannerBody:
+      "This Article6 report is a readiness support deliverable. It does not express a verifier decision and does not determine registration, issuance, or quantified carbon outcomes.",
+    heroSummary: `Article6 ${context.projectName} client readiness report`,
+    executiveCards,
+    body,
+    footerNote: "Readiness support only. Article6 does not issue a verifier decision in this export.",
+  });
 }
 
 function assertNoForbiddenClaims(serialized: string): void {

--- a/src/lib/readiness/reportHtmlTheme.ts
+++ b/src/lib/readiness/reportHtmlTheme.ts
@@ -1,0 +1,143 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function joinEscaped(values: string[], fallback: string): string {
+  return values.length ? values.map(escapeHtml).join(", ") : escapeHtml(fallback);
+}
+
+export function renderList(items: string[], empty: string): string {
+  if (!items.length) return `<p class="empty-note">${escapeHtml(empty)}</p>`;
+  return `<ul class="detail-list">${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
+}
+
+export function renderMetricCard(label: string, value: string, note?: string): string {
+  return `
+    <div class="metric-card">
+      <div class="metric-label">${escapeHtml(label)}</div>
+      <div class="metric-value">${escapeHtml(value)}</div>
+      ${note ? `<div class="metric-note">${escapeHtml(note)}</div>` : ""}
+    </div>`;
+}
+
+export function renderKeyValueGrid(items: Array<{ label: string; value: string }>): string {
+  return `
+    <dl class="meta-grid">
+      ${items
+        .map(
+          (item) => `
+            <div class="meta-item">
+              <dt>${escapeHtml(item.label)}</dt>
+              <dd>${escapeHtml(item.value)}</dd>
+            </div>`,
+        )
+        .join("")}
+    </dl>`;
+}
+
+export function renderReportHtmlDocument(input: {
+  title: string;
+  reportType: string;
+  scopeLabel: string;
+  reportId: string;
+  generatedAt: string;
+  methodologyLabel: string;
+  contextLabel?: string;
+  bannerTitle: string;
+  bannerBody: string;
+  heroSummary: string;
+  executiveCards: string;
+  body: string;
+  footerNote: string;
+}): string {
+  return [
+    "<!DOCTYPE html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charSet="utf-8" />',
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />',
+    `<title>${escapeHtml(input.title)}</title>`,
+    "<style>",
+    "body{margin:0;background:#f3f6f8;color:#0f172a;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;}",
+    ".report-shell{max-width:1120px;margin:0 auto;padding:28px 24px 40px;}",
+    ".report-page{background:#fff;border:1px solid #dbe3ea;border-radius:28px;box-shadow:0 24px 80px rgba(15,23,42,.08);overflow:hidden;}",
+    ".report-header{padding:28px 32px 22px;background:linear-gradient(180deg,#f8fbfc 0%,#ffffff 100%);border-bottom:1px solid #e2e8f0;}",
+    ".brand-row{display:flex;justify-content:space-between;gap:20px;align-items:flex-start;flex-wrap:wrap;}",
+    ".brand-mark{display:inline-flex;align-items:center;gap:10px;font-size:13px;font-weight:700;letter-spacing:.18em;text-transform:uppercase;color:#0f172a;}",
+    ".brand-dot{width:12px;height:12px;border-radius:999px;background:linear-gradient(135deg,#0f172a 0%,#2563eb 100%);box-shadow:0 0 0 6px rgba(37,99,235,.08);}",
+    ".scope-chip{display:inline-flex;align-items:center;border:1px solid #cbd5e1;border-radius:999px;padding:7px 12px;font-size:12px;font-weight:600;color:#334155;background:#fff;}",
+    ".report-title{margin:18px 0 6px;font-size:34px;line-height:1.05;font-weight:700;letter-spacing:-.03em;color:#020617;}",
+    ".report-subtitle{margin:0;color:#475569;font-size:15px;line-height:1.6;max-width:820px;}",
+    ".meta-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;margin:22px 0 0;padding:0;}",
+    ".meta-item{padding:14px 16px;border:1px solid #e2e8f0;border-radius:18px;background:#fbfdff;min-width:0;}",
+    ".meta-item dt{font-size:11px;line-height:1.3;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:#64748b;margin:0 0 7px;}",
+    ".meta-item dd{margin:0;font-size:14px;line-height:1.45;color:#0f172a;word-break:break-word;}",
+    ".banner{margin:20px 0 0;padding:16px 18px;border:1px solid #bfdbfe;border-radius:18px;background:linear-gradient(180deg,#eff6ff 0%,#f8fbff 100%);}",
+    ".banner-title{margin:0 0 6px;font-size:12px;line-height:1.3;font-weight:800;letter-spacing:.16em;text-transform:uppercase;color:#1d4ed8;}",
+    ".banner-body{margin:0;font-size:14px;line-height:1.6;color:#1e293b;}",
+    ".hero-summary{padding:0 32px 26px;font-size:16px;line-height:1.75;color:#334155;}",
+    ".executive-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;padding:0 32px 26px;}",
+    ".metric-card{padding:16px 18px;border:1px solid #dbe3ea;border-radius:20px;background:#fff;box-shadow:inset 0 1px 0 rgba(255,255,255,.8);}",
+    ".metric-label{font-size:11px;line-height:1.3;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:#64748b;}",
+    ".metric-value{margin-top:10px;font-size:28px;line-height:1;font-weight:700;letter-spacing:-.03em;color:#0f172a;}",
+    ".metric-note{margin-top:8px;font-size:12px;line-height:1.5;color:#64748b;}",
+    ".report-body{padding:6px 32px 36px;}",
+    ".report-section{padding:22px 0;border-top:1px solid #eef2f7;}",
+    ".report-section:first-child{border-top:0;padding-top:10px;}",
+    ".section-kicker{margin:0 0 6px;font-size:11px;line-height:1.3;font-weight:800;letter-spacing:.16em;text-transform:uppercase;color:#94a3b8;}",
+    ".section-title{margin:0;font-size:22px;line-height:1.2;font-weight:700;letter-spacing:-.02em;color:#020617;}",
+    ".section-body{margin-top:14px;font-size:14px;line-height:1.75;color:#334155;}",
+    ".section-body p{margin:0 0 12px;}",
+    ".section-body p:last-child{margin-bottom:0;}",
+    ".detail-list{margin:0;padding-left:20px;display:grid;gap:8px;color:#334155;}",
+    ".empty-note{margin:0;color:#64748b;font-style:italic;}",
+    ".subsection-title{margin:18px 0 8px;font-size:12px;line-height:1.3;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:#475569;}",
+    ".pill-row{display:flex;flex-wrap:wrap;gap:8px;}",
+    ".pill{display:inline-flex;align-items:center;padding:7px 11px;border-radius:999px;border:1px solid #dbe3ea;background:#f8fafc;font-size:12px;line-height:1.2;font-weight:600;color:#334155;}",
+    "table.report-table{width:100%;border-collapse:separate;border-spacing:0;margin-top:14px;border:1px solid #dbe3ea;border-radius:20px;overflow:hidden;background:#fff;}",
+    ".report-table thead th{padding:12px 14px;background:#f8fafc;border-bottom:1px solid #dbe3ea;font-size:11px;line-height:1.4;font-weight:800;letter-spacing:.13em;text-transform:uppercase;color:#475569;text-align:left;vertical-align:top;}",
+    ".report-table tbody td{padding:14px;border-bottom:1px solid #eef2f7;font-size:13px;line-height:1.6;color:#1e293b;vertical-align:top;}",
+    ".report-table tbody tr:nth-child(even) td{background:#fbfdff;}",
+    ".report-table tbody tr:last-child td{border-bottom:0;}",
+    ".cell-title{display:block;font-weight:700;color:#020617;}",
+    ".cell-subtitle{display:block;margin-top:4px;color:#64748b;}",
+    ".report-footer{display:flex;justify-content:space-between;gap:16px;flex-wrap:wrap;padding:18px 32px 28px;border-top:1px solid #e2e8f0;background:#fcfdff;color:#64748b;font-size:12px;line-height:1.6;}",
+    ".footer-brand{font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#0f172a;}",
+    "@media print{body{background:#fff}.report-shell{max-width:none;padding:0}.report-page{box-shadow:none;border:0;border-radius:0}.report-header,.hero-summary,.executive-grid,.report-body,.report-footer{padding-left:20px;padding-right:20px}.banner,.meta-item,.metric-card,.report-table{break-inside:avoid}}",
+    "@media (max-width:900px){.meta-grid,.executive-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.report-title{font-size:28px}}",
+    "@media (max-width:640px){.report-shell{padding:16px}.report-header,.hero-summary,.executive-grid,.report-body,.report-footer{padding-left:18px;padding-right:18px}.meta-grid,.executive-grid{grid-template-columns:minmax(0,1fr)}.report-title{font-size:24px}}",
+    "</style>",
+    "</head>",
+    "<body>",
+    '<div class="report-shell"><div class="report-page">',
+    '<header class="report-header">',
+    '<div class="brand-row">',
+    `<div class="brand-mark"><span class="brand-dot"></span><span>Article6</span></div>`,
+    `<div class="scope-chip">${escapeHtml(input.scopeLabel)}</div>`,
+    "</div>",
+    `<h1 class="report-title">${escapeHtml(input.reportType)}</h1>`,
+    `<p class="report-subtitle">${escapeHtml(input.heroSummary)}</p>`,
+    renderKeyValueGrid(
+      [
+        { label: "Report ID", value: input.reportId },
+        { label: "Generated", value: input.generatedAt },
+        { label: "Methodology", value: input.methodologyLabel },
+        { label: "Context", value: input.contextLabel ?? "Article6 export workspace" },
+      ],
+    ),
+    `<div class="banner"><div class="banner-title">${escapeHtml(input.bannerTitle)}</div><p class="banner-body">${escapeHtml(input.bannerBody)}</p></div>`,
+    "</header>",
+    `<div class="hero-summary">${escapeHtml(input.title)}</div>`,
+    `<section class="executive-grid">${input.executiveCards}</section>`,
+    `<main class="report-body">${input.body}</main>`,
+    `<footer class="report-footer"><div><span class="footer-brand">Article6</span><br />${escapeHtml(input.footerNote)}</div><div>${escapeHtml(input.reportId)}</div></footer>`,
+    "</div></div>",
+    "</body>",
+    "</html>",
+  ].join("");
+}

--- a/src/lib/readiness/vvbWorkpaperExport.tsx
+++ b/src/lib/readiness/vvbWorkpaperExport.tsx
@@ -1,5 +1,12 @@
 import { zipSync } from "fflate";
 import { canonicalStringify, sha256Hex } from "@/integrity/artifacts";
+import {
+  escapeHtml,
+  joinEscaped,
+  renderList,
+  renderMetricCard,
+  renderReportHtmlDocument,
+} from "@/lib/readiness/reportHtmlTheme";
 import type { VvbWorkpaperReport } from "@/lib/readiness/vvbWorkpaperReport";
 
 export type VvbWorkpaperAppendixArtifact = {
@@ -81,22 +88,8 @@ function isoForZip(iso: string): Date {
   return parsed;
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-function listOrFallback(items: string[], fallback: string): string {
-  if (!items.length) return `<p>${escapeHtml(fallback)}</p>`;
-  return `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
-}
-
 function joinOrFallback(items: string[], fallback: string): string {
-  return items.length ? items.map(escapeHtml).join(", ") : escapeHtml(fallback);
+  return joinEscaped(items, fallback);
 }
 
 function buildVvbWorkpaperAppendixArtifact(input: BuildVvbWorkpaperExportInput): VvbWorkpaperAppendixArtifact {
@@ -140,7 +133,7 @@ function renderRuleReviewRows(report: VvbWorkpaperReport): string {
     .map(
       (row) => `
         <tr>
-          <td><strong>${escapeHtml(row.ruleId)}</strong><br /><span>${escapeHtml(row.ruleTitle)}</span></td>
+          <td><span class="cell-title">${escapeHtml(row.ruleId)}</span><span class="cell-subtitle">${escapeHtml(row.ruleTitle)}</span></td>
           <td>${escapeHtml(row.reviewStatusLabel)}</td>
           <td>${escapeHtml(row.reviewRecordScopeLabel)}</td>
           <td>${escapeHtml(row.reviewerRationale)}</td>
@@ -158,7 +151,7 @@ function renderReadinessRows(report: VvbWorkpaperReport): string {
     .map(
       (row) => `
         <tr>
-          <td><strong>${escapeHtml(row.ruleId)}</strong><br /><span>${escapeHtml(row.ruleTitle)}</span></td>
+          <td><span class="cell-title">${escapeHtml(row.ruleId)}</span><span class="cell-subtitle">${escapeHtml(row.ruleTitle)}</span></td>
           <td>${escapeHtml(row.readinessState.replaceAll("_", " "))}</td>
           <td>${escapeHtml(row.severity)}</td>
           <td>${joinOrFallback(row.expectedEvidence, "No encoded expectation")}</td>
@@ -174,7 +167,7 @@ function renderArtifactRows(report: VvbWorkpaperReport): string {
     .map(
       (row) => `
         <tr>
-          <td><strong>${escapeHtml(row.ruleId)}</strong><br /><span>${escapeHtml(row.ruleTitle)}</span></td>
+          <td><span class="cell-title">${escapeHtml(row.ruleId)}</span><span class="cell-subtitle">${escapeHtml(row.ruleTitle)}</span></td>
           <td>${escapeHtml(row.state)}</td>
           <td>${escapeHtml(row.savedAt)}</td>
           <td>${escapeHtml(row.note)}</td>
@@ -188,7 +181,7 @@ function renderEvidenceRows(report: VvbWorkpaperReport): string {
     .map(
       (row) => `
         <tr>
-          <td><strong>${escapeHtml(row.id)}</strong><br /><span>${escapeHtml(row.label)}</span></td>
+          <td><span class="cell-title">${escapeHtml(row.id)}</span><span class="cell-subtitle">${escapeHtml(row.label)}</span></td>
           <td>${escapeHtml(row.type)}</td>
           <td>${escapeHtml(row.referenceState.replaceAll("_", " "))}</td>
           <td>${joinOrFallback(row.linkedRuleIds, "No linked rules")}</td>
@@ -201,160 +194,164 @@ function renderEvidenceRows(report: VvbWorkpaperReport): string {
 function reportHtmlDocument(report: VvbWorkpaperReport): string {
   const context = report.projectMethodVersionContext;
   const totals = report.executiveSummary.totals;
+  const executiveCards = [
+    renderMetricCard("Reviewed rules", String(totals.reviewed), `${totals.rules} total`),
+    renderMetricCard("Pending or not reviewed", String(totals.pendingOrNotReviewed)),
+    renderMetricCard("Missing evidence", String(totals.missingEvidence), `${totals.unknownExpectation} unknown expectation`),
+    renderMetricCard("Reviewer artifact saved", String(totals.reviewerArtifactSaved), `${totals.needsFollowup} follow-up item${totals.needsFollowup === 1 ? "" : "s"}`),
+  ].join("");
   const body = `
-    <article>
-      <section>
-        <p><strong>VVB draft workpaper support</strong> · <strong>Draft export only</strong></p>
-        <h1>${escapeHtml(context.projectName)}</h1>
-        <p>${escapeHtml(context.methodologyCode)}@${escapeHtml(context.methodologyVersion)} · ${escapeHtml(report.workpaperStatus.label)}</p>
-        <p>${escapeHtml(report.executiveSummary.headline)}</p>
-        <p>${escapeHtml(report.workpaperStatus.note)}</p>
-        <dl>
-          <dt>Source run scope</dt><dd>${escapeHtml(report.workpaperStatus.sourceRunScope.replaceAll("_", " "))}</dd>
-          <dt>Review record scope</dt><dd>${escapeHtml(report.workpaperStatus.reviewRecordScope.replaceAll("_", " "))}</dd>
-          <dt>Project ID</dt><dd>${escapeHtml(context.projectId)}</dd>
-          <dt>Proponent</dt><dd>${escapeHtml(context.proponent)}</dd>
-          <dt>Region</dt><dd>${escapeHtml(context.region)}</dd>
-          <dt>Methodology</dt><dd>${escapeHtml(context.methodologyCode)}@${escapeHtml(context.methodologyVersion)}</dd>
-          <dt>Generated</dt><dd>${escapeHtml(report.generatedAt)}</dd>
-          <dt>Report ID</dt><dd>${escapeHtml(report.reportId)}</dd>
-        </dl>
+      <section class="report-section">
+        <div class="section-kicker">Project context</div>
+        <h2 class="section-title">Project, method, and run context</h2>
+        <div class="section-body">
+          <p><strong>Methodology name:</strong> ${escapeHtml(context.methodologyName)}</p>
+          <p><strong>Sector:</strong> ${escapeHtml(context.sector)}</p>
+          <p><strong>Description:</strong> ${escapeHtml(context.projectDescription)}</p>
+          <div class="pill-row">
+            <span class="pill">Source run scope: ${escapeHtml(report.workpaperStatus.sourceRunScope.replaceAll("_", " "))}</span>
+            <span class="pill">Review record scope: ${escapeHtml(report.workpaperStatus.reviewRecordScope.replaceAll("_", " "))}</span>
+            <span class="pill">${escapeHtml(report.workpaperStatus.label)}</span>
+          </div>
+        </div>
       </section>
 
-      <section>
-        <h2>Project / method / version context</h2>
-        <p><strong>Methodology name:</strong> ${escapeHtml(context.methodologyName)}</p>
-        <p><strong>Sector:</strong> ${escapeHtml(context.sector)}</p>
-        <p><strong>Description:</strong> ${escapeHtml(context.projectDescription)}</p>
+      <section class="report-section">
+        <div class="section-kicker">Registry context</div>
+        <h2 class="section-title">Registry and program context</h2>
+        <div class="section-body">
+          <p><strong>Registry program:</strong> ${escapeHtml(report.registryAndProgramContext.registryProgram)}</p>
+          <p><strong>Registry project ID:</strong> ${escapeHtml(report.registryAndProgramContext.registryProjectId)}</p>
+          <p>${escapeHtml(report.registryAndProgramContext.note)}</p>
+        </div>
       </section>
 
-      <section>
-        <h2>Registry and program context</h2>
-        <p><strong>Registry program:</strong> ${escapeHtml(report.registryAndProgramContext.registryProgram)}</p>
-        <p><strong>Registry project ID:</strong> ${escapeHtml(report.registryAndProgramContext.registryProjectId)}</p>
-        <p>${escapeHtml(report.registryAndProgramContext.note)}</p>
+      <section class="report-section">
+        <div class="section-kicker">Executive summary</div>
+        <h2 class="section-title">Draft workpaper status</h2>
+        <div class="section-body">
+          <p>${escapeHtml(report.executiveSummary.note)}</p>
+        </div>
       </section>
 
-      <section>
-        <h2>Executive Summary</h2>
-        <ul>
-          <li>Total rules: ${totals.rules}</li>
-          <li>Reviewed rules: ${totals.reviewed}</li>
-          <li>Pending or not reviewed: ${totals.pendingOrNotReviewed}</li>
-          <li>Needs follow-up: ${totals.needsFollowup}</li>
-          <li>Missing evidence / not started: ${totals.missingEvidence}</li>
-          <li>Unknown expectation: ${totals.unknownExpectation}</li>
-          <li>Saved reviewer artifact state: ${totals.reviewerArtifactSaved}</li>
-        </ul>
-        <p>${escapeHtml(report.executiveSummary.note)}</p>
-      </section>
-
-      <section>
-        <h2>Rule review workpaper table</h2>
+      <section class="report-section">
+        <div class="section-kicker">Workpaper table</div>
+        <h2 class="section-title">Rule review workpaper table</h2>
+        <div class="section-body">
         <p>Rows remain draft workpaper support unless a reviewer has explicitly recorded a non-pending judgment. Review rows are workspace-level method/version records unless separately saved as run-bound reviewer artifact state.</p>
-        <table>
+        <table class="report-table">
           <thead>
             <tr><th>Rule</th><th>Review status</th><th>Record scope</th><th>Reviewer rationale</th><th>Support reference</th><th>Linked evidence refs</th><th>Candidate evidence refs</th><th>Attachment refs</th></tr>
           </thead>
           <tbody>${renderRuleReviewRows(report)}</tbody>
         </table>
+        </div>
       </section>
 
-      <section>
-        <h2>Readiness / gap status</h2>
-        <table>
+      <section class="report-section">
+        <div class="section-kicker">Readiness</div>
+        <h2 class="section-title">Readiness and gap status</h2>
+        <div class="section-body">
+        <table class="report-table">
           <thead>
             <tr><th>Rule</th><th>Readiness state</th><th>Severity</th><th>Expected evidence</th><th>Missing evidence</th><th>Next actions</th></tr>
           </thead>
           <tbody>${renderReadinessRows(report)}</tbody>
         </table>
+        </div>
       </section>
 
-      <section>
-        <h2>Reviewer artifact state</h2>
-        <table>
+      <section class="report-section">
+        <div class="section-kicker">Reviewer record</div>
+        <h2 class="section-title">Reviewer artifact state</h2>
+        <div class="section-body">
+        <table class="report-table">
           <thead>
             <tr><th>Rule</th><th>State</th><th>Saved at</th><th>Note</th></tr>
           </thead>
           <tbody>${renderArtifactRows(report)}</tbody>
         </table>
+        </div>
       </section>
 
-      <section>
-        <h2>Evidence / provenance references</h2>
-        <h3>Supplied documents</h3>
+      <section class="report-section">
+        <div class="section-kicker">Traceability</div>
+        <h2 class="section-title">Evidence and provenance references</h2>
+        <div class="section-body">
+        <h3 class="subsection-title">Supplied documents</h3>
         ${
           report.evidenceProvenanceReferences.suppliedDocuments.length
             ? `<ul>${report.evidenceProvenanceReferences.suppliedDocuments
                 .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)}${item.note ? ` · ${escapeHtml(item.note)}` : ""}</li>`)
                 .join("")}</ul>`
-            : "<p>No supplied documents recorded.</p>"
+            : '<p class="empty-note">No supplied documents recorded.</p>'
         }
-        <h3>Missing documents</h3>
+        <h3 class="subsection-title">Missing documents</h3>
         ${
           report.evidenceProvenanceReferences.missingDocuments.length
             ? `<ul>${report.evidenceProvenanceReferences.missingDocuments
                 .map((item) => `<li>${escapeHtml(item.label)} · ${escapeHtml(item.type)}</li>`)
                 .join("")}</ul>`
-            : "<p>No missing documents recorded.</p>"
+            : '<p class="empty-note">No missing documents recorded.</p>'
         }
-        <h3>Evidence reference index</h3>
-        <table>
+        <h3 class="subsection-title">Evidence reference index</h3>
+        <table class="report-table">
           <thead>
             <tr><th>Reference</th><th>Type</th><th>Reference state</th><th>Linked rules</th><th>Note</th></tr>
           </thead>
           <tbody>${renderEvidenceRows(report)}</tbody>
         </table>
-        <h3>Bundle references</h3>
+        <h3 class="subsection-title">Bundle references</h3>
         <ul>
           ${report.evidenceProvenanceReferences.bundleReferences
             .map((item) => `<li>${escapeHtml(item.label)}: ${escapeHtml(item.value)} (${escapeHtml(item.availability)})</li>`)
             .join("")}
         </ul>
+        </div>
       </section>
 
-      <section>
-        <h2>Limitations and non-claims</h2>
-        <h3>Limitations</h3>
-        ${listOrFallback(report.limitationsAndNonClaims.limitations, "No limitations listed.")}
-        <h3>Non-claims</h3>
-        ${listOrFallback(report.limitationsAndNonClaims.nonClaims, "No non-claims listed.")}
+      <section class="report-section">
+        <div class="section-kicker">Limits</div>
+        <h2 class="section-title">Limitations and non-claims</h2>
+        <div class="section-body">
+        <h3 class="subsection-title">Limitations</h3>
+        ${renderList(report.limitationsAndNonClaims.limitations, "No limitations listed.")}
+        <h3 class="subsection-title">Non-claims</h3>
+        ${renderList(report.limitationsAndNonClaims.nonClaims, "No non-claims listed.")}
+        </div>
       </section>
 
-      <section>
-        <h2>Technical Appendix</h2>
+      <section class="report-section">
+        <div class="section-kicker">Appendix</div>
+        <h2 class="section-title">Technical appendix</h2>
+        <div class="section-body">
         <p><strong>Generated:</strong> ${escapeHtml(report.technicalAppendix.generatedAt)}</p>
-        <h3>State definitions</h3>
-        ${listOrFallback(
+        <h3 class="subsection-title">State definitions</h3>
+        ${renderList(
           report.technicalAppendix.stateDefinitions.map(
             (item) => `${item.state.replaceAll("_", " ")} · ${item.description}`,
           ),
           "No state definitions listed.",
         )}
-      </section>
-    </article>`;
+        </div>
+      </section>`;
 
-  return [
-    "<!DOCTYPE html>",
-    '<html lang="en">',
-    "<head>",
-    '<meta charSet="utf-8" />',
-    '<meta name="viewport" content="width=device-width, initial-scale=1" />',
-    `<title>${escapeHtml(context.projectName)} VVB draft workpaper support</title>`,
-    "<style>",
-    "body{margin:0;background:#f8fafc;color:#0f172a;font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;}",
-    ".report-shell{max-width:1120px;margin:0 auto;padding:24px;}",
-    "table{width:100%;border-collapse:collapse;margin-top:12px;}",
-    "th,td{border:1px solid #cbd5e1;padding:8px;vertical-align:top;text-align:left;font-size:12px;}",
-    "th{background:#e2e8f0;}",
-    "section{margin-bottom:24px;}",
-    "</style>",
-    "</head>",
-    "<body>",
-    `<div class="report-shell">${body}</div>`,
-    "</body>",
-    "</html>",
-  ].join("");
+  return renderReportHtmlDocument({
+    title: report.executiveSummary.headline,
+    reportType: "VVB Draft Workpaper Export",
+    scopeLabel: "Draft workpaper support only",
+    reportId: report.reportId,
+    generatedAt: report.generatedAt,
+    methodologyLabel: `${context.methodologyCode}@${context.methodologyVersion}`,
+    contextLabel: report.workpaperStatus.sourceRunId !== "Unavailable" ? `Run ${report.workpaperStatus.sourceRunId}` : context.projectName,
+    bannerTitle: "Support-only scope notice",
+    bannerBody:
+      "This Article6 export is draft VVB workpaper support only. It preserves readiness and review traceability but does not express verifier authority, registry acceptance, or issuance outcomes.",
+    heroSummary: `Article6 ${context.projectName} VVB draft workpaper support`,
+    executiveCards,
+    body,
+    footerNote: "Support-only export. Article6 does not provide a formal verification or approval decision in this workpaper.",
+  });
 }
 
 function assertNoForbiddenClaims(serialized: string): void {

--- a/tests/lib/readiness/clientReadinessReportExport.test.ts
+++ b/tests/lib/readiness/clientReadinessReportExport.test.ts
@@ -106,6 +106,18 @@ describe("buildClientReadinessReportExport", () => {
     expect(serialized).not.toContain("assurance opinion");
   });
 
+  test("brands the HTML with Article6 and shows the scope banner", async () => {
+    const result = buildSampleExport();
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const html = (await zip.file("client-readiness-report/report.html")?.async("string")) ?? "";
+
+    expect(html).toContain("Article6");
+    expect(html).toContain("Client Readiness Report");
+    expect(html).toContain("Scope and non-claim notice");
+    expect(html).toContain("Pre-verification readiness assessment");
+    expect(html).toContain("Readiness support only. Article6 does not issue a verifier decision in this export.");
+  });
+
   test("includes traceable appendix fields for report id, timestamp, rules, and evidence ids", async () => {
     const result = buildSampleExport();
     const zip = await JSZip.loadAsync(result.zipBytes);

--- a/tests/lib/readiness/vvbWorkpaperExport.test.ts
+++ b/tests/lib/readiness/vvbWorkpaperExport.test.ts
@@ -138,6 +138,18 @@ describe("buildVvbWorkpaperExport", () => {
     expect(serialized).not.toContain("vvb approval");
   });
 
+  test("brands the HTML with Article6 and shows the support-only banner", async () => {
+    const result = buildVvbWorkpaperExport({ report: buildSampleReport() });
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const html = (await zip.file("vvb-draft-workpaper/workpaper.html")?.async("string")) ?? "";
+
+    expect(html).toContain("Article6");
+    expect(html).toContain("VVB Draft Workpaper Export");
+    expect(html).toContain("Support-only scope notice");
+    expect(html).toContain("Draft workpaper support only");
+    expect(html).toContain("Support-only export. Article6 does not provide a formal verification or approval decision in this workpaper.");
+  });
+
   test("keeps candidate evidence distinct from linked support and preserves traceability", async () => {
     const result = buildVvbWorkpaperExport({ report: buildSampleReport() });
     const zip = await JSZip.loadAsync(result.zipBytes);


### PR DESCRIPTION
## WHAT

- Upgrade exported report HTML styling with Article6 branding
- Improve readability of VVB workpaper and client readiness report sections
- Preserve truthful scope, limitation, and non-claim language

## WHY

- Export content is now structurally useful, but buyer-facing reports need premium presentation
- Branded, readable reports make the product easier to demo and sell
- Presentation polish should happen before adding more export features

**Signed-off-by:** Fred E <fredilly@article6.org>**