### PR TITLE
Complete Phase 5 — premium PDF wording and design for all registries

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -204,7 +204,7 @@ Lane status: Active
 Wire Verra and Gold Standard into the app through a safe, incremental, standard-aware path. UNFCCC remains unchanged. The app consumes methodology metadata from the pack/manifest. Standard-specific composers come later, after the generic standard-aware path works.
 
 Current focus:
-- Premium PDF wording and design for all registries (Phase 5)
+- QuickCheck standard detection hardening (Phase 6)
 
 Not active now:
 - Verra-specific or Gold Standard-specific report composers
@@ -217,7 +217,7 @@ Not active now:
 3) RC2 — Standard-grouped method picker: Done
 4) RC3 — Project detail registry badge: Done
 5) RC4 — Generic standard-aware export composer: Done
-6) RC5 — Premium PDF wording and design: Planned
+6) RC5 — Premium PDF wording and design: Done
 7) RC6 — QuickCheck standard detection hardening: Planned
 8) RC7 — Standard-specific composers (future): Planned
 
@@ -239,3 +239,4 @@ Not active now:
 - STAC auto-verification (support facts only, not auto-verify)
 - AI-assisted review (post-moat)
 - Multi-methodology cross-referencing (Phase 5+)
+

--- a/docs/roadmaps/standard-registry-wiring/PLAN.md
+++ b/docs/roadmaps/standard-registry-wiring/PLAN.md
@@ -44,7 +44,7 @@ The app does not own, duplicate, or override canonical methodology metadata. If 
 | 2 | Standard-grouped method picker | Done | Picker grouped by standard |
 | 3 | Project detail registry badge | Done | Badge in project header |
 | 4 | Generic standard-aware export composer | Done | Structured report for all registries |
-| 5 | Premium PDF wording and design | Planned | Polished PDF, no stub text |
+| 5 | Premium PDF wording and design | Done | Polished PDF, no stub text |
 | 6 | QuickCheck standard detection hardening | Planned | Context hints in analysis |
 | 7 | Standard-specific composers (future) | Planned | None (doc only) |
 
@@ -490,11 +490,11 @@ Note: This is intentionally generic. Standard-specific sections (e.g. SDG contri
 - Exported PDF for a Verra or Gold Standard project has clean wording: "Verification Readiness Report" or similar — no "fallback", "stub", "not yet implemented", or "v1 limitation" text.
 - PDF reads like a professional deliverable regardless of registry.
 
-**Wording rules:**
-- `registry_not_fully_supported` → maps to "ready" for any known registry
-- `"Truthful fallback: ..."` → remove; use standard readiness language
-- `"full renderer not yet implemented in v1"` → remove; the generic composer is the renderer
-- `"This export is not a full {registry} verification report"` → replace with standard limitation language matching UNFCCC's pattern
+**Implementation notes:**
+- Cover page uses dynamic `report.title` (e.g. "VERRA READINESS REPORT", "UNFCCC VERIFICATION REPORT") with "Readiness Review" subtitle and registry label.
+- Inner page section header shows "READINESS REVIEW" for non-UNFCCC, "VERIFICATION REPORT" for UNFCCC.
+- Footer label varies by registry: "Verification Report" for UNFCCC, "Readiness Review" for others.
+- No debug, internal, or stub wording appears in any registry's PDF output.
 
 ---
 
@@ -542,7 +542,7 @@ Note: This is intentionally generic. Standard-specific sections (e.g. SDG contri
 | Manifest consumption path is stale | Phase 1 was completed — the app correctly consumes the committed manifest | No further action needed; manifest is the SSOT for methodology indexing |
 | Hand-stitched entries may already exist | App could be displaying Verra/GS entries from app-side data, not the pack | Audit the manifest and method loading paths — do not add fake entries; only show what the pack provides |
 | UNFCCC regression in grouped picker | Category grouping inside UNFCCC may change, confusing existing users | UNFCCC remains the first group with the same display format; groups added below it (Phase 2 complete) |
-| PDF output still contains debug text | Professional users see internal messages | Phase 4 removed stub/fallback wording; gate on known registry vs unknown |
+| PDF output still contains debug text | Professional users see internal messages | Phase 5 completed — cover page, header, and footer are registry-aware with premium wording |
 | QuickCheck detection is treated as authoritative | Automatic registry assignment could be wrong | Detection is hints-only; final registry is set during project creation from the manifest provider |
 
 ## Testing strategy
@@ -554,7 +554,7 @@ Note: This is intentionally generic. Standard-specific sections (e.g. SDG contri
 | 2 | 7 unit tests for `groupMethodsByRegistry`: grouping, ordering, sorting, empty, Unknown |
 | 3 | 4 component tests for RegistryBadge rendering (UNFCCC, Verra, Gold Standard, Unknown); existing tests pass unchanged |
 | 4 | Unit + PDF export tests: Verra/GS/Unknown route to generic composer, output includes registry/method/version/category, no stub/fallback wording, UNFCCC unchanged |
-| 5 | PDF snapshot/content tests confirm no stub/debug text; wording audit |
+| 5 | PDF content tests for Verra/Gold Standard readiness report titles, forbidden wording across UNFCCC/Verra/GS, footer label correctness |
 | 6 | Unit tests for all new detection patterns; existing QuickCheck tests pass unchanged |
 | 7 | Review and signoff only |
 

--- a/docs/roadmaps/standard-registry-wiring/phase-status.json
+++ b/docs/roadmaps/standard-registry-wiring/phase-status.json
@@ -11,7 +11,7 @@
     "status": "active",
     "summary": "Wire Verra and Gold Standard into the app through a safe, incremental, standard-aware path. UNFCCC remains unchanged. The app consumes methodology metadata from the pack/manifest. Standard-specific composers come later, after the generic standard-aware path works.",
     "current_focus": [
-      "Premium PDF wording and design for all registries (Phase 5)"
+      "QuickCheck standard detection hardening (Phase 6)"
     ],
     "not_active_now": [
       "Verra-specific or Gold Standard-specific report composers",
@@ -101,7 +101,7 @@
       ]
     },
     "phase_5_premium_pdf_wording_and_design": {
-      "status": "planned",
+      "status": "done",
       "title": "Premium PDF wording and design",
       "repo": "app.article6",
       "description": "Replace fallback/stub wording for Verra and Gold Standard. Use Article6-branded readiness review language. Hide internal/debug language from user-facing PDF output.",

--- a/src/lib/projects/exportPdf.ts
+++ b/src/lib/projects/exportPdf.ts
@@ -125,22 +125,25 @@ const TXT = (x: number, y: number, font: 'F1' | 'FB', size: number, text: string
   'ET',
 ];
 
-function buildCoverPage(project: Project, coverage: ProjectCoverage, now: string): string[] {
+function buildCoverPage(project: Project, coverage: ProjectCoverage, now: string, report: { title: string; registry: string }): string[] {
   const lines: string[] = [];
   const reviewed = coverage.verified + coverage.gap;
   const cx = W / 2;
+  const reportLabel = report.title;
 
   lines.push(...centerText(520, 'FB', 10, 'ARTICLE6', '0.5 0.5 0.5 rg'));
   lines.push(RC(cx - 150, 498, 300, 1, 0.8));
-  lines.push(...centerText(470, 'FB', 24, 'VERIFICATION REPORT', '0.2 0.2 0.2 rg'));
-  lines.push(...centerText(430, 'F1', 12, truncate(project.name, 70), '0.35 0.35 0.35 rg'));
-  lines.push(...TXT(cx - 190, 390, 'F1', 9, `Project ID: ${project.id}`, '0.5 0.5 0.5 rg'));
-  lines.push(...TXT(cx + 10, 390, 'F1', 9, `Findings: ${reviewed} of ${coverage.total} rules reviewed`, '0.5 0.5 0.5 rg'));
-  lines.push(...TXT(cx - 190, 372, 'F1', 9, `Methodology: ${project.methodCode} @ ${project.methodVersion}`, '0.5 0.5 0.5 rg'));
-  lines.push(...TXT(cx + 10, 372, 'F1', 9, `Evidence references: ${project.reviews.reduce((s,r)=>s+r.evidenceIds.length,0)}`, '0.5 0.5 0.5 rg'));
-  lines.push(RC(cx - 150, 350, 300, 1, 0.8));
-  lines.push(...centerText(310, 'F1', 8, `Generated ${now}`, '0.6 0.6 0.6 rg'));
-  lines.push(...centerText(292, 'F1', 8, 'article6.org', '0.6 0.6 0.6 rg'));
+  lines.push(...centerText(470, 'FB', 24, reportLabel, '0.2 0.2 0.2 rg'));
+  lines.push(...centerText(435, 'F1', 11, 'Readiness Review', '0.45 0.45 0.45 rg'));
+  lines.push(RC(cx - 150, 418, 300, 1, 0.8));
+  lines.push(...centerText(400, 'F1', 12, truncate(project.name, 70), '0.35 0.35 0.35 rg'));
+  lines.push(...TXT(cx - 190, 370, 'F1', 9, `Project ID: ${project.id}`, '0.5 0.5 0.5 rg'));
+  lines.push(...TXT(cx + 10, 370, 'F1', 9, `Findings: ${reviewed} of ${coverage.total} rules reviewed`, '0.5 0.5 0.5 rg'));
+  lines.push(...TXT(cx - 190, 352, 'F1', 9, `Methodology: ${project.methodCode} @ ${project.methodVersion}`, '0.5 0.5 0.5 rg'));
+  lines.push(...TXT(cx + 10, 352, 'F1', 9, `Registry: ${report.registry}`, '0.5 0.5 0.5 rg'));
+  lines.push(RC(cx - 150, 330, 300, 1, 0.8));
+  lines.push(...centerText(290, 'F1', 8, `Generated ${now}`, '0.6 0.6 0.6 rg'));
+  lines.push(...centerText(272, 'F1', 8, 'article6.org', '0.6 0.6 0.6 rg'));
   return lines;
 }
 
@@ -203,7 +206,7 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
   {
     const coverLines = isManual
       ? buildManualCoverPage(project, coverage, now, report)
-      : buildCoverPage(project, coverage, now);
+      : buildCoverPage(project, coverage, now, report);
     streams.push(coverLines.join('\n'));
     pg = 1;
   }
@@ -220,10 +223,15 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
     }
     hdr.push(...TXT(R - 26, HEADER_Y, 'F1', 8, `p.${pageNum}`, '0.4 0.4 0.4 rg'));
 
+    const footerLabel = isManual
+      ? 'article6.org | Manual Review Export'
+      : report.registry === 'UNFCCC'
+        ? 'article6.org | Verification Report'
+        : 'article6.org | Readiness Review';
     ln.push(
       LN(FOOTER_Y + 10),
       ...TXT(L, FOOTER_Y, 'F1', 7, `Generated ${now}`, '0.6 0.6 0.6 rg'),
-      ...TXT(R - 120, FOOTER_Y, 'F1', 7, isManual ? 'article6.org | Manual Review Export' : 'article6.org | Verification Report', '0.6 0.6 0.6 rg'),
+      ...TXT(R - 140, FOOTER_Y, 'F1', 7, footerLabel, '0.6 0.6 0.6 rg'),
     );
     streams.push([...hdr, ...ln].join('\n'));
     ln = [];
@@ -261,8 +269,9 @@ export function buildProjectExportPdf(project: Project, coverage: ProjectCoverag
   }
 
   if (!isManual) {
+    const sectionLabel = report.registry === 'UNFCCC' ? 'VERIFICATION REPORT' : 'READINESS REVIEW';
     ln.push(
-      ...TXT(L, y + 20, 'F1', 8, 'VERIFICATION REPORT', LIGHTER),
+      ...TXT(L, y + 20, 'F1', 8, sectionLabel, LIGHTER),
       ...TXT(L, y + 4,  'FB', 18, report.title, DARK),
       ...TXT(L, y - 14, 'F1', 9, truncate(report.subtitle, 84), '0.4 0.4 0.4 rg'),
     );

--- a/tests/api/project.export-pdf.route.test.ts
+++ b/tests/api/project.export-pdf.route.test.ts
@@ -131,6 +131,45 @@ describe('/api/projects/[id]/export-pdf route', () => {
     expect(parsed.text).not.toMatch(/fallback|stub|not yet implemented/i);
   }, 15000);
 
+  it('renders a standard-aware readiness report for Gold Standard projects', async () => {
+    const project = {
+      ...makeProject(),
+      methodCode: 'GS-VER1',
+      registry: 'Gold Standard' as const,
+    };
+    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ project }),
+    });
+    const res = await POST(req);
+    const bytes = await res.arrayBuffer();
+    const parsed = await extractPdfTextWithPdfParse({ bytes });
+
+    expect(parsed.text).toContain('GOLD STANDARD READINESS REPORT');
+    expect(parsed.text).toContain('Registry / Standard: Gold Standard');
+    expect(parsed.text).not.toMatch(/fallback|stub|not yet implemented/i);
+  }, 15000);
+
+  it('does not contain forbidden wording for any registry', async () => {
+    for (const registry of ['UNFCCC' as const, 'Verra' as const, 'Gold Standard' as const]) {
+      const project = {
+        ...makeProject(),
+        registry,
+        methodCode: registry === 'UNFCCC' ? 'AR-AMS0007' : registry === 'Verra' ? 'VM0007' : 'GS-VER1',
+      };
+      const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project }),
+      });
+      const res = await POST(req);
+      const bytes = await res.arrayBuffer();
+      const parsed = await extractPdfTextWithPdfParse({ bytes });
+      expect(parsed.text).not.toMatch(/fallback|stub|not yet implemented|registry_not_fully_supported|composer unavailable/i);
+    }
+  }, 30000);
+
   it('exports manual review mode without methodology code in the header copy', async () => {
     const project: Project = {
       id: 'manual-project-1',


### PR DESCRIPTION
### Roadmap-Update
- slug: standard-registry-wiring
- items:
  - RC0: done
  - RC1: done
  - RC2: done
  - RC3: done
  - RC4: done
  - RC5: done
  - RC6: planned
  - RC7: planned

---

Complete Phase 5 of the `standard-registry-wiring` roadmap.

Premium PDF presentation for all registries. Cover page uses dynamic report.title with "Readiness Review" subtitle and registry label. Inner page header and footer are registry-aware (VERIFICATION REPORT for UNFCCC, READINESS REVIEW for others).

- `src/lib/projects/exportPdf.ts`: dynamic cover title/subtitle, registry-aware headers and footers
- `tests/api/project.export-pdf.route.test.ts`: Gold Standard PDF test, cross-registry forbidden wording test

101 suites, 542 tests pass.

Roadmap: standard-registry-wiring
Roadmap-Item: phase_5_premium_pdf_wording_and_design
SSOT: docs/roadmaps/standard-registry-wiring/phase-status.json