### PR TITLE
feat(rc4): premium PDF/ZIP export with full provenance

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -183,7 +183,7 @@ Lane status: Active
 Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.
 
 Current focus:
-- Build premium PDF export pipeline with full provenance (Phase 4)
+- Complete premium PDF/ZIP export with full provenance (Phase 4)
 - Cover Quick Check extraction edge case tests
 - Responsive UI QA for reconciliation and decision badges
 
@@ -196,7 +196,7 @@ Not active now:
 2) RC1 — Deterministic evidence extraction foundation: Done
 3) RC2 — Evidence inventory reconciliation: Done
 4) RC3 — Reviewer decision records with provenance: Done
-5) RC4 — Premium PDF/ZIP export with full provenance: Planned
+5) RC4 — Premium PDF/ZIP export with full provenance: In progress
 6) RC5 — Verification pack integration with evidence intelligence: Planned
 7) RC6 — Evidence quality and coverage metrics: Planned
 8) RC7 — Evidence snapshot and comparison: Planned

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -3,7 +3,7 @@
   "RC1": "done",
   "RC2": "done",
   "RC3": "done",
-  "RC4": "planned",
+  "RC4": "in_progress",
   "RC5": "planned",
   "RC6": "planned",
   "RC7": "planned",
@@ -12,7 +12,7 @@
     "status": "active",
     "summary": "Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.",
     "current_focus": [
-      "Build premium PDF export pipeline with full provenance (Phase 4)",
+      "Complete premium PDF/ZIP export with full provenance (Phase 4)",
       "Cover Quick Check extraction edge case tests",
       "Responsive UI QA for reconciliation and decision badges"
     ],
@@ -100,7 +100,7 @@
       ]
     },
     "phase_4_premium_pdf_zips_export": {
-      "status": "planned",
+      "status": "in_progress",
       "title": "Premium PDF/ZIP export with full provenance",
       "repo": "app.article6",
       "description": "Build premium PDF and ZIP export pipelines that include evidence fragments, extracted facts, coverage matrix, reviewer decisions, and full provenance. The export must be beautiful enough to sell and structured enough to defend.",

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -115,6 +115,9 @@
       "visible_ui_change": "Premium PDF and ZIP export options available from project detail and review panels",
       "depends_on": [
         "phase_3_reviewer_decision_records"
+      ],
+      "prs": [
+        612
       ]
     },
     "phase_5_verification_pack_integration": {

--- a/src/app/api/projects/[id]/export-premium/route.ts
+++ b/src/app/api/projects/[id]/export-premium/route.ts
@@ -1,0 +1,87 @@
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { buildPremiumPdf, buildPremiumZip } from '@/lib/evidence/export';
+import type { PremiumExportInput } from '@/lib/evidence/export';
+import type { Project, ProjectCoverage } from '@/lib/projects/types';
+import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
+import type { SourceDocument, DocumentFragment, ExtractedFact, CandidateLink } from '@/lib/evidence/extraction/types';
+import type { ReconciliationRun } from '@/lib/evidence/reconciliation/types';
+import type { DecisionRun } from '@/lib/evidence/decisions/types';
+
+async function handlePost(request: Request) {
+  try {
+    const body = await request.json();
+    const project = body.project as Project | undefined;
+    const format = body.format as string | undefined; // 'pdf' | 'zip' | 'both'
+
+    if (!project) {
+      return NextResponse.json({ error: 'Missing project data' }, { status: 400 });
+    }
+
+    const coverage = body.coverage as ProjectCoverage | undefined;
+    const inventory = (body.inventory ?? []) as EvidenceInventoryItem[];
+    const sources = (body.sources ?? []) as SourceDocument[];
+    const fragments = (body.fragments ?? []) as DocumentFragment[];
+    const facts = (body.facts ?? []) as ExtractedFact[];
+    const candidateLinks = (body.candidateLinks ?? []) as CandidateLink[];
+    const reconciliationRun = body.reconciliationRun as ReconciliationRun | undefined;
+    const decisionRun = body.decisionRun as DecisionRun | undefined;
+
+    const safeCoverage: ProjectCoverage = coverage ?? {
+      total: project.reviews.length,
+      verified: project.reviews.filter((r) => r.status === 'verified').length,
+      gap: project.reviews.filter((r) => r.status === 'gap').length,
+      notStarted: project.reviews.filter((r) => r.status === 'not-started').length,
+      notApplicable: project.reviews.filter((r) => r.status === 'not-applicable').length,
+      inProgress: project.reviews.filter((r) => r.status === 'in-progress').length,
+      percentComplete: 0,
+    };
+
+    const input: PremiumExportInput = {
+      project,
+      coverage: safeCoverage,
+      inventory,
+      sources,
+      fragments,
+      facts,
+      candidateLinks,
+      reconciliationRun,
+      decisionRun,
+      exportTime: body.exportTime,
+      pipelineVersion: body.pipelineVersion ?? '1.0.0',
+    };
+
+    const fmt = format === 'zip' ? 'zip' : format === 'both' ? 'both' : 'pdf';
+
+    if (fmt === 'pdf') {
+      const pdf = buildPremiumPdf(input);
+      const filename = `premium-evidence-report-${project.id.slice(0, 8)}.pdf`;
+      const ab = new ArrayBuffer(pdf.byteLength);
+      new Uint8Array(ab).set(pdf);
+      const blob = new Blob([ab], { type: 'application/pdf' });
+      return new NextResponse(blob, {
+        headers: {
+          'Content-Type': 'application/pdf',
+          'Content-Disposition': `attachment; filename="${filename}"`,
+        },
+      });
+    }
+
+    const zip = await buildPremiumZip(input);
+    const filename = `premium-evidence-export-${project.id.slice(0, 8)}.zip`;
+    const ab = new ArrayBuffer(zip.byteLength);
+    new Uint8Array(ab).set(zip);
+    const blob = new Blob([ab], { type: 'application/zip' });
+    return new NextResponse(blob, {
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (err) {
+    return NextResponse.json({ error: 'Premium export generation failed', detail: String(err) }, { status: 500 });
+  }
+}
+
+export const POST = handlePost;

--- a/src/app/api/projects/[id]/export-premium/route.ts
+++ b/src/app/api/projects/[id]/export-premium/route.ts
@@ -1,7 +1,7 @@
 export const runtime = 'nodejs';
 
 import { NextResponse } from 'next/server';
-import { buildPremiumPdf, buildPremiumZip } from '@/lib/evidence/export';
+import { buildPremiumPdf, buildPremiumZip, buildPremiumExportInputFromProject } from '@/lib/evidence/export';
 import type { PremiumExportInput } from '@/lib/evidence/export';
 import type { Project, ProjectCoverage } from '@/lib/projects/types';
 import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
@@ -35,22 +35,31 @@ async function handlePost(request: Request) {
       notStarted: project.reviews.filter((r) => r.status === 'not-started').length,
       notApplicable: project.reviews.filter((r) => r.status === 'not-applicable').length,
       inProgress: project.reviews.filter((r) => r.status === 'in-progress').length,
-      percentComplete: 0,
+      percentComplete: Math.round(
+        (project.reviews.filter((r) => r.status === 'verified' || r.status === 'gap').length / Math.max(1, project.reviews.length - project.reviews.filter((r) => r.status === 'not-applicable').length)) * 100,
+      ),
     };
 
-    const input: PremiumExportInput = {
-      project,
-      coverage: safeCoverage,
-      inventory,
-      sources,
-      fragments,
-      facts,
-      candidateLinks,
-      reconciliationRun,
-      decisionRun,
-      exportTime: body.exportTime,
-      pipelineVersion: body.pipelineVersion ?? '1.0.0',
-    };
+    const input: PremiumExportInput = inventory.length > 0 || sources.length > 0 || fragments.length > 0 || facts.length > 0 || candidateLinks.length > 0 || reconciliationRun || decisionRun
+      ? {
+          project,
+          coverage: safeCoverage,
+          inventory,
+          sources,
+          fragments,
+          facts,
+          candidateLinks,
+          reconciliationRun,
+          decisionRun,
+          exportTime: body.exportTime,
+          pipelineVersion: body.pipelineVersion ?? '1.0.0',
+        }
+      : await buildPremiumExportInputFromProject({
+          project,
+          coverage: safeCoverage,
+          exportTime: body.exportTime,
+          pipelineVersion: body.pipelineVersion ?? '1.0.0',
+        });
 
     const fmt = format === 'zip' ? 'zip' : format === 'both' ? 'both' : 'pdf';
 

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -72,6 +72,22 @@ const EMPTY_MANUAL_FINDING: ManualFindingDraft = {
   reviewerNote: '',
 };
 
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    const chunk = bytes.subarray(index, index + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+async function sha256Hex(buffer: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  return Array.from(new Uint8Array(digest)).map((value) => value.toString(16).padStart(2, '0')).join('');
+}
+
 export function shouldShowLockReview(project: Project, coverage: ProjectCoverage | null): boolean {
   if (project.status !== 'in-progress' || !coverage) return false;
   if (project.reviewMode === 'manual') return project.manualFindings.length > 0;
@@ -82,6 +98,7 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
   const [project, setProject] = useState<Project | null>(null);
   const [coverage, setCoverage] = useState<ProjectCoverage | null>(null);
   const [downloading, setDownloading] = useState(false);
+  const [premiumExportingFormat, setPremiumExportingFormat] = useState<'pdf' | 'zip' | null>(null);
   const [uploading, setUploading] = useState(false);
   const [manualDraft, setManualDraft] = useState<ManualFindingDraft>(EMPTY_MANUAL_FINDING);
 
@@ -120,8 +137,8 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
     }
   };
 
-  const handleStatusChange = (ruleId: string, status: RuleReview['status']) => {
-    refreshProject(updateRuleReview(projectId, ruleId, { status }));
+  const handleReviewChange = (ruleId: string, update: Partial<RuleReview>) => {
+    refreshProject(updateRuleReview(projectId, ruleId, update));
   };
 
   const handleLock = () => {
@@ -164,18 +181,49 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
     }
   };
 
+  const handlePremiumExport = async (format: 'pdf' | 'zip') => {
+    setPremiumExportingFormat(format);
+    try {
+      const res = await fetch('/api/projects/' + projectId + '/export-premium', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project, coverage, format }),
+      });
+      if (!res.ok) throw new Error('Premium export generation failed');
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = format === 'zip'
+        ? `premium-evidence-export-${project.id.slice(0, 8)}.zip`
+        : `premium-evidence-report-${project.id.slice(0, 8)}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+      if (project.reviewMode === 'manual') {
+        refreshProject(recordManualReviewLearningCase(projectId, 'export_generated'));
+      }
+    } catch (err) {
+      alert('Failed to generate premium export: ' + String(err));
+    } finally {
+      setPremiumExportingFormat(null);
+    }
+  };
+
   const handleUploadDocuments = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? []);
     if (files.length === 0) return;
     setUploading(true);
 
     for (const file of files) {
+      const fileBuffer = await file.arrayBuffer();
+      const contentBase64 = arrayBufferToBase64(fileBuffer);
+      const contentSha256 = await sha256Hex(fileBuffer);
       let extractedText = '';
       let extractionStatus: ProjectDocument['manualFindingExtractionStatus'] = 'not-run';
       let extractionMessage = '';
       let extractionTrace = '';
       let extractedDrafts: Array<Omit<ExtractedManualFindingDraft, 'id' | 'createdAt' | 'updatedAt' | 'sourceDocumentId'>> = [];
-      if ((file.type || '').includes('pdf') || file.name.toLowerCase().endsWith('.pdf')) {
+      if (project.reviewMode === 'manual' && ((file.type || '').includes('pdf') || file.name.toLowerCase().endsWith('.pdf'))) {
         try {
           const response = await fetch('/api/projects/manual-review/extract-findings', {
             method: 'POST',
@@ -183,7 +231,7 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
               'Content-Type': 'application/pdf',
               'x-article6-filename': encodeURIComponent(file.name),
             },
-            body: await file.arrayBuffer(),
+            body: fileBuffer,
           });
           const data = await response.json();
           extractedText = typeof data.text === 'string' ? data.text.slice(0, 2000) : '';
@@ -214,6 +262,8 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
         fileName: file.name,
         mimeType: file.type || 'application/octet-stream',
         sizeBytes: file.size,
+        contentBase64,
+        contentSha256,
         extractedText,
         manualFindingExtractionStatus: extractionStatus,
         manualFindingExtractionMessage: extractionMessage || undefined,
@@ -354,13 +404,29 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
             </button>
           ) : null}
           {project.status === 'locked' ? (
-            <button
-              onClick={handleDownloadPack}
-              disabled={downloading}
-              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
-            >
-              {downloading ? 'Generating...' : 'Download Export'}
-            </button>
+            <>
+              <button
+                onClick={() => handlePremiumExport('pdf')}
+                disabled={premiumExportingFormat !== null}
+                className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 disabled:opacity-50"
+              >
+                {premiumExportingFormat === 'pdf' ? 'Preparing PDF...' : 'Premium PDF'}
+              </button>
+              <button
+                onClick={() => handlePremiumExport('zip')}
+                disabled={premiumExportingFormat !== null}
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {premiumExportingFormat === 'zip' ? 'Preparing ZIP...' : 'Premium ZIP'}
+              </button>
+              <button
+                onClick={handleDownloadPack}
+                disabled={downloading || premiumExportingFormat !== null}
+                className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+              >
+                {downloading ? 'Generating...' : 'Standard PDF'}
+              </button>
+            </>
           ) : null}
         </div>
       </div>
@@ -407,77 +473,80 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
         </>
       ) : null}
 
-      {project.reviewMode === 'manual' ? (
-        <div className="grid gap-6 lg:grid-cols-[1.1fr_1.4fr]">
-          <section className="rounded-lg border border-slate-200 bg-white p-5">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h2 className="text-lg font-semibold text-slate-900">Source Documents</h2>
-                <p className="mt-1 text-sm text-slate-500">Upload project documents used in manual findings reconstruction.</p>
+      <section className="rounded-lg border border-slate-200 bg-white p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Source Documents</h2>
+            <p className="mt-1 text-sm text-slate-500">Retain original uploads so premium PDF and ZIP exports can include full provenance and source evidence.</p>
+          </div>
+          {project.status === 'in-progress' ? (
+            <label className="rounded-lg bg-slate-900 px-3 py-2 text-sm font-semibold text-white hover:bg-slate-800">
+              {uploading ? 'Uploading...' : 'Upload Documents'}
+              <input
+                type="file"
+                multiple
+                className="hidden"
+                onChange={handleUploadDocuments}
+                disabled={uploading}
+              />
+            </label>
+          ) : null}
+        </div>
+
+        <div className="mt-4 flex flex-col gap-3">
+          {project.documents.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+              No source documents uploaded yet.
+            </div>
+          ) : project.documents.map((document: ProjectDocument) => (
+            <div key={document.id} className="rounded-lg border border-slate-200 p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold text-slate-800">{document.fileName}</div>
+                  <div className="mt-1 text-xs text-slate-500">
+                    {document.mimeType} · {document.sizeBytes} bytes · {new Date(document.uploadedAt).toLocaleString()}
+                  </div>
+                  {document.contentSha256 ? (
+                    <div className="mt-1 font-mono text-[11px] text-slate-400">sha256 {document.contentSha256}</div>
+                  ) : null}
+                </div>
+                {project.status === 'in-progress' ? (
+                  <button
+                    onClick={() => refreshProject(deleteProjectDocument(projectId, document.id))}
+                    className="text-xs text-red-500 hover:text-red-700"
+                  >
+                    Remove
+                  </button>
+                ) : null}
               </div>
-              {project.status === 'in-progress' ? (
-                <label className="rounded-lg bg-slate-900 px-3 py-2 text-sm font-semibold text-white hover:bg-slate-800">
-                  {uploading ? 'Uploading...' : 'Upload Documents'}
-                  <input
-                    type="file"
-                    multiple
-                    className="hidden"
-                    onChange={handleUploadDocuments}
-                    disabled={uploading}
-                  />
-                </label>
+              {document.extractedText?.trim() ? (
+                <p className="mt-2 rounded bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                  {document.extractedText.slice(0, 280)}
+                </p>
+              ) : null}
+              {document.manualFindingExtractionMessage ? (
+                <p className={`mt-2 text-xs ${
+                  document.manualFindingExtractionStatus === 'extraction-failed'
+                    ? 'text-red-600'
+                    : document.manualFindingExtractionStatus === 'no-findings'
+                      ? 'text-slate-500'
+                      : 'text-blue-600'
+                }`}>
+                  {document.manualFindingExtractionMessage}
+                </p>
+              ) : null}
+              {document.manualFindingExtractionTrace ? (
+                <p className="mt-1 font-mono text-[11px] text-slate-400">
+                  Trace: {document.manualFindingExtractionTrace}
+                </p>
               ) : null}
             </div>
+          ))}
+        </div>
+      </section>
 
-            <div className="mt-4 flex flex-col gap-3">
-              {project.documents.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500">
-                  No source documents uploaded yet.
-                </div>
-              ) : project.documents.map((document: ProjectDocument) => (
-                <div key={document.id} className="rounded-lg border border-slate-200 p-3">
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <div className="text-sm font-semibold text-slate-800">{document.fileName}</div>
-                      <div className="mt-1 text-xs text-slate-500">
-                        {document.mimeType} · {document.sizeBytes} bytes · {new Date(document.uploadedAt).toLocaleString()}
-                      </div>
-                    </div>
-                    {project.status === 'in-progress' ? (
-                      <button
-                        onClick={() => refreshProject(deleteProjectDocument(projectId, document.id))}
-                        className="text-xs text-red-500 hover:text-red-700"
-                      >
-                        Remove
-                      </button>
-                    ) : null}
-                  </div>
-                  {document.extractedText?.trim() ? (
-                    <p className="mt-2 rounded bg-slate-50 px-3 py-2 text-xs text-slate-600">
-                      {document.extractedText.slice(0, 280)}
-                    </p>
-                  ) : null}
-                  {document.manualFindingExtractionMessage ? (
-                    <p className={`mt-2 text-xs ${
-                      document.manualFindingExtractionStatus === 'extraction-failed'
-                        ? 'text-red-600'
-                        : document.manualFindingExtractionStatus === 'no-findings'
-                          ? 'text-slate-500'
-                          : 'text-blue-600'
-                    }`}>
-                      {document.manualFindingExtractionMessage}
-                    </p>
-                  ) : null}
-                  {document.manualFindingExtractionTrace ? (
-                    <p className="mt-1 font-mono text-[11px] text-slate-400">
-                      Trace: {document.manualFindingExtractionTrace}
-                    </p>
-                  ) : null}
-                </div>
-              ))}
-            </div>
-          </section>
-
+      {project.reviewMode === 'manual' ? (
+        <div className="grid gap-6 lg:grid-cols-[1.1fr_1.4fr]">
           <section className="rounded-lg border border-slate-200 bg-white p-5">
             <div>
               <h2 className="text-lg font-semibold text-slate-900">Extraction Review</h2>
@@ -892,7 +961,12 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
           </section>
         </div>
       ) : (
-        <MethodologyLinkedReview project={project} onStatusChange={handleStatusChange} />
+        <MethodologyLinkedReview
+          project={project}
+          onReviewChange={handleReviewChange}
+          onPremiumExport={handlePremiumExport}
+          premiumExportingFormat={premiumExportingFormat}
+        />
       )}
     </div>
   );
@@ -900,10 +974,14 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
 
 function MethodologyLinkedReview({
   project,
-  onStatusChange,
+  onReviewChange,
+  onPremiumExport,
+  premiumExportingFormat,
 }: {
   project: Project;
-  onStatusChange: (ruleId: string, status: RuleReview['status']) => void;
+  onReviewChange: (ruleId: string, update: Partial<RuleReview>) => void;
+  onPremiumExport: (format: 'pdf' | 'zip') => void;
+  premiumExportingFormat: 'pdf' | 'zip' | null;
 }) {
   const grouped = project.reviews.reduce((acc, review) => {
     if (!acc[review.sectionId]) acc[review.sectionId] = [];
@@ -913,6 +991,32 @@ function MethodologyLinkedReview({
 
   return (
     <>
+      {project.status === 'locked' ? (
+        <div className="rounded-lg border border-slate-200 bg-white p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <div className="text-sm font-semibold text-slate-900">Premium Review Export</div>
+              <div className="mt-1 text-xs text-slate-500">Download the locked methodology review as a premium PDF or a provenance ZIP directly from the review workspace.</div>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => onPremiumExport('pdf')}
+                disabled={premiumExportingFormat !== null}
+                className="rounded-lg bg-slate-900 px-3 py-2 text-sm font-semibold text-white hover:bg-slate-800 disabled:opacity-50"
+              >
+                {premiumExportingFormat === 'pdf' ? 'Preparing PDF...' : 'Premium PDF'}
+              </button>
+              <button
+                onClick={() => onPremiumExport('zip')}
+                disabled={premiumExportingFormat !== null}
+                className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {premiumExportingFormat === 'zip' ? 'Preparing ZIP...' : 'Premium ZIP'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
       {Object.entries(grouped).map(([sectionId, reviews]) => (
         <div key={sectionId} className="rounded-lg border border-slate-200 bg-white">
           <div className="border-b border-slate-100 px-4 py-3">
@@ -920,44 +1024,79 @@ function MethodologyLinkedReview({
           </div>
           <div className="divide-y divide-slate-50">
             {reviews.map((review) => (
-              <div key={review.ruleId} className="flex items-center gap-3 px-4 py-3">
-                <div className="flex-1">
+              <div key={review.ruleId} className="px-4 py-3">
+                <div className="flex items-start gap-3">
+                  <div className="flex-1">
                   <div className="text-sm font-medium text-slate-800">{review.ruleTitle}</div>
                   <div className="font-mono text-xs text-slate-400">{review.ruleId}</div>
+                  </div>
+                  {project.status === 'in-progress' ? (
+                    <select
+                      value={review.status}
+                      onChange={event => onReviewChange(review.ruleId, { status: event.target.value as RuleReview['status'] })}
+                      className={`rounded border px-2 py-1 text-xs font-semibold ${
+                        review.status === 'verified'
+                          ? 'border-green-300 bg-green-50 text-green-700'
+                          : review.status === 'gap'
+                            ? 'border-red-300 bg-red-50 text-red-700'
+                            : review.status === 'not-applicable'
+                              ? 'border-slate-200 bg-slate-50 text-slate-400'
+                              : 'border-slate-200 bg-white text-slate-500'
+                      }`}
+                    >
+                      <option value="not-started">Not Started</option>
+                      <option value="in-progress">In Progress</option>
+                      <option value="verified">Verified</option>
+                      <option value="gap">Gap</option>
+                      <option value="not-applicable">N/A</option>
+                    </select>
+                  ) : (
+                    <span
+                      className={`rounded px-2 py-1 text-xs font-semibold ${
+                        review.status === 'verified'
+                          ? 'bg-green-100 text-green-700'
+                          : review.status === 'gap'
+                            ? 'bg-red-100 text-red-700'
+                            : 'bg-slate-100 text-slate-500'
+                      }`}
+                    >
+                      {review.status}
+                    </span>
+                  )}
                 </div>
-                {project.status === 'in-progress' ? (
-                  <select
-                    value={review.status}
-                    onChange={event => onStatusChange(review.ruleId, event.target.value as RuleReview['status'])}
-                    className={`rounded border px-2 py-1 text-xs font-semibold ${
-                      review.status === 'verified'
-                        ? 'border-green-300 bg-green-50 text-green-700'
-                        : review.status === 'gap'
-                          ? 'border-red-300 bg-red-50 text-red-700'
-                          : review.status === 'not-applicable'
-                            ? 'border-slate-200 bg-slate-50 text-slate-400'
-                            : 'border-slate-200 bg-white text-slate-500'
-                    }`}
-                  >
-                    <option value="not-started">Not Started</option>
-                    <option value="in-progress">In Progress</option>
-                    <option value="verified">Verified</option>
-                    <option value="gap">Gap</option>
-                    <option value="not-applicable">N/A</option>
-                  </select>
-                ) : (
-                  <span
-                    className={`rounded px-2 py-1 text-xs font-semibold ${
-                      review.status === 'verified'
-                        ? 'bg-green-100 text-green-700'
-                        : review.status === 'gap'
-                          ? 'bg-red-100 text-red-700'
-                          : 'bg-slate-100 text-slate-500'
-                    }`}
-                  >
-                    {review.status}
-                  </span>
-                )}
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <Field label="Evidence References">
+                    {project.status === 'in-progress' ? (
+                      <input
+                        type="text"
+                        value={review.evidenceIds.join(', ')}
+                        onChange={(event) => onReviewChange(review.ruleId, {
+                          evidenceIds: event.target.value
+                            .split(',')
+                            .map((value) => value.trim())
+                            .filter(Boolean),
+                        })}
+                        placeholder="document-id, fragment-id"
+                        className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                      />
+                    ) : (
+                      <StaticValue value={review.evidenceIds.length > 0 ? review.evidenceIds.join(', ') : 'No evidence refs linked'} />
+                    )}
+                  </Field>
+                  <Field label="Reviewer Rationale">
+                    {project.status === 'in-progress' ? (
+                      <textarea
+                        rows={3}
+                        value={review.note || ''}
+                        onChange={(event) => onReviewChange(review.ruleId, { note: event.target.value || undefined })}
+                        placeholder="Why this rule is verified, a gap, or still needs review."
+                        className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                      />
+                    ) : (
+                      <StaticValue value={review.note || 'No reviewer rationale recorded'} />
+                    )}
+                  </Field>
+                </div>
               </div>
             ))}
           </div>

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type ChangeEvent, type FormEvent, type ReactNode } from 'react';
 import Link from 'next/link';
+import { sha256ArrayBuffer } from '@/lib/proof/hash';
 import type {
   ExtractedManualFindingDraft,
   ManualFinding,
@@ -84,8 +85,7 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 }
 
 async function sha256Hex(buffer: ArrayBuffer): Promise<string> {
-  const digest = await crypto.subtle.digest('SHA-256', buffer);
-  return Array.from(new Uint8Array(digest)).map((value) => value.toString(16).padStart(2, '0')).join('');
+  return sha256ArrayBuffer(buffer);
 }
 
 export function shouldShowLockReview(project: Project, coverage: ProjectCoverage | null): boolean {

--- a/src/lib/evidence/export/index.ts
+++ b/src/lib/evidence/export/index.ts
@@ -1,0 +1,3 @@
+export { buildPremiumPdf } from './pdfExporter';
+export { buildPremiumZip } from './zipExporter';
+export type { PremiumExportInput, PremiumExportOutput, PremiumExportMeta, ManifestEntry } from './types';

--- a/src/lib/evidence/export/index.ts
+++ b/src/lib/evidence/export/index.ts
@@ -1,3 +1,4 @@
 export { buildPremiumPdf } from './pdfExporter';
 export { buildPremiumZip } from './zipExporter';
+export { buildPremiumExportInputFromProject } from './projectExportData';
 export type { PremiumExportInput, PremiumExportOutput, PremiumExportMeta, ManifestEntry } from './types';

--- a/src/lib/evidence/export/pdfExporter.ts
+++ b/src/lib/evidence/export/pdfExporter.ts
@@ -104,6 +104,10 @@ function safeDate(iso: string | undefined): string {
   return /^\d{4}-\d{2}-\d{2}$/.test(d) ? d : iso.slice(0, 16);
 }
 
+function exportTimestamp(input: PremiumExportInput): string {
+  return input.exportTime ?? input.project.lockedAt ?? input.project.createdAt ?? '1970-01-01T00:00:00.000Z';
+}
+
 function centerText(y: number, font: 'F1' | 'FB', size: number, text: string, color?: string): string[] {
   const tw = textWidth(text, size);
   const x = W / 2 - tw / 2;
@@ -123,7 +127,7 @@ function makePageState(): PdfPage {
 
 function addCoverPage(state: PdfPage, input: PremiumExportInput): void {
   const { project, coverage } = input;
-  const now = input.exportTime ?? new Date().toISOString().replace('T', ' ').slice(0, 16);
+  const now = exportTimestamp(input).replace('T', ' ').slice(0, 16);
   const cx = W / 2;
   const registry = project.registry ?? 'Unknown';
   const lines = state.ln;
@@ -289,7 +293,7 @@ function addMethodologySections(state: PdfPage, input: PremiumExportInput): void
 
 function addEvidenceInventory(state: PdfPage, input: PremiumExportInput): void {
   sec(state, 'EVIDENCE INVENTORY');
-  const { inventory, sources } = input;
+  const { inventory, sources, fragments } = input;
 
   if (inventory.length === 0) {
     bodyLine(state, 'No evidence items in the inventory.');
@@ -319,6 +323,36 @@ function addEvidenceInventory(state: PdfPage, input: PremiumExportInput): void {
       state.ln.push(...TXT(rsX, state.y, 'F1', 7, rStatus, LIGHT));
     }
     state.y -= 18;
+
+    const relatedFragments = fragments
+      .filter((fragment) => fragment.documentId === item.evidence_id)
+      .sort((a, b) => a.fragmentId.localeCompare(b.fragmentId))
+      .slice(0, 3);
+
+    if (relatedFragments.length === 0) {
+      state.ln.push(...TXT(L + 62, state.y, 'F1', 7, 'No extracted fragments with provenance for this evidence item.', LIGHTER));
+      state.y -= 14;
+    }
+
+    for (const fragment of relatedFragments) {
+      const provenance = [
+        fragment.fragmentId,
+        fragment.pageStart ? `p.${fragment.pageStart}${fragment.pageEnd && fragment.pageEnd !== fragment.pageStart ? `-${fragment.pageEnd}` : ''}` : null,
+        fragment.sheetName ? `sheet ${fragment.sheetName}` : null,
+      ].filter(Boolean).join(' · ');
+      state.ln.push(...TXT(L + 72, state.y, 'FB', 7, fragment.label, MED));
+      state.y -= 11;
+      if (provenance) {
+        state.ln.push(...TXT(L + 72, state.y, 'F1', 7, provenance, LIGHTER));
+        state.y -= 11;
+      }
+      for (const line of wrapText(truncate(fragment.text.replace(/\s+/g, ' '), 180), 82)) {
+        state.ln.push(...TXT(L + 72, state.y, 'F1', 7, line, LIGHT));
+        state.y -= 10;
+      }
+      state.ln.push(...TXT(L + 72, state.y, 'F1', 7, `sha256 ${fragment.contentSha256}`, LIGHTER));
+      state.y -= 12;
+    }
   }
   state.y -= 4;
 }
@@ -555,7 +589,7 @@ function coverageSummary(input: PremiumExportInput): string {
 }
 
 function buildPdfStream(state: PdfPage, input: PremiumExportInput): string[] {
-  const now = input.exportTime ?? new Date().toISOString().replace('T', ' ').slice(0, 16);
+  const now = exportTimestamp(input).replace('T', ' ').slice(0, 16);
   const isManual = input.project.reviewMode === 'manual';
 
   addCoverPage(state, input);

--- a/src/lib/evidence/export/pdfExporter.ts
+++ b/src/lib/evidence/export/pdfExporter.ts
@@ -1,0 +1,638 @@
+import type { PremiumExportInput } from './types';
+import type { ExtractedFact } from '@/lib/evidence/extraction/types';
+
+function esc(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+}
+
+function asciiSafeText(input: string): string {
+  return input
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/[\u2013\u2014]/g, '-')
+    .replace(/\u2022/g, '-')
+    .replace(/\u00B7/g, '-')
+    .replace(/\u00B0/g, ' deg')
+    .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, '');
+}
+
+const H_WIDTH: Record<string, number> = {
+  'A': 667, 'B': 667, 'C': 722, 'D': 722, 'E': 667, 'F': 611, 'G': 778, 'H': 722,
+  'I': 278, 'J': 500, 'K': 667, 'L': 556, 'M': 833, 'N': 722, 'O': 778, 'P': 667,
+  'Q': 778, 'R': 722, 'S': 667, 'T': 611, 'U': 722, 'V': 667, 'W': 944, 'X': 667,
+  'Y': 667, 'Z': 611,
+  'a': 556, 'b': 556, 'c': 500, 'd': 556, 'e': 556, 'f': 278, 'g': 556, 'h': 556,
+  'i': 222, 'j': 222, 'k': 500, 'l': 222, 'm': 833, 'n': 556, 'o': 556, 'p': 556,
+  'q': 556, 'r': 333, 's': 500, 't': 278, 'u': 556, 'v': 500, 'w': 722, 'x': 500,
+  'y': 500, 'z': 500,
+  '0': 556, '1': 556, '2': 556, '3': 556, '4': 556, '5': 556, '6': 556, '7': 556,
+  '8': 556, '9': 556,
+  ' ': 278, '.': 278, ',': 278, ':': 278, ';': 278, '!': 278, '?': 556, '/': 278,
+  '(': 333, ')': 333, '-': 333, '_': 500, '+': 584, "'": 278, '"': 333, '&': 667,
+  '*': 278, '@': 975, '|': 278, '#': 556, '$': 556, '%': 889, '\\': 278,
+};
+
+function textWidth(text: string, size: number): number {
+  let w = 0;
+  for (const ch of text) {
+    w += H_WIDTH[ch] !== undefined ? H_WIDTH[ch] : 500;
+  }
+  return w * size / 1000;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 3) + '...' : s;
+}
+
+function splitLongToken(token: string, max: number): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < token.length; i += max) chunks.push(token.slice(i, i + max));
+  return chunks;
+}
+
+function wrapText(text: string, max = 96): string[] {
+  const words = text.split(/\s+/).filter(Boolean).flatMap((word) => (
+    word.length > max ? splitLongToken(word, max) : [word]
+  ));
+  const lines: string[] = [];
+  let current = '';
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= max) {
+      current = next;
+    } else {
+      if (current) lines.push(current);
+      current = word;
+    }
+  }
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [''];
+}
+
+const DARK = '0.15 0.15 0.15 rg';
+const MED = '0.4 0.4 0.4 rg';
+const LIGHT = '0.55 0.55 0.55 rg';
+const LIGHTER = '0.65 0.65 0.65 rg';
+const CARD_BG = 0.97;
+const NOTE_BG = 0.95;
+
+const W = 612;
+const PAGE_H = 792;
+const M = 56;
+const L = M;
+const R = W - M;
+const BODY_TOP = 678;
+const BOT = 84;
+const HEADER_Y = PAGE_H - 48;
+const FOOTER_Y = 34;
+const CARD_INDENT = 12;
+
+const LN = (y: number) => `0.85 G ${L} ${y} m ${R} ${y} l S 0 G`;
+const RC = (x: number, y: number, w: number, h: number, g: number) => `${g} g ${x} ${y} ${w} ${h} re f 0 g`;
+const TXT = (x: number, y: number, font: 'F1' | 'FB', size: number, text: string, color = '0 0 0 rg') => [
+  'BT',
+  `/${font} ${size} Tf`,
+  color,
+  `${x} ${y} Td`,
+  `(${esc(asciiSafeText(text))}) Tj`,
+  'ET',
+];
+
+function safeDate(iso: string | undefined): string {
+  if (!iso) return 'n/a';
+  const d = iso.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(d) ? d : iso.slice(0, 16);
+}
+
+function centerText(y: number, font: 'F1' | 'FB', size: number, text: string, color?: string): string[] {
+  const tw = textWidth(text, size);
+  const x = W / 2 - tw / 2;
+  return TXT(x, y, font, size, text, color);
+}
+
+export type PdfPage = {
+  streams: string[];
+  ln: string[];
+  y: number;
+  pg: number;
+};
+
+function makePageState(): PdfPage {
+  return { streams: [], ln: [], y: BODY_TOP, pg: 0 };
+}
+
+function addCoverPage(state: PdfPage, input: PremiumExportInput): void {
+  const { project, coverage } = input;
+  const now = input.exportTime ?? new Date().toISOString().replace('T', ' ').slice(0, 16);
+  const cx = W / 2;
+  const registry = project.registry ?? 'Unknown';
+  const lines = state.ln;
+
+  lines.push(...centerText(520, 'FB', 10, 'ARTICLE6', '0.5 0.5 0.5 rg'));
+  lines.push(RC(cx - 150, 498, 300, 1, 0.8));
+  lines.push(...centerText(470, 'FB', 24, 'PREMIUM EVIDENCE REPORT', '0.2 0.2 0.2 rg'));
+  lines.push(...centerText(435, 'F1', 11, 'Review-Grade Evidence Export', '0.45 0.45 0.45 rg'));
+  lines.push(RC(cx - 150, 418, 300, 1, 0.8));
+  lines.push(...centerText(400, 'F1', 12, truncate(project.name, 70), '0.35 0.35 0.35 rg'));
+  lines.push(...TXT(cx - 190, 370, 'F1', 9, `Project ID: ${project.id}`, '0.5 0.5 0.5 rg'));
+  const reviewed = coverage.verified + coverage.gap;
+  lines.push(...TXT(cx + 10, 370, 'F1', 9, `Coverage: ${reviewed} of ${coverage.total} rules`, '0.5 0.5 0.5 rg'));
+  lines.push(...TXT(cx - 190, 352, 'F1', 9, `Registry: ${registry}`, '0.5 0.5 0.5 rg'));
+  lines.push(...TXT(cx + 10, 352, 'F1', 9, `Methodology: ${project.methodCode ?? 'n/a'} @ ${project.methodVersion ?? 'n/a'}`, '0.5 0.5 0.5 rg'));
+  lines.push(RC(cx - 150, 330, 300, 1, 0.8));
+  lines.push(...centerText(290, 'F1', 8, `Generated ${now}`, '0.6 0.6 0.6 rg'));
+  lines.push(...centerText(272, 'F1', 8, 'article6.org | Premium Evidence Export', '0.6 0.6 0.6 rg'));
+
+  state.streams.push(lines.join('\n'));
+  state.pg = 1;
+  state.ln = [];
+  state.y = BODY_TOP;
+}
+
+function flushPage(state: PdfPage, projectName: string, isManual: boolean, registry: string, now: string, showProjectName: boolean): void {
+  if (state.ln.length === 0) return;
+  const hdr = [
+    RC(0, HEADER_Y - 6, W, 22, 0.96),
+    LN(HEADER_Y - 6),
+    ...TXT(L, HEADER_Y, 'FB', 9, 'ARTICLE6', '0.4 0.4 0.4 rg'),
+  ];
+  if (showProjectName) {
+    hdr.push(...TXT(L + 62, HEADER_Y, 'F1', 8, projectName, '0.25 0.25 0.25 rg'));
+  }
+  hdr.push(...TXT(R - 26, HEADER_Y, 'F1', 8, `p.${state.pg}`, '0.4 0.4 0.4 rg'));
+
+  const footerLabel = isManual
+    ? 'article6.org | Premium Evidence Export'
+    : 'article6.org | Premium Evidence Export';
+  state.ln.push(
+    LN(FOOTER_Y + 10),
+    ...TXT(L, FOOTER_Y, 'F1', 7, `Generated ${now}`, '0.6 0.6 0.6 rg'),
+    ...TXT(R - 160, FOOTER_Y, 'F1', 7, footerLabel, '0.6 0.6 0.6 rg'),
+  );
+  state.streams.push([...hdr, ...state.ln].join('\n'));
+  state.ln = [];
+  state.y = BODY_TOP;
+}
+
+function need(state: PdfPage): void {
+  if (state.y - 16 < BOT) {
+    flushPage(state, '', false, '', '', false);
+    state.pg += 1;
+    state.ln.push(
+      RC(0, HEADER_Y - 6, W, 22, 0.96),
+      LN(HEADER_Y - 6),
+      ...TXT(L, HEADER_Y, 'FB', 9, 'ARTICLE6', '0.4 0.4 0.4 rg'),
+      ...TXT(R - 26, HEADER_Y, 'F1', 8, `p.${state.pg}`, '0.4 0.4 0.4 rg'),
+    );
+  }
+}
+
+function sec(state: PdfPage, label: string): void {
+  state.y -= 12;
+  need(state);
+  state.ln.push(LN(state.y));
+  state.ln.push(RC(L, state.y - 16, R - L, 20, 0.97));
+  state.ln.push(...TXT(L + 10, state.y - 6, 'FB', 10, label, '0.25 0.25 0.25 rg'));
+  state.ln.push(LN(state.y - 18));
+  state.y -= 34;
+}
+
+function bodyLine(state: PdfPage, text: string, font: 'F1' | 'FB' = 'F1', size = 9, color = DARK): void {
+  for (const line of wrapText(text)) {
+    need(state);
+    state.ln.push(...TXT(L, state.y, font, size, line, color));
+    state.y -= 14;
+  }
+}
+
+function bulletLine(state: PdfPage, text: string, font: 'F1' | 'FB' = 'F1', size = 9, color = DARK): void {
+  for (const line of wrapText(text, 92)) {
+    need(state);
+    state.ln.push(...TXT(L + 10, state.y, font, size, `- ${line}`, color));
+    state.y -= 14;
+  }
+}
+
+function addExecutiveSummary(state: PdfPage, input: PremiumExportInput): void {
+  const { project, coverage } = input;
+  const registry = project.registry ?? 'Unknown';
+  const reviewed = coverage.verified + coverage.gap;
+
+  sec(state, 'EXECUTIVE SUMMARY');
+  bodyLine(state, `Registry / Standard: ${registry}`);
+  bodyLine(state, `Methodology: ${project.methodCode ?? 'n/a'} @ ${project.methodVersion ?? 'n/a'}`);
+  if (project.methodCategory) bodyLine(state, `Category: ${project.methodCategory}`);
+  bodyLine(state, `Review mode: ${project.reviewMode === 'manual' ? 'Manual review' : 'Methodology-linked'}`);
+  bodyLine(state, `Project status: ${project.status === 'locked' ? 'Locked' : 'In Progress'}`);
+  bodyLine(state, `Coverage summary: ${reviewed} of ${coverage.total} rules reviewed (${coverage.percentComplete}% complete)`);
+  bodyLine(state, `Verified: ${coverage.verified} | Gap: ${coverage.gap} | Not started: ${coverage.notStarted} | In progress: ${coverage.inProgress} | NA: ${coverage.notApplicable}`);
+  bodyLine(state, `Evidence inventory items: ${input.inventory.length}`);
+  bodyLine(state, `Extracted fragments: ${input.fragments.length}`);
+  bodyLine(state, `Extracted facts: ${input.facts.length}`);
+  bodyLine(state, `Candidate links: ${input.candidateLinks.length}`);
+  if (input.reconciliationRun) {
+    bodyLine(state, `Gaps identified: ${input.reconciliationRun.gaps.length}`);
+  }
+  if (input.decisionRun) {
+    bodyLine(state, `Reviewer decisions: ${input.decisionRun.decisions.length}`);
+  }
+  state.y -= 4;
+}
+
+function addProjectInformation(state: PdfPage, input: PremiumExportInput): void {
+  const { project } = input;
+  sec(state, 'PROJECT INFORMATION');
+  bodyLine(state, `Project name: ${project.name}`);
+  bodyLine(state, `Project ID: ${project.id}`);
+  if (project.aoiLabel) bodyLine(state, `AOI label: ${project.aoiLabel}`);
+  if (project.description) bodyLine(state, `Description: ${project.description}`);
+  bodyLine(state, `Created: ${safeDate(project.createdAt)}`);
+  if (project.lockedAt) bodyLine(state, `Locked: ${safeDate(project.lockedAt)}`);
+  bodyLine(state, `Registry: ${project.registry ?? 'Unknown'}`);
+  bodyLine(state, `Documents uploaded: ${project.documents.length}`);
+  bodyLine(state, `Review mode: ${project.reviewMode}`);
+  bodyLine(state, `Review items: ${project.reviews.length}`);
+  state.y -= 4;
+}
+
+function addMethodologySections(state: PdfPage, input: PremiumExportInput): void {
+  const project = input.project;
+  sec(state, 'METHODOLOGY SOURCE SECTIONS');
+  if (project.methodCode && project.methodVersion) {
+    bodyLine(state, `Methodology: ${project.methodCode} @ ${project.methodVersion}`);
+  } else {
+    bodyLine(state, 'No methodology linked to this project.');
+    state.y -= 4;
+    return;
+  }
+
+  const sections = new Map<string, { title: string; count: number }>();
+  for (const review of project.reviews) {
+    const sectionId = review.sectionId || 'Requirements';
+    const existing = sections.get(sectionId);
+    if (existing) {
+      existing.count++;
+    } else {
+      sections.set(sectionId, { title: sectionId, count: 1 });
+    }
+  }
+
+  for (const [sectionId, info] of sections) {
+    bulletLine(state, `${sectionId}: ${info.count} rule${info.count === 1 ? '' : 's'}`);
+  }
+
+  if (sections.size === 0) {
+    bodyLine(state, 'No methodology sections loaded.');
+  }
+  state.y -= 4;
+}
+
+function addEvidenceInventory(state: PdfPage, input: PremiumExportInput): void {
+  sec(state, 'EVIDENCE INVENTORY');
+  const { inventory, sources } = input;
+
+  if (inventory.length === 0) {
+    bodyLine(state, 'No evidence items in the inventory.');
+    state.y -= 4;
+    return;
+  }
+
+  bodyLine(state, `Total evidence items: ${inventory.length}`, 'F1', 9, MED);
+  bodyLine(state, `Source documents: ${sources.length}`, 'F1', 9, MED);
+  state.y -= 4;
+
+  for (const item of inventory) {
+    need(state);
+    const lineHeight = 22 + item.display_name.length > 60 ? 34 : 22;
+    state.ln.push(RC(L + 4, state.y - lineHeight + 8, R - L - 8, lineHeight - 4, CARD_BG));
+    const kindLabel = item.kind.toUpperCase();
+    state.ln.push(RC(L + 10, state.y - 4 - 10, 44, 10, 0.9));
+    state.ln.push(...TXT(L + 12, state.y - 4, 'FB', 7, kindLabel, '0.4 0.4 0.4 rg'));
+    const name = truncate(item.display_name, 80);
+    state.ln.push(...TXT(L + 62, state.y - 2, 'F1', 8, name, DARK));
+    state.y -= lineHeight;
+    state.ln.push(...TXT(L + 62, state.y, 'F1', 7, `Added: ${safeDate(item.added_at)}`, LIGHT));
+    state.ln.push(...TXT(L + 62 + textWidth(`Added: ${safeDate(item.added_at)}`, 7) + 20, state.y, 'F1', 7, `Fragments: ${(item.pdd_fragments ?? []).length}`, LIGHT));
+    const rStatus = item.reconciliation_status ? `Status: ${item.reconciliation_status}` : '';
+    if (rStatus) {
+      const rsX = L + 62 + textWidth(`Added: ${safeDate(item.added_at)}`, 7) + textWidth(`Fragments: ${(item.pdd_fragments ?? []).length}`, 7) + 40;
+      state.ln.push(...TXT(rsX, state.y, 'F1', 7, rStatus, LIGHT));
+    }
+    state.y -= 18;
+  }
+  state.y -= 4;
+}
+
+function addExtractedFacts(state: PdfPage, input: PremiumExportInput): void {
+  sec(state, 'EXTRACTED FACTS');
+  const { facts } = input;
+
+  if (facts.length === 0) {
+    bodyLine(state, 'No extracted facts available.');
+    state.y -= 4;
+    return;
+  }
+
+  const grouped = new Map<string, ExtractedFact[]>();
+  for (const fact of facts) {
+    const type = fact.factType;
+    const existing = grouped.get(type) ?? [];
+    existing.push(fact);
+    grouped.set(type, existing);
+  }
+
+  bodyLine(state, `Total extracted facts: ${facts.length} across ${grouped.size} types`, 'F1', 9, MED);
+
+  for (const [factType, typeFacts] of grouped) {
+    state.y -= 8;
+    need(state);
+    const typeLabel = factType.replace(/-/g, ' ');
+    state.ln.push(...TXT(L + 8, state.y, 'FB', 9, typeLabel.toUpperCase(), DARK));
+    state.y -= 16;
+    state.ln.push(...TXT(L + 8, state.y, 'F1', 8, `${typeFacts.length} fact${typeFacts.length === 1 ? '' : 's'}`, LIGHT));
+    state.y -= 16;
+
+    const display = typeFacts.slice(0, 8);
+    for (const fact of display) {
+      need(state);
+      state.ln.push(...TXT(L + 16, state.y, 'F1', 8, `- ${truncate(fact.value, 80)}`, MED));
+      state.y -= 13;
+      state.ln.push(...TXT(L + 26, state.y, 'F1', 7, `[${fact.fragmentId}]`, LIGHTER));
+      state.y -= 13;
+    }
+    if (typeFacts.length > 8) {
+      state.ln.push(...TXT(L + 16, state.y, 'F1', 8, `... and ${typeFacts.length - 8} more`, LIGHT));
+      state.y -= 14;
+    }
+  }
+  state.y -= 4;
+}
+
+function addCoverageMatrix(state: PdfPage, input: PremiumExportInput): void {
+  sec(state, 'COVERAGE MATRIX');
+  const { project, reconciliationRun } = input;
+
+  if (project.reviews.length === 0) {
+    bodyLine(state, 'No reviews recorded for this project.');
+    state.y -= 4;
+    return;
+  }
+
+  bodyLine(state, `Total rules: ${project.reviews.length}`, 'F1', 9, MED);
+  if (reconciliationRun) {
+    bodyLine(state, `Reconciliation status: ${reconciliationRun.status}`, 'F1', 9, MED);
+    bodyLine(state, `Coverage gaps: ${reconciliationRun.gaps.length}`, 'F1', 9, MED);
+    bodyLine(state, `Reconciliation fingerprints: ${reconciliationRun.reconciliationFingerprint}`, 'F1', 7, LIGHT);
+  }
+  state.y -= 4;
+
+  for (const review of project.reviews) {
+    need(state);
+    const statusLabel = review.status.toUpperCase();
+    const statusColorMap: Record<string, string> = {
+      'VERIFIED': '0.3 0.75 0.3 rg',
+      'GAP': '0.7 0.3 0.3 rg',
+      'NOT-STARTED': '0.7 0.7 0.7 rg',
+      'IN-PROGRESS': '0.75 0.65 0.3 rg',
+      'NOT-APPLICABLE': '0.6 0.6 0.6 rg',
+    };
+    const chipColor = statusColorMap[statusLabel] || '0.5 0.5 0.5 rg';
+
+    const lineCount = Math.max(2, Math.ceil((review.ruleTitle.length + review.ruleId.length) / 96) + 1);
+    const cardH = 18 + lineCount * 14;
+
+    state.ln.push(RC(L + 4, state.y - cardH + 8, R - L - 8, cardH - 4, CARD_BG));
+    state.ln.push(RC(L + 10, state.y - 4 - 10, 32, 10, 0.9));
+    state.ln.push(...TXT(L + 13, state.y - 4, 'FB', 6, `[${statusLabel}]`, chipColor));
+    state.ln.push(...TXT(L + 50, state.y - 2, 'FB', 8, review.ruleId, DARK));
+    state.y -= 16;
+
+    for (const line of wrapText(review.ruleTitle, 88)) {
+      state.ln.push(...TXT(L + 50, state.y, 'F1', 8, line, MED));
+      state.y -= 13;
+    }
+    state.y -= 4;
+
+    if (review.evidenceIds.length > 0) {
+      state.ln.push(...TXT(L + 60, state.y, 'F1', 7, `Evidence: ${review.evidenceIds.length} reference(s)`, LIGHT));
+      state.y -= 12;
+    } else {
+      state.ln.push(...TXT(L + 60, state.y, 'F1', 7, 'No evidence linked', LIGHTER));
+      state.y -= 12;
+    }
+
+    state.y -= 8;
+  }
+  state.y -= 4;
+
+  if (reconciliationRun && reconciliationRun.gaps.length > 0) {
+    sec(state, 'COVERAGE GAPS');
+    for (const gap of reconciliationRun.gaps) {
+      need(state);
+      state.ln.push(RC(L + 8, state.y - 22, R - L - 16, 18, NOTE_BG));
+      state.ln.push(...TXT(L + 16, state.y - 5, 'FB', 8, gap.ruleId, DARK));
+      state.y -= 18;
+      state.ln.push(...TXT(L + 24, state.y, 'F1', 7, gap.ruleTitle, MED));
+      state.y -= 16;
+    }
+  }
+}
+
+function addReviewerDecisions(state: PdfPage, input: PremiumExportInput): void {
+  sec(state, 'REVIEWER DECISIONS');
+  const { decisionRun } = input;
+
+  const decisions = decisionRun?.decisions ?? [];
+  if (decisions.length === 0) {
+    bodyLine(state, 'No reviewer decisions recorded for this project.');
+    state.y -= 4;
+    return;
+  }
+
+  bodyLine(state, `Total decisions: ${decisions.length}`, 'F1', 9, MED);
+  if (decisionRun) {
+    bodyLine(state, `Decision set fingerprint: ${decisionRun.decisionSetFingerprint}`, 'F1', 7, LIGHT);
+  }
+  state.y -= 4;
+
+  for (const decision of decisions) {
+    need(state);
+    const statusColorMap: Record<string, string> = {
+      'approved': '0.3 0.75 0.3 rg',
+      'rejected': '0.7 0.3 0.3 rg',
+      'needs-review': '0.75 0.65 0.3 rg',
+    };
+    const chipColor = statusColorMap[decision.status] || '0.5 0.5 0.5 rg';
+    const statusLabel = decision.status.toUpperCase();
+
+    const rationaleLines = wrapText(decision.rationale, 90).length;
+    const cardH = 40 + rationaleLines * 12 + (decision.evidenceInventoryIds.length > 0 ? 12 : 0);
+
+    state.ln.push(RC(L + 4, state.y - cardH + 8, R - L - 8, cardH - 4, CARD_BG));
+    state.ln.push(RC(L + 10, state.y - 4 - 10, 50, 10, 0.9));
+    state.ln.push(...TXT(L + 13, state.y - 4, 'FB', 6, `[${statusLabel}]`, chipColor));
+    state.ln.push(...TXT(L + 68, state.y - 2, 'FB', 8, decision.ruleId, DARK));
+    state.y -= 16;
+
+    state.ln.push(...TXT(L + 68, state.y, 'F1', 8, truncate(decision.ruleTitle, 70), MED));
+    state.y -= 14;
+
+    state.ln.push(...TXT(L + CARD_INDENT, state.y, 'F1', 8, 'Rationale:', LIGHT));
+    state.y -= 13;
+    for (const line of wrapText(decision.rationale, 90)) {
+      state.ln.push(...TXT(L + CARD_INDENT + 6, state.y, 'F1', 9, line, DARK));
+      state.y -= 12;
+    }
+
+    if (decision.evidenceInventoryIds.length > 0) {
+      state.ln.push(...TXT(L + CARD_INDENT, state.y, 'F1', 7, `Evidence refs: ${decision.evidenceInventoryIds.join(', ')}`, LIGHT));
+      state.y -= 12;
+    }
+
+    state.y -= 6;
+    state.ln.push(...TXT(L + CARD_INDENT, state.y, 'F1', 7, `Reviewer: ${decision.reviewerId} | ${safeDate(decision.reviewedAt)}`, LIGHTER));
+    state.y -= 12;
+
+    state.ln.push(...TXT(L + CARD_INDENT, state.y, 'F1', 7, `Provenance: ${decision.provenanceHash}`, LIGHTER));
+    state.y -= 14;
+  }
+  state.y -= 4;
+}
+
+function addLimitations(state: PdfPage): void {
+  sec(state, 'LIMITATIONS AND DISCLAIMERS');
+  bodyLine(state, 'This export is a readiness-review artifact. It is not:');
+  bulletLine(state, 'An official verification opinion, validation statement, or certification decision.');
+  bulletLine(state, 'A registry-approved compliance determination or issuance approval.');
+  bulletLine(state, 'A legal opinion or binding assessment of carbon credit eligibility.');
+  state.y -= 4;
+  bodyLine(state, 'Evidence sufficiency is a reviewer determination. Metrics and candidate links are advisory.');
+  bodyLine(state, 'All pipeline artifacts are deterministic: same inputs produce identical outputs.');
+  state.y -= 4;
+  bodyLine(state, 'Canonical deterministic artifacts are produced by the app pipeline. Advisory candidate intelligence does not establish final evidence sufficiency.');
+  state.y -= 4;
+}
+
+function addProvenance(state: PdfPage, input: PremiumExportInput): void {
+  sec(state, 'PROVENANCE CHAIN');
+  const now = input.exportTime ?? new Date().toISOString();
+  const { project, inventory, fragments, facts, candidateLinks, reconciliationRun, decisionRun } = input;
+
+  const provenanceItems: Array<[string, string]> = [
+    ['Export time', now],
+    ['Project', `${project.name} (${project.id})`],
+    ['Registry', project.registry ?? 'Unknown'],
+    ['Methodology', project.methodCode && project.methodVersion ? `${project.methodCode} @ ${project.methodVersion}` : 'n/a'],
+    ['Review mode', project.reviewMode],
+    ['Coverage', `${coverageSummary(input)}`],
+    ['Evidence inventory', `${inventory.length} items`],
+    ['Extracted fragments', `${fragments.length}`],
+    ['Extracted facts', `${facts.length}`],
+    ['Candidate links', `${candidateLinks.length}`],
+  ];
+
+  if (reconciliationRun) {
+    provenanceItems.push(['Reconciliation status', reconciliationRun.status]);
+    provenanceItems.push(['Reconciliation fingerprint', reconciliationRun.reconciliationFingerprint]);
+    provenanceItems.push(['Coverage gaps', `${reconciliationRun.gaps.length}`]);
+  }
+
+  if (decisionRun) {
+    provenanceItems.push(['Decision set fingerprint', decisionRun.decisionSetFingerprint]);
+    provenanceItems.push(['Reviewer decisions', `${decisionRun.decisions.length}`]);
+  }
+
+  for (const [label, value] of provenanceItems) {
+    const line = `${label}: ${value}`;
+    bodyLine(state, line, 'F1', 8, LIGHT);
+  }
+  state.y -= 4;
+}
+
+function coverageSummary(input: PremiumExportInput): string {
+  const { coverage } = input;
+  return `${coverage.verified + coverage.gap} of ${coverage.total} rules (${coverage.percentComplete}%)`;
+}
+
+function buildPdfStream(state: PdfPage, input: PremiumExportInput): string[] {
+  const now = input.exportTime ?? new Date().toISOString().replace('T', ' ').slice(0, 16);
+  const isManual = input.project.reviewMode === 'manual';
+
+  addCoverPage(state, input);
+
+  state.y = BODY_TOP;
+  addExecutiveSummary(state, input);
+  addProjectInformation(state, input);
+  addMethodologySections(state, input);
+  addEvidenceInventory(state, input);
+  addExtractedFacts(state, input);
+  addCoverageMatrix(state, input);
+  addReviewerDecisions(state, input);
+  addLimitations(state);
+  addProvenance(state, input);
+
+  need(state);
+  state.ln.push(
+    LN(state.y),
+    ...TXT(L, state.y - 12, 'F1', 7, 'This export was generated deterministically from project evidence pipeline data.', '0.65 0.65 0.65 rg'),
+    ...TXT(L, state.y - 24, 'F1', 7, `Export time ${safeDate(now)}. article6.org | Premium Evidence Export`, '0.65 0.65 0.65 rg'),
+  );
+
+  flushPage(state, input.project.name, isManual, input.project.registry ?? 'Unknown', now, false);
+  return state.streams;
+}
+
+function assemblePdf(streams: string[]): Buffer {
+  const enc = (s: string) => Buffer.from(s, 'utf-8');
+  const parts: Buffer[] = [];
+  const offsets: number[] = [0];
+  let pos = 0;
+  const write = (s: string) => {
+    parts.push(enc(s));
+    pos += s.length;
+  };
+
+  write('%PDF-1.4\n');
+
+  const allObjs: string[] = [];
+  const pageObjNums: number[] = [];
+  let totalAfter = 0;
+  for (let i = 0; i < streams.length; i++) totalAfter += 4;
+  const catNum = totalAfter + 1;
+  const pgsNum = totalAfter + 2;
+
+  for (const stream of streams) {
+    const fR = allObjs.length + 1;
+    const fB = allObjs.length + 2;
+    const cs = allObjs.length + 3;
+    allObjs.push('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
+    allObjs.push('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>');
+    allObjs.push(`<< /Length ${enc(stream).length} >>\nstream\n${stream}\nendstream`);
+    const pn = allObjs.length + 1;
+    allObjs.push(`<< /Type /Page /Parent ${pgsNum} 0 R /MediaBox [0 0 ${W} 792] /Resources << /Font << /F1 ${fR} 0 R /FB ${fB} 0 R >> >> /Contents ${cs} 0 R >>`);
+    pageObjNums.push(pn);
+  }
+
+  allObjs.push(`<< /Type /Catalog /Pages ${pgsNum} 0 R >>`);
+  allObjs.push(`<< /Type /Pages /Kids [${pageObjNums.map((num) => `${num} 0 R`).join(' ')}] /Count ${streams.length} >>`);
+
+  for (let i = 0; i < allObjs.length; i++) {
+    offsets.push(pos);
+    write(`${i + 1} 0 obj\n${allObjs[i]}\nendobj\n`);
+  }
+
+  const xrefOff = pos;
+  write(`xref\n0 ${allObjs.length + 1}\n0000000000 65535 f \n`);
+  for (let i = 1; i <= allObjs.length; i++) {
+    write(`${String(offsets[i]).padStart(10, '0')} 00000 n \n`);
+  }
+  write(`trailer\n<< /Size ${allObjs.length + 1} /Root ${catNum} 0 R >>\nstartxref\n${xrefOff}\n%%EOF`);
+
+  return Buffer.concat(parts);
+}
+
+export function buildPremiumPdf(input: PremiumExportInput): Buffer {
+  const state = makePageState();
+  const streams = buildPdfStream(state, input);
+  return assemblePdf(streams);
+}

--- a/src/lib/evidence/export/projectExportData.ts
+++ b/src/lib/evidence/export/projectExportData.ts
@@ -1,0 +1,458 @@
+import { canonicalJsonStringify } from '@/lib/export/canonicalJson';
+import { sha256Text } from '@/lib/proof/hash';
+import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
+import type { ReviewerDecision, DecisionRun } from '@/lib/evidence/decisions/types';
+import { computeDecisionProvenance, computeDecisionSetFingerprint } from '@/lib/evidence/decisions/engine';
+import type { ReconciliationItem, ReconciliationRun, CoverageGap, ReconciliationStatus } from '@/lib/evidence/reconciliation/types';
+import { computeGapFingerprint, computeItemFingerprint, reconcileEvidence } from '@/lib/evidence/reconciliation/reconciler';
+import { runExtraction } from '@/lib/evidence/extraction/pipeline';
+import type { CandidateLink, DocumentFragment, SourceDocument, ExtractedFact } from '@/lib/evidence/extraction/types';
+import type { PremiumExportInput, SourceArtifact } from './types';
+import type { Project, ProjectCoverage, ProjectDocument, RuleReview, ManualFinding } from '@/lib/projects/types';
+
+function sortByString<T>(items: T[], select: (item: T) => string): T[] {
+  return [...items].sort((a, b) => select(a).localeCompare(select(b)));
+}
+
+function sanitizeId(value: string): string {
+  const normalized = value.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  return normalized || 'item';
+}
+
+async function sha256OrFallback(value: string): Promise<string> {
+  if (!value) return sha256Text('');
+  return sha256Text(value);
+}
+
+function resolveSourceKind(document: ProjectDocument): SourceDocument['kind'] {
+  const lower = document.fileName.toLowerCase();
+  if (document.mimeType === 'application/pdf' || lower.endsWith('.pdf')) return 'pdd';
+  if (
+    document.mimeType.includes('spreadsheet') ||
+    document.mimeType.includes('csv') ||
+    lower.endsWith('.xlsx') ||
+    lower.endsWith('.csv')
+  ) return 'workbook';
+  if (lower.includes('monitor') || document.mimeType.includes('word')) return 'monitoring-report';
+  return 'other';
+}
+
+function resolveExportTime(project: Project, requested?: string): string {
+  return requested
+    ?? project.lockedAt
+    ?? project.reviews.map((review) => review.reviewedAt).filter(Boolean).sort().at(-1)
+    ?? project.manualFindings.map((finding) => finding.updatedAt).sort().at(-1)
+    ?? project.createdAt
+    ?? '1970-01-01T00:00:00.000Z';
+}
+
+function decodeBase64ToArrayBuffer(contentBase64: string): ArrayBuffer {
+  const buffer = Buffer.from(contentBase64, 'base64');
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+}
+
+function buildSourceArtifacts(project: Project): SourceArtifact[] {
+  return sortByString(
+    project.documents
+      .filter((document) => document.contentBase64 && document.contentSha256)
+      .map((document) => ({
+        documentId: document.id,
+        fileName: document.fileName,
+        mime: document.mimeType,
+        sizeBytes: document.sizeBytes,
+        contentSha256: document.contentSha256 as string,
+        contentBase64: document.contentBase64 as string,
+      })),
+    (artifact) => artifact.documentId,
+  );
+}
+
+function buildSources(project: Project, sourceArtifacts: SourceArtifact[]): SourceDocument[] {
+  const shaById = new Map(sourceArtifacts.map((artifact) => [artifact.documentId, artifact.contentSha256]));
+  return sortByString(project.documents.map((document) => ({
+    id: document.id,
+    fileName: document.fileName,
+    mime: document.mimeType,
+    kind: resolveSourceKind(document),
+    sizeBytes: document.sizeBytes,
+    contentSha256: document.contentSha256 ?? shaById.get(document.id) ?? `${document.id}_missing_sha`,
+  })), (document) => document.id);
+}
+
+async function buildFallbackFragments(project: Project, sources: SourceDocument[]): Promise<DocumentFragment[]> {
+  const fragments: DocumentFragment[] = [];
+  const sourceById = new Map(sources.map((source) => [source.id, source]));
+  for (const document of sortByString(project.documents, (item) => item.id)) {
+    if (!document.extractedText?.trim()) continue;
+    const source = sourceById.get(document.id);
+    if (!source) continue;
+    const text = document.extractedText.trim();
+    fragments.push({
+      fragmentId: `fragment_${sanitizeId(document.id)}_001`,
+      documentId: document.id,
+      kind: source.kind,
+      index: 0,
+      label: 'Extracted source text',
+      text,
+      contentSha256: await sha256OrFallback(`${document.id}:${text}`),
+    });
+  }
+  return fragments;
+}
+
+async function buildFallbackFacts(fragments: DocumentFragment[]): Promise<ExtractedFact[]> {
+  const facts: ExtractedFact[] = [];
+  for (const fragment of sortByString(fragments, (item) => item.fragmentId)) {
+    const summary = fragment.text.replace(/\s+/g, ' ').trim().slice(0, 160);
+    if (!summary) continue;
+    facts.push({
+      factId: `${fragment.fragmentId}__fact_001`,
+      fragmentId: fragment.fragmentId,
+      documentId: fragment.documentId,
+      factType: 'other',
+      value: summary,
+      context: fragment.label,
+      contentSha256: await sha256OrFallback(`${fragment.fragmentId}:${summary}`),
+    });
+  }
+  return facts;
+}
+
+function extractLinkedRequirementIds(project: Project, documentId: string, fragmentIds: string[]): string[] {
+  const linked = new Set<string>();
+  const fragmentIdSet = new Set(fragmentIds);
+  for (const review of project.reviews) {
+    if (review.evidenceIds.includes(documentId) || review.evidenceIds.some((item) => fragmentIdSet.has(item))) {
+      linked.add(review.ruleId);
+    }
+  }
+  for (const finding of project.manualFindings) {
+    if (finding.sourceDocumentId === documentId) {
+      linked.add(finding.findingId);
+    }
+  }
+  return Array.from(linked).sort((a, b) => a.localeCompare(b));
+}
+
+function buildInventory(
+  project: Project,
+  sources: SourceDocument[],
+  fragments: DocumentFragment[],
+  reconciliationRun?: ReconciliationRun,
+): EvidenceInventoryItem[] {
+  const fragmentsByDocument = new Map<string, DocumentFragment[]>();
+  for (const fragment of fragments) {
+    const existing = fragmentsByDocument.get(fragment.documentId) ?? [];
+    existing.push(fragment);
+    fragmentsByDocument.set(fragment.documentId, existing);
+  }
+
+  const statusesByDocument = new Map<string, EvidenceInventoryItem['reconciliation_status']>();
+  for (const item of reconciliationRun?.items ?? []) {
+    if (!item.fragmentId) continue;
+    const fragment = fragments.find((candidate) => candidate.fragmentId === item.fragmentId);
+    if (!fragment) continue;
+    if (item.status === 'linked') {
+      statusesByDocument.set(fragment.documentId, 'linked');
+    } else if (!statusesByDocument.has(fragment.documentId)) {
+      statusesByDocument.set(fragment.documentId, 'unmatched');
+    }
+  }
+
+  return sortByString(sources.map((source) => {
+    const documentFragments = sortByString(fragmentsByDocument.get(source.id) ?? [], (fragment) => fragment.fragmentId);
+    const linkedRequirementIds = extractLinkedRequirementIds(
+      project,
+      source.id,
+      documentFragments.map((fragment) => fragment.fragmentId),
+    );
+    const inventoryKind = source.kind === 'monitoring-report'
+      ? 'document'
+      : source.kind === 'other'
+        ? 'upload'
+        : source.kind;
+    return {
+      evidence_id: source.id,
+      dedupe_key: source.contentSha256,
+      display_name: source.fileName,
+      kind: inventoryKind,
+      type: source.kind === 'pdd'
+        ? 'PDD'
+        : source.kind === 'workbook'
+          ? 'Workbook'
+          : source.kind === 'monitoring-report'
+            ? 'Monitoring report'
+            : 'Document',
+      source_summary: 'Project source document',
+      provenance_summary: `${source.fileName} · sha256 ${source.contentSha256}`,
+      added_at: project.documents.find((document) => document.id === source.id)?.uploadedAt ?? project.createdAt,
+      link_state: linkedRequirementIds.length > 0 ? 'linked' : 'unlinked',
+      linked_requirement_ids: linkedRequirementIds,
+      reconciliation_status: statusesByDocument.get(source.id),
+      pdd_fragments: source.kind === 'pdd'
+        ? documentFragments.map((fragment) => ({
+            fragment_id: fragment.fragmentId,
+            evidence_id: source.id,
+            label: fragment.label,
+            page_start: fragment.pageStart,
+            page_end: fragment.pageEnd ?? fragment.pageStart,
+            section_label: fragment.sheetName,
+            section_heading: fragment.label,
+            excerpt: fragment.text.slice(0, 240),
+            bbox_hint: null,
+          }))
+        : undefined,
+    } satisfies EvidenceInventoryItem;
+  }), (item) => item.evidence_id);
+}
+
+function buildFallbackReconciliationGaps(project: Project): CoverageGap[] {
+  return sortByString(
+    project.reviews
+      .filter((review) => review.status !== 'verified' && review.status !== 'not-applicable')
+      .map((review) => ({
+        ruleId: review.ruleId,
+        ruleTitle: review.ruleTitle,
+        sectionId: review.sectionId,
+        expectedEvidenceIds: [...review.evidenceIds].sort((a, b) => a.localeCompare(b)),
+        matchedEvidenceIds: review.status === 'gap' ? [] : [...review.evidenceIds].sort((a, b) => a.localeCompare(b)),
+      })),
+    (gap) => gap.ruleId,
+  );
+}
+
+async function buildFallbackReconciliationRun(
+  project: Project,
+  fragments: DocumentFragment[],
+  candidateLinks: CandidateLink[],
+  exportTime: string,
+): Promise<ReconciliationRun> {
+  const items: ReconciliationItem[] = [];
+  for (const fragment of sortByString(fragments, (item) => item.fragmentId)) {
+    const linkedReview = project.reviews.find(
+      (review) => review.evidenceIds.includes(fragment.documentId) || review.evidenceIds.includes(fragment.fragmentId),
+    );
+    items.push({
+      id: `rec_${fragment.fragmentId}`,
+      fragmentId: fragment.fragmentId,
+      ruleId: linkedReview?.ruleId,
+      ruleTitle: linkedReview?.ruleTitle,
+      sectionId: linkedReview?.sectionId,
+      status: linkedReview ? 'linked' : 'unmatched',
+      matchType: linkedReview ? 'manual-link' : undefined,
+      confidence: linkedReview ? 1 : undefined,
+      isManualOverride: Boolean(linkedReview),
+      contentSha256: fragment.contentSha256,
+    });
+  }
+
+  const gaps = buildFallbackReconciliationGaps(project);
+  const itemFingerprint = await computeItemFingerprint(items);
+  const gapFingerprint = await computeGapFingerprint(gaps);
+  const reconciliationFingerprint = await sha256Text(canonicalJsonStringify({
+    projectId: project.id,
+    itemFingerprint,
+    gapFingerprint,
+  }));
+
+  const status: ReconciliationStatus = project.reviews.length > 0 ? 'complete' : 'no-rules';
+  return {
+    runId: reconciliationFingerprint,
+    createdAt: exportTime,
+    projectId: project.id,
+    status,
+    items,
+    gaps,
+    itemFingerprint,
+    gapFingerprint,
+    reconciliationFingerprint,
+  };
+}
+
+function mapReviewStatusToDecisionStatus(review: RuleReview): ReviewerDecision['status'] {
+  if (review.status === 'verified') return 'approved';
+  if (review.status === 'gap') return 'rejected';
+  return 'needs-review';
+}
+
+function mapFindingStatusToDecisionStatus(finding: ManualFinding): ReviewerDecision['status'] {
+  if (finding.closureStatus === 'closed') return 'approved';
+  if (finding.closureStatus === 'open') return 'rejected';
+  return 'needs-review';
+}
+
+function reviewRationale(review: RuleReview): string {
+  if (review.note?.trim()) return review.note.trim();
+  if (review.status === 'verified') return 'Reviewer marked this requirement as verified from the linked evidence set.';
+  if (review.status === 'gap') return 'Reviewer marked this requirement as a gap due to insufficient supporting evidence.';
+  if (review.status === 'not-applicable') return 'Reviewer marked this requirement as not applicable for the current project scope.';
+  return 'Reviewer has not finalized this requirement and additional evidence review is still pending.';
+}
+
+function findingRationale(finding: ManualFinding): string {
+  return (
+    finding.reviewerNote?.trim()
+    || finding.auditTeamEvaluation?.trim()
+    || finding.projectResponse?.trim()
+    || finding.evidenceExcerpt?.trim()
+    || 'Reviewer decision derived from the manual findings register.'
+  );
+}
+
+async function buildDecisionRunFromProject(
+  project: Project,
+  exportTime: string,
+  reconciliationRun?: ReconciliationRun,
+): Promise<DecisionRun> {
+  const decisions: ReviewerDecision[] = [];
+
+  if (project.reviewMode === 'manual') {
+    for (const finding of sortByString(project.manualFindings, (item) => item.findingId)) {
+      const reviewedAt = finding.updatedAt || finding.createdAt || exportTime;
+      const decision: ReviewerDecision = {
+        decisionId: `dec_${sanitizeId(finding.findingId)}_${sanitizeId(project.id)}`,
+        ruleId: finding.findingId,
+        ruleTitle: finding.requirement || finding.description || finding.findingType,
+        sectionId: 'Manual Findings',
+        status: mapFindingStatusToDecisionStatus(finding),
+        rationale: findingRationale(finding),
+        reviewerId: 'project-reviewer',
+        reviewedAt,
+        updatedAt: reviewedAt,
+        evidenceInventoryIds: finding.sourceDocumentId ? [finding.sourceDocumentId] : [],
+        reconciliationRunId: reconciliationRun?.runId,
+        provenanceHash: '',
+      };
+      decision.provenanceHash = await computeDecisionProvenance(decision);
+      decisions.push(decision);
+    }
+  } else {
+    for (const review of sortByString(project.reviews, (item) => item.ruleId)) {
+      if (review.status === 'not-started' && !review.note?.trim() && review.evidenceIds.length === 0) continue;
+      const reviewedAt = review.reviewedAt || project.lockedAt || exportTime;
+      const decision: ReviewerDecision = {
+        decisionId: `dec_${sanitizeId(review.ruleId)}_${sanitizeId(project.id)}`,
+        ruleId: review.ruleId,
+        ruleTitle: review.ruleTitle,
+        sectionId: review.sectionId,
+        status: mapReviewStatusToDecisionStatus(review),
+        rationale: reviewRationale(review),
+        reviewerId: 'project-reviewer',
+        reviewedAt,
+        updatedAt: reviewedAt,
+        evidenceInventoryIds: [...review.evidenceIds].sort((a, b) => a.localeCompare(b)),
+        reconciliationRunId: reconciliationRun?.runId,
+        provenanceHash: '',
+      };
+      decision.provenanceHash = await computeDecisionProvenance(decision);
+      decisions.push(decision);
+    }
+  }
+
+  const sortedDecisions = sortByString(decisions, (decision) => decision.decisionId);
+  const decisionSetFingerprint = await computeDecisionSetFingerprint(sortedDecisions);
+  const runId = await sha256Text(canonicalJsonStringify({
+    projectId: project.id,
+    decisionSetFingerprint,
+    reconciliationRunId: reconciliationRun?.runId,
+  }));
+
+  return {
+    runId,
+    projectId: project.id,
+    createdAt: exportTime,
+    decisions: sortedDecisions,
+    decisionSetFingerprint,
+    reconciliationRunId: reconciliationRun?.runId,
+  };
+}
+
+export async function buildPremiumExportInputFromProject(params: {
+  project: Project;
+  coverage?: ProjectCoverage;
+  exportTime?: string;
+  pipelineVersion?: string;
+}): Promise<PremiumExportInput> {
+  const { project } = params;
+  const coverage = params.coverage ?? {
+    total: project.reviews.length,
+    verified: project.reviews.filter((review) => review.status === 'verified').length,
+    gap: project.reviews.filter((review) => review.status === 'gap').length,
+    notStarted: project.reviews.filter((review) => review.status === 'not-started').length,
+    notApplicable: project.reviews.filter((review) => review.status === 'not-applicable').length,
+    inProgress: project.reviews.filter((review) => review.status === 'in-progress').length,
+    percentComplete: Math.round(
+      (project.reviews.filter((review) => review.status === 'verified' || review.status === 'gap').length / Math.max(1, project.reviews.length - project.reviews.filter((review) => review.status === 'not-applicable').length)) * 100,
+    ),
+  };
+  const exportTime = resolveExportTime(project, params.exportTime);
+  const pipelineVersion = params.pipelineVersion ?? '1.0.0';
+  const sourceArtifacts = buildSourceArtifacts(project);
+  const sources = buildSources(project, sourceArtifacts);
+
+  let fragments: DocumentFragment[] = [];
+  let facts: ExtractedFact[] = [];
+  let candidateLinks: CandidateLink[] = [];
+
+  if (project.reviewMode === 'methodology-linked' && project.methodCode && project.methodVersion && sourceArtifacts.length > 0) {
+    const extractionRun = await runExtraction({
+      projectId: project.id,
+      documents: sortByString(sourceArtifacts, (artifact) => artifact.documentId).map((artifact) => ({
+        doc: sources.find((source) => source.id === artifact.documentId)!,
+        buffer: decodeBase64ToArrayBuffer(artifact.contentBase64),
+      })),
+      methodCode: project.methodCode,
+      methodVersion: project.methodVersion,
+    });
+    fragments = sortByString(extractionRun.fragments, (fragment) => fragment.fragmentId);
+    facts = sortByString(extractionRun.facts, (fact) => fact.factId);
+    candidateLinks = sortByString(extractionRun.candidateLinks, (link) => link.linkId);
+  } else {
+    fragments = await buildFallbackFragments(project, sources);
+    facts = await buildFallbackFacts(fragments);
+  }
+
+  let reconciliationRun: ReconciliationRun | undefined;
+  if (project.reviewMode === 'methodology-linked' && project.methodCode && project.methodVersion) {
+    try {
+      reconciliationRun = await reconcileEvidence({
+        fragments,
+        facts,
+        candidateLinks,
+        methodCode: project.methodCode,
+        methodVersion: project.methodVersion,
+        projectId: project.id,
+      });
+      if (reconciliationRun.status !== 'complete') {
+        reconciliationRun = await buildFallbackReconciliationRun(project, fragments, candidateLinks, exportTime);
+      } else {
+        reconciliationRun = {
+          ...reconciliationRun,
+          createdAt: exportTime,
+        };
+      }
+    } catch {
+      reconciliationRun = await buildFallbackReconciliationRun(project, fragments, candidateLinks, exportTime);
+    }
+  } else {
+    reconciliationRun = await buildFallbackReconciliationRun(project, fragments, candidateLinks, exportTime);
+  }
+
+  const inventory = buildInventory(project, sources, fragments, reconciliationRun);
+  const decisionRun = await buildDecisionRunFromProject(project, exportTime, reconciliationRun);
+
+  return {
+    project,
+    coverage,
+    inventory,
+    sources,
+    sourceArtifacts,
+    fragments,
+    facts,
+    candidateLinks,
+    reconciliationRun,
+    decisionRun,
+    exportTime,
+    pipelineVersion,
+  };
+}

--- a/src/lib/evidence/export/types.ts
+++ b/src/lib/evidence/export/types.ts
@@ -1,0 +1,39 @@
+import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
+import type { SourceDocument, DocumentFragment, ExtractedFact, CandidateLink } from '@/lib/evidence/extraction/types';
+import type { ReconciliationRun } from '@/lib/evidence/reconciliation/types';
+import type { DecisionRun } from '@/lib/evidence/decisions/types';
+import type { Project, ProjectCoverage } from '@/lib/projects/types';
+
+export type PremiumExportInput = {
+  project: Project;
+  coverage: ProjectCoverage;
+  inventory: EvidenceInventoryItem[];
+  sources: SourceDocument[];
+  fragments: DocumentFragment[];
+  facts: ExtractedFact[];
+  candidateLinks: CandidateLink[];
+  reconciliationRun?: ReconciliationRun;
+  decisionRun?: DecisionRun;
+  exportTime?: string;
+  pipelineVersion?: string;
+};
+
+export type PremiumExportOutput = {
+  pdf: Buffer;
+  zip: Buffer;
+};
+
+export type PremiumExportMeta = {
+  exportId: string;
+  projectId: string;
+  exportedAt: string;
+  pipelineVersion: string;
+  inputFingerprint: string;
+  contentHash: string;
+};
+
+export type ManifestEntry = {
+  path: string;
+  contentSha256: string;
+  sizeBytes: number;
+};

--- a/src/lib/evidence/export/types.ts
+++ b/src/lib/evidence/export/types.ts
@@ -4,11 +4,21 @@ import type { ReconciliationRun } from '@/lib/evidence/reconciliation/types';
 import type { DecisionRun } from '@/lib/evidence/decisions/types';
 import type { Project, ProjectCoverage } from '@/lib/projects/types';
 
+export type SourceArtifact = {
+  documentId: string;
+  fileName: string;
+  mime: string;
+  sizeBytes: number;
+  contentSha256: string;
+  contentBase64: string;
+};
+
 export type PremiumExportInput = {
   project: Project;
   coverage: ProjectCoverage;
   inventory: EvidenceInventoryItem[];
   sources: SourceDocument[];
+  sourceArtifacts?: SourceArtifact[];
   fragments: DocumentFragment[];
   facts: ExtractedFact[];
   candidateLinks: CandidateLink[];

--- a/src/lib/evidence/export/zipExporter.ts
+++ b/src/lib/evidence/export/zipExporter.ts
@@ -1,0 +1,201 @@
+import JSZip from 'jszip';
+import type { PremiumExportInput, ManifestEntry } from './types';
+import { buildPremiumPdf } from './pdfExporter';
+import { canonicalJsonStringify } from '@/lib/export/canonicalJson';
+import { createHash } from 'crypto';
+
+function sha256(input: string): string {
+  return createHash('sha256').update(input, 'utf-8').digest('hex');
+}
+
+function byteLength(input: string): number {
+  return Buffer.byteLength(input, 'utf-8');
+}
+
+function buildExportJson(input: PremiumExportInput): string {
+  const { project, coverage, inventory, sources, fragments, facts, candidateLinks, reconciliationRun, decisionRun } = input;
+  const now = input.exportTime ?? new Date().toISOString();
+  const pipelineVersion = input.pipelineVersion ?? '1.0.0';
+
+  const data = {
+    exportMeta: {
+      exportedAt: now,
+      pipelineVersion,
+      projectId: project.id,
+      projectName: project.name,
+    },
+    project: {
+      id: project.id,
+      name: project.name,
+      reviewMode: project.reviewMode,
+      registry: project.registry,
+      methodCode: project.methodCode,
+      methodVersion: project.methodVersion,
+      status: project.status,
+      createdAt: project.createdAt,
+      lockedAt: project.lockedAt,
+      aoiLabel: project.aoiLabel,
+      description: project.description,
+    },
+    coverage: {
+      total: coverage.total,
+      verified: coverage.verified,
+      gap: coverage.gap,
+      notStarted: coverage.notStarted,
+      notApplicable: coverage.notApplicable,
+      inProgress: coverage.inProgress,
+      percentComplete: coverage.percentComplete,
+    },
+    evidenceInventory: inventory.map((item) => ({
+      evidence_id: item.evidence_id,
+      dedupe_key: item.dedupe_key,
+      display_name: item.display_name,
+      kind: item.kind,
+      type: item.type,
+      added_at: item.added_at,
+      link_state: item.link_state,
+      linked_requirement_ids: item.linked_requirement_ids,
+      reconciliation_status: item.reconciliation_status,
+      fragment_count: (item.pdd_fragments ?? []).length,
+    })),
+    documents: sources.map((doc) => ({
+      id: doc.id,
+      fileName: doc.fileName,
+      mime: doc.mime,
+      kind: doc.kind,
+      sizeBytes: doc.sizeBytes,
+      contentSha256: doc.contentSha256,
+    })),
+    fragments: fragments.map((f) => ({
+      fragmentId: f.fragmentId,
+      documentId: f.documentId,
+      kind: f.kind,
+      index: f.index,
+      label: f.label,
+      textLength: f.text.length,
+      contentSha256: f.contentSha256,
+      pageStart: f.pageStart,
+      pageEnd: f.pageEnd,
+      sheetName: f.sheetName,
+    })),
+    facts: facts.map((fact) => ({
+      factId: fact.factId,
+      fragmentId: fact.fragmentId,
+      documentId: fact.documentId,
+      factType: fact.factType,
+      value: fact.value,
+      contentSha256: fact.contentSha256,
+    })),
+    candidateLinks: candidateLinks.map((link) => ({
+      linkId: link.linkId,
+      factId: link.factId,
+      ruleId: link.ruleId,
+      matchType: link.matchType,
+      confidence: link.confidence,
+      contentSha256: link.contentSha256,
+    })),
+    reconciliation: reconciliationRun
+      ? {
+          runId: reconciliationRun.runId,
+          status: reconciliationRun.status,
+          loadError: reconciliationRun.loadError,
+          itemCount: reconciliationRun.items.length,
+          gapCount: reconciliationRun.gaps.length,
+          reconciliationFingerprint: reconciliationRun.reconciliationFingerprint,
+          gaps: reconciliationRun.gaps.map((g) => ({
+            ruleId: g.ruleId,
+            ruleTitle: g.ruleTitle,
+            sectionId: g.sectionId,
+          })),
+        }
+      : null,
+    decisions: decisionRun
+      ? {
+          runId: decisionRun.runId,
+          decisionSetFingerprint: decisionRun.decisionSetFingerprint,
+          decisions: decisionRun.decisions.map((d) => ({
+            decisionId: d.decisionId,
+            ruleId: d.ruleId,
+            status: d.status,
+            rationale: d.rationale,
+            reviewerId: d.reviewerId,
+            reviewedAt: d.reviewedAt,
+            evidenceInventoryIds: d.evidenceInventoryIds,
+            provenanceHash: d.provenanceHash,
+          })),
+        }
+      : null,
+  };
+
+  return canonicalJsonStringify(data);
+}
+
+function buildManifest(entries: ManifestEntry[]): string {
+  const manifest = {
+    exportVersion: '1.0.0',
+    generatedAt: new Date().toISOString(),
+    entries: entries.map((e) => ({
+      path: e.path,
+      contentSha256: e.contentSha256,
+      sizeBytes: e.sizeBytes,
+    })),
+  };
+  return canonicalJsonStringify(manifest);
+}
+
+export async function buildPremiumZip(input: PremiumExportInput): Promise<Buffer> {
+  const zip = new JSZip();
+  const entries: ManifestEntry[] = [];
+
+  const exportJson = buildExportJson(input);
+  zip.file('export.json', exportJson);
+  entries.push({
+    path: 'export.json',
+    contentSha256: sha256(exportJson),
+    sizeBytes: byteLength(exportJson),
+  });
+
+  const fragmentsDir = zip.folder('fragments');
+  if (fragmentsDir) {
+    for (const fragment of input.fragments) {
+      const fragContent = [
+        `Fragment ID: ${fragment.fragmentId}`,
+        `Document ID: ${fragment.documentId}`,
+        `Kind: ${fragment.kind}`,
+        `Label: ${fragment.label}`,
+        `Page: ${fragment.pageStart ?? ''}${fragment.pageEnd && fragment.pageEnd !== fragment.pageStart ? `-${fragment.pageEnd}` : ''}`,
+        `Sheet: ${fragment.sheetName ?? ''}`,
+        `Content SHA-256: ${fragment.contentSha256}`,
+        '',
+        fragment.text,
+      ].join('\n');
+      const fragPath = `fragments/${fragment.fragmentId}.txt`;
+      fragmentsDir.file(`${fragment.fragmentId}.txt`, fragContent);
+      entries.push({
+        path: fragPath,
+        contentSha256: sha256(fragContent),
+        sizeBytes: byteLength(fragContent),
+      });
+    }
+  }
+
+  const pdf = buildPremiumPdf(input);
+  const pdfContent = pdf.toString('binary');
+  zip.file('reports/premium-evidence-report.pdf', pdfContent, { binary: true });
+  entries.push({
+    path: 'reports/premium-evidence-report.pdf',
+    contentSha256: sha256(pdf.toString('utf-8')),
+    sizeBytes: pdf.length,
+  });
+
+  const manifestJson = buildManifest(entries);
+  zip.file('manifest.json', manifestJson);
+  entries.push({
+    path: 'manifest.json',
+    contentSha256: sha256(manifestJson),
+    sizeBytes: byteLength(manifestJson),
+  });
+
+  const zipBuffer = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+  return zipBuffer;
+}

--- a/src/lib/evidence/export/zipExporter.ts
+++ b/src/lib/evidence/export/zipExporter.ts
@@ -8,8 +8,20 @@ function sha256(input: string): string {
   return createHash('sha256').update(input, 'utf-8').digest('hex');
 }
 
+function sha256Buffer(input: Buffer): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
 function byteLength(input: string): number {
   return Buffer.byteLength(input, 'utf-8');
+}
+
+function exportTimestamp(input: PremiumExportInput): string {
+  return input.exportTime ?? input.project.lockedAt ?? input.project.createdAt ?? '1970-01-01T00:00:00.000Z';
+}
+
+function stableDate(input: PremiumExportInput): Date {
+  return new Date(exportTimestamp(input));
 }
 
 function buildExportJson(input: PremiumExportInput): string {
@@ -130,25 +142,13 @@ function buildExportJson(input: PremiumExportInput): string {
   return canonicalJsonStringify(data);
 }
 
-function buildManifest(entries: ManifestEntry[]): string {
-  const manifest = {
-    exportVersion: '1.0.0',
-    generatedAt: new Date().toISOString(),
-    entries: entries.map((e) => ({
-      path: e.path,
-      contentSha256: e.contentSha256,
-      sizeBytes: e.sizeBytes,
-    })),
-  };
-  return canonicalJsonStringify(manifest);
-}
-
 export async function buildPremiumZip(input: PremiumExportInput): Promise<Buffer> {
   const zip = new JSZip();
   const entries: ManifestEntry[] = [];
+  const fileDate = stableDate(input);
 
   const exportJson = buildExportJson(input);
-  zip.file('export.json', exportJson);
+  zip.file('export.json', exportJson, { date: fileDate });
   entries.push({
     path: 'export.json',
     contentSha256: sha256(exportJson),
@@ -170,7 +170,7 @@ export async function buildPremiumZip(input: PremiumExportInput): Promise<Buffer
         fragment.text,
       ].join('\n');
       const fragPath = `fragments/${fragment.fragmentId}.txt`;
-      fragmentsDir.file(`${fragment.fragmentId}.txt`, fragContent);
+      fragmentsDir.file(`${fragment.fragmentId}.txt`, fragContent, { date: fileDate });
       entries.push({
         path: fragPath,
         contentSha256: sha256(fragContent),
@@ -179,23 +179,50 @@ export async function buildPremiumZip(input: PremiumExportInput): Promise<Buffer
     }
   }
 
+  const sourcesDir = zip.folder('sources');
+  if (sourcesDir) {
+    for (const source of (input.sourceArtifacts ?? []).slice().sort((a, b) => a.documentId.localeCompare(b.documentId))) {
+      const bytes = Buffer.from(source.contentBase64, 'base64');
+      const safeFileName = `${source.documentId}_${source.fileName}`.replace(/[^a-zA-Z0-9._-]+/g, '_');
+      const sourcePath = `sources/${safeFileName}`;
+      sourcesDir.file(safeFileName, bytes, { binary: true, date: fileDate });
+      entries.push({
+        path: sourcePath,
+        contentSha256: source.contentSha256,
+        sizeBytes: bytes.length,
+      });
+    }
+  }
+
   const pdf = buildPremiumPdf(input);
-  const pdfContent = pdf.toString('binary');
-  zip.file('reports/premium-evidence-report.pdf', pdfContent, { binary: true });
+  zip.file('reports/premium-evidence-report.pdf', pdf, { binary: true, date: fileDate });
   entries.push({
     path: 'reports/premium-evidence-report.pdf',
-    contentSha256: sha256(pdf.toString('utf-8')),
+    contentSha256: sha256Buffer(pdf),
     sizeBytes: pdf.length,
   });
 
-  const manifestJson = buildManifest(entries);
-  zip.file('manifest.json', manifestJson);
+  const manifest = {
+    exportVersion: '1.0.0',
+    generatedAt: exportTimestamp(input),
+    entries: entries.map((entry) => ({
+      path: entry.path,
+      contentSha256: entry.contentSha256,
+      sizeBytes: entry.sizeBytes,
+    })),
+  };
+  const manifestJson = canonicalJsonStringify(manifest);
+  zip.file('manifest.json', manifestJson, { date: fileDate });
   entries.push({
     path: 'manifest.json',
     contentSha256: sha256(manifestJson),
     sizeBytes: byteLength(manifestJson),
   });
 
-  const zipBuffer = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+  const zipBuffer = await zip.generateAsync({
+    type: 'nodebuffer',
+    compression: 'DEFLATE',
+    platform: 'UNIX',
+  });
   return zipBuffer;
 }

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -83,6 +83,8 @@ export type ProjectDocument = {
   mimeType: string;
   sizeBytes: number;
   uploadedAt: string;
+  contentSha256?: string;
+  contentBase64?: string;
   extractedText?: string;
   manualFindingExtractionStatus?: 'not-run' | 'no-findings' | 'extracted' | 'extraction-failed';
   manualFindingExtractionMessage?: string;

--- a/tests/lib/evidence/export/premiumExport.test.ts
+++ b/tests/lib/evidence/export/premiumExport.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it } from '@jest/globals';
+import { buildPremiumPdf, buildPremiumZip } from '@/lib/evidence/export';
+import type { PremiumExportInput } from '@/lib/evidence/export';
+import type { Project } from '@/lib/projects/types';
+import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
+import type { SourceDocument, DocumentFragment, ExtractedFact, CandidateLink } from '@/lib/evidence/extraction/types';
+import type { ReconciliationRun } from '@/lib/evidence/reconciliation/types';
+import type { DecisionRun } from '@/lib/evidence/decisions/types';
+
+function makeProject(reviewCount = 6): Project {
+  return {
+    id: 'project-12345678',
+    name: 'Malawi Verification Project',
+    reviewMode: 'methodology-linked',
+    methodCode: 'AR-AMS0007',
+    methodVersion: 'v03-1',
+    registry: 'UNFCCC',
+    status: 'locked',
+    createdAt: '2026-04-15T00:00:00Z',
+    aoiLabel: 'Machinga District',
+    documents: [],
+    manualFindings: [],
+    extractedManualFindingDrafts: [],
+    learningCases: [],
+    reviews: Array.from({ length: reviewCount }, (_, index) => ({
+      ruleId: `R-${index + 1}`,
+      ruleTitle: `Verification requirement ${index + 1} for monitoring`,
+      sectionId: index < reviewCount / 2 ? 'Eligibility' : 'Monitoring',
+      status: index % 5 === 0 ? 'gap' : index % 3 === 0 ? 'not-started' : 'verified',
+      evidenceIds: [`evidence-${index + 1}`],
+    })),
+  };
+}
+
+function makeInventory(): EvidenceInventoryItem[] {
+  return [
+    {
+      evidence_id: 'pin-001',
+      dedupe_key: 'attachment:abc123',
+      display_name: 'PDD Malawi v2.pdf',
+      kind: 'pdd',
+      type: 'PDD',
+      source_summary: 'PDD upload',
+      provenance_summary: 'PDD document',
+      added_at: '2026-04-15T00:00:00Z',
+      link_state: 'linked',
+      linked_requirement_ids: ['R-1'],
+      reconciliation_status: 'linked',
+      pdd_fragments: [
+        {
+          fragment_id: 'frag-001',
+          evidence_id: 'pin-001',
+          label: 'Section 1',
+          page_start: 1,
+          page_end: 3,
+          section_label: 'Project Description',
+          section_heading: 'Project Description',
+          excerpt: 'Project description excerpt',
+          bbox_hint: null,
+        },
+      ],
+    },
+    {
+      evidence_id: 'pin-002',
+      dedupe_key: 'attachment:def456',
+      display_name: 'Workbook.xlsx',
+      kind: 'workbook',
+      type: 'Workbook',
+      source_summary: 'Workbook upload',
+      provenance_summary: 'Workbook with calculations',
+      added_at: '2026-04-16T00:00:00Z',
+      link_state: 'unlinked',
+      linked_requirement_ids: [],
+    },
+  ];
+}
+
+function makeSources(): SourceDocument[] {
+  return [
+    { id: 'src-001', fileName: 'PDD Malawi v2.pdf', mime: 'application/pdf', kind: 'pdd', sizeBytes: 500000, contentSha256: 'a'.repeat(64) },
+    { id: 'src-002', fileName: 'Workbook.xlsx', mime: 'application/xlsx', kind: 'workbook', sizeBytes: 200000, contentSha256: 'b'.repeat(64) },
+  ];
+}
+
+function makeFragments(): DocumentFragment[] {
+  return [
+    { fragmentId: 'frag-001', documentId: 'src-001', kind: 'pdd', index: 0, label: 'Section 1', text: 'Project description for Malawi. The project covers 500 ha of forest.', contentSha256: 'c'.repeat(64), pageStart: 1, pageEnd: 3 },
+    { fragmentId: 'frag-002', documentId: 'src-001', kind: 'pdd', index: 1, label: 'Section 2', text: 'Baseline scenario calculation.', contentSha256: 'd'.repeat(64), pageStart: 4, pageEnd: 6 },
+  ];
+}
+
+function makeFacts(): ExtractedFact[] {
+  return [
+    { factId: 'fact-001', fragmentId: 'frag-001', documentId: 'src-001', factType: 'location', value: 'Machinga District, Malawi', context: 'project location', contentSha256: 'e'.repeat(64) },
+    { factId: 'fact-002', fragmentId: 'frag-001', documentId: 'src-001', factType: 'quantity', value: '500 ha', context: 'project area', contentSha256: 'f'.repeat(64) },
+    { factId: 'fact-003', fragmentId: 'frag-002', documentId: 'src-001', factType: 'baseline-scenario', value: 'Business-as-usual deforestation', context: 'baseline description', contentSha256: 'g'.repeat(64) },
+  ];
+}
+
+function makeCandidateLinks(): CandidateLink[] {
+  return [
+    { linkId: 'link-001', factId: 'fact-001', ruleId: 'R-1', ruleTitle: 'Location requirement', sectionId: 'S-1', matchType: 'keyword-overlap', matchReason: 'Location keyword match', confidence: 0.85, contentSha256: 'h'.repeat(64) },
+    { linkId: 'link-002', factId: 'fact-002', ruleId: 'R-2', ruleTitle: 'Area requirement', sectionId: 'S-1', matchType: 'keyword-overlap', matchReason: 'Quantity keyword match', confidence: 0.75, contentSha256: 'i'.repeat(64) },
+  ];
+}
+
+function makeInput(overrides?: Partial<PremiumExportInput>): PremiumExportInput {
+  const base: PremiumExportInput = {
+    project: makeProject(),
+    coverage: {
+      total: 6,
+      verified: 4,
+      gap: 1,
+      notStarted: 1,
+      notApplicable: 0,
+      inProgress: 0,
+      percentComplete: 83,
+    },
+    inventory: makeInventory(),
+    sources: makeSources(),
+    fragments: makeFragments(),
+    facts: makeFacts(),
+    candidateLinks: makeCandidateLinks(),
+    reconciliationRun: {
+      runId: 'rec-run-001',
+      createdAt: '2026-05-01T00:00:00Z',
+      projectId: 'project-12345678',
+      status: 'complete',
+      items: [],
+      gaps: [{ ruleId: 'R-3', ruleTitle: 'Monitoring requirement', sectionId: 'S-2', expectedEvidenceIds: [], matchedEvidenceIds: [] }],
+      itemFingerprint: 'j'.repeat(64),
+      gapFingerprint: 'k'.repeat(64),
+      reconciliationFingerprint: 'l'.repeat(64),
+    },
+    decisionRun: {
+      runId: 'dec-run-001',
+      projectId: 'project-12345678',
+      createdAt: '2026-05-02T00:00:00Z',
+      decisionSetFingerprint: 'm'.repeat(64),
+      decisions: [
+        {
+          decisionId: 'dec_R-1_reviewer_abc_001',
+          ruleId: 'R-1',
+          ruleTitle: 'Location requirement',
+          sectionId: 'S-1',
+          status: 'approved',
+          rationale: 'Methodology defines forest threshold which is satisfied.',
+          reviewerId: 'reviewer_abc',
+          reviewedAt: '2026-05-02T10:00:00Z',
+          updatedAt: '2026-05-02T10:00:00Z',
+          evidenceInventoryIds: ['pin-001'],
+          provenanceHash: 'n'.repeat(64),
+        },
+        {
+          decisionId: 'dec_R-2_reviewer_abc_002',
+          ruleId: 'R-2',
+          ruleTitle: 'Area requirement',
+          sectionId: 'S-1',
+          status: 'needs-review',
+          rationale: 'Need more data on area calculation.',
+          reviewerId: 'reviewer_abc',
+          reviewedAt: '2026-05-02T11:00:00Z',
+          updatedAt: '2026-05-02T11:00:00Z',
+          evidenceInventoryIds: [],
+          provenanceHash: 'o'.repeat(64),
+        },
+      ],
+    },
+    exportTime: '2026-05-20T00:00:00.000Z',
+    pipelineVersion: '1.0.0',
+  };
+  return { ...base, ...overrides };
+}
+
+async function extractPdfText(bytes: ArrayBuffer): Promise<string> {
+  const { extractPdfTextWithPdfParse } = await import('@/lib/chat/quickCheckPdfExtractor');
+  const result = await extractPdfTextWithPdfParse({ bytes });
+  return result.text;
+}
+
+describe('Premium PDF Export', () => {
+  it('produces a valid PDF buffer', () => {
+    const input = makeInput();
+    const pdf = buildPremiumPdf(input);
+
+    expect(pdf).toBeInstanceOf(Buffer);
+    expect(pdf.length).toBeGreaterThan(1000);
+    expect(pdf.toString('utf-8', 0, 8)).toBe('%PDF-1.4');
+  });
+
+  it('includes premium export branding', () => {
+    const input = makeInput();
+    const pdf = buildPremiumPdf(input);
+    const raw = pdf.toString('utf-8');
+
+    expect(raw).toContain('PREMIUM EVIDENCE REPORT');
+    expect(raw).toContain('Review-Grade Evidence Export');
+    expect(raw).toContain('ARTICLE6');
+  });
+
+  it('includes all 9 standard sections in the content', async () => {
+    const input = makeInput();
+    const pdf = buildPremiumPdf(input);
+    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));
+
+    expect(text).toContain('EXECUTIVE SUMMARY');
+    expect(text).toContain('PROJECT INFORMATION');
+    expect(text).toContain('METHODOLOGY SOURCE SECTIONS');
+    expect(text).toContain('EVIDENCE INVENTORY');
+    expect(text).toContain('EXTRACTED FACTS');
+    expect(text).toContain('COVERAGE MATRIX');
+    expect(text).toContain('REVIEWER DECISIONS');
+    expect(text).toContain('LIMITATIONS AND DISCLAIMERS');
+    expect(text).toContain('PROVENANCE CHAIN');
+  }, 15000);
+
+  it('includes project info from the input', async () => {
+    const input = makeInput();
+    const pdf = buildPremiumPdf(input);
+    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));
+
+    expect(text).toContain('Malawi Verification Project');
+    expect(text).toContain('AR-AMS0007');
+    expect(text).toContain('UNFCCC');
+    expect(text).toContain('Machinga District');
+  }, 15000);
+
+  it('includes evidence inventory items', async () => {
+    const input = makeInput();
+    const pdf = buildPremiumPdf(input);
+    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));
+
+    expect(text).toContain('PDD Malawi v2.pdf');
+    expect(text).toContain('PDD');
+    expect(text).toContain('Workbook.xlsx');
+    expect(text).toContain('WORKBOOK');
+  }, 15000);
+
+  it('includes extracted facts grouped by type', async () => {
+    const input = makeInput();
+    const pdf = buildPremiumPdf(input);
+    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));
+
+    expect(text).toContain('LOCATION');
+    expect(text).toContain('QUANTITY');
+    expect(text).toContain('BASELINE SCENARIO');
+    expect(text).toContain('Machinga District, Malawi');
+    expect(text).toContain('500 ha');
+  }, 15000);
+
+  it('includes coverage matrix with rule statuses', async () => {
+    const input = makeInput();
+    const pdf = buildPremiumPdf(input);
+    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));
+
+    expect(text).toContain('VERIFIED');
+    expect(text).toContain('R-1');
+    expect(text).toContain('R-2');
+    expect(text).toContain('Verification requirement');
+    expect(text).toContain('COVERAGE GAPS');
+    expect(text).toContain('R-3');
+  }, 15000);
+
+  it('includes reviewer decisions', async () => {
+    const input = makeInput();
+    const pdf = buildPremiumPdf(input);
+    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));
+
+    expect(text).toContain('APPROVED');
+    expect(text).toContain('NEEDS-REVIEW');
+    expect(text).toContain('forest threshold');
+    expect(text).toContain('reviewer_abc');
+  }, 15000);
+
+  it('handles empty pipeline data gracefully', async () => {
+    const input: PremiumExportInput = {
+      project: makeProject(2),
+      coverage: { total: 2, verified: 0, gap: 0, notStarted: 2, notApplicable: 0, inProgress: 0, percentComplete: 0 },
+      inventory: [],
+      sources: [],
+      fragments: [],
+      facts: [],
+      candidateLinks: [],
+    };
+    const pdf = buildPremiumPdf(input);
+    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));
+
+    expect(text).toContain('PREMIUM EVIDENCE REPORT');
+    expect(text).toContain('No evidence items in the inventory');
+    expect(text).toContain('No extracted facts available');
+    expect(text).toContain('No reviewer decisions recorded');
+    expect(text).not.toMatch(/undefined|null/);
+  }, 15000);
+
+  it('does not contain restricted certification phrasing', async () => {
+    const input = makeInput();
+    const pdf = buildPremiumPdf(input);
+    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));
+
+    const phrases = [
+      'certified emission reductions are approved',
+      'verification opinion: positive',
+      'VCUs issued',
+      'registry approved',
+      'validated successfully',
+    ];
+    for (const phrase of phrases) {
+      expect(text).not.toContain(phrase);
+    }
+  }, 15000);
+});
+
+describe('Premium ZIP Export', () => {
+  it('produces a valid ZIP buffer', async () => {
+    const input = makeInput();
+    const zip = await buildPremiumZip(input);
+
+    expect(zip).toBeInstanceOf(Buffer);
+    expect(zip.length).toBeGreaterThan(500);
+  });
+
+  it('includes expected entries in the ZIP', async () => {
+    const input = makeInput();
+    const zipBuffer = await buildPremiumZip(input);
+    const JSZip = await import('jszip');
+    const zip = await JSZip.default.loadAsync(zipBuffer);
+
+    const files = Object.keys(zip.files);
+    expect(files).toContain('export.json');
+    expect(files).toContain('manifest.json');
+    expect(files).toContain('reports/premium-evidence-report.pdf');
+    expect(files).toContain('fragments/frag-001.txt');
+    expect(files).toContain('fragments/frag-002.txt');
+  });
+
+  it('contains valid JSON in export.json', async () => {
+    const input = makeInput();
+    const zipBuffer = await buildPremiumZip(input);
+    const JSZip = await import('jszip');
+    const zip = await JSZip.default.loadAsync(zipBuffer);
+
+    const exportJson = await zip.file('export.json')!.async('string');
+    const parsed = JSON.parse(exportJson);
+
+    expect(parsed.exportMeta.projectId).toBe('project-12345678');
+    expect(parsed.exportMeta.projectName).toBe('Malawi Verification Project');
+    expect(parsed.project.methodCode).toBe('AR-AMS0007');
+    expect(parsed.evidenceInventory).toHaveLength(2);
+    expect(parsed.fragments).toHaveLength(2);
+    expect(parsed.facts).toHaveLength(3);
+    expect(parsed.candidateLinks).toHaveLength(2);
+    expect(parsed.reconciliation.gaps).toHaveLength(1);
+    expect(parsed.decisions.decisions).toHaveLength(2);
+  });
+
+  it('contains valid manifest.json with content hashes', async () => {
+    const input = makeInput();
+    const zipBuffer = await buildPremiumZip(input);
+    const JSZip = await import('jszip');
+    const zip = await JSZip.default.loadAsync(zipBuffer);
+
+    const manifestJson = await zip.file('manifest.json')!.async('string');
+    const manifest = JSON.parse(manifestJson);
+
+    expect(manifest.exportVersion).toBe('1.0.0');
+    expect(manifest.entries.length).toBeGreaterThanOrEqual(4);
+    for (const entry of manifest.entries) {
+      expect(entry.path).toBeTruthy();
+      expect(entry.contentSha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(entry.sizeBytes).toBeGreaterThan(0);
+    }
+  });
+
+  it('includes fragment text content in fragments/', async () => {
+    const input = makeInput();
+    const zipBuffer = await buildPremiumZip(input);
+    const JSZip = await import('jszip');
+    const zip = await JSZip.default.loadAsync(zipBuffer);
+
+    const fragContent = await zip.file('fragments/frag-001.txt')!.async('string');
+    expect(fragContent).toContain('Fragment ID: frag-001');
+    expect(fragContent).toContain('Project description for Malawi');
+  });
+
+  it('handles empty data gracefully', async () => {
+    const input: PremiumExportInput = {
+      project: makeProject(),
+      coverage: { total: 6, verified: 4, gap: 1, notStarted: 1, notApplicable: 0, inProgress: 0, percentComplete: 83 },
+      inventory: [],
+      sources: [],
+      fragments: [],
+      facts: [],
+      candidateLinks: [],
+    };
+    const zipBuffer = await buildPremiumZip(input);
+    const JSZip = await import('jszip');
+    const zip = await JSZip.default.loadAsync(zipBuffer);
+
+    expect(Object.keys(zip.files)).toContain('export.json');
+    expect(Object.keys(zip.files)).toContain('manifest.json');
+  });
+});
+
+describe('/api/projects/[id]/export-premium route', () => {
+  it('returns a PDF attachment on POST with format=pdf', async () => {
+    const { POST } = await import('@/app/api/projects/[id]/export-premium/route');
+    const input = makeInput();
+    const req = new Request('http://localhost/api/projects/project-12345678/export-premium', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...input, format: 'pdf' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/pdf');
+    expect(res.headers.get('Content-Disposition')).toContain('attachment; filename="premium-evidence-report-project-.pdf"');
+  });
+
+  it('returns a ZIP attachment on POST with format=zip', async () => {
+    const { POST } = await import('@/app/api/projects/[id]/export-premium/route');
+    const input = makeInput();
+    const req = new Request('http://localhost/api/projects/project-12345678/export-premium', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...input, format: 'zip' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/zip');
+    expect(res.headers.get('Content-Disposition')).toContain('attachment; filename="premium-evidence-export-project-.zip"');
+  });
+
+  it('returns 400 when project is missing', async () => {
+    const { POST } = await import('@/app/api/projects/[id]/export-premium/route');
+    const req = new Request('http://localhost/api/projects/project-12345678/export-premium', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ format: 'pdf' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('defaults to PDF format when format is not specified', async () => {
+    const { POST } = await import('@/app/api/projects/[id]/export-premium/route');
+    const input = makeInput();
+    const req = new Request('http://localhost/api/projects/project-12345678/export-premium', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/pdf');
+  });
+});

--- a/tests/lib/evidence/export/premiumExport.test.ts
+++ b/tests/lib/evidence/export/premiumExport.test.ts
@@ -118,6 +118,24 @@ function makeInput(overrides?: Partial<PremiumExportInput>): PremiumExportInput 
     },
     inventory: makeInventory(),
     sources: makeSources(),
+    sourceArtifacts: [
+      {
+        documentId: 'src-001',
+        fileName: 'PDD Malawi v2.pdf',
+        mime: 'application/pdf',
+        sizeBytes: 500000,
+        contentSha256: 'a'.repeat(64),
+        contentBase64: Buffer.from('fake-pdf-source').toString('base64'),
+      },
+      {
+        documentId: 'src-002',
+        fileName: 'Workbook.xlsx',
+        mime: 'application/xlsx',
+        sizeBytes: 200000,
+        contentSha256: 'b'.repeat(64),
+        contentBase64: Buffer.from('fake-workbook-source').toString('base64'),
+      },
+    ],
     fragments: makeFragments(),
     facts: makeFacts(),
     candidateLinks: makeCandidateLinks(),
@@ -331,6 +349,8 @@ describe('Premium ZIP Export', () => {
     expect(files).toContain('reports/premium-evidence-report.pdf');
     expect(files).toContain('fragments/frag-001.txt');
     expect(files).toContain('fragments/frag-002.txt');
+    expect(files).toContain('sources/src-001_PDD_Malawi_v2.pdf');
+    expect(files).toContain('sources/src-002_Workbook.xlsx');
   });
 
   it('contains valid JSON in export.json', async () => {
@@ -398,6 +418,14 @@ describe('Premium ZIP Export', () => {
 
     expect(Object.keys(zip.files)).toContain('export.json');
     expect(Object.keys(zip.files)).toContain('manifest.json');
+  });
+
+  it('is deterministic for the same project state', async () => {
+    const input = makeInput();
+    const zipA = await buildPremiumZip(input);
+    const zipB = await buildPremiumZip(input);
+
+    expect(zipA.equals(zipB)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## WHAT

- Implements Phase 4 (Premium PDF/ZIP Export with Full Provenance) of the review-grade-evidence-intelligence roadmap.
- **New:** `src/lib/evidence/export/` — premium PDF builder (`pdfExporter.ts`), ZIP builder (`zipExporter.ts`), types, barrel exports.
- **New:** `POST /api/projects/[id]/export-premium` — returns either PDF or ZIP based on `format` field.
- **Premium PDF** (Section 8 of standard): 9 sections — executive summary, project info, methodology sections, evidence inventory, extracted facts, coverage matrix, reviewer decisions, limitations, full provenance chain.
- **Premium ZIP** (Section 9 of standard): `export.json` with structured data, `fragments/` with per-fragment text files, `reports/` with premium PDF, `manifest.json` with SHA-256 content hashes.
- **20 tests:** PDF section presence, ZIP entry/JSON/manifest validation, API route behavior, empty-data edge cases.
- **111 suites, 684 tests passing** — lint + typecheck clean.

## WHY

Enables beautiful, deterministic, review-grade exports with full provenance — evidence inventory, extracted facts, coverage matrix, and reviewer decisions all in one package.

## Caveats

- PDF uses Type1 Helvetica (ASCII-safe) — no Unicode glyph support.
- ZIP manifest entry count dynamically matches input data.
- Quick Check edge case tests and responsive UI QA from Phase 2/3 still deferred.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>