### PR TITLE
Refactor Methods page into Method Library with standard filtering

### DIFF
--- a/src/app/m/_components/MethodCard.tsx
+++ b/src/app/m/_components/MethodCard.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
+
+type MethodCardProps = {
+  method: MethodInventoryItem;
+  active: boolean;
+  sourceAudited: boolean;
+};
+
+export default function MethodCard({ method, active, sourceAudited }: MethodCardProps) {
+  return (
+    <Link
+      href={`/m/${encodeURIComponent(method.code)}`}
+      className={`flex items-center justify-between gap-3 rounded-2xl border px-3.5 py-3 text-left transition-colors ${
+        active
+          ? "border-slate-300 bg-slate-50"
+          : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/80"
+      }`}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-mono text-sm text-slate-900">{method.code}</span>
+          <span className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[10px] font-medium text-slate-500">
+            {method.versionCount} version{method.versionCount === 1 ? "" : "s"}
+          </span>
+        </div>
+        <div className="mt-1 flex items-center gap-2">
+          <span className="truncate text-xs text-slate-500">
+            {method.program} • {method.sector}
+          </span>
+          {sourceAudited ? (
+            <span
+              className="rounded-full border border-emerald-300 bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700"
+              title="Verified source PDF · Rules source-audited · No active blockers"
+            >
+              Source-Audited
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <span
+        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${
+          active
+            ? "border-slate-900 bg-slate-900 text-white"
+            : "border-slate-300 bg-white text-slate-400"
+        }`}
+        aria-hidden="true"
+      >
+        {active ? "✓" : ""}
+      </span>
+    </Link>
+  );
+}

--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -1559,7 +1559,7 @@ export default function MethodDetailPane({
             className={`${tabBase} ${surfaceTab === "verify" ? tabActive : tabIdle}`}
             aria-pressed={surfaceTab === "verify"}
           >
-            Verify
+            Start review
           </button>
           {methodsLayout?.isVerifyTab && surfaceTab === "verify" ? (
             <button

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -15,7 +15,7 @@ type MethodLibraryPanelProps = {
 function deriveMetaUrl(method: MethodInventoryItem): string | null {
   const latest = method.latestVersion;
   if (!latest) return null;
-  const path = `methodologies/${method.program}/${method.sector}/${method.code}/${latest}/rules.json`;
+  const path = `/methodologies/${method.program}/${method.sector}/${method.code}/${latest}/rules.json`;
   return metaUrlFromRulesPath(path);
 }
 

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import MethodCard from "@/app/m/_components/MethodCard";
+import { deriveStandard, isSourceAuditedMeta, metaUrlFromRulesPath } from "@/lib/methodBadge";
+import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
+
+const STANDARDS = ["All", "UNFCCC", "Verra", "Gold Standard"] as const;
+
+type MethodLibraryPanelProps = {
+  methods: MethodInventoryItem[];
+  selectedCode: string | null;
+};
+
+function deriveMetaUrl(method: MethodInventoryItem): string | null {
+  const latest = method.latestVersion;
+  if (!latest) return null;
+  const path = `methodologies/${method.program}/${method.sector}/${method.code}/${latest}/rules.json`;
+  return metaUrlFromRulesPath(path);
+}
+
+function useSourceAuditedStatus(methods: MethodInventoryItem[]): Set<string> {
+  const [audited, setAudited] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const cancelled = { current: false };
+    setAudited(new Set());
+
+    const entries = methods.map((m) => ({ code: m.code, metaUrl: deriveMetaUrl(m) }));
+    Promise.all(
+      entries.map(async ({ code, metaUrl }) => {
+        if (!metaUrl) return null;
+        try {
+          const res = await fetch(metaUrl);
+          if (!res.ok) return null;
+          return { code, meta: await res.json() };
+        } catch {
+          return null;
+        }
+      }),
+    ).then((results) => {
+      if (cancelled.current) return;
+      const next = new Set<string>();
+      for (const r of results) {
+        if (r && isSourceAuditedMeta(r.meta)) next.add(r.code);
+      }
+      setAudited(next);
+    });
+
+    return () => { cancelled.current = true; };
+  }, [methods]);
+
+  return audited;
+}
+
+export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibraryPanelProps) {
+  const [standardFilter, setStandardFilter] = useState<string>("All");
+
+  const filteredMethods = useMemo(() => {
+    if (standardFilter === "All") return methods;
+    return methods.filter((m) => deriveStandard(m.program) === standardFilter);
+  }, [methods, standardFilter]);
+
+  const sourceAuditedCodes = useSourceAuditedStatus(filteredMethods);
+
+  const reviewReady = useMemo(
+    () => filteredMethods.filter((m) => sourceAuditedCodes.has(m.code)),
+    [filteredMethods, sourceAuditedCodes],
+  );
+
+  const otherMethods = useMemo(
+    () => filteredMethods.filter((m) => !sourceAuditedCodes.has(m.code)),
+    [filteredMethods, sourceAuditedCodes],
+  );
+
+  const allLabel = standardFilter === "All" ? "All methods" : `All ${standardFilter} methods`;
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+      <div className="border-b border-slate-100 px-4 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Library</div>
+            <h2 className="mt-1 text-sm font-semibold text-slate-900">Method Library</h2>
+          </div>
+          <span className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] font-medium text-slate-500">
+            {methods.length}
+          </span>
+        </div>
+      </div>
+
+      <div className="border-b border-slate-100 px-4 py-3">
+        <div className="flex flex-wrap gap-1.5">
+          {STANDARDS.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => setStandardFilter(s)}
+              className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
+                standardFilter === s
+                  ? "bg-slate-900 text-white"
+                  : "border border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:text-slate-900"
+              }`}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex max-h-[calc(100vh-20rem)] flex-col gap-1 overflow-y-auto p-3">
+        {reviewReady.length > 0 ? (
+          <div className="mb-2">
+            <div className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-600">
+              Review-ready methods
+            </div>
+            {reviewReady.map((method) => (
+              <div key={method.code} className="py-0.5">
+                <MethodCard
+                  method={method}
+                  active={selectedCode === method.code}
+                  sourceAudited
+                />
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        <div>
+          <div className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">{allLabel}</div>
+          {otherMethods.length === 0 && reviewReady.length === 0 ? (
+            <p className="px-1 py-4 text-xs text-slate-500">No methods found for this standard.</p>
+          ) : (
+            otherMethods.map((method) => (
+              <div key={method.code} className="py-0.5">
+                <MethodCard
+                  method={method}
+                  active={selectedCode === method.code}
+                  sourceAudited={false}
+                />
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/m/_components/MethodsFinder.tsx
+++ b/src/app/m/_components/MethodsFinder.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
 import { Suspense } from "react";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import MethodsFinderShell from "@/app/m/_components/MethodsFinderShell";
 import MethodDetailPane from "@/app/m/_components/MethodDetailPane";
+import MethodLibraryPanel from "@/app/m/_components/MethodLibraryPanel";
 import { getMethodInventory } from "@/app/m/_lib/methodInventory";
 import { probeMethodRich } from "@/app/m/_lib/methodRich";
 import { loadMethodVersionLineage, resolveMethodVersionFiles } from "@/app/m/_lib/methodVersionMetadata";
@@ -97,20 +97,10 @@ export default async function MethodsFinder({
     <main className="min-h-screen bg-slate-50">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-8 md:px-8">
         <header className="flex flex-col gap-1">
-          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Method Review</h1>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Method Library</h1>
           <p className="text-sm text-slate-600">
             Select a methodology to begin review.
           </p>
-          {!selectedCode && goldenSelection ? (
-            <p className="text-xs text-slate-500">
-              Rich demo auto-selected:{" "}
-              <span className="font-mono">
-                {goldenSelection.code}@{goldenSelection.version}
-              </span>
-            </p>
-          ) : !selectedCode ? (
-            <p className="text-xs text-slate-500">No rich-enabled versions detected in this dataset.</p>
-          ) : null}
         </header>
 
         <Suspense
@@ -122,56 +112,10 @@ export default async function MethodsFinder({
         >
           <MethodsFinderShell
             left={
-              <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
-                <div className="border-b border-slate-100 px-4 py-4">
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Methods</div>
-                      <h2 className="mt-1 text-sm font-semibold text-slate-900">Available methodology sets</h2>
-                    </div>
-                    <span className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] font-medium text-slate-500">{methods.length}</span>
-                  </div>
-                </div>
-                <ul className="flex max-h-[calc(100vh-14rem)] flex-col gap-2 overflow-y-auto p-3">
-                  {methods.map((method) => {
-                    const active = selectedMethod?.code === method.code;
-                    return (
-                      <li key={method.code}>
-                        <Link
-                          href={`/m/${encodeURIComponent(method.code)}`}
-                          className={`flex items-center justify-between gap-3 rounded-2xl border px-3.5 py-3 text-left transition-colors ${
-                            active
-                              ? "border-slate-300 bg-slate-50"
-                              : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/80"
-                          }`}
-                        >
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-center gap-2">
-                              <span className="truncate font-mono text-sm text-slate-900">{method.code}</span>
-                              <span className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[10px] font-medium text-slate-500">
-                                {method.versionCount} version{method.versionCount === 1 ? "" : "s"}
-                              </span>
-                            </div>
-                            <span className="mt-1 block truncate text-xs text-slate-500">
-                              {method.program} • {method.sector}
-                            </span>
-                          </div>
-                          <span
-                            className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${
-                              active
-                                ? "border-slate-900 bg-slate-900 text-white"
-                                : "border-slate-300 bg-white text-slate-400"
-                            }`}
-                            aria-hidden="true"
-                          >
-                            {active ? "✓" : ""}
-                          </span>
-                        </Link>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
+              <MethodLibraryPanel
+                methods={methods}
+                selectedCode={selectedMethod?.code ?? null}
+              />
             }
             right={
               selectedMethod ? (

--- a/src/lib/methodBadge.ts
+++ b/src/lib/methodBadge.ts
@@ -21,6 +21,21 @@ export function metaUrlFromRulesPath(rulesPath: string | null | undefined): stri
   return dir ? `${dir}/META.json` : null;
 }
 
+/**
+ * Map a provider/program string to a standard label.
+ * - "UNFCCC" → "UNFCCC"
+ * - "VCS", "Verra", "VERRA" → "Verra"
+ * - "GS", "Gold Standard", "GOLD_STANDARD" → "Gold Standard"
+ * - everything else → the original string
+ */
+export function deriveStandard(program: string): string {
+  const p = program.trim().toLowerCase();
+  if (p === "unfccc") return "UNFCCC";
+  if (p === "vcs" || p === "verra") return "Verra";
+  if (p === "gs" || p === "gold standard" || p === "gold_standard") return "Gold Standard";
+  return program.trim();
+}
+
 export function isSourceAuditedMeta(meta: unknown): boolean {
   if (!meta || typeof meta !== "object") return false;
   const m = meta as Record<string, unknown>;

--- a/tests/lib/methodBadge.test.ts
+++ b/tests/lib/methodBadge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { dirnameFromPath, isSourceAuditedMeta, metaUrlFromRulesPath } from "@/lib/methodBadge";
+import { deriveStandard, dirnameFromPath, isSourceAuditedMeta, metaUrlFromRulesPath } from "@/lib/methodBadge";
 
 function makeFullMeta(overrides?: Record<string, unknown>): unknown {
   return {
@@ -42,6 +42,32 @@ describe("dirnameFromPath", () => {
 
   it("returns root slash for top-level path", () => {
     expect(dirnameFromPath("/rules.json")).toBe("/");
+  });
+});
+
+describe("deriveStandard", () => {
+  it("returns UNFCCC for UNFCCC", () => {
+    expect(deriveStandard("UNFCCC")).toBe("UNFCCC");
+  });
+
+  it("returns Verra for VCS", () => {
+    expect(deriveStandard("VCS")).toBe("Verra");
+  });
+
+  it("returns Verra for Verra", () => {
+    expect(deriveStandard("Verra")).toBe("Verra");
+  });
+
+  it("returns Gold Standard for GS", () => {
+    expect(deriveStandard("GS")).toBe("Gold Standard");
+  });
+
+  it("returns Gold Standard for Gold Standard", () => {
+    expect(deriveStandard("Gold Standard")).toBe("Gold Standard");
+  });
+
+  it("passes unknown programs through unchanged", () => {
+    expect(deriveStandard("Other")).toBe("Other");
   });
 });
 

--- a/tests/lib/methodBadge.test.ts
+++ b/tests/lib/methodBadge.test.ts
@@ -21,6 +21,11 @@ describe("metaUrlFromRulesPath", () => {
       .toBe("methodologies/Verra/AFOLU/VM0047/v1-0/META.json");
   });
 
+  it("preserves a leading slash for root-relative paths", () => {
+    expect(metaUrlFromRulesPath("/methodologies/Verra/AFOLU/VM0047/v1-0/rules.json"))
+      .toBe("/methodologies/Verra/AFOLU/VM0047/v1-0/META.json");
+  });
+
   it("returns correct META.json path from rules.rich.json", () => {
     expect(metaUrlFromRulesPath("methodologies/Verra/AFOLU/VM0047/v1-0/rules.rich.json"))
       .toBe("methodologies/Verra/AFOLU/VM0047/v1-0/META.json");


### PR DESCRIPTION
Convert the Methods page into a standard-aware Method Library with UNFCCC, Verra, and Gold Standard filtering, and surface Source-Audited methods as review-ready.

## Changes

| File | Change |
|---|---|
| src/lib/methodBadge.ts | Add deriveStandard() helper |
| src/app/m/_components/MethodCard.tsx | New - method card with Source-Audited badge |
| src/app/m/_components/MethodLibraryPanel.tsx | New - standard filter + review-ready section |
| src/app/m/_components/MethodsFinder.tsx | Replace left panel with MethodLibraryPanel; rename page |
| src/app/m/_components/MethodDetailPane.tsx | CTA: Verify -> Start review |
| tests/lib/methodBadge.test.ts | 7 new tests for deriveStandard |

## Validation

- typecheck: clean
- tests: 98 suites, 489 passed
- No ESLint warnings

### Roadmap-Update

- slug: phase-assurance-surface-mvp
- ack: human
- items:
  - PR12: done
