### PR TITLE
Fix Method Library filter reset on page navigation

### DIFF
--- a/config/methodologies_pack.json
+++ b/config/methodologies_pack.json
@@ -1,5 +1,5 @@
 {
   "repo": "Fredilly/article6-methodologies",
-  "tag": "methodologies-pack-3ea9dc32bfaf",
-  "asset": "methodologies-pack-3ea9dc32bfaf.tar.gz"
+  "tag": "methodologies-pack-afb90934ecf4",
+  "asset": "methodologies-pack-afb90934ecf4.tar.gz"
 }

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -53,8 +53,18 @@ function useSourceAuditedStatus(methods: MethodInventoryItem[]): Set<string> {
   return audited;
 }
 
+const STANDARD_FILTER_KEY = "a6:methodStandardFilter";
+
 export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibraryPanelProps) {
-  const [standardFilter, setStandardFilter] = useState<string>("All");
+  const [standardFilter, setStandardFilter] = useState<string>(() => {
+    if (typeof window === "undefined") return "All";
+    return window.sessionStorage.getItem(STANDARD_FILTER_KEY) ?? "All";
+  });
+
+  useEffect(() => {
+    try { window.sessionStorage.setItem(STANDARD_FILTER_KEY, standardFilter); }
+    catch { /* quota exceeded, ignore */ }
+  }, [standardFilter]);
 
   const filteredMethods = useMemo(() => {
     if (standardFilter === "All") return methods;


### PR DESCRIPTION
### Roadmap-Update
- slug: standard-registry-wiring
- items:
  - RC0: done
  - RC1: done
  - RC2: done
  - RC3: done
  - RC4: done
  - RC5: done
  - RC6: planned
  - RC7: planned

---

Fix the Method Library filter resetting to "All" when navigating between the root methods page and a specific methodology page.

### Root cause

`standardFilter` state in `MethodLibraryPanel` was local `useState("All")` — it re-initialized on every component mount, which happens on every page navigation between `/m` and `/m/[code]`.

### Fix

Persist the selected filter in `sessionStorage` (key `a6:methodStandardFilter`). Restore on mount if present. This matches the existing pattern used by `MethodsFinderShell` for panel collapse state.

No URL param changes. MethodCard links unchanged.

Roadmap: standard-registry-wiring
SSOT: docs/roadmaps/standard-registry-wiring/phase-status.json