### PR TITLE
Polish Manual Review export into VVB findings reconstruction report

### DIFF
--- a/src/lib/projects/exportPdf.ts
+++ b/src/lib/projects/exportPdf.ts
@@ -5,6 +5,20 @@ function esc(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
 }
 
+function asciiSafeText(input: string): string {
+  return input
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/[\u2013\u2014]/g, '-')
+    .replace(/\u2022/g, '-')
+    .replace(/\u00B0/g, ' deg')
+    .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, '');
+}
+
+function punctuateText(value: string): string {
+  return /[.!?]$/.test(value) ? value : `${value}.`;
+}
+
 export function getProjectCoverage(reviews: RuleReview[]): ProjectCoverage {
   const total = reviews.length;
   const verified = reviews.filter(r => r.status === 'verified').length;
@@ -76,7 +90,7 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
     `/${font} ${size} Tf`,
     color,
     `${x} ${y} Td`,
-    `(${esc(text)}) Tj`,
+    `(${esc(asciiSafeText(text))}) Tj`,
     'ET',
   ];
 
@@ -261,7 +275,7 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
       }
     }
 
-    const provenanceLines = report.provenance.map(([label, value]) => `${label}: ${value}.`);
+    const provenanceLines = report.provenance.map(([label, value]) => `${label}: ${punctuateText(value)}`);
     ensureManualProvenanceFits(provenanceLines);
     sec('Provenance And Limitations');
     for (let index = 0; index < report.provenance.length; index += 1) {

--- a/src/lib/projects/exportPdf.ts
+++ b/src/lib/projects/exportPdf.ts
@@ -54,6 +54,10 @@ function wrapText(text: string, max = 96): string[] {
   return lines.length > 0 ? lines : [''];
 }
 
+function estimateWrappedTextHeight(text: string, max = 96, lineHeight = 12): number {
+  return wrapText(text, max).length * lineHeight;
+}
+
 export function buildProjectExportPdf(project: Project, coverage: ProjectCoverage): Buffer {
   const now = new Date().toISOString().replace('T', ' ').slice(0, 16);
   const report = composeVerificationReport(project, coverage, now);
@@ -115,6 +119,19 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
       need(14);
       ln.push(...TXT(L, y, font, size, line, color));
       y -= 12;
+    }
+  }
+
+  function ensureManualProvenanceFits(lines: string[]): void {
+    const headingHeight = 28;
+    const trailingPadding = 12;
+    const totalHeight = headingHeight + trailingPadding + lines.reduce(
+      (sum, line) => sum + estimateWrappedTextHeight(line),
+      0,
+    );
+
+    if (y - totalHeight < BOT) {
+      flush();
     }
   }
 
@@ -244,9 +261,12 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
       }
     }
 
+    const provenanceLines = report.provenance.map(([label, value]) => `${label}: ${value}.`);
+    ensureManualProvenanceFits(provenanceLines);
     sec('Provenance And Limitations');
-    for (const [label, value] of report.provenance) {
-      bodyLine(`${label}: ${value}.`, 'F1', 8, label === 'Limitation' ? '0.36 0.38 0.42 rg' : '0.22 0.22 0.22 rg');
+    for (let index = 0; index < report.provenance.length; index += 1) {
+      const [label] = report.provenance[index];
+      bodyLine(provenanceLines[index], 'F1', 8, label === 'Limitation' ? '0.36 0.38 0.42 rg' : '0.22 0.22 0.22 rg');
     }
   }
 

--- a/src/lib/projects/exportPdf.ts
+++ b/src/lib/projects/exportPdf.ts
@@ -1,5 +1,5 @@
 import type { Project, ProjectCoverage, RuleReview } from '@/lib/projects/types';
-import { composeVerificationReport } from '@/lib/projects/verificationReport';
+import { composeVerificationReport, manualRegistryLabel } from '@/lib/projects/verificationReport';
 
 function esc(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
@@ -170,7 +170,7 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
     const closedCount = manualFindings.filter((finding) => finding.closureStatus === 'closed').length;
     const openCount = manualFindings.filter((finding) => finding.closureStatus === 'open').length;
     const inReviewCount = manualFindings.filter((finding) => finding.closureStatus === 'in-review').length;
-    const registryLabel = project.registry && project.registry !== 'Unknown' ? project.registry : 'Unknown registry';
+    const registryLabel = manualRegistryLabel(project);
     const methodologyLabel = project.methodCode && project.methodVersion
       ? `${project.methodCode} @ ${project.methodVersion}`
       : 'Manual review - methodology not wired';

--- a/src/lib/projects/exportPdf.ts
+++ b/src/lib/projects/exportPdf.ts
@@ -118,31 +118,169 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
     }
   }
 
-  ln.push(
-    ...TXT(L, y + 20, 'F1', 8, 'VERIFICATION REPORT', '0.5 0.5 0.5 rg'),
-    ...TXT(L, y + 4, 'FB', 18, report.title, '0.1 0.1 0.1 rg'),
-    ...TXT(L, y - 14, 'F1', 9, truncate(report.subtitle, 84), '0.35 0.35 0.35 rg'),
-  );
-  let metaX = L;
-  for (const item of report.summaryItems.slice(0, 3)) {
-    ln.push(...TXT(metaX, y - 34, 'F1', 8, truncate(item, 26), '0.45 0.45 0.45 rg'));
-    metaX += 160;
+  function cardLabelValue(label: string, value: string, valueColor = '0.15 0.15 0.15 rg'): void {
+    need(18);
+    ln.push(...TXT(L + 10, y, 'FB', 7, label, '0.42 0.52 0.60 rg'));
+    y -= 10;
+    for (const line of wrapText(value, 92)) {
+      need(14);
+      ln.push(...TXT(L + 10, y, 'F1', 8, line, valueColor));
+      y -= 11;
+    }
+    y -= 3;
   }
-  y -= 68;
 
-  for (const section of report.sections) {
-    sec(section.title);
-    for (const line of section.lines) bodyLine(line);
+  function renderManualReport(): void {
+    const manualFindings = project.manualFindings;
+    const sourceDocument = project.documents[0];
+    const carCount = manualFindings.filter((finding) => finding.findingType === 'CAR').length;
+    const clCount = manualFindings.filter((finding) => finding.findingType === 'CL').length;
+    const farCount = manualFindings.filter((finding) => finding.findingType === 'FAR').length;
+    const closedCount = manualFindings.filter((finding) => finding.closureStatus === 'closed').length;
+    const openCount = manualFindings.filter((finding) => finding.closureStatus === 'open').length;
+    const inReviewCount = manualFindings.filter((finding) => finding.closureStatus === 'in-review').length;
+    const registryLabel = project.registry && project.registry !== 'Unknown' ? project.registry : 'Unknown registry';
+    const methodologyLabel = project.methodCode && project.methodVersion
+      ? `${project.methodCode} @ ${project.methodVersion}`
+      : 'Manual review - methodology not wired';
+    const projectArea = project.aoiLabel?.trim() || 'Not provided';
+    const projectDescription = project.description?.trim() || 'Not provided';
+    const sourceDocumentType = sourceDocument?.mimeType === 'application/pdf'
+      ? 'Published verification report PDF'
+      : sourceDocument
+        ? 'Uploaded source document'
+        : 'Not provided';
+
+    ln.push(
+      RC(0, HEADER_Y - 14, W, 40, 0.98),
+      ...TXT(L, y + 30, 'FB', 11, 'ARTICLE6', '0.18 0.23 0.28 rg'),
+      ...TXT(L, y + 12, 'FB', 18, 'MANUAL REVIEW REPORT', '0.10 0.12 0.15 rg'),
+      ...TXT(L, y - 6, 'FB', 15, report.title, '0.12 0.18 0.23 rg'),
+      ...TXT(L, y - 22, 'F1', 8, truncate('Project-level reconstruction of published VVB findings', 80), '0.38 0.44 0.50 rg'),
+    );
+    y -= 54;
+
+    ln.push(
+      RC(L, y - 38, R - L, 34, 0.95),
+      ...TXT(L + 10, y - 12, 'F1', 8, truncate(report.limitation, 110), '0.30 0.34 0.38 rg'),
+    );
+    y -= 54;
+
+    sec('Outcome');
+    bodyLine(`${manualFindings.length} VVB finding sections were reconstructed from the uploaded source document set.`, 'FB', 9, '0.12 0.18 0.23 rg');
+    bodyLine(`The review identified ${closedCount} closed findings, ${openCount} open findings, and ${inReviewCount} findings still marked in review.`, 'F1', 8, '0.22 0.22 0.22 rg');
+    bodyLine('Findings remain reviewer-controlled records and do not represent a new verification opinion.', 'F1', 8, '0.22 0.22 0.22 rg');
     y -= 4;
+
+    need(78);
+    const cardY = y;
+    const cardW = 152;
+    const gap = 14;
+    const cardX = [L, L + cardW + gap, L + (cardW + gap) * 2];
+    const cards = [
+      { title: 'Finding Types', value: `CAR: ${carCount}  CL: ${clCount}  FAR: ${farCount}` },
+      { title: 'Closure Status', value: `Closed: ${closedCount}  Open: ${openCount}  In review: ${inReviewCount}` },
+      { title: 'Source Set', value: `Documents: ${project.documents.length}  Findings: ${manualFindings.length}` },
+    ];
+    cards.forEach((card, index) => {
+      ln.push(
+        RC(cardX[index], cardY - 46, cardW, 40, 0.97),
+        ...TXT(cardX[index] + 8, cardY - 14, 'FB', 7, card.title.toUpperCase(), '0.42 0.52 0.60 rg'),
+        ...TXT(cardX[index] + 8, cardY - 28, 'F1', 8, truncate(card.value, 28), '0.12 0.15 0.18 rg'),
+      );
+    });
+    y -= 62;
+
+    sec('Project Metadata');
+    const metadataPairs = [
+      ['Registry / Standard', registryLabel],
+      ['Registry project ID', 'Not provided'],
+      ['Project name', project.name],
+      ['Source document type', sourceDocumentType],
+      ['Source document name', sourceDocument?.fileName ?? 'Not provided'],
+      ['Methodology / reference', methodologyLabel],
+      ['Review mode', 'Manual review'],
+      ['Locked status', project.status === 'locked' ? 'Locked' : 'In Progress'],
+      ['Export timestamp', now],
+      ['Project area', projectArea],
+      ['Project description', projectDescription],
+    ];
+    for (const [label, value] of metadataPairs) {
+      bodyLine(`${label}: ${value}.`);
+    }
+    y -= 4;
+
+    sec('Finding Details');
+    if (manualFindings.length === 0) {
+      bodyLine('No manual findings have been recorded yet.');
+    } else {
+      for (const finding of manualFindings) {
+        const sourceDocumentLabel = project.documents.find((document) => document.id === finding.sourceDocumentId)?.fileName ?? 'Not provided';
+        const fieldLines: Array<[string, string, string?]> = [
+          ['Finding ID', finding.findingId],
+          ['Type', finding.findingType],
+          ['Closure status', finding.closureStatus],
+          ['Source document', sourceDocumentLabel],
+          ['Source page/range', finding.sourcePageRange?.trim() || 'Not provided'],
+          ['Requirement', finding.requirement?.trim() || 'Not provided'],
+          ['Description', finding.description?.trim() || 'Not provided'],
+          ['Project response', finding.projectResponse?.trim() || 'Not provided'],
+          ['Documentation submitted', finding.documentationSubmitted?.trim() || 'Not provided'],
+          ['Audit team evaluation', finding.auditTeamEvaluation?.trim() || 'Not provided'],
+          ['Reviewer note', finding.reviewerNote?.trim() || 'Needs review'],
+          ['Source excerpt', finding.evidenceExcerpt?.trim() || 'Not provided', '0.36 0.38 0.42 rg'],
+        ];
+        const estimatedHeight = fieldLines.reduce((sum, [, value]) => sum + wrapText(value, 92).length * 11 + 16, 26);
+        need(estimatedHeight + 18);
+        ln.push(
+          RC(L, y - estimatedHeight + 8, R - L, estimatedHeight, 0.985),
+          ...TXT(L + 10, y - 8, 'FB', 10, `${finding.findingId}  ${finding.findingType}`, '0.10 0.12 0.15 rg'),
+        );
+        y -= 24;
+        for (const [label, value, color] of fieldLines) {
+          cardLabelValue(label, value, color);
+        }
+        y -= 8;
+      }
+    }
+
+    sec('Provenance And Limitations');
+    for (const [label, value] of report.provenance) {
+      bodyLine(`${label}: ${value}.`, 'F1', 8, label === 'Limitation' ? '0.36 0.38 0.42 rg' : '0.22 0.22 0.22 rg');
+    }
   }
 
-  need(30);
-  ln.push(
-    LN(y),
-    ...TXT(L, y - 12, 'F1', 7, truncate(report.limitation, 110), '0.7 0.7 0.7 rg'),
-    ...TXT(L, y - 24, 'F1', 7, `Export time ${safeDate(now)}.`, '0.7 0.7 0.7 rg'),
-  );
-  flush();
+  if (project.reviewMode === 'manual') {
+    renderManualReport();
+    flush();
+  } else {
+
+    ln.push(
+      ...TXT(L, y + 20, 'F1', 8, 'VERIFICATION REPORT', '0.5 0.5 0.5 rg'),
+      ...TXT(L, y + 4, 'FB', 18, report.title, '0.1 0.1 0.1 rg'),
+      ...TXT(L, y - 14, 'F1', 9, truncate(report.subtitle, 84), '0.35 0.35 0.35 rg'),
+    );
+    let metaX = L;
+    for (const item of report.summaryItems.slice(0, 3)) {
+      ln.push(...TXT(metaX, y - 34, 'F1', 8, truncate(item, 26), '0.45 0.45 0.45 rg'));
+      metaX += 160;
+    }
+    y -= 68;
+
+    for (const section of report.sections) {
+      sec(section.title);
+      for (const line of section.lines) bodyLine(line);
+      y -= 4;
+    }
+
+    need(30);
+    ln.push(
+      LN(y),
+      ...TXT(L, y - 12, 'F1', 7, truncate(report.limitation, 110), '0.7 0.7 0.7 rg'),
+      ...TXT(L, y - 24, 'F1', 7, `Export time ${safeDate(now)}.`, '0.7 0.7 0.7 rg'),
+    );
+    flush();
+  }
 
   const enc = (s: string) => Buffer.from(s, 'utf-8');
   const parts: Buffer[] = [];

--- a/src/lib/projects/reportFindings.ts
+++ b/src/lib/projects/reportFindings.ts
@@ -1,6 +1,6 @@
 import type { ManualFinding, RuleReview } from '@/lib/projects/types';
 
-export type ReportFindingCode = 'OK' | 'CL' | 'NC' | 'FAR' | 'PENDING' | 'NA';
+export type ReportFindingCode = 'OK' | 'CL' | 'NC' | 'CAR' | 'FAR' | 'PENDING' | 'NA';
 
 export type ReportFinding = {
   findingId: string;
@@ -63,7 +63,8 @@ export function buildReportFinding(
 }
 
 export function manualFindingCodeFromType(type: ManualFinding['findingType']): ReportFindingCode {
-  if (type === 'CAR' || type === 'VVB finding' || type === 'evidence gap') return 'NC';
+  if (type === 'CAR') return 'CAR';
+  if (type === 'VVB finding' || type === 'evidence gap') return 'NC';
   if (type === 'FAR') return 'FAR';
   return 'CL';
 }

--- a/src/lib/projects/verificationReport.ts
+++ b/src/lib/projects/verificationReport.ts
@@ -103,6 +103,36 @@ function buildSummaryItems(project: Project, coverage: ProjectCoverage, registry
   return items;
 }
 
+function fallbackValue(value: string | undefined, fallback: string): string {
+  const normalized = value?.trim();
+  return normalized ? normalized : fallback;
+}
+
+function manualRegistryLabel(project: Project): string {
+  return project.registry && project.registry !== 'Unknown' ? project.registry : 'Unknown registry';
+}
+
+function manualMethodologyLabel(project: Project): string {
+  return project.methodCode && project.methodVersion
+    ? `${project.methodCode} @ ${project.methodVersion}`
+    : 'Manual review - methodology not wired';
+}
+
+function sourceDocumentTypeLabel(project: Project): string {
+  if (project.documents.some((document) => document.mimeType === 'application/pdf')) return 'Published verification report PDF';
+  if (project.documents.length > 0) return 'Uploaded source document';
+  return 'Not provided';
+}
+
+function manualFindingTypeCounts(project: Project): { CAR: number; CL: number; FAR: number } {
+  return project.manualFindings.reduce((counts, finding) => {
+    if (finding.findingType === 'CAR' || finding.findingType === 'CL' || finding.findingType === 'FAR') {
+      counts[finding.findingType] += 1;
+    }
+    return counts;
+  }, { CAR: 0, CL: 0, FAR: 0 });
+}
+
 function buildEvidenceSummary(project: Project): string[] {
   const linkedEvidenceCount = project.reviews.reduce((sum, review) => sum + review.evidenceIds.length, 0);
   const notedRules = project.reviews.filter((review) => Boolean(review.note?.trim())).length;
@@ -125,7 +155,7 @@ function countFindings(findings: ReportFinding[]): Record<ReportFindingCode, num
   return findings.reduce((acc, finding) => {
     acc[finding.code] += 1;
     return acc;
-  }, { OK: 0, CL: 0, NC: 0, FAR: 0, PENDING: 0, NA: 0 } as Record<ReportFindingCode, number>);
+  }, { OK: 0, CL: 0, NC: 0, CAR: 0, FAR: 0, PENDING: 0, NA: 0 } as Record<ReportFindingCode, number>);
 }
 
 function linesFromProvenance(provenance: Array<[string, string]>): string[] {
@@ -320,82 +350,109 @@ export function composeManualVerificationReport(
     const sourceDocumentLabel = project.documents.find((document) => document.id === finding.sourceDocumentId)?.fileName ?? 'No source document linked';
     return buildManualReportFinding(finding, sourceDocumentLabel);
   });
-  const findingCounts = countFindings(findings);
-  const provenance = buildProvenance(project, coverage, project.registry ?? 'Unknown', findings.length === 0 ? 'insufficient_source_content' : 'ready', exportTime);
+  const exportTimestamp = exportTime ?? 'generated during export';
+  const status = findings.length === 0 ? 'insufficient_source_content' : 'ready';
+  const registryLabel = manualRegistryLabel(project);
+  const methodologyLabel = manualMethodologyLabel(project);
+  const sourceDocumentName = project.documents[0]?.fileName ?? 'Not provided';
+  const typeCounts = manualFindingTypeCounts(project);
+  const openCount = project.manualFindings.filter((finding) => finding.closureStatus === 'open').length;
+  const inReviewCount = project.manualFindings.filter((finding) => finding.closureStatus === 'in-review').length;
+  const closedCount = project.manualFindings.filter((finding) => finding.closureStatus === 'closed').length;
+  const provenance = [
+    ['Manual review mode', 'true'],
+    ['Project ID', project.id],
+    ['Source document count', String(project.documents.length)],
+    ['Findings count', String(project.manualFindings.length)],
+    ['Locked status', project.status === 'locked' ? 'Locked' : 'In Progress'],
+    ['Locked timestamp', project.lockedAt ?? 'Not provided'],
+    ['Export timestamp', exportTimestamp],
+    ['Registry / Standard', registryLabel],
+    ['Registry project ID', 'Not provided'],
+    ['Methodology / reference', methodologyLabel],
+    ['Limitation', 'This report reconstructs findings from uploaded source documents. It is not an independent verification opinion, validation statement, or methodology compliance determination.'],
+  ] satisfies Array<[string, string]>;
 
   return {
     registry: project.registry ?? 'Unknown',
-    status: findings.length === 0 ? 'insufficient_source_content' : 'ready',
-    title: 'MANUAL REVIEW REPORT',
-    subtitle: 'Project-level manual review workspace for VVB findings reconstruction and evidence-gap tracking.',
+    status,
+    title: 'VVB FINDINGS RECONSTRUCTION',
+    subtitle: 'Project-level reconstruction of published VVB findings from uploaded source documents.',
     summaryItems: [
-      `Manual review mode: true`,
+      `Manual review report`,
       `Project: ${project.name}`,
-      `Findings recorded: ${project.manualFindings.length}`,
+      `Registry / Standard: ${registryLabel}`,
       `Source documents: ${project.documents.length}`,
     ],
     sections: [
       {
-        title: 'REVIEW STATUS',
+        title: 'REPORT LIMITATION',
         lines: [
-          'Manual review mode: true.',
-          `Project status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}.`,
-          `Project title: ${project.name}.`,
-          `Findings recorded: ${project.manualFindings.length}.`,
-          `Source documents uploaded: ${project.documents.length}.`,
+          'This report reconstructs findings from uploaded source documents. It is not an independent verification opinion, validation statement, or methodology compliance determination.',
         ],
       },
       {
-        title: 'PROJECT CONTEXT',
+        title: 'OUTCOME',
         lines: [
+          `${project.manualFindings.length} VVB finding sections were reconstructed from the uploaded source document set.`,
+          `The review identified ${closedCount} closed findings, ${openCount} open findings, and ${inReviewCount} findings still marked in review.`,
+          'Findings remain reviewer-controlled records and do not represent a new verification opinion.',
+        ],
+      },
+      {
+        title: 'PROJECT METADATA',
+        lines: [
+          `Registry / Standard: ${registryLabel}.`,
+          'Registry project ID: Not provided.',
           `Project name: ${project.name}.`,
-          project.aoiLabel ? `Project area: ${project.aoiLabel}.` : 'Project area: not provided.',
-          project.description ? `Project description: ${project.description}.` : 'Project description: not provided.',
-          `Created date: ${project.createdAt || 'n/a'}.`,
-          project.lockedAt ? `Locked date: ${project.lockedAt}.` : 'Locked date: not locked.',
+          `Source document type: ${sourceDocumentTypeLabel(project)}.`,
+          `Source document name: ${sourceDocumentName}.`,
+          `Methodology / reference: ${methodologyLabel}.`,
+          'Review mode: Manual review.',
+          `Locked status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}.`,
+          `Export timestamp: ${exportTimestamp}.`,
+          `Project area: ${fallbackValue(project.aoiLabel, 'Not provided')}.`,
+          `Project description: ${fallbackValue(project.description, 'Not provided')}.`,
         ],
-      },
-      {
-        title: 'SOURCE DOCUMENTS',
-        lines: project.documents.length > 0
-          ? project.documents.flatMap((document) => [
-            `${document.fileName} (${document.mimeType || 'unknown'}, ${document.sizeBytes} bytes).`,
-            document.extractedText?.trim()
-              ? `Document preview: ${document.extractedText.trim().slice(0, 220)}.`
-              : 'Document preview: not captured.',
-          ])
-          : ['No source documents uploaded.'],
       },
       {
         title: 'FINDINGS SUMMARY',
         lines: [
-          `NC: ${findingCounts.NC}. CL: ${findingCounts.CL}. FAR: ${findingCounts.FAR}.`,
-          `Open: ${project.manualFindings.filter((finding) => finding.closureStatus === 'open').length}. In review: ${project.manualFindings.filter((finding) => finding.closureStatus === 'in-review').length}. Closed: ${project.manualFindings.filter((finding) => finding.closureStatus === 'closed').length}.`,
+          `CAR: ${typeCounts.CAR}. CL: ${typeCounts.CL}. FAR: ${typeCounts.FAR}.`,
+          `Closed: ${closedCount}. Open: ${openCount}. In review: ${inReviewCount}.`,
+          `Source documents: ${project.documents.length}. Findings recorded: ${project.manualFindings.length}.`,
         ],
       },
       {
-        title: 'MANUAL FINDINGS',
+        title: 'FINDING DETAILS',
         lines: project.manualFindings.length > 0
           ? project.manualFindings.flatMap((finding) => {
             const sourceDocumentLabel = project.documents.find((document) => document.id === finding.sourceDocumentId)?.fileName ?? 'No source document linked';
             return [
-              `${finding.findingId} [${finding.findingType}] ${sourceDocumentLabel}.`,
+              `Finding ID: ${finding.findingId}.`,
+              `Type: ${finding.findingType}.`,
               `Closure status: ${finding.closureStatus}.`,
-              `Evidence excerpt: ${finding.evidenceExcerpt?.trim() || 'Not provided.'}`,
-              `Project response: ${finding.projectResponse?.trim() || 'Not provided.'}`,
-              `Reviewer note: ${finding.reviewerNote?.trim() || 'Not provided.'}`,
+              `Source document: ${sourceDocumentLabel}.`,
+              `Source page/range: ${finding.sourcePageRange?.trim() || 'Not provided'}.`,
+              `Requirement: ${finding.requirement?.trim() || 'Not provided'}.`,
+              `Description: ${finding.description?.trim() || 'Not provided'}.`,
+              `Project response: ${finding.projectResponse?.trim() || 'Not provided'}.`,
+              `Documentation submitted: ${finding.documentationSubmitted?.trim() || 'Not provided'}.`,
+              `Audit team evaluation: ${finding.auditTeamEvaluation?.trim() || 'Not provided'}.`,
+              `Reviewer note: ${finding.reviewerNote?.trim() || 'Needs review'}.`,
+              `Source excerpt: ${finding.evidenceExcerpt?.trim() || 'Not provided'}.`,
             ];
           })
           : ['No manual findings have been recorded yet.'],
       },
       {
-        title: 'PROVENANCE',
+        title: 'PROVENANCE AND LIMITATIONS',
         lines: linesFromProvenance(provenance),
       },
     ],
     findings,
     provenance,
-    limitation: 'This export reflects a project-level manual review workspace. It does not imply methodology compliance, certification status, or registry approval.',
+    limitation: 'This report reconstructs findings from uploaded source documents. It is not an independent verification opinion, validation statement, or methodology compliance determination.',
   };
 }
 

--- a/src/lib/projects/verificationReport.ts
+++ b/src/lib/projects/verificationReport.ts
@@ -133,7 +133,7 @@ function inferManualRegistryLabel(project: Project): string | undefined {
   return undefined;
 }
 
-function manualRegistryLabel(project: Project): string {
+export function manualRegistryLabel(project: Project): string {
   if (project.registry && project.registry !== 'Unknown') return project.registry;
   return inferManualRegistryLabel(project) ?? 'Unknown registry';
 }

--- a/src/lib/projects/verificationReport.ts
+++ b/src/lib/projects/verificationReport.ts
@@ -108,8 +108,34 @@ function fallbackValue(value: string | undefined, fallback: string): string {
   return normalized ? normalized : fallback;
 }
 
+function punctuateLine(value: string): string {
+  return /[.!?]$/.test(value) ? value : `${value}.`;
+}
+
+function inferManualRegistryLabel(project: Project): string | undefined {
+  const signals = [
+    project.registry,
+    ...project.documents.map((document) => document.fileName),
+    ...project.documents.map((document) => document.extractedText),
+  ]
+    .filter(Boolean)
+    .map((value) => value!.toLowerCase());
+
+  const hasVerra = signals.some((value) => value.includes('verra') || value.includes('vcs'));
+  const hasCcb = signals.some((value) => value.includes('ccb'));
+  const hasGoldStandard = signals.some((value) => value.includes('gold standard'));
+  const hasUnfccc = signals.some((value) => value.includes('unfccc') || value.includes('cdm'));
+
+  if (hasVerra && hasCcb) return 'Verra / VCS + CCB';
+  if (hasVerra) return 'Verra';
+  if (hasGoldStandard) return 'Gold Standard';
+  if (hasUnfccc) return 'UNFCCC';
+  return undefined;
+}
+
 function manualRegistryLabel(project: Project): string {
-  return project.registry && project.registry !== 'Unknown' ? project.registry : 'Unknown registry';
+  if (project.registry && project.registry !== 'Unknown') return project.registry;
+  return inferManualRegistryLabel(project) ?? 'Unknown registry';
 }
 
 function manualMethodologyLabel(project: Project): string {
@@ -159,7 +185,7 @@ function countFindings(findings: ReportFinding[]): Record<ReportFindingCode, num
 }
 
 function linesFromProvenance(provenance: Array<[string, string]>): string[] {
-  return provenance.map(([label, value]) => `${label}: ${value || 'n/a'}.`);
+  return provenance.map(([label, value]) => `${label}: ${punctuateLine(value || 'n/a')}`);
 }
 
 function buildRequirementFindingLines(findings: ReportFinding[]): string[] {
@@ -359,7 +385,7 @@ export function composeManualVerificationReport(
   const openCount = project.manualFindings.filter((finding) => finding.closureStatus === 'open').length;
   const inReviewCount = project.manualFindings.filter((finding) => finding.closureStatus === 'in-review').length;
   const closedCount = project.manualFindings.filter((finding) => finding.closureStatus === 'closed').length;
-  const provenance = [
+    const provenance = [
     ['Manual review mode', 'true'],
     ['Project ID', project.id],
     ['Source document count', String(project.documents.length)],
@@ -402,17 +428,17 @@ export function composeManualVerificationReport(
       {
         title: 'PROJECT METADATA',
         lines: [
-          `Registry / Standard: ${registryLabel}.`,
+          `Registry / Standard: ${punctuateLine(registryLabel)}`,
           'Registry project ID: Not provided.',
-          `Project name: ${project.name}.`,
-          `Source document type: ${sourceDocumentTypeLabel(project)}.`,
-          `Source document name: ${sourceDocumentName}.`,
-          `Methodology / reference: ${methodologyLabel}.`,
+          `Project name: ${punctuateLine(project.name)}`,
+          `Source document type: ${punctuateLine(sourceDocumentTypeLabel(project))}`,
+          `Source document name: ${punctuateLine(sourceDocumentName)}`,
+          `Methodology / reference: ${punctuateLine(methodologyLabel)}`,
           'Review mode: Manual review.',
-          `Locked status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}.`,
-          `Export timestamp: ${exportTimestamp}.`,
-          `Project area: ${fallbackValue(project.aoiLabel, 'Not provided')}.`,
-          `Project description: ${fallbackValue(project.description, 'Not provided')}.`,
+          `Locked status: ${punctuateLine(project.status === 'locked' ? 'Locked' : 'In Progress')}`,
+          `Export timestamp: ${punctuateLine(exportTimestamp)}`,
+          `Project area: ${punctuateLine(fallbackValue(project.aoiLabel, 'Not provided'))}`,
+          `Project description: ${punctuateLine(fallbackValue(project.description, 'Not provided'))}`,
         ],
       },
       {
@@ -429,18 +455,18 @@ export function composeManualVerificationReport(
           ? project.manualFindings.flatMap((finding) => {
             const sourceDocumentLabel = project.documents.find((document) => document.id === finding.sourceDocumentId)?.fileName ?? 'No source document linked';
             return [
-              `Finding ID: ${finding.findingId}.`,
-              `Type: ${finding.findingType}.`,
-              `Closure status: ${finding.closureStatus}.`,
-              `Source document: ${sourceDocumentLabel}.`,
-              `Source page/range: ${finding.sourcePageRange?.trim() || 'Not provided'}.`,
-              `Requirement: ${finding.requirement?.trim() || 'Not provided'}.`,
-              `Description: ${finding.description?.trim() || 'Not provided'}.`,
-              `Project response: ${finding.projectResponse?.trim() || 'Not provided'}.`,
-              `Documentation submitted: ${finding.documentationSubmitted?.trim() || 'Not provided'}.`,
-              `Audit team evaluation: ${finding.auditTeamEvaluation?.trim() || 'Not provided'}.`,
-              `Reviewer note: ${finding.reviewerNote?.trim() || 'Needs review'}.`,
-              `Source excerpt: ${finding.evidenceExcerpt?.trim() || 'Not provided'}.`,
+              `Finding ID: ${punctuateLine(finding.findingId)}`,
+              `Type: ${punctuateLine(finding.findingType)}`,
+              `Closure status: ${punctuateLine(finding.closureStatus)}`,
+              `Source document: ${punctuateLine(sourceDocumentLabel)}`,
+              `Source page/range: ${punctuateLine(finding.sourcePageRange?.trim() || 'Not provided')}`,
+              `Requirement: ${punctuateLine(finding.requirement?.trim() || 'Not provided')}`,
+              `Description: ${punctuateLine(finding.description?.trim() || 'Not provided')}`,
+              `Project response: ${punctuateLine(finding.projectResponse?.trim() || 'Not provided')}`,
+              `Documentation submitted: ${punctuateLine(finding.documentationSubmitted?.trim() || 'Not provided')}`,
+              `Audit team evaluation: ${punctuateLine(finding.auditTeamEvaluation?.trim() || 'Not provided')}`,
+              `Reviewer note: ${punctuateLine(finding.reviewerNote?.trim() || 'Needs review')}`,
+              `Source excerpt: ${punctuateLine(finding.evidenceExcerpt?.trim() || 'Not provided')}`,
             ];
           })
           : ['No manual findings have been recorded yet.'],

--- a/tests/api/project.export-pdf.route.test.ts
+++ b/tests/api/project.export-pdf.route.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import { POST } from '@/app/api/projects/[id]/export-pdf/route';
-import { extractPdfTextWithPdfParse } from '@/lib/chat/quickCheckPdfExtractor';
+import { extractPdfPagesWithPdfParse, extractPdfTextWithPdfParse } from '@/lib/chat/quickCheckPdfExtractor';
 import { buildProjectExportPdf } from '@/lib/projects/exportPdf';
 import type { Project } from '@/lib/projects/types';
 
@@ -198,6 +198,62 @@ describe('/api/projects/[id]/export-pdf route', () => {
     expect(parsed.text).toContain('Audit team evaluation');
     expect(parsed.text).toContain('Source excerpt');
     expect(parsed.text).toContain('Provenance And Limitations');
+  }, 15000);
+
+  it('keeps the manual review provenance block together instead of spilling a sentence fragment onto a nearly blank final page', async () => {
+    const project: Project = {
+      id: 'manual-project-15',
+      name: 'Long Manual Review Workspace',
+      reviewMode: 'manual',
+      registry: 'Unknown',
+      status: 'locked',
+      createdAt: '2026-04-15T00:00:00Z',
+      documents: [
+        {
+          id: 'doc-1',
+          fileName: 'CCB_VERIF_REP_ENG_1530_01AUG2011_12DEC2020.pdf',
+          mimeType: 'application/pdf',
+          sizeBytes: 420000,
+          uploadedAt: '2026-04-15T00:00:00Z',
+          extractedText: 'Appendix 1 CAR/CL/FAR findings excerpt',
+        },
+      ],
+      manualFindings: Array.from({ length: 17 }, (_, index) => ({
+        id: `finding-${index + 1}`,
+        findingId: index < 7 ? `CAR0${index + 1}` : index < 13 ? `CL0${index - 6}` : `FAR0${index - 12}`,
+        findingType: index < 7 ? 'CAR' : index < 13 ? 'CL' : 'FAR',
+        sourceDocumentId: 'doc-1',
+        sourcePageRange: `${40 + index}-${41 + index}`,
+        requirement: `Requirement reference ${index + 1} with enough text to wrap cleanly across the PDF card layout.`,
+        description: `Structured description for finding ${index + 1} explaining the reconstructed VVB issue in a compact but still realistic way.`,
+        evidenceExcerpt: `Source excerpt for finding ${index + 1} that remains visible for traceability while staying visually secondary in the report.`,
+        projectResponse: `Project response for finding ${index + 1} documenting the project-side remediation or clarification text used in the reconstruction.`,
+        documentationSubmitted: `Supporting attachment set ${index + 1} with workbook, report appendix, and memo references.`,
+        auditTeamEvaluation: `Audit team evaluation for finding ${index + 1} describing the recorded closure or remaining follow-up from the source report.`,
+        closureStatus: index < 13 ? 'closed' : 'open',
+        reviewerNote: `Reviewer note ${index + 1} captured in the manual review workspace.`,
+        createdAt: '2026-04-15T00:00:00Z',
+        updatedAt: '2026-04-15T00:00:00Z',
+      })),
+      extractedManualFindingDrafts: [],
+      reviews: [],
+    };
+
+    const req = new Request('http://localhost/api/projects/manual-project-15/export-pdf', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ project }),
+    });
+    const res = await POST(req);
+    const bytes = await res.arrayBuffer();
+    const parsed = await extractPdfPagesWithPdfParse({ bytes });
+    const lastPageText = parsed.pages.at(-1)?.text ?? '';
+    const lastPageWordCount = lastPageText.split(/\s+/).filter(Boolean).length;
+
+    expect(lastPageText).toContain('Provenance And Limitations');
+    expect(lastPageText).toContain('Manual review mode: true');
+    expect(lastPageText).toContain('Methodology / reference: Manual review - methodology not wired');
+    expect(lastPageWordCount).toBeGreaterThan(25);
   }, 15000);
 
   it('renders reviewer rationale under rules that have notes', async () => {

--- a/tests/api/project.export-pdf.route.test.ts
+++ b/tests/api/project.export-pdf.route.test.ts
@@ -140,11 +140,11 @@ describe('/api/projects/[id]/export-pdf route', () => {
       documents: [
         {
           id: 'doc-1',
-          fileName: 'project-monitoring-report.pdf',
+          fileName: 'CCB_VERIF_REP_ENG_1530_01AUG2011_12DEC2020.pdf',
           mimeType: 'application/pdf',
           sizeBytes: 2400,
           uploadedAt: '2026-04-15T00:00:00Z',
-          extractedText: 'Project monitoring report excerpt',
+          extractedText: 'CCB and VCS verification report excerpt',
         },
       ],
       manualFindings: [
@@ -187,6 +187,7 @@ describe('/api/projects/[id]/export-pdf route', () => {
     expect(parsed.text).toContain('Manual review mode: true');
     expect(parsed.text).toContain('Verra Reconstruction Workspace');
     expect(parsed.text).not.toContain('AR-AMS0007');
+    expect(parsed.text).toContain('Registry / Standard: Verra / VCS + CCB');
     expect(parsed.text).toContain('CAR: 1');
     expect(parsed.text).toContain('CL: 0');
     expect(parsed.text).toContain('FAR: 0');
@@ -198,6 +199,8 @@ describe('/api/projects/[id]/export-pdf route', () => {
     expect(parsed.text).toContain('Audit team evaluation');
     expect(parsed.text).toContain('Source excerpt');
     expect(parsed.text).toContain('Provenance And Limitations');
+    expect(parsed.text).not.toContain('determination..');
+    expect(parsed.text).not.toMatch(/â|â|ˆ‡|ˆ–|ˆ¡|ˆ'|´°/);
   }, 15000);
 
   it('keeps the manual review provenance block together instead of spilling a sentence fragment onto a nearly blank final page', async () => {

--- a/tests/api/project.export-pdf.route.test.ts
+++ b/tests/api/project.export-pdf.route.test.ts
@@ -150,11 +150,16 @@ describe('/api/projects/[id]/export-pdf route', () => {
       manualFindings: [
         {
           id: 'finding-1',
-          findingId: 'F-001',
-          findingType: 'VVB finding',
+          findingId: 'CAR01',
+          findingType: 'CAR',
           sourceDocumentId: 'doc-1',
+          sourcePageRange: '40-41',
+          requirement: 'CCB V3.1: G1.10',
+          description: 'Monitoring report omits appendix references.',
           evidenceExcerpt: 'Monitoring report omits appendix references.',
           projectResponse: 'Appendix references will be added.',
+          documentationSubmitted: 'Revised appendix set',
+          auditTeamEvaluation: 'Awaiting updated published report',
           closureStatus: 'open',
           reviewerNote: 'Hold open until revised report lands.',
           createdAt: '2026-04-15T00:00:00Z',
@@ -175,9 +180,24 @@ describe('/api/projects/[id]/export-pdf route', () => {
 
     expect(res.headers.get('Content-Disposition')).toContain('attachment; filename="manual-review-pack-manual-p.pdf"');
     expect(parsed.text).toContain('MANUAL REVIEW REPORT');
+    expect(parsed.text).toContain('VVB FINDINGS RECONSTRUCTION');
+    expect(parsed.text).not.toContain('VERIFICATION REPORT UNFCCC');
+    expect(parsed.text).not.toContain('UNFCCC VERIFICATION REPORT');
+    expect(parsed.text).toContain('This report reconstructs findings from uploaded source documents.');
     expect(parsed.text).toContain('Manual review mode: true');
     expect(parsed.text).toContain('Verra Reconstruction Workspace');
     expect(parsed.text).not.toContain('AR-AMS0007');
+    expect(parsed.text).toContain('CAR: 1');
+    expect(parsed.text).toContain('CL: 0');
+    expect(parsed.text).toContain('FAR: 0');
+    expect(parsed.text).not.toContain('NC: 1');
+    expect(parsed.text).toContain('Finding ID');
+    expect(parsed.text).toContain('Source page/range');
+    expect(parsed.text).toContain('Project response');
+    expect(parsed.text).toContain('Documentation submitted');
+    expect(parsed.text).toContain('Audit team evaluation');
+    expect(parsed.text).toContain('Source excerpt');
+    expect(parsed.text).toContain('Provenance And Limitations');
   }, 15000);
 
   it('renders reviewer rationale under rules that have notes', async () => {

--- a/tests/lib/projects/verificationReport.test.ts
+++ b/tests/lib/projects/verificationReport.test.ts
@@ -227,7 +227,7 @@ describe('verification report composition', () => {
             mimeType: 'application/pdf',
             sizeBytes: 1024,
             uploadedAt: '2026-04-23T00:00:00.000Z',
-            extractedText: 'Monitoring report excerpt',
+            extractedText: 'CCB and VCS verification report excerpt',
           },
         ],
         manualFindings: [
@@ -261,6 +261,7 @@ describe('verification report composition', () => {
     expect(reportText(report)).not.toContain('UNFCCC VERIFICATION REPORT');
     expect(reportText(report)).toContain('This report reconstructs findings from uploaded source documents.');
     expect(reportText(report)).toContain('CAR: 1. CL: 0. FAR: 0.');
+    expect(reportText(report)).toContain('Registry / Standard: Verra / VCS + CCB.');
     expect(reportText(report)).toContain('Finding ID: CAR01.');
     expect(reportText(report)).toContain('Source page/range: 40-41.');
     expect(reportText(report)).toContain('Documentation submitted: EPCAP requirements.');

--- a/tests/lib/projects/verificationReport.test.ts
+++ b/tests/lib/projects/verificationReport.test.ts
@@ -223,7 +223,7 @@ describe('verification report composition', () => {
         documents: [
           {
             id: 'doc-1',
-            fileName: 'verra-monitoring-report.pdf',
+            fileName: 'CCB_VERIF_REP_ENG_1530_01AUG2011_12DEC2020.pdf',
             mimeType: 'application/pdf',
             sizeBytes: 1024,
             uploadedAt: '2026-04-23T00:00:00.000Z',
@@ -233,11 +233,16 @@ describe('verification report composition', () => {
         manualFindings: [
           {
             id: 'finding-1',
-            findingId: 'F-001',
-            findingType: 'VVB finding',
+            findingId: 'CAR01',
+            findingType: 'CAR',
             sourceDocumentId: 'doc-1',
-            evidenceExcerpt: 'Emission factor table is missing.',
+            sourcePageRange: '40-41',
+            requirement: 'CCB V3.1: G1.10',
+            description: 'Environmental safeguards evidence is incomplete.',
+            evidenceExcerpt: 'Environmental safeguards evidence is incomplete.',
             projectResponse: 'Updated workbook to include the factor.',
+            documentationSubmitted: 'EPCAP requirements',
+            auditTeamEvaluation: 'Supports now demonstrate compliance.',
             closureStatus: 'open',
             reviewerNote: 'Needs revised attachment set.',
             createdAt: '2026-04-23T00:00:00.000Z',
@@ -250,10 +255,69 @@ describe('verification report composition', () => {
       makeCoverage({ total: 1, verified: 0, gap: 1, notStarted: 0, notApplicable: 0, inProgress: 0, percentComplete: 0 }),
     );
 
-    expect(report.title).toBe('MANUAL REVIEW REPORT');
-    expect(report.summaryItems).toContain('Manual review mode: true');
-    expect(report.sections.map((section) => section.title)).toContain('MANUAL FINDINGS');
+    expect(report.title).toBe('VVB FINDINGS RECONSTRUCTION');
+    expect(report.summaryItems).toContain('Manual review report');
+    expect(report.sections.map((section) => section.title)).toContain('FINDING DETAILS');
     expect(reportText(report)).not.toContain('UNFCCC VERIFICATION REPORT');
-    expect(reportText(report)).toContain('Manual review mode: true');
+    expect(reportText(report)).toContain('This report reconstructs findings from uploaded source documents.');
+    expect(reportText(report)).toContain('CAR: 1. CL: 0. FAR: 0.');
+    expect(reportText(report)).toContain('Finding ID: CAR01.');
+    expect(reportText(report)).toContain('Source page/range: 40-41.');
+    expect(reportText(report)).toContain('Documentation submitted: EPCAP requirements.');
+    expect(reportText(report)).toContain('Audit team evaluation: Supports now demonstrate compliance.');
+  });
+
+  it('summarizes 1530-style manual findings with CAR/CL/FAR and closed/open counts', () => {
+    const manualFindings: Project['manualFindings'] = [
+      ...Array.from({ length: 7 }, (_, index) => ({
+        id: `car-${index + 1}`,
+        findingId: `CAR0${index + 1}`,
+        findingType: 'CAR' as const,
+        closureStatus: 'closed' as const,
+        createdAt: '2026-04-23T00:00:00.000Z',
+        updatedAt: '2026-04-23T00:00:00.000Z',
+      })),
+      ...Array.from({ length: 6 }, (_, index) => ({
+        id: `cl-${index + 1}`,
+        findingId: `CL0${index + 1}`,
+        findingType: 'CL' as const,
+        closureStatus: 'closed' as const,
+        createdAt: '2026-04-23T00:00:00.000Z',
+        updatedAt: '2026-04-23T00:00:00.000Z',
+      })),
+      ...Array.from({ length: 4 }, (_, index) => ({
+        id: `far-${index + 1}`,
+        findingId: `FAR0${index + 1}`,
+        findingType: 'FAR' as const,
+        closureStatus: 'open' as const,
+        createdAt: '2026-04-23T00:00:00.000Z',
+        updatedAt: '2026-04-23T00:00:00.000Z',
+      })),
+    ];
+
+    const report = composeManualVerificationReport(
+      makeProject({
+        reviewMode: 'manual',
+        methodCode: undefined,
+        methodVersion: undefined,
+        registry: 'Verra',
+        documents: [{
+          id: 'doc-1',
+          fileName: 'CCB_VERIF_REP_ENG_1530_01AUG2011_12DEC2020.pdf',
+          mimeType: 'application/pdf',
+          sizeBytes: 1024,
+          uploadedAt: '2026-04-23T00:00:00.000Z',
+        }],
+        manualFindings,
+        extractedManualFindingDrafts: [],
+        reviews: [],
+      }),
+      makeCoverage({ total: 17, verified: 13, gap: 4, notStarted: 0, percentComplete: 100 }),
+    );
+
+    const text = reportText(report);
+    expect(text).toContain('17 VVB finding sections were reconstructed');
+    expect(text).toContain('13 closed findings, 4 open findings, and 0 findings still marked in review');
+    expect(text).toContain('CAR: 7. CL: 6. FAR: 4.');
   });
 });


### PR DESCRIPTION
## WHAT

- Upgrade Manual Review exports into Article6-branded VVB Findings Reconstruction reports.
- Fix CAR/CL/FAR summary terminology.
- Add a concise outcome section.
- Structure findings into premium labeled sections.
- Move provenance and limitation language into a clean end section.
- New pagination/orphan-page fix

## WHY

- Extraction now works, but the report needs to look credible enough for public autopsy and inbound sales.
- Current headings overclaim verification status.
- VVB-grade output needs clean traceability, structured findings, and explicit limits.

## Scope

- Manual Review export/report output for project-level manual reviews
- No extraction logic changes except what the renderer already consumes
- Keep source traceability and locked-project export behavior

## Validation

- npm run typecheck
- npm test -- tests/lib/projects/verificationReport.test.ts --runInBand
- npm test -- tests/api/project.export-pdf.route.test.ts --runInBand
- npm test -- tests/api/projects.manual-review.extract-findings.route.test.ts --runInBand
- npm test -- tests/lib/projects/manualFindingExtraction.test.ts --runInBand
- npm run build

## Visible export changes

- Primary title no longer leads with `VERIFICATION REPORT` for Manual Review exports
- Manual Review export reads as `MANUAL REVIEW REPORT` + `VVB FINDINGS RECONSTRUCTION`
- Summary shows `CAR`, `CL`, and `FAR` instead of mapping CAR to `NC`
- Outcome block summarizes reconstructed findings and closed/open counts
- Findings render with structured labels for requirement, description, response, documentation, audit evaluation, reviewer note, source page/range, and source excerpt
- Provenance and limitation language are moved to a clean closing section

**Signed-off-by:** Fred E <fredilly@article6.org>**
