### PR TITLE
Fence Manual Review learning cases as untrusted local metadata

### DIFF
--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -25,6 +25,7 @@ import {
   lockProject,
   manualFindingClosureLabel,
   nextManualFindingId,
+  recordManualReviewLearningCase,
   updateExtractedManualFindingDraft,
   updateManualFinding,
   updateRuleReview,
@@ -123,6 +124,10 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
 
   const handleLock = () => {
     const locked = lockProject(projectId);
+    if (locked?.reviewMode === 'manual') {
+      refreshProject(recordManualReviewLearningCase(projectId, 'project_locked'));
+      return;
+    }
     if (locked) {
       setProject(locked);
       setCoverage(getProjectCoverage(locked));
@@ -138,6 +143,9 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
         body: JSON.stringify({ project }),
       });
       if (!res.ok) throw new Error('Pack generation failed');
+      if (project.reviewMode === 'manual') {
+        refreshProject(recordManualReviewLearningCase(projectId, 'export_generated'));
+      }
       const blob = await res.blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');

--- a/src/lib/projects/learningCase.ts
+++ b/src/lib/projects/learningCase.ts
@@ -28,12 +28,64 @@ function uniqueSorted(values: string[]): string[] {
   return Array.from(new Set(values)).sort();
 }
 
+export function manualReviewLearningCaseDedupKey(
+  project: Project,
+  trigger: LearningCaseTrigger,
+): string {
+  const registryLabel = manualRegistryLabel(project);
+  const documentFingerprints = project.documents
+    .map((document) => [
+      document.fileName,
+      document.mimeType,
+      String(document.sizeBytes),
+      document.manualFindingExtractionStatus ?? 'not-run',
+    ].join('|'))
+    .sort();
+  const findingFingerprints = project.manualFindings
+    .map((finding) => [
+      finding.findingId,
+      finding.findingType,
+      finding.closureStatus,
+      finding.sourcePageRange?.trim() || '',
+      Boolean(finding.requirement?.trim()),
+      Boolean(finding.description?.trim()),
+      Boolean(finding.projectResponse?.trim()),
+      Boolean(finding.documentationSubmitted?.trim()),
+      Boolean(finding.auditTeamEvaluation?.trim()),
+      Boolean(finding.reviewerNote?.trim()),
+    ].join('|'))
+    .sort();
+  const draftFingerprints = project.extractedManualFindingDrafts
+    .map((draft) => [
+      draft.findingId.trim(),
+      draft.findingType ?? '',
+      draft.extractionStatus,
+      draft.closureStatus ?? '',
+      Boolean(draft.reviewerNote?.trim()),
+    ].join('|'))
+    .sort();
+
+  return JSON.stringify({
+    trigger,
+    status: project.status,
+    lockedAt: project.lockedAt ?? '',
+    registryLabel,
+    methodology: project.methodCode && project.methodVersion ? `${project.methodCode}@${project.methodVersion}` : '',
+    projectArea: Boolean(project.aoiLabel?.trim()),
+    projectDescription: Boolean(project.description?.trim()),
+    documentFingerprints,
+    findingFingerprints,
+    draftFingerprints,
+  });
+}
+
 export function buildManualReviewLearningCase(
   project: Project,
   trigger: LearningCaseTrigger,
   createdAt = new Date().toISOString(),
 ): LearningCase {
   const registryLabel = manualRegistryLabel(project);
+  const dedupKey = manualReviewLearningCaseDedupKey(project, trigger);
   const findingTypeCounts = project.manualFindings.reduce(
     (counts, finding) => {
       if (finding.findingType === 'CAR' || finding.findingType === 'CL' || finding.findingType === 'FAR') {
@@ -103,6 +155,9 @@ export function buildManualReviewLearningCase(
 
   const truthRulesTriggered = [
     'manual_review_reconstruction_only',
+    'user_entered_unverified',
+    'training_disabled_for_learning_case',
+    'human_review_required',
     'no_independent_verification_opinion',
     'no_validation_statement',
     'no_methodology_compliance_determination',
@@ -126,6 +181,9 @@ export function buildManualReviewLearningCase(
     created_at: createdAt,
     trigger,
     review_mode: project.reviewMode,
+    trust_level: 'user_entered_unverified',
+    training_eligible: false,
+    requires_human_review: true,
     registry_or_standard: registryLabel !== 'Unknown registry' ? registryLabel : undefined,
     document_type: manualDocumentTypeLabel(project),
     source_document_count: project.documents.length,
@@ -144,5 +202,6 @@ export function buildManualReviewLearningCase(
     truth_rules_triggered: truthRulesTriggered,
     recommended_evals: recommendedEvals,
     source_retention_policy: RETENTION_POLICY,
+    dedup_key: dedupKey,
   };
 }

--- a/src/lib/projects/learningCase.ts
+++ b/src/lib/projects/learningCase.ts
@@ -79,6 +79,11 @@ export function manualReviewLearningCaseDedupKey(
   });
 }
 
+export function isLearningCaseTrainingEligible(_learningCase: Pick<LearningCase, 'training_eligible'>): false {
+  void _learningCase;
+  return false;
+}
+
 export function buildManualReviewLearningCase(
   project: Project,
   trigger: LearningCaseTrigger,
@@ -165,7 +170,7 @@ export function buildManualReviewLearningCase(
     `limitation_text:${MANUAL_REVIEW_LIMITATION}`,
   ];
 
-  const recommendedEvals = uniqueSorted([
+  const evalCandidateSignals = uniqueSorted([
     'manual-review-finding-type-summary',
     'manual-review-closure-counts',
     'manual-review-field-coverage',
@@ -184,6 +189,8 @@ export function buildManualReviewLearningCase(
     trust_level: 'user_entered_unverified',
     training_eligible: false,
     requires_human_review: true,
+    promotion_status: 'not_promoted',
+    poisoning_boundary: 'not_allowed_to_update_rules_models_evals_or_scores',
     registry_or_standard: registryLabel !== 'Unknown registry' ? registryLabel : undefined,
     document_type: manualDocumentTypeLabel(project),
     source_document_count: project.documents.length,
@@ -200,7 +207,7 @@ export function buildManualReviewLearningCase(
     },
     export_quality_flags: exportQualityFlags,
     truth_rules_triggered: truthRulesTriggered,
-    recommended_evals: recommendedEvals,
+    eval_candidate_signals: evalCandidateSignals,
     source_retention_policy: RETENTION_POLICY,
     dedup_key: dedupKey,
   };

--- a/src/lib/projects/learningCase.ts
+++ b/src/lib/projects/learningCase.ts
@@ -1,0 +1,148 @@
+import { MANUAL_REVIEW_LIMITATION, manualRegistryLabel } from '@/lib/projects/verificationReport';
+import type { LearningCase, LearningCaseTrigger, Project } from '@/lib/projects/types';
+
+const RETENTION_POLICY =
+  'No raw document text, full source excerpts, or uploaded file bytes are retained. Learning cases store only redacted metadata and structured quality signals.';
+
+function generateLearningCaseId(): string {
+  return `lc_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function countPresent(values: Array<string | undefined>): number {
+  return values.filter((value) => Boolean(value?.trim())).length;
+}
+
+function manualDocumentTypeLabel(project: Project): string {
+  if (project.documents.some((document) => document.mimeType === 'application/pdf')) {
+    return 'Published verification report PDF';
+  }
+  if (project.documents.length > 0) return 'Uploaded source document';
+  return 'Not provided';
+}
+
+function manualMethodologyWired(project: Project): boolean {
+  return Boolean(project.methodCode?.trim() && project.methodVersion?.trim());
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort();
+}
+
+export function buildManualReviewLearningCase(
+  project: Project,
+  trigger: LearningCaseTrigger,
+  createdAt = new Date().toISOString(),
+): LearningCase {
+  const registryLabel = manualRegistryLabel(project);
+  const findingTypeCounts = project.manualFindings.reduce(
+    (counts, finding) => {
+      if (finding.findingType === 'CAR' || finding.findingType === 'CL' || finding.findingType === 'FAR') {
+        counts[finding.findingType] += 1;
+      } else {
+        counts.other += 1;
+      }
+      return counts;
+    },
+    { CAR: 0, CL: 0, FAR: 0, other: 0 },
+  );
+
+  const closureCounts = project.manualFindings.reduce(
+    (counts, finding) => {
+      counts[finding.closureStatus] += 1;
+      return counts;
+    },
+    { open: 0, 'in-review': 0, closed: 0 },
+  );
+
+  const fieldsPresent = {
+    registry_or_standard: registryLabel !== 'Unknown registry' ? 1 : 0,
+    methodology_reference: manualMethodologyWired(project) ? 1 : 0,
+    project_area: project.aoiLabel?.trim() ? 1 : 0,
+    project_description: project.description?.trim() ? 1 : 0,
+    source_page_range: countPresent(project.manualFindings.map((finding) => finding.sourcePageRange)),
+    requirement: countPresent(project.manualFindings.map((finding) => finding.requirement)),
+    description: countPresent(project.manualFindings.map((finding) => finding.description)),
+    project_response: countPresent(project.manualFindings.map((finding) => finding.projectResponse)),
+    documentation_submitted: countPresent(project.manualFindings.map((finding) => finding.documentationSubmitted)),
+    audit_team_evaluation: countPresent(project.manualFindings.map((finding) => finding.auditTeamEvaluation)),
+    reviewer_note: countPresent(project.manualFindings.map((finding) => finding.reviewerNote)),
+    closure_status: project.manualFindings.length,
+  };
+
+  const totalFindings = project.manualFindings.length;
+  const fieldsMissing = {
+    registry_or_standard: fieldsPresent.registry_or_standard ? 0 : 1,
+    methodology_reference: fieldsPresent.methodology_reference ? 0 : 1,
+    project_area: fieldsPresent.project_area ? 0 : 1,
+    project_description: fieldsPresent.project_description ? 0 : 1,
+    source_page_range: Math.max(0, totalFindings - fieldsPresent.source_page_range),
+    requirement: Math.max(0, totalFindings - fieldsPresent.requirement),
+    description: Math.max(0, totalFindings - fieldsPresent.description),
+    project_response: Math.max(0, totalFindings - fieldsPresent.project_response),
+    documentation_submitted: Math.max(0, totalFindings - fieldsPresent.documentation_submitted),
+    audit_team_evaluation: Math.max(0, totalFindings - fieldsPresent.audit_team_evaluation),
+    reviewer_note: Math.max(0, totalFindings - fieldsPresent.reviewer_note),
+    closure_status: 0,
+  };
+
+  const exportQualityFlags = uniqueSorted([
+    ...(registryLabel === 'Unknown registry' ? ['metadata_missing_registry_or_standard'] : []),
+    ...(!manualMethodologyWired(project) ? ['metadata_missing_methodology_reference'] : []),
+    ...(!project.aoiLabel?.trim() ? ['metadata_missing_project_area'] : []),
+    ...(!project.description?.trim() ? ['metadata_missing_project_description'] : []),
+    ...(project.documents.length === 0 ? ['source_document_set_missing'] : []),
+    ...(project.manualFindings.length === 0 ? ['manual_findings_missing'] : []),
+    ...(project.documents.some((document) => document.manualFindingExtractionStatus === 'extraction-failed')
+      ? ['document_extraction_failed']
+      : []),
+    ...(project.documents.some((document) => document.manualFindingExtractionStatus === 'no-findings')
+      ? ['document_extraction_returned_no_findings']
+      : []),
+    ...(project.extractedManualFindingDrafts.length > 0 ? ['draft_findings_pending_review'] : []),
+  ]);
+
+  const truthRulesTriggered = [
+    'manual_review_reconstruction_only',
+    'no_independent_verification_opinion',
+    'no_validation_statement',
+    'no_methodology_compliance_determination',
+    'no_customer_source_document_retention',
+    `limitation_text:${MANUAL_REVIEW_LIMITATION}`,
+  ];
+
+  const recommendedEvals = uniqueSorted([
+    'manual-review-finding-type-summary',
+    'manual-review-closure-counts',
+    'manual-review-field-coverage',
+    'manual-review-truthfulness-language',
+    'manual-review-source-retention',
+    ...(registryLabel === 'Unknown registry' ? ['manual-review-registry-inference'] : []),
+    ...(project.extractedManualFindingDrafts.length > 0 ? ['manual-review-draft-review-gate'] : []),
+    ...(exportQualityFlags.length > 0 ? ['manual-review-export-quality-flags'] : []),
+  ]);
+
+  return {
+    case_id: generateLearningCaseId(),
+    created_at: createdAt,
+    trigger,
+    review_mode: project.reviewMode,
+    registry_or_standard: registryLabel !== 'Unknown registry' ? registryLabel : undefined,
+    document_type: manualDocumentTypeLabel(project),
+    source_document_count: project.documents.length,
+    finding_count: project.manualFindings.length,
+    finding_type_counts: findingTypeCounts,
+    closure_counts: closureCounts,
+    fields_present: fieldsPresent,
+    fields_missing: fieldsMissing,
+    reviewer_correction_summary: {
+      extracted_draft_count: project.extractedManualFindingDrafts.length,
+      draft_findings_ready_count: project.extractedManualFindingDrafts.filter((draft) => draft.extractionStatus === 'draft').length,
+      draft_findings_needing_review_count: project.extractedManualFindingDrafts.filter((draft) => draft.extractionStatus === 'needs-review').length,
+      reviewer_note_count: fieldsPresent.reviewer_note,
+    },
+    export_quality_flags: exportQualityFlags,
+    truth_rules_triggered: truthRulesTriggered,
+    recommended_evals: recommendedEvals,
+    source_retention_policy: RETENTION_POLICY,
+  };
+}

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -1,5 +1,7 @@
+import { buildManualReviewLearningCase } from './learningCase';
 import type {
   ExtractedManualFindingDraft,
+  LearningCaseTrigger,
   ManualFinding,
   ManualFindingClosureStatus,
   Project,
@@ -69,6 +71,7 @@ export function createProject(input: {
     documents: [],
     manualFindings: [],
     extractedManualFindingDrafts: [],
+    learningCases: [],
   };
 
   const projects = loadAll();
@@ -107,6 +110,20 @@ export function lockProject(projectId: string): Project | undefined {
 
   project.status = 'locked';
   project.lockedAt = new Date().toISOString();
+  saveAll(projects);
+  return project;
+}
+
+export function recordManualReviewLearningCase(
+  projectId: string,
+  trigger: LearningCaseTrigger,
+): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find(p => p.id === projectId);
+  if (!project || project.reviewMode !== 'manual') return project;
+
+  project.learningCases = Array.isArray(project.learningCases) ? project.learningCases : [];
+  project.learningCases.push(buildManualReviewLearningCase(project, trigger));
   saveAll(projects);
   return project;
 }
@@ -335,6 +352,7 @@ function normalizeProject(project: Partial<Project>): Project {
     documents: Array.isArray(project.documents) ? project.documents : [],
     manualFindings: Array.isArray(project.manualFindings) ? project.manualFindings : [],
     extractedManualFindingDrafts: Array.isArray(project.extractedManualFindingDrafts) ? project.extractedManualFindingDrafts : [],
+    learningCases: Array.isArray(project.learningCases) ? project.learningCases : [],
   };
 }
 

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -123,7 +123,13 @@ export function recordManualReviewLearningCase(
   if (!project || project.reviewMode !== 'manual') return project;
 
   project.learningCases = Array.isArray(project.learningCases) ? project.learningCases : [];
-  project.learningCases.push(buildManualReviewLearningCase(project, trigger));
+  const nextCase = buildManualReviewLearningCase(project, trigger);
+  const latestCase = project.learningCases.at(-1);
+  if (latestCase?.trigger === trigger && latestCase.dedup_key === nextCase.dedup_key) {
+    return project;
+  }
+
+  project.learningCases.push(nextCase);
   saveAll(projects);
   return project;
 }

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -12,6 +12,42 @@ export type ManualFindingClosureStatus = 'open' | 'in-review' | 'closed';
 
 export type ExtractedManualFindingStatus = 'draft' | 'needs-review';
 
+export type LearningCaseTrigger = 'project_locked' | 'export_generated';
+
+export type LearningCase = {
+  case_id: string;
+  created_at: string;
+  trigger: LearningCaseTrigger;
+  review_mode: ProjectReviewMode;
+  registry_or_standard?: string;
+  document_type: string;
+  source_document_count: number;
+  finding_count: number;
+  finding_type_counts: {
+    CAR: number;
+    CL: number;
+    FAR: number;
+    other: number;
+  };
+  closure_counts: {
+    open: number;
+    'in-review': number;
+    closed: number;
+  };
+  fields_present: Record<string, number>;
+  fields_missing: Record<string, number>;
+  reviewer_correction_summary?: {
+    extracted_draft_count: number;
+    draft_findings_ready_count: number;
+    draft_findings_needing_review_count: number;
+    reviewer_note_count: number;
+  };
+  export_quality_flags: string[];
+  truth_rules_triggered: string[];
+  recommended_evals: string[];
+  source_retention_policy: string;
+};
+
 export type RuleReview = {
   ruleId: string;
   ruleTitle: string;
@@ -89,6 +125,7 @@ export type Project = {
   documents: ProjectDocument[];
   manualFindings: ManualFinding[];
   extractedManualFindingDrafts: ExtractedManualFindingDraft[];
+  learningCases: LearningCase[];
 };
 
 export type ProjectCoverage = {

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -19,6 +19,9 @@ export type LearningCase = {
   created_at: string;
   trigger: LearningCaseTrigger;
   review_mode: ProjectReviewMode;
+  trust_level: 'user_entered_unverified';
+  training_eligible: false;
+  requires_human_review: true;
   registry_or_standard?: string;
   document_type: string;
   source_document_count: number;
@@ -46,6 +49,7 @@ export type LearningCase = {
   truth_rules_triggered: string[];
   recommended_evals: string[];
   source_retention_policy: string;
+  dedup_key: string;
 };
 
 export type RuleReview = {

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -14,6 +14,9 @@ export type ExtractedManualFindingStatus = 'draft' | 'needs-review';
 
 export type LearningCaseTrigger = 'project_locked' | 'export_generated';
 
+// LearningCase is always local, user-derived, and untrusted. It may inform
+// future human review, but it must not be treated as trusted eval/training
+// material or used to update rules, models, scores, or extraction behavior.
 export type LearningCase = {
   case_id: string;
   created_at: string;
@@ -22,6 +25,8 @@ export type LearningCase = {
   trust_level: 'user_entered_unverified';
   training_eligible: false;
   requires_human_review: true;
+  promotion_status: 'not_promoted';
+  poisoning_boundary: 'not_allowed_to_update_rules_models_evals_or_scores';
   registry_or_standard?: string;
   document_type: string;
   source_document_count: number;
@@ -47,9 +52,18 @@ export type LearningCase = {
   };
   export_quality_flags: string[];
   truth_rules_triggered: string[];
-  recommended_evals: string[];
+  eval_candidate_signals: string[];
   source_retention_policy: string;
   dedup_key: string;
+};
+
+// ReviewedLearningCase is the only shape that may be considered for trusted
+// downstream eval design. Nothing in this PR creates this type.
+export type ReviewedLearningCase = {
+  source_learning_case_id: LearningCase['case_id'];
+  reviewed_by: string;
+  reviewed_at: string;
+  review_decision: 'approved_for_eval_design' | 'rejected';
 };
 
 export type RuleReview = {

--- a/src/lib/projects/verificationReport.ts
+++ b/src/lib/projects/verificationReport.ts
@@ -25,6 +25,9 @@ export type VerificationReportComposition = {
   limitation: string;
 };
 
+export const MANUAL_REVIEW_LIMITATION =
+  'This report reconstructs findings from uploaded source documents. It is not an independent verification opinion, validation statement, or methodology compliance determination.';
+
 const UNFCCC_SECTION_ORDER = [
   'REPORT STATUS',
   'PROJECT AND METHODOLOGY IDENTIFICATION',
@@ -396,7 +399,7 @@ export function composeManualVerificationReport(
     ['Registry / Standard', registryLabel],
     ['Registry project ID', 'Not provided'],
     ['Methodology / reference', methodologyLabel],
-    ['Limitation', 'This report reconstructs findings from uploaded source documents. It is not an independent verification opinion, validation statement, or methodology compliance determination.'],
+    ['Limitation', MANUAL_REVIEW_LIMITATION],
   ] satisfies Array<[string, string]>;
 
   return {
@@ -414,7 +417,7 @@ export function composeManualVerificationReport(
       {
         title: 'REPORT LIMITATION',
         lines: [
-          'This report reconstructs findings from uploaded source documents. It is not an independent verification opinion, validation statement, or methodology compliance determination.',
+          MANUAL_REVIEW_LIMITATION,
         ],
       },
       {
@@ -478,7 +481,7 @@ export function composeManualVerificationReport(
     ],
     findings,
     provenance,
-    limitation: 'This report reconstructs findings from uploaded source documents. It is not an independent verification opinion, validation statement, or methodology compliance determination.',
+    limitation: MANUAL_REVIEW_LIMITATION,
   };
 }
 

--- a/tests/api/project.export-pdf.route.test.ts
+++ b/tests/api/project.export-pdf.route.test.ts
@@ -27,6 +27,7 @@ function makeProject(reviewCount = 6): Project {
     documents: [],
     manualFindings: [],
     extractedManualFindingDrafts: [],
+    learningCases: [],
     reviews: Array.from({ length: reviewCount }, (_, index) => ({
       ruleId: `R-${index + 1}`,
       ruleTitle: `Verification requirement ${index + 1} for the monitoring report and workbook evidence`,
@@ -167,6 +168,7 @@ describe('/api/projects/[id]/export-pdf route', () => {
         },
       ],
       extractedManualFindingDrafts: [],
+      learningCases: [],
       reviews: [],
     };
     const req = new Request('http://localhost/api/projects/manual-project-1/export-pdf', {
@@ -239,6 +241,7 @@ describe('/api/projects/[id]/export-pdf route', () => {
         updatedAt: '2026-04-15T00:00:00Z',
       })),
       extractedManualFindingDrafts: [],
+      learningCases: [],
       reviews: [],
     };
 

--- a/tests/components/projectDetailLockGate.test.tsx
+++ b/tests/components/projectDetailLockGate.test.tsx
@@ -29,6 +29,7 @@ function makeMethodologyProject(overrides: Partial<Project> = {}): Project {
     documents: [],
     manualFindings: [],
     extractedManualFindingDrafts: [],
+    learningCases: [],
     ...overrides,
   };
 }
@@ -45,6 +46,7 @@ function makeManualProject(overrides: Partial<Project> = {}): Project {
     documents: [],
     manualFindings: [],
     extractedManualFindingDrafts: [],
+    learningCases: [],
     ...overrides,
   };
 }

--- a/tests/components/projectDetailManualExtraction.test.tsx
+++ b/tests/components/projectDetailManualExtraction.test.tsx
@@ -24,6 +24,7 @@ function makeProject(overrides: Partial<Project> = {}): Project {
     documents: [],
     manualFindings: [],
     extractedManualFindingDrafts: [],
+    learningCases: [],
     ...overrides,
   };
 }

--- a/tests/lib/projects/learningCase.test.ts
+++ b/tests/lib/projects/learningCase.test.ts
@@ -1,0 +1,163 @@
+/** @jest-environment jsdom */
+
+import { describe, expect, it } from '@jest/globals';
+import { buildManualReviewLearningCase } from '@/lib/projects/learningCase';
+import { recordManualReviewLearningCase } from '@/lib/projects/storage';
+import type { Project } from '@/lib/projects/types';
+
+function makeManualProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'proj-manual-learning',
+    name: 'Verra Reconstruction Workspace',
+    reviewMode: 'manual',
+    registry: 'Unknown',
+    status: 'locked',
+    createdAt: '2026-05-07T00:00:00.000Z',
+    reviews: [],
+    documents: [
+      {
+        id: 'doc-1',
+        fileName: 'CCB_VERIF_REP_ENG_1530_01AUG2011_12DEC2020.pdf',
+        mimeType: 'application/pdf',
+        sizeBytes: 2048,
+        uploadedAt: '2026-05-07T00:00:00.000Z',
+        extractedText: 'VCS CCB raw extracted appendix unique string that must not be retained in the learning case',
+        manualFindingExtractionStatus: 'extracted',
+        manualFindingExtractionMessage: '17 draft finding sections detected. Review before accepting.',
+        manualFindingExtractionTrace: 'bundled-pdf-parse',
+      },
+    ],
+    manualFindings: [
+      {
+        id: 'finding-1',
+        findingId: 'CAR01',
+        findingType: 'CAR',
+        sourceDocumentId: 'doc-1',
+        sourcePageRange: '40-41',
+        requirement: 'CCB V3.1: G1.10',
+        description: 'Missing appendix cross-reference.',
+        evidenceExcerpt: 'full excerpt text unique 123 that must not be retained in the learning case',
+        projectResponse: 'Updated appendix references submitted.',
+        documentationSubmitted: 'Revised appendix set',
+        auditTeamEvaluation: 'Closure supported in revised report.',
+        closureStatus: 'closed',
+        reviewerNote: 'Accepted after cross-check.',
+        createdAt: '2026-05-07T00:00:00.000Z',
+        updatedAt: '2026-05-07T00:00:00.000Z',
+      },
+      {
+        id: 'finding-2',
+        findingId: 'CL01',
+        findingType: 'CL',
+        sourceDocumentId: 'doc-1',
+        description: 'Clarification text still ambiguous.',
+        projectResponse: 'Clarification memo added.',
+        closureStatus: 'in-review',
+        createdAt: '2026-05-07T00:00:00.000Z',
+        updatedAt: '2026-05-07T00:00:00.000Z',
+      },
+      {
+        id: 'finding-3',
+        findingId: 'FAR01',
+        findingType: 'FAR',
+        sourceDocumentId: 'doc-1',
+        sourcePageRange: '55-56',
+        requirement: 'CCB V3.1: CM1.1',
+        description: 'Forward action remains open.',
+        closureStatus: 'open',
+        createdAt: '2026-05-07T00:00:00.000Z',
+        updatedAt: '2026-05-07T00:00:00.000Z',
+      },
+    ],
+    extractedManualFindingDrafts: [
+      {
+        id: 'draft-1',
+        findingId: 'CAR07',
+        findingType: 'CAR',
+        sourceDocumentId: 'doc-1',
+        extractionStatus: 'draft',
+        extractionMessage: 'draft',
+        createdAt: '2026-05-07T00:00:00.000Z',
+        updatedAt: '2026-05-07T00:00:00.000Z',
+      },
+      {
+        id: 'draft-2',
+        findingId: '',
+        sourceDocumentId: 'doc-1',
+        extractionStatus: 'needs-review',
+        extractionMessage: 'needs review',
+        createdAt: '2026-05-07T00:00:00.000Z',
+        updatedAt: '2026-05-07T00:00:00.000Z',
+      },
+    ],
+    learningCases: [],
+    ...overrides,
+  };
+}
+
+describe('manual review learning cases', () => {
+  it('captures structured Manual Review signals without copying raw source content', () => {
+    const learningCase = buildManualReviewLearningCase(
+      makeManualProject(),
+      'export_generated',
+      '2026-05-07T12:00:00.000Z',
+    );
+    const serialized = JSON.stringify(learningCase);
+
+    expect(learningCase.trigger).toBe('export_generated');
+    expect(learningCase.review_mode).toBe('manual');
+    expect(learningCase.registry_or_standard).toBe('Verra / VCS + CCB');
+    expect(learningCase.document_type).toBe('Published verification report PDF');
+    expect(learningCase.source_document_count).toBe(1);
+    expect(learningCase.finding_count).toBe(3);
+    expect(learningCase.finding_type_counts).toEqual({ CAR: 1, CL: 1, FAR: 1, other: 0 });
+    expect(learningCase.closure_counts).toEqual({ open: 1, 'in-review': 1, closed: 1 });
+    expect(learningCase.fields_present.documentation_submitted).toBe(1);
+    expect(learningCase.fields_missing.documentation_submitted).toBe(2);
+    expect(learningCase.fields_missing.project_area).toBe(1);
+    expect(learningCase.fields_missing.project_description).toBe(1);
+    expect(learningCase.reviewer_correction_summary).toEqual({
+      extracted_draft_count: 2,
+      draft_findings_ready_count: 1,
+      draft_findings_needing_review_count: 1,
+      reviewer_note_count: 1,
+    });
+    expect(learningCase.export_quality_flags).toEqual(expect.arrayContaining([
+      'draft_findings_pending_review',
+      'metadata_missing_methodology_reference',
+      'metadata_missing_project_area',
+      'metadata_missing_project_description',
+    ]));
+    expect(learningCase.truth_rules_triggered).toEqual(expect.arrayContaining([
+      'manual_review_reconstruction_only',
+      'no_independent_verification_opinion',
+      'no_validation_statement',
+      'no_methodology_compliance_determination',
+    ]));
+    expect(learningCase.recommended_evals).toEqual(expect.arrayContaining([
+      'manual-review-finding-type-summary',
+      'manual-review-closure-counts',
+      'manual-review-field-coverage',
+      'manual-review-truthfulness-language',
+      'manual-review-source-retention',
+    ]));
+    expect(learningCase.source_retention_policy).toContain('No raw document text');
+    expect(serialized).not.toContain('full excerpt text unique 123');
+    expect(serialized).not.toContain('VCS CCB raw extracted appendix unique string');
+  });
+
+  it('persists a redacted learning case into the project record for manual export or lock flows', () => {
+    window.localStorage.setItem('article6_projects', JSON.stringify([makeManualProject()]));
+
+    const updated = recordManualReviewLearningCase('proj-manual-learning', 'project_locked');
+    const stored = JSON.parse(window.localStorage.getItem('article6_projects') || '[]') as Project[];
+    const learningCase = stored[0]?.learningCases[0];
+
+    expect(updated?.learningCases).toHaveLength(1);
+    expect(learningCase?.trigger).toBe('project_locked');
+    expect(learningCase?.finding_type_counts).toEqual({ CAR: 1, CL: 1, FAR: 1, other: 0 });
+    expect(learningCase?.closure_counts).toEqual({ open: 1, 'in-review': 1, closed: 1 });
+    expect(JSON.stringify(learningCase)).not.toContain('full excerpt text unique 123');
+    expect(JSON.stringify(learningCase)).not.toContain('VCS CCB raw extracted appendix unique string');
+  });
+});

--- a/tests/lib/projects/learningCase.test.ts
+++ b/tests/lib/projects/learningCase.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
 import { describe, expect, it } from '@jest/globals';
-import { buildManualReviewLearningCase } from '@/lib/projects/learningCase';
+import { buildManualReviewLearningCase, isLearningCaseTrainingEligible } from '@/lib/projects/learningCase';
 import { recordManualReviewLearningCase } from '@/lib/projects/storage';
 import type { Project } from '@/lib/projects/types';
 
@@ -109,6 +109,8 @@ describe('manual review learning cases', () => {
     expect(learningCase.trust_level).toBe('user_entered_unverified');
     expect(learningCase.training_eligible).toBe(false);
     expect(learningCase.requires_human_review).toBe(true);
+    expect(learningCase.promotion_status).toBe('not_promoted');
+    expect(learningCase.poisoning_boundary).toBe('not_allowed_to_update_rules_models_evals_or_scores');
     expect(learningCase.registry_or_standard).toBe('Verra / VCS + CCB');
     expect(learningCase.document_type).toBe('Published verification report PDF');
     expect(learningCase.source_document_count).toBe(1);
@@ -140,13 +142,14 @@ describe('manual review learning cases', () => {
       'no_validation_statement',
       'no_methodology_compliance_determination',
     ]));
-    expect(learningCase.recommended_evals).toEqual(expect.arrayContaining([
+    expect(learningCase.eval_candidate_signals).toEqual(expect.arrayContaining([
       'manual-review-finding-type-summary',
       'manual-review-closure-counts',
       'manual-review-field-coverage',
       'manual-review-truthfulness-language',
       'manual-review-source-retention',
     ]));
+    expect(learningCase.eval_candidate_signals).not.toContain('approved_eval');
     expect(learningCase.source_retention_policy).toContain('No raw document text');
     expect(learningCase.dedup_key).toContain('"trigger":"export_generated"');
     expect(serialized).not.toContain('full excerpt text unique 123');
@@ -165,10 +168,14 @@ describe('manual review learning cases', () => {
     expect(learningCase?.trust_level).toBe('user_entered_unverified');
     expect(learningCase?.training_eligible).toBe(false);
     expect(learningCase?.requires_human_review).toBe(true);
+    expect(learningCase?.promotion_status).toBe('not_promoted');
     expect(learningCase?.finding_type_counts).toEqual({ CAR: 1, CL: 1, FAR: 1, other: 0 });
     expect(learningCase?.closure_counts).toEqual({ open: 1, 'in-review': 1, closed: 1 });
     expect(JSON.stringify(learningCase)).not.toContain('full excerpt text unique 123');
     expect(JSON.stringify(learningCase)).not.toContain('VCS CCB raw extracted appendix unique string');
+    expect('reviewed_by' in (learningCase ?? {})).toBe(false);
+    expect('reviewed_at' in (learningCase ?? {})).toBe(false);
+    expect('review_decision' in (learningCase ?? {})).toBe(false);
   });
 
   it('deduplicates repeated learning cases for the same project trigger and export state', () => {
@@ -193,14 +200,23 @@ describe('manual review learning cases', () => {
     expect(learningCase.training_eligible).toBe(false);
     expect(learningCase.requires_human_review).toBe(true);
     expect(learningCase.trust_level).toBe('user_entered_unverified');
+    expect(learningCase.promotion_status).toBe('not_promoted');
+    expect(learningCase.poisoning_boundary).toBe('not_allowed_to_update_rules_models_evals_or_scores');
     expect(learningCase.truth_rules_triggered).not.toContain('verified_ground_truth');
     expect(learningCase.truth_rules_triggered).toEqual(expect.arrayContaining([
       'training_disabled_for_learning_case',
       'human_review_required',
     ]));
-    expect(learningCase.recommended_evals).toEqual(expect.arrayContaining([
+    expect(learningCase.eval_candidate_signals).toEqual(expect.arrayContaining([
       'manual-review-truthfulness-language',
       'manual-review-field-coverage',
     ]));
+  });
+
+  it('exposes a guard that always blocks training eligibility for manual review learning cases', () => {
+    const learningCase = buildManualReviewLearningCase(makeManualProject(), 'export_generated');
+
+    expect(isLearningCaseTrainingEligible(learningCase)).toBe(false);
+    expect(learningCase.training_eligible).toBe(false);
   });
 });

--- a/tests/lib/projects/learningCase.test.ts
+++ b/tests/lib/projects/learningCase.test.ts
@@ -106,6 +106,9 @@ describe('manual review learning cases', () => {
 
     expect(learningCase.trigger).toBe('export_generated');
     expect(learningCase.review_mode).toBe('manual');
+    expect(learningCase.trust_level).toBe('user_entered_unverified');
+    expect(learningCase.training_eligible).toBe(false);
+    expect(learningCase.requires_human_review).toBe(true);
     expect(learningCase.registry_or_standard).toBe('Verra / VCS + CCB');
     expect(learningCase.document_type).toBe('Published verification report PDF');
     expect(learningCase.source_document_count).toBe(1);
@@ -130,6 +133,9 @@ describe('manual review learning cases', () => {
     ]));
     expect(learningCase.truth_rules_triggered).toEqual(expect.arrayContaining([
       'manual_review_reconstruction_only',
+      'user_entered_unverified',
+      'training_disabled_for_learning_case',
+      'human_review_required',
       'no_independent_verification_opinion',
       'no_validation_statement',
       'no_methodology_compliance_determination',
@@ -142,6 +148,7 @@ describe('manual review learning cases', () => {
       'manual-review-source-retention',
     ]));
     expect(learningCase.source_retention_policy).toContain('No raw document text');
+    expect(learningCase.dedup_key).toContain('"trigger":"export_generated"');
     expect(serialized).not.toContain('full excerpt text unique 123');
     expect(serialized).not.toContain('VCS CCB raw extracted appendix unique string');
   });
@@ -155,9 +162,45 @@ describe('manual review learning cases', () => {
 
     expect(updated?.learningCases).toHaveLength(1);
     expect(learningCase?.trigger).toBe('project_locked');
+    expect(learningCase?.trust_level).toBe('user_entered_unverified');
+    expect(learningCase?.training_eligible).toBe(false);
+    expect(learningCase?.requires_human_review).toBe(true);
     expect(learningCase?.finding_type_counts).toEqual({ CAR: 1, CL: 1, FAR: 1, other: 0 });
     expect(learningCase?.closure_counts).toEqual({ open: 1, 'in-review': 1, closed: 1 });
     expect(JSON.stringify(learningCase)).not.toContain('full excerpt text unique 123');
     expect(JSON.stringify(learningCase)).not.toContain('VCS CCB raw extracted appendix unique string');
+  });
+
+  it('deduplicates repeated learning cases for the same project trigger and export state', () => {
+    window.localStorage.setItem('article6_projects', JSON.stringify([makeManualProject()]));
+
+    recordManualReviewLearningCase('proj-manual-learning', 'export_generated');
+    const onceStored = JSON.parse(window.localStorage.getItem('article6_projects') || '[]') as Project[];
+    const firstDedupKey = onceStored[0]?.learningCases[0]?.dedup_key;
+
+    const updated = recordManualReviewLearningCase('proj-manual-learning', 'export_generated');
+    const twiceStored = JSON.parse(window.localStorage.getItem('article6_projects') || '[]') as Project[];
+
+    expect(firstDedupKey).toBeTruthy();
+    expect(updated?.learningCases).toHaveLength(1);
+    expect(twiceStored[0]?.learningCases).toHaveLength(1);
+    expect(twiceStored[0]?.learningCases[0]?.dedup_key).toBe(firstDedupKey);
+  });
+
+  it('treats learning cases as human-review eval candidates rather than verified ground truth', () => {
+    const learningCase = buildManualReviewLearningCase(makeManualProject(), 'project_locked');
+
+    expect(learningCase.training_eligible).toBe(false);
+    expect(learningCase.requires_human_review).toBe(true);
+    expect(learningCase.trust_level).toBe('user_entered_unverified');
+    expect(learningCase.truth_rules_triggered).not.toContain('verified_ground_truth');
+    expect(learningCase.truth_rules_triggered).toEqual(expect.arrayContaining([
+      'training_disabled_for_learning_case',
+      'human_review_required',
+    ]));
+    expect(learningCase.recommended_evals).toEqual(expect.arrayContaining([
+      'manual-review-truthfulness-language',
+      'manual-review-field-coverage',
+    ]));
   });
 });

--- a/tests/lib/projects/verificationReport.test.ts
+++ b/tests/lib/projects/verificationReport.test.ts
@@ -66,6 +66,7 @@ function makeProject(overrides: Partial<Project> = {}): Project {
     documents: [],
     manualFindings: [],
     extractedManualFindingDrafts: [],
+    learningCases: [],
     reviews: [
       {
         ruleId: 'R-1',
@@ -250,6 +251,7 @@ describe('verification report composition', () => {
           },
         ],
         extractedManualFindingDrafts: [],
+        learningCases: [],
         reviews: [],
       }),
       makeCoverage({ total: 1, verified: 0, gap: 1, notStarted: 0, notApplicable: 0, inProgress: 0, percentComplete: 0 }),
@@ -311,6 +313,7 @@ describe('verification report composition', () => {
         }],
         manualFindings,
         extractedManualFindingDrafts: [],
+        learningCases: [],
         reviews: [],
       }),
       makeCoverage({ total: 17, verified: 13, gap: 4, notStarted: 0, percentComplete: 100 }),


### PR DESCRIPTION
## WHAT

- Added explicit poisoning-boundary hardening for Manual Review learning cases.
- Marked generated `LearningCase` records as:
  - `trust_level: "user_entered_unverified"`
  - `training_eligible: false`
  - `requires_human_review: true`
  - `promotion_status: "not_promoted"`
  - `poisoning_boundary: "not_allowed_to_update_rules_models_evals_or_scores"`
- Renamed `recommended_evals` to `eval_candidate_signals` so local user data cannot be misread as approved eval coverage.
- Added a separate future-only `ReviewedLearningCase` type requiring reviewer identity, review timestamp, review decision, and source learning case ID.
- Added `isLearningCaseTrainingEligible(...)`, which currently always returns `false`.
- Preserved deduplication for unchanged repeated lock/export calls.
- Preserved the rule that raw extracted text and full evidence excerpts are not serialized into learning cases.
- Added tests proving untrusted status, no automatic promotion, no raw-source retention, deduplication, and untrusted eval candidate signals.

## WHY

- Manual Review learning cases are useful product-learning metadata, but they must not become a poisoning vector.
- Local browser data is user-entered and unverified, so it must never silently update methodology rules, model behavior, evals, scores, or trust signals.
- Any future promotion path must be explicit, reviewed, attributable, and separated from raw local storage.

**Signed-off-by:** Fred E <fredilly@article6.org>**