### PR TITLE
Add Manual Review Mode under Projects

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -192,3 +192,4 @@ Not active now:
 - STAC auto-verification (support facts only, not auto-verify)
 - AI-assisted review (post-moat)
 - Multi-methodology cross-referencing (Phase 5+)
+

--- a/src/app/api/exports/audit-pack/route.ts
+++ b/src/app/api/exports/audit-pack/route.ts
@@ -69,9 +69,10 @@ export async function POST(req: Request) {
     }
 
     const evidencePins = Array.isArray(record.evidencePins) ? (record.evidencePins as EvidencePin[]) : [];
+    const sourceFiles = Array.isArray(record.sourceFiles) ? record.sourceFiles : [];
     const currentReview = asCurrentMethodReviewInput(record.currentReview);
     const zip = buildAuditPackZip(method, version, {
-      finalizedReview: artifact ? { artifact, evidencePins } : null,
+      finalizedReview: artifact ? { artifact, evidencePins, sourceFiles } : null,
       currentReview: artifact ? null : currentReview,
     });
     return new Response(zip, {

--- a/src/app/api/projects/[id]/export-pdf/route.ts
+++ b/src/app/api/projects/[id]/export-pdf/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { Project } from '@/lib/projects/types';
-import { buildProjectExportPdf, getProjectCoverage } from '@/lib/projects/exportPdf';
+import { buildProjectExportPdf } from '@/lib/projects/exportPdf';
+import { getProjectCoverage } from '@/lib/projects/storage';
 
 export const runtime = 'nodejs';
 
@@ -8,13 +9,17 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
     const project = body.project as Project | undefined;
-    if (!project || !project.reviews?.length) {
+    const hasMethodologyReviews = Array.isArray(project?.reviews) && project.reviews.length > 0;
+    const hasManualReview = project?.reviewMode === 'manual';
+    if (!project || (!hasMethodologyReviews && !hasManualReview)) {
       return NextResponse.json({ error: 'Invalid project data' }, { status: 400 });
     }
 
-    const coverage = getProjectCoverage(project.reviews);
+    const coverage = getProjectCoverage(project);
     const pdf = buildProjectExportPdf(project, coverage);
-    const filename = `verification-pack-${project.methodCode}-${project.id.slice(0, 8)}.pdf`;
+    const filename = project.reviewMode === 'manual'
+      ? `manual-review-pack-${project.id.slice(0, 8)}.pdf`
+      : `verification-pack-${project.methodCode}-${project.id.slice(0, 8)}.pdf`;
     const ab = new ArrayBuffer(pdf.byteLength);
     new Uint8Array(ab).set(pdf);
     const blob = new Blob([ab], { type: 'application/pdf' });

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import NewProjectForm from '@/components/projects/NewProjectForm';
 
 export const metadata: Metadata = {
-  title: 'New Project | app.article6',
+  title: 'New Project Review | app.article6',
 };
 
 export default function NewProjectPage() {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -3,7 +3,7 @@ import ProjectsList from '@/components/projects/ProjectsList';
 
 export const metadata: Metadata = {
   title: 'Projects | app.article6',
-  description: 'Project verification workbench — track methodology verifications.',
+  description: 'Project review workspace for methodology-linked and manual reviews.',
 };
 
 export default function ProjectsPage() {

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { createProject } from '@/lib/projects/storage';
 import { projectRegistryFromMethodProgram } from '@/lib/projects/verificationReport';
+import type { ProjectReviewMode } from '@/lib/projects/types';
 
 type MethodOption = {
   code: string;
@@ -15,6 +16,7 @@ type MethodOption = {
 export default function NewProjectForm() {
   const router = useRouter();
   const [methods, setMethods] = useState<MethodOption[]>([]);
+  const [reviewMode, setReviewMode] = useState<ProjectReviewMode>('methodology-linked');
   const [name, setName] = useState('');
   const [selectedMethod, setSelectedMethod] = useState('');
   const [aoiLabel, setAoiLabel] = useState('');
@@ -31,28 +33,42 @@ export default function NewProjectForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name || !selectedMethod) return;
+    if (!name) return;
+    if (reviewMode === 'methodology-linked' && !selectedMethod) return;
 
     setLoading(true);
     setError('');
-    const [code, version] = selectedMethod.split('@');
 
     try {
+      if (reviewMode === 'manual') {
+        const project = createProject({
+          name,
+          reviewMode,
+          aoiLabel: aoiLabel || undefined,
+          description: description || undefined,
+        });
+        router.push(`/projects/${project.id}`);
+        return;
+      }
+
+      const [code, version] = selectedMethod.split('@');
       const rulesRes = await fetch(`/api/projects/method-rules?code=${code}&version=${version}`);
       const rulesData = await rulesRes.json();
       const rules = (rulesData.rules || []).filter((r: { id?: string }) => r.id);
 
       if (rules.length === 0) {
-        setError('No rules found for this methodology. Cannot create project.');
+        setError('No rules found for this methodology. Cannot create project review.');
         setLoading(false);
         return;
       }
 
+      const selectedMethodRecord = methods.find((method) => `${method.code}@${method.version}` === selectedMethod);
       const project = createProject({
         name,
+        reviewMode,
         methodCode: code,
         methodVersion: version,
-        registry: projectRegistryFromMethodProgram(methods.find((method) => `${method.code}@${method.version}` === selectedMethod)?.program),
+        registry: projectRegistryFromMethodProgram(selectedMethodRecord?.program),
         aoiLabel: aoiLabel || undefined,
         description: description || undefined,
         ruleIds: rules.map((r: { id: string; title: string; sectionId?: string }) => ({
@@ -64,7 +80,9 @@ export default function NewProjectForm() {
 
       router.push(`/projects/${project.id}`);
     } catch {
-      setError('Failed to load methodology rules. Try again.');
+      setError(reviewMode === 'manual'
+        ? 'Failed to create manual review. Try again.'
+        : 'Failed to load methodology rules. Try again.');
       setLoading(false);
     }
   };
@@ -72,9 +90,9 @@ export default function NewProjectForm() {
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-12 md:px-8">
       <div>
-        <h1 className="text-2xl font-bold text-slate-900">New Project</h1>
+        <h1 className="text-2xl font-bold text-slate-900">New Project Review</h1>
         <p className="mt-1 text-sm text-slate-500">
-          Create a verification project tied to a methodology
+          Create a long-lived project review workspace
         </p>
       </div>
 
@@ -85,6 +103,36 @@ export default function NewProjectForm() {
       )}
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div>
+          <label className="mb-1 block text-sm font-semibold text-slate-700">Review Type</label>
+          <div className="grid gap-3 md:grid-cols-2">
+            <button
+              type="button"
+              onClick={() => setReviewMode('methodology-linked')}
+              className={`rounded-lg border px-4 py-3 text-left ${
+                reviewMode === 'methodology-linked'
+                  ? 'border-blue-500 bg-blue-50 text-blue-900'
+                  : 'border-slate-200 bg-white text-slate-700'
+              }`}
+            >
+              <div className="text-sm font-semibold">Methodology-linked review</div>
+              <div className="mt-1 text-xs text-slate-500">Use a selected methodology and its rule set.</div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setReviewMode('manual')}
+              className={`rounded-lg border px-4 py-3 text-left ${
+                reviewMode === 'manual'
+                  ? 'border-blue-500 bg-blue-50 text-blue-900'
+                  : 'border-slate-200 bg-white text-slate-700'
+              }`}
+            >
+              <div className="text-sm font-semibold">Manual Review</div>
+              <div className="mt-1 text-xs text-slate-500">Project-level manual review / VVB findings reconstruction.</div>
+            </button>
+          </div>
+        </div>
+
         <div>
           <label className="mb-1 block text-sm font-semibold text-slate-700">Project Name</label>
           <input
@@ -97,22 +145,28 @@ export default function NewProjectForm() {
           />
         </div>
 
-        <div>
-          <label className="mb-1 block text-sm font-semibold text-slate-700">Methodology</label>
-          <select
-            value={selectedMethod}
-            onChange={e => setSelectedMethod(e.target.value)}
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            required
-          >
-            <option value="">Select a methodology...</option>
-            {methods.map(m => (
-              <option key={`${m.code}@${m.version}`} value={`${m.code}@${m.version}`}>
-                {m.code} v{m.version} — {m.program} ({m.ruleCount} rules)
-              </option>
-            ))}
-          </select>
-        </div>
+        {reviewMode === 'methodology-linked' ? (
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Methodology</label>
+            <select
+              value={selectedMethod}
+              onChange={e => setSelectedMethod(e.target.value)}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              required
+            >
+              <option value="">Select a methodology...</option>
+              {methods.map(m => (
+                <option key={`${m.code}@${m.version}`} value={`${m.code}@${m.version}`}>
+                  {m.code} v{m.version} — {m.program} ({m.ruleCount} rules)
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            Manual Review does not require a methodology selection. Use this mode for project-specific findings reconstruction, evidence gaps, reviewer notes, and export.
+          </div>
+        )}
 
         <div>
           <label className="mb-1 block text-sm font-semibold text-slate-700">Area Label (optional)</label>
@@ -130,7 +184,7 @@ export default function NewProjectForm() {
           <textarea
             value={description}
             onChange={e => setDescription(e.target.value)}
-            placeholder="Brief description of the project..."
+            placeholder="Brief description of the project review..."
             rows={3}
             className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
           />
@@ -138,10 +192,10 @@ export default function NewProjectForm() {
 
         <button
           type="submit"
-          disabled={loading || !name || !selectedMethod}
+          disabled={loading || !name || (reviewMode === 'methodology-linked' && !selectedMethod)}
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
         >
-          {loading ? 'Creating...' : 'Create Project'}
+          {loading ? 'Creating...' : 'Create Project Review'}
         </button>
       </form>
     </div>

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -1,24 +1,70 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ChangeEvent, type FormEvent, type ReactNode } from 'react';
 import Link from 'next/link';
-import type { Project, RuleReview, ProjectCoverage } from '@/lib/projects/types';
-import { getProject, updateRuleReview, lockProject, getProjectCoverage } from '@/lib/projects/storage';
+import type {
+  ManualFinding,
+  ManualFindingClosureStatus,
+  ManualFindingType,
+  Project,
+  ProjectCoverage,
+  ProjectDocument,
+  RuleReview,
+} from '@/lib/projects/types';
+import {
+  addManualFinding,
+  addProjectDocument,
+  deleteManualFinding,
+  deleteProjectDocument,
+  getProject,
+  getProjectCoverage,
+  lockProject,
+  manualFindingClosureLabel,
+  nextManualFindingId,
+  updateManualFinding,
+  updateRuleReview,
+} from '@/lib/projects/storage';
 
 type ProjectDetailProps = {
   projectId: string;
+};
+
+type ManualFindingDraft = {
+  findingId: string;
+  findingType: ManualFindingType;
+  sourceDocumentId: string;
+  evidenceExcerpt: string;
+  projectResponse: string;
+  closureStatus: ManualFindingClosureStatus;
+  reviewerNote: string;
+};
+
+const EMPTY_MANUAL_FINDING: ManualFindingDraft = {
+  findingId: '',
+  findingType: 'VVB finding',
+  sourceDocumentId: '',
+  evidenceExcerpt: '',
+  projectResponse: '',
+  closureStatus: 'open',
+  reviewerNote: '',
 };
 
 export default function ProjectDetail({ projectId }: ProjectDetailProps) {
   const [project, setProject] = useState<Project | null>(null);
   const [coverage, setCoverage] = useState<ProjectCoverage | null>(null);
   const [downloading, setDownloading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [manualDraft, setManualDraft] = useState<ManualFindingDraft>(EMPTY_MANUAL_FINDING);
 
   useEffect(() => {
     const p = getProject(projectId);
     if (p) {
       setProject(p);
       setCoverage(getProjectCoverage(p));
+      setManualDraft((current) => ({
+        ...current,
+        findingId: current.findingId || nextManualFindingId(p),
+      }));
     }
   }, [projectId]);
 
@@ -33,23 +79,31 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
     );
   }
 
-  const handleStatusChange = (ruleId: string, status: RuleReview['status']) => {
-    const updated = updateRuleReview(projectId, ruleId, { status });
-    if (updated) {
-      setProject(updated);
-      setCoverage(getProjectCoverage(updated));
+  const refreshProject = (nextProject: Project | undefined) => {
+    if (!nextProject) return;
+    setProject(nextProject);
+    setCoverage(getProjectCoverage(nextProject));
+    if (nextProject.reviewMode === 'manual') {
+      setManualDraft({
+        ...EMPTY_MANUAL_FINDING,
+        findingId: nextManualFindingId(nextProject),
+      });
     }
+  };
+
+  const handleStatusChange = (ruleId: string, status: RuleReview['status']) => {
+    refreshProject(updateRuleReview(projectId, ruleId, { status }));
   };
 
   const handleLock = () => {
     const locked = lockProject(projectId);
     if (locked) {
       setProject(locked);
+      setCoverage(getProjectCoverage(locked));
     }
   };
 
   const handleDownloadPack = async () => {
-    if (!project) return;
     setDownloading(true);
     try {
       const res = await fetch('/api/projects/' + projectId + '/export-pdf', {
@@ -62,7 +116,9 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `verification-pack-${project.methodCode}.pdf`;
+      a.download = project.reviewMode === 'manual'
+        ? `manual-review-pack-${project.id.slice(0, 8)}.pdf`
+        : `verification-pack-${project.methodCode}.pdf`;
       a.click();
       URL.revokeObjectURL(url);
     } catch (err) {
@@ -72,25 +128,90 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
     }
   };
 
-  const grouped = project.reviews.reduce((acc, r) => {
-    if (!acc[r.sectionId]) acc[r.sectionId] = [];
-    acc[r.sectionId].push(r);
-    return acc;
-  }, {} as Record<string, RuleReview[]>);
+  const handleUploadDocuments = async (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    if (files.length === 0) return;
+    setUploading(true);
+
+    for (const file of files) {
+      let extractedText = '';
+      if ((file.type || '').includes('pdf') || file.name.toLowerCase().endsWith('.pdf')) {
+        try {
+          const response = await fetch('/api/quick-check/pdf-extract', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/pdf' },
+            body: await file.arrayBuffer(),
+          });
+          const data = await response.json();
+          extractedText = typeof data.text === 'string' ? data.text.slice(0, 2000) : '';
+        } catch {
+          extractedText = '';
+        }
+      }
+
+      refreshProject(addProjectDocument(projectId, {
+        fileName: file.name,
+        mimeType: file.type || 'application/octet-stream',
+        sizeBytes: file.size,
+        extractedText,
+      }));
+    }
+
+    event.target.value = '';
+    setUploading(false);
+  };
+
+  const handleCreateManualFinding = (event: FormEvent) => {
+    event.preventDefault();
+    if (!manualDraft.findingId.trim()) return;
+
+    refreshProject(addManualFinding(projectId, {
+      findingId: manualDraft.findingId.trim(),
+      findingType: manualDraft.findingType,
+      sourceDocumentId: manualDraft.sourceDocumentId || undefined,
+      evidenceExcerpt: manualDraft.evidenceExcerpt.trim() || undefined,
+      projectResponse: manualDraft.projectResponse.trim() || undefined,
+      closureStatus: manualDraft.closureStatus,
+      reviewerNote: manualDraft.reviewerNote.trim() || undefined,
+    }));
+  };
+
+  const updateFindingField = (
+    findingId: string,
+    field: keyof Pick<ManualFinding, 'findingType' | 'sourceDocumentId' | 'evidenceExcerpt' | 'projectResponse' | 'closureStatus' | 'reviewerNote'>,
+    value: string,
+  ) => {
+    if (field === 'findingType') {
+      refreshProject(updateManualFinding(projectId, findingId, { findingType: value as ManualFindingType }));
+      return;
+    }
+    if (field === 'closureStatus') {
+      refreshProject(updateManualFinding(projectId, findingId, { closureStatus: value as ManualFindingClosureStatus }));
+      return;
+    }
+    refreshProject(updateManualFinding(projectId, findingId, {
+      [field]: value || undefined,
+    } as Partial<Omit<ManualFinding, 'id' | 'createdAt'>>));
+  };
 
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-12 md:px-8">
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-12 md:px-8">
       <Link href="/projects" className="text-sm text-slate-500 hover:text-slate-700">
         ← Back to projects
       </Link>
 
-      <div className="flex items-start justify-between">
+      <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-slate-900">{project.name}</h1>
-          <div className="mt-1 flex items-center gap-3 text-sm text-slate-500">
-            <span className="rounded bg-slate-100 px-2 py-0.5 font-mono text-xs">
-              {project.methodCode}@{project.methodVersion}
+          <div className="mt-1 flex flex-wrap items-center gap-3 text-sm text-slate-500">
+            <span className="rounded bg-slate-100 px-2 py-0.5 font-semibold text-slate-700">
+              {project.reviewMode === 'manual' ? 'Manual Review' : 'Methodology-linked review'}
             </span>
+            {project.reviewMode === 'methodology-linked' && project.methodCode && project.methodVersion ? (
+              <span className="rounded bg-slate-100 px-2 py-0.5 font-mono text-xs">
+                {project.methodCode}@{project.methodVersion}
+              </span>
+            ) : null}
             <span
               className={`rounded px-2 py-0.5 text-xs font-semibold ${
                 project.status === 'locked'
@@ -101,75 +222,384 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
               {project.status}
             </span>
           </div>
-          {project.aoiLabel && <p className="mt-1 text-sm text-slate-400">AOI: {project.aoiLabel}</p>}
+          {project.aoiLabel ? <p className="mt-1 text-sm text-slate-400">Project area: {project.aoiLabel}</p> : null}
+          {project.description ? <p className="mt-2 max-w-3xl text-sm text-slate-500">{project.description}</p> : null}
         </div>
 
         <div className="flex items-center gap-2">
-        {project.status === 'in-progress' && coverage && coverage.notStarted < coverage.total && (
-          <button
-            onClick={handleLock}
-            className="rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700"
-          >
-            Lock Review
-          </button>
-        )}
-        {project.status === 'locked' && (
-          <button
-            onClick={handleDownloadPack}
-            disabled={downloading}
-            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
-          >
-            {downloading ? 'Generating...' : 'Download Pack'}
-          </button>
-        )}
+          {project.status === 'in-progress' && coverage && coverage.total > 0 ? (
+            <button
+              onClick={handleLock}
+              className="rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700"
+            >
+              Lock Review
+            </button>
+          ) : null}
+          {project.status === 'locked' ? (
+            <button
+              onClick={handleDownloadPack}
+              disabled={downloading}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {downloading ? 'Generating...' : 'Download Export'}
+            </button>
+          ) : null}
         </div>
       </div>
 
-      {coverage && (
-        <div className="grid grid-cols-5 gap-3">
-          {[
-            { label: 'Verified', value: coverage.verified, color: 'text-green-600' },
-            { label: 'Gaps', value: coverage.gap, color: 'text-red-600' },
-            { label: 'In Progress', value: coverage.inProgress, color: 'text-amber-600' },
-            { label: 'Pending', value: coverage.notStarted, color: 'text-slate-400' },
-            { label: 'N/A', value: coverage.notApplicable, color: 'text-slate-300' },
-          ].map(s => (
-            <div key={s.label} className="rounded-lg border border-slate-200 bg-white p-3 text-center">
-              <div className={`text-2xl font-bold ${s.color}`}>{s.value}</div>
-              <div className="text-xs text-slate-500">{s.label}</div>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {coverage && (
-        <div>
-          <div className="h-3 overflow-hidden rounded-full bg-slate-100">
-            <div
-              className="h-full rounded-full bg-blue-500 transition-all"
-              style={{ width: `${coverage.percentComplete}%` }}
-            />
+      {coverage ? (
+        <>
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+            {project.reviewMode === 'manual'
+              ? [
+                { label: 'Closed', value: coverage.verified, color: 'text-green-600' },
+                { label: 'Open', value: coverage.gap, color: 'text-red-600' },
+                { label: 'In Review', value: coverage.inProgress, color: 'text-amber-600' },
+                { label: 'Documents', value: project.documents.length, color: 'text-slate-700' },
+                { label: 'Findings', value: coverage.total, color: 'text-slate-900' },
+              ].map(stat => (
+                <div key={stat.label} className="rounded-lg border border-slate-200 bg-white p-3 text-center">
+                  <div className={`text-2xl font-bold ${stat.color}`}>{stat.value}</div>
+                  <div className="text-xs text-slate-500">{stat.label}</div>
+                </div>
+              ))
+              : [
+                { label: 'Verified', value: coverage.verified, color: 'text-green-600' },
+                { label: 'Gaps', value: coverage.gap, color: 'text-red-600' },
+                { label: 'In Progress', value: coverage.inProgress, color: 'text-amber-600' },
+                { label: 'Pending', value: coverage.notStarted, color: 'text-slate-400' },
+                { label: 'N/A', value: coverage.notApplicable, color: 'text-slate-300' },
+              ].map(stat => (
+                <div key={stat.label} className="rounded-lg border border-slate-200 bg-white p-3 text-center">
+                  <div className={`text-2xl font-bold ${stat.color}`}>{stat.value}</div>
+                  <div className="text-xs text-slate-500">{stat.label}</div>
+                </div>
+              ))}
           </div>
-          <p className="mt-1 text-right text-xs text-slate-500">{coverage.percentComplete}% complete</p>
-        </div>
-      )}
 
+          <div>
+            <div className="h-3 overflow-hidden rounded-full bg-slate-100">
+              <div
+                className="h-full rounded-full bg-blue-500 transition-all"
+                style={{ width: `${coverage.percentComplete}%` }}
+              />
+            </div>
+            <p className="mt-1 text-right text-xs text-slate-500">{coverage.percentComplete}% complete</p>
+          </div>
+        </>
+      ) : null}
+
+      {project.reviewMode === 'manual' ? (
+        <div className="grid gap-6 lg:grid-cols-[1.1fr_1.4fr]">
+          <section className="rounded-lg border border-slate-200 bg-white p-5">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-900">Source Documents</h2>
+                <p className="mt-1 text-sm text-slate-500">Upload project documents used in manual findings reconstruction.</p>
+              </div>
+              {project.status === 'in-progress' ? (
+                <label className="rounded-lg bg-slate-900 px-3 py-2 text-sm font-semibold text-white hover:bg-slate-800">
+                  {uploading ? 'Uploading...' : 'Upload Documents'}
+                  <input
+                    type="file"
+                    multiple
+                    className="hidden"
+                    onChange={handleUploadDocuments}
+                    disabled={uploading}
+                  />
+                </label>
+              ) : null}
+            </div>
+
+            <div className="mt-4 flex flex-col gap-3">
+              {project.documents.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+                  No source documents uploaded yet.
+                </div>
+              ) : project.documents.map((document: ProjectDocument) => (
+                <div key={document.id} className="rounded-lg border border-slate-200 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-semibold text-slate-800">{document.fileName}</div>
+                      <div className="mt-1 text-xs text-slate-500">
+                        {document.mimeType} · {document.sizeBytes} bytes · {new Date(document.uploadedAt).toLocaleString()}
+                      </div>
+                    </div>
+                    {project.status === 'in-progress' ? (
+                      <button
+                        onClick={() => refreshProject(deleteProjectDocument(projectId, document.id))}
+                        className="text-xs text-red-500 hover:text-red-700"
+                      >
+                        Remove
+                      </button>
+                    ) : null}
+                  </div>
+                  {document.extractedText?.trim() ? (
+                    <p className="mt-2 rounded bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                      {document.extractedText.slice(0, 280)}
+                    </p>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-slate-200 bg-white p-5">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-900">Manual Findings</h2>
+              <p className="mt-1 text-sm text-slate-500">Track CAR, CL, FAR, VVB findings, evidence gaps, responses, and reviewer notes.</p>
+            </div>
+
+            {project.status === 'in-progress' ? (
+              <form onSubmit={handleCreateManualFinding} className="mt-4 grid gap-3 rounded-lg border border-slate-200 bg-slate-50 p-4">
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div>
+                    <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">Finding ID</label>
+                    <input
+                      type="text"
+                      value={manualDraft.findingId}
+                      onChange={(event) => setManualDraft((current) => ({ ...current, findingId: event.target.value }))}
+                      className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">Finding Type</label>
+                    <select
+                      value={manualDraft.findingType}
+                      onChange={(event) => setManualDraft((current) => ({ ...current, findingType: event.target.value as ManualFindingType }))}
+                      className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                    >
+                      <option value="CAR">CAR</option>
+                      <option value="CL">CL</option>
+                      <option value="FAR">FAR</option>
+                      <option value="VVB finding">VVB finding</option>
+                      <option value="evidence gap">evidence gap</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div>
+                    <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">Source Document</label>
+                    <select
+                      value={manualDraft.sourceDocumentId}
+                      onChange={(event) => setManualDraft((current) => ({ ...current, sourceDocumentId: event.target.value }))}
+                      className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                    >
+                      <option value="">Select a source document...</option>
+                      {project.documents.map(document => (
+                        <option key={document.id} value={document.id}>
+                          {document.fileName}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">Closure Status</label>
+                    <select
+                      value={manualDraft.closureStatus}
+                      onChange={(event) => setManualDraft((current) => ({ ...current, closureStatus: event.target.value as ManualFindingClosureStatus }))}
+                      className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                    >
+                      <option value="open">Open</option>
+                      <option value="in-review">In Review</option>
+                      <option value="closed">Closed</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">Evidence Excerpt</label>
+                  <textarea
+                    rows={3}
+                    value={manualDraft.evidenceExcerpt}
+                    onChange={(event) => setManualDraft((current) => ({ ...current, evidenceExcerpt: event.target.value }))}
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">Project Response</label>
+                  <textarea
+                    rows={3}
+                    value={manualDraft.projectResponse}
+                    onChange={(event) => setManualDraft((current) => ({ ...current, projectResponse: event.target.value }))}
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">Reviewer Note</label>
+                  <textarea
+                    rows={3}
+                    value={manualDraft.reviewerNote}
+                    onChange={(event) => setManualDraft((current) => ({ ...current, reviewerNote: event.target.value }))}
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+
+                <div className="flex justify-end">
+                  <button
+                    type="submit"
+                    className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+                  >
+                    Add Review Item
+                  </button>
+                </div>
+              </form>
+            ) : null}
+
+            <div className="mt-4 flex flex-col gap-4">
+              {project.manualFindings.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+                  No manual review items yet.
+                </div>
+              ) : project.manualFindings.map((finding) => {
+                const sourceDocument = project.documents.find((document) => document.id === finding.sourceDocumentId);
+                return (
+                  <div key={finding.id} className="rounded-lg border border-slate-200 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="text-sm font-semibold text-slate-900">{finding.findingId}</div>
+                        <div className="mt-1 text-xs text-slate-500">
+                          {finding.findingType} · {manualFindingClosureLabel(finding.closureStatus)} · {sourceDocument?.fileName || 'No source document'}
+                        </div>
+                      </div>
+                      {project.status === 'in-progress' ? (
+                        <button
+                          onClick={() => refreshProject(deleteManualFinding(projectId, finding.id))}
+                          className="text-xs text-red-500 hover:text-red-700"
+                        >
+                          Delete
+                        </button>
+                      ) : null}
+                    </div>
+
+                    <div className="mt-4 grid gap-3 md:grid-cols-2">
+                      <Field label="Finding Type">
+                        {project.status === 'in-progress' ? (
+                          <select
+                            value={finding.findingType}
+                            onChange={(event) => updateFindingField(finding.id, 'findingType', event.target.value)}
+                            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                          >
+                            <option value="CAR">CAR</option>
+                            <option value="CL">CL</option>
+                            <option value="FAR">FAR</option>
+                            <option value="VVB finding">VVB finding</option>
+                            <option value="evidence gap">evidence gap</option>
+                          </select>
+                        ) : (
+                          <StaticValue value={finding.findingType} />
+                        )}
+                      </Field>
+
+                      <Field label="Closure Status">
+                        {project.status === 'in-progress' ? (
+                          <select
+                            value={finding.closureStatus}
+                            onChange={(event) => updateFindingField(finding.id, 'closureStatus', event.target.value)}
+                            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                          >
+                            <option value="open">Open</option>
+                            <option value="in-review">In Review</option>
+                            <option value="closed">Closed</option>
+                          </select>
+                        ) : (
+                          <StaticValue value={manualFindingClosureLabel(finding.closureStatus)} />
+                        )}
+                      </Field>
+                    </div>
+
+                    <div className="mt-3">
+                      <Field label="Source Document">
+                        {project.status === 'in-progress' ? (
+                          <select
+                            value={finding.sourceDocumentId || ''}
+                            onChange={(event) => updateFindingField(finding.id, 'sourceDocumentId', event.target.value)}
+                            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                          >
+                            <option value="">Select a source document...</option>
+                            {project.documents.map(document => (
+                              <option key={document.id} value={document.id}>
+                                {document.fileName}
+                              </option>
+                            ))}
+                          </select>
+                        ) : (
+                          <StaticValue value={sourceDocument?.fileName || 'No source document linked'} />
+                        )}
+                      </Field>
+                    </div>
+
+                    <div className="mt-3 grid gap-3">
+                      <Field label="Evidence Excerpt">
+                        <EditableText
+                          readOnly={project.status !== 'in-progress'}
+                          value={finding.evidenceExcerpt || ''}
+                          onChange={(value) => updateFindingField(finding.id, 'evidenceExcerpt', value)}
+                        />
+                      </Field>
+                      <Field label="Project Response">
+                        <EditableText
+                          readOnly={project.status !== 'in-progress'}
+                          value={finding.projectResponse || ''}
+                          onChange={(value) => updateFindingField(finding.id, 'projectResponse', value)}
+                        />
+                      </Field>
+                      <Field label="Reviewer Note">
+                        <EditableText
+                          readOnly={project.status !== 'in-progress'}
+                          value={finding.reviewerNote || ''}
+                          onChange={(value) => updateFindingField(finding.id, 'reviewerNote', value)}
+                        />
+                      </Field>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      ) : (
+        <MethodologyLinkedReview project={project} onStatusChange={handleStatusChange} />
+      )}
+    </div>
+  );
+}
+
+function MethodologyLinkedReview({
+  project,
+  onStatusChange,
+}: {
+  project: Project;
+  onStatusChange: (ruleId: string, status: RuleReview['status']) => void;
+}) {
+  const grouped = project.reviews.reduce((acc, review) => {
+    if (!acc[review.sectionId]) acc[review.sectionId] = [];
+    acc[review.sectionId].push(review);
+    return acc;
+  }, {} as Record<string, RuleReview[]>);
+
+  return (
+    <>
       {Object.entries(grouped).map(([sectionId, reviews]) => (
         <div key={sectionId} className="rounded-lg border border-slate-200 bg-white">
           <div className="border-b border-slate-100 px-4 py-3">
             <h2 className="text-sm font-bold text-slate-700">{sectionId}</h2>
           </div>
           <div className="divide-y divide-slate-50">
-            {reviews.map(review => (
+            {reviews.map((review) => (
               <div key={review.ruleId} className="flex items-center gap-3 px-4 py-3">
                 <div className="flex-1">
                   <div className="text-sm font-medium text-slate-800">{review.ruleTitle}</div>
-                  <div className="text-xs text-slate-400 font-mono">{review.ruleId}</div>
+                  <div className="font-mono text-xs text-slate-400">{review.ruleId}</div>
                 </div>
                 {project.status === 'in-progress' ? (
                   <select
                     value={review.status}
-                    onChange={e => handleStatusChange(review.ruleId, e.target.value as RuleReview['status'])}
+                    onChange={event => onStatusChange(review.ruleId, event.target.value as RuleReview['status'])}
                     className={`rounded border px-2 py-1 text-xs font-semibold ${
                       review.status === 'verified'
                         ? 'border-green-300 bg-green-50 text-green-700'
@@ -204,6 +634,39 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
           </div>
         </div>
       ))}
+    </>
+  );
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</div>
+      {children}
     </div>
   );
+}
+
+function EditableText({
+  value,
+  onChange,
+  readOnly,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  readOnly: boolean;
+}) {
+  if (readOnly) return <StaticValue value={value || 'Not provided'} />;
+  return (
+    <textarea
+      rows={3}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+    />
+  );
+}
+
+function StaticValue({ value }: { value: string }) {
+  return <div className="rounded-lg bg-slate-50 px-3 py-2 text-sm text-slate-700">{value}</div>;
 }

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -49,6 +49,12 @@ const EMPTY_MANUAL_FINDING: ManualFindingDraft = {
   reviewerNote: '',
 };
 
+export function shouldShowLockReview(project: Project, coverage: ProjectCoverage | null): boolean {
+  if (project.status !== 'in-progress' || !coverage) return false;
+  if (project.reviewMode === 'manual') return project.manualFindings.length > 0;
+  return coverage.notStarted < coverage.total;
+}
+
 export default function ProjectDetail({ projectId }: ProjectDetailProps) {
   const [project, setProject] = useState<Project | null>(null);
   const [coverage, setCoverage] = useState<ProjectCoverage | null>(null);
@@ -227,7 +233,7 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
         </div>
 
         <div className="flex items-center gap-2">
-          {project.status === 'in-progress' && coverage && coverage.total > 0 ? (
+          {shouldShowLockReview(project, coverage) ? (
             <button
               onClick={handleLock}
               className="rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700"

--- a/src/components/projects/ProjectsList.tsx
+++ b/src/components/projects/ProjectsList.tsx
@@ -22,19 +22,19 @@ export default function ProjectsList() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-slate-900">Projects</h1>
-          <p className="mt-1 text-sm text-slate-500">Methodology verification workbench</p>
+          <p className="mt-1 text-sm text-slate-500">Long-lived project review workspace for methodology-linked and manual reviews</p>
         </div>
         <Link
           href="/projects/new"
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
         >
-          + New Project
+          + New Project Review
         </Link>
       </div>
 
       {projects.length === 0 ? (
         <div className="rounded-lg border border-dashed border-slate-300 bg-white p-12 text-center">
-          <p className="text-slate-500">No projects yet. Create one to start a verification.</p>
+          <p className="text-slate-500">No project reviews yet. Create one to start a durable review workspace.</p>
         </div>
       ) : (
         <div className="flex flex-col gap-3">
@@ -54,9 +54,14 @@ export default function ProjectsList() {
                       {project.name}
                     </Link>
                     <div className="mt-1 flex items-center gap-3 text-xs text-slate-500">
-                      <span className="rounded bg-slate-100 px-2 py-0.5 font-mono">
-                        {project.methodCode}@{project.methodVersion}
+                      <span className="rounded bg-slate-100 px-2 py-0.5 font-semibold text-slate-700">
+                        {project.reviewMode === 'manual' ? 'Manual Review' : 'Methodology-linked review'}
                       </span>
+                      {project.reviewMode === 'methodology-linked' && project.methodCode && project.methodVersion ? (
+                        <span className="rounded bg-slate-100 px-2 py-0.5 font-mono">
+                          {project.methodCode}@{project.methodVersion}
+                        </span>
+                      ) : null}
                       <span
                         className={`rounded px-2 py-0.5 font-semibold ${
                           project.status === 'locked'
@@ -88,9 +93,10 @@ export default function ProjectsList() {
                     />
                   </div>
                   <div className="mt-1 flex gap-3 text-xs text-slate-400">
-                    <span>{coverage.verified} verified</span>
-                    <span>{coverage.gap} gaps</span>
-                    <span>{coverage.notStarted} pending</span>
+                    <span>{coverage.verified} {project.reviewMode === 'manual' ? 'closed' : 'verified'}</span>
+                    <span>{coverage.gap} {project.reviewMode === 'manual' ? 'open' : 'gaps'}</span>
+                    <span>{coverage.inProgress} {project.reviewMode === 'manual' ? 'in review' : 'in progress'}</span>
+                    {project.reviewMode === 'methodology-linked' ? <span>{coverage.notStarted} pending</span> : null}
                     {coverage.notApplicable > 0 && <span>{coverage.notApplicable} n/a</span>}
                   </div>
                 </div>

--- a/src/components/verify/FinalReviewSummaryPanel.tsx
+++ b/src/components/verify/FinalReviewSummaryPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ReviewSummaryCard from "@/components/verify/ReviewSummaryCard";
+import { getAttachmentBytes } from "@/lib/proofMap/attachments";
 import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
 import type { EvidencePin } from "@/lib/proofMap/types";
 import type { ReviewSummary } from "@/lib/verify/buildReviewSummary";
@@ -56,6 +57,16 @@ function downloadBytes(bytes: Uint8Array, filename: string, mimeType: string) {
   URL.revokeObjectURL(url);
 }
 
+function base64FromArrayBuffer(bytes: ArrayBuffer): string {
+  let binary = "";
+  const chunk = 0x8000;
+  const view = new Uint8Array(bytes);
+  for (let index = 0; index < view.length; index += chunk) {
+    binary += String.fromCharCode(...view.subarray(index, index + chunk));
+  }
+  return btoa(binary);
+}
+
 export default function FinalReviewSummaryPanel({
   summary,
   artifact,
@@ -87,10 +98,40 @@ export default function FinalReviewSummaryPanel({
     if (!artifact) return;
     const method = artifact.method.code || summary.methodCode || "";
     const version = artifact.method.version || summary.version || "";
+    const sourceFiles = (
+      await Promise.all(
+        evidencePins.flatMap((pin) =>
+          (pin.attachments ?? []).map(async (attachment) => {
+            const bytes = await getAttachmentBytes(attachment.id);
+            if (!bytes) return null;
+            return {
+              evidence_ref:
+                pin.pdd_document?.attachment_id === attachment.id
+                  ? pin.pdd_document.evidence_id
+                  : `${pin.id}:${attachment.id}`,
+              source_pin_id: pin.id,
+              attachment_id: attachment.id,
+              file_name: attachment.filename,
+              mime: attachment.mime,
+              bytes_base64: base64FromArrayBuffer(bytes),
+              sha256: attachment.sha256,
+            };
+          }),
+        ),
+      )
+    ).filter((item): item is {
+      evidence_ref: string;
+      source_pin_id: string;
+      attachment_id: string;
+      file_name: string;
+      mime: string;
+      bytes_base64: string;
+      sha256: string;
+    } => Boolean(item));
     const response = await fetch("/api/exports/audit-pack", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ method, version, artifact, evidencePins }),
+      body: JSON.stringify({ method, version, artifact, evidencePins, sourceFiles }),
     });
     if (!response.ok) throw new Error(await response.text());
     const bytes = new Uint8Array(await response.arrayBuffer());

--- a/src/exports/verificationPackContract.ts
+++ b/src/exports/verificationPackContract.ts
@@ -1,4 +1,4 @@
-import { canonicalStringify } from "../integrity/artifacts";
+import { canonicalStringify, sha256Hex } from "../integrity/artifacts";
 import type { EvidenceSnapshot } from "../lib/proofMap/evidenceSnapshot";
 import type { EvidencePin } from "../lib/proofMap/types";
 import type { TraceIndex, TraceSectionLink } from "../lib/trace/traceIndex";
@@ -53,8 +53,8 @@ type EvidenceManifestEntry = {
   status_basis: "demo_placeholder" | "current_method_review" | "finalized_project_review";
   source_kind: "project_evidence_slot" | "project_evidence_ref";
   included_in_pack: boolean;
-  file_path: null;
-  sha256: null;
+  file_path: string | null;
+  sha256: string | null;
   requested_for: string;
   placeholder: boolean;
   placeholder_reason: string;
@@ -62,6 +62,8 @@ type EvidenceManifestEntry = {
   source_pin_id?: string;
   evidence_title?: string;
   evidence_type?: string;
+  parent_source_evidence_ref?: string | null;
+  parent_source_file_path?: string | null;
 };
 
 type EvidenceManifest = {
@@ -235,6 +237,15 @@ const CURRENT_METHOD_REVIEW_REASON =
 export type FinalizedAuditPackReviewInput = {
   artifact?: EvidenceSnapshot | null;
   evidencePins?: EvidencePin[] | null;
+  sourceFiles?: Array<{
+    evidence_ref: string;
+    source_pin_id?: string | null;
+    attachment_id?: string | null;
+    file_name: string;
+    mime: string;
+    bytes_base64: string;
+    sha256?: string | null;
+  }> | null;
 };
 
 export type CurrentMethodReviewExportInput = {
@@ -289,6 +300,84 @@ function uniqueSorted(values: Array<string | null | undefined>): string[] {
   return Array.from(new Set(values.map((value) => value?.trim()).filter((value): value is string => Boolean(value)))).sort((a, b) =>
     a.localeCompare(b),
   );
+}
+
+function safeZipSegment(value: string | null | undefined, fallback: string): string {
+  const trimmed = value?.trim() || fallback;
+  const sanitized = trimmed.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
+  return sanitized || fallback;
+}
+
+function safeZipFilename(value: string | null | undefined, fallback: string): string {
+  const normalized = (value?.trim() || fallback).replace(/[\\/]+/g, "_");
+  const sanitized = normalized.replace(/[^A-Za-z0-9._ -]+/g, "_").replace(/\s+/g, "_");
+  return sanitized || fallback;
+}
+
+function decodeBase64Bytes(value: string): Buffer {
+  return Buffer.from(value, "base64");
+}
+
+type PackagedEvidenceSourceFile = {
+  evidence_ref: string;
+  source_pin_id?: string | null;
+  attachment_id?: string | null;
+  file_name: string;
+  mime: string;
+  bytes: Buffer;
+  sha256: string;
+  file_path: string;
+  label: string;
+  evidence_type: string;
+};
+
+function collectPackagedEvidenceSourceFiles(input: FinalizedAuditPackReviewInput | null | undefined): PackagedEvidenceSourceFile[] {
+  const packaged: PackagedEvidenceSourceFile[] = [];
+  const sourceFiles = input?.sourceFiles ?? [];
+  for (const source of sourceFiles) {
+    const evidenceRef = source.evidence_ref?.trim();
+    const fileName = source.file_name?.trim();
+    if (!evidenceRef || !fileName || !source.bytes_base64?.trim()) continue;
+    const bytes = decodeBase64Bytes(source.bytes_base64);
+    const safeEvidenceRef = safeZipSegment(evidenceRef, "evidence");
+    const safeName = safeZipFilename(fileName, "evidence.bin");
+    packaged.push({
+      evidence_ref: evidenceRef,
+      source_pin_id: source.source_pin_id?.trim() || null,
+      attachment_id: source.attachment_id?.trim() || null,
+      file_name: fileName,
+      mime: source.mime?.trim() || "application/octet-stream",
+      bytes,
+      sha256: "",
+      file_path: `evidence/source/${safeEvidenceRef}/${safeName}`,
+      label: fileName,
+      evidence_type: "uploaded_source",
+    });
+  }
+  const artifactAoi = input?.artifact?.aoi?.geojson;
+  if (artifactAoi) {
+    const aoiId = input?.artifact?.aoi?.id?.trim() || "aoi";
+    const aoiLabel = input?.artifact?.summary?.aoiLabel?.trim() || "active-area";
+    const bytes = Buffer.from(canonicalStringify(artifactAoi), "utf8");
+    packaged.push({
+      evidence_ref: aoiId,
+      source_pin_id: null,
+      attachment_id: null,
+      file_name: `${safeZipFilename(aoiLabel, "active-area")}.geojson`,
+      mime: "application/geo+json",
+      bytes,
+      sha256: "",
+      file_path: `evidence/source/${safeZipSegment(aoiId, "aoi")}/${safeZipFilename(aoiLabel, "active-area")}.geojson`,
+      label: `${aoiLabel}.geojson`,
+      evidence_type: "aoi_geojson",
+    });
+  }
+  return packaged
+    .map((item) => ({
+      ...item,
+      sha256: sha256Hex(item.bytes),
+    }))
+    .sort((a, b) => a.file_path.localeCompare(b.file_path));
 }
 
 function canonicalRuleKey(value: string | null | undefined): string | null {
@@ -397,6 +486,8 @@ function evidenceRefsFromPinsForRule(
         source_pin_id: pin.id,
         evidence_title: pin.title,
         evidence_type: pin.kind,
+        parent_source_evidence_ref: pin.pdd_document?.evidence_id ?? null,
+        parent_source_file_path: null,
       });
     }
   }
@@ -502,6 +593,8 @@ function mergeEvidenceManifestEntries(entries: EvidenceManifestEntry[]): Evidenc
           ? "provided"
           : "not_provided",
       included_in_pack: current.included_in_pack || entry.included_in_pack,
+      file_path: current.file_path ?? entry.file_path ?? null,
+      sha256: current.sha256 ?? entry.sha256 ?? null,
       requested_for: current.requested_for || entry.requested_for,
       placeholder: current.placeholder && entry.placeholder,
       placeholder_reason: current.placeholder_reason || entry.placeholder_reason,
@@ -509,9 +602,77 @@ function mergeEvidenceManifestEntries(entries: EvidenceManifestEntry[]): Evidenc
       source_pin_id: current.source_pin_id ?? entry.source_pin_id,
       evidence_title: current.evidence_title ?? entry.evidence_title,
       evidence_type: current.evidence_type ?? entry.evidence_type,
+      parent_source_evidence_ref: current.parent_source_evidence_ref ?? entry.parent_source_evidence_ref ?? null,
+      parent_source_file_path: current.parent_source_file_path ?? entry.parent_source_file_path ?? null,
     });
   }
   return Array.from(byRef.values()).sort((a, b) => a.evidence_ref.localeCompare(b.evidence_ref));
+}
+
+function evidenceManifestEntriesFromPackagedSources(input: {
+  sources: PackagedEvidenceSourceFile[];
+  selectedRuleIds: string[];
+  evidencePins: EvidencePin[];
+}): EvidenceManifestEntry[] {
+  if (!input.sources.length) return [];
+  const pinById = new Map(input.evidencePins.map((pin) => [pin.id, pin]));
+  return input.sources.map((source) => {
+    const pin = source.source_pin_id ? pinById.get(source.source_pin_id) ?? null : null;
+    const linkedRuleIds = uniqueSorted([
+      ...input.selectedRuleIds,
+      pin?.ruleId,
+      ...(pin?.cited_ids ?? []),
+      ...(pin?.pdd_fragment_links ?? []).map((link) => link.rule_id),
+    ]);
+    return {
+      evidence_ref: source.evidence_ref,
+      label: source.label,
+      rule_ids: linkedRuleIds,
+      status: "provided",
+      status_basis: "finalized_project_review",
+      source_kind: "project_evidence_ref",
+      included_in_pack: true,
+      file_path: source.file_path,
+      sha256: source.sha256,
+      requested_for:
+        source.evidence_type === "aoi_geojson"
+          ? "Finalized AOI source file"
+          : input.selectedRuleIds[0]
+            ? `Finalized uploaded evidence for ${input.selectedRuleIds[0]}`
+            : "Finalized uploaded evidence source file",
+      placeholder: false,
+      placeholder_reason: "",
+      source_pin_id: source.source_pin_id ?? undefined,
+      evidence_title: source.file_name,
+      evidence_type: source.evidence_type,
+      parent_source_evidence_ref: null,
+      parent_source_file_path: null,
+    };
+  });
+}
+
+function applyPackagedSourceReferences(
+  entries: EvidenceManifestEntry[],
+  sources: PackagedEvidenceSourceFile[],
+): EvidenceManifestEntry[] {
+  if (!sources.length) return entries;
+  const sourceByRef = new Map(sources.map((source) => [source.evidence_ref, source]));
+  return entries.map((entry) => {
+    const directSource = sourceByRef.get(entry.evidence_ref);
+    const parentSource =
+      !directSource && entry.parent_source_evidence_ref ? sourceByRef.get(entry.parent_source_evidence_ref) ?? null : null;
+    if (!directSource && !parentSource) return entry;
+    return {
+      ...entry,
+      status: directSource ? "provided" : entry.status,
+      included_in_pack: directSource ? true : entry.included_in_pack,
+      file_path: directSource ? directSource.file_path : entry.file_path,
+      sha256: directSource ? directSource.sha256 : entry.sha256,
+      evidence_title: directSource ? directSource.file_name : entry.evidence_title,
+      evidence_type: directSource ? directSource.evidence_type : entry.evidence_type,
+      parent_source_file_path: parentSource?.file_path ?? entry.parent_source_file_path ?? null,
+    };
+  });
 }
 
 function selectedRuleFromArtifact(artifact: EvidenceSnapshot | null | undefined): string | null {
@@ -594,6 +755,18 @@ function evidenceRefsForRule(input: {
     });
   }
   return entries.sort((a, b) => a.evidence_ref.localeCompare(b.evidence_ref));
+}
+
+function ruleIdsFromFinalizedContext(
+  selectedRuleId: string | null,
+  artifact: EvidenceSnapshot | null | undefined,
+): string[] {
+  return uniqueSorted([
+    selectedRuleId,
+    artifact?.summary?.ruleId ?? null,
+    artifact?.outcome?.linkage.selectedRuleId ?? null,
+    ...(artifact?.outcome?.linkage.linkedRuleIds ?? []),
+  ]);
 }
 
 function summarizeRuleText(text: string): string {
@@ -764,7 +937,9 @@ function renderVerificationReportHtml(input: {
   <td>${escapeHtml(sourceName)}</td>
   <td>${escapeHtml(entry.evidence_type || entry.source_kind)}</td>
   <td>${escapeHtml(entry.rule_ids.join(", ") || "None")}</td>
-  <td>${escapeHtml(includedState)}</td>
+  <td>${escapeHtml(includedState)}${
+    entry.parent_source_file_path ? `<div class="muted">Parent source: ${escapeHtml(entry.parent_source_file_path)}</div>` : ""
+  }</td>
   <td>${escapeHtml(entry.sha256 ?? "Unavailable")}</td>
 </tr>`;
     })
@@ -1089,6 +1264,8 @@ export function buildVerificationPackContract(input: {
   const currentReviewEntries = currentReview?.reviews ?? [];
   const currentVerifierBundle = currentReview?.verifierBundle ?? null;
   const finalizedRuleId = selectedRuleFromArtifact(finalizedArtifact);
+  const finalizedRuleIds = ruleIdsFromFinalizedContext(finalizedRuleId, finalizedArtifact);
+  const packagedFinalizedSources = collectPackagedEvidenceSourceFiles(input.finalizedReview ?? null);
   const finalizedEvidence = evidenceRefsForRule({
     ruleId: finalizedRuleId,
     artifact: finalizedArtifact,
@@ -1180,7 +1357,19 @@ export function buildVerificationPackContract(input: {
   };
 
   const evidence = hasFinalizedReview
-    ? finalizedEvidence
+    ? mergeEvidenceManifestEntries(
+        applyPackagedSourceReferences(
+          [
+            ...finalizedEvidence,
+            ...evidenceManifestEntriesFromPackagedSources({
+              sources: packagedFinalizedSources,
+              selectedRuleIds: finalizedRuleIds,
+              evidencePins: finalizedPins,
+            }),
+          ],
+          packagedFinalizedSources,
+        ),
+      )
     : hasCurrentReview
       ? mergeEvidenceManifestEntries(
           rules.flatMap((rule) => {
@@ -1450,6 +1639,7 @@ export function buildVerificationPackContractFiles(input: {
   currentReview?: CurrentMethodReviewExportInput | null;
 }): Array<{ path: string; bytes: Buffer }> {
   const contract = buildVerificationPackContract(input);
+  const packagedFinalizedSources = collectPackagedEvidenceSourceFiles(input.finalizedReview ?? null);
   return [
     {
       path: "project.json",
@@ -1475,6 +1665,10 @@ export function buildVerificationPackContractFiles(input: {
       path: "VERIFICATION_REPORT.html",
       bytes: Buffer.from(contract.reportHtml, "utf8"),
     },
+    ...packagedFinalizedSources.map((source) => ({
+      path: source.file_path,
+      bytes: source.bytes,
+    })),
   ];
 }
 

--- a/src/lib/projects/reportFindings.ts
+++ b/src/lib/projects/reportFindings.ts
@@ -1,4 +1,4 @@
-import type { RuleReview } from '@/lib/projects/types';
+import type { ManualFinding, RuleReview } from '@/lib/projects/types';
 
 export type ReportFindingCode = 'OK' | 'CL' | 'NC' | 'FAR' | 'PENDING' | 'NA';
 
@@ -9,7 +9,7 @@ export type ReportFinding = {
   sectionId: string;
   sectionTitle: string;
   code: ReportFindingCode;
-  sourceStatus: RuleReview['status'];
+  sourceStatus: RuleReview['status'] | ManualFinding['closureStatus'];
   rationale: string;
   evidenceIds: string[];
   limitation?: string;
@@ -59,5 +59,36 @@ export function buildReportFinding(
       : code === 'PENDING' || code === 'CL'
         ? 'Finding is not a completed verification conclusion.'
         : undefined,
+  };
+}
+
+export function manualFindingCodeFromType(type: ManualFinding['findingType']): ReportFindingCode {
+  if (type === 'CAR' || type === 'VVB finding' || type === 'evidence gap') return 'NC';
+  if (type === 'FAR') return 'FAR';
+  return 'CL';
+}
+
+export function buildManualReportFinding(
+  finding: ManualFinding,
+  sourceDocumentLabel: string,
+): ReportFinding {
+  const rationale = finding.reviewerNote?.trim()
+    || finding.evidenceExcerpt?.trim()
+    || finding.projectResponse?.trim()
+    || 'Manual review finding recorded without additional reviewer rationale.';
+
+  return {
+    findingId: finding.findingId,
+    ruleId: sourceDocumentLabel,
+    ruleTitle: finding.findingType,
+    sectionId: 'MANUAL',
+    sectionTitle: 'Manual Review Findings',
+    code: manualFindingCodeFromType(finding.findingType),
+    sourceStatus: finding.closureStatus,
+    rationale,
+    evidenceIds: finding.sourceDocumentId ? [finding.sourceDocumentId] : [],
+    limitation: finding.closureStatus === 'closed'
+      ? undefined
+      : 'Finding remains open inside a project-level manual review workflow.',
   };
 }

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -1,4 +1,12 @@
-import type { Project, RuleReview, ProjectCoverage, RuleReviewStatus } from './types';
+import type {
+  ManualFinding,
+  ManualFindingClosureStatus,
+  Project,
+  ProjectCoverage,
+  ProjectDocument,
+  RuleReview,
+  RuleReviewStatus,
+} from './types';
 
 const STORAGE_KEY = 'article6_projects';
 
@@ -10,7 +18,7 @@ function loadAll(): Project[] {
   if (typeof window === 'undefined') return [];
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : [];
+    return raw ? normalizeProjects(JSON.parse(raw)) : [];
   } catch {
     return [];
   }
@@ -31,16 +39,18 @@ export function getProject(id: string): Project | undefined {
 
 export function createProject(input: {
   name: string;
-  methodCode: string;
-  methodVersion: string;
+  reviewMode: Project['reviewMode'];
+  methodCode?: string;
+  methodVersion?: string;
   registry?: Project['registry'];
   aoiLabel?: string;
   description?: string;
-  ruleIds: Array<{ id: string; title: string; sectionId: string }>;
+  ruleIds?: Array<{ id: string; title: string; sectionId: string }>;
 }): Project {
   const project: Project = {
     id: generateId(),
     name: input.name,
+    reviewMode: input.reviewMode,
     methodCode: input.methodCode,
     methodVersion: input.methodVersion,
     registry: input.registry,
@@ -48,13 +58,15 @@ export function createProject(input: {
     createdAt: new Date().toISOString(),
     aoiLabel: input.aoiLabel,
     description: input.description,
-    reviews: input.ruleIds.map(r => ({
+    reviews: (input.ruleIds ?? []).map(r => ({
       ruleId: r.id,
       ruleTitle: r.title,
       sectionId: r.sectionId,
       status: 'not-started' as RuleReviewStatus,
       evidenceIds: [],
     })),
+    documents: [],
+    manualFindings: [],
   };
 
   const projects = loadAll();
@@ -103,6 +115,17 @@ export function deleteProject(projectId: string): void {
 }
 
 export function getProjectCoverage(project: Project): ProjectCoverage {
+  if (project.reviewMode === 'manual') {
+    const total = project.manualFindings.length;
+    const verified = project.manualFindings.filter(f => f.closureStatus === 'closed').length;
+    const gap = project.manualFindings.filter(f => f.closureStatus === 'open').length;
+    const inProgress = project.manualFindings.filter(f => f.closureStatus === 'in-review').length;
+    const notStarted = 0;
+    const notApplicable = 0;
+    const percentComplete = total > 0 ? Math.round((verified / total) * 100) : 0;
+    return { total, verified, gap, notStarted, notApplicable, inProgress, percentComplete };
+  }
+
   const reviews = project.reviews;
   const total = reviews.length;
   const verified = reviews.filter(r => r.status === 'verified').length;
@@ -114,4 +137,126 @@ export function getProjectCoverage(project: Project): ProjectCoverage {
   const percentComplete = actionable > 0 ? Math.round(((verified + gap) / actionable) * 100) : 0;
 
   return { total, verified, gap, notStarted, notApplicable, inProgress, percentComplete };
+}
+
+export function addProjectDocument(
+  projectId: string,
+  document: Omit<ProjectDocument, 'id' | 'uploadedAt'>,
+): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find(p => p.id === projectId);
+  if (!project || project.status === 'locked') return undefined;
+
+  project.documents.push({
+    id: generateId(),
+    uploadedAt: new Date().toISOString(),
+    ...document,
+  });
+
+  saveAll(projects);
+  return project;
+}
+
+export function deleteProjectDocument(projectId: string, documentId: string): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find(p => p.id === projectId);
+  if (!project || project.status === 'locked') return undefined;
+
+  project.documents = project.documents.filter(document => document.id !== documentId);
+  project.manualFindings = project.manualFindings.map(finding => (
+    finding.sourceDocumentId === documentId
+      ? { ...finding, sourceDocumentId: undefined, updatedAt: new Date().toISOString() }
+      : finding
+  ));
+
+  saveAll(projects);
+  return project;
+}
+
+export function addManualFinding(
+  projectId: string,
+  input: Omit<ManualFinding, 'id' | 'createdAt' | 'updatedAt'>,
+): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find(p => p.id === projectId);
+  if (!project || project.status === 'locked') return undefined;
+
+  const now = new Date().toISOString();
+  project.manualFindings.push({
+    id: generateId(),
+    createdAt: now,
+    updatedAt: now,
+    ...input,
+  });
+
+  saveAll(projects);
+  return project;
+}
+
+export function updateManualFinding(
+  projectId: string,
+  findingId: string,
+  update: Partial<Omit<ManualFinding, 'id' | 'createdAt'>>,
+): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find(p => p.id === projectId);
+  if (!project || project.status === 'locked') return undefined;
+
+  const finding = project.manualFindings.find(item => item.id === findingId);
+  if (!finding) return undefined;
+
+  Object.assign(finding, update, { updatedAt: new Date().toISOString() });
+  saveAll(projects);
+  return project;
+}
+
+export function deleteManualFinding(projectId: string, findingId: string): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find(p => p.id === projectId);
+  if (!project || project.status === 'locked') return undefined;
+
+  project.manualFindings = project.manualFindings.filter(finding => finding.id !== findingId);
+  saveAll(projects);
+  return project;
+}
+
+function normalizeProjects(raw: unknown): Project[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((item) => item && typeof item === 'object')
+    .map((item) => normalizeProject(item as Partial<Project>));
+}
+
+function normalizeProject(project: Partial<Project>): Project {
+  return {
+    id: project.id ?? generateId(),
+    name: project.name ?? 'Untitled project',
+    reviewMode: project.reviewMode ?? 'methodology-linked',
+    methodCode: project.methodCode,
+    methodVersion: project.methodVersion,
+    registry: project.registry,
+    status: project.status ?? 'in-progress',
+    createdAt: project.createdAt ?? new Date().toISOString(),
+    lockedAt: project.lockedAt,
+    aoiLabel: project.aoiLabel,
+    description: project.description,
+    reviews: Array.isArray(project.reviews) ? project.reviews : [],
+    documents: Array.isArray(project.documents) ? project.documents : [],
+    manualFindings: Array.isArray(project.manualFindings) ? project.manualFindings : [],
+  };
+}
+
+export function nextManualFindingId(project: Project): string {
+  const max = project.manualFindings.reduce((currentMax, finding) => {
+    const match = finding.findingId.match(/(\d+)$/);
+    const numeric = match ? Number(match[1]) : 0;
+    return Number.isFinite(numeric) ? Math.max(currentMax, numeric) : currentMax;
+  }, 0);
+  return `F-${String(max + 1).padStart(3, '0')}`;
+}
+
+export function manualFindingClosureLabel(status: ManualFindingClosureStatus): string {
+  if (status === 'open') return 'Open';
+  if (status === 'in-review') return 'In Review';
+  return 'Closed';
 }

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -1,8 +1,14 @@
 export type ProjectStatus = 'in-progress' | 'locked';
 
+export type ProjectReviewMode = 'methodology-linked' | 'manual';
+
 export type RuleReviewStatus = 'not-started' | 'in-progress' | 'verified' | 'gap' | 'not-applicable';
 
 export type ProjectRegistry = 'UNFCCC' | 'Verra' | 'Gold Standard' | 'Unknown';
+
+export type ManualFindingType = 'CAR' | 'CL' | 'FAR' | 'VVB finding' | 'evidence gap';
+
+export type ManualFindingClosureStatus = 'open' | 'in-review' | 'closed';
 
 export type RuleReview = {
   ruleId: string;
@@ -15,11 +21,34 @@ export type RuleReview = {
   reviewedAt?: string;
 };
 
+export type ProjectDocument = {
+  id: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  uploadedAt: string;
+  extractedText?: string;
+};
+
+export type ManualFinding = {
+  id: string;
+  findingId: string;
+  findingType: ManualFindingType;
+  sourceDocumentId?: string;
+  evidenceExcerpt?: string;
+  projectResponse?: string;
+  closureStatus: ManualFindingClosureStatus;
+  reviewerNote?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type Project = {
   id: string;
   name: string;
-  methodCode: string;
-  methodVersion: string;
+  reviewMode: ProjectReviewMode;
+  methodCode?: string;
+  methodVersion?: string;
   registry?: ProjectRegistry;
   status: ProjectStatus;
   createdAt: string;
@@ -27,6 +56,8 @@ export type Project = {
   aoiLabel?: string;
   description?: string;
   reviews: RuleReview[];
+  documents: ProjectDocument[];
+  manualFindings: ManualFinding[];
 };
 
 export type ProjectCoverage = {

--- a/src/lib/projects/verificationReport.ts
+++ b/src/lib/projects/verificationReport.ts
@@ -1,4 +1,9 @@
-import { buildReportFinding, type ReportFinding, type ReportFindingCode } from '@/lib/projects/reportFindings';
+import {
+  buildManualReportFinding,
+  buildReportFinding,
+  type ReportFinding,
+  type ReportFindingCode,
+} from '@/lib/projects/reportFindings';
 import type { Project, ProjectCoverage, ProjectRegistry } from '@/lib/projects/types';
 
 export type VerificationReportStatus = 'ready' | 'registry_not_fully_supported' | 'insufficient_source_content';
@@ -56,7 +61,7 @@ export function resolveProjectRegistry(project: Pick<Project, 'methodCode' | 're
   const explicit = normalizeRegistry(project.registry);
   if (explicit !== 'Unknown') return explicit;
 
-  const code = project.methodCode.trim().toUpperCase();
+  const code = project.methodCode?.trim().toUpperCase() ?? '';
   if (!code) return 'Unknown';
   if (code.startsWith('UNFCCC.') || code.includes('UNFCCC')) return 'UNFCCC';
   if (code.startsWith('VM') || code.startsWith('VMR') || code.includes('VERRA')) return 'Verra';
@@ -73,10 +78,11 @@ function buildProvenance(
   exportTime = 'generated during export',
 ): Array<[string, string]> {
   const items: Array<[string, string]> = [
+    ['Manual review mode', project.reviewMode === 'manual' ? 'true' : 'false'],
     ['Registry', registry],
     ['Report status', status],
     ['Project ID', project.id],
-    ['Methodology', `${project.methodCode} @ ${project.methodVersion}`],
+    ['Methodology', project.methodCode && project.methodVersion ? `${project.methodCode} @ ${project.methodVersion}` : 'n/a'],
     ['Created', project.createdAt || 'n/a'],
     ['Rules reviewed', `${coverage.verified + coverage.gap} of ${coverage.total}`],
     ['Export time', exportTime],
@@ -88,9 +94,10 @@ function buildProvenance(
 
 function buildSummaryItems(project: Project, coverage: ProjectCoverage, registry: ProjectRegistry): string[] {
   const items = [
+    `Manual review mode: ${project.reviewMode === 'manual' ? 'true' : 'false'}`,
     `Registry: ${registry}`,
-    `Methodology: ${project.methodCode} @ ${project.methodVersion}`,
-    `Reviewed: ${coverage.verified + coverage.gap} of ${coverage.total} rules`,
+    `Methodology: ${project.methodCode && project.methodVersion ? `${project.methodCode} @ ${project.methodVersion}` : 'n/a'}`,
+    `Reviewed: ${coverage.verified + coverage.gap} of ${coverage.total} items`,
   ];
   if (project.aoiLabel) items.push(`Area: ${project.aoiLabel}`);
   return items;
@@ -304,11 +311,100 @@ export function composeGoldStandardVerificationReport(project: Project, coverage
   return composeRecognizedFallbackReport('Gold Standard', project, coverage);
 }
 
+export function composeManualVerificationReport(
+  project: Project,
+  coverage: ProjectCoverage,
+  exportTime?: string,
+): VerificationReportComposition {
+  const findings = project.manualFindings.map((finding) => {
+    const sourceDocumentLabel = project.documents.find((document) => document.id === finding.sourceDocumentId)?.fileName ?? 'No source document linked';
+    return buildManualReportFinding(finding, sourceDocumentLabel);
+  });
+  const findingCounts = countFindings(findings);
+  const provenance = buildProvenance(project, coverage, project.registry ?? 'Unknown', findings.length === 0 ? 'insufficient_source_content' : 'ready', exportTime);
+
+  return {
+    registry: project.registry ?? 'Unknown',
+    status: findings.length === 0 ? 'insufficient_source_content' : 'ready',
+    title: 'MANUAL REVIEW REPORT',
+    subtitle: 'Project-level manual review workspace for VVB findings reconstruction and evidence-gap tracking.',
+    summaryItems: [
+      `Manual review mode: true`,
+      `Project: ${project.name}`,
+      `Findings recorded: ${project.manualFindings.length}`,
+      `Source documents: ${project.documents.length}`,
+    ],
+    sections: [
+      {
+        title: 'REVIEW STATUS',
+        lines: [
+          'Manual review mode: true.',
+          `Project status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}.`,
+          `Project title: ${project.name}.`,
+          `Findings recorded: ${project.manualFindings.length}.`,
+          `Source documents uploaded: ${project.documents.length}.`,
+        ],
+      },
+      {
+        title: 'PROJECT CONTEXT',
+        lines: [
+          `Project name: ${project.name}.`,
+          project.aoiLabel ? `Project area: ${project.aoiLabel}.` : 'Project area: not provided.',
+          project.description ? `Project description: ${project.description}.` : 'Project description: not provided.',
+          `Created date: ${project.createdAt || 'n/a'}.`,
+          project.lockedAt ? `Locked date: ${project.lockedAt}.` : 'Locked date: not locked.',
+        ],
+      },
+      {
+        title: 'SOURCE DOCUMENTS',
+        lines: project.documents.length > 0
+          ? project.documents.flatMap((document) => [
+            `${document.fileName} (${document.mimeType || 'unknown'}, ${document.sizeBytes} bytes).`,
+            document.extractedText?.trim()
+              ? `Document preview: ${document.extractedText.trim().slice(0, 220)}.`
+              : 'Document preview: not captured.',
+          ])
+          : ['No source documents uploaded.'],
+      },
+      {
+        title: 'FINDINGS SUMMARY',
+        lines: [
+          `NC: ${findingCounts.NC}. CL: ${findingCounts.CL}. FAR: ${findingCounts.FAR}.`,
+          `Open: ${project.manualFindings.filter((finding) => finding.closureStatus === 'open').length}. In review: ${project.manualFindings.filter((finding) => finding.closureStatus === 'in-review').length}. Closed: ${project.manualFindings.filter((finding) => finding.closureStatus === 'closed').length}.`,
+        ],
+      },
+      {
+        title: 'MANUAL FINDINGS',
+        lines: project.manualFindings.length > 0
+          ? project.manualFindings.flatMap((finding) => {
+            const sourceDocumentLabel = project.documents.find((document) => document.id === finding.sourceDocumentId)?.fileName ?? 'No source document linked';
+            return [
+              `${finding.findingId} [${finding.findingType}] ${sourceDocumentLabel}.`,
+              `Closure status: ${finding.closureStatus}.`,
+              `Evidence excerpt: ${finding.evidenceExcerpt?.trim() || 'Not provided.'}`,
+              `Project response: ${finding.projectResponse?.trim() || 'Not provided.'}`,
+              `Reviewer note: ${finding.reviewerNote?.trim() || 'Not provided.'}`,
+            ];
+          })
+          : ['No manual findings have been recorded yet.'],
+      },
+      {
+        title: 'PROVENANCE',
+        lines: linesFromProvenance(provenance),
+      },
+    ],
+    findings,
+    provenance,
+    limitation: 'This export reflects a project-level manual review workspace. It does not imply methodology compliance, certification status, or registry approval.',
+  };
+}
+
 export function composeVerificationReport(
   project: Project,
   coverage: ProjectCoverage,
   exportTime?: string,
 ): VerificationReportComposition {
+  if (project.reviewMode === 'manual') return composeManualVerificationReport(project, coverage, exportTime);
   const registry = resolveProjectRegistry(project);
   if (registry === 'UNFCCC') return composeUnfcccVerificationReport(project, coverage, exportTime);
   if (registry === 'Verra') return composeVerraVerificationReport(project, coverage);

--- a/tests/api/project.export-pdf.route.test.ts
+++ b/tests/api/project.export-pdf.route.test.ts
@@ -17,12 +17,15 @@ function makeProject(reviewCount = 6): Project {
   return {
     id: 'project-12345678',
     name: 'Malawi Verification Project',
+    reviewMode: 'methodology-linked',
     methodCode: 'AR-AMS0007',
     methodVersion: 'v03-1',
     registry: 'UNFCCC',
     status: 'locked',
     createdAt: '2026-04-15T00:00:00Z',
     aoiLabel: 'Machinga District',
+    documents: [],
+    manualFindings: [],
     reviews: Array.from({ length: reviewCount }, (_, index) => ({
       ruleId: `R-${index + 1}`,
       ruleTitle: `Verification requirement ${index + 1} for the monitoring report and workbook evidence`,
@@ -123,6 +126,56 @@ describe('/api/projects/[id]/export-pdf route', () => {
     expect(parsed.text).toContain('REGISTRY SUPPORT STATUS');
     expect(parsed.text).toContain('full renderer not yet implemented');
     expect(parsed.text).not.toContain('REQUIREMENT FINDINGS');
+  }, 15000);
+
+  it('exports manual review mode without methodology code in the header copy', async () => {
+    const project: Project = {
+      id: 'manual-project-1',
+      name: 'Verra Reconstruction Workspace',
+      reviewMode: 'manual',
+      registry: 'Unknown',
+      status: 'locked',
+      createdAt: '2026-04-15T00:00:00Z',
+      documents: [
+        {
+          id: 'doc-1',
+          fileName: 'project-monitoring-report.pdf',
+          mimeType: 'application/pdf',
+          sizeBytes: 2400,
+          uploadedAt: '2026-04-15T00:00:00Z',
+          extractedText: 'Project monitoring report excerpt',
+        },
+      ],
+      manualFindings: [
+        {
+          id: 'finding-1',
+          findingId: 'F-001',
+          findingType: 'VVB finding',
+          sourceDocumentId: 'doc-1',
+          evidenceExcerpt: 'Monitoring report omits appendix references.',
+          projectResponse: 'Appendix references will be added.',
+          closureStatus: 'open',
+          reviewerNote: 'Hold open until revised report lands.',
+          createdAt: '2026-04-15T00:00:00Z',
+          updatedAt: '2026-04-15T00:00:00Z',
+        },
+      ],
+      reviews: [],
+    };
+    const req = new Request('http://localhost/api/projects/manual-project-1/export-pdf', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ project }),
+    });
+    const res = await POST(req);
+    const bytes = await res.arrayBuffer();
+    const parsed = await extractPdfTextWithPdfParse({ bytes });
+
+    expect(res.headers.get('Content-Disposition')).toContain('attachment; filename="manual-review-pack-manual-p.pdf"');
+    expect(parsed.text).toContain('MANUAL REVIEW REPORT');
+    expect(parsed.text).toContain('Manual review mode: true');
+    expect(parsed.text).toContain('Verra Reconstruction Workspace');
+    expect(parsed.text).not.toContain('AR-AMS0007');
   }, 15000);
 
   it('renders reviewer rationale under rules that have notes', async () => {

--- a/tests/components/projectDetailLockGate.test.tsx
+++ b/tests/components/projectDetailLockGate.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from '@jest/globals';
+import { shouldShowLockReview } from '@/components/projects/ProjectDetail';
+import type { Project, ProjectCoverage } from '@/lib/projects/types';
+
+function makeCoverage(overrides: Partial<ProjectCoverage> = {}): ProjectCoverage {
+  return {
+    total: 3,
+    verified: 0,
+    gap: 0,
+    notStarted: 3,
+    notApplicable: 0,
+    inProgress: 0,
+    percentComplete: 0,
+    ...overrides,
+  };
+}
+
+function makeMethodologyProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'proj-method',
+    name: 'Methodology Review',
+    reviewMode: 'methodology-linked',
+    methodCode: 'AR-ACM0003',
+    methodVersion: 'v02-0',
+    registry: 'UNFCCC',
+    status: 'in-progress',
+    createdAt: '2026-05-06T00:00:00.000Z',
+    reviews: [],
+    documents: [],
+    manualFindings: [],
+    ...overrides,
+  };
+}
+
+function makeManualProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'proj-manual',
+    name: 'Manual Review',
+    reviewMode: 'manual',
+    registry: 'Unknown',
+    status: 'in-progress',
+    createdAt: '2026-05-06T00:00:00.000Z',
+    reviews: [],
+    documents: [],
+    manualFindings: [],
+    ...overrides,
+  };
+}
+
+describe('shouldShowLockReview', () => {
+  it('hides Lock Review for methodology-linked reviews when every rule is still not-started', () => {
+    expect(shouldShowLockReview(
+      makeMethodologyProject(),
+      makeCoverage({ total: 5, notStarted: 5, verified: 0, gap: 0, inProgress: 0, percentComplete: 0 }),
+    )).toBe(false);
+  });
+
+  it('shows Lock Review for methodology-linked reviews after at least one rule leaves not-started', () => {
+    expect(shouldShowLockReview(
+      makeMethodologyProject(),
+      makeCoverage({ total: 5, notStarted: 4, inProgress: 1, percentComplete: 20 }),
+    )).toBe(true);
+  });
+
+  it('hides Lock Review for manual reviews with no findings', () => {
+    expect(shouldShowLockReview(
+      makeManualProject(),
+      makeCoverage({ total: 0, verified: 0, gap: 0, inProgress: 0, percentComplete: 0 }),
+    )).toBe(false);
+  });
+
+  it('shows Lock Review for manual reviews once at least one finding exists', () => {
+    expect(shouldShowLockReview(
+      makeManualProject({
+        manualFindings: [{
+          id: 'finding-1',
+          findingId: 'F-001',
+          findingType: 'VVB finding',
+          closureStatus: 'open',
+          createdAt: '2026-05-06T00:00:00.000Z',
+          updatedAt: '2026-05-06T00:00:00.000Z',
+        }],
+      }),
+      makeCoverage({ total: 1, gap: 1, notStarted: 0, percentComplete: 0 }),
+    )).toBe(true);
+  });
+});

--- a/tests/exports/auditPack.contract.test.ts
+++ b/tests/exports/auditPack.contract.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { strFromU8, unzipSync } from "fflate";
 import { buildAuditPackZip } from "@/exports/auditPack";
 import { buildVerificationPackContractFiles } from "@/exports/verificationPackContract";
+import { sha256Hex } from "@/integrity/artifacts";
 import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
 import type { EvidencePin } from "@/lib/proofMap/types";
 import type { RuleReview } from "@/lib/verify/reviewStore";
@@ -150,6 +151,18 @@ describe("audit pack verification contract", () => {
   test("uses finalized review artifact and linked evidence in audit-pack zip when supplied", () => {
     const artifact: EvidenceSnapshot = {
       method: { code: "AR-ACM0003", version: "v02-0" },
+      aoi: {
+        id: "aoi_demo",
+        bbox: [1, 2, 3, 4],
+        geojson: {
+          type: "Feature",
+          properties: { name: "Demo AOI" },
+          geometry: {
+            type: "Polygon",
+            coordinates: [[[1, 2], [3, 2], [3, 4], [1, 4], [1, 2]]],
+          },
+        },
+      },
       evidence_source: { type: "stac_url", ref: "https://stac.example.test" },
       selected: {
         id: "sentinel-scene-1",
@@ -273,13 +286,49 @@ describe("audit pack verification contract", () => {
         title: "PDD.pdf",
         cited_ids: [],
         created_at: "2026-04-24T11:56:00.000Z",
+        attachments: [
+          {
+            id: "att-pdd-1",
+            pin_id: "pin-pdd-1",
+            filename: "mai_ndombe_synthetic_pdd.pdf",
+            mime: "application/pdf",
+            size: 24,
+            sha256: sha256Hex(Buffer.from("%PDF-1.4 synthetic PDD bytes", "utf8")),
+            created_at: "2026-04-24T11:56:00.000Z",
+          },
+        ],
         pdd_fragments: [{ evidence_id: "pin-pdd-1", fragment_id: "frag-monitoring-period", label: "Monitoring period", page_start: 12 }],
         pdd_fragment_links: [{ fragment_id: "frag-monitoring-period", rule_id: "R-1-0001", linked_at: "2026-04-24T11:57:00.000Z" }],
+        pdd_document: {
+          evidence_id: "pin-pdd-1",
+          attachment_id: "att-pdd-1",
+          file_name: "mai_ndombe_synthetic_pdd.pdf",
+          mime: "application/pdf",
+          added_at: "2026-04-24T11:56:00.000Z",
+          sha256: sha256Hex(Buffer.from("%PDF-1.4 synthetic PDD bytes", "utf8")),
+        },
       },
     ];
+    const pddBytes = Buffer.from("%PDF-1.4 synthetic PDD bytes", "utf8");
 
     const zip = withTemporaryMethodologyCheckout(() =>
-      buildAuditPackZip("AR-ACM0003", "v02-0", { finalizedReview: { artifact, evidencePins } }),
+      buildAuditPackZip("AR-ACM0003", "v02-0", {
+        finalizedReview: {
+          artifact,
+          evidencePins,
+          sourceFiles: [
+            {
+              evidence_ref: "pin-pdd-1",
+              source_pin_id: "pin-pdd-1",
+              attachment_id: "att-pdd-1",
+              file_name: "mai_ndombe_synthetic_pdd.pdf",
+              mime: "application/pdf",
+              bytes_base64: pddBytes.toString("base64"),
+              sha256: sha256Hex(pddBytes),
+            },
+          ],
+        },
+      }),
     );
     const entries = unzipSync(new Uint8Array(zip));
     const readJson = (entry: string) => JSON.parse(strFromU8(entries[entry]));
@@ -331,17 +380,60 @@ describe("audit pack verification contract", () => {
 
     const evidenceManifest = readJson("evidence-manifest.json") as {
       summary: { provided_refs: number; placeholder_refs: number };
-      evidence: Array<{ evidence_ref: string; status: string; placeholder: boolean }>;
+      evidence: Array<{
+        evidence_ref: string;
+        status: string;
+        placeholder: boolean;
+        included_in_pack: boolean;
+        file_path: string | null;
+        sha256: string | null;
+        parent_source_evidence_ref?: string | null;
+        parent_source_file_path?: string | null;
+      }>;
     };
-    expect(evidenceManifest.summary.provided_refs).toBe(0);
+    expect(evidenceManifest.summary.provided_refs).toBe(2);
     expect(evidenceManifest.summary.placeholder_refs).toBe(0);
     expect(evidenceManifest.evidence).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ evidence_ref: "sentinel-scene-1", status: "not_provided", placeholder: false }),
-        expect.objectContaining({ evidence_ref: "frag-monitoring-period", status: "not_provided", placeholder: false }),
+        expect.objectContaining({
+          evidence_ref: "pin-pdd-1",
+          status: "provided",
+          placeholder: false,
+          included_in_pack: true,
+          file_path: "evidence/source/pin-pdd-1/mai_ndombe_synthetic_pdd.pdf",
+          sha256: sha256Hex(pddBytes),
+        }),
+        expect.objectContaining({
+          evidence_ref: "frag-monitoring-period",
+          status: "not_provided",
+          placeholder: false,
+          included_in_pack: false,
+          parent_source_evidence_ref: "pin-pdd-1",
+          parent_source_file_path: "evidence/source/pin-pdd-1/mai_ndombe_synthetic_pdd.pdf",
+        }),
+        expect.objectContaining({
+          evidence_ref: "aoi_demo",
+          status: "provided",
+          placeholder: false,
+          included_in_pack: true,
+          file_path: "evidence/source/aoi_demo/Demo_AOI.geojson",
+        }),
       ]),
     );
     expect(JSON.stringify(evidenceManifest)).not.toContain("awaiting_project_evidence");
+    expect(entries["evidence/source/pin-pdd-1/mai_ndombe_synthetic_pdd.pdf"]).toEqual(new Uint8Array(pddBytes));
+    expect(entries["evidence/source/aoi_demo/Demo_AOI.geojson"]).toBeTruthy();
+    const manifestFiles = (readJson("manifest.json") as { files: Array<{ path: string; sha256: string; bytes: number }> }).files;
+    expect(manifestFiles).toEqual(
+      expect.arrayContaining([
+        {
+          path: "evidence/source/pin-pdd-1/mai_ndombe_synthetic_pdd.pdf",
+          sha256: sha256Hex(pddBytes),
+          bytes: pddBytes.length,
+        },
+      ]),
+    );
   });
 
   test("uses current Method Review state for non-finalized exports instead of demo placeholders", () => {

--- a/tests/lib/projects/verificationReport.test.ts
+++ b/tests/lib/projects/verificationReport.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import type { Project, ProjectCoverage } from '@/lib/projects/types';
 import {
+  composeManualVerificationReport,
   composeGoldStandardVerificationReport,
   composeUnfcccVerificationReport,
   composeVerificationReport,
@@ -56,11 +57,14 @@ function makeProject(overrides: Partial<Project> = {}): Project {
   return {
     id: 'proj_123',
     name: 'Demo Forestry Project',
+    reviewMode: 'methodology-linked',
     methodCode: 'AR-ACM0003',
     methodVersion: 'v02-0',
     registry: 'UNFCCC',
     status: 'locked',
     createdAt: '2026-04-23T00:00:00.000Z',
+    documents: [],
+    manualFindings: [],
     reviews: [
       {
         ruleId: 'R-1',
@@ -206,5 +210,48 @@ describe('verification report composition', () => {
     for (const phrase of UNSUPPORTED_CERTIFICATION_PHRASES) {
       expect(text).not.toContain(phrase);
     }
+  });
+
+  it('renders manual reviews without methodology framing', () => {
+    const report = composeManualVerificationReport(
+      makeProject({
+        reviewMode: 'manual',
+        methodCode: undefined,
+        methodVersion: undefined,
+        registry: 'Unknown',
+        documents: [
+          {
+            id: 'doc-1',
+            fileName: 'verra-monitoring-report.pdf',
+            mimeType: 'application/pdf',
+            sizeBytes: 1024,
+            uploadedAt: '2026-04-23T00:00:00.000Z',
+            extractedText: 'Monitoring report excerpt',
+          },
+        ],
+        manualFindings: [
+          {
+            id: 'finding-1',
+            findingId: 'F-001',
+            findingType: 'VVB finding',
+            sourceDocumentId: 'doc-1',
+            evidenceExcerpt: 'Emission factor table is missing.',
+            projectResponse: 'Updated workbook to include the factor.',
+            closureStatus: 'open',
+            reviewerNote: 'Needs revised attachment set.',
+            createdAt: '2026-04-23T00:00:00.000Z',
+            updatedAt: '2026-04-23T00:00:00.000Z',
+          },
+        ],
+        reviews: [],
+      }),
+      makeCoverage({ total: 1, verified: 0, gap: 1, notStarted: 0, notApplicable: 0, inProgress: 0, percentComplete: 0 }),
+    );
+
+    expect(report.title).toBe('MANUAL REVIEW REPORT');
+    expect(report.summaryItems).toContain('Manual review mode: true');
+    expect(report.sections.map((section) => section.title)).toContain('MANUAL FINDINGS');
+    expect(reportText(report)).not.toContain('UNFCCC VERIFICATION REPORT');
+    expect(reportText(report)).toContain('Manual review mode: true');
   });
 });

--- a/tests/lib/quickCheckPdfExtractor.test.ts
+++ b/tests/lib/quickCheckPdfExtractor.test.ts
@@ -70,5 +70,5 @@ describe("quick check pdf-parse extractor", () => {
     expect(result.engine).toBe("pdf-parse");
     expect(result.text).toContain("Gold Standard TPDDTEC, Version 4.0");
     expect(result.text).toContain("The monitoring report covers the full reporting period");
-  });
+  }, 15000);
 });


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: phase-assurance-surface-mvp
- ack: human
- items:
  - PR12: done

Allowed statuses: planned | next | in_progress | done | blocked

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

## Summary

Adds a second project review mode under `Projects`: `Manual Review`.

This keeps:
- `Quick Check` as a fast triage/intake surface
- `Methods` as the methodology-bound review surface
- `Projects` as the durable workspace for project-level reviews

## What Changed

- Renamed the create action in `Projects` to `New Project Review`
- Added review type choices:
  - `Methodology-linked review`
  - `Manual Review`
- Allowed manual reviews to be created without selecting a methodology
- Added manual-review project detail UI for:
  - source document upload
  - manual findings
  - evidence excerpts
  - project responses
  - closure status
  - reviewer notes
- Added manual-review export/report rendering
- Added `Manual review mode: true` to exported provenance/report output
- Kept the existing methodology-linked project flow intact

## Acceptance Mapping

- `Projects` includes a `New Project Review` action
- User can choose `Manual Review`
- Manual Review header does not show any UNFCCC method code
- User can upload source documents to the project
- User can create review items with:
  - finding ID
  - finding type: `CAR / CL / FAR / VVB finding / evidence gap`
  - source document
  - evidence excerpt
  - project response
  - closure status
  - reviewer note
- Export includes manual review mode as true
- No UI copy implies methodology compliance in Manual Review

## Validation

- `npm run typecheck`
- `npm test -- --runTestsByPath tests/components/projectDetailLockGate.test.tsx tests/lib/projects/verificationReport.test.ts tests/api/project.export-pdf.route.test.ts`

## Visible UI Changes To Look For

- In `Projects`, a new `New Project Review` button
- Review type choices: `Methodology-linked review` and `Manual Review`
- Manual Review pages show a project title instead of a methodology code
- Manual Review export says `Manual review mode: true`
