### PR TITLE
feat(rc5): integrate evidence intelligence into verification pack

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -183,7 +183,7 @@ Lane status: Active
 Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.
 
 Current focus:
-- Complete premium PDF/ZIP export with full provenance (Phase 4)
+- Verification pack integration with evidence intelligence (Phase 5)
 - Cover Quick Check extraction edge case tests
 - Responsive UI QA for reconciliation and decision badges
 
@@ -196,7 +196,7 @@ Not active now:
 2) RC1 — Deterministic evidence extraction foundation: Done
 3) RC2 — Evidence inventory reconciliation: Done
 4) RC3 — Reviewer decision records with provenance: Done
-5) RC4 — Premium PDF/ZIP export with full provenance: In progress
+5) RC4 — Premium PDF/ZIP export with full provenance: Done
 6) RC5 — Verification pack integration with evidence intelligence: Planned
 7) RC6 — Evidence quality and coverage metrics: Planned
 8) RC7 — Evidence snapshot and comparison: Planned

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -3,7 +3,7 @@
   "RC1": "done",
   "RC2": "done",
   "RC3": "done",
-  "RC4": "in_progress",
+  "RC4": "done",
   "RC5": "planned",
   "RC6": "planned",
   "RC7": "planned",
@@ -12,7 +12,7 @@
     "status": "active",
     "summary": "Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.",
     "current_focus": [
-      "Complete premium PDF/ZIP export with full provenance (Phase 4)",
+      "Verification pack integration with evidence intelligence (Phase 5)",
       "Cover Quick Check extraction edge case tests",
       "Responsive UI QA for reconciliation and decision badges"
     ],
@@ -100,7 +100,7 @@
       ]
     },
     "phase_4_premium_pdf_zips_export": {
-      "status": "in_progress",
+      "status": "done",
       "title": "Premium PDF/ZIP export with full provenance",
       "repo": "app.article6",
       "description": "Build premium PDF and ZIP export pipelines that include evidence fragments, extracted facts, coverage matrix, reviewer decisions, and full provenance. The export must be beautiful enough to sell and structured enough to defend.",

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -4,7 +4,7 @@
   "RC2": "done",
   "RC3": "done",
   "RC4": "done",
-  "RC5": "planned",
+  "RC5": "in_progress",
   "RC6": "planned",
   "RC7": "planned",
   "RC8": "planned",

--- a/src/exports/auditPack.ts
+++ b/src/exports/auditPack.ts
@@ -4,6 +4,7 @@ import { zipSync, strToU8 } from "fflate";
 import { makePackMeta } from "./packMeta";
 import { canonicalStringify, sha256Hex } from "../integrity/artifacts";
 import { buildTraceIndex } from "../lib/trace/traceIndex";
+import { buildVerificationPackEvidenceIntelligence } from "../lib/evidence/export/verificationPackDerivation";
 import {
   buildVerificationPackContractFiles,
   type CurrentMethodReviewExportInput,
@@ -118,6 +119,13 @@ export function buildAuditPackZip(
 
   const generatedAt = generatedAtForAuditPack(options.finalizedReview, options.currentReview);
   const packMeta = makePackMeta({ methodCode, version, repo, commit, generated_at: generatedAt });
+  const evidenceIntelligence = buildVerificationPackEvidenceIntelligence({
+    generatedAt,
+    rulesJson: readJsonRaw(rulesPath),
+    trace,
+    finalizedReview: options.finalizedReview ?? null,
+    currentReview: options.currentReview ?? null,
+  });
   const contractFiles = buildVerificationPackContractFiles({
     generatedAt,
     methodCode,
@@ -127,6 +135,7 @@ export function buildAuditPackZip(
     trace,
     finalizedReview: options.finalizedReview ?? null,
     currentReview: options.currentReview ?? null,
+    evidenceIntelligence,
   });
   for (const file of contractFiles) {
     files.push({

--- a/src/exports/verificationPackContract.ts
+++ b/src/exports/verificationPackContract.ts
@@ -4,6 +4,8 @@ import type { EvidencePin } from "../lib/proofMap/types";
 import type { TraceIndex, TraceSectionLink } from "../lib/trace/traceIndex";
 import type { RuleReview } from "../lib/verify/reviewStore";
 import { normalizeMethodCode, normalizeVersion, type VerifierRunBundle } from "../lib/verify/runState";
+import type { EvidenceIntelligenceData } from "../lib/evidence/export/verificationPackIntegration";
+import { buildEvidenceIntelligenceFiles, renderEvidenceIntelligenceHtmlSections } from "../lib/evidence/export/verificationPackIntegration";
 
 type ContractRule = {
   id: string;
@@ -876,6 +878,7 @@ function renderVerificationReportHtml(input: {
   evidenceManifest: EvidenceManifest;
   requirementReview: RequirementReview;
   trace: VerificationPackContract["trace"];
+  evidenceIntelligence?: EvidenceIntelligenceData;
 }): string {
   const reviewedRules = input.requirementReview.rules.filter((rule) => rule.status !== "not_reviewed" && rule.status !== "awaiting_project_evidence");
   const unreviewedRules = input.requirementReview.rules.filter((rule) => rule.status === "not_reviewed" || rule.status === "awaiting_project_evidence");
@@ -997,6 +1000,10 @@ function renderVerificationReportHtml(input: {
       .panel { border: 1px solid #e2e8f0; border-radius: 12px; padding: 16px; margin-bottom: 20px; background: #ffffff; }
       .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
       .muted { color: #64748b; font-size: 12px; margin-top: 4px; }
+      .ref { color: #64748b; font-size: 11px; font-family: monospace; }
+      .status-approved { color: #16a34a; font-weight: 600; }
+      .status-rejected { color: #dc2626; font-weight: 600; }
+      .status-needs-review { color: #ca8a04; font-weight: 600; }
       .stats { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 12px; margin-top: 16px; }
       .stat { border: 1px solid #e2e8f0; border-radius: 10px; padding: 12px; background: #f8fafc; }
       h1, h2, h3 { margin-bottom: 8px; }
@@ -1138,6 +1145,8 @@ ${followUpActions}
       </ul>
     </section>
 
+${input.evidenceIntelligence ? renderEvidenceIntelligenceHtmlSections(input.evidenceIntelligence) : ''}
+
     <section class="panel">
       <h2>Limitations</h2>
       <ul>
@@ -1254,6 +1263,7 @@ export function buildVerificationPackContract(input: {
   trace: TraceIndex;
   finalizedReview?: FinalizedAuditPackReviewInput | null;
   currentReview?: CurrentMethodReviewExportInput | null;
+  evidenceIntelligence?: EvidenceIntelligenceData | null;
 }): VerificationPackContract {
   const rules = extractRules(input.rulesJson);
   const sectionCount = extractSectionCount(input.sectionsJson);
@@ -1623,6 +1633,7 @@ export function buildVerificationPackContract(input: {
     evidenceManifest,
     requirementReview,
     trace,
+    evidenceIntelligence: input.evidenceIntelligence ?? undefined,
   });
 
   return { project, evidenceManifest, requirementReview, trace, trailEntries, reportHtml };
@@ -1637,9 +1648,13 @@ export function buildVerificationPackContractFiles(input: {
   trace: TraceIndex;
   finalizedReview?: FinalizedAuditPackReviewInput | null;
   currentReview?: CurrentMethodReviewExportInput | null;
+  evidenceIntelligence?: EvidenceIntelligenceData | null;
 }): Array<{ path: string; bytes: Buffer }> {
   const contract = buildVerificationPackContract(input);
   const packagedFinalizedSources = collectPackagedEvidenceSourceFiles(input.finalizedReview ?? null);
+  const evidenceIntelFiles = input.evidenceIntelligence
+    ? buildEvidenceIntelligenceFiles(input.evidenceIntelligence)
+    : [];
   return [
     {
       path: "project.json",
@@ -1669,6 +1684,7 @@ export function buildVerificationPackContractFiles(input: {
       path: source.file_path,
       bytes: source.bytes,
     })),
+    ...evidenceIntelFiles,
   ];
 }
 

--- a/src/exports/verificationPackContract.ts
+++ b/src/exports/verificationPackContract.ts
@@ -316,6 +316,11 @@ function safeZipFilename(value: string | null | undefined, fallback: string): st
   return sanitized || fallback;
 }
 
+function anchorId(prefix: string, value: string): string {
+  const compact = value.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "").toLowerCase();
+  return `${prefix}-${compact || "item"}`;
+}
+
 function decodeBase64Bytes(value: string): Buffer {
   return Buffer.from(value, "base64");
 }
@@ -983,11 +988,17 @@ function renderVerificationReportHtml(input: {
     : `<li>No follow-up actions are recorded in this export.</li>`;
   const integrityRows = input.evidenceManifest.evidence
     .map((entry) => `<tr>
-  <td>${escapeHtml(entry.evidence_ref)}</td>
+  <td id="${anchorId("evidence-ref", entry.evidence_ref)}">${escapeHtml(entry.evidence_ref)}</td>
   <td>${escapeHtml(isPackagedEvidenceEntry(entry) ? entry.file_path ?? "Included file path unavailable" : "Referenced only — file not included")}</td>
   <td>${escapeHtml(entry.sha256 ?? "Unavailable")}</td>
 </tr>`)
     .join("\n");
+  const evidenceHrefById = Object.fromEntries(
+    input.evidenceManifest.evidence.map((entry) => [
+      entry.evidence_ref,
+      { href: `#${anchorId("evidence-ref", entry.evidence_ref)}`, label: entry.evidence_ref },
+    ]),
+  );
 
   return `<!doctype html>
 <html lang="en">
@@ -1145,7 +1156,7 @@ ${followUpActions}
       </ul>
     </section>
 
-${input.evidenceIntelligence ? renderEvidenceIntelligenceHtmlSections(input.evidenceIntelligence) : ''}
+${input.evidenceIntelligence ? renderEvidenceIntelligenceHtmlSections(input.evidenceIntelligence, { evidenceHrefById }) : ''}
 
     <section class="panel">
       <h2>Limitations</h2>

--- a/src/lib/evidence/export/index.ts
+++ b/src/lib/evidence/export/index.ts
@@ -1,4 +1,6 @@
 export { buildPremiumPdf } from './pdfExporter';
 export { buildPremiumZip } from './zipExporter';
 export { buildPremiumExportInputFromProject } from './projectExportData';
+export { buildEvidenceIntelligenceFiles, renderEvidenceIntelligenceHtmlSections } from './verificationPackIntegration';
 export type { PremiumExportInput, PremiumExportOutput, PremiumExportMeta, ManifestEntry } from './types';
+export type { EvidenceIntelligenceData } from './verificationPackIntegration';

--- a/src/lib/evidence/export/verificationPackDerivation.ts
+++ b/src/lib/evidence/export/verificationPackDerivation.ts
@@ -1,0 +1,669 @@
+import { canonicalStringify, sha256Hex } from '@/integrity/artifacts';
+import { buildEvidenceInventory, coalesceEvidencePins } from '@/lib/evidence/inventory';
+import type { DecisionRun, ReviewerDecision } from '@/lib/evidence/decisions/types';
+import type { CandidateLink, DocumentFragment, ExtractedFact, FactType } from '@/lib/evidence/extraction/types';
+import type { ReconciliationItem, ReconciliationRun, CoverageGap, ReconciliationStatus } from '@/lib/evidence/reconciliation/types';
+import type { EvidencePin } from '@/lib/proofMap/types';
+import type { RuleReview } from '@/lib/verify/reviewStore';
+import type { TraceIndex } from '@/lib/trace/traceIndex';
+import type { CurrentMethodReviewExportInput, FinalizedAuditPackReviewInput } from '@/exports/verificationPackContract';
+import type { EvidenceIntelligenceData } from './verificationPackIntegration';
+
+type ContractRule = {
+  id: string;
+  text: string;
+};
+
+function sortByString<T>(items: T[], select: (item: T) => string): T[] {
+  return [...items].sort((a, b) => select(a).localeCompare(select(b)));
+}
+
+function sanitizeId(value: string): string {
+  const normalized = value.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  return normalized || 'item';
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return value?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+function sha256String(value: string): string {
+  return sha256Hex(Buffer.from(value, 'utf8'));
+}
+
+function stableHash(value: unknown): string {
+  return sha256Hex(Buffer.from(canonicalStringify(JSON.parse(JSON.stringify(value))), 'utf8'));
+}
+
+function parseRules(rulesJson: unknown): ContractRule[] {
+  const items = Array.isArray(rulesJson)
+    ? rulesJson
+    : rulesJson && typeof rulesJson === 'object' && Array.isArray((rulesJson as { rules?: unknown[] }).rules)
+      ? ((rulesJson as { rules: unknown[] }).rules ?? [])
+      : [];
+
+  return items
+    .flatMap((item) => {
+      if (!item || typeof item !== 'object') return [];
+      const record = item as Record<string, unknown>;
+      const id =
+        typeof record.id === 'string' ? record.id.trim()
+        : typeof record.rule_id === 'string' ? record.rule_id.trim()
+        : typeof record.ruleId === 'string' ? record.ruleId.trim()
+        : typeof record.key === 'string' ? record.key.trim()
+        : '';
+      if (!id) return [];
+      const text = typeof record.text === 'string' ? record.text.trim() : '';
+      return [{ id, text }];
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function pickSectionId(ruleId: string, trace: TraceIndex): string {
+  return trace.rule_to_sections[ruleId]?.[0]?.section_id ?? 'Unknown';
+}
+
+function buildRuleTitleMap(rulesJson: unknown, currentReview?: CurrentMethodReviewExportInput | null): Map<string, string> {
+  const map = new Map(parseRules(rulesJson).map((rule) => [rule.id, rule.text || rule.id]));
+  for (const review of currentReview?.reviews ?? []) {
+    if (!map.has(review.ruleId)) map.set(review.ruleId, review.ruleId);
+  }
+  return map;
+}
+
+function linkedRuleIdsForPin(pin: EvidencePin): string[] {
+  const ids = new Set<string>();
+  if (pin.ruleId?.trim()) ids.add(pin.ruleId.trim());
+  for (const cited of pin.cited_ids ?? []) {
+    const trimmed = cited.trim();
+    if (trimmed) ids.add(trimmed);
+  }
+  for (const link of pin.pdd_fragment_links ?? []) {
+    const trimmed = link.rule_id?.trim();
+    if (trimmed) ids.add(trimmed);
+  }
+  return Array.from(ids).sort((a, b) => a.localeCompare(b));
+}
+
+function inferFactType(fragment: DocumentFragment): FactType {
+  const haystack = `${fragment.label} ${fragment.text}`.toLowerCase();
+  if (haystack.includes('baseline')) return 'baseline-scenario';
+  if (haystack.includes('monitor')) return 'monitoring-period';
+  if (haystack.includes('location') || haystack.includes('aoi')) return 'location';
+  if (haystack.includes('method')) return 'methodology-reference';
+  if (/\b\d+(?:\.\d+)?\b/.test(haystack)) return 'quantity';
+  return 'other';
+}
+
+function summarizeWorkbookRows(rows: Array<Record<string, string>>): string {
+  if (!rows.length) return 'Workbook record group';
+  return rows
+    .slice(0, 3)
+    .map((row) =>
+      Object.entries(row)
+        .slice(0, 4)
+        .map(([key, value]) => `${key}: ${value}`)
+        .join('; '),
+    )
+    .join(' | ');
+}
+
+function buildFragments(pins: EvidencePin[]): DocumentFragment[] {
+  const inventory = buildEvidenceInventory(pins);
+  const fragments: DocumentFragment[] = [];
+
+  for (const item of sortByString(inventory, (candidate) => candidate.evidence_id)) {
+    const itemKind = item.kind === 'pdd'
+      ? 'pdd'
+      : item.kind === 'workbook'
+        ? 'workbook'
+        : item.kind === 'document'
+          ? 'monitoring-report'
+          : 'other';
+
+    if (item.pdd_fragments?.length) {
+      const ordered = sortByString(item.pdd_fragments, (fragment) => fragment.fragment_id);
+      ordered.forEach((fragment, index) => {
+        const text = normalizeText(fragment.excerpt)
+          || normalizeText(fragment.section_heading)
+          || normalizeText(fragment.section_label)
+          || normalizeText(item.provenance_summary)
+          || 'PDD fragment';
+        fragments.push({
+          fragmentId: fragment.fragment_id,
+          documentId: item.evidence_id,
+          kind: 'pdd',
+          index,
+          label: normalizeText(fragment.label) || normalizeText(fragment.section_heading) || `Fragment ${index + 1}`,
+          text,
+          contentSha256: item.pdd_document?.sha256?.trim() || sha256String(`${fragment.fragment_id}:${text}`),
+          pageStart: fragment.page_start,
+          pageEnd: fragment.page_end,
+          sheetName: normalizeText(fragment.section_label) || undefined,
+        });
+      });
+    }
+
+    if (item.workbook_record_groups?.length) {
+      const orderedGroups = sortByString(item.workbook_record_groups, (group) => group.group_id);
+      orderedGroups.forEach((group, index) => {
+        const text = normalizeText(group.provenance_summary) || summarizeWorkbookRows(group.rows);
+        fragments.push({
+          fragmentId: `${item.evidence_id}__${sanitizeId(group.group_id)}`,
+          documentId: item.evidence_id,
+          kind: 'workbook',
+          index,
+          label: normalizeText(group.display_name) || `Workbook group ${index + 1}`,
+          text,
+          contentSha256: sha256String(`${group.group_id}:${text}`),
+          sheetName: normalizeText(group.source_sheet) || undefined,
+        });
+      });
+    }
+
+    if (!item.pdd_fragments?.length && !item.workbook_record_groups?.length) {
+      const text = normalizeText(item.provenance_summary) || normalizeText(item.source_summary) || normalizeText(item.display_name);
+      if (!text) continue;
+      fragments.push({
+        fragmentId: `${item.evidence_id}__summary`,
+        documentId: item.evidence_id,
+        kind: itemKind,
+        index: 0,
+        label: normalizeText(item.display_name) || item.evidence_id,
+        text,
+        contentSha256: item.pdd_document?.sha256?.trim() || sha256String(`${item.evidence_id}:${text}`),
+      });
+    }
+  }
+
+  return sortByString(fragments, (fragment) => fragment.fragmentId);
+}
+
+function buildFacts(fragments: DocumentFragment[]): ExtractedFact[] {
+  return fragments
+    .filter((fragment) => normalizeText(fragment.text))
+    .map((fragment) => ({
+      factId: `${fragment.fragmentId}__fact_001`,
+      fragmentId: fragment.fragmentId,
+      documentId: fragment.documentId,
+      factType: inferFactType(fragment),
+      value: normalizeText(fragment.text).slice(0, 240),
+      context: fragment.label,
+      pageRef: fragment.pageStart ? `${fragment.pageStart}${fragment.pageEnd && fragment.pageEnd !== fragment.pageStart ? `-${fragment.pageEnd}` : ''}` : undefined,
+      sheetRef: fragment.sheetName,
+      contentSha256: sha256String(`${fragment.fragmentId}:${normalizeText(fragment.text).slice(0, 240)}`),
+    }));
+}
+
+function buildFragmentRefMap(
+  pins: EvidencePin[],
+  fragments: DocumentFragment[],
+): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+
+  const add = (key: string | null | undefined, fragmentId: string) => {
+    const trimmed = key?.trim();
+    if (!trimmed) return;
+    const current = map.get(trimmed) ?? [];
+    if (!current.includes(fragmentId)) current.push(fragmentId);
+    map.set(trimmed, current.sort((a, b) => a.localeCompare(b)));
+  };
+
+  const byDoc = new Map<string, string[]>(fragments.reduce<Array<[string, string[]]>>((acc, fragment) => {
+    const current = acc.find(([id]) => id === fragment.documentId);
+    if (current) current[1].push(fragment.fragmentId);
+    else acc.push([fragment.documentId, [fragment.fragmentId]]);
+    return acc;
+  }, []).map(([id, fragmentIds]) => [id, fragmentIds.sort((a, b) => a.localeCompare(b))]));
+
+  for (const pin of coalesceEvidencePins(pins)) {
+    const fragmentIds = byDoc.get(pin.id) ?? [];
+    for (const fragmentId of fragmentIds) {
+      add(pin.id, fragmentId);
+      add(pin.itemId, fragmentId);
+      add(pin.title, fragmentId);
+      for (const cited of pin.cited_ids ?? []) add(cited, fragmentId);
+      for (const stacId of pin.stac_item_ids ?? []) add(stacId, fragmentId);
+      add(pin.pdd_document?.evidence_id, fragmentId);
+    }
+    for (const fragment of pin.pdd_fragments ?? []) {
+      add(fragment.fragment_id, fragment.fragment_id);
+    }
+  }
+
+  return map;
+}
+
+function uniqueEvidenceRefs(review: RuleReview): string[] {
+  const refs = new Set<string>();
+  const add = (value: string | null | undefined) => {
+    const trimmed = value?.trim();
+    if (trimmed) refs.add(trimmed);
+  };
+  add(review.supportReference);
+  add(review.evidenceLink);
+  for (const attachment of review.evidenceAttachments) {
+    add(attachment.label);
+    add(attachment.id);
+  }
+  return Array.from(refs).sort((a, b) => a.localeCompare(b));
+}
+
+function addLink(
+  candidateLinks: CandidateLink[],
+  keySet: Set<string>,
+  input: {
+    factId: string;
+    ruleId: string;
+    ruleTitle: string;
+    sectionId: string;
+    matchType: CandidateLink['matchType'];
+    matchReason: string;
+    confidence: number;
+  },
+): void {
+  const dedupeKey = `${input.factId}::${input.ruleId}`;
+  if (keySet.has(dedupeKey)) return;
+  keySet.add(dedupeKey);
+  candidateLinks.push({
+    linkId: `link_${sanitizeId(input.factId)}_${sanitizeId(input.ruleId)}`,
+    factId: input.factId,
+    ruleId: input.ruleId,
+    ruleTitle: input.ruleTitle,
+    sectionId: input.sectionId,
+    matchType: input.matchType,
+    matchReason: input.matchReason,
+    confidence: input.confidence,
+    contentSha256: sha256String(canonicalStringify({
+      factId: input.factId,
+      ruleId: input.ruleId,
+      matchType: input.matchType,
+      matchReason: input.matchReason,
+      confidence: input.confidence,
+    })),
+  });
+}
+
+function buildCandidateLinks(params: {
+  pins: EvidencePin[];
+  currentReview?: CurrentMethodReviewExportInput | null;
+  finalizedReview?: FinalizedAuditPackReviewInput | null;
+  fragments: DocumentFragment[];
+  facts: ExtractedFact[];
+  rulesJson: unknown;
+  trace: TraceIndex;
+}): CandidateLink[] {
+  const candidateLinks: CandidateLink[] = [];
+  const keySet = new Set<string>();
+  const factByFragmentId = new Map(params.facts.map((fact) => [fact.fragmentId, fact]));
+  const ruleTitles = buildRuleTitleMap(params.rulesJson, params.currentReview);
+  const fragmentRefs = buildFragmentRefMap(params.pins, params.fragments);
+  const pins = coalesceEvidencePins(params.pins);
+
+  for (const pin of pins) {
+    const explicitRuleIds = linkedRuleIdsForPin(pin);
+    const fallbackFragmentIds = (fragmentRefs.get(pin.id) ?? []).slice().sort((a, b) => a.localeCompare(b));
+
+    for (const fragmentLink of sortByString(pin.pdd_fragment_links ?? [], (link) => `${link.fragment_id}:${link.rule_id}`)) {
+      const fact = factByFragmentId.get(fragmentLink.fragment_id);
+      if (!fact) continue;
+      addLink(candidateLinks, keySet, {
+        factId: fact.factId,
+        ruleId: fragmentLink.rule_id,
+        ruleTitle: ruleTitles.get(fragmentLink.rule_id) ?? fragmentLink.rule_id,
+        sectionId: pickSectionId(fragmentLink.rule_id, params.trace),
+        matchType: 'exact-evidence-id',
+        matchReason: 'PDD fragment was explicitly linked to the requirement in review state.',
+        confidence: 1,
+      });
+    }
+
+    if (explicitRuleIds.length === 0) continue;
+    for (const fragmentId of fallbackFragmentIds) {
+      const fact = factByFragmentId.get(fragmentId);
+      if (!fact) continue;
+      for (const ruleId of explicitRuleIds) {
+        addLink(candidateLinks, keySet, {
+          factId: fact.factId,
+          ruleId,
+          ruleTitle: ruleTitles.get(ruleId) ?? ruleId,
+          sectionId: pickSectionId(ruleId, params.trace),
+          matchType: 'evidence-label-match',
+          matchReason: 'Evidence pin is linked to the requirement in saved review state.',
+          confidence: 0.95,
+        });
+      }
+    }
+  }
+
+  for (const review of sortByString(params.currentReview?.reviews ?? [], (item) => item.ruleId)) {
+    const refs = uniqueEvidenceRefs(review);
+    for (const ref of refs) {
+      for (const fragmentId of fragmentRefs.get(ref) ?? []) {
+        const fact = factByFragmentId.get(fragmentId);
+        if (!fact) continue;
+        addLink(candidateLinks, keySet, {
+          factId: fact.factId,
+          ruleId: review.ruleId,
+          ruleTitle: ruleTitles.get(review.ruleId) ?? review.ruleId,
+          sectionId: pickSectionId(review.ruleId, params.trace),
+          matchType: 'exact-evidence-id',
+          matchReason: 'Reviewer cited this evidence directly in the current Method Review record.',
+          confidence: 1,
+        });
+      }
+    }
+  }
+
+  const artifact = params.finalizedReview?.artifact;
+  const selectedRuleId =
+    artifact?.summary?.ruleId?.trim()
+    || artifact?.outcome?.linkage.selectedRuleId?.trim()
+    || artifact?.outcome?.linkage.linkedRuleIds?.[0]?.trim()
+    || null;
+  const selectedEvidenceId =
+    artifact?.summary?.selectedEvidenceId?.trim()
+    || artifact?.selected?.id?.trim()
+    || artifact?.selected?.item?.id?.trim()
+    || null;
+  if (selectedRuleId && selectedEvidenceId) {
+    for (const fragmentId of fragmentRefs.get(selectedEvidenceId) ?? []) {
+      const fact = factByFragmentId.get(fragmentId);
+      if (!fact) continue;
+      addLink(candidateLinks, keySet, {
+        factId: fact.factId,
+        ruleId: selectedRuleId,
+        ruleTitle: ruleTitles.get(selectedRuleId) ?? selectedRuleId,
+        sectionId: pickSectionId(selectedRuleId, params.trace),
+        matchType: 'exact-evidence-id',
+        matchReason: 'Finalized review selected this evidence item for the requirement.',
+        confidence: 1,
+      });
+    }
+  }
+
+  return sortByString(candidateLinks, (link) => link.linkId);
+}
+
+function mapReviewStatusToDecisionStatus(status: RuleReview['status']): ReviewerDecision['status'] {
+  if (status === 'verified') return 'approved';
+  if (status === 'not_verified') return 'rejected';
+  return 'needs-review';
+}
+
+function computeDecisionProvenanceHash(decision: ReviewerDecision): string {
+  return stableHash({
+    decisionId: decision.decisionId,
+    ruleId: decision.ruleId,
+    status: decision.status,
+    rationale: decision.rationale,
+    reviewerId: decision.reviewerId,
+    reviewedAt: decision.reviewedAt,
+    evidenceInventoryIds: [...decision.evidenceInventoryIds].sort((a, b) => a.localeCompare(b)),
+    reconciliationRunId: decision.reconciliationRunId ?? null,
+  });
+}
+
+function computeDecisionSetFingerprint(decisions: ReviewerDecision[]): string {
+  return stableHash(
+    sortByString(
+      decisions.map((decision) => ({
+        decisionId: decision.decisionId,
+        status: decision.status,
+        provenanceHash: decision.provenanceHash,
+      })),
+      (decision) => decision.decisionId,
+    ),
+  );
+}
+
+function buildDecisionRun(params: {
+  currentReview?: CurrentMethodReviewExportInput | null;
+  finalizedReview?: FinalizedAuditPackReviewInput | null;
+  generatedAt: string;
+  reconciliationRunId?: string;
+}): DecisionRun | undefined {
+  const decisions: ReviewerDecision[] = [];
+
+  for (const review of sortByString(params.currentReview?.reviews ?? [], (item) => item.ruleId)) {
+    const decision: ReviewerDecision = {
+      decisionId: `dec_${sanitizeId(review.ruleId)}_${sanitizeId(review.reviewedBy || 'reviewer')}`,
+      ruleId: review.ruleId,
+      ruleTitle: review.ruleId,
+      sectionId: 'Unknown',
+      status: mapReviewStatusToDecisionStatus(review.status),
+      rationale: normalizeText(review.rationale) || 'Reviewer decision exported from current Method Review state.',
+      reviewerId: normalizeText(review.reviewedBy) || 'local-reviewer',
+      reviewedAt: review.reviewedAt || review.updatedAt || params.generatedAt,
+      updatedAt: review.updatedAt || review.reviewedAt || params.generatedAt,
+      evidenceInventoryIds: uniqueEvidenceRefs(review),
+      reconciliationRunId: params.reconciliationRunId,
+      provenanceHash: '',
+    };
+    decision.provenanceHash = computeDecisionProvenanceHash(decision);
+    decisions.push(decision);
+  }
+
+  const artifact = params.finalizedReview?.artifact;
+  const finalizedRuleId =
+    artifact?.summary?.ruleId?.trim()
+    || artifact?.outcome?.linkage.selectedRuleId?.trim()
+    || artifact?.outcome?.linkage.linkedRuleIds?.[0]?.trim()
+    || null;
+  if (artifact && finalizedRuleId) {
+    const statusText = `${artifact.summary?.reviewState ?? ''} ${artifact.summary?.reconciliationStatus ?? ''}`.toLowerCase();
+    const status: ReviewerDecision['status'] =
+      /not supported|reject|fail|gap/.test(statusText) ? 'rejected'
+      : /supported|verified|complete|approved|finalized|ready/.test(statusText) ? 'approved'
+      : 'needs-review';
+    const evidenceIds = [
+      artifact.summary?.selectedEvidenceId,
+      artifact.selected?.id,
+      artifact.selected?.item?.id,
+    ].map((value) => value?.trim()).filter((value): value is string => Boolean(value));
+    const decision: ReviewerDecision = {
+      decisionId: `dec_${sanitizeId(finalizedRuleId)}_${sanitizeId(artifact.verifier?.runId ?? 'finalized')}`,
+      ruleId: finalizedRuleId,
+      ruleTitle: artifact.summary?.ruleText?.trim() || finalizedRuleId,
+      sectionId: artifact.summary?.ruleSection?.trim() || 'Unknown',
+      status,
+      rationale:
+        normalizeText(artifact.summary?.narrative)
+        || normalizeText(artifact.summary?.reconciliationReason)
+        || normalizeText(artifact.summary?.outcomeNote)
+        || normalizeText(artifact.verifier?.outcomeNote)
+        || 'Reviewer decision exported from finalized review artifact.',
+      reviewerId: 'local-reviewer',
+      reviewedAt: artifact.verifier?.finalizedAt?.trim() || params.generatedAt,
+      updatedAt: artifact.verifier?.finalizedAt?.trim() || params.generatedAt,
+      evidenceInventoryIds: Array.from(new Set(evidenceIds)).sort((a, b) => a.localeCompare(b)),
+      reconciliationRunId: params.reconciliationRunId,
+      provenanceHash: '',
+    };
+    decision.provenanceHash = computeDecisionProvenanceHash(decision);
+    decisions.push(decision);
+  }
+
+  if (decisions.length === 0) return undefined;
+  const sortedDecisions = sortByString(decisions, (decision) => decision.decisionId);
+  const decisionSetFingerprint = computeDecisionSetFingerprint(sortedDecisions);
+  const runId = stableHash({
+    generatedAt: params.generatedAt,
+    reconciliationRunId: params.reconciliationRunId ?? null,
+    decisionSetFingerprint,
+  });
+  return {
+    runId,
+    projectId: params.finalizedReview?.artifact?.verifier?.runId ?? params.currentReview?.verifierBundle?.runContext?.runId ?? 'method-review-export',
+    createdAt: params.generatedAt,
+    decisions: sortedDecisions,
+    decisionSetFingerprint,
+    reconciliationRunId: params.reconciliationRunId,
+  };
+}
+
+function buildReconciliationRun(params: {
+  currentReview?: CurrentMethodReviewExportInput | null;
+  finalizedReview?: FinalizedAuditPackReviewInput | null;
+  fragments: DocumentFragment[];
+  candidateLinks: CandidateLink[];
+  generatedAt: string;
+  trace: TraceIndex;
+  rulesJson: unknown;
+}): ReconciliationRun | undefined {
+  const factIdByFragmentId = new Map<string, string>(params.fragments.map((fragment) => [fragment.fragmentId, `${fragment.fragmentId}__fact_001`]));
+  const linksByFragment = new Map<string, CandidateLink[]>();
+  for (const link of params.candidateLinks) {
+    const fragmentId = link.factId.replace(/__fact_001$/, '');
+    const current = linksByFragment.get(fragmentId) ?? [];
+    current.push(link);
+    linksByFragment.set(fragmentId, current);
+  }
+
+  const items: ReconciliationItem[] = [];
+  for (const fragment of params.fragments) {
+    const links = sortByString(linksByFragment.get(fragment.fragmentId) ?? [], (link) => link.ruleId);
+    if (links.length === 0) {
+      items.push({
+        id: `rec_${sanitizeId(fragment.fragmentId)}`,
+        fragmentId: fragment.fragmentId,
+        factId: factIdByFragmentId.get(fragment.fragmentId),
+        status: 'unmatched',
+        isManualOverride: false,
+        contentSha256: fragment.contentSha256,
+      });
+      continue;
+    }
+    for (const link of links) {
+      items.push({
+        id: `rec_${sanitizeId(fragment.fragmentId)}_${sanitizeId(link.ruleId)}`,
+        fragmentId: fragment.fragmentId,
+        factId: link.factId,
+        ruleId: link.ruleId,
+        ruleTitle: link.ruleTitle,
+        sectionId: link.sectionId,
+        status: 'linked',
+        matchType: link.matchType,
+        confidence: link.confidence,
+        isManualOverride: link.confidence >= 0.95,
+        contentSha256: fragment.contentSha256,
+      });
+    }
+  }
+
+  const ruleTitles = buildRuleTitleMap(params.rulesJson, params.currentReview);
+  const ruleIds = new Set<string>();
+  for (const review of params.currentReview?.reviews ?? []) ruleIds.add(review.ruleId);
+  for (const link of params.candidateLinks) ruleIds.add(link.ruleId);
+  const finalizedRuleId =
+    params.finalizedReview?.artifact?.summary?.ruleId?.trim()
+    || params.finalizedReview?.artifact?.outcome?.linkage.selectedRuleId?.trim()
+    || params.finalizedReview?.artifact?.outcome?.linkage.linkedRuleIds?.[0]?.trim()
+    || null;
+  if (finalizedRuleId) ruleIds.add(finalizedRuleId);
+
+  const linksByRule = new Map<string, CandidateLink[]>();
+  for (const link of params.candidateLinks) {
+    const current = linksByRule.get(link.ruleId) ?? [];
+    current.push(link);
+    linksByRule.set(link.ruleId, current);
+  }
+
+  const reviewByRule = new Map((params.currentReview?.reviews ?? []).map((review) => [review.ruleId, review]));
+  const gaps: CoverageGap[] = [];
+  for (const ruleId of Array.from(ruleIds).sort((a, b) => a.localeCompare(b))) {
+    const review = reviewByRule.get(ruleId) ?? null;
+    const matchedEvidenceIds = Array.from(
+      new Set((linksByRule.get(ruleId) ?? []).map((link) => {
+        const fragmentId = link.factId.replace(/__fact_001$/, '');
+        return params.fragments.find((fragment) => fragment.fragmentId === fragmentId)?.documentId ?? fragmentId;
+      })),
+    ).sort((a, b) => a.localeCompare(b));
+    const expectedEvidenceIds = review ? uniqueEvidenceRefs(review) : [...matchedEvidenceIds];
+    const isSatisfied = review?.status === 'verified' && matchedEvidenceIds.length > 0;
+    if (!isSatisfied) {
+      gaps.push({
+        ruleId,
+        ruleTitle: ruleTitles.get(ruleId) ?? ruleId,
+        sectionId: pickSectionId(ruleId, params.trace),
+        expectedEvidenceIds,
+        matchedEvidenceIds,
+      });
+    }
+  }
+
+  const itemFingerprint = stableHash(sortByString(items, (item) => item.id));
+  const gapFingerprint = stableHash(sortByString(gaps, (gap) => gap.ruleId));
+  const reconciliationFingerprint = stableHash({ itemFingerprint, gapFingerprint });
+  const status: ReconciliationStatus =
+    items.length > 0 || gaps.length > 0 || (params.currentReview?.reviews?.length ?? 0) > 0 || finalizedRuleId
+      ? 'complete'
+      : 'no-rules';
+
+  return {
+    runId: reconciliationFingerprint,
+    createdAt: params.generatedAt,
+    projectId: params.finalizedReview?.artifact?.verifier?.runId ?? params.currentReview?.verifierBundle?.runContext?.runId ?? 'method-review-export',
+    status,
+    items: sortByString(items, (item) => item.id),
+    gaps: sortByString(gaps, (gap) => gap.ruleId),
+    itemFingerprint,
+    gapFingerprint,
+    reconciliationFingerprint,
+  };
+}
+
+export function buildVerificationPackEvidenceIntelligence(params: {
+  generatedAt: string;
+  rulesJson: unknown;
+  trace: TraceIndex;
+  currentReview?: CurrentMethodReviewExportInput | null;
+  finalizedReview?: FinalizedAuditPackReviewInput | null;
+}): EvidenceIntelligenceData | null {
+  const pins = coalesceEvidencePins([
+    ...(params.currentReview?.evidencePins ?? []),
+    ...(params.finalizedReview?.evidencePins ?? []),
+  ]);
+  if (pins.length === 0 && (params.currentReview?.reviews?.length ?? 0) === 0 && !params.finalizedReview?.artifact) {
+    return null;
+  }
+
+  const fragments = buildFragments(pins);
+  const facts = buildFacts(fragments);
+  const candidateLinks = buildCandidateLinks({
+    pins,
+    currentReview: params.currentReview,
+    finalizedReview: params.finalizedReview,
+    fragments,
+    facts,
+    rulesJson: params.rulesJson,
+    trace: params.trace,
+  });
+  const reconciliationRun = buildReconciliationRun({
+    currentReview: params.currentReview,
+    finalizedReview: params.finalizedReview,
+    fragments,
+    candidateLinks,
+    generatedAt: params.generatedAt,
+    trace: params.trace,
+    rulesJson: params.rulesJson,
+  });
+  const decisionRun = buildDecisionRun({
+    currentReview: params.currentReview,
+    finalizedReview: params.finalizedReview,
+    generatedAt: params.generatedAt,
+    reconciliationRunId: reconciliationRun?.runId,
+  });
+
+  if (fragments.length === 0 && facts.length === 0 && candidateLinks.length === 0 && !reconciliationRun && !decisionRun) {
+    return null;
+  }
+
+  return {
+    fragments,
+    facts,
+    candidateLinks,
+    reconciliationRun,
+    decisionRun,
+  };
+}

--- a/src/lib/evidence/export/verificationPackIntegration.ts
+++ b/src/lib/evidence/export/verificationPackIntegration.ts
@@ -11,6 +11,11 @@ export type EvidenceIntelligenceData = {
   decisionRun?: DecisionRun;
 };
 
+type EvidenceLinkTarget = {
+  href: string;
+  label?: string;
+};
+
 export type EvidenceIntelligenceFiles = Array<{ path: string; bytes: Buffer }>;
 
 function escapeHtml(value: string): string {
@@ -30,6 +35,11 @@ function safeDate(iso: string | undefined): string {
 
 function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 3) + '...' : s;
+}
+
+function anchorId(prefix: string, value: string): string {
+  const compact = value.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-+|-+$/g, '').toLowerCase();
+  return `${prefix}-${compact || 'item'}`;
 }
 
 export function buildEvidenceIntelligenceJson(data: EvidenceIntelligenceData): Record<string, unknown> {
@@ -100,10 +110,14 @@ export function buildEvidenceIntelligenceJson(data: EvidenceIntelligenceData): R
             ruleId: d.ruleId,
             ruleTitle: d.ruleTitle,
             status: d.status,
-            rationale: d.rationale,
-            reviewerId: d.reviewerId,
-            reviewedAt: d.reviewedAt,
-            evidenceInventoryIds: d.evidenceInventoryIds,
+	          rationale: d.rationale,
+	          reviewerId: d.reviewerId,
+	          reviewedAt: d.reviewedAt,
+	            evidenceInventoryIds: [...d.evidenceInventoryIds],
+	            evidenceLinks: d.evidenceInventoryIds.map((id) => ({
+	              evidenceRef: id,
+	              reportAnchor: `#${anchorId('evidence-ref', id)}`,
+	            })),
             provenanceHash: d.provenanceHash,
           })),
         }
@@ -159,44 +173,67 @@ export function buildEvidenceIntelligenceFiles(data: EvidenceIntelligenceData): 
         totalItems: run.items.length,
         gapCount: run.gaps.length,
       },
-      gaps: run.gaps.map((g) => ({
-        ruleId: g.ruleId,
-        ruleTitle: g.ruleTitle,
-        sectionId: g.sectionId,
-        expectedEvidenceIds: g.expectedEvidenceIds,
-        matchedEvidenceIds: g.matchedEvidenceIds,
-      })),
-    };
+	      gaps: run.gaps.map((g) => ({
+	        ruleId: g.ruleId,
+	        ruleTitle: g.ruleTitle,
+	        sectionId: g.sectionId,
+	        expectedEvidenceIds: [...g.expectedEvidenceIds],
+	        matchedEvidenceIds: [...g.matchedEvidenceIds],
+	      })),
+	    };
     files.push({ path: 'coverage-matrix.json', bytes: Buffer.from(canonicalStringify(coverageJson), 'utf8') });
   }
 
-  if (hasDecisions) {
-    const run = data.decisionRun!;
-    const decisionsJson = {
-      kind: 'article6.reviewer_decisions',
-      version: 1,
-      runId: run.runId,
-      decisionSetFingerprint: run.decisionSetFingerprint,
-      decisions: run.decisions.map((d) => ({
-        decisionId: d.decisionId,
-        ruleId: d.ruleId,
-        ruleTitle: d.ruleTitle,
-        status: d.status,
-        rationale: d.rationale,
-        reviewerId: d.reviewerId,
-        reviewedAt: d.reviewedAt,
-        evidenceInventoryIds: d.evidenceInventoryIds,
-        provenanceHash: d.provenanceHash,
-      })),
-    };
-    files.push({ path: 'reviewer-decisions.json', bytes: Buffer.from(canonicalStringify(decisionsJson), 'utf8') });
-  }
+	  if (hasDecisions) {
+	    const run = data.decisionRun!;
+	    const decisionsJson = {
+	      kind: 'article6.reviewer_decisions',
+	      version: 1,
+	      runId: run.runId,
+	      decisionSetFingerprint: run.decisionSetFingerprint,
+	      decisions: run.decisions.map((d) => ({
+	        decisionId: d.decisionId,
+	        ruleId: d.ruleId,
+	        ruleTitle: d.ruleTitle,
+	        status: d.status,
+	        rationale: d.rationale,
+	        reviewerId: d.reviewerId,
+	        reviewedAt: d.reviewedAt,
+	        evidenceInventoryIds: [...d.evidenceInventoryIds],
+	        evidenceLinks: d.evidenceInventoryIds.map((id) => ({
+	          evidenceRef: id,
+	          reportAnchor: `#${anchorId('evidence-ref', id)}`,
+	        })),
+	        provenanceHash: d.provenanceHash,
+	      })),
+	    };
+	    files.push({ path: 'reviewer-decisions.json', bytes: Buffer.from(canonicalStringify(decisionsJson), 'utf8') });
+	  }
 
   return files;
 }
 
-export function renderEvidenceIntelligenceHtmlSections(data: EvidenceIntelligenceData): string {
+export function renderEvidenceIntelligenceHtmlSections(
+  data: EvidenceIntelligenceData,
+  options?: { evidenceHrefById?: Record<string, EvidenceLinkTarget> },
+): string {
   const sections: string[] = [];
+  const fragmentsById = new Map(data.fragments.map((fragment) => [fragment.fragmentId, fragment]));
+  const evidenceHrefById = options?.evidenceHrefById ?? {};
+  const renderFragmentRef = (fragmentId: string) => {
+    const fragment = fragmentsById.get(fragmentId);
+    const location = fragment?.pageStart
+      ? ` p.${fragment.pageStart}${fragment.pageEnd && fragment.pageEnd !== fragment.pageStart ? `-${fragment.pageEnd}` : ''}`
+      : fragment?.sheetName
+        ? ` ${fragment.sheetName}`
+        : '';
+    return `<a href="#${anchorId('fragment', fragmentId)}" class="ref">[${escapeHtml(fragmentId)}${escapeHtml(location)}]</a>`;
+  };
+  const renderEvidenceRef = (evidenceId: string) => {
+    const target = evidenceHrefById[evidenceId];
+    if (!target) return `<span class="ref">${escapeHtml(evidenceId)}</span>`;
+    return `<a href="${escapeHtml(target.href)}" class="ref">${escapeHtml(target.label ?? evidenceId)}</a>`;
+  };
 
   if (data.facts.length > 0) {
     const grouped = new Map<string, ExtractedFact[]>();
@@ -211,7 +248,7 @@ export function renderEvidenceIntelligenceHtmlSections(data: EvidenceIntelligenc
       .map(([type, typeFacts]) => {
         const typeLabel = type.replace(/-/g, ' ');
         const samples = typeFacts.slice(0, 5).map((f) =>
-          `<div class="muted">${escapeHtml(truncate(f.value, 120))} <span class="ref">[${escapeHtml(f.fragmentId)}]</span></div>`
+          `<div class="muted">${escapeHtml(truncate(f.value, 120))} ${renderFragmentRef(f.fragmentId)}</div>`
         ).join('\n');
         const more = typeFacts.length > 5 ? `<div class="muted">... and ${typeFacts.length - 5} more</div>` : '';
         return `<tr>
@@ -282,7 +319,7 @@ ${gapRows}
   <td>${escapeHtml(truncate(d.rationale, 200))}</td>
   <td>${escapeHtml(d.reviewerId)}</td>
   <td>${safeDate(d.reviewedAt)}</td>
-  <td>${d.evidenceInventoryIds.length > 0 ? escapeHtml(d.evidenceInventoryIds.join(', ')) : '<span class="muted">None</span>'}</td>
+  <td>${d.evidenceInventoryIds.length > 0 ? d.evidenceInventoryIds.map((id) => renderEvidenceRef(id)).join(', ') : '<span class="muted">None</span>'}</td>
 </tr>`).join('\n');
 
     sections.push(`
@@ -308,7 +345,7 @@ ${decisionRows}
   }
 
   if (data.fragments.length > 0) {
-    const fragmentRows = data.fragments.slice(0, 20).map((f) => `<tr>
+    const fragmentRows = data.fragments.slice(0, 20).map((f) => `<tr id="${anchorId('fragment', f.fragmentId)}">
   <td>${escapeHtml(f.fragmentId)}</td>
   <td>${escapeHtml(f.documentId)}</td>
   <td>${escapeHtml(f.kind)}</td>

--- a/src/lib/evidence/export/verificationPackIntegration.ts
+++ b/src/lib/evidence/export/verificationPackIntegration.ts
@@ -1,0 +1,345 @@
+import { canonicalStringify } from '@/integrity/artifacts';
+import type { DocumentFragment, ExtractedFact, CandidateLink } from '@/lib/evidence/extraction/types';
+import type { ReconciliationRun } from '@/lib/evidence/reconciliation/types';
+import type { DecisionRun } from '@/lib/evidence/decisions/types';
+
+export type EvidenceIntelligenceData = {
+  fragments: DocumentFragment[];
+  facts: ExtractedFact[];
+  candidateLinks: CandidateLink[];
+  reconciliationRun?: ReconciliationRun;
+  decisionRun?: DecisionRun;
+};
+
+export type EvidenceIntelligenceFiles = Array<{ path: string; bytes: Buffer }>;
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function safeDate(iso: string | undefined): string {
+  if (!iso) return 'n/a';
+  const d = iso.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(d) ? d : iso.slice(0, 16);
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 3) + '...' : s;
+}
+
+export function buildEvidenceIntelligenceJson(data: EvidenceIntelligenceData): Record<string, unknown> {
+  return {
+    kind: 'article6.evidence_intelligence',
+    version: 1,
+    summary: {
+      fragmentCount: data.fragments.length,
+      factCount: data.facts.length,
+      candidateLinkCount: data.candidateLinks.length,
+      reconciliationStatus: data.reconciliationRun?.status ?? null,
+      gapCount: data.reconciliationRun?.gaps.length ?? 0,
+      decisionCount: data.decisionRun?.decisions.length ?? 0,
+    },
+    fragments: data.fragments.map((f) => ({
+      fragmentId: f.fragmentId,
+      documentId: f.documentId,
+      kind: f.kind,
+      index: f.index,
+      label: f.label,
+      textLength: f.text.length,
+      textPreview: f.text.slice(0, 500),
+      contentSha256: f.contentSha256,
+      pageStart: f.pageStart,
+      pageEnd: f.pageEnd,
+      sheetName: f.sheetName,
+    })),
+    facts: data.facts.map((f) => ({
+      factId: f.factId,
+      fragmentId: f.fragmentId,
+      documentId: f.documentId,
+      factType: f.factType,
+      value: f.value,
+      context: f.context,
+      contentSha256: f.contentSha256,
+    })),
+    candidateLinks: data.candidateLinks.map((link) => ({
+      linkId: link.linkId,
+      factId: link.factId,
+      ruleId: link.ruleId,
+      ruleTitle: link.ruleTitle,
+      sectionId: link.sectionId,
+      matchType: link.matchType,
+      confidence: link.confidence,
+      contentSha256: link.contentSha256,
+    })),
+    reconciliation: data.reconciliationRun
+      ? {
+          runId: data.reconciliationRun.runId,
+          status: data.reconciliationRun.status,
+          loadError: data.reconciliationRun.loadError,
+          reconciliationFingerprint: data.reconciliationRun.reconciliationFingerprint,
+          gaps: data.reconciliationRun.gaps.map((g) => ({
+            ruleId: g.ruleId,
+            ruleTitle: g.ruleTitle,
+            sectionId: g.sectionId,
+            expectedEvidenceCount: g.expectedEvidenceIds.length,
+            matchedEvidenceCount: g.matchedEvidenceIds.length,
+          })),
+        }
+      : null,
+    decisions: data.decisionRun
+      ? {
+          runId: data.decisionRun.runId,
+          decisionSetFingerprint: data.decisionRun.decisionSetFingerprint,
+          decisions: data.decisionRun.decisions.map((d) => ({
+            decisionId: d.decisionId,
+            ruleId: d.ruleId,
+            ruleTitle: d.ruleTitle,
+            status: d.status,
+            rationale: d.rationale,
+            reviewerId: d.reviewerId,
+            reviewedAt: d.reviewedAt,
+            evidenceInventoryIds: d.evidenceInventoryIds,
+            provenanceHash: d.provenanceHash,
+          })),
+        }
+      : null,
+  };
+}
+
+export function buildEvidenceIntelligenceFiles(data: EvidenceIntelligenceData): EvidenceIntelligenceFiles {
+  if (data.fragments.length === 0 && data.facts.length === 0 && data.candidateLinks.length === 0 && !data.reconciliationRun && !data.decisionRun) {
+    return [];
+  }
+
+  const json = buildEvidenceIntelligenceJson(data);
+  const jsonBytes = Buffer.from(canonicalStringify(json), 'utf8');
+
+  const files: EvidenceIntelligenceFiles = [
+    { path: 'evidence-intelligence.json', bytes: jsonBytes },
+  ];
+
+  const hasFragments = data.fragments.length > 0;
+  const hasCoverage = data.reconciliationRun !== undefined;
+  const hasDecisions = data.decisionRun !== undefined;
+
+  if (hasFragments) {
+    const fragmentsJson = {
+      kind: 'article6.evidence_fragments',
+      version: 1,
+      fragments: data.fragments.map((f) => ({
+        fragmentId: f.fragmentId,
+        documentId: f.documentId,
+        kind: f.kind,
+        index: f.index,
+        label: f.label,
+        text: f.text,
+        contentSha256: f.contentSha256,
+        pageStart: f.pageStart,
+        pageEnd: f.pageEnd,
+        sheetName: f.sheetName,
+      })),
+    };
+    files.push({ path: 'evidence-fragments.json', bytes: Buffer.from(canonicalStringify(fragmentsJson), 'utf8') });
+  }
+
+  if (hasCoverage) {
+    const run = data.reconciliationRun!;
+    const coverageJson = {
+      kind: 'article6.coverage_matrix',
+      version: 1,
+      status: run.status,
+      loadError: run.loadError ?? null,
+      reconciliationFingerprint: run.reconciliationFingerprint,
+      summary: {
+        totalItems: run.items.length,
+        gapCount: run.gaps.length,
+      },
+      gaps: run.gaps.map((g) => ({
+        ruleId: g.ruleId,
+        ruleTitle: g.ruleTitle,
+        sectionId: g.sectionId,
+        expectedEvidenceIds: g.expectedEvidenceIds,
+        matchedEvidenceIds: g.matchedEvidenceIds,
+      })),
+    };
+    files.push({ path: 'coverage-matrix.json', bytes: Buffer.from(canonicalStringify(coverageJson), 'utf8') });
+  }
+
+  if (hasDecisions) {
+    const run = data.decisionRun!;
+    const decisionsJson = {
+      kind: 'article6.reviewer_decisions',
+      version: 1,
+      runId: run.runId,
+      decisionSetFingerprint: run.decisionSetFingerprint,
+      decisions: run.decisions.map((d) => ({
+        decisionId: d.decisionId,
+        ruleId: d.ruleId,
+        ruleTitle: d.ruleTitle,
+        status: d.status,
+        rationale: d.rationale,
+        reviewerId: d.reviewerId,
+        reviewedAt: d.reviewedAt,
+        evidenceInventoryIds: d.evidenceInventoryIds,
+        provenanceHash: d.provenanceHash,
+      })),
+    };
+    files.push({ path: 'reviewer-decisions.json', bytes: Buffer.from(canonicalStringify(decisionsJson), 'utf8') });
+  }
+
+  return files;
+}
+
+export function renderEvidenceIntelligenceHtmlSections(data: EvidenceIntelligenceData): string {
+  const sections: string[] = [];
+
+  if (data.facts.length > 0) {
+    const grouped = new Map<string, ExtractedFact[]>();
+    for (const fact of data.facts) {
+      const type = fact.factType;
+      const existing = grouped.get(type) ?? [];
+      existing.push(fact);
+      grouped.set(type, existing);
+    }
+
+    const factRows = Array.from(grouped.entries())
+      .map(([type, typeFacts]) => {
+        const typeLabel = type.replace(/-/g, ' ');
+        const samples = typeFacts.slice(0, 5).map((f) =>
+          `<div class="muted">${escapeHtml(truncate(f.value, 120))} <span class="ref">[${escapeHtml(f.fragmentId)}]</span></div>`
+        ).join('\n');
+        const more = typeFacts.length > 5 ? `<div class="muted">... and ${typeFacts.length - 5} more</div>` : '';
+        return `<tr>
+  <td><strong>${escapeHtml(typeLabel)}</strong></td>
+  <td>${typeFacts.length}</td>
+  <td>${samples}${more}</td>
+</tr>`;
+      })
+      .join('\n');
+
+    sections.push(`
+    <section class="panel">
+      <h2>Extracted Facts</h2>
+      <p>${data.facts.length} extracted facts across ${grouped.size} types, sourced from document fragments.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Fact Type</th>
+            <th>Count</th>
+            <th>Samples</th>
+          </tr>
+        </thead>
+        <tbody>
+${factRows}
+        </tbody>
+      </table>
+    </section>`);
+  }
+
+  if (data.reconciliationRun) {
+    const run = data.reconciliationRun;
+    const gapRows = run.gaps.length > 0
+      ? run.gaps.map((g) => `<tr>
+  <td>${escapeHtml(g.ruleId)}</td>
+  <td>${escapeHtml(g.ruleTitle)}</td>
+  <td>${escapeHtml(g.sectionId)}</td>
+  <td>${g.expectedEvidenceIds.length}</td>
+  <td>${g.matchedEvidenceIds.length}</td>
+</tr>`).join('\n')
+      : '<tr><td colspan="5">No coverage gaps identified.</td></tr>';
+
+    sections.push(`
+    <section class="panel">
+      <h2>Coverage Matrix</h2>
+      <p>Reconciliation status: <strong>${escapeHtml(run.status)}</strong>${run.reconciliationFingerprint ? ` &mdash; <span class="ref">${escapeHtml(run.reconciliationFingerprint)}</span>` : ''}</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Rule ID</th>
+            <th>Rule Title</th>
+            <th>Section</th>
+            <th>Expected</th>
+            <th>Matched</th>
+          </tr>
+        </thead>
+        <tbody>
+${gapRows}
+        </tbody>
+      </table>
+    </section>`);
+  }
+
+  if (data.decisionRun && data.decisionRun.decisions.length > 0) {
+    const run = data.decisionRun;
+    const decisionRows = run.decisions.map((d) => `<tr>
+  <td>${escapeHtml(d.ruleId)}</td>
+  <td><span class="status-${d.status}">${escapeHtml(d.status)}</span></td>
+  <td>${escapeHtml(truncate(d.rationale, 200))}</td>
+  <td>${escapeHtml(d.reviewerId)}</td>
+  <td>${safeDate(d.reviewedAt)}</td>
+  <td>${d.evidenceInventoryIds.length > 0 ? escapeHtml(d.evidenceInventoryIds.join(', ')) : '<span class="muted">None</span>'}</td>
+</tr>`).join('\n');
+
+    sections.push(`
+    <section class="panel">
+      <h2>Reviewer Decisions</h2>
+      <p>${run.decisions.length} reviewer decision${run.decisions.length === 1 ? '' : 's'} recorded. <span class="ref">${escapeHtml(run.decisionSetFingerprint)}</span></p>
+      <table>
+        <thead>
+          <tr>
+            <th>Rule</th>
+            <th>Status</th>
+            <th>Rationale</th>
+            <th>Reviewer</th>
+            <th>Date</th>
+            <th>Evidence Refs</th>
+          </tr>
+        </thead>
+        <tbody>
+${decisionRows}
+        </tbody>
+      </table>
+    </section>`);
+  }
+
+  if (data.fragments.length > 0) {
+    const fragmentRows = data.fragments.slice(0, 20).map((f) => `<tr>
+  <td>${escapeHtml(f.fragmentId)}</td>
+  <td>${escapeHtml(f.documentId)}</td>
+  <td>${escapeHtml(f.kind)}</td>
+  <td>${escapeHtml(f.label)}</td>
+  <td>${escapeHtml(truncate(f.text, 100))}</td>
+  <td><span class="ref">${escapeHtml(f.contentSha256 ?? '')}</span></td>
+</tr>`).join('\n');
+
+    const more = data.fragments.length > 20 ? `<p class="muted">... and ${data.fragments.length - 20} more fragments. Full list in evidence-fragments.json.</p>` : '';
+    sections.push(`
+    <section class="panel">
+      <h2>Evidence Fragments</h2>
+      <p>${data.fragments.length} extracted fragment${data.fragments.length === 1 ? '' : 's'} with provenance.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Fragment ID</th>
+            <th>Source Doc</th>
+            <th>Kind</th>
+            <th>Label</th>
+            <th>Preview</th>
+            <th>SHA-256</th>
+          </tr>
+        </thead>
+        <tbody>
+${fragmentRows}
+        </tbody>
+      </table>
+      ${more}
+    </section>`);
+  }
+
+  return sections.join('\n');
+}

--- a/tests/app/api/exports/audit-pack.route.test.ts
+++ b/tests/app/api/exports/audit-pack.route.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { strFromU8, unzipSync } from "fflate";
 import { GET, POST } from "@/app/api/exports/audit-pack/route";
 import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
 
@@ -283,5 +284,8 @@ describe("/api/exports/audit-pack route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/zip");
+    const zip = unzipSync(new Uint8Array(await response.arrayBuffer()));
+    expect(zip["evidence-intelligence.json"]).toBeDefined();
+    expect(strFromU8(zip["VERIFICATION_REPORT.html"])).toContain("Reviewer Decisions");
   });
 });

--- a/tests/exports/auditPack.contract.test.ts
+++ b/tests/exports/auditPack.contract.test.ts
@@ -540,6 +540,150 @@ describe("audit pack verification contract", () => {
     expect(strFromU8(entries["VERIFICATION_REPORT.html"])).not.toContain("Demo review record only.");
   });
 
+  test("integrates evidence intelligence into live audit-pack exports", () => {
+    const reviews: RuleReview[] = [
+      {
+        ruleId: "R-1-0001",
+        methodology: "AR-ACM0003",
+        version: "v02-0",
+        status: "verified",
+        rationale: "Monitoring-period evidence is linked directly to the rule.",
+        supportReference: "pin-pdd-1",
+        evidenceLink: "frag-monitoring-period",
+        evidenceAttachments: [],
+        reviewedBy: "Verifier A",
+        reviewedAt: "2026-04-24T12:00:00.000Z",
+        updatedAt: "2026-04-24T12:00:00.000Z",
+      },
+    ];
+    const evidencePins: EvidencePin[] = [
+      {
+        id: "pin-pdd-1",
+        kind: "pdd",
+        title: "Monitoring period PDD",
+        ruleId: "R-1-0001",
+        cited_ids: ["R-1-0001"],
+        created_at: "2026-04-24T11:55:00.000Z",
+        pdd_document: {
+          evidence_id: "pin-pdd-1",
+          file_name: "monitoring-period.pdf",
+          mime: "application/pdf",
+          added_at: "2026-04-24T11:55:00.000Z",
+          sha256: "a".repeat(64),
+        },
+        pdd_fragments: [
+          {
+            fragment_id: "frag-monitoring-period",
+            evidence_id: "pin-pdd-1",
+            label: "Monitoring period",
+            page_start: 12,
+            page_end: 13,
+            section_label: "Section 4",
+            section_heading: "Monitoring period",
+            excerpt: "The monitoring period covers 2023-01-01 through 2023-12-31.",
+          },
+        ],
+        pdd_fragment_links: [
+          {
+            fragment_id: "frag-monitoring-period",
+            rule_id: "R-1-0001",
+            linked_at: "2026-04-24T11:56:00.000Z",
+          },
+        ],
+      },
+    ];
+
+    const zip = withTemporaryMethodologyCheckout(() =>
+      buildAuditPackZip("AR-ACM0003", "v02-0", {
+        currentReview: {
+          latestReviewAt: "2026-04-24T12:05:00.000Z",
+          reviews,
+          evidencePins,
+          verifierBundle: {
+            runContext: {
+              runId: "run-evidence-intel-1",
+              createdAt: "2026-04-24T11:45:00.000Z",
+            },
+            savedReviewerArtifactAt: "2026-04-24T12:05:00.000Z",
+            finalizedAt: null,
+            minutes: "Reviewer minutes",
+            outcomeNote: "Draft outcome note",
+            savedReviewerArtifactContext: {
+              methodCode: "AR-ACM0003",
+              version: "v02-0",
+              ruleId: "R-1-0001",
+              runId: "run-evidence-intel-1",
+            },
+          },
+        },
+      }),
+    );
+
+    const entries = unzipSync(new Uint8Array(zip));
+    expect(entries["evidence-intelligence.json"]).toBeDefined();
+    expect(entries["evidence-fragments.json"]).toBeDefined();
+    expect(entries["coverage-matrix.json"]).toBeDefined();
+    expect(entries["reviewer-decisions.json"]).toBeDefined();
+
+    const evidenceIntel = JSON.parse(strFromU8(entries["evidence-intelligence.json"])) as {
+      summary: { fragmentCount: number; factCount: number };
+      fragments: Array<{ fragmentId: string; pageStart?: number }>;
+      decisions: { decisions: Array<{ evidenceLinks: Array<{ evidenceRef: string; reportAnchor: string }> }> };
+    };
+    expect(evidenceIntel.summary.fragmentCount).toBeGreaterThanOrEqual(1);
+    expect(evidenceIntel.summary.factCount).toBeGreaterThanOrEqual(1);
+    expect(evidenceIntel.fragments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fragmentId: "frag-monitoring-period",
+          pageStart: 12,
+        }),
+      ]),
+    );
+    expect(evidenceIntel.decisions.decisions[0]?.evidenceLinks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          evidenceRef: "frag-monitoring-period",
+          reportAnchor: "#evidence-ref-frag-monitoring-period",
+        }),
+      ]),
+    );
+
+    const html = strFromU8(entries["VERIFICATION_REPORT.html"]);
+    expect(html).toContain("Evidence Fragments");
+    expect(html).toContain("Coverage Matrix");
+    expect(html).toContain("Reviewer Decisions");
+    expect(html).toContain('href="#evidence-ref-frag-monitoring-period"');
+    expect(html).toContain('id="fragment-frag-monitoring-period"');
+
+    const secondZip = withTemporaryMethodologyCheckout(() =>
+      buildAuditPackZip("AR-ACM0003", "v02-0", {
+        currentReview: {
+          latestReviewAt: "2026-04-24T12:05:00.000Z",
+          reviews,
+          evidencePins,
+          verifierBundle: {
+            runContext: {
+              runId: "run-evidence-intel-1",
+              createdAt: "2026-04-24T11:45:00.000Z",
+            },
+            savedReviewerArtifactAt: "2026-04-24T12:05:00.000Z",
+            finalizedAt: null,
+            minutes: "Reviewer minutes",
+            outcomeNote: "Draft outcome note",
+            savedReviewerArtifactContext: {
+              methodCode: "AR-ACM0003",
+              version: "v02-0",
+              ruleId: "R-1-0001",
+              runId: "run-evidence-intel-1",
+            },
+          },
+        },
+      }),
+    );
+    expect(Buffer.from(zip).equals(Buffer.from(secondZip))).toBe(true);
+  });
+
   test("upgrades VERIFICATION_REPORT.html into a truthful readiness review skeleton when project context and files are missing", () => {
     const reviews: RuleReview[] = [
       {

--- a/tests/lib/evidence/export/verificationPackIntegration.test.ts
+++ b/tests/lib/evidence/export/verificationPackIntegration.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from '@jest/globals';
+import { buildEvidenceIntelligenceFiles, renderEvidenceIntelligenceHtmlSections } from '@/lib/evidence/export';
+import type { EvidenceIntelligenceData } from '@/lib/evidence/export';
+import type { DocumentFragment, ExtractedFact, CandidateLink } from '@/lib/evidence/extraction/types';
+import type { ReconciliationRun } from '@/lib/evidence/reconciliation/types';
+import type { DecisionRun } from '@/lib/evidence/decisions/types';
+
+function makeFragments(): DocumentFragment[] {
+  return [
+    { fragmentId: 'frag-001', documentId: 'doc-1', kind: 'pdd', index: 0, label: 'Section 1', text: 'Project description text.', contentSha256: 'a'.repeat(64), pageStart: 1, pageEnd: 3 },
+    { fragmentId: 'frag-002', documentId: 'doc-1', kind: 'pdd', index: 1, label: 'Section 2', text: 'Baseline scenario.', contentSha256: 'b'.repeat(64), pageStart: 4, pageEnd: 6 },
+  ];
+}
+
+function makeFacts(): ExtractedFact[] {
+  return [
+    { factId: 'fact-001', fragmentId: 'frag-001', documentId: 'doc-1', factType: 'location', value: 'Malawi', context: 'project location', contentSha256: 'c'.repeat(64) },
+    { factId: 'fact-002', fragmentId: 'frag-001', documentId: 'doc-1', factType: 'quantity', value: '500 ha', context: 'area', contentSha256: 'd'.repeat(64) },
+  ];
+}
+
+function makeLinks(): CandidateLink[] {
+  return [
+    { linkId: 'link-001', factId: 'fact-001', ruleId: 'R-1', ruleTitle: 'Location', sectionId: 'S-1', matchType: 'keyword-overlap', matchReason: 'match', confidence: 0.8, contentSha256: 'e'.repeat(64) },
+  ];
+}
+
+function makeReconciliationRun(): ReconciliationRun {
+  return {
+    runId: 'rec-001',
+    createdAt: '2026-05-01T00:00:00Z',
+    projectId: 'proj-1',
+    status: 'complete',
+    items: [],
+    gaps: [{ ruleId: 'R-3', ruleTitle: 'Monitoring', sectionId: 'S-2', expectedEvidenceIds: [], matchedEvidenceIds: [] }],
+    itemFingerprint: 'f'.repeat(64),
+    gapFingerprint: 'g'.repeat(64),
+    reconciliationFingerprint: 'h'.repeat(64),
+  };
+}
+
+function makeDecisionRun(): DecisionRun {
+  return {
+    runId: 'dec-001',
+    projectId: 'proj-1',
+    createdAt: '2026-05-02T00:00:00Z',
+    decisionSetFingerprint: 'i'.repeat(64),
+    decisions: [
+      {
+        decisionId: 'dec-001',
+        ruleId: 'R-1',
+        ruleTitle: 'Location',
+        sectionId: 'S-1',
+        status: 'approved',
+        rationale: 'Evidence matches requirement.',
+        reviewerId: 'reviewer_abc',
+        reviewedAt: '2026-05-02T10:00:00Z',
+        updatedAt: '2026-05-02T10:00:00Z',
+        evidenceInventoryIds: ['EV-001'],
+        provenanceHash: 'j'.repeat(64),
+      },
+    ],
+  };
+}
+
+describe('buildEvidenceIntelligenceFiles', () => {
+  it('returns empty array when no evidence data is provided', () => {
+    const data: EvidenceIntelligenceData = { fragments: [], facts: [], candidateLinks: [] };
+    expect(buildEvidenceIntelligenceFiles(data)).toEqual([]);
+  });
+
+  it('includes evidence-intelligence.json with facts', () => {
+    const data: EvidenceIntelligenceData = { fragments: [], facts: makeFacts(), candidateLinks: [] };
+    const files = buildEvidenceIntelligenceFiles(data);
+    expect(files.length).toBeGreaterThanOrEqual(1);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('evidence-intelligence.json');
+    const json = JSON.parse(files.find((f) => f.path === 'evidence-intelligence.json')!.bytes.toString('utf8'));
+    expect(json.kind).toBe('article6.evidence_intelligence');
+    expect(json.summary.factCount).toBe(2);
+  });
+
+  it('includes evidence-fragments.json when fragments exist', () => {
+    const data: EvidenceIntelligenceData = { fragments: makeFragments(), facts: [], candidateLinks: [] };
+    const files = buildEvidenceIntelligenceFiles(data);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('evidence-fragments.json');
+    const json = JSON.parse(files.find((f) => f.path === 'evidence-fragments.json')!.bytes.toString('utf8'));
+    expect(json.kind).toBe('article6.evidence_fragments');
+    expect(json.fragments).toHaveLength(2);
+  });
+
+  it('includes coverage-matrix.json when reconciliationRun is provided', () => {
+    const data: EvidenceIntelligenceData = { fragments: [], facts: [], candidateLinks: [], reconciliationRun: makeReconciliationRun() };
+    const files = buildEvidenceIntelligenceFiles(data);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('coverage-matrix.json');
+    const json = JSON.parse(files.find((f) => f.path === 'coverage-matrix.json')!.bytes.toString('utf8'));
+    expect(json.kind).toBe('article6.coverage_matrix');
+    expect(json.gaps).toHaveLength(1);
+    expect(json.status).toBe('complete');
+  });
+
+  it('includes reviewer-decisions.json when decisionRun is provided', () => {
+    const data: EvidenceIntelligenceData = { fragments: [], facts: [], candidateLinks: [], decisionRun: makeDecisionRun() };
+    const files = buildEvidenceIntelligenceFiles(data);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('reviewer-decisions.json');
+    const json = JSON.parse(files.find((f) => f.path === 'reviewer-decisions.json')!.bytes.toString('utf8'));
+    expect(json.kind).toBe('article6.reviewer_decisions');
+    expect(json.decisions).toHaveLength(1);
+  });
+
+  it('includes all files when all data is provided', () => {
+    const data: EvidenceIntelligenceData = {
+      fragments: makeFragments(),
+      facts: makeFacts(),
+      candidateLinks: makeLinks(),
+      reconciliationRun: makeReconciliationRun(),
+      decisionRun: makeDecisionRun(),
+    };
+    const files = buildEvidenceIntelligenceFiles(data);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('evidence-intelligence.json');
+    expect(paths).toContain('evidence-fragments.json');
+    expect(paths).toContain('coverage-matrix.json');
+    expect(paths).toContain('reviewer-decisions.json');
+  });
+
+  it('produces deterministic JSON (sorted keys)', () => {
+    const data: EvidenceIntelligenceData = { fragments: makeFragments(), facts: makeFacts(), candidateLinks: [] };
+    const files1 = buildEvidenceIntelligenceFiles(data);
+    const files2 = buildEvidenceIntelligenceFiles(data);
+    for (let i = 0; i < files1.length; i++) {
+      expect(files1[i].bytes.toString('utf8')).toBe(files2[i].bytes.toString('utf8'));
+    }
+  });
+});
+
+describe('renderEvidenceIntelligenceHtmlSections', () => {
+  it('returns empty string when no evidence data is provided', () => {
+    const data: EvidenceIntelligenceData = { fragments: [], facts: [], candidateLinks: [] };
+    expect(renderEvidenceIntelligenceHtmlSections(data)).toBe('');
+  });
+
+  it('renders extracted facts section when facts exist', () => {
+    const data: EvidenceIntelligenceData = { fragments: [], facts: makeFacts(), candidateLinks: [] };
+    const html = renderEvidenceIntelligenceHtmlSections(data);
+    expect(html).toContain('Extracted Facts');
+    expect(html).toContain('location');
+    expect(html).toContain('quantity');
+  });
+
+  it('renders coverage matrix section when reconciliationRun is provided', () => {
+    const data: EvidenceIntelligenceData = { fragments: [], facts: [], candidateLinks: [], reconciliationRun: makeReconciliationRun() };
+    const html = renderEvidenceIntelligenceHtmlSections(data);
+    expect(html).toContain('Coverage Matrix');
+    expect(html).toContain('complete');
+    expect(html).toContain('R-3');
+  });
+
+  it('renders reviewer decisions section when decisionRun is provided', () => {
+    const data: EvidenceIntelligenceData = { fragments: [], facts: [], candidateLinks: [], decisionRun: makeDecisionRun() };
+    const html = renderEvidenceIntelligenceHtmlSections(data);
+    expect(html).toContain('Reviewer Decisions');
+    expect(html).toContain('approved');
+    expect(html).toContain('reviewer_abc');
+  });
+
+  it('renders evidence fragments section when fragments exist', () => {
+    const data: EvidenceIntelligenceData = { fragments: makeFragments(), facts: [], candidateLinks: [] };
+    const html = renderEvidenceIntelligenceHtmlSections(data);
+    expect(html).toContain('Evidence Fragments');
+    expect(html).toContain('frag-001');
+    expect(html).toContain('frag-002');
+  });
+
+  it('renders all sections when all data is provided', () => {
+    const data: EvidenceIntelligenceData = {
+      fragments: makeFragments(),
+      facts: makeFacts(),
+      candidateLinks: makeLinks(),
+      reconciliationRun: makeReconciliationRun(),
+      decisionRun: makeDecisionRun(),
+    };
+    const html = renderEvidenceIntelligenceHtmlSections(data);
+    expect(html).toContain('Extracted Facts');
+    expect(html).toContain('Coverage Matrix');
+    expect(html).toContain('Reviewer Decisions');
+    expect(html).toContain('Evidence Fragments');
+  });
+});
+
+describe('Verification pack contract integration', () => {
+  it('buildVerificationPackContractFiles includes evidence intelligence files when data is provided', async () => {
+    const { buildVerificationPackContractFiles } = await import('@/exports/verificationPackContract');
+    const data: EvidenceIntelligenceData = {
+      fragments: makeFragments(),
+      facts: makeFacts(),
+      candidateLinks: makeLinks(),
+      reconciliationRun: makeReconciliationRun(),
+      decisionRun: makeDecisionRun(),
+    };
+
+    const files = buildVerificationPackContractFiles({
+      generatedAt: '2026-05-20T00:00:00.000Z',
+      methodCode: 'VM0007',
+      version: 'v1.0',
+      rulesJson: [],
+      sectionsJson: [],
+      trace: {
+        sections: [],
+        rules: [],
+        rule_to_evidence: {},
+        verification_contract: {
+          mode: 'demo_placeholder_review_contract',
+          project_path: 'project.json',
+          evidence_manifest_path: 'evidence-manifest.json',
+          requirement_review_path: 'requirement-review.json',
+          trail_path: 'trail.jsonl',
+          report_path: 'VERIFICATION_REPORT.html',
+          placeholder: true,
+          placeholder_reason: 'test',
+        },
+        rule_to_review: {},
+        rule_to_section: {},
+        section_to_rules: {},
+      } as any,
+      evidenceIntelligence: data,
+    });
+
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('evidence-intelligence.json');
+    expect(paths).toContain('evidence-fragments.json');
+    expect(paths).toContain('coverage-matrix.json');
+    expect(paths).toContain('reviewer-decisions.json');
+  });
+
+  it('includes evidence intelligence sections in HTML report when data is provided', async () => {
+    const { buildVerificationPackContract } = await import('@/exports/verificationPackContract');
+    const data: EvidenceIntelligenceData = {
+      fragments: makeFragments(),
+      facts: makeFacts(),
+      candidateLinks: makeLinks(),
+      reconciliationRun: makeReconciliationRun(),
+      decisionRun: makeDecisionRun(),
+    };
+
+    const contract = buildVerificationPackContract({
+      generatedAt: '2026-05-20T00:00:00.000Z',
+      methodCode: 'VM0007',
+      version: 'v1.0',
+      rulesJson: [],
+      sectionsJson: [],
+      trace: {
+        sections: [],
+        rules: [],
+        rule_to_evidence: {},
+        verification_contract: {
+          mode: 'demo_placeholder_review_contract',
+          project_path: 'project.json',
+          evidence_manifest_path: 'evidence-manifest.json',
+          requirement_review_path: 'requirement-review.json',
+          trail_path: 'trail.jsonl',
+          report_path: 'VERIFICATION_REPORT.html',
+          placeholder: true,
+          placeholder_reason: 'test',
+        },
+        rule_to_review: {},
+        rule_to_section: {},
+        section_to_rules: {},
+      } as any,
+      evidenceIntelligence: data,
+    });
+
+    expect(contract.reportHtml).toContain('Extracted Facts');
+    expect(contract.reportHtml).toContain('Coverage Matrix');
+    expect(contract.reportHtml).toContain('Reviewer Decisions');
+    expect(contract.reportHtml).toContain('Evidence Fragments');
+    expect(contract.reportHtml).toContain('location');
+    expect(contract.reportHtml).toContain('approved');
+  });
+
+  it('does not include evidence intelligence sections when data is not provided', async () => {
+    const { buildVerificationPackContract } = await import('@/exports/verificationPackContract');
+
+    const contract = buildVerificationPackContract({
+      generatedAt: '2026-05-20T00:00:00.000Z',
+      methodCode: 'VM0007',
+      version: 'v1.0',
+      rulesJson: [],
+      sectionsJson: [],
+      trace: {
+        sections: [],
+        rules: [],
+        rule_to_evidence: {},
+        verification_contract: {
+          mode: 'demo_placeholder_review_contract',
+          project_path: 'project.json',
+          evidence_manifest_path: 'evidence-manifest.json',
+          requirement_review_path: 'requirement-review.json',
+          trail_path: 'trail.jsonl',
+          report_path: 'VERIFICATION_REPORT.html',
+          placeholder: true,
+          placeholder_reason: 'test',
+        },
+        rule_to_review: {},
+        rule_to_section: {},
+        section_to_rules: {},
+      } as any,
+    });
+
+    expect(contract.reportHtml).not.toContain('Extracted Facts');
+    expect(contract.reportHtml).not.toContain('Coverage Matrix');
+    expect(contract.reportHtml).not.toContain('Reviewer Decisions');
+  });
+});


### PR DESCRIPTION
### Roadmap-Update
- slug: review-grade-evidence-intelligence
- items:
  - RC5: in_progress
  - PR12: in_progress

## WHAT

- Implements Phase 5 (Verification Pack Integration with Evidence Intelligence) of the review-grade-evidence-intelligence roadmap.
- **New:** `src/lib/evidence/export/verificationPackIntegration.ts` — `buildEvidenceIntelligenceFiles()` produces structured JSON files (`evidence-intelligence.json`, `evidence-fragments.json`, `coverage-matrix.json`, `reviewer-decisions.json`) and `renderEvidenceIntelligenceHtmlSections()` renders evidence intelligence into the HTML report.
- **Modified:** `src/exports/verificationPackContract.ts` — `buildVerificationPackContract()` and `buildVerificationPackContractFiles()` accept an optional `evidenceIntelligence` input. When provided, the verification pack includes evidence intelligence JSON files and the HTML report gains Extracted Facts, Coverage Matrix, Reviewer Decisions, and Evidence Fragments sections. Existing consumers are unaffected when the field is omitted.
- **Modified:** `src/exports/auditPack.ts` — the live audit-pack pipeline now derives and passes evidence intelligence from current/finalized review state so the verification pack integration is end to end, not just an optional hook.
- **New:** `src/lib/evidence/export/verificationPackDerivation.ts` — deterministic derivation of fragments, facts, candidate links, coverage, and reviewer decisions from verification-pack review state.
- **Targeted tests** covering live audit-pack ZIP contents, HTML anchors/links, route output, and determinism.

## WHY

Bridges the evidence intelligence pipeline (fragments, facts, coverage, decisions) into the existing verification pack, making the pack a richer, better-evidenced artifact without breaking existing consumers.

## Backward Compatibility

The `evidenceIntelligence` input is optional. When omitted, the verification pack contract and files are identical to before this change — all existing consumers (audit trail, export) are preserved.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>