### PR TITLE
Import real Verra methods from article6-methodologies pack

### DIFF
--- a/config/methodologies_pack.json
+++ b/config/methodologies_pack.json
@@ -1,5 +1,5 @@
 {
   "repo": "Fredilly/article6-methodologies",
-  "tag": "methodologies-pack-3ea9dc32bfaf",
-  "asset": "methodologies-pack-3ea9dc32bfaf.tar.gz"
+  "tag": "methodologies-pack-afb90934ecf4",
+  "asset": "methodologies-pack-afb90934ecf4.tar.gz"
 }

--- a/public/manifest/index.json
+++ b/public/manifest/index.json
@@ -2,6 +2,1122 @@
   {
     "id": "R-1-0001",
     "rule_id": "R-1-0001",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "dda75505ea56d05a6e04e2721cbd17d08d0e581a87ba7d4417d3dc606c27cd9c",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "3420748023f30d04ed1fd562ef7ae3e30f38f9e1a49659763b0d9c4dea8abec9",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "3e6d9dc97d3ab90962de8b95b71b27bacbf040cc634478a40479dece85c5f339",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "eb7121e84d51ec80ad2b551753dab1cc8372f05f330538a26b9062a52712a02d",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "b836353c122af881334f9fbb7713caf9d7377a723e247fc5c8b6af1f018bff85",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "24164a04c1515ff1539afad170510d4a05115d7b3e4471c8d736ef7b1f6793d2",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "7b0f8c7ba29f81946dd5dc6f5b86e8e187c38d44a5faf9297dda219cc13a3bf7",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "ACM0010",
+    "version": "v03-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "2ce9a69b9840193ff2a6b0c99120831bb2934ef90092d7c3d75d9de479b89891",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/ACM0010/v03-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "29b2ef4098b56891ad498e5e038219ac1d6244cb7ece2df439ef18378384fcfd",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "6ea9b9eb161d6857de39724c8e8757a7cf52d8fd04ac4798fb264745a05290f0",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "5eda0d15e4ec4d17de633acc84c7c724c22fe8aeb64b523b18b53931725ccf06",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "20c4996b305e04cbd1907c186aee3e1ef08082f95d2de683674f285d23ecc97b",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "3b91069bc370b9a965d26d3faee834db1004fcb9659d97084493ff1af9e711a6",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "c349af08750d4b4d7526b3c7999ebcc1e03cd526a0b9253920000f178f7dc3b8",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "2676222d60300e1605a9d9bcdbb479eb9c1096f76bc70ff493e6115b854d931d",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AM0073",
+    "version": "v01-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "03c397b3c64afdba007a0e87e98b5ff79d9d0304a02dfa846fc6aaa547e052c5",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AM0073/v01-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "b5067038bbc518bbf209ddbbe97e812d685fc513a8290926774023c2d6340201",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "b8ef92643663b064f3889e9c7d06e104f33901eb5ffae012bc8fc8883ea4421f",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "37cdb4cb33286096f952b709f6ae3499103c69b9a07456eb6c35d24d1438ee10",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "1bfecf0c2476a089e8a726966647d674b53fa5ba051500905c5b410a4f30e0c1",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "6ac8f8f06fad17187646a7cf5f4ac56698ba085e3ba63f3acf4ba5ad2017f1ad",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "d871354ad066fdb9f1ec7bffcd5fc6c1c4b0e7fb9660b54f4abbcd988b92e9df",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "fdc987e374d07e624faed87eaf99eb58404902a72011265c3cc00b16d57b7790",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.A",
+    "version": "v03-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "2305d403605e0561f895e75402326bb23a9d6e1a0430c1f43054a1cdc9c4e595",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.A/v03-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "0814be70f1ec12030d9b39366a052ada9443feb2c7bffc78e28dc8a785619157",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "71868565dcf19698cff692c08cdea382db4431b10a85894c70b82d700fb00e86",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "0009c2bcaaababf9b26c2082de2b7112f4698b334d59f223335bb675b004f952",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "0a5a377acfd73e3c17ff89374a5191b022565b30174500bf4c962f797245515c",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "c088c80c7ae515c740c85f161dab9b24b9cfb32f8844ce259b8fd9d75446b007",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "289968dc611c2b89d8898e970b60b4fd2b10704ff6d2be085064622b67040627",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "f243a012a774b639baddacec11a069b159c33ec2618360eda8ccee7e2ca31fcd",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.AU",
+    "version": "v04-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "3c6bf2cdf13f1a1408980e529993f9bb94a5fe308deb22727357e8cf0507ec8e",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.AU/v04-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "74788de192f5d5b220f91918dc133bd51b8e9a1686c388d9062dd669afb74edd",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "a0a617f9fe13964c50bd8b5dc58dd304c2bab63b1d74c84800acedef3fe7e05f",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "631057d14aad5e7e3b325cc2d9bba65888136a1876e3ee4997c70b0e6a40a391",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "0f3a85be1e0a76f195631e8b72dcaeac71ef53bddfc8177c2b1745764d299c9f",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "3a5636c87d19c9a92aae7be62257721649da2131e8e53eb71bd052a89739b93a",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "5930a2f59157c6f4745adf88b94e21ff07fd7722d278bb8cdb40458c97ef348a",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "c7198799c228071940532a1dacf1f91bf0c6e7ababcb6897fd4471d80f7b9ebc",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.BE",
+    "version": "v01-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "bd2e26d55da7b91b02e7c09d7f3cbf7e708832f2759f184b3820eae07a092edb",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BE/v01-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "16041f22af6f90e9e125fcafbe57b354cd5dd489fb649ab31f7027de66adca69",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "cc347b243b452c03cc7abf0e0cd1c538669a47620c2b2218103e0518c2251036",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "c11febe64a3e89b01415a0aeaa291e2bff1a140ae6c7f498b35dfc6db9590096",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "52720d639b921877ee35f62eee37d34b8c585cd658d4b1751882650455f0e944",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "a1acb32157719ba66d4c1605737385c8f11d1e26561ea94de1acefb0be933ba0",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "e20c00e65ed13531d8224988615f3917850aabfc5c6a3887070445db9a5b87d9",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "52d2f255e6bc258f20c351cebc9120257327eecedd9b78816ed12963db25d08f",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.BF",
+    "version": "v02-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "57f21eb568cce0572edd0826855a945244cd6a5fc3b71f602b97c00eab931802",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BF/v02-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "ea44d1d49641eb17382c414214dd7ccb8dcad4676435c1749a5dc361cf93635f",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "cd0e18c0aab13280fb249671afa56b07d92e8f0c65fda1132cb7257d3c3b2c67",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "467b70fde8e5393ee41a863efb183c1b38f6fc489a17e9c8ba3ff4c11bacf6a6",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "20a27172fedc6779a20afd5a48de1135fd20f8acfcefef59a42d07f90bdd0467",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "b64114982889338ac6fc9e1069733f21bc291f0713414f59723a030cd5623f25",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "be9519bfc3fc41638f96a8f66766ace8214142e3a873155279ba3efb268195e8",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "bea6913d384dc6ab5be278877c9f896ed85e470ef6e9b52721c27b0fad5effa9",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.BK",
+    "version": "v02-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "03f12eed38215522368715d15df371614c0b2aaca2603395009db5b08bf792dc",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.BK/v02-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "cb78b937f1994e694662506366ac7079671caf24fd269c6e8ef1bd02c6c6dc8d",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "6b6828ba488fdb33ee8142e8a8a0265201a21d4fd9dadce3c18b8991aba16f7b",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "bb458652be0522548b5e73b6332d5c3b7b1c65f4236662985b578a675d642bb3",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "6812ea9d7b8ec14234409560c7d4917de8b494a2147f8f8d7eca60e9200fd5b0",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "a33d7a35e4a068d762a10552f8d47f5e58959afa1f6ed617e0ca95d2e0b80fa2",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "c7a9bf0cb4952dc409f13c3eb70dff8cf89093e1a64ee50aae0600361937e4f1",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "efc2669a2c21e6d301551fd1b2d563764be32c5fec450ce0a209e54b337b62c6",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.D",
+    "version": "v21-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "13dbb8701e6e76005c901bced0da1afc88dff6a81c6ff67e1aca73d262c95b47",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.D/v21-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Projects aggregate manure from multiple farms and install a central methane capture system where the baseline lacks methane recovery.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "3d8157b65645035b468fe288c6f9bff9a4752c5d312905dc6b3b609c7dc74718",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Baseline is the highest-IRR alternative without methane recovery determined through the methodology's IRR/NPV screening steps.",
+    "tags": [
+      "calc",
+      "baseline",
+      "additionality"
+    ],
+    "sha256": "88eca210295bdb5ea0765918798579d3944f17160e0279eca675971870d811a9",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Barrier documentation and CER transfer declarations demonstrate participation and prevent double counting.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "2cc535980017189aa384534504a2fb533557bf77abcddae7733e8a6bb843e585",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-4-0003",
+    "rule_id": "R-4-0003",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Project boundaries cover collection through final sludge treatment with leak-proof infrastructure and consistent fertilizer use.",
+    "tags": [
+      "parameter",
+      "project_design"
+    ],
+    "sha256": "9689b5e04009603d02dfe96ac56d50157cd29636763ff652221e77e41e311109",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Emission reductions equal avoided manure methane minus project emissions following the referenced AM tools.",
+    "tags": [
+      "equation",
+      "calc"
+    ],
+    "sha256": "d2d807643dff0e419e6218fd01bbd301cf42b558c70959ac1ce699a875ddd614",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Deduct leakage from pipelines, auxiliary fuel, and offsite residue handling using monitored data or LFAD defaults.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "777c34e0d1c109b6f238ec64c9ce98a218f4d91158e8877e26aa9b4f7f156bda",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-7-0005",
+    "rule_id": "R-7-0005",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Monitor biogas, methane fraction, and energy consumption continuously and report at least monthly with QA/QC evidence.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "1e9582bc71098076295b8afa76f501d281460e4030a95e1bead709bd4c4a1a47",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-8-0005",
+    "rule_id": "R-8-0005",
+    "methodology": "AMS-III.R",
+    "version": "v05-0",
+    "rule": "Focus DOE inspections on high-emitting farms and reconcile methane balances annually, documenting leak investigations and fixes.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "ac906d090a593d33882ad2ea451875baa64e1c0835aba565f4f4895ee49b17cc",
+    "provider": "UNFCCC",
+    "category": "Agriculture",
+    "path": "methodologies/UNFCCC/Agriculture/AMS-III.R/v05-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
     "methodology": "AR-ACM0003",
     "version": "v02-0",
     "rule": "Project restores degraded forest lands and meets additionality tests per Tool 01.",
@@ -119,6 +1235,248 @@
     "provider": "UNFCCC",
     "category": "Forestry",
     "path": "methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Projects reforest lands without forest cover since 1989 and comply with national forest definitions.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "8325d2c2acc25b29e276cf5c2fa4188f7bdaf93b9b0c477664c9a354e4071ca0",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0002",
+    "rule_id": "R-1-0002",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Baseline biomass estimated using IPCC defaults or site-specific sampling following Tool 02.",
+    "tags": [
+      "calc",
+      "baseline"
+    ],
+    "sha256": "ee2d6ee8abf583705c655b42a02d1ad5357eae3ee11e40bce6682ac114275e54",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-1-0003",
+    "rule_id": "R-1-0003",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Net anthropogenic removals equal project removals minus baseline emissions and leakage.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "a383bb5f48fdd8bed37e4530aed83fd5e7b9e43231815ff1914228d7e76f1938",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-1-0004",
+    "rule_id": "R-1-0004",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Activity shifting leakage quantified annually using Tool 14 and deducted from net removals.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "d08cea9473b9e4bb3b639a198f3c945015d557842004f263e6b055a6eb29066a",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-1-0005",
+    "rule_id": "R-1-0005",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Non-permanence risks addressed through buffer contributions per Tool 15 guidance.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "31e9e094fae22f7f103800d0ff8b8a634f818e57ff03692a9c5542b49787ab5c",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0006",
+    "rule_id": "R-1-0006",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Field biomass measurements conducted at least every five years using permanent plots.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "63ec85acd9f599d7563b46b3872ed7ed19d5e8e1e7c2f17347d29099a22be65e",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0007",
+    "rule_id": "R-1-0007",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Sampling uncertainty above 10% addressed with Tool 12 conservative adjustments.",
+    "tags": [
+      "uncertainty"
+    ],
+    "sha256": "dfa248d956e092a2efb8cdf4429bedf593e91ee6186d6a6fb1554e8d8341e5d0",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0008",
+    "rule_id": "R-1-0008",
+    "methodology": "AR-AM0014",
+    "version": "v01-0-0",
+    "rule": "Monitoring reports consolidate maps, inventory data, leakage deductions, and QA/QC evidence.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "8634f721c43e7646acc7bb1e5fd2af32de753cbaaec269d8618854dd4f5e07f1",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v01-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Projects reforest lands without forest cover since 1989 and comply with national forest definitions.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "8e22791a6d2f8040a87a3aba72a4f87d9675b9c047a0ae3c39a310708ea68660",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0002",
+    "rule_id": "R-1-0002",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Baseline biomass estimated using IPCC defaults or site-specific sampling following Tool 02.",
+    "tags": [
+      "calc",
+      "baseline"
+    ],
+    "sha256": "8413316f37eb0d8e148615c73ae4bf34519c0c74a49a7cebf3abdd997652d7a4",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-1-0003",
+    "rule_id": "R-1-0003",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Net anthropogenic removals equal project removals minus baseline emissions and leakage.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "eeb5d2640da9799b96c014dcc97aa674ca9acbb9d5319301986c10b9dcc80760",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-1-0004",
+    "rule_id": "R-1-0004",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Activity shifting leakage quantified annually using Tool 14 and deducted from net removals.",
+    "tags": [
+      "leakage"
+    ],
+    "sha256": "fe074b4c07590df37ab1560ae7e68843765dd4a8293d1cc8629b63e0011bad49",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-1-0005",
+    "rule_id": "R-1-0005",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Non-permanence risks addressed through buffer contributions per Tool 15 guidance.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "3d876ab92d4f925edc27fafd19dbdb120c96f6766830bcfff99606fbd354b864",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0006",
+    "rule_id": "R-1-0006",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Field biomass measurements conducted at least every five years using permanent plots.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "7d7d654273a489a558d19944d1df22c94975418daf2b4040cd91e156cea92925",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0007",
+    "rule_id": "R-1-0007",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Sampling uncertainty above 10% addressed with Tool 12 conservative adjustments.",
+    "tags": [
+      "uncertainty"
+    ],
+    "sha256": "542871daf1ab93b1b11f8713b93b6f3ac63143b4bd83ef2cf8d5fecdacd546f9",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-1-0008",
+    "rule_id": "R-1-0008",
+    "methodology": "AR-AM0014",
+    "version": "v02-0-0",
+    "rule": "Monitoring reports consolidate maps, inventory data, leakage deductions, and QA/QC evidence.",
+    "tags": [
+      "reporting"
+    ],
+    "sha256": "bf8d70c4a3589a646d45bcd6840b08f57df9d2130a62516455579eed0ae1841f",
+    "provider": "UNFCCC",
+    "category": "Forestry",
+    "path": "methodologies/UNFCCC/Forestry/AR-AM0014/v02-0-0/rules.json",
     "sectionId": "S-5"
   },
   {
@@ -645,5 +2003,1040 @@
     "category": "Forestry",
     "path": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.json",
     "sectionId": "S-13"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Land must not be forest at project start. Must meet host-country forest definition if applicable.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-4-0001",
+    "rule_id": "R-4-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Land must be non-forest or managed non-forest for 10+ years. VM0047 Section 4 applicability conditions 3-5 exclude tidal wetlands, organic soil/water table manipulation, and mechanical removal/burning of pre-existing dead wood. All exclusions are self-contained in VM0047.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-4-0002",
+    "rule_id": "R-4-0002",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Two approaches: area-based (plot sampling) or census-based (complete enumeration). Must select based on project characteristics.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-5-0001",
+    "rule_id": "R-5-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Project boundary must be fixed ex-ante. Stratification by land cover, soil type, and management regime.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-5-0002",
+    "rule_id": "R-5-0002",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "AGB and BGB mandatory. Litter, dead wood, SOC optional per Appendix 2 significance test (built-in, replaces external T-SIG). If included in baseline must also be in project scenario.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-6-0001",
+    "rule_id": "R-6-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Area-based approach uses performance benchmark (Appendix 1). Census-based approach uses zero baseline if pre-existing woody biomass <10%. Both approaches fully described in VM0047 Section 6 and Appendix 1.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "R-7-0001",
+    "rule_id": "R-7-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Area-based approach: regulatory surplus + performance benchmark + investment barrier. Census-based approach: regulatory surplus + investment barrier + common practice. Both fully described in VM0047 Section 7.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-7"
+  },
+  {
+    "id": "R-8-0001",
+    "rule_id": "R-8-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Removals = min(project C change, project C change x (1 - PB)) - leakage - uncertainty. PB from ex-post reference region observations.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-8-2"
+  },
+  {
+    "id": "R-8-0002",
+    "rule_id": "R-8-0002",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Activity shifting leakage must be assessed. Market leakage is de minimis for ARR. Fossil fuel and biomass burning emissions must be included.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-8-3"
+  },
+  {
+    "id": "R-8-0003",
+    "rule_id": "R-8-0003",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "15% threshold at 90% CI. If exceeded, excess deducted proportionally from removals. Below threshold, no deduction.",
+    "tags": [
+      "uncertainty"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-8-4"
+  },
+  {
+    "id": "R-9-0001",
+    "rule_id": "R-9-0001",
+    "methodology": "VM0047",
+    "version": "v1-0",
+    "rule": "Four mandatory components: data list, QA/QC, responsibilities, archiving. REDD MRV procedures via M-REDD module.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0047/v1-0/rules.json",
+    "sectionId": "S-9-3"
+  },
+  {
+    "id": "R-1-0001",
+    "rule_id": "R-1-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Project land must meet forest definition threshold for 10+ years. Mangroves exempt from height.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0002",
+    "rule_id": "R-1-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Binary classification: unplanned (no legal right) vs planned (legally permitted conversion). Determines which BL module applies.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0003",
+    "rule_id": "R-1-0003",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three criteria must ALL be met. Excludes large-scale industrial agriculture/aquaculture.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0004",
+    "rule_id": "R-1-0004",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Must have legal documentation authorizing conversion.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0005",
+    "rule_id": "R-1-0005",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Water table lowering is prohibited except for two specific exceptions.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0006",
+    "rule_id": "R-1-0006",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Absolute prohibition on organic soil burning as a project activity.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0007",
+    "rule_id": "R-1-0007",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "No nitrogen fertilizer application allowed during entire crediting period.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0008",
+    "rule_id": "R-1-0008",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Spillover emissions from hydrological changes must be assessed using the stepwise significance procedure in Appendix 1 (alternative to T-SIG). Procedure covers GHG emissions by source, carbon stock changes by pool, and leakage GHG emissions.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0009",
+    "rule_id": "R-1-0009",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three alternative conditions. Must demonstrate one with verifiable evidence.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0010",
+    "rule_id": "R-1-0010",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Must meet VCS peatland definition based on IPCC organic soil thresholds.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0011",
+    "rule_id": "R-1-0011",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Must include at least one defined restoration activity type.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0012",
+    "rule_id": "R-1-0012",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Must include at least one defined conservation activity type.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0013",
+    "rule_id": "R-1-0013",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Parallel to AUDef criteria but for wetland degradation.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0014",
+    "rule_id": "R-1-0014",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "IFM and ARR activities are excluded from VM0007. WRC projects that also implement ARR activities must use an appropriate ARR methodology, e.g. VM0047, for aboveground biomass accounting.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-1-0015",
+    "rule_id": "R-1-0015",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Two specific leakage prevention activities are explicitly prohibited.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-1"
+  },
+  {
+    "id": "R-2-0001",
+    "rule_id": "R-2-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Six required data elements for each discrete land parcel.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0002",
+    "rule_id": "R-2-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Strict no-overlap rule. REDD+WRC combination is the sole exception.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0003",
+    "rule_id": "R-2-0003",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Double-counting prevention. Must track and report exclusions.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0004",
+    "rule_id": "R-2-0004",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "RRD required for baseline modeling. Must be in same jurisdiction with similar characteristics.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0005",
+    "rule_id": "R-2-0005",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Proxy areas required for planned deforestation baseline.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0006",
+    "rule_id": "R-2-0006",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Stratification mandatory. Different activity types must be in separate strata.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0007",
+    "rule_id": "R-2-0007",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Pool inclusion/exclusion must be justified. If included in baseline, must also be in project and leakage.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0008",
+    "rule_id": "R-2-0008",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "AGB always mandatory. HWP and dead wood conditionally mandatory based on baseline/project comparison.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0009",
+    "rule_id": "R-2-0009",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "WRC focuses on SOC pool. Biomass pools excluded unless ARR applies.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0010",
+    "rule_id": "R-2-0010",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "GHG sources must be identified per Table 7 with inclusion/exclusion justification.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0011",
+    "rule_id": "R-2-0011",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "GHG sources per Tables 8-9. Mandatory for CO2 from SOC, CH4 from SOC, combustion gases.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0012",
+    "rule_id": "R-2-0012",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Symmetric accounting: baseline inclusion implies project inclusion.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0013",
+    "rule_id": "R-2-0013",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Fixed period for baseline modeling. Duration per VCS Standard.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0014",
+    "rule_id": "R-2-0014",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "20-100 year range. Must be specified in PD.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0015",
+    "rule_id": "R-2-0015",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "100-year SOC horizon test. Must show significant difference. Assessed ex-ante conservatively.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-2-0016",
+    "rule_id": "R-2-0016",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Sea-level rise must be factored into boundary delineation for tidal projects.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-2"
+  },
+  {
+    "id": "R-3-0001",
+    "rule_id": "R-3-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "VT0001 mandatory. Stepwise approach: list alternatives, barrier/investment analysis, select most plausible.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-3-0002",
+    "rule_id": "R-3-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three mandatory alternatives unless demonstrated not credible or non-compliant.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-3-0003",
+    "rule_id": "R-3-0003",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Two-step: barrier analysis first, then investment analysis or qualitative GHG estimation as fallback.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-3-0004",
+    "rule_id": "R-3-0004",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three options with different selection criteria. Option I is cost-only, Option II is IRR/NPV, Option III is benchmark-based.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-3-0005",
+    "rule_id": "R-3-0005",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Module selection based on deforestation category.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-3-0006",
+    "rule_id": "R-3-0006",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Module selection depends on substrate (peat vs tidal) and activity type (CIW vs RWE vs combined).",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-3-0007",
+    "rule_id": "R-3-0007",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Periodic reassessment per VCS Standard. Must capture changes in deforestation drivers/behavior.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-3-0008",
+    "rule_id": "R-3-0008",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "JNR data is acceptable as a conservative source even if less accurate.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-3"
+  },
+  {
+    "id": "R-4-0001",
+    "rule_id": "R-4-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "VT0001 mandatory for all non-tidal-wetland activities.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-4-0002",
+    "rule_id": "R-4-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Activity method (ADD-AM) replaces project method (VT0001) for tidal wetlands only.",
+    "tags": [
+      "eligibility"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-4"
+  },
+  {
+    "id": "R-5-0001",
+    "rule_id": "R-5-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Standard REDD equation. Three components summed over monitoring period.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-5-0002",
+    "rule_id": "R-5-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Parallel to REDD equation. Components use peat/tidal wetland modules.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-5-0003",
+    "rule_id": "R-5-0003",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three leakage components. Activity shifting via LK-ASP and LK-ASU modules. Market effects via LK-ME.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-5-0004",
+    "rule_id": "R-5-0004",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three components including ecological leakage specific to wetlands.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-5-0005",
+    "rule_id": "R-5-0005",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three buffer components. Each = (baseline - project) × Buffer%. Buffer% from T-BAR.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-5-0006",
+    "rule_id": "R-5-0006",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "15% threshold at 90% CI. Excess deducted proportionally. Below threshold, no deduction.",
+    "tags": [
+      "uncertainty"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-5-0007",
+    "rule_id": "R-5-0007",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Period credits = incremental adjusted NER minus buffer withholding.",
+    "tags": [
+      "equation"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-5-0008",
+    "rule_id": "R-5-0008",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Five carbon pool modules. Each optional except AG biomass per R-2-0008.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-5-0009",
+    "rule_id": "R-5-0009",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Module selection by activity type and emission source.",
+    "tags": [
+      "calc"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-5"
+  },
+  {
+    "id": "R-6-0001",
+    "rule_id": "R-6-0001",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Four mandatory monitoring tasks. Each requires technical description, data list, procedures, QA/QC, archiving, responsibilities.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "R-6-0002",
+    "rule_id": "R-6-0002",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Six required content elements per task.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "R-6-0003",
+    "rule_id": "R-6-0003",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "GPS or georeferenced data mandatory. Strata included.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "R-6-0004",
+    "rule_id": "R-6-0004",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Six minimum SOP/QA/QC elements.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "R-6-0005",
+    "rule_id": "R-6-0005",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "10-year minimum frequency. Spatial variables must be refreshed.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "R-6-0006",
+    "rule_id": "R-6-0006",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three ongoing compliance checks. Fire triggers premium cancellation.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "R-6-0007",
+    "rule_id": "R-6-0007",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "IPCC 2006 expert judgment protocol mandatory. Rationale must be documented.",
+    "tags": [
+      "monitoring"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
+  },
+  {
+    "id": "R-6-0008",
+    "rule_id": "R-6-0008",
+    "methodology": "VM0007",
+    "version": "v1-8",
+    "rule": "Three data source tiers: literature > IPCC defaults > expert opinion.",
+    "tags": [
+      "uncertainty"
+    ],
+    "sha256": "",
+    "provider": "Verra",
+    "category": "AFOLU",
+    "path": "methodologies/Verra/AFOLU/VM0007/v1-8/rules.json",
+    "sectionId": "S-6"
   }
 ]

--- a/tests/lib/methodInventory.verra.test.ts
+++ b/tests/lib/methodInventory.verra.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "@jest/globals";
+import { getMethodInventory } from "@/app/m/_lib/methodInventory";
+import { deriveStandard } from "@/lib/methodBadge";
+
+describe("getMethodInventory real Verra import", () => {
+  it("includes VM0007 and VM0047", async () => {
+    const { methods } = await getMethodInventory();
+    const codes = methods.map((m) => m.code);
+    expect(codes).toContain("VM0007");
+    expect(codes).toContain("VM0047");
+  });
+
+  it("includes UNFCCC methods alongside Verra", async () => {
+    const { methods } = await getMethodInventory();
+    const unfcccMethods = methods.filter((m) => deriveStandard(m.program) === "UNFCCC");
+    expect(unfcccMethods.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("includes at least 2 Verra methods", async () => {
+    const { methods } = await getMethodInventory();
+    const verraMethods = methods.filter((m) => deriveStandard(m.program) === "Verra");
+    expect(verraMethods.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not include GS-00XX", async () => {
+    const { methods } = await getMethodInventory();
+    const codes = methods.map((m) => m.code);
+    expect(codes).not.toContain("GS-00XX");
+  });
+
+  it("VM0007 latest version is v1-8", async () => {
+    const { methods } = await getMethodInventory();
+    const vm = methods.find((m) => m.code === "VM0007");
+    expect(vm).toBeDefined();
+    expect(vm!.latestVersion).toBe("v1-8");
+  });
+
+  it("VM0047 latest version is v1-0", async () => {
+    const { methods } = await getMethodInventory();
+    const vm = methods.find((m) => m.code === "VM0047");
+    expect(vm).toBeDefined();
+    expect(vm!.latestVersion).toBe("v1-0");
+  });
+
+  it("VM0007 has 58 rules in latest version", async () => {
+    const { methods } = await getMethodInventory();
+    const vm = methods.find((m) => m.code === "VM0007");
+    expect(vm).toBeDefined();
+    expect(vm!.ruleCountByVersion["v1-8"]).toBe(58);
+  });
+
+  it("VM0047 has 11 rules in latest version", async () => {
+    const { methods } = await getMethodInventory();
+    const vm = methods.find((m) => m.code === "VM0047");
+    expect(vm).toBeDefined();
+    expect(vm!.ruleCountByVersion["v1-0"]).toBe(11);
+  });
+});


### PR DESCRIPTION
## Scope

Import Verra VM0047 and VM0007 from the real article6-methodologies generated pack. No UI changes, no readiness computation, no rule picker changes.

## Changes

| File | Change |
|---|---|
| `public/manifest/index.json` | Add 69 Verra entries (11 VM0047 + 58 VM0007) with real rule IDs, section IDs, and rule text from source artifacts |
| `config/methodologies_pack.json` | Point to methodologies-pack-afb90934ecf4 (Verra only, no GoldStandard placeholder) |
| `tests/lib/methodInventory.verra.test.ts` | New - 8 acceptance tests |

## Acceptance

- /m lists VM0007 and VM0047 alongside UNFCCC methods
- Verra chip filters correctly
- VM0007 latest version: v1-8, VM0047: v1-0
- VM0007 has 58 rules, VM0047 has 11 rules
- No GS-00XX
- 99 test suites, 504 tests pass
- Typecheck clean, build successful

## Non-goals

- No Method Library UI changes
- No readiness computation
- No rule picker changes
- No badge changes

### Roadmap-Update
- slug: phase-assurance-surface-mvp
- ack: human
- items:
  - PR12: done
