### PR TITLE
Bump pack to afb90934ecf4 + fix Method Library filter reset

### DIFF
--- a/config/methodologies_pack.json
+++ b/config/methodologies_pack.json
@@ -1,5 +1,5 @@
 {
   "repo": "Fredilly/article6-methodologies",
-  "tag": "methodologies-pack-3ea9dc32bfaf",
-  "asset": "methodologies-pack-3ea9dc32bfaf.tar.gz"
+  "tag": "methodologies-pack-afb90934ecf4",
+  "asset": "methodologies-pack-afb90934ecf4.tar.gz"
 }

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -29,11 +29,25 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
   );
   const selectedMethodStandard = selectedMethod ? deriveStandard(selectedMethod.program) : null;
 
-  // User's manual tab choice — only used when no method is selected.
+  // User's manual tab override. On route change (selectedCode), clear it so
+  // the filter re-syncs to the selected method's standard. Manual tab clicks
+  // set the override and win until the next navigation.
+  const [userOverride, setUserOverride] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    return null; // start clean — let selectedMethodStandard or sessionStorage drive
+  });
   const [userTab, setUserTab] = useState<string>(() => {
     if (typeof window === "undefined") return "All";
     return window.sessionStorage.getItem(STANDARD_FILTER_KEY) ?? "All";
   });
+
+  // Clear user override on route change so the method's standard takes effect again.
+  const prevSelectedCode = useRef(selectedCode);
+  useEffect(() => {
+    if (prevSelectedCode.current === selectedCode) return;
+    prevSelectedCode.current = selectedCode;
+    setUserOverride(null);
+  }, [selectedCode]);
 
   // Persist only manual tab choices, not method-forced filters.
   const persistUserTab = useRef(false);
@@ -43,10 +57,9 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
     catch { /* quota exceeded, ignore */ }
   }, [userTab]);
 
-  // The effective filter is driven by the selected method when present.
-  // When no method is selected, the user's manual tab choice applies.
-  // This is derived synchronously — no post-render correction needed.
-  const effectiveStandard = selectedMethodStandard ?? userTab;
+  // The effective filter: user override wins when set; otherwise derive from
+  // the selected method; fall back to user's session-stored tab or All.
+  const effectiveStandard = userOverride ?? selectedMethodStandard ?? userTab;
 
   const filteredMethods = useMemo(() => {
     if (effectiveStandard === "All") return methods;
@@ -95,6 +108,7 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
   const handleTabClick = (s: string) => {
     persistUserTab.current = true;
     setUserTab(s);
+    setUserOverride(s);
   };
 
   return (

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -53,8 +53,18 @@ function useSourceAuditedStatus(methods: MethodInventoryItem[]): Set<string> {
   return audited;
 }
 
+const STANDARD_FILTER_KEY = "a6:methodStandardFilter";
+
 export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibraryPanelProps) {
-  const [standardFilter, setStandardFilter] = useState<string>("All");
+  const [standardFilter, setStandardFilter] = useState<string>(() => {
+    if (typeof window === "undefined") return "All";
+    return window.sessionStorage.getItem(STANDARD_FILTER_KEY) ?? "All";
+  });
+
+  useEffect(() => {
+    try { window.sessionStorage.setItem(STANDARD_FILTER_KEY, standardFilter); }
+    catch { /* quota exceeded, ignore */ }
+  }, [standardFilter]);
 
   const filteredMethods = useMemo(() => {
     if (standardFilter === "All") return methods;

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -57,6 +57,13 @@ const STANDARD_FILTER_KEY = "a6:methodStandardFilter";
 
 export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibraryPanelProps) {
   const [standardFilter, setStandardFilter] = useState<string>(() => {
+    if (selectedCode) {
+      const method = methods.find((m) => m.code === selectedCode);
+      if (method) {
+        const derived = deriveStandard(method.program);
+        if (derived) return derived;
+      }
+    }
     if (typeof window === "undefined") return "All";
     return window.sessionStorage.getItem(STANDARD_FILTER_KEY) ?? "All";
   });

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import MethodCard from "@/app/m/_components/MethodCard";
 import { deriveStandard, isSourceAuditedMeta, metaUrlFromRulesPath } from "@/lib/methodBadge";
 import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
@@ -19,13 +19,46 @@ function deriveMetaUrl(method: MethodInventoryItem): string | null {
   return metaUrlFromRulesPath(path);
 }
 
-function useSourceAuditedStatus(methods: MethodInventoryItem[]): Set<string> {
-  const [audited, setAudited] = useState<Set<string>>(new Set());
+const STANDARD_FILTER_KEY = "a6:methodStandardFilter";
 
+export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibraryPanelProps) {
+  // Derived from selected method — no effect needed, synchronous before first render.
+  const selectedMethod = useMemo(
+    () => (selectedCode ? methods.find((m) => m.code === selectedCode) ?? null : null),
+    [methods, selectedCode],
+  );
+  const selectedMethodStandard = selectedMethod ? deriveStandard(selectedMethod.program) : null;
+
+  // User's manual tab choice — only used when no method is selected.
+  const [userTab, setUserTab] = useState<string>(() => {
+    if (typeof window === "undefined") return "All";
+    return window.sessionStorage.getItem(STANDARD_FILTER_KEY) ?? "All";
+  });
+
+  // Persist only manual tab choices, not method-forced filters.
+  const persistUserTab = useRef(false);
   useEffect(() => {
-    const cancelled = { current: false };
-    setAudited(new Set());
+    if (!persistUserTab.current) return;
+    try { window.sessionStorage.setItem(STANDARD_FILTER_KEY, userTab); }
+    catch { /* quota exceeded, ignore */ }
+  }, [userTab]);
 
+  // The effective filter is driven by the selected method when present.
+  // When no method is selected, the user's manual tab choice applies.
+  // This is derived synchronously — no post-render correction needed.
+  const effectiveStandard = selectedMethodStandard ?? userTab;
+
+  const filteredMethods = useMemo(() => {
+    if (effectiveStandard === "All") return methods;
+    if (!effectiveStandard) return methods;
+    return methods.filter((m) => deriveStandard(m.program) === effectiveStandard);
+  }, [methods, effectiveStandard]);
+
+  // Stable audited status: fetch once per method list, keep previous results while loading.
+  // Using methods (the full list) as key, not filteredMethods, so filter changes don't trigger refetch.
+  const [audited, setAudited] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    let cancelled = false;
     const entries = methods.map((m) => ({ code: m.code, metaUrl: deriveMetaUrl(m) }));
     Promise.all(
       entries.map(async ({ code, metaUrl }) => {
@@ -34,63 +67,35 @@ function useSourceAuditedStatus(methods: MethodInventoryItem[]): Set<string> {
           const res = await fetch(metaUrl);
           if (!res.ok) return null;
           return { code, meta: await res.json() };
-        } catch {
-          return null;
-        }
+        } catch { return null; }
       }),
     ).then((results) => {
-      if (cancelled.current) return;
+      if (cancelled) return;
       const next = new Set<string>();
       for (const r of results) {
         if (r && isSourceAuditedMeta(r.meta)) next.add(r.code);
       }
       setAudited(next);
     });
-
-    return () => { cancelled.current = true; };
+    return () => { cancelled = true; };
   }, [methods]);
 
-  return audited;
-}
-
-const STANDARD_FILTER_KEY = "a6:methodStandardFilter";
-
-export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibraryPanelProps) {
-  const [standardFilter, setStandardFilter] = useState<string>(() => {
-    if (selectedCode) {
-      const method = methods.find((m) => m.code === selectedCode);
-      if (method) {
-        const derived = deriveStandard(method.program);
-        if (derived) return derived;
-      }
-    }
-    if (typeof window === "undefined") return "All";
-    return window.sessionStorage.getItem(STANDARD_FILTER_KEY) ?? "All";
-  });
-
-  useEffect(() => {
-    try { window.sessionStorage.setItem(STANDARD_FILTER_KEY, standardFilter); }
-    catch { /* quota exceeded, ignore */ }
-  }, [standardFilter]);
-
-  const filteredMethods = useMemo(() => {
-    if (standardFilter === "All") return methods;
-    return methods.filter((m) => deriveStandard(m.program) === standardFilter);
-  }, [methods, standardFilter]);
-
-  const sourceAuditedCodes = useSourceAuditedStatus(filteredMethods);
-
   const reviewReady = useMemo(
-    () => filteredMethods.filter((m) => sourceAuditedCodes.has(m.code)),
-    [filteredMethods, sourceAuditedCodes],
+    () => filteredMethods.filter((m) => audited.has(m.code)),
+    [filteredMethods, audited],
   );
 
   const otherMethods = useMemo(
-    () => filteredMethods.filter((m) => !sourceAuditedCodes.has(m.code)),
-    [filteredMethods, sourceAuditedCodes],
+    () => filteredMethods.filter((m) => !audited.has(m.code)),
+    [filteredMethods, audited],
   );
 
-  const allLabel = standardFilter === "All" ? "All methods" : `All ${standardFilter} methods`;
+  const allLabel = effectiveStandard === "All" ? "All methods" : `All ${effectiveStandard} methods`;
+
+  const handleTabClick = (s: string) => {
+    persistUserTab.current = true;
+    setUserTab(s);
+  };
 
   return (
     <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
@@ -112,9 +117,9 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
             <button
               key={s}
               type="button"
-              onClick={() => setStandardFilter(s)}
+              onClick={() => handleTabClick(s)}
               className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
-                standardFilter === s
+                (effectiveStandard === "All" ? "All" : effectiveStandard) === s
                   ? "bg-slate-900 text-white"
                   : "border border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:text-slate-900"
               }`}


### PR DESCRIPTION
### Roadmap-Update
- slug: standard-registry-wiring
- items:
  - RC0: done
  - RC1: done
  - RC2: done
  - RC3: done
  - RC4: done
  - RC5: done
  - RC6: planned
  - RC7: planned

---

Bump the pinned methodology pack to `methodologies-pack-afb90934ecf4` (Verra methods now in the pack). Also fix the Method Library filter resetting to "All" on page navigation.

### Changes

- `config/methodologies_pack.json`: tag → `methodologies-pack-afb90934ecf4`
- `public/manifest/index.json`: regenerated (199 entries, 69 Verra)
- `src/app/m/_components/MethodLibraryPanel.tsx`: persist standard filter in sessionStorage so it survives page navigations between `/m` and `/m/[code]`

### Test results

All 101 test suites pass (542 tests).

Roadmap: standard-registry-wiring
SSOT: docs/roadmaps/standard-registry-wiring/phase-status.json