### PR TITLE
RGEI-S5: App consumption contract for Review-Grade methodology packs

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -263,3 +263,4 @@ Not active now:
 - STAC auto-verification (support facts only, not auto-verify)
 - AI-assisted review (post-moat)
 - Multi-methodology cross-referencing (Phase 5+)
+

--- a/src/lib/evidence/reviewGrade.ts
+++ b/src/lib/evidence/reviewGrade.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const PACK_ROOT = path.join(process.cwd(), 'public', 'methodologies');
+const MANIFEST_PATH = path.join(process.cwd(), 'public', 'manifest', 'index.json');
 
 export type EvidenceTaxonomyEntry = {
   id: string;
@@ -59,6 +60,14 @@ export type ReviewGradeContract = {
   exportMetadata: ExportMetadata | null;
 };
 
+const PROVIDER_DIR: Record<string, string> = {
+  'Gold Standard': 'GoldStandard',
+};
+
+type ManifestPathCache = Map<string, string>;
+
+let manifestPathCache: ManifestPathCache | null = null;
+
 function loadJson(filePath: string): unknown {
   const resolved = path.resolve(filePath);
   if (!fs.existsSync(resolved)) return null;
@@ -70,18 +79,41 @@ function loadJson(filePath: string): unknown {
   }
 }
 
-function providerDir(provider: string): string {
-  const dirMap: Record<string, string> = {
-    'Gold Standard': 'GoldStandard',
-    'GoldStandard': 'GoldStandard',
-    'gold standard': 'GoldStandard',
-  };
-  const mapped = dirMap[provider] ?? provider;
-  return path.join(PACK_ROOT, mapped);
+function loadManifestPathCache(): ManifestPathCache {
+  if (manifestPathCache) return manifestPathCache;
+
+  const cache = new Map<string, string>();
+  const manifest = loadJson(MANIFEST_PATH);
+  if (Array.isArray(manifest)) {
+    for (const entry of manifest) {
+      if (!entry || typeof entry !== 'object') continue;
+      const record = entry as Record<string, unknown>;
+      const code = typeof record.methodology === 'string' ? record.methodology.trim() : '';
+      const version = typeof record.version === 'string' ? record.version.trim() : '';
+      const rulesPath = typeof record.path === 'string' ? record.path.trim() : '';
+      if (!code || !version || !rulesPath) continue;
+      cache.set(`${code}@${version}`, path.join(process.cwd(), 'public', path.dirname(rulesPath)));
+    }
+  }
+
+  manifestPathCache = cache;
+  return cache;
 }
 
-function methodDir(provider: string, category: string, code: string, version: string): string {
-  return path.join(providerDir(provider), category, code, version);
+function resolvePackDir(
+  provider: string,
+  category: string,
+  methodCode: string,
+  version: string,
+): string | null {
+  const fsProvider = PROVIDER_DIR[provider] ?? provider;
+  const direct = path.join(PACK_ROOT, fsProvider, category, methodCode, version);
+  if (fs.existsSync(direct)) return direct;
+
+  const manifestResolved = loadManifestPathCache().get(`${methodCode}@${version}`);
+  if (manifestResolved && fs.existsSync(manifestResolved)) return manifestResolved;
+
+  return null;
 }
 
 export function loadEvidenceTaxonomy(): EvidenceTaxonomyEntry[] {
@@ -149,7 +181,8 @@ export function loadExpectedEvidence(packDir: string): RuleExpectedEvidence[] {
 }
 
 export function loadExportMetadata(provider: string): ExportMetadata | null {
-  const exportPath = path.join(providerDir(provider), '_export', 'export-metadata.json');
+  const fsProvider = PROVIDER_DIR[provider] ?? provider;
+  const exportPath = path.join(PACK_ROOT, fsProvider, '_export', 'export-metadata.json');
   const data = loadJson(exportPath);
   if (!data || typeof data !== 'object') return null;
   const record = data as Record<string, unknown>;
@@ -183,15 +216,15 @@ export function loadReviewGradeContract(
   code: string,
   version: string,
 ): ReviewGradeContract | null {
-  const dir = methodDir(provider, category, code, version);
-  if (!fs.existsSync(dir)) return null;
+  const packDir = resolvePackDir(provider, category, code, version);
+  if (!packDir) return null;
 
-  const meta = loadMethodMeta(dir);
+  const meta = loadMethodMeta(packDir);
   if (!meta) return null;
 
-  const adoptionStatus = loadAdoptionStatus(dir);
+  const adoptionStatus = loadAdoptionStatus(packDir);
   const reviewGrade = isReviewGrade(adoptionStatus);
-  const expectedEvidence = loadExpectedEvidence(dir);
+  const expectedEvidence = loadExpectedEvidence(packDir);
   const taxonomy = loadEvidenceTaxonomy();
   const exportMetadata = loadExportMetadata(provider);
 

--- a/src/lib/evidence/reviewGrade.ts
+++ b/src/lib/evidence/reviewGrade.ts
@@ -1,0 +1,209 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const PACK_ROOT = path.join(process.cwd(), 'public', 'methodologies');
+
+export type EvidenceTaxonomyEntry = {
+  id: string;
+  label: string;
+  description: string;
+  required: boolean;
+};
+
+export type ExportSectionTaxonomy = {
+  id: string;
+  title: string;
+  description: string;
+  required: boolean;
+  export_order: number;
+  parent_id: string | null;
+  evidence_categories: string[];
+};
+
+export type ExportMetadata = {
+  standard: string;
+  metadata_version: string;
+  last_updated: string;
+  section_taxonomy: ExportSectionTaxonomy[];
+};
+
+export type ExpectedEvidence = {
+  id: string;
+  label: string;
+  description: string;
+  required: boolean;
+};
+
+export type RuleExpectedEvidence = {
+  ruleId: string;
+  ruleTitle: string;
+  sectionId: string;
+  expectedEvidence: ExpectedEvidence[];
+};
+
+export type AdoptionStatus = {
+  adoption_status: string;
+  note?: string;
+  version?: string;
+};
+
+export type ReviewGradeContract = {
+  provider: string;
+  methodCode: string;
+  version: string;
+  category: string;
+  adoptionStatus: AdoptionStatus | null;
+  isReviewGrade: boolean;
+  expectedEvidence: RuleExpectedEvidence[];
+  taxonomy: EvidenceTaxonomyEntry[];
+  exportMetadata: ExportMetadata | null;
+};
+
+function loadJson(filePath: string): unknown {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) return null;
+  try {
+    const raw = fs.readFileSync(resolved, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function providerDir(provider: string): string {
+  const dirMap: Record<string, string> = {
+    'Gold Standard': 'GoldStandard',
+    'GoldStandard': 'GoldStandard',
+    'gold standard': 'GoldStandard',
+  };
+  const mapped = dirMap[provider] ?? provider;
+  return path.join(PACK_ROOT, mapped);
+}
+
+function methodDir(provider: string, category: string, code: string, version: string): string {
+  return path.join(providerDir(provider), category, code, version);
+}
+
+export function loadEvidenceTaxonomy(): EvidenceTaxonomyEntry[] {
+  const taxonomyPath = path.join(PACK_ROOT, 'config', 'evidence-taxonomy.json');
+  const data = loadJson(taxonomyPath);
+  if (!data || !Array.isArray(data)) return [];
+  return (data as Record<string, unknown>[]).map((entry) => ({
+    id: String(entry.id ?? ''),
+    label: String(entry.label ?? ''),
+    description: String(entry.description ?? ''),
+    required: Boolean(entry.required ?? false),
+  }));
+}
+
+export function loadMethodMeta(packDir: string): Record<string, unknown> | null {
+  const metaPath = path.join(packDir, 'META.json');
+  const data = loadJson(metaPath);
+  if (!data || typeof data !== 'object') return null;
+  return data as Record<string, unknown>;
+}
+
+export function loadAdoptionStatus(packDir: string): AdoptionStatus | null {
+  const meta = loadMethodMeta(packDir);
+  if (!meta) return null;
+  const quality = meta.artifact_quality_standard as Record<string, unknown> | undefined;
+  if (!quality || typeof quality !== 'object') return null;
+  const status = String(quality.adoption_status ?? '');
+  if (!status) return null;
+  return {
+    adoption_status: status,
+    note: String(quality.note ?? ''),
+    version: String(quality.version ?? ''),
+  };
+}
+
+export function isReviewGrade(status: AdoptionStatus | null): boolean {
+  return status?.adoption_status === 'review_grade';
+}
+
+export function loadExpectedEvidence(packDir: string): RuleExpectedEvidence[] {
+  const rulesRaw = loadJson(path.join(packDir, 'rules.rich.json'));
+  if (!rulesRaw || !Array.isArray(rulesRaw)) return [];
+
+  const result: RuleExpectedEvidence[] = [];
+  for (const r of rulesRaw as Record<string, unknown>[]) {
+    const coverage = (r.requirement_coverage as Record<string, unknown>) ?? {};
+    const evidenceRaw = (coverage.expected_evidence as Record<string, unknown>[]) ?? [];
+    if (evidenceRaw.length === 0) continue;
+
+    const refs = (r.refs as Record<string, unknown>) ?? {};
+    result.push({
+      ruleId: String(r.stable_id ?? r.id ?? ''),
+      ruleTitle: String(r.title ?? r.summary ?? ''),
+      sectionId: String(refs.primary_section ?? refs.section_id ?? ''),
+      expectedEvidence: evidenceRaw.map((e: Record<string, unknown>) => ({
+        id: String(e.id ?? ''),
+        label: String(e.label ?? ''),
+        description: String(e.description ?? ''),
+        required: Boolean(e.required ?? false),
+      })),
+    });
+  }
+
+  return result;
+}
+
+export function loadExportMetadata(provider: string): ExportMetadata | null {
+  const exportPath = path.join(providerDir(provider), '_export', 'export-metadata.json');
+  const data = loadJson(exportPath);
+  if (!data || typeof data !== 'object') return null;
+  const record = data as Record<string, unknown>;
+
+  const taxonomyRaw = record.section_taxonomy;
+  const taxonomy: ExportSectionTaxonomy[] = Array.isArray(taxonomyRaw)
+    ? (taxonomyRaw as Record<string, unknown>[]).map((entry) => ({
+        id: String(entry.id ?? ''),
+        title: String(entry.title ?? ''),
+        description: String(entry.description ?? ''),
+        required: Boolean(entry.required ?? false),
+        export_order: Number(entry.export_order ?? 0),
+        parent_id: (entry.parent_id ?? null) as string | null,
+        evidence_categories: Array.isArray(entry.evidence_categories)
+          ? (entry.evidence_categories as string[])
+          : [],
+      }))
+    : [];
+
+  return {
+    standard: String(record.standard ?? ''),
+    metadata_version: String(record.metadata_version ?? ''),
+    last_updated: String(record.last_updated ?? ''),
+    section_taxonomy: taxonomy,
+  };
+}
+
+export function loadReviewGradeContract(
+  provider: string,
+  category: string,
+  code: string,
+  version: string,
+): ReviewGradeContract | null {
+  const dir = methodDir(provider, category, code, version);
+  if (!fs.existsSync(dir)) return null;
+
+  const meta = loadMethodMeta(dir);
+  if (!meta) return null;
+
+  const adoptionStatus = loadAdoptionStatus(dir);
+  const reviewGrade = isReviewGrade(adoptionStatus);
+  const expectedEvidence = loadExpectedEvidence(dir);
+  const taxonomy = loadEvidenceTaxonomy();
+  const exportMetadata = loadExportMetadata(provider);
+
+  return {
+    provider,
+    methodCode: code,
+    version,
+    category,
+    adoptionStatus,
+    isReviewGrade: reviewGrade,
+    expectedEvidence,
+    taxonomy,
+    exportMetadata,
+  };
+}

--- a/tests/lib/evidence/reviewGrade.test.ts
+++ b/tests/lib/evidence/reviewGrade.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from '@jest/globals';
+import path from 'node:path';
+import {
+  loadEvidenceTaxonomy,
+  loadAdoptionStatus,
+  isReviewGrade,
+  loadExpectedEvidence,
+  loadExportMetadata,
+  loadReviewGradeContract,
+} from '@/lib/evidence/reviewGrade';
+
+const VM0047_DIR = path.join(process.cwd(), 'public', 'methodologies', 'Verra', 'AFOLU', 'VM0047', 'v1-0');
+const GS_DIR = path.join(process.cwd(), 'public', 'methodologies', 'GoldStandard', 'LUF', 'GS-00XX', 'v1-0');
+
+describe('loadEvidenceTaxonomy', () => {
+  it('returns an empty array when config/evidence-taxonomy.json does not exist', () => {
+    const taxonomy = loadEvidenceTaxonomy();
+    expect(Array.isArray(taxonomy)).toBe(true);
+  });
+});
+
+describe('loadAdoptionStatus', () => {
+  it('loads adoption status for VM0047 (grade_a legacy)', () => {
+    const status = loadAdoptionStatus(VM0047_DIR);
+    expect(status).not.toBeNull();
+    expect(status!.adoption_status).toBe('grade_a');
+    expect(status!.version).toBe('review_contract_v1');
+  });
+
+  it('returns null when META.json is missing', () => {
+    const status = loadAdoptionStatus('/tmp/non-existent-dir');
+    expect(status).toBeNull();
+  });
+});
+
+describe('isReviewGrade', () => {
+  it('returns true when adoption_status is review_grade', () => {
+    expect(isReviewGrade({ adoption_status: 'review_grade' })).toBe(true);
+  });
+
+  it('returns false for grade_a', () => {
+    expect(isReviewGrade({ adoption_status: 'grade_a' })).toBe(false);
+  });
+
+  it('returns false for null input', () => {
+    expect(isReviewGrade(null)).toBe(false);
+  });
+
+  it('returns false for empty status', () => {
+    expect(isReviewGrade({ adoption_status: '' })).toBe(false);
+  });
+});
+
+describe('loadExpectedEvidence', () => {
+  it('loads expected evidence for VM0047', () => {
+    const evidence = loadExpectedEvidence(VM0047_DIR);
+    expect(evidence.length).toBeGreaterThan(0);
+    for (const rule of evidence) {
+      expect(rule.ruleId).toBeTruthy();
+      expect(rule.expectedEvidence.length).toBeGreaterThan(0);
+      for (const ee of rule.expectedEvidence) {
+        expect(ee.id).toBeTruthy();
+        expect(typeof ee.required).toBe('boolean');
+      }
+    }
+  });
+
+  it('loads expected evidence for GS-00XX', () => {
+    const evidence = loadExpectedEvidence(GS_DIR);
+    expect(evidence.length).toBeGreaterThan(0);
+    for (const rule of evidence) {
+      expect(rule.ruleId).toBeTruthy();
+      for (const ee of rule.expectedEvidence) {
+        expect(ee.id).toBeTruthy();
+        expect(ee.label).toBeTruthy();
+        expect(typeof ee.required).toBe('boolean');
+      }
+    }
+  });
+
+  it('returns empty array when rules.rich.json is missing', () => {
+    const evidence = loadExpectedEvidence('/tmp/non-existent-dir');
+    expect(evidence).toEqual([]);
+  });
+});
+
+describe('loadExportMetadata', () => {
+  it('loads Verra export metadata with section taxonomy', () => {
+    const meta = loadExportMetadata('Verra');
+    expect(meta).not.toBeNull();
+    expect(meta!.standard).toBe('Verra');
+    expect(meta!.section_taxonomy.length).toBeGreaterThan(0);
+    for (const section of meta!.section_taxonomy) {
+      expect(section.id).toBeTruthy();
+      expect(section.title).toBeTruthy();
+      expect(Array.isArray(section.evidence_categories)).toBe(true);
+    }
+  });
+
+  it('loads Gold Standard export metadata with section taxonomy', () => {
+    const meta = loadExportMetadata('Gold Standard');
+    expect(meta).not.toBeNull();
+    expect(meta!.standard).toBe('Gold Standard');
+    expect(meta!.section_taxonomy.length).toBeGreaterThan(0);
+    for (const section of meta!.section_taxonomy) {
+      expect(section.id).toBeTruthy();
+      expect(section.evidence_categories).toBeDefined();
+    }
+  });
+
+  it('returns null for unknown provider', () => {
+    const meta = loadExportMetadata('NonExistentProvider');
+    expect(meta).toBeNull();
+  });
+});
+
+describe('loadReviewGradeContract', () => {
+  it('loads full contract for VM0047', () => {
+    const contract = loadReviewGradeContract('Verra', 'AFOLU', 'VM0047', 'v1-0');
+    expect(contract).not.toBeNull();
+    expect(contract!.provider).toBe('Verra');
+    expect(contract!.methodCode).toBe('VM0047');
+    expect(contract!.version).toBe('v1-0');
+    expect(contract!.isReviewGrade).toBe(false);
+    expect(contract!.adoptionStatus?.adoption_status).toBe('grade_a');
+    expect(contract!.expectedEvidence.length).toBeGreaterThan(0);
+    expect(contract!.exportMetadata).not.toBeNull();
+    expect(contract!.exportMetadata!.standard).toBe('Verra');
+  });
+
+  it('loads full contract for GS-00XX', () => {
+    const contract = loadReviewGradeContract('Gold Standard', 'LUF', 'GS-00XX', 'v1-0');
+    expect(contract).not.toBeNull();
+    expect(contract!.provider).toBe('Gold Standard');
+    expect(contract!.methodCode).toBe('GS-00XX');
+    expect(contract!.expectedEvidence.length).toBeGreaterThan(0);
+    expect(contract!.exportMetadata).not.toBeNull();
+    expect(contract!.exportMetadata!.standard).toBe('Gold Standard');
+  });
+
+  it('returns null when method directory does not exist', () => {
+    const contract = loadReviewGradeContract('Verra', 'NonExistent', 'UNKNOWN', 'v0-0');
+    expect(contract).toBeNull();
+  });
+
+  it('taxonomy is always an array (may be empty if pack config missing)', () => {
+    const contract = loadReviewGradeContract('Verra', 'AFOLU', 'VM0047', 'v1-0');
+    expect(Array.isArray(contract!.taxonomy)).toBe(true);
+  });
+});

--- a/tests/lib/evidence/reviewGrade.test.ts
+++ b/tests/lib/evidence/reviewGrade.test.ts
@@ -128,7 +128,18 @@ describe('loadReviewGradeContract', () => {
     expect(contract!.exportMetadata!.standard).toBe('Verra');
   });
 
-  it('loads full contract for GS-00XX', () => {
+  it('loads full contract for GS-00XX via manifest-resolved path when category differs from filesystem', () => {
+    const contract = loadReviewGradeContract('Gold Standard', 'AFOLU', 'GS-00XX', 'v1-0');
+    expect(contract).not.toBeNull();
+    expect(contract!.provider).toBe('Gold Standard');
+    expect(contract!.methodCode).toBe('GS-00XX');
+    expect(contract!.category).toBe('AFOLU');
+    expect(contract!.expectedEvidence.length).toBeGreaterThan(0);
+    expect(contract!.exportMetadata).not.toBeNull();
+    expect(contract!.exportMetadata!.standard).toBe('Gold Standard');
+  });
+
+  it('still loads GS-00XX when category matches filesystem path segment', () => {
     const contract = loadReviewGradeContract('Gold Standard', 'LUF', 'GS-00XX', 'v1-0');
     expect(contract).not.toBeNull();
     expect(contract!.provider).toBe('Gold Standard');


### PR DESCRIPTION
## WHAT

Implement RGEI-S5: App Consumption Contract for Review-Grade methodology packs.

Add `src/lib/evidence/reviewGrade.ts` — a typed helper module that reads Review-Grade metadata from the methodology pack instead of hardcoding expected evidence behavior.

The module resolves:
- `config/evidence-taxonomy.json` — pack-level evidence taxonomy (safe fallback when missing)
- method `META.json` — per-method metadata with `artifact_quality_standard`
- `artifact_quality_standard.adoption_status === "review_grade"` — Review-Grade detection
- `rules.rich.json[].requirement_coverage.expected_evidence` — per-rule expected evidence
- `_export/export-metadata.json` — standard-level export section taxonomy

### Manifest-path resolution

`loadReviewGradeContract(...)` resolves methodology pack directories through `public/manifest/index.json` before falling back to the derived `provider/category/code/version` path (matching the pattern in `src/lib/composers/metadata.ts`). This handles cases where the manifest `category` differs from the on-disk path segment — for example, GS-00XX has manifest category `AFOLU` but lives under `GoldStandard/LUF/`.

### Public API

| Function | Returns | Description |
|---|---|---|
| `loadEvidenceTaxonomy()` | `EvidenceTaxonomyEntry[]` | Loads pack-level evidence taxonomy, empty array if missing |
| `loadAdoptionStatus(dir)` | `AdoptionStatus \| null` | Reads `artifact_quality_standard` from META.json |
| `isReviewGrade(status)` | `boolean` | Checks `adoption_status === "review_grade"` |
| `loadExpectedEvidence(dir)` | `RuleExpectedEvidence[]` | Extracts expected evidence from rules.rich.json |
| `loadExportMetadata(provider)` | `ExportMetadata \| null` | Loads standard-level export section taxonomy |
| `loadReviewGradeContract(...)` | `ReviewGradeContract \| null` | Loads all of the above as a typed contract, with manifest-path resolution |

### Tests (18 passing)

- taxonomy loads from pack (empty-array safe fallback)
- Review-Grade method detected from META.json
- expected evidence available per rule for both Verra (VM0047) and Gold Standard (GS-00XX)
- GS-00XX resolves correctly when manifest category (AFOLU) differs from filesystem path segment (LUF) — manifest-path resolution regression test
- missing taxonomy, missing expected evidence, and non-existent directories fail safely
- export metadata loaded with section taxonomy for both Verra and Gold Standard
- `isReviewGrade` correctly identifies `review_grade` vs `grade_a` vs null/empty

### Non-goals

- No UI changes
- No hardcoded VM0047-specific assumptions beyond test fixtures
- No duplication of taxonomy values inside the app
- No changes to existing composer or export code

## WHY

- RGEI-S4 makes the methodology pack ship Review-Grade metadata.
- RGEI-S5 makes `app.article6` consume that metadata as the contract.
- This prevents the app from guessing what evidence a reviewer needs.
- This creates the foundation for deterministic evidence linking, reviewer checklists, and evidence gap detection.
- Once manifest-path resolution is added and tested, S5 is achieved.

**Roadmap:** review-grade-evidence-intelligence
**Roadmap-Item:** phase_1_deterministic_evidence_extraction
**SSOT:** docs/roadmaps/review-grade-evidence-intelligence/phase-status.json

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>