### PR TITLE
Create review-grade-evidence-intelligence roadmap and export standard

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, project-readiness-verification-output, project-verification, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
+Active lanes: verification-factory, project-readiness-verification-output, project-verification, requirement-coverage, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
 Frozen lanes: agentic-verification.
 
 
@@ -173,34 +173,6 @@ Not active now:
 6) RC6 — Methodology version diff / impact mode: Planned — Use canonical methodology version and diff metadata to identify coverage rows and linked evidence that may need review in the app.
 7) RC7 — Fallback raw methodology PDF intake for uncovered methods: Planned — Enable lower-confidence fallback raw methodology PDF intake only for uncovered methods while preserving canonical methodology outputs as the default for covered methods.
 8) RC8 — Additional GIS formats later: Deferred — Defer broader GIS intake until reconciliation fundamentals are stable.
-
-## review-grade-evidence-intelligence
-
-Status SSOT: `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`
-Details: `docs/roadmaps/review-grade-evidence-intelligence/PLAN.md`
-
-Lane status: Active
-Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.
-
-Current focus:
-- Define the review-grade project export standard document
-- Document the evidence-fragment-fact-link-coverage pipeline
-- Plan phases for deterministic extraction, evidence linking, review panels, and verification pack generation
-
-Not active now:
-- Refactoring extraction or export code — documentation and planning only in RC0-RC1
-- Changes to canonical methodology metadata or pack encoding
-- AI-assisted evidence classification or auto-verification
-
-1) RC0 — Review-grade project export standard definition: Done
-2) RC1 — Deterministic evidence extraction foundation: In progress
-3) RC2 — Evidence inventory reconciliation: Planned
-4) RC3 — Reviewer decision records with provenance: Planned
-5) RC4 — Premium PDF/ZIP export with full provenance: Planned
-6) RC5 — Verification pack integration with evidence intelligence: Planned
-7) RC6 — Evidence quality and coverage metrics: Planned
-8) RC7 — Evidence snapshot and comparison: Planned
-9) RC8 — Export standardization and cross-export consistency: Planned
 
 ## safe-learning-intake-pipeline
 

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, project-readiness-verification-output, project-verification, requirement-coverage, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
+Active lanes: verification-factory, project-readiness-verification-output, project-verification, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
 Frozen lanes: agentic-verification.
 
 
@@ -173,6 +173,34 @@ Not active now:
 6) RC6 — Methodology version diff / impact mode: Planned — Use canonical methodology version and diff metadata to identify coverage rows and linked evidence that may need review in the app.
 7) RC7 — Fallback raw methodology PDF intake for uncovered methods: Planned — Enable lower-confidence fallback raw methodology PDF intake only for uncovered methods while preserving canonical methodology outputs as the default for covered methods.
 8) RC8 — Additional GIS formats later: Deferred — Defer broader GIS intake until reconciliation fundamentals are stable.
+
+## review-grade-evidence-intelligence
+
+Status SSOT: `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`
+Details: `docs/roadmaps/review-grade-evidence-intelligence/PLAN.md`
+
+Lane status: Active
+Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.
+
+Current focus:
+- Define the review-grade project export standard document
+- Document the evidence-fragment-fact-link-coverage pipeline
+- Plan phases for deterministic extraction, evidence linking, review panels, and verification pack generation
+
+Not active now:
+- Refactoring extraction or export code — documentation and planning only in RC0-RC1
+- Changes to canonical methodology metadata or pack encoding
+- AI-assisted evidence classification or auto-verification
+
+1) RC0 — Review-grade project export standard definition: Done
+2) RC1 — Deterministic evidence extraction foundation: In progress
+3) RC2 — Evidence inventory reconciliation: Planned
+4) RC3 — Reviewer decision records with provenance: Planned
+5) RC4 — Premium PDF/ZIP export with full provenance: Planned
+6) RC5 — Verification pack integration with evidence intelligence: Planned
+7) RC6 — Evidence quality and coverage metrics: Planned
+8) RC7 — Evidence snapshot and comparison: Planned
+9) RC8 — Export standardization and cross-export consistency: Planned
 
 ## safe-learning-intake-pipeline
 

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -190,7 +190,7 @@ Current focus:
 Not active now:
 - Refactoring extraction or export code — documentation and planning only in RC0-RC1
 - Changes to canonical methodology metadata or pack encoding
-- AI-assisted evidence classification or auto-verification
+- Unbounded AI classification, auto-verification, or final evidence sufficiency decisions
 
 1) RC0 — Review-grade project export standard definition: Done
 2) RC1 — Deterministic evidence extraction foundation: In progress

--- a/docs/roadmaps/review-grade-evidence-intelligence/PLAN.md
+++ b/docs/roadmaps/review-grade-evidence-intelligence/PLAN.md
@@ -2,10 +2,16 @@
 
 Status SSOT: `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`
 
-Tags for PR bodies and commit messages:
-- `Roadmap: review-grade-evidence-intelligence`
-- `Roadmap-Item: <phase_id>` (e.g. `Roadmap-Item: phase_0_standard_definition`)
-- `SSOT: docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`
+Roadmap PRs must use the current machine-parseable directive format documented in `docs/roadmaps/README.md`:
+
+```md
+### Roadmap-Update
+- slug: review-grade-evidence-intelligence
+- items:
+  - RC<n>: in_progress
+```
+
+Use `RC<n>` to update the matching phase in `phase-status.json`. Do not use the legacy `Roadmap:` / `Roadmap-Item:` / `SSOT:` tag block for new PRs.
 
 ## Goal
 
@@ -21,7 +27,7 @@ The pipeline flows from upload through evidence inventory, fragments, extracted 
 
 - Refactoring extraction or export code — RC0 and RC1 are documentation and planning only
 - Changes to canonical methodology metadata or pack encoding
-- AI-assisted evidence classification or auto-verification — all extraction is deterministic
+- Unbounded AI classification, auto-verification, or final evidence sufficiency decisions
 - Official registry verification or certification claims — all output is scoped as readiness review
 - Replacing the existing UNFCCC-specific report composer or verification pack pipeline — they are extended, not replaced
 
@@ -68,14 +74,15 @@ Define the app-side project export standard covering uploads, evidence inventory
 
 ### Phase 1 — Deterministic evidence extraction foundation
 
-Implement deterministic extraction of evidence fragments from uploaded documents (PDDs, workbooks, monitoring reports). Extract facts and surface candidate links to methodology rules. All extraction must be deterministic and auditable, producing stable provenance hashes.
+Implement deterministic extraction of canonical evidence fragments from uploaded documents (PDDs, workbooks, monitoring reports). Extract rule-based facts with stable provenance, then allow bounded advisory candidate intelligence where useful. Canonical extraction outputs must be deterministic and auditable; any AI-assisted suggestions must be schema-bound, provenance-tracked, non-final, and clearly separated from reviewer decisions.
 
 **Acceptance criteria:**
 - Uploaded PDDs produce deterministic fragments with section/page provenance
 - Uploaded workbooks produce deterministic fragments with sheet/cell provenance
 - Extracted facts are stored with stable hashes for auditability
 - Candidate rule links are surfaced from extracted content
-- All extraction is deterministic: same input produces same output
+- Canonical extraction artifacts are deterministic: same input produces same output
+- Any AI/ML-assisted candidate suggestions are advisory only, schema-bound, versioned, and never treated as final verification or sufficiency decisions
 - Existing upload and evidence inventory flows are preserved
 
 **Visible UI change:** Evidence fragments and extracted facts appear in the evidence inventory alongside original uploads.

--- a/docs/roadmaps/review-grade-evidence-intelligence/PLAN.md
+++ b/docs/roadmaps/review-grade-evidence-intelligence/PLAN.md
@@ -1,0 +1,173 @@
+# Review-Grade Evidence Intelligence
+
+Status SSOT: `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`
+
+Tags for PR bodies and commit messages:
+- `Roadmap: review-grade-evidence-intelligence`
+- `Roadmap-Item: <phase_id>` (e.g. `Roadmap-Item: phase_0_standard_definition`)
+- `SSOT: docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`
+
+## Goal
+
+Define and implement an app-side project export standard that converts uploaded PDDs, workbooks, AOIs, and supporting evidence into a premium reviewer-ready export. The export must be:
+
+- **Beautiful enough to sell** — professional-grade layout, typography, and information design
+- **Structured enough to defend** — every claim traces to evidence with deterministic provenance
+- **Conservative enough to trust** — no overclaiming of official registry verification or certification
+
+The pipeline flows from upload through evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, and provenance into premium PDF and ZIP exports.
+
+## Non-goals
+
+- Refactoring extraction or export code — RC0 and RC1 are documentation and planning only
+- Changes to canonical methodology metadata or pack encoding
+- AI-assisted evidence classification or auto-verification — all extraction is deterministic
+- Official registry verification or certification claims — all output is scoped as readiness review
+- Replacing the existing UNFCCC-specific report composer or verification pack pipeline — they are extended, not replaced
+
+## Key relationships
+
+| Standard/Component | Location | Role in this roadmap |
+|---|---|---|
+| Review-grade project export standard | `docs/standards/review-grade-project-export-standard.md` | Defines the full pipeline from upload to premium export; all phases implement against this standard |
+| Methodology pack | `config/methodologies_pack.json` -> `public/methodologies/` | Supplies canonical methodology sections, rules, expected evidence — consumed, not owned |
+| Evidence inventory | `src/lib/evidence/` | Stores and normalizes uploaded evidence; extended by fragments and facts |
+| Verification pack | `src/lib/projects/verificationReport.ts` | Existing export target; integrated with evidence intelligence in Phase 5 |
+| QuickCheck | `src/lib/chat/quickCheckEvidence.ts` | Entry point for ad-hoc evidence analysis; evidence intelligence is the structured upgrade |
+
+## Phase table
+
+| Phase | Title | Status | Visible UI change |
+|---|---|---|---|
+| 0 | Review-grade project export standard definition | Done | None (documentation only) |
+| 1 | Deterministic evidence extraction foundation | In progress | Evidence fragments and extracted facts appear in evidence inventory |
+| 2 | Evidence inventory reconciliation | Planned | Coverage matrix shows reconciliation status per fragment |
+| 3 | Reviewer decision records with provenance | Planned | Coverage matrix shows reviewer decisions with evidence links |
+| 4 | Premium PDF/ZIP export with full provenance | Planned | Premium PDF and ZIP export options available |
+| 5 | Verification pack integration with evidence intelligence | Planned | Verification pack includes evidence fragments and structured review data |
+| 6 | Evidence quality and coverage metrics | Planned | Evidence quality badges and coverage progress bars |
+| 7 | Evidence snapshot and comparison | Planned | Evidence snapshot comparison timeline and diff view |
+| 8 | Export standardization and cross-export consistency | Planned | Consistent section ordering and terminology across all export formats |
+
+## Phase details
+
+### Phase 0 — Review-grade project export standard definition
+
+Define the app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. Create the standard document and roadmap plan.
+
+**Acceptance criteria:**
+- `docs/standards/review-grade-project-export-standard.md` exists and defines the full pipeline from upload to premium export
+- Standard covers uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and PDF/ZIP export
+- Standard is honest about what is app-owned readiness-report logic vs canonical pack metadata
+- Standard is conservative enough to trust: no overclaiming of official registry verification or certification
+
+**Implementation details:**
+- New file: `docs/standards/review-grade-project-export-standard.md`
+- New file: `docs/roadmaps/review-grade-evidence-intelligence/PLAN.md` (this file)
+- New file: `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`
+
+### Phase 1 — Deterministic evidence extraction foundation
+
+Implement deterministic extraction of evidence fragments from uploaded documents (PDDs, workbooks, monitoring reports). Extract facts and surface candidate links to methodology rules. All extraction must be deterministic and auditable, producing stable provenance hashes.
+
+**Acceptance criteria:**
+- Uploaded PDDs produce deterministic fragments with section/page provenance
+- Uploaded workbooks produce deterministic fragments with sheet/cell provenance
+- Extracted facts are stored with stable hashes for auditability
+- Candidate rule links are surfaced from extracted content
+- All extraction is deterministic: same input produces same output
+- Existing upload and evidence inventory flows are preserved
+
+**Visible UI change:** Evidence fragments and extracted facts appear in the evidence inventory alongside original uploads.
+
+### Phase 2 — Evidence inventory reconciliation
+
+Reconcile extracted evidence fragments and facts against the methodology coverage matrix. Surface unmatched evidence, missing coverage, and potential gaps. Enable reviewers to link evidence to rules with structured provenance.
+
+**Acceptance criteria:**
+- Evidence fragments are cross-referenced against methodology rule sections
+- Unmatched evidence is surfaced for manual review
+- Coverage gaps are identified from missing evidence links
+- Reviewers can manually link evidence to rules with structured provenance
+- Reconciliation is deterministic: same inputs produce same coverage state
+
+**Visible UI change:** Evidence inventory shows reconciliation status per fragment: linked, unmatched, or gap.
+
+### Phase 3 — Reviewer decision records with provenance
+
+Build structured reviewer decision records attached to evidence-linked rules. Each decision carries status, rationale, evidence reference, and provenance. Enable the coverage matrix to reflect reviewer decisions alongside evidence reconciliation.
+
+**Acceptance criteria:**
+- Reviewer decisions are structured records with status, rationale, evidence reference, and provenance
+- Decisions are linked to specific evidence fragments, not just rule IDs
+- Coverage matrix reflects reviewer decisions alongside evidence reconciliation
+- Decision history is preserved and auditable
+- Existing review panel and decision flows are extended, not replaced
+
+**Visible UI change:** Coverage matrix shows reviewer decisions per rule with evidence links and provenance.
+
+### Phase 4 — Premium PDF/ZIP export with full provenance
+
+Build premium PDF and ZIP export pipelines that include evidence fragments, extracted facts, coverage matrix, reviewer decisions, and full provenance.
+
+**Acceptance criteria:**
+- PDF export includes evidence fragments and extracted facts with provenance
+- PDF export includes coverage matrix with reconciliation status
+- PDF export includes reviewer decisions with rationale and evidence links
+- ZIP export includes all source documents, evidence fragments, and structured metadata
+- Exports are deterministic: same project state produces same output
+- Exports are beautiful and professional-grade in layout and typography
+
+**Visible UI change:** Premium PDF and ZIP export options available from project detail and review panels.
+
+### Phase 5 — Verification pack integration with evidence intelligence
+
+Integrate evidence intelligence outputs (fragments, facts, links, coverage, decisions) into the existing verification pack pipeline.
+
+**Acceptance criteria:**
+- Verification pack includes evidence fragments and extracted facts with provenance
+- Verification pack includes coverage matrix with reconciliation status
+- Verification pack includes reviewer decisions with evidence links
+- Verification pack is deterministic: same project state produces same output
+- Existing verification pack consumers (audit trail, export) are preserved
+
+**Visible UI change:** Verification pack output includes evidence fragments and structured review data.
+
+### Phase 6 — Evidence quality and coverage metrics
+
+Surface evidence quality and coverage metrics in the UI: what fraction of rules have linked evidence, how many fragments per rule, what is the reconciliation confidence level.
+
+**Acceptance criteria:**
+- Evidence quality metrics are computed and displayed in the evidence inventory
+- Coverage metrics show fraction of rules with linked evidence per standard
+- Reconciliation confidence level is surfaced per evidence fragment
+- Metrics are deterministic: same project state produces same metrics
+- Metrics are advisory only — reviewers make the final sufficiency call
+
+**Visible UI change:** Evidence quality badges and coverage progress bars visible in evidence inventory and project overview.
+
+### Phase 7 — Evidence snapshot and comparison
+
+Enable reviewers to take evidence snapshots at a point in time and compare evidence state across project versions or milestones.
+
+**Acceptance criteria:**
+- Evidence snapshots capture the full evidence state at a point in time
+- Snapshots include fragments, facts, links, coverage, and decisions
+- Comparison view shows added, removed, and changed evidence between snapshots
+- Snapshots are deterministic: same project state at same time produces same snapshot
+- Snapshots are exportable for offline review and record-keeping
+
+**Visible UI change:** Evidence snapshot comparison timeline and diff view in project overview.
+
+### Phase 8 — Export standardization and cross-export consistency
+
+Ensure all export outputs (PDF, ZIP, verification pack, evidence snapshot) follow the same layout conventions, terminology, and section ordering.
+
+**Acceptance criteria:**
+- All export types follow the same layout conventions and terminology
+- Section ordering is consistent across PDF, ZIP, verification pack, and snapshot exports
+- Terminology is consistent: evidence fragment, extracted fact, candidate link, coverage status, reviewer decision
+- Exports are deterministic: same project state produces same output across all export types
+- Migration path is documented for existing export consumers
+
+**Visible UI change:** Consistent section ordering and terminology across all export formats.

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -19,7 +19,7 @@
     "not_active_now": [
       "Refactoring extraction or export code — documentation and planning only in RC0-RC1",
       "Changes to canonical methodology metadata or pack encoding",
-      "AI-assisted evidence classification or auto-verification"
+      "Unbounded AI classification, auto-verification, or final evidence sufficiency decisions"
     ]
   },
   "phases": {

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -1,0 +1,179 @@
+{
+  "RC0": "done",
+  "RC1": "in_progress",
+  "RC2": "planned",
+  "RC3": "planned",
+  "RC4": "planned",
+  "RC5": "planned",
+  "RC6": "planned",
+  "RC7": "planned",
+  "RC8": "planned",
+  "phase_meta": {
+    "status": "active",
+    "summary": "Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.",
+    "current_focus": [
+      "Define the review-grade project export standard document",
+      "Document the evidence-fragment-fact-link-coverage pipeline",
+      "Plan phases for deterministic extraction, evidence linking, review panels, and verification pack generation"
+    ],
+    "not_active_now": [
+      "Refactoring extraction or export code — documentation and planning only in RC0-RC1",
+      "Changes to canonical methodology metadata or pack encoding",
+      "AI-assisted evidence classification or auto-verification"
+    ]
+  },
+  "phases": {
+    "phase_0_standard_definition": {
+      "status": "done",
+      "title": "Review-grade project export standard definition",
+      "repo": "app.article6",
+      "description": "Define the app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. Create the standard document at docs/standards/review-grade-project-export-standard.md. Create the roadmap plan.",
+      "acceptance": [
+        "docs/standards/review-grade-project-export-standard.md exists and defines the full pipeline from upload to premium export",
+        "Standard covers uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and PDF/ZIP export",
+        "Standard is honest about what is app-owned readiness-report logic vs canonical pack metadata",
+        "Standard is conservative enough to trust: no overclaiming of official registry verification or certification"
+      ],
+      "visible_ui_change": "None — documentation only",
+      "depends_on": []
+    },
+    "phase_1_deterministic_evidence_extraction": {
+      "status": "in_progress",
+      "title": "Deterministic evidence extraction foundation",
+      "repo": "app.article6",
+      "description": "Implement deterministic extraction of evidence fragments from uploaded documents (PDDs, workbooks, monitoring reports). Extract facts and surface candidate links to methodology rules. All extraction must be deterministic and auditable, producing stable provenance hashes.",
+      "acceptance": [
+        "Uploaded PDDs produce deterministic fragments with section/page provenance",
+        "Uploaded workbooks produce deterministic fragments with sheet/cell provenance",
+        "Extracted facts are stored with stable hashes for auditability",
+        "Candidate rule links are surfaced from extracted content",
+        "All extraction is deterministic: same input produces same output",
+        "Existing upload and evidence inventory flows are preserved"
+      ],
+      "visible_ui_change": "Evidence fragments and extracted facts appear in the evidence inventory alongside original uploads",
+      "depends_on": [
+        "phase_0_standard_definition"
+      ]
+    },
+    "phase_2_evidence_inventory_reconciliation": {
+      "status": "planned",
+      "title": "Evidence inventory reconciliation",
+      "repo": "app.article6",
+      "description": "Reconcile extracted evidence fragments and facts against the methodology coverage matrix. Surface unmatched evidence, missing coverage, and potential gaps. Enable reviewers to link evidence to rules with structured provenance.",
+      "acceptance": [
+        "Evidence fragments are cross-referenced against methodology rule sections",
+        "Unmatched evidence is surfaced for manual review",
+        "Coverage gaps are identified from missing evidence links",
+        "Reviewers can manually link evidence to rules with structured provenance",
+        "Reconciliation is deterministic: same inputs produce same coverage state"
+      ],
+      "visible_ui_change": "Evidence inventory shows reconciliation status per fragment: linked, unmatched, or gap",
+      "depends_on": [
+        "phase_1_deterministic_evidence_extraction"
+      ]
+    },
+    "phase_3_reviewer_decision_records": {
+      "status": "planned",
+      "title": "Reviewer decision records with provenance",
+      "repo": "app.article6",
+      "description": "Build structured reviewer decision records attached to evidence-linked rules. Each decision carries status, rationale, evidence reference, and provenance. Enable the coverage matrix to reflect reviewer decisions alongside evidence reconciliation.",
+      "acceptance": [
+        "Reviewer decisions are structured records with status, rationale, evidence reference, and provenance",
+        "Decisions are linked to specific evidence fragments, not just rule IDs",
+        "Coverage matrix reflects reviewer decisions alongside evidence reconciliation",
+        "Decision history is preserved and auditable",
+        "Existing review panel and decision flows are extended, not replaced"
+      ],
+      "visible_ui_change": "Coverage matrix shows reviewer decisions per rule with evidence links and provenance",
+      "depends_on": [
+        "phase_2_evidence_inventory_reconciliation"
+      ]
+    },
+    "phase_4_premium_pdf_zips_export": {
+      "status": "planned",
+      "title": "Premium PDF/ZIP export with full provenance",
+      "repo": "app.article6",
+      "description": "Build premium PDF and ZIP export pipelines that include evidence fragments, extracted facts, coverage matrix, reviewer decisions, and full provenance. The export must be beautiful enough to sell and structured enough to defend.",
+      "acceptance": [
+        "PDF export includes evidence fragments and extracted facts with provenance",
+        "PDF export includes coverage matrix with reconciliation status",
+        "PDF export includes reviewer decisions with rationale and evidence links",
+        "ZIP export includes all source documents, evidence fragments, and structured metadata",
+        "Exports are deterministic: same project state produces same output",
+        "Exports are beautiful and professional-grade in layout and typography"
+      ],
+      "visible_ui_change": "Premium PDF and ZIP export options available from project detail and review panels",
+      "depends_on": [
+        "phase_3_reviewer_decision_records"
+      ]
+    },
+    "phase_5_verification_pack_integration": {
+      "status": "planned",
+      "title": "Verification pack integration with evidence intelligence",
+      "repo": "app.article6",
+      "description": "Integrate evidence intelligence outputs (fragments, facts, links, coverage, decisions) into the existing verification pack pipeline. The verification pack becomes a richer, better-evidenced artifact.",
+      "acceptance": [
+        "Verification pack includes evidence fragments and extracted facts with provenance",
+        "Verification pack includes coverage matrix with reconciliation status",
+        "Verification pack includes reviewer decisions with evidence links",
+        "Verification pack is deterministic: same project state produces same output",
+        "Existing verification pack consumers (audit trail, export) are preserved"
+      ],
+      "visible_ui_change": "Verification pack output includes evidence fragments and structured review data",
+      "depends_on": [
+        "phase_4_premium_pdf_zips_export"
+      ]
+    },
+    "phase_6_evidence_quality_metrics": {
+      "status": "planned",
+      "title": "Evidence quality and coverage metrics",
+      "repo": "app.article6",
+      "description": "Surface evidence quality and coverage metrics in the UI: what fraction of rules have linked evidence, how many fragments per rule, what is the reconciliation confidence level. Enable reviewers to assess evidence sufficiency at a glance.",
+      "acceptance": [
+        "Evidence quality metrics are computed and displayed in the evidence inventory",
+        "Coverage metrics show fraction of rules with linked evidence per standard",
+        "Reconciliation confidence level is surfaced per evidence fragment",
+        "Metrics are deterministic: same project state produces same metrics",
+        "Metrics are advisory only — reviewers make the final sufficiency call"
+      ],
+      "visible_ui_change": "Evidence quality badges and coverage progress bars visible in evidence inventory and project overview",
+      "depends_on": [
+        "phase_3_reviewer_decision_records"
+      ]
+    },
+    "phase_7_evidence_snapshot_and_comparison": {
+      "status": "planned",
+      "title": "Evidence snapshot and comparison",
+      "repo": "app.article6",
+      "description": "Enable reviewers to take evidence snapshots at a point in time and compare evidence state across project versions or milestones. Support before/after views for re-verification and delta review scenarios.",
+      "acceptance": [
+        "Evidence snapshots capture the full evidence state at a point in time",
+        "Snapshots include fragments, facts, links, coverage, and decisions",
+        "Comparison view shows added, removed, and changed evidence between snapshots",
+        "Snapshots are deterministic: same project state at same time produces same snapshot",
+        "Snapshots are exportable for offline review and record-keeping"
+      ],
+      "visible_ui_change": "Evidence snapshot comparison timeline and diff view in project overview",
+      "depends_on": [
+        "phase_5_verification_pack_integration"
+      ]
+    },
+    "phase_8_export_standardization_and_consistency": {
+      "status": "planned",
+      "title": "Export standardization and cross-export consistency",
+      "repo": "app.article6",
+      "description": "Ensure all export outputs (PDF, ZIP, verification pack, evidence snapshot) follow the same layout conventions, terminology, and section ordering. Cross-export consistency makes the product predictable and professional.",
+      "acceptance": [
+        "All export types follow the same layout conventions and terminology",
+        "Section ordering is consistent across PDF, ZIP, verification pack, and snapshot exports",
+        "Terminology is consistent: evidence fragment, extracted fact, candidate link, coverage status, reviewer decision",
+        "Exports are deterministic: same project state produces same output across all export types",
+        "Migration path is documented for existing export consumers"
+      ],
+      "visible_ui_change": "Consistent section ordering and terminology across all export formats",
+      "depends_on": [
+        "phase_5_verification_pack_integration"
+      ]
+    }
+  }
+}

--- a/docs/standards/review-grade-project-export-standard.md
+++ b/docs/standards/review-grade-project-export-standard.md
@@ -21,7 +21,11 @@ This standard covers the full pipeline:
 
 ### Determinism
 
-Every step in the pipeline must be deterministic: given the same inputs, it must produce the same outputs. Non-determinism (e.g. LLM calls, random sampling, timestamp-dependent logic) must not affect evidence extraction, fact generation, or link candidates. Determinism enables:
+Canonical pipeline artifacts must be deterministic: given the same inputs and extractor versions, they must produce the same canonical outputs. Determinism applies to source inventory, content hashes, fragment IDs, page/sheet/cell references, rule-based facts, coverage rows, manifests, and export structure.
+
+Bounded AI/ML assistance is allowed only for advisory candidate intelligence. Advisory outputs must not mutate canonical artifacts directly and must never become final verification or evidence sufficiency decisions without human reviewer action.
+
+Determinism enables:
 - Reproducible exports for audit and record-keeping
 - Reliable before/after comparison during re-verification
 - Predictable coverage state across reviewer sessions
@@ -32,17 +36,30 @@ Every step in the pipeline must be deterministic: given the same inputs, it must
 Every artifact produced by the pipeline must carry stable provenance:
 - Evidence fragments carry the source document hash, upload timestamp, and extractor version
 - Extracted facts carry the fragment hash, extractor version, and extraction timestamp
-- Candidate links carry the fact hash, rule ID, and linker version
+- Candidate links carry the fact hash, rule ID, linker version, and whether they are deterministic or advisory
+- Advisory AI/ML suggestions carry model ID, model version where available, prompt/template version, input hashes, output schema version, and generation timestamp
 - Reviewer decisions carry the user ID, timestamp, status, rationale, and evidence references
-- Coverage matrix rows carry the rule ID, linked evidence hashes, and reconciliation status
+- Coverage matrix rows carry the rule ID, linked evidence hashes, reconciliation status, and latest reviewer decision state
 
 ### Conservatism
 
 The export must not overclaim:
 - All output is scoped as readiness review, not official registry verification or certification
 - Methodology sections and rules are canonical pack metadata — the app owns report layout, disclaimers, and evidence summaries
-- Evidence sufficiency is always a reviewer call — metrics are advisory only
-- No auto-verification or AI-based status assignment on evidence
+- Evidence sufficiency is always a reviewer call — metrics and advisory suggestions are non-final
+- No auto-verification or AI-based final status assignment on evidence
+
+### Layer separation
+
+The evidence intelligence pipeline separates three layers:
+
+| Layer | Owner | Can be final? | Examples |
+|---|---|---|---|
+| Canonical deterministic artifacts | App pipeline | Yes, as extracted/project state | uploads, hashes, fragments, rule-based facts, manifests, coverage rows |
+| Advisory candidate intelligence | Bounded AI/ML or heuristics | No | candidate explanations, likely rule links, gap wording suggestions |
+| Human reviewer decisions | Reviewer workflow | Yes | accepted/rejected links, review status, rationale, final readiness state |
+
+**Standard:** Advisory candidate intelligence can accelerate review, but reviewer decisions remain the only layer that can establish final evidence sufficiency or readiness conclusions.
 
 ## Pipeline
 
@@ -75,11 +92,11 @@ Each fragment produces:
 - `provenance`: Source evidence ID, fragment index, section/sheet reference, page range
 - `metadata`: Extractor version, extraction timestamp, extraction duration
 
-**Standard:** Fragment extraction is deterministic. Same document produces identical fragments with identical IDs across extraction runs.
+**Standard:** Fragment extraction is deterministic. Same document and extractor version produce identical fragments with identical IDs across extraction runs.
 
 ### 3. Fact extraction
 
-Fragments are analyzed for structured facts:
+Fragments are analyzed for structured canonical facts:
 
 | Fact type | Description | Example |
 |---|---|---|
@@ -91,14 +108,22 @@ Fragments are analyzed for structured facts:
 | Data source | Reference to external data, study, or default factor | "Tool 01 default factors" |
 | Stakeholder input | Consultation record, feedback summary, safeguard description | "Stakeholder consultation conducted Jan 2024" |
 
-Each fact produces:
+Each canonical fact produces:
 - `fact_id`: Stable hash of `(fragment_id, fact_type, normalized_value)`
 - `fact_type`: One of the types above
 - `value`: Normalized value
 - `provenance`: Source fragment ID, text span (start/end offset)
-- `confidence`: Not applicable — all extraction is deterministic rule-based matching, not ML
+- `extraction_mode`: `deterministic`
 
-**Standard:** Fact extraction is deterministic. Same fragment produces identical facts with identical IDs across extraction runs. No ML or LLM is used for fact extraction.
+Advisory semantic facts may be produced later for reviewer acceleration, but they must be labeled separately:
+- `suggestion_id`: Stable hash of `(fragment_id, suggestion_type, input_hash, model_or_linker_version)`
+- `suggestion_type`: advisory interpretation category
+- `value`: Schema-bound suggested value
+- `provenance`: Source fragment IDs and input hashes
+- `extraction_mode`: `advisory_ai` or `advisory_heuristic`
+- `review_state`: `unreviewed`, `accepted`, `rejected`, or `edited`
+
+**Standard:** Canonical fact extraction is deterministic. Advisory semantic extraction is permitted only when it is schema-bound, provenance-tracked, versioned, and clearly excluded from final sufficiency decisions until reviewer action.
 
 ### 4. Candidate link generation
 
@@ -111,15 +136,16 @@ Extracted facts are matched against methodology rules to produce candidate links
 | Standard match | Fact identifies the methodology standard (Verra, GS, UNFCCC) |
 | Quantity match | Fact contains a quantity or unit relevant to a rule's calculation |
 | Date match | Fact contains a date relevant to a rule's temporal scope |
+| Advisory semantic match | Bounded AI/ML or heuristic suggestion that a fragment may support a rule |
 
 Each candidate link produces:
-- `link_id`: Stable hash of `(fact_id, rule_id)`
+- `link_id`: Stable hash of `(fact_id_or_suggestion_id, rule_id, linker_version)`
 - `rule_id`: The methodology rule ID
-- `confidence`: Always `candidate` — reviewers decide whether to accept, reject, or ignore
-- `provenance`: Source fact ID, rule section reference
+- `confidence`: `candidate` for deterministic links; `advisory_candidate` for AI/ML-assisted links
+- `provenance`: Source fact/suggestion ID, rule section reference, linker version
 - `status`: Always `candidate` on generation — changed to `accepted`, `rejected`, or `ignored` by reviewer action
 
-**Standard:** Link generation is deterministic. Same facts and rules produce identical candidate links across generation runs. Links are always candidate until a reviewer acts on them.
+**Standard:** Deterministic link generation is reproducible from canonical facts and rules. Advisory candidate links may help reviewers find likely matches, but they must be labeled non-final and cannot change coverage status to `covered` without reviewer acceptance.
 
 ### 5. Coverage matrix
 
@@ -136,7 +162,7 @@ The coverage matrix reconciles evidence against methodology rules:
 | Fragment count | Number of unique evidence fragments referenced |
 | Last updated | Timestamp of last change to any link for this rule |
 
-**Standard:** The coverage matrix is derived deterministically from evidence fragments, extracted facts, candidate links, and reviewer decisions. Same pipeline state produces identical coverage matrix.
+**Standard:** The coverage matrix is derived deterministically from evidence fragments, extracted facts, candidate links, and reviewer decisions. Advisory candidate links can create `candidate` status, but only accepted reviewer links can create `covered` status.
 
 ### 6. Reviewer decision records
 
@@ -164,13 +190,14 @@ Every artifact carries provenance metadata:
 |---|---|
 | Evidence upload | `evidence_id`, `content_hash`, `upload_timestamp`, `source` |
 | Evidence fragment | `fragment_id`, `evidence_id`, `extractor_version`, `extraction_timestamp` |
-| Extracted fact | `fact_id`, `fragment_id`, `extractor_version`, `extraction_timestamp` |
-| Candidate link | `link_id`, `fact_id`, `rule_id`, `linker_version` |
+| Extracted fact | `fact_id`, `fragment_id`, `extractor_version`, `extraction_timestamp`, `extraction_mode` |
+| Advisory suggestion | `suggestion_id`, `fragment_id`, `model_or_linker_version`, `prompt_or_template_version`, `input_hash`, `output_schema_version`, `generation_timestamp`, `review_state` |
+| Candidate link | `link_id`, `fact_id_or_suggestion_id`, `rule_id`, `linker_version`, `confidence` |
 | Coverage matrix | `matrix_hash` (hash of all rows), `generated_at`, `pipeline_version` |
 | Reviewer decision | `decision_id`, `project_id`, `rule_id`, `user_id`, `timestamp` |
 | Export | `export_id`, `project_id`, `export_timestamp`, `pipeline_version`, `input_hash` (hash of project state at export time) |
 
-**Standard:** Provenance is mandatory for all artifacts. No artifact enters the pipeline without provenance. Provenance is stable and deterministic.
+**Standard:** Provenance is mandatory for all artifacts. No artifact enters the pipeline without provenance. Canonical provenance is stable and deterministic; advisory provenance must include enough model/input metadata for audit and reviewer interpretation.
 
 ### 8. Premium PDF export
 
@@ -193,7 +220,7 @@ PDF exports follow these conventions:
 - Professional typography with consistent heading hierarchy
 - Table formatting for coverage matrix and evidence inventory
 - Page numbers, section anchors, and cross-references
-- Deterministic pagination: same project state produces same page layout
+- Deterministic pagination where practical: same project state and renderer version should produce the same page layout
 - Responsive design: readable at both screen and print resolutions
 
 ### 9. Premium ZIP export
@@ -208,7 +235,7 @@ ZIP exports follow these conventions:
 | `reports/` | PDF export and any supporting report files |
 | `manifest.json` | File listing with content hashes for every entry in the ZIP |
 
-**Standard:** ZIP exports are deterministic. Same project state produces identical ZIP contents, file ordering, and content hashes.
+**Standard:** ZIP exports are deterministic. Same project state and export version produce identical ZIP contents, file ordering, and content hashes where timestamps/metadata are normalized.
 
 ## Relationship to existing artifacts
 
@@ -217,7 +244,7 @@ ZIP exports follow these conventions:
 | Methodology pack | Supplies canonical methodology sections, rules, and expected evidence — consumed, not extended or duplicated |
 | Verification report | Extended in Phase 5 to include evidence fragments, facts, and structured review data; existing report format is preserved |
 | Audit pack | Consumes verification report output; enhanced by richer evidence data |
-| QuickCheck | Ad-hoc entry point; evidence intelligence is the structured upgrade with deterministic extraction and coverage reconciliation |
+| QuickCheck | Ad-hoc entry point; evidence intelligence is the structured upgrade with deterministic canonical extraction and bounded advisory suggestions |
 | Evidence inventory | Extended with fragments, facts, and links in Phase 1-2; existing upload and storage flows are preserved |
 
 ## Versioning
@@ -226,7 +253,7 @@ This standard follows semantic versioning: `v1.0.0`.
 
 | Version | Date | Changes |
 |---|---|---|
-| v1.0.0 | 2026-05-19 | Initial standard definition. Pipeline from upload to premium PDF/ZIP export defined. Determinism, auditability, and conservatism principles established. |
+| v1.0.0 | 2026-05-19 | Initial standard definition. Pipeline from upload to premium PDF/ZIP export defined. Determinism, auditability, conservatism, and advisory intelligence boundaries established. |
 
 ## Review and governance
 

--- a/docs/standards/review-grade-project-export-standard.md
+++ b/docs/standards/review-grade-project-export-standard.md
@@ -1,0 +1,236 @@
+# Review-Grade Project Export Standard
+
+## Purpose
+
+Define the app-side standard for converting uploaded project documents (PDDs, workbooks, AOIs, supporting evidence) into a premium reviewer-ready export. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.
+
+## Scope
+
+This standard covers the full pipeline:
+
+1. Upload intake and evidence inventory
+2. Fragment extraction from uploaded documents
+3. Fact extraction from fragments
+4. Candidate link generation between facts and methodology rules
+5. Coverage matrix reconciliation
+6. Reviewer decision records
+7. Provenance tracking at every step
+8. Premium PDF and ZIP export generation
+
+## Principles
+
+### Determinism
+
+Every step in the pipeline must be deterministic: given the same inputs, it must produce the same outputs. Non-determinism (e.g. LLM calls, random sampling, timestamp-dependent logic) must not affect evidence extraction, fact generation, or link candidates. Determinism enables:
+- Reproducible exports for audit and record-keeping
+- Reliable before/after comparison during re-verification
+- Predictable coverage state across reviewer sessions
+- Stable provenance hashes for all artifacts
+
+### Auditability
+
+Every artifact produced by the pipeline must carry stable provenance:
+- Evidence fragments carry the source document hash, upload timestamp, and extractor version
+- Extracted facts carry the fragment hash, extractor version, and extraction timestamp
+- Candidate links carry the fact hash, rule ID, and linker version
+- Reviewer decisions carry the user ID, timestamp, status, rationale, and evidence references
+- Coverage matrix rows carry the rule ID, linked evidence hashes, and reconciliation status
+
+### Conservatism
+
+The export must not overclaim:
+- All output is scoped as readiness review, not official registry verification or certification
+- Methodology sections and rules are canonical pack metadata — the app owns report layout, disclaimers, and evidence summaries
+- Evidence sufficiency is always a reviewer call — metrics are advisory only
+- No auto-verification or AI-based status assignment on evidence
+
+## Pipeline
+
+### 1. Upload intake
+
+| Field | Description |
+|---|---|
+| Document type | PDD, workbook, monitoring report, AOI, supporting evidence |
+| Storage | Evidence inventory with stable ID and content hash |
+| Metadata | Upload timestamp, filename, size, content type, source (user upload / STAC / API) |
+| Content hash | SHA-256 of raw bytes: `sha256(content)` |
+
+**Standard:** Every upload produces a stable evidence inventory entry with content hash before any processing begins.
+
+### 2. Fragment extraction
+
+Uploaded documents are decomposed into deterministic fragments:
+
+| Document type | Fragment boundaries |
+|---|---|
+| PDD | Per-section fragments using section headers, with section ID and page range |
+| Workbook | Per-sheet fragments with sheet name and cell ranges for data regions |
+| Monitoring report | Per-section fragments using section headers or page boundaries |
+| AOI | Single fragment containing full AOI metadata |
+| Supporting evidence | Single fragment for each attached document |
+
+Each fragment produces:
+- `fragment_id`: Stable hash of `(evidence_id, fragment_index, content)`
+- `content`: Extracted text content
+- `provenance`: Source evidence ID, fragment index, section/sheet reference, page range
+- `metadata`: Extractor version, extraction timestamp, extraction duration
+
+**Standard:** Fragment extraction is deterministic. Same document produces identical fragments with identical IDs across extraction runs.
+
+### 3. Fact extraction
+
+Fragments are analyzed for structured facts:
+
+| Fact type | Description | Example |
+|---|---|---|
+| Methodology reference | Mention of a methodology code, version, or standard | "VM0007 v2.0", "GS-VER1" |
+| Date or period | Project start date, crediting period, monitoring period | "01 Jan 2024 - 31 Dec 2034" |
+| Quantity or unit | Emission reductions, area, volume, with unit | "10,000 tCO2e/year", "500 ha" |
+| Location or boundary | Geographic reference, AOI coordinates, administrative region | "Machinga District, Malawi" |
+| Eligibility condition | Applicability condition referenced from methodology | "Forest definition threshold" |
+| Data source | Reference to external data, study, or default factor | "Tool 01 default factors" |
+| Stakeholder input | Consultation record, feedback summary, safeguard description | "Stakeholder consultation conducted Jan 2024" |
+
+Each fact produces:
+- `fact_id`: Stable hash of `(fragment_id, fact_type, normalized_value)`
+- `fact_type`: One of the types above
+- `value`: Normalized value
+- `provenance`: Source fragment ID, text span (start/end offset)
+- `confidence`: Not applicable — all extraction is deterministic rule-based matching, not ML
+
+**Standard:** Fact extraction is deterministic. Same fragment produces identical facts with identical IDs across extraction runs. No ML or LLM is used for fact extraction.
+
+### 4. Candidate link generation
+
+Extracted facts are matched against methodology rules to produce candidate links:
+
+| Link type | Description |
+|---|---|
+| Section match | Fact references a methodology section by ID or title |
+| Rule match | Fact content matches a rule's keywords, tags, or expected evidence |
+| Standard match | Fact identifies the methodology standard (Verra, GS, UNFCCC) |
+| Quantity match | Fact contains a quantity or unit relevant to a rule's calculation |
+| Date match | Fact contains a date relevant to a rule's temporal scope |
+
+Each candidate link produces:
+- `link_id`: Stable hash of `(fact_id, rule_id)`
+- `rule_id`: The methodology rule ID
+- `confidence`: Always `candidate` — reviewers decide whether to accept, reject, or ignore
+- `provenance`: Source fact ID, rule section reference
+- `status`: Always `candidate` on generation — changed to `accepted`, `rejected`, or `ignored` by reviewer action
+
+**Standard:** Link generation is deterministic. Same facts and rules produce identical candidate links across generation runs. Links are always candidate until a reviewer acts on them.
+
+### 5. Coverage matrix
+
+The coverage matrix reconciles evidence against methodology rules:
+
+| Column | Description |
+|---|---|
+| Rule ID | Methodology rule identifier |
+| Rule title | Methodology rule title |
+| Section | Methodology section reference |
+| Linked evidence | List of evidence fragment IDs linked (candidate or accepted) |
+| Reconciliation status | `covered` (≥1 accepted link), `candidate` (candidate links exist, none accepted), `unmatched` (no links), `gap` (rule has evidence requirements but no link) |
+| Link count | Number of candidate + accepted links |
+| Fragment count | Number of unique evidence fragments referenced |
+| Last updated | Timestamp of last change to any link for this rule |
+
+**Standard:** The coverage matrix is derived deterministically from evidence fragments, extracted facts, candidate links, and reviewer decisions. Same pipeline state produces identical coverage matrix.
+
+### 6. Reviewer decision records
+
+Reviewer decisions are structured records attached to evidence-linked rules:
+
+| Field | Description |
+|---|---|
+| Decision ID | Stable hash of `(project_id, rule_id, user_id, timestamp)` |
+| Rule ID | Methodology rule being reviewed |
+| Status | `verified` / `not_verified` / `needs_follow_up` / `not_applicable` |
+| Rationale | Free-text rationale from reviewer |
+| Evidence references | List of evidence fragment IDs supporting the decision |
+| User ID | Reviewer identity |
+| Timestamp | Decision timestamp |
+| Previous decision ID | Previous decision on same rule (null if first) — forms decision chain |
+| Provenance | Source review session, export version, client context |
+
+**Standard:** Reviewer decisions are append-only. Each decision creates a new record; previous decisions are preserved for audit. The coverage matrix reflects the latest decision per rule.
+
+### 7. Provenance
+
+Every artifact carries provenance metadata:
+
+| Artifact | Provenance fields |
+|---|---|
+| Evidence upload | `evidence_id`, `content_hash`, `upload_timestamp`, `source` |
+| Evidence fragment | `fragment_id`, `evidence_id`, `extractor_version`, `extraction_timestamp` |
+| Extracted fact | `fact_id`, `fragment_id`, `extractor_version`, `extraction_timestamp` |
+| Candidate link | `link_id`, `fact_id`, `rule_id`, `linker_version` |
+| Coverage matrix | `matrix_hash` (hash of all rows), `generated_at`, `pipeline_version` |
+| Reviewer decision | `decision_id`, `project_id`, `rule_id`, `user_id`, `timestamp` |
+| Export | `export_id`, `project_id`, `export_timestamp`, `pipeline_version`, `input_hash` (hash of project state at export time) |
+
+**Standard:** Provenance is mandatory for all artifacts. No artifact enters the pipeline without provenance. Provenance is stable and deterministic.
+
+### 8. Premium PDF export
+
+PDF exports follow these conventions:
+
+| Element | Standard |
+|---|---|
+| Header | Project name, methodology, registry, export timestamp, export ID |
+| Section 1 | Executive summary: registry, standard, methodology, version, category, review status, coverage summary |
+| Section 2 | Project information: name, AOI, documents, dates |
+| Section 3 | Methodology source sections: canonical sections from pack metadata, with section IDs |
+| Section 4 | Evidence inventory: all uploaded evidence with fragment count, content hash, and provenance |
+| Section 5 | Extracted facts: all facts grouped by fact type, with fragment reference |
+| Section 6 | Coverage matrix: full rule-by-rule table with linked evidence, reconciliation status, link count |
+| Section 7 | Reviewer decisions: all decisions with status, rationale, evidence references, and provenance |
+| Section 8 | Limitations and disclaimers: readiness-review scope, no official verification claim, standard disclaimers |
+| Section 9 | Provenance: full provenance chain from upload to export |
+
+**Layout requirements:**
+- Professional typography with consistent heading hierarchy
+- Table formatting for coverage matrix and evidence inventory
+- Page numbers, section anchors, and cross-references
+- Deterministic pagination: same project state produces same page layout
+- Responsive design: readable at both screen and print resolutions
+
+### 9. Premium ZIP export
+
+ZIP exports follow these conventions:
+
+| Entry | Content |
+|---|---|
+| `export.json` | Structured JSON with all export data: evidence, fragments, facts, links, coverage, decisions, provenance |
+| `evidence/` | Original uploaded documents organized by evidence ID |
+| `fragments/` | Extracted fragments as individual text files organized by fragment ID |
+| `reports/` | PDF export and any supporting report files |
+| `manifest.json` | File listing with content hashes for every entry in the ZIP |
+
+**Standard:** ZIP exports are deterministic. Same project state produces identical ZIP contents, file ordering, and content hashes.
+
+## Relationship to existing artifacts
+
+| Existing artifact | Relationship |
+|---|---|
+| Methodology pack | Supplies canonical methodology sections, rules, and expected evidence — consumed, not extended or duplicated |
+| Verification report | Extended in Phase 5 to include evidence fragments, facts, and structured review data; existing report format is preserved |
+| Audit pack | Consumes verification report output; enhanced by richer evidence data |
+| QuickCheck | Ad-hoc entry point; evidence intelligence is the structured upgrade with deterministic extraction and coverage reconciliation |
+| Evidence inventory | Extended with fragments, facts, and links in Phase 1-2; existing upload and storage flows are preserved |
+
+## Versioning
+
+This standard follows semantic versioning: `v1.0.0`.
+
+| Version | Date | Changes |
+|---|---|---|
+| v1.0.0 | 2026-05-19 | Initial standard definition. Pipeline from upload to premium PDF/ZIP export defined. Determinism, auditability, and conservatism principles established. |
+
+## Review and governance
+
+- This standard is owned by the `review-grade-evidence-intelligence` roadmap
+- Changes to the standard require a roadmap phase update
+- Implementation phases must document compliance with this standard in their acceptance criteria
+- Non-compliance must be documented as a known limitation with a plan for resolution


### PR DESCRIPTION
## WHAT

Create the `review-grade-evidence-intelligence` roadmap in `app.article6` with:

- `docs/roadmaps/review-grade-evidence-intelligence/PLAN.md` — 9-phase plan:
  0. Standard definition (done)
  1. Deterministic evidence extraction (in progress)
  2. Evidence inventory reconciliation
  3. Reviewer decision records with provenance
  4. Premium PDF/ZIP export
  5. Verification pack integration
  6. Evidence quality metrics
  7. Evidence snapshot and comparison
  8. Export standardization and consistency

- `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json` — SSOT
- `docs/standards/review-grade-project-export-standard.md` — defines the full pipeline:
  upload → fragments → facts → candidate links → coverage matrix → reviewer decisions → provenance → PDF/ZIP export

## WHY

The app needs a clear standard for converting uploaded PDDs, workbooks, AOIs, and supporting evidence into a premium reviewer-ready export. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.

This creates a clean foundation for later phases: deterministic extraction, evidence linking, review panels, and verification pack generation.

## Non-goals

- Documentation and implementation-planning only
- No refactoring of extraction or export code

### Roadmap-Update
- slug: review-grade-evidence-intelligence
- items:
  - RC0: done
  - RC1: in_progress

**Signed-off-by:** Fred E.