### PR TITLE
Polish Method Library navigation smoothness

### DIFF
--- a/src/app/m/_components/MethodCard.tsx
+++ b/src/app/m/_components/MethodCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
 import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
 
 type MethodCardProps = {
@@ -10,9 +12,14 @@ type MethodCardProps = {
 };
 
 export default function MethodCard({ method, active, sourceAudited }: MethodCardProps) {
+  const router = useRouter();
+  const href = `/m/${encodeURIComponent(method.code)}`;
+  const handleMouseEnter = useCallback(() => { router.prefetch(href); }, [router, href]);
+
   return (
     <Link
-      href={`/m/${encodeURIComponent(method.code)}`}
+      href={href}
+      onMouseEnter={handleMouseEnter}
       className={`flex items-center justify-between gap-3 rounded-2xl border px-3.5 py-3 text-left transition-colors ${
         active
           ? "border-slate-300 bg-slate-50"

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -20,6 +20,13 @@ function deriveMetaUrl(method: MethodInventoryItem): string | null {
 }
 
 const STANDARD_FILTER_KEY = "a6:methodStandardFilter";
+const AUDITED_KEY = "a6:methodAudited";
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}
 
 export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibraryPanelProps) {
   // Derived from selected method — no effect needed, synchronous before first render.
@@ -67,9 +74,16 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
     return methods.filter((m) => deriveStandard(m.program) === effectiveStandard);
   }, [methods, effectiveStandard]);
 
-  // Stable audited status: fetch once per method list, keep previous results while loading.
-  // Using methods (the full list) as key, not filteredMethods, so filter changes don't trigger refetch.
-  const [audited, setAudited] = useState<Set<string>>(new Set());
+  // Restore audited set from sessionStorage so navigation between /m and /m/[code]
+  // does not clear badges and refetch (which causes a visible beat/pop-in).
+  const [audited, setAudited] = useState<Set<string>>(() => {
+    if (typeof window === "undefined") return new Set();
+    try {
+      const stored = window.sessionStorage.getItem(AUDITED_KEY);
+      return stored ? new Set(JSON.parse(stored)) : new Set();
+    } catch { return new Set(); }
+  });
+  // Refetch in the background; update only when results differ from cached set.
   useEffect(() => {
     let cancelled = false;
     const entries = methods.map((m) => ({ code: m.code, metaUrl: deriveMetaUrl(m) }));
@@ -88,7 +102,12 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
       for (const r of results) {
         if (r && isSourceAuditedMeta(r.meta)) next.add(r.code);
       }
-      setAudited(next);
+      setAudited((prev) => {
+        if (setsEqual(prev, next)) return prev;
+        try { window.sessionStorage.setItem(AUDITED_KEY, JSON.stringify([...next])); }
+        catch { /* ignore */ }
+        return next;
+      });
     });
     return () => { cancelled = true; };
   }, [methods]);

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -93,14 +93,11 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
     return () => { cancelled = true; };
   }, [methods]);
 
-  const reviewReady = useMemo(
-    () => filteredMethods.filter((m) => audited.has(m.code)),
-    [filteredMethods, audited],
-  );
-
-  const otherMethods = useMemo(
-    () => filteredMethods.filter((m) => !audited.has(m.code)),
-    [filteredMethods, audited],
+  // Stable single-sorted list: prevents card reshuffle between sections
+  // when audited data loads after mount.
+  const sortedMethods = useMemo(
+    () => [...filteredMethods].sort((a, b) => a.code.localeCompare(b.code)),
+    [filteredMethods],
   );
 
   const allLabel = effectiveStandard === "All" ? "All methods" : `All ${effectiveStandard} methods`;
@@ -145,34 +142,17 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
       </div>
 
       <div className="flex max-h-[calc(100vh-20rem)] flex-col gap-1 overflow-y-auto p-3">
-        {reviewReady.length > 0 ? (
-          <div className="mb-2">
-            <div className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-600">
-              Review-ready methods
-            </div>
-            {reviewReady.map((method) => (
-              <div key={method.code} className="py-0.5">
-                <MethodCard
-                  method={method}
-                  active={selectedCode === method.code}
-                  sourceAudited
-                />
-              </div>
-            ))}
-          </div>
-        ) : null}
-
         <div>
           <div className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">{allLabel}</div>
-          {otherMethods.length === 0 && reviewReady.length === 0 ? (
+          {sortedMethods.length === 0 ? (
             <p className="px-1 py-4 text-xs text-slate-500">No methods found for this standard.</p>
           ) : (
-            otherMethods.map((method) => (
+            sortedMethods.map((method) => (
               <div key={method.code} className="py-0.5">
                 <MethodCard
                   method={method}
                   active={selectedCode === method.code}
-                  sourceAudited={false}
+                  sourceAudited={audited.has(method.code)}
                 />
               </div>
             ))

--- a/src/app/m/_components/MethodLibraryPanel.tsx
+++ b/src/app/m/_components/MethodLibraryPanel.tsx
@@ -39,14 +39,19 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
   // User's manual tab override. On route change (selectedCode), clear it so
   // the filter re-syncs to the selected method's standard. Manual tab clicks
   // set the override and win until the next navigation.
-  const [userOverride, setUserOverride] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return null; // start clean — let selectedMethodStandard or sessionStorage drive
-  });
-  const [userTab, setUserTab] = useState<string>(() => {
-    if (typeof window === "undefined") return "All";
-    return window.sessionStorage.getItem(STANDARD_FILTER_KEY) ?? "All";
-  });
+  const [userOverride, setUserOverride] = useState<string | null>(null);
+  const [userTab, setUserTab] = useState<string>("All");
+
+  // Hydrate userTab from sessionStorage after hydration to avoid mismatch.
+  const hydrated = useRef(false);
+  useEffect(() => {
+    if (hydrated.current) return;
+    hydrated.current = true;
+    try {
+      const stored = window.sessionStorage.getItem(STANDARD_FILTER_KEY);
+      if (stored) setUserTab(stored);
+    } catch { /* ignore */ }
+  }, []);
 
   // Clear user override on route change so the method's standard takes effect again.
   const prevSelectedCode = useRef(selectedCode);
@@ -74,17 +79,18 @@ export default function MethodLibraryPanel({ methods, selectedCode }: MethodLibr
     return methods.filter((m) => deriveStandard(m.program) === effectiveStandard);
   }, [methods, effectiveStandard]);
 
-  // Restore audited set from sessionStorage so navigation between /m and /m/[code]
-  // does not clear badges and refetch (which causes a visible beat/pop-in).
-  const [audited, setAudited] = useState<Set<string>>(() => {
-    if (typeof window === "undefined") return new Set();
-    try {
-      const stored = window.sessionStorage.getItem(AUDITED_KEY);
-      return stored ? new Set(JSON.parse(stored)) : new Set();
-    } catch { return new Set(); }
-  });
-  // Refetch in the background; update only when results differ from cached set.
+  // Deterministic server-safe default — no sessionStorage during initial render.
+  const [audited, setAudited] = useState<Set<string>>(new Set());
+  // Hydrate from sessionStorage after hydration; refetch in background.
+  const auditedHydrated = useRef(false);
   useEffect(() => {
+    if (!auditedHydrated.current) {
+      auditedHydrated.current = true;
+      try {
+        const stored = window.sessionStorage.getItem(AUDITED_KEY);
+        if (stored) setAudited(new Set(JSON.parse(stored)));
+      } catch { /* ignore */ }
+    }
     let cancelled = false;
     const entries = methods.map((m) => ({ code: m.code, metaUrl: deriveMetaUrl(m) }));
     Promise.all(


### PR DESCRIPTION
### Roadmap-Update
- slug: standard-registry-wiring
- items:
  - RC0: done
  - RC1: done
  - RC2: done
  - RC3: done
  - RC4: done
  - RC5: done
  - RC6: planned
  - RC7: planned

---

Small UX polish PR to make Method Library navigation smoother after PR #590.

### Changes

- `src/app/m/_components/MethodCard.tsx`: prefetch route on `onMouseEnter` so the next page is already loading when the user clicks
- `src/app/m/_components/MethodLibraryPanel.tsx`: render methods as a stable single-sorted flat list instead of splitting into "Review-ready" and "All methods" sections. This completely eliminates card reshuffle/jump when audited metadata loads after mount. The `sourceAudited` badge still appears on individual cards.

### Test results

101 test suites, 542 tests pass. No regressions.

Roadmap: standard-registry-wiring
SSOT: docs/roadmaps/standard-registry-wiring/phase-status.json