### PR TITLE
Wire Method Library to actual method review data with readiness computation

### DIFF
--- a/config/methodologies_pack.json
+++ b/config/methodologies_pack.json
@@ -1,5 +1,5 @@
 {
   "repo": "Fredilly/article6-methodologies",
-  "tag": "methodologies-pack-591097422520",
-  "asset": "methodologies-pack-591097422520.tar.gz"
+  "tag": "methodologies-pack-2f0f676a6c7d",
+  "asset": "methodologies-pack-2f0f676a6c7d.tar.gz"
 }

--- a/config/methodologies_pack.json
+++ b/config/methodologies_pack.json
@@ -1,5 +1,5 @@
 {
   "repo": "Fredilly/article6-methodologies",
-  "tag": "methodologies-pack-3ea9dc32bfaf",
-  "asset": "methodologies-pack-3ea9dc32bfaf.tar.gz"
+  "tag": "methodologies-pack-591097422520",
+  "asset": "methodologies-pack-591097422520.tar.gz"
 }

--- a/config/methodologies_pack.json
+++ b/config/methodologies_pack.json
@@ -1,5 +1,5 @@
 {
   "repo": "Fredilly/article6-methodologies",
-  "tag": "methodologies-pack-2f0f676a6c7d",
-  "asset": "methodologies-pack-2f0f676a6c7d.tar.gz"
+  "tag": "methodologies-pack-afb90934ecf4",
+  "asset": "methodologies-pack-afb90934ecf4.tar.gz"
 }

--- a/public/manifest/index.json
+++ b/public/manifest/index.json
@@ -2,6 +2,1122 @@
   {
     "id": "R-1-0001",
     "rule_id": "R-1-0001",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "dda75505ea56d05a6e04e2721cbd17d08d0e581a87ba7d4417d3dc606c27cd9c",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "3420748023f30d04ed1fd562ef7ae3e30f38f9e1a49659763b0d9c4dea8abec9",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "3e6d9dc97d3ab90962de8b95b71b27bacbf040cc634478a40479dece85c5f339",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "eb7121e84d51ec80ad2b551753dab1cc8372f05f330538a26b9062a52712a02d",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "b836353c122af881334f9fbb7713caf9d7377a723e247fc5c8b6af1f018bff85",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "24164a04c1515ff1539afad170510d4a05115d7b3e4471c8d736ef7b1f6793d2",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "7b0f8c7ba29f81946dd5dc6f5b86e8e187c38d44a5faf9297dda219cc13a3bf7",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "2ce9a69b9840193ff2a6b0c99120831bb2934ef90092d7c3d75d9de479b89891",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "29b2ef4098b56891ad498e5e038219ac1d6244cb7ece2df439ef18378384fcfd",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "6ea9b9eb161d6857de39724c8e8757a7cf52d8fd04ac4798fb264745a05290f0",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "5eda0d15e4ec4d17de633acc84c7c724c22fe8aeb64b523b18b53931725ccf06",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "20c4996b305e04cbd1907c186aee3e1ef08082f95d2de683674f285d23ecc97b",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "3b91069bc370b9a965d26d3faee834db1004fcb9659d97084493ff1af9e711a6",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "c349af08750d4b4d7526b3c7999ebcc1e03cd526a0b9253920000f178f7dc3b8",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "2676222d60300e1605a9d9bcdbb479eb9c1096f76bc70ff493e6115b854d931d",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "03c397b3c64afdba007a0e87e98b5ff79d9d0304a02dfa846fc6aaa547e052c5",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "b5067038bbc518bbf209ddbbe97e812d685fc513a8290926774023c2d6340201",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "b8ef92643663b064f3889e9c7d06e104f33901eb5ffae012bc8fc8883ea4421f",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "37cdb4cb33286096f952b709f6ae3499103c69b9a07456eb6c35d24d1438ee10",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "1bfecf0c2476a089e8a726966647d674b53fa5ba051500905c5b410a4f30e0c1",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "6ac8f8f06fad17187646a7cf5f4ac56698ba085e3ba63f3acf4ba5ad2017f1ad",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "d871354ad066fdb9f1ec7bffcd5fc6c1c4b0e7fb9660b54f4abbcd988b92e9df",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "fdc987e374d07e624faed87eaf99eb58404902a72011265c3cc00b16d57b7790",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "2305d403605e0561f895e75402326bb23a9d6e1a0430c1f43054a1cdc9c4e595",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "0814be70f1ec12030d9b39366a052ada9443feb2c7bffc78e28dc8a785619157",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "71868565dcf19698cff692c08cdea382db4431b10a85894c70b82d700fb00e86",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "0009c2bcaaababf9b26c2082de2b7112f4698b334d59f223335bb675b004f952",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "0a5a377acfd73e3c17ff89374a5191b022565b30174500bf4c962f797245515c",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "c088c80c7ae515c740c85f161dab9b24b9cfb32f8844ce259b8fd9d75446b007",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "289968dc611c2b89d8898e970b60b4fd2b10704ff6d2be085064622b67040627",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "f243a012a774b639baddacec11a069b159c33ec2618360eda8ccee7e2ca31fcd",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "3c6bf2cdf13f1a1408980e529993f9bb94a5fe308deb22727357e8cf0507ec8e",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "74788de192f5d5b220f91918dc133bd51b8e9a1686c388d9062dd669afb74edd",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "a0a617f9fe13964c50bd8b5dc58dd304c2bab63b1d74c84800acedef3fe7e05f",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "631057d14aad5e7e3b325cc2d9bba65888136a1876e3ee4997c70b0e6a40a391",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "0f3a85be1e0a76f195631e8b72dcaeac71ef53bddfc8177c2b1745764d299c9f",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "3a5636c87d19c9a92aae7be62257721649da2131e8e53eb71bd052a89739b93a",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "5930a2f59157c6f4745adf88b94e21ff07fd7722d278bb8cdb40458c97ef348a",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "c7198799c228071940532a1dacf1f91bf0c6e7ababcb6897fd4471d80f7b9ebc",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "bd2e26d55da7b91b02e7c09d7f3cbf7e708832f2759f184b3820eae07a092edb",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "16041f22af6f90e9e125fcafbe57b354cd5dd489fb649ab31f7027de66adca69",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "cc347b243b452c03cc7abf0e0cd1c538669a47620c2b2218103e0518c2251036",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "c11febe64a3e89b01415a0aeaa291e2bff1a140ae6c7f498b35dfc6db9590096",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "52720d639b921877ee35f62eee37d34b8c585cd658d4b1751882650455f0e944",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "a1acb32157719ba66d4c1605737385c8f11d1e26561ea94de1acefb0be933ba0",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "e20c00e65ed13531d8224988615f3917850aabfc5c6a3887070445db9a5b87d9",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "52d2f255e6bc258f20c351cebc9120257327eecedd9b78816ed12963db25d08f",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "57f21eb568cce0572edd0826855a945244cd6a5fc3b71f602b97c00eab931802",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "ea44d1d49641eb17382c414214dd7ccb8dcad4676435c1749a5dc361cf93635f",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "cd0e18c0aab13280fb249671afa56b07d92e8f0c65fda1132cb7257d3c3b2c67",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "467b70fde8e5393ee41a863efb183c1b38f6fc489a17e9c8ba3ff4c11bacf6a6",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "20a27172fedc6779a20afd5a48de1135fd20f8acfcefef59a42d07f90bdd0467",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "b64114982889338ac6fc9e1069733f21bc291f0713414f59723a030cd5623f25",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "be9519bfc3fc41638f96a8f66766ace8214142e3a873155279ba3efb268195e8",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "bea6913d384dc6ab5be278877c9f896ed85e470ef6e9b52721c27b0fad5effa9",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "03f12eed38215522368715d15df371614c0b2aaca2603395009db5b08bf792dc",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "cb78b937f1994e694662506366ac7079671caf24fd269c6e8ef1bd02c6c6dc8d",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "6b6828ba488fdb33ee8142e8a8a0265201a21d4fd9dadce3c18b8991aba16f7b",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "bb458652be0522548b5e73b6332d5c3b7b1c65f4236662985b578a675d642bb3",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "6812ea9d7b8ec14234409560c7d4917de8b494a2147f8f8d7eca60e9200fd5b0",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "a33d7a35e4a068d762a10552f8d47f5e58959afa1f6ed617e0ca95d2e0b80fa2",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "c7a9bf0cb4952dc409f13c3eb70dff8cf89093e1a64ee50aae0600361937e4f1",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "efc2669a2c21e6d301551fd1b2d563764be32c5fec450ce0a209e54b337b62c6",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "13dbb8701e6e76005c901bced0da1afc88dff6a81c6ff67e1aca73d262c95b47",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "3d8157b65645035b468fe288c6f9bff9a4752c5d312905dc6b3b609c7dc74718",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "88eca210295bdb5ea0765918798579d3944f17160e0279eca675971870d811a9",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "2cc535980017189aa384534504a2fb533557bf77abcddae7733e8a6bb843e585",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "9689b5e04009603d02dfe96ac56d50157cd29636763ff652221e77e41e311109",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "d2d807643dff0e419e6218fd01bbd301cf42b558c70959ac1ce699a875ddd614",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "777c34e0d1c109b6f238ec64c9ce98a218f4d91158e8877e26aa9b4f7f156bda",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "1e9582bc71098076295b8afa76f501d281460e4030a95e1bead709bd4c4a1a47",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "ac906d090a593d33882ad2ea451875baa64e1c0835aba565f4f4895ee49b17cc",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
     "methodology": "AR-ACM0003",
     "version": "v02-0",
     "rule": "Project restores degraded forest lands and meets additionality tests per Tool 01.",
@@ -119,6 +1235,248 @@
     "provider": "UNFCCC",
     "category": "Forestry",
     "path": "methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Projects reforest lands without forest cover since 1989 and comply with national forest definitions.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "8325d2c2acc25b29e276cf5c2fa4188f7bdaf93b9b0c477664c9a354e4071ca0",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0002",
+    "rule_id": "R-1-0002",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Baseline biomass estimated using IPCC defaults or site-specific sampling following Tool 02.",
+    "tags": [
+      "calc",
+      "baseline"
+    ],
+    "sha256": "ee2d6ee8abf583705c655b42a02d1ad5357eae3ee11e40bce6682ac114275e54",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-1-0003",
+    "rule_id": "R-1-0003",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Net anthropogenic removals equal project removals minus baseline emissions and leakage.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "a383bb5f48fdd8bed37e4530aed83fd5e7b9e43231815ff1914228d7e76f1938",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-1-0004",
+    "rule_id": "R-1-0004",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Activity shifting leakage quantified annually using Tool 14 and deducted from net removals.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "d08cea9473b9e4bb3b639a198f3c945015d557842004f263e6b055a6eb29066a",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-1-0005",
+    "rule_id": "R-1-0005",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Non-permanence risks addressed through buffer contributions per Tool 15 guidance.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "31e9e094fae22f7f103800d0ff8b8a634f818e57ff03692a9c5542b49787ab5c",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0006",
+    "rule_id": "R-1-0006",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Field biomass measurements conducted at least every five years using permanent plots.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "63ec85acd9f599d7563b46b3872ed7ed19d5e8e1e7c2f17347d29099a22be65e",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0007",
+    "rule_id": "R-1-0007",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Sampling uncertainty above 10% addressed with Tool 12 conservative adjustments.",
+    "tags": [
+      "uncertainty"
+    ],
+    "sha256": "dfa248d956e092a2efb8cdf4429bedf593e91ee6186d6a6fb1554e8d8341e5d0",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0008",
+    "rule_id": "R-1-0008",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Monitoring reports consolidate maps, inventory data, leakage deductions, and QA/QC evidence.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "8634f721c43e7646acc7bb1e5fd2af32de753cbaaec269d8618854dd4f5e07f1",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Projects reforest lands without forest cover since 1989 and comply with national forest definitions.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "8e22791a6d2f8040a87a3aba72a4f87d9675b9c047a0ae3c39a310708ea68660",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0002",
+    "rule_id": "R-1-0002",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Baseline biomass estimated using IPCC defaults or site-specific sampling following Tool 02.",
+    "tags": [
+      "calc",
+      "baseline"
+    ],
+    "sha256": "8413316f37eb0d8e148615c73ae4bf34519c0c74a49a7cebf3abdd997652d7a4",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-1-0003",
+    "rule_id": "R-1-0003",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Net anthropogenic removals equal project removals minus baseline emissions and leakage.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "eeb5d2640da9799b96c014dcc97aa674ca9acbb9d5319301986c10b9dcc80760",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-1-0004",
+    "rule_id": "R-1-0004",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Activity shifting leakage quantified annually using Tool 14 and deducted from net removals.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "fe074b4c07590df37ab1560ae7e68843765dd4a8293d1cc8629b63e0011bad49",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-1-0005",
+    "rule_id": "R-1-0005",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Non-permanence risks addressed through buffer contributions per Tool 15 guidance.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "3d876ab92d4f925edc27fafd19dbdb120c96f6766830bcfff99606fbd354b864",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0006",
+    "rule_id": "R-1-0006",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Field biomass measurements conducted at least every five years using permanent plots.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "7d7d654273a489a558d19944d1df22c94975418daf2b4040cd91e156cea92925",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0007",
+    "rule_id": "R-1-0007",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Sampling uncertainty above 10% addressed with Tool 12 conservative adjustments.",
+    "tags": [
+      "uncertainty"
+    ],
+    "sha256": "542871daf1ab93b1b11f8713b93b6f3ac63143b4bd83ef2cf8d5fecdacd546f9",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0008",
+    "rule_id": "R-1-0008",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Monitoring reports consolidate maps, inventory data, leakage deductions, and QA/QC evidence.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "bf8d70c4a3589a646d45bcd6840b08f57df9d2130a62516455579eed0ae1841f",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
     "sectionId": "S-5"
   },
   {
@@ -647,174 +2005,1038 @@
     "sectionId": "S-13"
   },
   {
-    "id": "R-VM0047-1",
-    "rule_id": "R-VM0047-1",
+    "id": "Verra.AFOLU.VM0047.v1-0.R-1-0001",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-1-0001",
     "methodology": "VM0047",
     "version": "v1-0",
-    "provider": "Verra",
-    "category": "AFOLU",
-    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
-    "rule": "Project area must consist of degraded or marginal agricultural land.",
+    "rule": "Land must not be forest at project start. Must meet host-country forest definition if applicable.",
     "tags": [
       "eligibility"
     ],
-    "sectionId": "VM0047-S-1",
-    "sha256": "d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e"
-  },
-  {
-    "id": "R-VM0047-2",
-    "rule_id": "R-VM0047-2",
-    "methodology": "VM0047",
-    "version": "v1-0",
+    "sha256": "generated-VM0047-0",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
-    "rule": "Baseline soil organic carbon must be measured using field sampling.",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0047.v1-0.R-4-0001",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-4-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Land must be non-forest or managed non-forest for 10+ years. VM0047 Section 4 applicability conditions 3-5 exclude tidal wetlands, organic soil/water table manipulation, and mechanical removal/burning of pre-existing dead wood. All exclusions are self-contained in VM0047.",
     "tags": [
-      "baseline",
-      "measurement"
+      "eligibility"
     ],
-    "sectionId": "VM0047-S-2",
-    "sha256": "e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f"
-  },
-  {
-    "id": "R-VM0047-3",
-    "rule_id": "R-VM0047-3",
-    "methodology": "VM0047",
-    "version": "v1-0",
+    "sha256": "generated-VM0047-1",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
-    "rule": "Emission reductions must be calculated using the approved quantification methodology.",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "Verra.AFOLU.VM0047.v1-0.R-4-0002",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-4-0002",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Two approaches: area-based (plot sampling) or census-based (complete enumeration). Must select based on project characteristics.",
     "tags": [
-      "quantification"
+      "eligibility"
     ],
-    "sectionId": "VM0047-S-3",
-    "sha256": "f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a"
-  },
-  {
-    "id": "R-VM0047-4",
-    "rule_id": "R-VM0047-4",
-    "methodology": "VM0047",
-    "version": "v1-0",
+    "sha256": "generated-VM0047-2",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
-    "rule": "Monitoring must include annual soil sampling and analysis.",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "Verra.AFOLU.VM0047.v1-0.R-5-0001",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-5-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Project boundary must be fixed ex-ante. Stratification by land cover, soil type, and management regime.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0047-3",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0047.v1-0.R-5-0002",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-5-0002",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "AGB and BGB mandatory. Litter, dead wood, SOC optional per Appendix 2 significance test (built-in, replaces external T-SIG). If included in baseline must also be in project scenario.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0047-4",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0047.v1-0.R-6-0001",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-6-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Area-based approach uses performance benchmark (Appendix 1). Census-based approach uses zero baseline if pre-existing woody biomass <10%. Both approaches fully described in VM0047 Section 6 and Appendix 1.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0047-5",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "Verra.AFOLU.VM0047.v1-0.R-7-0001",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-7-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Area-based approach: regulatory surplus + performance benchmark + investment barrier. Census-based approach: regulatory surplus + investment barrier + common practice. Both fully described in VM0047 Section 7.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0047-6",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-7"
+  },
+  {
+    "id": "Verra.AFOLU.VM0047.v1-0.R-8-0001",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-8-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Removals = min(project C change, project C change x (1 - PB)) - leakage - uncertainty. PB from ex-post reference region observations.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "generated-VM0047-7",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-8-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0047.v1-0.R-8-0002",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-8-0002",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Activity shifting leakage must be assessed. Market leakage is de minimis for ARR. Fossil fuel and biomass burning emissions must be included.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0047-8",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-8-3"
+  },
+  {
+    "id": "Verra.AFOLU.VM0047.v1-0.R-8-0003",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-8-0003",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "15% threshold at 90% CI. If exceeded, excess deducted proportionally from removals. Below threshold, no deduction.",
+    "tags": [
+      "uncertainty"
+    ],
+    "sha256": "generated-VM0047-9",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-8-4"
+  },
+  {
+    "id": "Verra.AFOLU.VM0047.v1-0.R-9-0001",
+    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-9-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Four mandatory components: data list, QA/QC, responsibilities, archiving. REDD MRV procedures via M-REDD module.",
     "tags": [
       "monitoring"
     ],
-    "sectionId": "VM0047-S-2",
-    "sha256": "a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b"
-  },
-  {
-    "id": "R-VM0047-5",
-    "rule_id": "R-VM0047-5",
-    "methodology": "VM0047",
-    "version": "v1-0",
+    "sha256": "generated-VM0047-10",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
-    "rule": "Third-party verification must be conducted by a VVB accredited under the Verra VCS Program.",
-    "tags": [
-      "verification",
-      "quality"
-    ],
-    "sectionId": "VM0047-S-4",
-    "sha256": "b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c"
+    "sectionId": "S-9-3"
   },
   {
-    "id": "R-VM0007-1",
-    "rule_id": "R-VM0007-1",
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
     "methodology": "VM0007",
-    "version": "v1-6",
-    "provider": "Verra",
-    "category": "AFOLU",
-    "path": "methodologies/Verra/AFOLU/VM0007/v1-6/rules.json",
-    "rule": "Project area must be degraded forest land eligible for afforestation or reforestation.",
+    "version": "v1-8",
+    "rule": "Project land must meet forest definition threshold for 10+ years. Mangroves exempt from height.",
     "tags": [
       "eligibility"
     ],
-    "sectionId": "VM0007-S-1",
-    "sha256": "d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e"
-  },
-  {
-    "id": "R-VM0007-2",
-    "rule_id": "R-VM0007-2",
-    "methodology": "VM0007",
-    "version": "v1-6",
+    "sha256": "generated-VM0007-0",
     "provider": "Verra",
     "category": "AFOLU",
-    "path": "methodologies/Verra/AFOLU/VM0007/v1-6/rules.json",
-    "rule": "Baseline carbon stocks must be estimated using approved forest inventory methods.",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Binary classification: unplanned (no legal right) vs planned (legally permitted conversion). Determines which BL module applies.",
     "tags": [
-      "baseline",
-      "measurement"
+      "eligibility"
     ],
-    "sectionId": "VM0007-S-2",
-    "sha256": "e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f"
-  },
-  {
-    "id": "R-VM0007-3",
-    "rule_id": "R-VM0007-3",
-    "methodology": "VM0007",
-    "version": "v1-6",
+    "sha256": "generated-VM0007-1",
     "provider": "Verra",
     "category": "AFOLU",
-    "path": "methodologies/Verra/AFOLU/VM0007/v1-6/rules.json",
-    "rule": "Monitoring must include periodic forest carbon inventory and re-measurement.",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0003",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0003",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three criteria must ALL be met. Excludes large-scale industrial agriculture/aquaculture.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-2",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0004",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0004",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Must have legal documentation authorizing conversion.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-3",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0005",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0005",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Water table lowering is prohibited except for two specific exceptions.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-4",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0006",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0006",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Absolute prohibition on organic soil burning as a project activity.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-5",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0007",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0007",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "No nitrogen fertilizer application allowed during entire crediting period.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-6",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0008",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0008",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Spillover emissions from hydrological changes must be assessed using the stepwise significance procedure in Appendix 1 (alternative to T-SIG). Procedure covers GHG emissions by source, carbon stock changes by pool, and leakage GHG emissions.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-7",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0009",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0009",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three alternative conditions. Must demonstrate one with verifiable evidence.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-8",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0010",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0010",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Must meet VCS peatland definition based on IPCC organic soil thresholds.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-9",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0011",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0011",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Must include at least one defined restoration activity type.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-10",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0012",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0012",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Must include at least one defined conservation activity type.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-11",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0013",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0013",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Parallel to AUDef criteria but for wetland degradation.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-12",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0014",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0014",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "IFM and ARR activities are excluded from VM0007. WRC projects that also implement ARR activities must use an appropriate ARR methodology, e.g. VM0047, for aboveground biomass accounting.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-13",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0015",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0015",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Two specific leakage prevention activities are explicitly prohibited.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-14",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0001",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Six required data elements for each discrete land parcel.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-15",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0002",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Strict no-overlap rule. REDD+WRC combination is the sole exception.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-16",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Double-counting prevention. Must track and report exclusions.",
     "tags": [
       "monitoring"
     ],
-    "sectionId": "VM0007-S-2",
-    "sha256": "f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a"
+    "sha256": "generated-VM0007-17",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
   },
   {
-    "id": "R-GS-00XX-1",
-    "rule_id": "R-GS-00XX-1",
-    "methodology": "GS-00XX",
-    "version": "v1-0",
-    "provider": "Gold Standard",
-    "category": "LUF",
-    "path": "methodologies/GoldStandard/LUF/GS-00XX/v1-0/rules.json",
-    "rule": "Project activities must demonstrate additional greenhouse gas reductions beyond business-as-usual.",
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "RRD required for baseline modeling. Must be in same jurisdiction with similar characteristics.",
     "tags": [
-      "additionality",
       "eligibility"
     ],
-    "sectionId": "GS-00XX-S-1",
-    "sha256": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
+    "sha256": "generated-VM0007-18",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
   },
   {
-    "id": "R-GS-00XX-2",
-    "rule_id": "R-GS-00XX-2",
-    "methodology": "GS-00XX",
-    "version": "v1-0",
-    "provider": "Gold Standard",
-    "category": "LUF",
-    "path": "methodologies/GoldStandard/LUF/GS-00XX/v1-0/rules.json",
-    "rule": "Sustainable development impacts must be assessed and reported using the GS SDG tool.",
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0005",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0005",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Proxy areas required for planned deforestation baseline.",
     "tags": [
-      "sustainable-development",
-      "reporting"
+      "eligibility"
     ],
-    "sectionId": "GS-00XX-S-2",
-    "sha256": "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3"
+    "sha256": "generated-VM0007-19",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
   },
   {
-    "id": "R-GS-00XX-3",
-    "rule_id": "R-GS-00XX-3",
-    "methodology": "GS-00XX",
-    "version": "v1-0",
-    "provider": "Gold Standard",
-    "category": "LUF",
-    "path": "methodologies/GoldStandard/LUF/GS-00XX/v1-0/rules.json",
-    "rule": "Validation and verification must be conducted by a GS-approved VVB.",
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0006",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0006",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Stratification mandatory. Different activity types must be in separate strata.",
     "tags": [
-      "verification",
-      "quality"
+      "eligibility"
     ],
-    "sectionId": "GS-00XX-S-3",
-    "sha256": "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3"
+    "sha256": "generated-VM0007-20",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0007",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0007",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Pool inclusion/exclusion must be justified. If included in baseline, must also be in project and leakage.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-21",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0008",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0008",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "AGB always mandatory. HWP and dead wood conditionally mandatory based on baseline/project comparison.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-22",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "WRC focuses on SOC pool. Biomass pools excluded unless ARR applies.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-23",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "GHG sources must be identified per Table 7 with inclusion/exclusion justification.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-24",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "GHG sources per Tables 8-9. Mandatory for CO2 from SOC, CH4 from SOC, combustion gases.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-25",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Symmetric accounting: baseline inclusion implies project inclusion.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-26",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Fixed period for baseline modeling. Duration per VCS Standard.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-27",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "20-100 year range. Must be specified in PD.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-28",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "100-year SOC horizon test. Must show significant difference. Assessed ex-ante conservatively.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-29",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0016",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0016",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Sea-level rise must be factored into boundary delineation for tidal projects.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-30",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0001",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "VT0001 mandatory. Stepwise approach: list alternatives, barrier/investment analysis, select most plausible.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-31",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0002",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three mandatory alternatives unless demonstrated not credible or non-compliant.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-32",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Two-step: barrier analysis first, then investment analysis or qualitative GHG estimation as fallback.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-33",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0004",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0004",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three options with different selection criteria. Option I is cost-only, Option II is IRR/NPV, Option III is benchmark-based.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-34",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Module selection based on deforestation category.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-35",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0006",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0006",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Module selection depends on substrate (peat vs tidal) and activity type (CIW vs RWE vs combined).",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-36",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0007",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0007",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Periodic reassessment per VCS Standard. Must capture changes in deforestation drivers/behavior.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "generated-VM0007-37",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0008",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0008",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "JNR data is acceptable as a conservative source even if less accurate.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-38",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-4-0001",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-4-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "VT0001 mandatory for all non-tidal-wetland activities.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-39",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-4-0002",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-4-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Activity method (ADD-AM) replaces project method (VT0001) for tidal wetlands only.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "generated-VM0007-40",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0001",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Standard REDD equation. Three components summed over monitoring period.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "generated-VM0007-41",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0002",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Parallel to REDD equation. Components use peat/tidal wetland modules.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "generated-VM0007-42",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0003",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0003",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three leakage components. Activity shifting via LK-ASP and LK-ASU modules. Market effects via LK-ME.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-43",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0004",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0004",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three components including ecological leakage specific to wetlands.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-44",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0005",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0005",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three buffer components. Each = (baseline - project) × Buffer%. Buffer% from T-BAR.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-45",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0006",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0006",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "15% threshold at 90% CI. Excess deducted proportionally. Below threshold, no deduction.",
+    "tags": [
+      "uncertainty"
+    ],
+    "sha256": "generated-VM0007-46",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0007",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0007",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Period credits = incremental adjusted NER minus buffer withholding.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "generated-VM0007-47",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0008",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0008",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Five carbon pool modules. Each optional except AG biomass per R-2-0008.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-48",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0009",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0009",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Module selection by activity type and emission source.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "generated-VM0007-49",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0001",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Four mandatory monitoring tasks. Each requires technical description, data list, procedures, QA/QC, archiving, responsibilities.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "generated-VM0007-50",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0002",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Six required content elements per task.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "generated-VM0007-51",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0003",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0003",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "GPS or georeferenced data mandatory. Strata included.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "generated-VM0007-52",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0004",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0004",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Six minimum SOP/QA/QC elements.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "generated-VM0007-53",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "10-year minimum frequency. Spatial variables must be refreshed.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "generated-VM0007-54",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0006",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0006",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three ongoing compliance checks. Fire triggers premium cancellation.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "generated-VM0007-55",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0007",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0007",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "IPCC 2006 expert judgment protocol mandatory. Rationale must be documented.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "generated-VM0007-56",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0008",
+    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0008",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three data source tiers: literature > IPCC defaults > expert opinion.",
+    "tags": [
+      "uncertainty"
+    ],
+    "sha256": "generated-VM0007-57",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
   }
 ]

--- a/public/manifest/index.json
+++ b/public/manifest/index.json
@@ -2005,1035 +2005,1035 @@
     "sectionId": "S-13"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-1-0001",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-1-0001",
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "Land must not be forest at project start. Must meet host-country forest definition if applicable.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0047-0",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-4-0001",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-4-0001",
+    "id": "R-4-0001",
+    "rule_id": "R-4-0001",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "Land must be non-forest or managed non-forest for 10+ years. VM0047 Section 4 applicability conditions 3-5 exclude tidal wetlands, organic soil/water table manipulation, and mechanical removal/burning of pre-existing dead wood. All exclusions are self-contained in VM0047.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0047-1",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-4"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-4-0002",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-4-0002",
+    "id": "R-4-0002",
+    "rule_id": "R-4-0002",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "Two approaches: area-based (plot sampling) or census-based (complete enumeration). Must select based on project characteristics.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0047-2",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-4"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-5-0001",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-5-0001",
+    "id": "R-5-0001",
+    "rule_id": "R-5-0001",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "Project boundary must be fixed ex-ante. Stratification by land cover, soil type, and management regime.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0047-3",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-5-0002",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-5-0002",
+    "id": "R-5-0002",
+    "rule_id": "R-5-0002",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "AGB and BGB mandatory. Litter, dead wood, SOC optional per Appendix 2 significance test (built-in, replaces external T-SIG). If included in baseline must also be in project scenario.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0047-4",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-6-0001",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-6-0001",
+    "id": "R-6-0001",
+    "rule_id": "R-6-0001",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "Area-based approach uses performance benchmark (Appendix 1). Census-based approach uses zero baseline if pre-existing woody biomass <10%. Both approaches fully described in VM0047 Section 6 and Appendix 1.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0047-5",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-6"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-7-0001",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-7-0001",
+    "id": "R-7-0001",
+    "rule_id": "R-7-0001",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "Area-based approach: regulatory surplus + performance benchmark + investment barrier. Census-based approach: regulatory surplus + investment barrier + common practice. Both fully described in VM0047 Section 7.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0047-6",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-7"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-8-0001",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-8-0001",
+    "id": "R-8-0001",
+    "rule_id": "R-8-0001",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "Removals = min(project C change, project C change x (1 - PB)) - leakage - uncertainty. PB from ex-post reference region observations.",
     "tags": [
       "equation"
     ],
-    "sha256": "generated-VM0047-7",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-8-2"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-8-0002",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-8-0002",
+    "id": "R-8-0002",
+    "rule_id": "R-8-0002",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "Activity shifting leakage must be assessed. Market leakage is de minimis for ARR. Fossil fuel and biomass burning emissions must be included.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0047-8",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-8-3"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-8-0003",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-8-0003",
+    "id": "R-8-0003",
+    "rule_id": "R-8-0003",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "15% threshold at 90% CI. If exceeded, excess deducted proportionally from removals. Below threshold, no deduction.",
     "tags": [
       "uncertainty"
     ],
-    "sha256": "generated-VM0047-9",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-8-4"
   },
   {
-    "id": "Verra.AFOLU.VM0047.v1-0.R-9-0001",
-    "rule_id": "Verra.AFOLU.VM0047.v1-0.R-9-0001",
+    "id": "R-9-0001",
+    "rule_id": "R-9-0001",
     "methodology": "VM0047",
     "version": "v1-0",
     "rule": "Four mandatory components: data list, QA/QC, responsibilities, archiving. REDD MRV procedures via M-REDD module.",
     "tags": [
       "monitoring"
     ],
-    "sha256": "generated-VM0047-10",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
     "sectionId": "S-9-3"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Project land must meet forest definition threshold for 10+ years. Mangroves exempt from height.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-0",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
+    "id": "R-1-0002",
+    "rule_id": "R-1-0002",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Binary classification: unplanned (no legal right) vs planned (legally permitted conversion). Determines which BL module applies.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-1",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0003",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0003",
+    "id": "R-1-0003",
+    "rule_id": "R-1-0003",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Three criteria must ALL be met. Excludes large-scale industrial agriculture/aquaculture.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-2",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0004",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0004",
+    "id": "R-1-0004",
+    "rule_id": "R-1-0004",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Must have legal documentation authorizing conversion.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-3",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0005",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0005",
+    "id": "R-1-0005",
+    "rule_id": "R-1-0005",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Water table lowering is prohibited except for two specific exceptions.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-4",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0006",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0006",
+    "id": "R-1-0006",
+    "rule_id": "R-1-0006",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Absolute prohibition on organic soil burning as a project activity.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-5",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0007",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0007",
+    "id": "R-1-0007",
+    "rule_id": "R-1-0007",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "No nitrogen fertilizer application allowed during entire crediting period.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-6",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0008",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0008",
+    "id": "R-1-0008",
+    "rule_id": "R-1-0008",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Spillover emissions from hydrological changes must be assessed using the stepwise significance procedure in Appendix 1 (alternative to T-SIG). Procedure covers GHG emissions by source, carbon stock changes by pool, and leakage GHG emissions.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-7",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0009",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0009",
+    "id": "R-1-0009",
+    "rule_id": "R-1-0009",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Three alternative conditions. Must demonstrate one with verifiable evidence.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-8",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0010",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0010",
+    "id": "R-1-0010",
+    "rule_id": "R-1-0010",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Must meet VCS peatland definition based on IPCC organic soil thresholds.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-9",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0011",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0011",
+    "id": "R-1-0011",
+    "rule_id": "R-1-0011",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Must include at least one defined restoration activity type.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-10",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0012",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0012",
+    "id": "R-1-0012",
+    "rule_id": "R-1-0012",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Must include at least one defined conservation activity type.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-11",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0013",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0013",
+    "id": "R-1-0013",
+    "rule_id": "R-1-0013",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Parallel to AUDef criteria but for wetland degradation.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-12",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0014",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0014",
+    "id": "R-1-0014",
+    "rule_id": "R-1-0014",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "IFM and ARR activities are excluded from VM0007. WRC projects that also implement ARR activities must use an appropriate ARR methodology, e.g. VM0047, for aboveground biomass accounting.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-13",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-1-0015",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-1-0015",
+    "id": "R-1-0015",
+    "rule_id": "R-1-0015",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Two specific leakage prevention activities are explicitly prohibited.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-14",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-1"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0001",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0001",
+    "id": "R-2-0001",
+    "rule_id": "R-2-0001",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Six required data elements for each discrete land parcel.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-15",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0002",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0002",
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Strict no-overlap rule. REDD+WRC combination is the sole exception.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-16",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+    "id": "R-2-0003",
+    "rule_id": "R-2-0003",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Double-counting prevention. Must track and report exclusions.",
     "tags": [
       "monitoring"
     ],
-    "sha256": "generated-VM0007-17",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+    "id": "R-2-0004",
+    "rule_id": "R-2-0004",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "RRD required for baseline modeling. Must be in same jurisdiction with similar characteristics.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-18",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0005",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0005",
+    "id": "R-2-0005",
+    "rule_id": "R-2-0005",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Proxy areas required for planned deforestation baseline.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-19",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0006",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0006",
+    "id": "R-2-0006",
+    "rule_id": "R-2-0006",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Stratification mandatory. Different activity types must be in separate strata.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-20",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0007",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0007",
+    "id": "R-2-0007",
+    "rule_id": "R-2-0007",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Pool inclusion/exclusion must be justified. If included in baseline, must also be in project and leakage.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-21",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0008",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0008",
+    "id": "R-2-0008",
+    "rule_id": "R-2-0008",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "AGB always mandatory. HWP and dead wood conditionally mandatory based on baseline/project comparison.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-22",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+    "id": "R-2-0009",
+    "rule_id": "R-2-0009",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "WRC focuses on SOC pool. Biomass pools excluded unless ARR applies.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-23",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+    "id": "R-2-0010",
+    "rule_id": "R-2-0010",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "GHG sources must be identified per Table 7 with inclusion/exclusion justification.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-24",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+    "id": "R-2-0011",
+    "rule_id": "R-2-0011",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "GHG sources per Tables 8-9. Mandatory for CO2 from SOC, CH4 from SOC, combustion gases.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-25",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+    "id": "R-2-0012",
+    "rule_id": "R-2-0012",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Symmetric accounting: baseline inclusion implies project inclusion.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-26",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+    "id": "R-2-0013",
+    "rule_id": "R-2-0013",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Fixed period for baseline modeling. Duration per VCS Standard.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-27",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+    "id": "R-2-0014",
+    "rule_id": "R-2-0014",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "20-100 year range. Must be specified in PD.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-28",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+    "id": "R-2-0015",
+    "rule_id": "R-2-0015",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "100-year SOC horizon test. Must show significant difference. Assessed ex-ante conservatively.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-29",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-2-0016",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-2-0016",
+    "id": "R-2-0016",
+    "rule_id": "R-2-0016",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Sea-level rise must be factored into boundary delineation for tidal projects.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-30",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-2"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0001",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0001",
+    "id": "R-3-0001",
+    "rule_id": "R-3-0001",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "VT0001 mandatory. Stepwise approach: list alternatives, barrier/investment analysis, select most plausible.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-31",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-3"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0002",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0002",
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Three mandatory alternatives unless demonstrated not credible or non-compliant.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-32",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-3"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+    "id": "R-3-0003",
+    "rule_id": "R-3-0003",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Two-step: barrier analysis first, then investment analysis or qualitative GHG estimation as fallback.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-33",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-3"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0004",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0004",
+    "id": "R-3-0004",
+    "rule_id": "R-3-0004",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Three options with different selection criteria. Option I is cost-only, Option II is IRR/NPV, Option III is benchmark-based.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-34",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-3"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
+    "id": "R-3-0005",
+    "rule_id": "R-3-0005",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Module selection based on deforestation category.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-35",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-3"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0006",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0006",
+    "id": "R-3-0006",
+    "rule_id": "R-3-0006",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Module selection depends on substrate (peat vs tidal) and activity type (CIW vs RWE vs combined).",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-36",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-3"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0007",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0007",
+    "id": "R-3-0007",
+    "rule_id": "R-3-0007",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Periodic reassessment per VCS Standard. Must capture changes in deforestation drivers/behavior.",
     "tags": [
       "monitoring"
     ],
-    "sha256": "generated-VM0007-37",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-3"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-3-0008",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-3-0008",
+    "id": "R-3-0008",
+    "rule_id": "R-3-0008",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "JNR data is acceptable as a conservative source even if less accurate.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-38",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-3"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-4-0001",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-4-0001",
+    "id": "R-4-0001",
+    "rule_id": "R-4-0001",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "VT0001 mandatory for all non-tidal-wetland activities.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-39",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-4"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-4-0002",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-4-0002",
+    "id": "R-4-0002",
+    "rule_id": "R-4-0002",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Activity method (ADD-AM) replaces project method (VT0001) for tidal wetlands only.",
     "tags": [
       "eligibility"
     ],
-    "sha256": "generated-VM0007-40",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-4"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0001",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0001",
+    "id": "R-5-0001",
+    "rule_id": "R-5-0001",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Standard REDD equation. Three components summed over monitoring period.",
     "tags": [
       "equation"
     ],
-    "sha256": "generated-VM0007-41",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0002",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0002",
+    "id": "R-5-0002",
+    "rule_id": "R-5-0002",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Parallel to REDD equation. Components use peat/tidal wetland modules.",
     "tags": [
       "equation"
     ],
-    "sha256": "generated-VM0007-42",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0003",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0003",
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Three leakage components. Activity shifting via LK-ASP and LK-ASU modules. Market effects via LK-ME.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-43",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0004",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0004",
+    "id": "R-5-0004",
+    "rule_id": "R-5-0004",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Three components including ecological leakage specific to wetlands.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-44",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0005",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0005",
+    "id": "R-5-0005",
+    "rule_id": "R-5-0005",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Three buffer components. Each = (baseline - project) × Buffer%. Buffer% from T-BAR.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-45",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0006",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0006",
+    "id": "R-5-0006",
+    "rule_id": "R-5-0006",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "15% threshold at 90% CI. Excess deducted proportionally. Below threshold, no deduction.",
     "tags": [
       "uncertainty"
     ],
-    "sha256": "generated-VM0007-46",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0007",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0007",
+    "id": "R-5-0007",
+    "rule_id": "R-5-0007",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Period credits = incremental adjusted NER minus buffer withholding.",
     "tags": [
       "equation"
     ],
-    "sha256": "generated-VM0007-47",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0008",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0008",
+    "id": "R-5-0008",
+    "rule_id": "R-5-0008",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Five carbon pool modules. Each optional except AG biomass per R-2-0008.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-48",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-5-0009",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-5-0009",
+    "id": "R-5-0009",
+    "rule_id": "R-5-0009",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Module selection by activity type and emission source.",
     "tags": [
       "calc"
     ],
-    "sha256": "generated-VM0007-49",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-5"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0001",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0001",
+    "id": "R-6-0001",
+    "rule_id": "R-6-0001",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Four mandatory monitoring tasks. Each requires technical description, data list, procedures, QA/QC, archiving, responsibilities.",
     "tags": [
       "monitoring"
     ],
-    "sha256": "generated-VM0007-50",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-6"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0002",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0002",
+    "id": "R-6-0002",
+    "rule_id": "R-6-0002",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Six required content elements per task.",
     "tags": [
       "monitoring"
     ],
-    "sha256": "generated-VM0007-51",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-6"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0003",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0003",
+    "id": "R-6-0003",
+    "rule_id": "R-6-0003",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "GPS or georeferenced data mandatory. Strata included.",
     "tags": [
       "monitoring"
     ],
-    "sha256": "generated-VM0007-52",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-6"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0004",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0004",
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Six minimum SOP/QA/QC elements.",
     "tags": [
       "monitoring"
     ],
-    "sha256": "generated-VM0007-53",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-6"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
+    "id": "R-6-0005",
+    "rule_id": "R-6-0005",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "10-year minimum frequency. Spatial variables must be refreshed.",
     "tags": [
       "monitoring"
     ],
-    "sha256": "generated-VM0007-54",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-6"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0006",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0006",
+    "id": "R-6-0006",
+    "rule_id": "R-6-0006",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Three ongoing compliance checks. Fire triggers premium cancellation.",
     "tags": [
       "monitoring"
     ],
-    "sha256": "generated-VM0007-55",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-6"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0007",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0007",
+    "id": "R-6-0007",
+    "rule_id": "R-6-0007",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "IPCC 2006 expert judgment protocol mandatory. Rationale must be documented.",
     "tags": [
       "monitoring"
     ],
-    "sha256": "generated-VM0007-56",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
     "sectionId": "S-6"
   },
   {
-    "id": "Verra.AFOLU.VM0007.v1-8.R-6-0008",
-    "rule_id": "Verra.AFOLU.VM0007.v1-8.R-6-0008",
+    "id": "R-6-0008",
+    "rule_id": "R-6-0008",
     "methodology": "VM0007",
     "version": "v1-8",
     "rule": "Three data source tiers: literature > IPCC defaults > expert opinion.",
     "tags": [
       "uncertainty"
     ],
-    "sha256": "generated-VM0007-57",
+    "sha256": "",
     "provider": "Verra",
     "category": "AFOLU",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",

--- a/public/manifest/index.json
+++ b/public/manifest/index.json
@@ -645,5 +645,176 @@
     "category": "Forestry",
     "path": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
     "sectionId": "S-13"
+  },
+  {
+    "id": "R-VM0047-1",
+    "rule_id": "R-VM0047-1",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "rule": "Project area must consist of degraded or marginal agricultural land.",
+    "tags": [
+      "eligibility"
+    ],
+    "sectionId": "VM0047-S-1",
+    "sha256": "d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e"
+  },
+  {
+    "id": "R-VM0047-2",
+    "rule_id": "R-VM0047-2",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "rule": "Baseline soil organic carbon must be measured using field sampling.",
+    "tags": [
+      "baseline",
+      "measurement"
+    ],
+    "sectionId": "VM0047-S-2",
+    "sha256": "e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f"
+  },
+  {
+    "id": "R-VM0047-3",
+    "rule_id": "R-VM0047-3",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "rule": "Emission reductions must be calculated using the approved quantification methodology.",
+    "tags": [
+      "quantification"
+    ],
+    "sectionId": "VM0047-S-3",
+    "sha256": "f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a"
+  },
+  {
+    "id": "R-VM0047-4",
+    "rule_id": "R-VM0047-4",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "rule": "Monitoring must include annual soil sampling and analysis.",
+    "tags": [
+      "monitoring"
+    ],
+    "sectionId": "VM0047-S-2",
+    "sha256": "a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b"
+  },
+  {
+    "id": "R-VM0047-5",
+    "rule_id": "R-VM0047-5",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "rule": "Third-party verification must be conducted by a VVB accredited under the Verra VCS Program.",
+    "tags": [
+      "verification",
+      "quality"
+    ],
+    "sectionId": "VM0047-S-4",
+    "sha256": "b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c"
+  },
+  {
+    "id": "R-VM0007-1",
+    "rule_id": "R-VM0007-1",
+    "methodology": "VM0007",
+    "version": "v1-6",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-6/rules.json",
+    "rule": "Project area must be degraded forest land eligible for afforestation or reforestation.",
+    "tags": [
+      "eligibility"
+    ],
+    "sectionId": "VM0007-S-1",
+    "sha256": "d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e"
+  },
+  {
+    "id": "R-VM0007-2",
+    "rule_id": "R-VM0007-2",
+    "methodology": "VM0007",
+    "version": "v1-6",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-6/rules.json",
+    "rule": "Baseline carbon stocks must be estimated using approved forest inventory methods.",
+    "tags": [
+      "baseline",
+      "measurement"
+    ],
+    "sectionId": "VM0007-S-2",
+    "sha256": "e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f"
+  },
+  {
+    "id": "R-VM0007-3",
+    "rule_id": "R-VM0007-3",
+    "methodology": "VM0007",
+    "version": "v1-6",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-6/rules.json",
+    "rule": "Monitoring must include periodic forest carbon inventory and re-measurement.",
+    "tags": [
+      "monitoring"
+    ],
+    "sectionId": "VM0007-S-2",
+    "sha256": "f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a"
+  },
+  {
+    "id": "R-GS-00XX-1",
+    "rule_id": "R-GS-00XX-1",
+    "methodology": "GS-00XX",
+    "version": "v1-0",
+    "provider": "Gold Standard",
+    "category": "LUF",
+    "path": "methodologies/GoldStandard/LUF/GS-00XX/v1-0/rules.json",
+    "rule": "Project activities must demonstrate additional greenhouse gas reductions beyond business-as-usual.",
+    "tags": [
+      "additionality",
+      "eligibility"
+    ],
+    "sectionId": "GS-00XX-S-1",
+    "sha256": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
+  },
+  {
+    "id": "R-GS-00XX-2",
+    "rule_id": "R-GS-00XX-2",
+    "methodology": "GS-00XX",
+    "version": "v1-0",
+    "provider": "Gold Standard",
+    "category": "LUF",
+    "path": "methodologies/GoldStandard/LUF/GS-00XX/v1-0/rules.json",
+    "rule": "Sustainable development impacts must be assessed and reported using the GS SDG tool.",
+    "tags": [
+      "sustainable-development",
+      "reporting"
+    ],
+    "sectionId": "GS-00XX-S-2",
+    "sha256": "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3"
+  },
+  {
+    "id": "R-GS-00XX-3",
+    "rule_id": "R-GS-00XX-3",
+    "methodology": "GS-00XX",
+    "version": "v1-0",
+    "provider": "Gold Standard",
+    "category": "LUF",
+    "path": "methodologies/GoldStandard/LUF/GS-00XX/v1-0/rules.json",
+    "rule": "Validation and verification must be conducted by a GS-approved VVB.",
+    "tags": [
+      "verification",
+      "quality"
+    ],
+    "sectionId": "GS-00XX-S-3",
+    "sha256": "c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3"
   }
 ]

--- a/src/app/m/_components/MethodCard.tsx
+++ b/src/app/m/_components/MethodCard.tsx
@@ -2,14 +2,17 @@
 
 import Link from "next/link";
 import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
+import type { MethodReadiness } from "@/lib/methodReadiness";
 
 type MethodCardProps = {
   method: MethodInventoryItem;
   active: boolean;
-  sourceAudited: boolean;
+  readiness: MethodReadiness | null;
 };
 
-export default function MethodCard({ method, active, sourceAudited }: MethodCardProps) {
+export default function MethodCard({ method, active, readiness }: MethodCardProps) {
+  const missing = readiness?.missingArtifacts ?? [];
+
   return (
     <Link
       href={`/m/${encodeURIComponent(method.code)}`}
@@ -30,12 +33,19 @@ export default function MethodCard({ method, active, sourceAudited }: MethodCard
           <span className="truncate text-xs text-slate-500">
             {method.program} • {method.sector}
           </span>
-          {sourceAudited ? (
+          {readiness?.sourceAudited && readiness?.hasRules && readiness?.hasSections ? (
             <span
               className="rounded-full border border-emerald-300 bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700"
               title="Verified source PDF · Rules source-audited · No active blockers"
             >
               Source-Audited
+            </span>
+          ) : missing.length > 0 && !readiness?.hasMeta ? (
+            <span
+              className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-600"
+              title={`Missing: ${missing.join(", ")}`}
+            >
+              {missing.length} artifact{missing.length === 1 ? "" : "s"} missing
             </span>
           ) : null}
         </div>

--- a/src/app/m/_components/MethodCard.tsx
+++ b/src/app/m/_components/MethodCard.tsx
@@ -40,7 +40,7 @@ export default function MethodCard({ method, active, readiness }: MethodCardProp
             >
               Source-Audited
             </span>
-          ) : missing.length > 0 && !readiness?.hasMeta ? (
+          ) : missing.length > 0 ? (
             <span
               className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-600"
               title={`Missing: ${missing.join(", ")}`}

--- a/src/app/m/_components/MethodCard.tsx
+++ b/src/app/m/_components/MethodCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
 import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
 import type { MethodReadiness } from "@/lib/methodReadiness";
 
@@ -11,11 +13,19 @@ type MethodCardProps = {
 };
 
 export default function MethodCard({ method, active, readiness }: MethodCardProps) {
+  const searchParams = useSearchParams();
   const missing = readiness?.missingArtifacts ?? [];
+
+  const href = useMemo(() => {
+    const standard = searchParams.get("standard");
+    const base = `/m/${encodeURIComponent(method.code)}`;
+    if (!standard || standard === "All") return base;
+    return `${base}?standard=${encodeURIComponent(standard)}`;
+  }, [method.code, searchParams]);
 
   return (
     <Link
-      href={`/m/${encodeURIComponent(method.code)}`}
+      href={href}
       className={`flex items-center justify-between gap-3 rounded-2xl border px-3.5 py-3 text-left transition-colors ${
         active
           ? "border-slate-300 bg-slate-50"

--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -271,6 +271,10 @@ export default function MethodDetailPane({
   };
   const [rules, setRules] = useState<RuleListItem[]>([]);
   const [activeRuleId, setActiveRuleId] = useState<string | null>(initialRuleId ?? null);
+
+  useEffect(() => {
+    setActiveRuleId(initialRuleId ?? null);
+  }, [method.code, activeVersion, initialRuleId]);
   const [traceIndex, setTraceIndex] = useState<TraceIndex | null>(null);
   const [traceLoading, setTraceLoading] = useState(false);
   const [, setTraceError] = useState<string | null>(null);
@@ -1313,7 +1317,7 @@ export default function MethodDetailPane({
       viewMode={verifyViewMode}
       verifierMode={verifierMode}
       activeRuleId={activeRuleId}
-      ruleOptions={rules.map((rule) => ({ id: rule.id, title: rule.title }))}
+      ruleOptions={rules.map((rule) => ({ id: rule.id, title: rule.title, sectionId: rule.sectionId }))}
       onSelectRuleId={(ruleId) => {
         if (!ruleId) {
           setActiveRuleId(null);

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import MethodCard from "@/app/m/_components/MethodCard";
-import { deriveStandard, isSourceAuditedMeta, metaUrlFromRulesPath } from "@/lib/methodBadge";
+import { deriveStandard } from "@/lib/methodBadge";
+import { computeReadiness, deriveArtifactUrls, emptyReadiness, type MethodReadiness } from "@/lib/methodReadiness";
 import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
 
 const STANDARDS = ["All", "UNFCCC", "Verra", "Gold Standard"] as const;
@@ -12,45 +13,72 @@ type MethodLibraryPanelProps = {
   selectedCode: string | null;
 };
 
-function deriveMetaUrl(method: MethodInventoryItem): string | null {
-  const latest = method.latestVersion;
-  if (!latest) return null;
-  const path = `/methodologies/${method.program}/${method.sector}/${method.code}/${latest}/rules.json`;
-  return metaUrlFromRulesPath(path);
+async function probeJson(url: string): Promise<unknown | null> {
+  try {
+    const res = await fetch(url);
+    return res.ok ? res.json() : null;
+  } catch {
+    return null;
+  }
 }
 
-function useSourceAuditedStatus(methods: MethodInventoryItem[]): Set<string> {
-  const [audited, setAudited] = useState<Set<string>>(new Set());
+async function headExists(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, { method: "HEAD" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function useMethodReadiness(methods: MethodInventoryItem[]): Map<string, MethodReadiness> {
+  const [readiness, setReadiness] = useState<Map<string, MethodReadiness>>(new Map());
 
   useEffect(() => {
     const cancelled = { current: false };
-    setAudited(new Set());
+    setReadiness(new Map());
 
-    const entries = methods.map((m) => ({ code: m.code, metaUrl: deriveMetaUrl(m) }));
+    const entries = methods.map((m) => ({
+      code: m.code,
+      urls: deriveArtifactUrls(m),
+      ruleCount: m.ruleCountByVersion[m.latestVersion ?? ""] ?? 0,
+    }));
+
     Promise.all(
-      entries.map(async ({ code, metaUrl }) => {
-        if (!metaUrl) return null;
-        try {
-          const res = await fetch(metaUrl);
-          if (!res.ok) return null;
-          return { code, meta: await res.json() };
-        } catch {
-          return null;
-        }
+      entries.map(async ({ code, urls, ruleCount }) => {
+        const [meta, rulesExists, sectionsExists] = await Promise.all([
+          urls.metaUrl ? probeJson(urls.metaUrl) : null,
+          urls.rulesUrl ? headExists(urls.rulesUrl) : false,
+          urls.sectionsUrl ? headExists(urls.sectionsUrl) : false,
+        ]);
+
+        if (cancelled.current) return { code, readiness: emptyReadiness() };
+
+        const base = meta ? computeReadiness(meta, ruleCount) : emptyReadiness();
+        return {
+          code,
+          readiness: {
+            ...base,
+            hasRules: base.hasRules && rulesExists,
+            hasSections: base.hasSections && sectionsExists,
+            hasMeta: Boolean(meta),
+            missingArtifacts: [
+              ...(!meta ? ["META.json"] : []),
+              ...(!rulesExists ? ["rules.json"] : []),
+              ...(!sectionsExists ? ["sections.json"] : []),
+            ],
+          },
+        };
       }),
     ).then((results) => {
       if (cancelled.current) return;
-      const next = new Set<string>();
-      for (const r of results) {
-        if (r && isSourceAuditedMeta(r.meta)) next.add(r.code);
-      }
-      setAudited(next);
+      setReadiness(new Map(results.map((r) => [r.code, r.readiness])));
     });
 
     return () => { cancelled.current = true; };
   }, [methods]);
 
-  return audited;
+  return readiness;
 }
 
 export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibraryPanelProps) {
@@ -61,16 +89,20 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
     return methods.filter((m) => deriveStandard(m.program) === standardFilter);
   }, [methods, standardFilter]);
 
-  const sourceAuditedCodes = useSourceAuditedStatus(filteredMethods);
+  const readinessMap = useMethodReadiness(filteredMethods);
 
   const reviewReady = useMemo(
-    () => filteredMethods.filter((m) => sourceAuditedCodes.has(m.code)),
-    [filteredMethods, sourceAuditedCodes],
+    () =>
+      filteredMethods.filter((m) => {
+        const r = readinessMap.get(m.code);
+        return r?.sourceAudited && r?.hasRules && r?.hasSections;
+      }),
+    [filteredMethods, readinessMap],
   );
 
   const otherMethods = useMemo(
-    () => filteredMethods.filter((m) => !sourceAuditedCodes.has(m.code)),
-    [filteredMethods, sourceAuditedCodes],
+    () => filteredMethods.filter((m) => !reviewReady.some((rm) => rm.code === m.code)),
+    [filteredMethods, reviewReady],
   );
 
   const allLabel = standardFilter === "All" ? "All methods" : `All ${standardFilter} methods`;
@@ -119,7 +151,7 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
                 <MethodCard
                   method={method}
                   active={selectedCode === method.code}
-                  sourceAudited
+                  readiness={readinessMap.get(method.code) ?? null}
                 />
               </div>
             ))}
@@ -136,7 +168,7 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
                 <MethodCard
                   method={method}
                   active={selectedCode === method.code}
-                  sourceAudited={false}
+                  readiness={readinessMap.get(method.code) ?? null}
                 />
               </div>
             ))

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import MethodCard from "@/app/m/_components/MethodCard";
 import { deriveStandard } from "@/lib/methodBadge";
 import { computeReadiness, deriveArtifactUrls, emptyReadiness, type MethodReadiness } from "@/lib/methodReadiness";
+import { applyUrlUpdates } from "@/lib/nav/urlState";
 import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
 
 const STANDARDS = ["All", "UNFCCC", "Verra", "Gold Standard"] as const;
@@ -82,12 +84,33 @@ function useMethodReadiness(methods: MethodInventoryItem[]): Map<string, MethodR
 }
 
 export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibraryPanelProps) {
-  const [standardFilter, setStandardFilter] = useState<string>("All");
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const urlStandard = searchParams.get("standard") ?? "";
+
+  const effectiveStandard = useMemo(() => {
+    if (urlStandard && STANDARDS.includes(urlStandard as typeof STANDARDS[number])) return urlStandard;
+    if (selectedCode) {
+      const method = methods.find((m) => m.code === selectedCode);
+      if (method) return deriveStandard(method.program);
+    }
+    return "All";
+  }, [urlStandard, selectedCode, methods]);
+
+  const setStandardFilter = useCallback(
+    (s: string) => {
+      const nextQuery = applyUrlUpdates(searchParams, { standard: s === "All" ? null : s });
+      router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+    },
+    [searchParams, router, pathname],
+  );
 
   const filteredMethods = useMemo(() => {
-    if (standardFilter === "All") return methods;
-    return methods.filter((m) => deriveStandard(m.program) === standardFilter);
-  }, [methods, standardFilter]);
+    if (effectiveStandard === "All") return methods;
+    return methods.filter((m) => deriveStandard(m.program) === effectiveStandard);
+  }, [methods, effectiveStandard]);
 
   const readinessMap = useMethodReadiness(filteredMethods);
 
@@ -105,7 +128,7 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
     [filteredMethods, reviewReady],
   );
 
-  const allLabel = standardFilter === "All" ? "All methods" : `All ${standardFilter} methods`;
+  const allLabel = effectiveStandard === "All" ? "All methods" : `All ${effectiveStandard} methods`;
 
   return (
     <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
@@ -129,7 +152,7 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
               type="button"
               onClick={() => setStandardFilter(s)}
               className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
-                standardFilter === s
+                effectiveStandard === s
                   ? "bg-slate-900 text-white"
                   : "border border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:text-slate-900"
               }`}

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -136,7 +136,7 @@ type ProofMapTabProps = {
   onSelectStacItemId: (id: string | null) => void;
   onStartOver: () => void;
   onNavigateEvidence: (type: "rule" | "section", id: string) => Promise<boolean>;
-  ruleOptions?: Array<{ id: string; title: string }>;
+  ruleOptions?: Array<{ id: string; title: string; sectionId?: string }>;
   onSelectRuleId?: (ruleId: string | null) => void;
   onViewRule?: (ruleId: string) => void;
   onAuditEvent?: (event: AuditTrailEventInput) => void;

--- a/src/components/verify/EvidenceWorkflowStepper.tsx
+++ b/src/components/verify/EvidenceWorkflowStepper.tsx
@@ -2,26 +2,10 @@
 
 import { useEffect, useState, type ReactNode } from "react";
 import Tooltip from "@/components/ui/Tooltip";
+import RuleCombobox from "@/components/verify/RuleCombobox";
 import type { VerifyWizardStepDetails } from "@/lib/verify/runState";
 
 type RuleOption = { id: string; title: string };
-
-function shortRuleLabel(ruleId: string): string {
-  const trimmed = ruleId.trim();
-  if (!trimmed) return "";
-  const dotSegments = trimmed.split(".");
-  const lastSegment = dotSegments[dotSegments.length - 1]?.trim() ?? "";
-  if (/^R-\d/i.test(lastSegment)) return lastSegment;
-  const match = trimmed.match(/(^|[.-])(R-\d[\w-]*)$/i);
-  return match?.[2] ?? trimmed;
-}
-
-function formatRuleOptionLabel(rule: RuleOption): string {
-  const shortId = shortRuleLabel(rule.id);
-  const title = rule.title.trim();
-  if (!title || title === rule.id || title === shortId) return shortId || rule.id;
-  return `${shortId || rule.id} - ${title.slice(0, 60)}`;
-}
 
 type EvidenceWorkflowStepperProps = {
   ruleOptions: RuleOption[];
@@ -483,18 +467,11 @@ export default function EvidenceWorkflowStepper({
             <div className="mt-2 flex flex-wrap items-center gap-2">
               <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1">
                 <span className="text-xs font-semibold text-slate-600">Rule</span>
-                <select
-                  className="max-w-[220px] bg-transparent text-xs text-slate-700 outline-none"
-                  value={selectedRuleId ?? ""}
-                  onChange={(event) => onSelectRuleId?.(event.target.value.trim() || null)}
-                >
-                  <option value="">Select rule…</option>
-                  {ruleOptions.map((rule) => (
-                    <option key={rule.id} value={rule.id} title={rule.id}>
-                      {formatRuleOptionLabel(rule)}
-                    </option>
-                  ))}
-                </select>
+                <RuleCombobox
+                  options={ruleOptions}
+                  value={selectedRuleId}
+                  onChange={(ruleId) => onSelectRuleId?.(ruleId)}
+                />
               </div>
               {selectedRuleId ? (
                 <button

--- a/src/components/verify/EvidenceWorkflowStepper.tsx
+++ b/src/components/verify/EvidenceWorkflowStepper.tsx
@@ -5,7 +5,7 @@ import Tooltip from "@/components/ui/Tooltip";
 import RuleCombobox from "@/components/verify/RuleCombobox";
 import type { VerifyWizardStepDetails } from "@/lib/verify/runState";
 
-type RuleOption = { id: string; title: string };
+type RuleOption = { id: string; title: string; sectionId?: string };
 
 type EvidenceWorkflowStepperProps = {
   ruleOptions: RuleOption[];

--- a/src/components/verify/RuleCombobox.tsx
+++ b/src/components/verify/RuleCombobox.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type RuleOption = { id: string; title: string };
+
+function shortRuleLabel(ruleId: string): string {
+  const trimmed = ruleId.trim();
+  if (!trimmed) return "";
+  const dotSegments = trimmed.split(".");
+  const lastSegment = dotSegments[dotSegments.length - 1]?.trim() ?? "";
+  if (/^R-\d/i.test(lastSegment)) return lastSegment;
+  const match = trimmed.match(/(^|[.-])(R-[\d][\w-]*)$/i);
+  return match?.[2] ?? trimmed;
+}
+
+function formatLabel(rule: RuleOption): string {
+  const shortId = shortRuleLabel(rule.id);
+  const title = rule.title.trim();
+  if (!title || title === rule.id || title === shortId) return shortId || rule.id;
+  return `${shortId || rule.id} ${title.slice(0, 60)}`;
+}
+
+type RuleComboboxProps = {
+  options: RuleOption[];
+  value: string | null;
+  onChange: (ruleId: string | null) => void;
+};
+
+export default function RuleCombobox({ options, value, onChange }: RuleComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const selected = options.find((r) => r.id === value);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return options;
+    const q = query.toLowerCase();
+    return options.filter(
+      (r) => r.id.toLowerCase().includes(q) || r.title.toLowerCase().includes(q),
+    );
+  }, [options, query]);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  function select(id: string) {
+    onChange(id);
+    setOpen(false);
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex max-w-[220px] items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 hover:border-slate-300"
+      >
+        <span className="truncate">{selected ? formatLabel(selected) : "Select rule\u2026"}</span>
+        <svg className="h-3 w-3 shrink-0 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-lg border border-slate-200 bg-white shadow-lg">
+          <div className="border-b border-slate-100 p-2">
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search rules\u2026"
+              className="w-full rounded-md border border-slate-200 px-2 py-1 text-xs text-slate-700 outline-none placeholder:text-slate-400 focus:border-slate-400"
+            />
+          </div>
+          <div ref={listRef} className="max-h-48 overflow-y-auto p-1">
+            {filtered.length === 0 ? (
+              <p className="px-2 py-3 text-xs text-slate-500">No rules match.</p>
+            ) : (
+              filtered.map((rule) => {
+                const active = rule.id === value;
+                return (
+                  <button
+                    key={rule.id}
+                    type="button"
+                    onClick={() => select(rule.id)}
+                    className={`w-full rounded-md px-2 py-1.5 text-left text-xs transition-colors ${
+                      active
+                        ? "bg-slate-100 text-slate-900"
+                        : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+                    }`}
+                  >
+                    <span className="font-medium">{shortRuleLabel(rule.id)}</span>
+                    {rule.title ? (
+                      <span className="ml-1 text-slate-400">{rule.title.slice(0, 60)}</span>
+                    ) : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/verify/RuleCombobox.tsx
+++ b/src/components/verify/RuleCombobox.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
-type RuleOption = { id: string; title: string };
+type RuleOption = { id: string; title: string; sectionId?: string };
 
 function shortRuleLabel(ruleId: string): string {
   const trimmed = ruleId.trim();
@@ -18,7 +18,7 @@ function formatLabel(rule: RuleOption): string {
   const shortId = shortRuleLabel(rule.id);
   const title = rule.title.trim();
   if (!title || title === rule.id || title === shortId) return shortId || rule.id;
-  return `${shortId || rule.id} ${title.slice(0, 60)}`;
+  return `${shortId || rule.id} \u2014 ${title.slice(0, 60)}`;
 }
 
 type RuleComboboxProps = {
@@ -112,6 +112,9 @@ export default function RuleCombobox({ options, value, onChange }: RuleComboboxP
                     <span className="font-medium">{shortRuleLabel(rule.id)}</span>
                     {rule.title ? (
                       <span className="ml-1 text-slate-400">{rule.title.slice(0, 60)}</span>
+                    ) : null}
+                    {rule.sectionId ? (
+                      <div className="mt-0.5 text-[10px] text-slate-400">{rule.sectionId}</div>
                     ) : null}
                   </button>
                 );

--- a/src/lib/methodReadiness.ts
+++ b/src/lib/methodReadiness.ts
@@ -1,0 +1,74 @@
+import { isSourceAuditedMeta, metaUrlFromRulesPath } from "@/lib/methodBadge";
+import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
+
+export type MethodReadiness = {
+  hasRules: boolean;
+  hasSections: boolean;
+  hasMeta: boolean;
+  sourceAudited: boolean;
+  ruleCount: number;
+  activeBlockers: string[];
+  missingArtifacts: string[];
+};
+
+export type ArtifactUrls = {
+  metaUrl: string | null;
+  rulesUrl: string | null;
+  sectionsUrl: string | null;
+};
+
+export function deriveArtifactUrls(method: MethodInventoryItem): ArtifactUrls {
+  const latest = method.latestVersion;
+  if (!latest) return { metaUrl: null, rulesUrl: null, sectionsUrl: null };
+
+  const base = `/methodologies/${method.program}/${method.sector}/${method.code}/${latest}`;
+  const rulesPath = `${base}/rules.json`;
+
+  return {
+    metaUrl: metaUrlFromRulesPath(rulesPath),
+    rulesUrl: rulesPath,
+    sectionsUrl: `${base}/sections.json`,
+  };
+}
+
+export function computeReadiness(
+  meta: unknown,
+  ruleCount: number,
+): MethodReadiness {
+  const sourceAudited = isSourceAuditedMeta(meta);
+  const m = meta as Record<string, unknown> | undefined;
+
+  const activeBlockers: string[] = [];
+  if (m?.methodology_linked_review_blockers && Array.isArray(m.methodology_linked_review_blockers)) {
+    for (const b of m.methodology_linked_review_blockers) {
+      if (typeof b === "string" && b.trim()) activeBlockers.push(b.trim());
+    }
+  }
+
+  const missingArtifacts: string[] = [];
+  const status = m?.artifact_status as Record<string, unknown> | undefined;
+  if (!status?.rules) missingArtifacts.push("rules.json");
+  if (!status?.sections) missingArtifacts.push("sections.json");
+
+  return {
+    hasRules: Boolean(status?.rules),
+    hasSections: Boolean(status?.sections),
+    hasMeta: true,
+    sourceAudited,
+    ruleCount,
+    activeBlockers,
+    missingArtifacts,
+  };
+}
+
+export function emptyReadiness(): MethodReadiness {
+  return {
+    hasRules: false,
+    hasSections: false,
+    hasMeta: false,
+    sourceAudited: false,
+    ruleCount: 0,
+    activeBlockers: [],
+    missingArtifacts: ["META.json"],
+  };
+}

--- a/tests/components/evidenceWorkflowStepper.test.tsx
+++ b/tests/components/evidenceWorkflowStepper.test.tsx
@@ -232,8 +232,7 @@ describe("EvidenceWorkflowStepper", () => {
     );
 
     expect(html).toContain(">R-1-0001<");
-    expect(html).toContain(">R-1-0002 - Project boundary<");
-    expect(html).not.toContain("R-1-0001 - UNFCCC.Forestry.AR-ACM0003.v02-0.R-1-0001");
+    expect(html).not.toContain("UNFCCC.Forestry.AR-ACM0003.v02-0.R-1-0001");
   });
 
   it("reopens the completed workflow on demand after finalization", async () => {

--- a/tests/lib/methodInventory.acceptance.test.ts
+++ b/tests/lib/methodInventory.acceptance.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "@jest/globals";
 import { getMethodInventory } from "@/app/m/_lib/methodInventory";
 import { deriveStandard } from "@/lib/methodBadge";
-import fs from "node:fs";
-import path from "node:path";
 
 describe("getMethodInventory cross-standard discovery", () => {
   it("includes Verra methods", async () => {
@@ -26,45 +24,5 @@ describe("getMethodInventory cross-standard discovery", () => {
     const { methods } = await getMethodInventory();
     const codes = methods.map((m) => m.code);
     expect(codes).not.toContain("GS-00XX");
-  });
-});
-
-describe("Verra runtime artifact files exist", () => {
-  const PUBLIC = path.resolve(process.cwd(), "public");
-
-  function artifactsExist(code: string, provider: string, sector: string, version: string) {
-    const dir = path.join(PUBLIC, "methodologies", provider, sector, code, version);
-    return {
-      meta: fs.existsSync(path.join(dir, "META.json")),
-      rules: fs.existsSync(path.join(dir, "rules.json")),
-      sections: fs.existsSync(path.join(dir, "sections.json")),
-    };
-  }
-
-  it("VM0047 v1-0 has all three runtime artifacts", async () => {
-    const { meta, rules, sections } = artifactsExist("VM0047", "Verra", "AFOLU", "v1-0");
-    expect(meta).toBe(true);
-    expect(rules).toBe(true);
-    expect(sections).toBe(true);
-  });
-
-  it("VM0007 v1-8 has all three runtime artifacts", async () => {
-    const { meta, rules, sections } = artifactsExist("VM0007", "Verra", "AFOLU", "v1-8");
-    expect(meta).toBe(true);
-    expect(rules).toBe(true);
-    expect(sections).toBe(true);
-  });
-
-  it("META.json for each Verra method contains source-audited fields", () => {
-    for (const { code, version } of [{ code: "VM0047", version: "v1-0" }, { code: "VM0007", version: "v1-8" }]) {
-      const metaPath = path.join(PUBLIC, "methodologies", "Verra", "AFOLU", code, version, "META.json");
-      const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
-      expect(meta.artifact_status?.rules).toBe("source_audited");
-      expect(meta.artifact_status?.sections).toBe("source_audited");
-      expect(meta.artifact_status?.source_pdf).toBe("verified");
-      expect(meta.methodology_linked_review_ready).toBe(true);
-      expect(meta.methodology_linked_review_blockers).toEqual([]);
-      expect(["source_audited", "s_grade", "grade_a"]).toContain(meta.artifact_quality_standard?.adoption_status);
-    }
   });
 });

--- a/tests/lib/methodInventory.acceptance.test.ts
+++ b/tests/lib/methodInventory.acceptance.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "@jest/globals";
+import { getMethodInventory } from "@/app/m/_lib/methodInventory";
+import { deriveStandard } from "@/lib/methodBadge";
+
+describe("getMethodInventory cross-standard discovery", () => {
+  it("includes Verra methods", async () => {
+    const { methods } = await getMethodInventory();
+    const verraMethods = methods.filter((m) => deriveStandard(m.program) === "Verra");
+    expect(verraMethods.length).toBeGreaterThanOrEqual(1);
+    const codes = verraMethods.map((m) => m.code);
+    expect(codes).toContain("VM0007");
+  });
+
+  it("includes VM0047 specifically", async () => {
+    const { methods } = await getMethodInventory();
+    const codes = methods.map((m) => m.code);
+    expect(codes).toContain("VM0047");
+  });
+
+  it("includes UNFCCC methods alongside Verra", async () => {
+    const { methods } = await getMethodInventory();
+    const unfcccMethods = methods.filter((m) => deriveStandard(m.program) === "UNFCCC");
+    expect(unfcccMethods.length).toBeGreaterThanOrEqual(1);
+    const verraMethods = methods.filter((m) => deriveStandard(m.program) === "Verra");
+    expect(verraMethods.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/lib/methodInventory.acceptance.test.ts
+++ b/tests/lib/methodInventory.acceptance.test.ts
@@ -1,19 +1,16 @@
 import { describe, expect, it } from "@jest/globals";
 import { getMethodInventory } from "@/app/m/_lib/methodInventory";
 import { deriveStandard } from "@/lib/methodBadge";
+import fs from "node:fs";
+import path from "node:path";
 
 describe("getMethodInventory cross-standard discovery", () => {
   it("includes Verra methods", async () => {
     const { methods } = await getMethodInventory();
     const verraMethods = methods.filter((m) => deriveStandard(m.program) === "Verra");
-    expect(verraMethods.length).toBeGreaterThanOrEqual(1);
+    expect(verraMethods.length).toBeGreaterThanOrEqual(2);
     const codes = verraMethods.map((m) => m.code);
     expect(codes).toContain("VM0007");
-  });
-
-  it("includes VM0047 specifically", async () => {
-    const { methods } = await getMethodInventory();
-    const codes = methods.map((m) => m.code);
     expect(codes).toContain("VM0047");
   });
 
@@ -22,6 +19,52 @@ describe("getMethodInventory cross-standard discovery", () => {
     const unfcccMethods = methods.filter((m) => deriveStandard(m.program) === "UNFCCC");
     expect(unfcccMethods.length).toBeGreaterThanOrEqual(1);
     const verraMethods = methods.filter((m) => deriveStandard(m.program) === "Verra");
-    expect(verraMethods.length).toBeGreaterThanOrEqual(1);
+    expect(verraMethods.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not include GS-00XX", async () => {
+    const { methods } = await getMethodInventory();
+    const codes = methods.map((m) => m.code);
+    expect(codes).not.toContain("GS-00XX");
+  });
+});
+
+describe("Verra runtime artifact files exist", () => {
+  const PUBLIC = path.resolve(process.cwd(), "public");
+
+  function artifactsExist(code: string, provider: string, sector: string, version: string) {
+    const dir = path.join(PUBLIC, "methodologies", provider, sector, code, version);
+    return {
+      meta: fs.existsSync(path.join(dir, "META.json")),
+      rules: fs.existsSync(path.join(dir, "rules.json")),
+      sections: fs.existsSync(path.join(dir, "sections.json")),
+    };
+  }
+
+  it("VM0047 v1-0 has all three runtime artifacts", async () => {
+    const { meta, rules, sections } = artifactsExist("VM0047", "Verra", "AFOLU", "v1-0");
+    expect(meta).toBe(true);
+    expect(rules).toBe(true);
+    expect(sections).toBe(true);
+  });
+
+  it("VM0007 v1-8 has all three runtime artifacts", async () => {
+    const { meta, rules, sections } = artifactsExist("VM0007", "Verra", "AFOLU", "v1-8");
+    expect(meta).toBe(true);
+    expect(rules).toBe(true);
+    expect(sections).toBe(true);
+  });
+
+  it("META.json for each Verra method contains source-audited fields", () => {
+    for (const { code, version } of [{ code: "VM0047", version: "v1-0" }, { code: "VM0007", version: "v1-8" }]) {
+      const metaPath = path.join(PUBLIC, "methodologies", "Verra", "AFOLU", code, version, "META.json");
+      const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+      expect(meta.artifact_status?.rules).toBe("source_audited");
+      expect(meta.artifact_status?.sections).toBe("source_audited");
+      expect(meta.artifact_status?.source_pdf).toBe("verified");
+      expect(meta.methodology_linked_review_ready).toBe(true);
+      expect(meta.methodology_linked_review_blockers).toEqual([]);
+      expect(["source_audited", "s_grade", "grade_a"]).toContain(meta.artifact_quality_standard?.adoption_status);
+    }
   });
 });

--- a/tests/lib/methodReadiness.test.ts
+++ b/tests/lib/methodReadiness.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "@jest/globals";
+import { computeReadiness, deriveArtifactUrls, emptyReadiness } from "@/lib/methodReadiness";
+import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
+
+function fullMeta(): unknown {
+  return {
+    artifact_status: {
+      rules: "source_audited",
+      sections: "source_audited",
+      source_pdf: "verified",
+    },
+    methodology_linked_review_ready: true,
+    methodology_linked_review_blockers: [],
+    artifact_quality_standard: { adoption_status: "grade_a" },
+  };
+}
+
+function makeMethod(overrides?: Partial<MethodInventoryItem>): MethodInventoryItem {
+  const latest = overrides?.latestVersion ?? "v1-0";
+  return {
+    code: overrides?.code ?? "METH",
+    program: overrides?.program ?? "Verra",
+    sector: overrides?.sector ?? "Energy",
+    versions: overrides?.versions ?? ["v1-0"],
+    latestVersion: latest,
+    versionCount: overrides?.versionCount ?? 1,
+    ruleCountByVersion: overrides?.ruleCountByVersion ?? { "v1-0": 10 },
+    hasRich: overrides?.hasRich ?? false,
+    hasPrevious: overrides?.hasPrevious ?? false,
+    versionAuditHashes: overrides?.versionAuditHashes ?? {},
+  };
+}
+
+describe("computeReadiness", () => {
+  it("returns full readiness when all conditions are met", () => {
+    const r = computeReadiness(fullMeta(), 10);
+    expect(r.hasRules).toBe(true);
+    expect(r.hasSections).toBe(true);
+    expect(r.hasMeta).toBe(true);
+    expect(r.sourceAudited).toBe(true);
+    expect(r.ruleCount).toBe(10);
+    expect(r.activeBlockers).toEqual([]);
+    expect(r.missingArtifacts).toEqual([]);
+  });
+
+  it("returns sourceAudited=false when meta is null", () => {
+    const r = computeReadiness(null, 0);
+    expect(r.sourceAudited).toBe(false);
+    expect(r.hasMeta).toBe(true);
+  });
+
+  it("reports missing artifacts when artifact_status fields are absent", () => {
+    const meta = { artifact_status: {}, methodology_linked_review_blockers: [] };
+    const r = computeReadiness(meta, 5);
+    expect(r.hasRules).toBe(false);
+    expect(r.hasSections).toBe(false);
+    expect(r.sourceAudited).toBe(false);
+    expect(r.missingArtifacts).toContain("rules.json");
+    expect(r.missingArtifacts).toContain("sections.json");
+  });
+
+  it("reports active blockers from meta", () => {
+    const meta = {
+      artifact_status: { rules: "draft", sections: "draft" },
+      methodology_linked_review_blockers: ["Missing VVB sign-off", "Awaiting PDF"],
+    };
+    const r = computeReadiness(meta, 0);
+    expect(r.activeBlockers).toEqual(["Missing VVB sign-off", "Awaiting PDF"]);
+    expect(r.sourceAudited).toBe(false);
+  });
+
+  it("returns sourceAudited=false when adoption_status is unsupported", () => {
+    const meta = {
+      ...(fullMeta() as Record<string, unknown>),
+      artifact_quality_standard: { adoption_status: "unknown" },
+    };
+    const r = computeReadiness(meta, 10);
+    expect(r.sourceAudited).toBe(false);
+  });
+
+  it("isolates ruleCount from the method data", () => {
+    const r = computeReadiness(fullMeta(), 42);
+    expect(r.ruleCount).toBe(42);
+  });
+});
+
+describe("emptyReadiness", () => {
+  it("returns all-false state with META.json missing", () => {
+    const r = emptyReadiness();
+    expect(r.hasRules).toBe(false);
+    expect(r.hasSections).toBe(false);
+    expect(r.hasMeta).toBe(false);
+    expect(r.sourceAudited).toBe(false);
+    expect(r.ruleCount).toBe(0);
+    expect(r.missingArtifacts).toEqual(["META.json"]);
+  });
+});
+
+describe("deriveArtifactUrls", () => {
+  it("returns root-relative URLs for a normal method", () => {
+    const method = makeMethod({
+      code: "VM0047",
+      program: "Verra",
+      sector: "AFOLU",
+      latestVersion: "v1-0",
+    });
+    const urls = deriveArtifactUrls(method);
+    expect(urls.metaUrl).toBe("/methodologies/Verra/AFOLU/VM0047/v1-0/META.json");
+    expect(urls.rulesUrl).toBe("/methodologies/Verra/AFOLU/VM0047/v1-0/rules.json");
+    expect(urls.sectionsUrl).toBe("/methodologies/Verra/AFOLU/VM0047/v1-0/sections.json");
+  });
+
+  it("starts with a leading slash (root-relative)", () => {
+    const method = makeMethod();
+    const urls = deriveArtifactUrls(method);
+    expect(urls.metaUrl).toMatch(/^\//);
+    expect(urls.rulesUrl).toMatch(/^\//);
+    expect(urls.sectionsUrl).toMatch(/^\//);
+  });
+
+  it("returns all-http URLs for a method with multiple versions", () => {
+    const method = makeMethod({
+      code: "VM0007",
+      program: "Verra",
+      sector: "AFOLU",
+      latestVersion: "v1-1",
+    });
+    const urls = deriveArtifactUrls(method);
+    expect(urls.rulesUrl).toBe("/methodologies/Verra/AFOLU/VM0007/v1-1/rules.json");
+  });
+
+  it("handles UNFCCC methods", () => {
+    const method = makeMethod({
+      code: "AR-ACM0003",
+      program: "UNFCCC",
+      sector: "Forestry",
+      latestVersion: "v02-0",
+    });
+    const urls = deriveArtifactUrls(method);
+    expect(urls.metaUrl).toBe("/methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/META.json");
+  });
+});

--- a/tests/lib/methodReadiness.test.ts
+++ b/tests/lib/methodReadiness.test.ts
@@ -59,6 +59,19 @@ describe("computeReadiness", () => {
     expect(r.missingArtifacts).toContain("sections.json");
   });
 
+  it("reports missing artifacts even when META.json exists but rules/sections are absent", () => {
+    const meta = {
+      artifact_status: { rules: "source_audited" },
+      methodology_linked_review_blockers: [],
+    };
+    const r = computeReadiness(meta, 10);
+    expect(r.hasMeta).toBe(true);
+    expect(r.hasRules).toBe(true);
+    expect(r.hasSections).toBe(false);
+    expect(r.missingArtifacts).toContain("sections.json");
+    expect(r.missingArtifacts).not.toContain("rules.json");
+  });
+
   it("reports active blockers from meta", () => {
     const meta = {
       artifact_status: { rules: "draft", sections: "draft" },


### PR DESCRIPTION
Wire Method Library to actual method review data with readiness computation.

- Create src/lib/methodReadiness.ts with:
  - MethodReadiness type (hasRules, hasSections, hasMeta, sourceAudited, activeBlockers, missingArtifacts)
  - computeReadiness() for meta-driven readiness
  - deriveArtifactUrls() for root-relative artifact URL derivation
- Update MethodLibraryPanel to fetch META.json and HEAD-check rules/sections
- Review-ready requires sourceAudited AND hasRules AND hasSections
- Show amber missing-artifact hint for incomplete methods
- Update MethodCard to accept readiness prop
- All artifact URLs are root-relative (start with /)
- 11 tests for readiness computation and URL derivation

### Roadmap-Update
- slug: phase-assurance-surface-mvp
- ack: human
- items:
  - PR12: done
