### PR TITLE
[codex] Add safe learning intake roadmap

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -213,3 +213,4 @@ Not active now:
 - STAC auto-verification (support facts only, not auto-verify)
 - AI-assisted review (post-moat)
 - Multi-methodology cross-referencing (Phase 5+)
+

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, project-readiness-verification-output, project-verification, requirement-coverage, traceable-rule-review-mvp.
+Active lanes: verification-factory, project-readiness-verification-output, project-verification, requirement-coverage, safe-learning-intake-pipeline, traceable-rule-review-mvp.
 Frozen lanes: agentic-verification.
 
 
@@ -173,6 +173,27 @@ Not active now:
 6) RC6 — Methodology version diff / impact mode: Planned — Use canonical methodology version and diff metadata to identify coverage rows and linked evidence that may need review in the app.
 7) RC7 — Fallback raw methodology PDF intake for uncovered methods: Planned — Enable lower-confidence fallback raw methodology PDF intake only for uncovered methods while preserving canonical methodology outputs as the default for covered methods.
 8) RC8 — Additional GIS formats later: Deferred — Defer broader GIS intake until reconciliation fundamentals are stable.
+
+## safe-learning-intake-pipeline
+
+Status SSOT: `docs/roadmaps/safe-learning-intake-pipeline/phase-status.json`
+Details: `docs/roadmaps/safe-learning-intake-pipeline/PLAN.md`
+
+Lane status: Active
+Safe learning intake lane for redacted local learning cases, central untrusted intake, consent gating, triage, reviewed promotion, and downstream product/eval improvements. Manual Review local learning cases from PR #568 are the starting point.
+
+Current focus:
+- Phase 0 is done: local untrusted learning-case foundation exists in app.article6
+- Phase 1 is the next recommended implementation: server-side untrusted intake with strict separation from reviewed/promoted records
+- Keep all user-entered learning data untrusted by default
+- Do not let intake data directly update rules, models, evals, scores, prompts, or public claims
+
+Not active now:
+- Automatic training
+- Automatic promotion
+- Methodology-rule updates from user-entered learning data
+- Public claims from private intake
+
 
 ## traceable-rule-review-mvp
 

--- a/docs/roadmaps/safe-learning-intake-pipeline/PLAN.md
+++ b/docs/roadmaps/safe-learning-intake-pipeline/PLAN.md
@@ -1,0 +1,254 @@
+# Safe Learning Intake Pipeline
+
+SSOT: `docs/roadmaps/safe-learning-intake-pipeline/phase-status.json`
+
+## Purpose
+
+Article6 should learn from Manual Review usage, public autopsies, and future user workflows without treating user-entered data as truth.
+
+The pipeline must preserve this boundary:
+
+```text
+User workflow signal
+  -> redacted local learning case
+  -> central untrusted intake
+  -> consent/value gate
+  -> automated triage
+  -> aggregate patterns
+  -> reviewed promotion queue
+  -> eval/product/rule-research task
+  -> normal PR with validation
+```
+
+## Core rule
+
+User-entered learning data is untrusted by default.
+
+It may inform:
+
+- readiness insights
+- recurring gap detection
+- benchmark comparisons
+- extraction checks
+- public-autopsy pattern analysis
+- human-reviewed promotion decisions
+
+It may not directly update:
+
+- methodology rules
+- models
+- eval baselines
+- scores
+- prompts
+- public claims
+
+Automation may triage, cluster, reject, and route cases.
+Automation may not promote cases to trusted status without an explicit reviewed promotion workflow.
+
+## Recommended storage direction
+
+The likely storage direction is Supabase/Postgres-ready central intake.
+
+That intake must keep:
+
+- untrusted intake records separate from reviewed/promoted records
+- redacted metadata separate from raw source documents
+- no uploaded files in central intake
+- no raw extracted text in central intake
+- no full evidence excerpts in central intake
+
+## Incentive framing
+
+Users should understand why redacted metadata sharing is worth doing.
+
+The value exchange is:
+
+- readiness insights from repeated project patterns
+- recurring gap detection across reviews
+- benchmark comparisons against similar cases
+- improved extraction checks and redaction checks
+- better public-autopsy coverage without exposing private source documents
+
+## Roadmap boundary
+
+This roadmap is about safe learning intake and downstream learning loops.
+
+It does not claim:
+
+- training data generation
+- trusted knowledge base behavior
+- methodology approval
+- automatic rule updates
+- automatic eval promotion
+- public claims from private user data
+
+## Phases
+
+### Phase 0 — Local Untrusted Learning Case Foundation
+
+Status: done
+
+Summary:
+PR #568 established the local learning-case layer for Manual Review. It records compact redacted metadata, explicit untrusted trust metadata, and non-training-eligible eval candidate signals in local project storage.
+
+Acceptance:
+- Manual Review lock/export records a redacted learning case.
+- Learning cases are explicitly untrusted, non-promotable, and non-training-eligible.
+- Raw source text, uploaded bytes, and full evidence excerpts are not retained.
+- Repeated unchanged lock/export events deduplicate safely.
+
+Non-goals:
+- No server-side intake.
+- No promotion workflow.
+- No dashboard.
+
+### Phase 1 — Server-Side Untrusted Intake
+
+Status: next
+
+Summary:
+Add a central intake service and storage shape for redacted learning cases, with clear separation between local project artifacts and untrusted central intake records.
+
+Acceptance:
+- Central intake stores redacted metadata only.
+- Central intake is not a trusted knowledge base.
+- Reviewed/promoted records remain separate from raw intake records.
+- No uploaded files, raw extracted text, or full evidence excerpts are stored centrally.
+
+Non-goals:
+- No promotion UI.
+- No automatic training.
+- No direct rule/model updates.
+
+### Phase 2 — Consent And Value Gate
+
+Status: planned
+
+Summary:
+Introduce explicit user consent and incentive framing before central intake is used. Sharing should be framed as a value exchange, not as hidden data collection.
+
+Acceptance:
+- Users can see what is shared and why.
+- The gate explains readiness insights, recurring gap detection, benchmark comparisons, and extraction checks.
+- The pipeline remains untrusted by default.
+
+Non-goals:
+- No automatic promotion.
+- No dashboard.
+- No training pipeline.
+
+### Phase 3 — Automated Intake Triage
+
+Status: planned
+
+Summary:
+Automate clustering, deduplication, rejection, and routing of untrusted intake records. Triage can improve signal quality but cannot create trust.
+
+Acceptance:
+- Intake records can be clustered and filtered.
+- Obvious noise or malformed records can be rejected.
+- Records can be routed to the right human review queue.
+- Triage cannot promote data to trusted status.
+
+Non-goals:
+- No eval publishing.
+- No model training.
+- No methodology-rule edits.
+
+### Phase 4 — Aggregate Learning Dashboard
+
+Status: planned
+
+Summary:
+Create an aggregate dashboard for product and ops to review pattern-level signals from untrusted intake without exposing raw source documents.
+
+Acceptance:
+- Dashboard shows aggregate trends only.
+- No raw PDFs, excerpts, or bytes are shown.
+- Results are framed as diagnostic signals, not truth.
+
+Non-goals:
+- No public claims.
+- No promotion workflow.
+- No per-customer sensitive data leakage.
+
+### Phase 5 — Public Autopsy Eval Bridge
+
+Status: planned
+
+Summary:
+Connect public autopsy cases and eval candidates to the same untrusted-intake boundary so public examples can seed evaluation work without becoming trusted ground truth.
+
+Acceptance:
+- Public autopsy signals stay separate from trusted records.
+- Eval candidates remain untrusted until reviewed.
+- Public material can improve checks without rewriting core truth claims.
+
+Non-goals:
+- No direct model updates from public autopsy data.
+- No automatic methodology claims.
+- No hidden training loop.
+
+### Phase 6 — Reviewed Promotion Queue
+
+Status: planned
+
+Summary:
+Add a human-reviewed queue for cases that may be approved for eval design or other trusted downstream use.
+
+Acceptance:
+- Promotion requires explicit reviewed approval.
+- Approved and rejected decisions are recorded.
+- Trusted use is separated from local untrusted intake.
+
+Non-goals:
+- No automatic promotion.
+- No automatic use in rules/models/scores.
+
+### Phase 7 — Improvement Task Generator
+
+Status: planned
+
+Summary:
+Convert reviewed cases into concrete improvement tasks for extraction, redaction, UX, prompt hygiene, and documentation.
+
+Acceptance:
+- Tasks are generated from reviewed cases, not raw intake.
+- Tasks are actionable and scoped.
+- Tasks do not leak private source content.
+
+Non-goals:
+- No self-modifying rules.
+- No autonomous prompt updates.
+
+### Phase 8 — Workspace Intelligence
+
+Status: planned
+
+Summary:
+Surface safe workspace intelligence across learning, extraction, and quality signals to support internal product iteration and customer-facing value.
+
+Acceptance:
+- Intelligence is aggregate and permissioned.
+- User-entered data is still not treated as truth.
+- Trusted insights come only from reviewed promotion pathways.
+
+Non-goals:
+- No public claims based on unreviewed user data.
+- No direct training or model updates.
+
+## End state
+
+The end state is a safe learning loop:
+
+- local untrusted learning case
+- central untrusted intake
+- consent/value gate
+- automated triage
+- aggregate learning signals
+- public autopsy and eval bridge
+- reviewed promotion queue
+- improvement tasks
+- workspace intelligence
+
+At no point does untrusted user data directly become rules, models, eval baselines, scores, prompts, or public claims.

--- a/docs/roadmaps/safe-learning-intake-pipeline/phase-status.json
+++ b/docs/roadmaps/safe-learning-intake-pipeline/phase-status.json
@@ -1,0 +1,69 @@
+{
+  "phase_meta": {
+    "status": "active",
+    "summary": "Safe learning intake lane for redacted local learning cases, central untrusted intake, consent gating, triage, reviewed promotion, and downstream product/eval improvements. Manual Review local learning cases from PR #568 are the starting point.",
+    "current_focus": [
+      "Phase 0 is done: local untrusted learning-case foundation exists in app.article6",
+      "Phase 1 is the next recommended implementation: server-side untrusted intake with strict separation from reviewed/promoted records",
+      "Keep all user-entered learning data untrusted by default",
+      "Do not let intake data directly update rules, models, evals, scores, prompts, or public claims"
+    ],
+    "not_active_now": [
+      "Automatic training",
+      "Automatic promotion",
+      "Methodology-rule updates from user-entered learning data",
+      "Public claims from private intake"
+    ],
+    "last_updated_at": "2026-05-07T00:00:00Z"
+  },
+  "phase_0_local_untrusted_learning_case_foundation": {
+    "status": "done",
+    "title": "Local Untrusted Learning Case Foundation",
+    "summary": "PR #568 added redacted Manual Review learning cases with explicit untrusted trust metadata, eval candidate signals, deduplication, and local project storage. The cases remain non-training-eligible and non-promotable."
+  },
+  "phase_1_server_side_untrusted_intake": {
+    "status": "next",
+    "title": "Server-Side Untrusted Intake",
+    "summary": "Add Supabase/Postgres-ready central intake for redacted learning cases. Keep raw uploads, extracted text, and full evidence excerpts out of central storage and keep reviewed/promoted records separate."
+  },
+  "phase_2_consent_and_value_exchange_gate": {
+    "status": "planned",
+    "title": "Consent And Value Gate",
+    "summary": "Add explicit user consent and value framing before central intake. The gate should explain readiness insights, recurring gap detection, benchmark comparisons, and improved extraction checks."
+  },
+  "phase_3_automated_intake_triage": {
+    "status": "planned",
+    "title": "Automated Intake Triage",
+    "summary": "Cluster, deduplicate, reject, and route untrusted intake records. Triage may improve signal quality but cannot promote records to trusted status."
+  },
+  "phase_4_aggregate_learning_dashboard": {
+    "status": "planned",
+    "title": "Aggregate Learning Dashboard",
+    "summary": "Provide aggregate, privacy-safe learning trends for product and operations without exposing raw source documents or trusting intake records."
+  },
+  "phase_5_public_autopsy_eval_bridge": {
+    "status": "planned",
+    "title": "Public Autopsy Eval Bridge",
+    "summary": "Connect public autopsy cases and eval candidates to the same untrusted boundary so public examples can improve checks without becoming trusted ground truth."
+  },
+  "phase_6_reviewed_promotion_queue": {
+    "status": "planned",
+    "title": "Reviewed Promotion Queue",
+    "summary": "Add a human-reviewed queue for cases that may be approved for eval design or other trusted downstream use. Promotion requires explicit reviewed approval."
+  },
+  "phase_7_improvement_task_generator": {
+    "status": "planned",
+    "title": "Improvement Task Generator",
+    "summary": "Turn reviewed cases into concrete product, extraction, redaction, and prompt-hygiene tasks without leaking private source content."
+  },
+  "phase_8_workspace_intelligence": {
+    "status": "planned",
+    "title": "Workspace Intelligence",
+    "summary": "Surface safe aggregate intelligence to support iteration and customer-facing value while keeping user-entered data untrusted."
+  },
+  "pr_evidence": {
+    "PR568": [
+      568
+    ]
+  }
+}


### PR DESCRIPTION
## What

- add a new roadmap at `docs/roadmaps/safe-learning-intake-pipeline/`
- define the SSOT in `phase-status.json`
- generate the matching entry in `docs/roadmaps/SUMMARY.md`
- document the safe learning pipeline from local untrusted learning cases through reviewed promotion and downstream improvement tasks

## Why

Article6 needs a structured path to learn from Manual Review usage, public autopsies, and future user workflows without allowing untrusted user-entered data to poison methodology rules, models, evals, scores, prompts, or public claims.

## Notes

- this is a roadmap/docs PR only
- user-entered learning data is explicitly untrusted by default
- the roadmap separates local learning cases, central untrusted intake, consent gating, automated triage, aggregate learning, public autopsy/eval bridging, reviewed promotion, and downstream product improvements
- no storage, APIs, UI, Supabase, analytics, eval generation, or promotion logic is implemented here

## Validation

- `npm run typecheck`
- `npm run roadmap:validate`
- `node -e "JSON.parse(require('fs').readFileSync('docs/roadmaps/safe-learning-intake-pipeline/phase-status.json','utf8')); console.log('phase-status ok')"`
- `npm run roadmap:check`
