### PR TITLE
feat(rc6): evidence quality and coverage metrics

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: review-grade-evidence-intelligence, verification-factory, project-readiness-verification-output, project-verification, requirement-coverage, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
+Active lanes: verification-factory, project-readiness-verification-output, project-verification, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
 Frozen lanes: agentic-verification.
 
 
@@ -30,26 +30,6 @@ Details: `docs/roadmaps/phase-assurance-surface-mvp/PLAN.md`
 5) PR15 — Verifier Mode + Audit Trail + Rule Jump: Done (PR #347)
 6) PR16 — CI Hardening + Self-Upgrading Deps: Done (PR #348)
 7) PR17 — Derived MRV artifacts + hashes (future): Done (PR #429, #432)
-
-## review-grade-evidence-intelligence
-
-Status SSOT: `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`
-Details: `docs/roadmaps/review-grade-evidence-intelligence/PLAN.md`
-
-Lane status: Active
-Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.
-
-Current focus:
-- Evidence snapshot and comparison (Phase 7)
-- Cover Quick Check extraction edge case tests
-- Responsive UI QA for reconciliation and decision badges
-
-Not active now:
-- Refactoring extraction or export code — documentation and planning only in RC0-RC1
-- Changes to canonical methodology metadata or pack encoding
-- Unbounded AI classification, auto-verification, or final evidence sufficiency decisions
-
-1) PR12: Done
 
 ## verifier-moat
 
@@ -193,6 +173,34 @@ Not active now:
 6) RC6 — Methodology version diff / impact mode: Planned — Use canonical methodology version and diff metadata to identify coverage rows and linked evidence that may need review in the app.
 7) RC7 — Fallback raw methodology PDF intake for uncovered methods: Planned — Enable lower-confidence fallback raw methodology PDF intake only for uncovered methods while preserving canonical methodology outputs as the default for covered methods.
 8) RC8 — Additional GIS formats later: Deferred — Defer broader GIS intake until reconciliation fundamentals are stable.
+
+## review-grade-evidence-intelligence
+
+Status SSOT: `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`
+Details: `docs/roadmaps/review-grade-evidence-intelligence/PLAN.md`
+
+Lane status: Active
+Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.
+
+Current focus:
+- Evidence snapshot and comparison (Phase 7)
+- Cover Quick Check extraction edge case tests
+- Responsive UI QA for reconciliation and decision badges
+
+Not active now:
+- Refactoring extraction or export code — documentation and planning only in RC0-RC1
+- Changes to canonical methodology metadata or pack encoding
+- Unbounded AI classification, auto-verification, or final evidence sufficiency decisions
+
+1) RC0 — Review-grade project export standard definition: Done
+2) RC1 — Deterministic evidence extraction foundation: Done
+3) RC2 — Evidence inventory reconciliation: Done
+4) RC3 — Reviewer decision records with provenance: Done
+5) RC4 — Premium PDF/ZIP export with full provenance: Done
+6) RC5 — Verification pack integration with evidence intelligence: Done
+7) RC6 — Evidence quality and coverage metrics: Done
+8) RC7 — Evidence snapshot and comparison: Planned
+9) RC8 — Export standardization and cross-export consistency: Planned
 
 ## safe-learning-intake-pipeline
 

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -40,7 +40,7 @@ Lane status: Active
 Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.
 
 Current focus:
-- Verification pack integration with evidence intelligence (Phase 5)
+- Evidence snapshot and comparison (Phase 7)
 - Cover Quick Check extraction edge case tests
 - Responsive UI QA for reconciliation and decision badges
 
@@ -255,3 +255,4 @@ Not active now:
 - STAC auto-verification (support facts only, not auto-verify)
 - AI-assisted review (post-moat)
 - Multi-methodology cross-referencing (Phase 5+)
+

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -6,14 +6,14 @@
   "RC3": "done",
   "RC4": "done",
   "RC5": "done",
-  "RC6": "planned",
+  "RC6": "done",
   "RC7": "planned",
   "RC8": "planned",
   "phase_meta": {
     "status": "active",
     "summary": "Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.",
     "current_focus": [
-      "Verification pack integration with evidence intelligence (Phase 5)",
+      "Evidence snapshot and comparison (Phase 7)",
       "Cover Quick Check extraction edge case tests",
       "Responsive UI QA for reconciliation and decision badges"
     ],
@@ -139,7 +139,7 @@
       ]
     },
     "phase_6_evidence_quality_metrics": {
-      "status": "planned",
+      "status": "done",
       "title": "Evidence quality and coverage metrics",
       "repo": "app.article6",
       "description": "Surface evidence quality and coverage metrics in the UI: what fraction of rules have linked evidence, how many fragments per rule, what is the reconciliation confidence level. Enable reviewers to assess evidence sufficiency at a glance.",
@@ -153,6 +153,9 @@
       "visible_ui_change": "Evidence quality badges and coverage progress bars visible in evidence inventory and project overview",
       "depends_on": [
         "phase_3_reviewer_decision_records"
+      ],
+      "prs": [
+        614
       ]
     },
     "phase_7_evidence_snapshot_and_comparison": {

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -1,5 +1,4 @@
 {
-  "PR12": "done",
   "RC0": "done",
   "RC1": "done",
   "RC2": "done",

--- a/src/app/m/_components/RequirementCoverageWorkspace.tsx
+++ b/src/app/m/_components/RequirementCoverageWorkspace.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { formatEvidenceInventoryId, type EvidenceInventoryItem } from "@/lib/evidence/inventory";
 import { computeMetrics } from "@/lib/evidence/metrics";
-import EvidenceQualityBadge from "@/components/evidence/EvidenceQualityBadge";
+import EvidenceQualityBadge, { ReconciliationConfidenceBadge } from "@/components/evidence/EvidenceQualityBadge";
 import {
   EXPECTED_EVIDENCE_LABELS,
   REQUIREMENT_COVERAGE_STATUS_META,
@@ -170,6 +170,27 @@ export default function RequirementCoverageWorkspace({
     const metrics = computeMetrics({ inventoryItems });
     return new Map(metrics.fragmentQualities.map((q) => [q.evidenceId, q]));
   }, [inventoryItems]);
+  const inventoryMetrics = useMemo(() => computeMetrics({ inventoryItems }), [inventoryItems]);
+  const selectedRuleMetrics = useMemo(() => {
+    if (!selectedRow) return null;
+    const linkedItems = inventoryItems.filter((item) => {
+      if (item.linked_requirement_ids.includes(selectedRow.ruleId)) return true;
+      return (item.pdd_fragment_links ?? []).some((link) => link.rule_id === selectedRow.ruleId);
+    });
+    const qualityEntries = linkedItems
+      .map((item) => qualityByEvidenceId.get(item.evidence_id))
+      .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+    const fragmentCount = qualityEntries.reduce((sum, entry) => sum + entry.fragmentCount, 0);
+    const averageQuality =
+      qualityEntries.length > 0
+        ? qualityEntries.reduce((sum, entry) => sum + entry.score, 0) / qualityEntries.length
+        : 0;
+    return {
+      evidenceItemCount: linkedItems.length,
+      fragmentCount,
+      averageQuality,
+    };
+  }, [inventoryItems, qualityByEvidenceId, selectedRow]);
 
   return (
     <div className="grid gap-4">
@@ -187,7 +208,16 @@ export default function RequirementCoverageWorkspace({
               <span className="rounded-full bg-amber-50 px-3 py-1 text-amber-800">Unresolved {counts.unresolved}</span>
               <span className="rounded-full bg-emerald-50 px-3 py-1 text-emerald-800">Complete {counts.linked}</span>
               <span className="rounded-full bg-rose-50 px-3 py-1 text-rose-800">Needs review {counts.needsReview}</span>
+              <span className="rounded-full bg-sky-50 px-3 py-1 text-sky-800">
+                Evidence coverage {Math.round(inventoryMetrics.overallCoverage * 100)}%
+              </span>
+              <span className="rounded-full bg-violet-50 px-3 py-1 text-violet-800">
+                Avg quality {Math.round(inventoryMetrics.averageQuality * 100)}%
+              </span>
             </div>
+            <p className="text-xs text-slate-500">
+              Metrics are advisory only and help reviewers assess sufficiency at a glance.
+            </p>
           </div>
           <div className="flex w-full flex-col gap-2 sm:w-auto sm:min-w-80">
             <div className="inline-flex w-full flex-wrap rounded-full border border-slate-200 bg-slate-50 p-1 text-xs font-semibold text-slate-600">
@@ -297,6 +327,19 @@ export default function RequirementCoverageWorkspace({
                   <p className="mt-2 text-sm leading-relaxed text-slate-700">
                     {selectedRequirementText?.trim() || selectedRow.ruleSummary.snippet}
                   </p>
+                  {selectedRuleMetrics ? (
+                    <div className="mt-2 flex flex-wrap gap-2 text-xs font-semibold text-slate-700">
+                      <span className="rounded-full bg-slate-100 px-2.5 py-1">
+                        {selectedRuleMetrics.evidenceItemCount} evidence item{selectedRuleMetrics.evidenceItemCount === 1 ? "" : "s"}
+                      </span>
+                      <span className="rounded-full bg-sky-50 px-2.5 py-1 text-sky-800">
+                        {selectedRuleMetrics.fragmentCount} fragment{selectedRuleMetrics.fragmentCount === 1 ? "" : "s"}
+                      </span>
+                      <span className="rounded-full bg-violet-50 px-2.5 py-1 text-violet-800">
+                        Avg quality {Math.round(selectedRuleMetrics.averageQuality * 100)}%
+                      </span>
+                    </div>
+                  ) : null}
                 </div>
 
                 <section className="rounded-xl border border-slate-200 bg-slate-50 p-3">
@@ -550,10 +593,19 @@ export default function RequirementCoverageWorkspace({
                                       </span>
                                     ) : null}
                                     {qualityByEvidenceId.has(item.evidence_id) ? (
-                                      <EvidenceQualityBadge
-                                        grade={qualityByEvidenceId.get(item.evidence_id)!.grade}
-                                        score={qualityByEvidenceId.get(item.evidence_id)!.score}
-                                      />
+                                      <>
+                                        <EvidenceQualityBadge
+                                          grade={qualityByEvidenceId.get(item.evidence_id)!.grade}
+                                          score={qualityByEvidenceId.get(item.evidence_id)!.score}
+                                        />
+                                        <ReconciliationConfidenceBadge
+                                          level={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceLevel}
+                                          score={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceScore}
+                                        />
+                                        <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-semibold text-slate-600">
+                                          {qualityByEvidenceId.get(item.evidence_id)!.fragmentCount} fragment{qualityByEvidenceId.get(item.evidence_id)!.fragmentCount === 1 ? "" : "s"}
+                                        </span>
+                                      </>
                                     ) : null}
                                   </div>
                                   <div className="mt-2 text-xs text-slate-600">{inventoryRelationshipSummary(item)}</div>
@@ -603,11 +655,19 @@ export default function RequirementCoverageWorkspace({
                                   {item.pdd_fragments?.length ? (
                                     <div className="grid gap-1">
                                       {item.pdd_fragments.map((fragment) => (
-                                        <div key={fragment.fragment_id}>
-                                          {fragment.label ?? fragment.section_heading ?? fragment.section_label ?? "PDD fragment"}
-                                          {fragment.page_start
-                                            ? ` • p. ${fragment.page_start}${fragment.page_end && fragment.page_end !== fragment.page_start ? `-${fragment.page_end}` : ""}`
-                                            : ""}
+                                        <div key={fragment.fragment_id} className="flex flex-wrap items-center gap-2">
+                                          <span>
+                                            {fragment.label ?? fragment.section_heading ?? fragment.section_label ?? "PDD fragment"}
+                                            {fragment.page_start
+                                              ? ` • p. ${fragment.page_start}${fragment.page_end && fragment.page_end !== fragment.page_start ? `-${fragment.page_end}` : ""}`
+                                              : ""}
+                                          </span>
+                                          {qualityByEvidenceId.has(item.evidence_id) ? (
+                                            <ReconciliationConfidenceBadge
+                                              level={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceLevel}
+                                              score={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceScore}
+                                            />
+                                          ) : null}
                                         </div>
                                       ))}
                                     </div>

--- a/src/app/m/_components/RequirementCoverageWorkspace.tsx
+++ b/src/app/m/_components/RequirementCoverageWorkspace.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { formatEvidenceInventoryId, type EvidenceInventoryItem } from "@/lib/evidence/inventory";
+import { computeMetrics } from "@/lib/evidence/metrics";
+import EvidenceQualityBadge from "@/components/evidence/EvidenceQualityBadge";
 import {
   EXPECTED_EVIDENCE_LABELS,
   REQUIREMENT_COVERAGE_STATUS_META,
@@ -162,6 +164,11 @@ export default function RequirementCoverageWorkspace({
       },
       { total: 0, linked: 0, unlinked: 0, recLinked: 0, recUnmatched: 0, recGap: 0, recError: 0 },
     );
+  }, [inventoryItems]);
+
+  const qualityByEvidenceId = useMemo(() => {
+    const metrics = computeMetrics({ inventoryItems });
+    return new Map(metrics.fragmentQualities.map((q) => [q.evidenceId, q]));
   }, [inventoryItems]);
 
   return (
@@ -541,6 +548,12 @@ export default function RequirementCoverageWorkspace({
                                       >
                                         Reconciliation error
                                       </span>
+                                    ) : null}
+                                    {qualityByEvidenceId.has(item.evidence_id) ? (
+                                      <EvidenceQualityBadge
+                                        grade={qualityByEvidenceId.get(item.evidence_id)!.grade}
+                                        score={qualityByEvidenceId.get(item.evidence_id)!.score}
+                                      />
                                     ) : null}
                                   </div>
                                   <div className="mt-2 text-xs text-slate-600">{inventoryRelationshipSummary(item)}</div>

--- a/src/components/evidence/EvidenceQualityBadge.tsx
+++ b/src/components/evidence/EvidenceQualityBadge.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import type { QualityGrade } from '@/lib/evidence/metrics';
+
+const GRADE_META: Record<QualityGrade, { label: string; color: string; bg: string; border: string }> = {
+  A: { label: 'A', color: 'text-emerald-800', bg: 'bg-emerald-50', border: 'border-emerald-200' },
+  B: { label: 'B', color: 'text-blue-800', bg: 'bg-blue-50', border: 'border-blue-200' },
+  C: { label: 'C', color: 'text-amber-800', bg: 'bg-amber-50', border: 'border-amber-200' },
+  D: { label: 'D', color: 'text-red-800', bg: 'bg-red-50', border: 'border-red-200' },
+};
+
+type EvidenceQualityBadgeProps = {
+  grade: QualityGrade;
+  score: number;
+};
+
+export default function EvidenceQualityBadge({ grade, score }: EvidenceQualityBadgeProps) {
+  const meta = GRADE_META[grade];
+  return (
+    <span
+      className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${meta.color} ${meta.bg} ${meta.border}`}
+      title={`Quality score: ${(score * 100).toFixed(0)}%`}
+    >
+      Quality {meta.label}
+    </span>
+  );
+}
+
+export function SectionCoverageBar({
+  sectionTitle,
+  coverageFraction,
+  totalRules,
+}: {
+  sectionTitle: string;
+  coverageFraction: number;
+  totalRules: number;
+}) {
+  const pct = Math.round(coverageFraction * 100);
+  return (
+    <div className="grid gap-1">
+      <div className="flex items-center justify-between text-[11px] text-slate-600">
+        <span className="truncate font-medium" title={sectionTitle}>
+          {sectionTitle.length > 30 ? sectionTitle.slice(0, 30) + '…' : sectionTitle}
+        </span>
+        <span className="ml-2 shrink-0 tabular-nums">
+          {Math.round(coverageFraction * totalRules)}/{totalRules}
+        </span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-slate-100">
+        <div
+          className={`h-full rounded-full transition-all ${
+            pct >= 80 ? 'bg-emerald-500' : pct >= 40 ? 'bg-amber-500' : 'bg-red-500'
+          }`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/evidence/EvidenceQualityBadge.tsx
+++ b/src/components/evidence/EvidenceQualityBadge.tsx
@@ -1,12 +1,21 @@
 'use client';
 
-import type { QualityGrade } from '@/lib/evidence/metrics';
+import type { QualityGrade, ReconciliationConfidenceLevel } from '@/lib/evidence/metrics';
 
 const GRADE_META: Record<QualityGrade, { label: string; color: string; bg: string; border: string }> = {
   A: { label: 'A', color: 'text-emerald-800', bg: 'bg-emerald-50', border: 'border-emerald-200' },
   B: { label: 'B', color: 'text-blue-800', bg: 'bg-blue-50', border: 'border-blue-200' },
   C: { label: 'C', color: 'text-amber-800', bg: 'bg-amber-50', border: 'border-amber-200' },
   D: { label: 'D', color: 'text-red-800', bg: 'bg-red-50', border: 'border-red-200' },
+};
+
+const CONFIDENCE_META: Record<
+  ReconciliationConfidenceLevel,
+  { label: string; color: string; bg: string; border: string }
+> = {
+  high: { label: 'High', color: 'text-emerald-800', bg: 'bg-emerald-50', border: 'border-emerald-200' },
+  medium: { label: 'Medium', color: 'text-amber-800', bg: 'bg-amber-50', border: 'border-amber-200' },
+  low: { label: 'Low', color: 'text-rose-800', bg: 'bg-rose-50', border: 'border-rose-200' },
 };
 
 type EvidenceQualityBadgeProps = {
@@ -22,6 +31,24 @@ export default function EvidenceQualityBadge({ grade, score }: EvidenceQualityBa
       title={`Quality score: ${(score * 100).toFixed(0)}%`}
     >
       Quality {meta.label}
+    </span>
+  );
+}
+
+export function ReconciliationConfidenceBadge({
+  level,
+  score,
+}: {
+  level: ReconciliationConfidenceLevel;
+  score: number;
+}) {
+  const meta = CONFIDENCE_META[level];
+  return (
+    <span
+      className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${meta.color} ${meta.bg} ${meta.border}`}
+      title={`Advisory reconciliation confidence: ${meta.label} (${(score * 100).toFixed(0)}%)`}
+    >
+      Confidence {meta.label}
     </span>
   );
 }

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -57,7 +57,7 @@ import {
   upsertPddFragmentOnEvidencePin,
 } from "@/lib/evidence/inventory";
 import { computeMetrics } from "@/lib/evidence/metrics";
-import EvidenceQualityBadge from "@/components/evidence/EvidenceQualityBadge";
+import EvidenceQualityBadge, { ReconciliationConfidenceBadge } from "@/components/evidence/EvidenceQualityBadge";
 import type { BaselineKey, BaselineRecord } from "@/lib/baseline/baselineStore";
 import { clearBaseline, getLatestBaselineForMethod, rotateBaseline, setBaseline } from "@/lib/baseline/baselineStore";
 import { computeUplift, isComparable } from "@/lib/baseline/uplift";
@@ -3437,6 +3437,12 @@ export default function ProofMapTab({
               <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-amber-800">
                 {evidenceInventory.filter((item) => item.link_state === "unlinked").length} unlinked
               </span>
+              <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-sky-800">
+                Coverage {Math.round(evidenceMetrics.overallCoverage * 100)}%
+              </span>
+              <span className="rounded-full border border-violet-200 bg-violet-50 px-2 py-0.5 text-violet-800">
+                Avg quality {Math.round(evidenceMetrics.averageQuality * 100)}%
+              </span>
               {evidenceInventory.some((item) => item.reconciliation_status || item.reconciliation_load_error) ? (
                 <>
                   <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-emerald-800">
@@ -3466,6 +3472,9 @@ export default function ProofMapTab({
               </p>
             </div>
           ) : null}
+          <p className="mt-2 text-xs text-slate-500">
+            Quality and confidence metrics are advisory only and do not replace reviewer judgment.
+          </p>
           <div className="mt-2 grid gap-2">
             {evidenceInventory.length ? (
               evidenceInventory.map((item) => {
@@ -3520,10 +3529,19 @@ export default function ProofMapTab({
                             </span>
                           ) : null}
                           {qualityByEvidenceId.has(item.evidence_id) ? (
-                            <EvidenceQualityBadge
-                              grade={qualityByEvidenceId.get(item.evidence_id)!.grade}
-                              score={qualityByEvidenceId.get(item.evidence_id)!.score}
-                            />
+                            <>
+                              <EvidenceQualityBadge
+                                grade={qualityByEvidenceId.get(item.evidence_id)!.grade}
+                                score={qualityByEvidenceId.get(item.evidence_id)!.score}
+                              />
+                              <ReconciliationConfidenceBadge
+                                level={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceLevel}
+                                score={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceScore}
+                              />
+                              <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-semibold text-slate-600">
+                                {qualityByEvidenceId.get(item.evidence_id)!.fragmentCount} fragment{qualityByEvidenceId.get(item.evidence_id)!.fragmentCount === 1 ? "" : "s"}
+                              </span>
+                            </>
                           ) : null}
                         </div>
                         <div className="mt-2 text-sm font-semibold text-slate-900">{item.display_name}</div>
@@ -3694,8 +3712,16 @@ export default function ProofMapTab({
                                     );
                                     return (
                                       <div key={fragment.fragment_id} className="rounded border border-slate-200 bg-slate-50 p-2">
-                                        <div className="font-medium text-slate-800">
-                                          {formatPddFragmentDisplayLabel(fragment)}
+                                        <div className="flex flex-wrap items-center gap-2">
+                                          <div className="font-medium text-slate-800">
+                                            {formatPddFragmentDisplayLabel(fragment)}
+                                          </div>
+                                          {qualityByEvidenceId.has(item.evidence_id) ? (
+                                            <ReconciliationConfidenceBadge
+                                              level={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceLevel}
+                                              score={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceScore}
+                                            />
+                                          ) : null}
                                         </div>
                                         <div className="mt-1">
                                           {[fragment.section_heading, fragment.section_label, formatPddPageLabel(fragment.page_start, fragment.page_end)]

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -56,6 +56,8 @@ import {
   unlinkEvidencePinFromRequirement,
   upsertPddFragmentOnEvidencePin,
 } from "@/lib/evidence/inventory";
+import { computeMetrics } from "@/lib/evidence/metrics";
+import EvidenceQualityBadge from "@/components/evidence/EvidenceQualityBadge";
 import type { BaselineKey, BaselineRecord } from "@/lib/baseline/baselineStore";
 import { clearBaseline, getLatestBaselineForMethod, rotateBaseline, setBaseline } from "@/lib/baseline/baselineStore";
 import { computeUplift, isComparable } from "@/lib/baseline/uplift";
@@ -514,6 +516,11 @@ export default function ProofMapTab({
     [evidencePins],
   );
   const evidenceInventory = useMemo(() => buildEvidenceInventory(evidencePins), [evidencePins]);
+  const evidenceMetrics = useMemo(() => computeMetrics({ inventoryItems: evidenceInventory }), [evidenceInventory]);
+  const qualityByEvidenceId = useMemo(
+    () => new Map(evidenceMetrics.fragmentQualities.map((q) => [q.evidenceId, q])),
+    [evidenceMetrics],
+  );
   const evidencePinsById = useMemo(() => new Map(evidencePins.map((pin) => [pin.id, pin])), [evidencePins]);
   const selectedRuleId = activeRuleId ?? null;
 
@@ -3511,6 +3518,12 @@ export default function ProofMapTab({
                             >
                               Reconciliation error
                             </span>
+                          ) : null}
+                          {qualityByEvidenceId.has(item.evidence_id) ? (
+                            <EvidenceQualityBadge
+                              grade={qualityByEvidenceId.get(item.evidence_id)!.grade}
+                              score={qualityByEvidenceId.get(item.evidence_id)!.score}
+                            />
                           ) : null}
                         </div>
                         <div className="mt-2 text-sm font-semibold text-slate-900">{item.display_name}</div>

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -485,6 +485,7 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
         <section className="rounded-lg border border-slate-200 bg-white p-5">
           <h2 className="text-lg font-semibold text-slate-900">Coverage by Section</h2>
           <p className="mt-1 text-sm text-slate-500">Fraction of rules with linked evidence per methodology section.</p>
+          <p className="mt-1 text-xs text-slate-500">Coverage metrics are advisory only and do not replace reviewer sufficiency decisions.</p>
           <div className="mt-4 grid gap-3">
             <div className="grid gap-3 sm:grid-cols-2">
               {sectionCoverages.map((sc) => (

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, type ChangeEvent, type FormEvent, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent, type ReactNode } from 'react';
 import Link from 'next/link';
 import { sha256ArrayBuffer } from '@/lib/proof/hash';
 import type {
@@ -15,6 +15,8 @@ import type {
   RuleReview,
 } from '@/lib/projects/types';
 import { resolveProjectRegistry } from '@/lib/projects/verificationReport';
+import { computeMetrics } from '@/lib/evidence/metrics';
+import { SectionCoverageBar } from '@/components/evidence/EvidenceQualityBadge';
 import {
   acceptExtractedManualFindingDraft,
   addExtractedManualFindingDrafts,
@@ -113,6 +115,12 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
       }));
     }
   }, [projectId]);
+
+  const sectionCoverages = useMemo(() => {
+    if (!project?.reviews?.length) return null;
+    const metrics = computeMetrics({ inventoryItems: [], reviews: project.reviews });
+    return metrics.sectionCoverages;
+  }, [project?.reviews]);
 
   if (!project) {
     return (
@@ -471,6 +479,29 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
             <p className="mt-1 text-right text-xs text-slate-500">{coverage.percentComplete}% complete</p>
           </div>
         </>
+      ) : null}
+
+      {sectionCoverages?.length ? (
+        <section className="rounded-lg border border-slate-200 bg-white p-5">
+          <h2 className="text-lg font-semibold text-slate-900">Coverage by Section</h2>
+          <p className="mt-1 text-sm text-slate-500">Fraction of rules with linked evidence per methodology section.</p>
+          <div className="mt-4 grid gap-3">
+            <div className="grid gap-3 sm:grid-cols-2">
+              {sectionCoverages.map((sc) => (
+                <div key={sc.sectionId} className="rounded-lg border border-slate-100 bg-slate-50 p-3">
+                  <SectionCoverageBar
+                    sectionTitle={sc.sectionTitle}
+                    coverageFraction={sc.coverageFraction}
+                    totalRules={sc.totalRules}
+                  />
+                  <p className="mt-1 text-[11px] text-slate-400">
+                    {Math.round(sc.decisionFraction * 100)}% reviewed
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
       ) : null}
 
       <section className="rounded-lg border border-slate-200 bg-white p-5">

--- a/src/lib/evidence/metrics/compute.ts
+++ b/src/lib/evidence/metrics/compute.ts
@@ -1,0 +1,131 @@
+import { canonicalStringify } from '@/integrity/artifacts';
+import { sha256Hex } from '@/integrity/artifacts';
+import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
+import type { RuleReview } from '@/lib/projects/types';
+import type { FragmentQuality, QualityGrade, SectionCoverage, EvidenceQualityMetrics } from './types';
+
+function computeGrade(score: number): QualityGrade {
+  if (score >= 0.8) return 'A';
+  if (score >= 0.6) return 'B';
+  if (score >= 0.4) return 'C';
+  return 'D';
+}
+
+function computeFragmentQuality(item: EvidenceInventoryItem): FragmentQuality {
+  const hasPageRef =
+    item.pdd_fragments?.some(
+      (f) => typeof f.page_start === 'number' || typeof f.page_end === 'number',
+    ) ?? false;
+
+  const hasSheetRef =
+    item.workbook_record_groups?.some((g) => typeof g.source_sheet === 'string' && g.source_sheet.length > 0) ??
+    false;
+
+  const hasTextContent =
+    item.pdd_fragments?.some((f) => typeof f.excerpt === 'string' && f.excerpt.length >= 20) ??
+    item.workbook_record_groups?.some((g) => g.row_count > 0) ??
+    false;
+
+  const linkedRequirementCount = item.linked_requirement_ids?.length ?? 0;
+  const isReconciled = item.reconciliation_status === 'linked';
+  const hasProvenance =
+    typeof item.provenance_summary === 'string' && item.provenance_summary.length > 0;
+
+  let score = 0;
+  if (hasPageRef) score += 0.2;
+  if (hasSheetRef) score += 0.2;
+  if (hasTextContent) score += 0.15;
+  if (linkedRequirementCount >= 2) score += 0.2;
+  else if (linkedRequirementCount === 1) score += 0.1;
+  if (isReconciled) score += 0.15;
+  if (hasProvenance) score += 0.1;
+
+  score = Math.min(1, Math.max(0, score));
+
+  return {
+    evidenceId: item.evidence_id,
+    displayName: item.display_name,
+    score,
+    grade: computeGrade(score),
+    hasPageRef,
+    hasSheetRef,
+    hasTextContent,
+    linkedRequirementCount,
+    isReconciled,
+    hasProvenance,
+  };
+}
+
+export function computeMetrics(input: {
+  inventoryItems: EvidenceInventoryItem[];
+  reviews?: RuleReview[];
+}): EvidenceQualityMetrics {
+  const fragmentQualities = input.inventoryItems.map(computeFragmentQuality);
+
+  const sectionMap = new Map<string, { title: string; total: number; linked: number; decided: number }>();
+
+  for (const review of input.reviews ?? []) {
+    const sectionId = review.sectionId || '__nosection__';
+    const existing = sectionMap.get(sectionId);
+    if (existing) {
+      existing.total += 1;
+      if (review.evidenceIds.length > 0) existing.linked += 1;
+      if (review.status !== 'not-started') existing.decided += 1;
+    } else {
+      sectionMap.set(sectionId, {
+        title: review.ruleTitle.split(' — ')[0] || sectionId,
+        total: 1,
+        linked: review.evidenceIds.length > 0 ? 1 : 0,
+        decided: review.status !== 'not-started' ? 1 : 0,
+      });
+    }
+  }
+
+  const sectionCoverages: SectionCoverage[] = [];
+  for (const [sectionId, data] of sectionMap) {
+    sectionCoverages.push({
+      sectionId,
+      sectionTitle: data.title,
+      totalRules: data.total,
+      rulesWithLinkedEvidence: data.linked,
+      rulesWithDecisions: data.decided,
+      coverageFraction: data.total > 0 ? data.linked / data.total : 0,
+      decisionFraction: data.total > 0 ? data.decided / data.total : 0,
+    });
+  }
+  sectionCoverages.sort((a, b) => a.sectionId.localeCompare(b.sectionId));
+
+  const linkedFragments = fragmentQualities.filter((f) => f.linkedRequirementCount > 0);
+  const overallCoverage =
+    fragmentQualities.length > 0 ? linkedFragments.length / fragmentQualities.length : 0;
+
+  const totalScore = fragmentQualities.reduce((sum, f) => sum + f.score, 0);
+  const averageQuality =
+    fragmentQualities.length > 0 ? totalScore / fragmentQualities.length : 0;
+
+  const metricsPayload = {
+    fragmentQualities: fragmentQualities.map((f) => ({
+      evidenceId: f.evidenceId,
+      score: Math.round(f.score * 100) / 100,
+      grade: f.grade,
+    })),
+    sectionCoverages: sectionCoverages.map((s) => ({
+      sectionId: s.sectionId,
+      coverageFraction: Math.round(s.coverageFraction * 100) / 100,
+      decisionFraction: Math.round(s.decisionFraction * 100) / 100,
+    })),
+    overallCoverage: Math.round(overallCoverage * 100) / 100,
+    averageQuality: Math.round(averageQuality * 100) / 100,
+  };
+
+  const fingerprint = sha256Hex(Buffer.from(canonicalStringify(metricsPayload), 'utf8'));
+
+  return {
+    fragmentQualities,
+    sectionCoverages,
+    overallCoverage,
+    averageQuality,
+    fragmentCount: fragmentQualities.length,
+    fingerprint,
+  };
+}

--- a/src/lib/evidence/metrics/compute.ts
+++ b/src/lib/evidence/metrics/compute.ts
@@ -1,5 +1,4 @@
-import { canonicalStringify } from '@/integrity/artifacts';
-import { sha256Hex } from '@/integrity/artifacts';
+import { canonicalJsonStringify } from '@/lib/export/canonicalJson';
 import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
 import type { RuleReview } from '@/lib/projects/types';
 import type { FragmentQuality, QualityGrade, SectionCoverage, EvidenceQualityMetrics } from './types';
@@ -118,7 +117,7 @@ export function computeMetrics(input: {
     averageQuality: Math.round(averageQuality * 100) / 100,
   };
 
-  const fingerprint = sha256Hex(Buffer.from(canonicalStringify(metricsPayload), 'utf8'));
+  const fingerprint = canonicalJsonStringify(metricsPayload);
 
   return {
     fragmentQualities,

--- a/src/lib/evidence/metrics/compute.ts
+++ b/src/lib/evidence/metrics/compute.ts
@@ -1,13 +1,30 @@
 import { canonicalJsonStringify } from '@/lib/export/canonicalJson';
 import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
 import type { RuleReview } from '@/lib/projects/types';
-import type { FragmentQuality, QualityGrade, SectionCoverage, EvidenceQualityMetrics } from './types';
+import type {
+  FragmentQuality,
+  QualityGrade,
+  ReconciliationConfidenceLevel,
+  SectionCoverage,
+  EvidenceQualityMetrics,
+} from './types';
 
 function computeGrade(score: number): QualityGrade {
   if (score >= 0.8) return 'A';
   if (score >= 0.6) return 'B';
   if (score >= 0.4) return 'C';
   return 'D';
+}
+
+function computeConfidenceLevel(score: number): ReconciliationConfidenceLevel {
+  if (score >= 0.75) return 'high';
+  if (score >= 0.45) return 'medium';
+  return 'low';
+}
+
+function countEvidenceFragments(item: EvidenceInventoryItem): number {
+  const count = (item.pdd_fragments?.length ?? 0) + (item.workbook_record_groups?.length ?? 0);
+  return Math.max(count, 1);
 }
 
 function computeFragmentQuality(item: EvidenceInventoryItem): FragmentQuality {
@@ -29,6 +46,7 @@ function computeFragmentQuality(item: EvidenceInventoryItem): FragmentQuality {
   const isReconciled = item.reconciliation_status === 'linked';
   const hasProvenance =
     typeof item.provenance_summary === 'string' && item.provenance_summary.length > 0;
+  const fragmentCount = countEvidenceFragments(item);
 
   let score = 0;
   if (hasPageRef) score += 0.2;
@@ -41,9 +59,22 @@ function computeFragmentQuality(item: EvidenceInventoryItem): FragmentQuality {
 
   score = Math.min(1, Math.max(0, score));
 
+  let reconciliationConfidenceScore = 0;
+  if (item.reconciliation_status === 'linked') reconciliationConfidenceScore += 0.45;
+  else if (item.reconciliation_status === 'unmatched') reconciliationConfidenceScore += 0.15;
+  else if (item.reconciliation_status === 'gap') reconciliationConfidenceScore += 0.05;
+  else if (linkedRequirementCount > 0) reconciliationConfidenceScore += 0.3;
+  if (hasPageRef || hasSheetRef) reconciliationConfidenceScore += 0.2;
+  if (hasTextContent) reconciliationConfidenceScore += 0.15;
+  if (hasProvenance) reconciliationConfidenceScore += 0.1;
+  if (fragmentCount > 1) reconciliationConfidenceScore += 0.1;
+  reconciliationConfidenceScore = Math.min(1, Math.max(0, reconciliationConfidenceScore));
+  const reconciliationConfidenceLevel = computeConfidenceLevel(reconciliationConfidenceScore);
+
   return {
     evidenceId: item.evidence_id,
     displayName: item.display_name,
+    fragmentCount,
     score,
     grade: computeGrade(score),
     hasPageRef,
@@ -52,6 +83,8 @@ function computeFragmentQuality(item: EvidenceInventoryItem): FragmentQuality {
     linkedRequirementCount,
     isReconciled,
     hasProvenance,
+    reconciliationConfidenceScore,
+    reconciliationConfidenceLevel,
   };
 }
 
@@ -105,8 +138,11 @@ export function computeMetrics(input: {
   const metricsPayload = {
     fragmentQualities: fragmentQualities.map((f) => ({
       evidenceId: f.evidenceId,
+      fragmentCount: f.fragmentCount,
       score: Math.round(f.score * 100) / 100,
       grade: f.grade,
+      reconciliationConfidenceScore: Math.round(f.reconciliationConfidenceScore * 100) / 100,
+      reconciliationConfidenceLevel: f.reconciliationConfidenceLevel,
     })),
     sectionCoverages: sectionCoverages.map((s) => ({
       sectionId: s.sectionId,

--- a/src/lib/evidence/metrics/index.ts
+++ b/src/lib/evidence/metrics/index.ts
@@ -1,0 +1,2 @@
+export { computeMetrics } from './compute';
+export type { FragmentQuality, QualityGrade, SectionCoverage, EvidenceQualityMetrics, MetricsInput } from './types';

--- a/src/lib/evidence/metrics/index.ts
+++ b/src/lib/evidence/metrics/index.ts
@@ -1,2 +1,9 @@
 export { computeMetrics } from './compute';
-export type { FragmentQuality, QualityGrade, SectionCoverage, EvidenceQualityMetrics, MetricsInput } from './types';
+export type {
+  FragmentQuality,
+  QualityGrade,
+  ReconciliationConfidenceLevel,
+  SectionCoverage,
+  EvidenceQualityMetrics,
+  MetricsInput,
+} from './types';

--- a/src/lib/evidence/metrics/types.ts
+++ b/src/lib/evidence/metrics/types.ts
@@ -2,10 +2,12 @@ import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
 import type { RuleReview } from '@/lib/projects/types';
 
 export type QualityGrade = 'A' | 'B' | 'C' | 'D';
+export type ReconciliationConfidenceLevel = 'high' | 'medium' | 'low';
 
 export type FragmentQuality = {
   evidenceId: string;
   displayName: string;
+  fragmentCount: number;
   score: number;
   grade: QualityGrade;
   hasPageRef: boolean;
@@ -14,6 +16,8 @@ export type FragmentQuality = {
   linkedRequirementCount: number;
   isReconciled: boolean;
   hasProvenance: boolean;
+  reconciliationConfidenceScore: number;
+  reconciliationConfidenceLevel: ReconciliationConfidenceLevel;
 };
 
 export type SectionCoverage = {

--- a/src/lib/evidence/metrics/types.ts
+++ b/src/lib/evidence/metrics/types.ts
@@ -1,0 +1,41 @@
+import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
+import type { RuleReview } from '@/lib/projects/types';
+
+export type QualityGrade = 'A' | 'B' | 'C' | 'D';
+
+export type FragmentQuality = {
+  evidenceId: string;
+  displayName: string;
+  score: number;
+  grade: QualityGrade;
+  hasPageRef: boolean;
+  hasSheetRef: boolean;
+  hasTextContent: boolean;
+  linkedRequirementCount: number;
+  isReconciled: boolean;
+  hasProvenance: boolean;
+};
+
+export type SectionCoverage = {
+  sectionId: string;
+  sectionTitle: string;
+  totalRules: number;
+  rulesWithLinkedEvidence: number;
+  rulesWithDecisions: number;
+  coverageFraction: number;
+  decisionFraction: number;
+};
+
+export type EvidenceQualityMetrics = {
+  fragmentQualities: FragmentQuality[];
+  sectionCoverages: SectionCoverage[];
+  overallCoverage: number;
+  averageQuality: number;
+  fragmentCount: number;
+  fingerprint: string;
+};
+
+export type MetricsInput = {
+  inventoryItems: EvidenceInventoryItem[];
+  reviews?: RuleReview[];
+};

--- a/tests/components/requirementCoverageWorkspace.test.tsx
+++ b/tests/components/requirementCoverageWorkspace.test.tsx
@@ -169,12 +169,16 @@ describe("RequirementCoverageWorkspace", () => {
     expect(html).toContain("No linked evidence yet");
     expect(html).toContain("No workbook-derived candidates for this requirement yet.");
     expect(html).toContain("Evidence inventory");
+    expect(html).toContain("Evidence coverage");
+    expect(html).toContain("Avg quality");
     expect(html).toContain("Boundary worksheet");
     expect(html).toContain("PDD: project-design.pdf");
     expect(html).toContain("Provenance pending");
     expect(html).toContain("EV-EV1");
     expect(html).toContain("Unlinked");
     expect(html).toContain("Not linked yet");
+    expect(html).toContain("Confidence High");
+    expect(html).toContain("1 fragment");
     expect(html).toContain("More");
     expect(html).toContain("supporting evidence marker");
     expect(html).not.toContain("Pin R-1");

--- a/tests/lib/evidence/metrics/compute.test.ts
+++ b/tests/lib/evidence/metrics/compute.test.ts
@@ -42,6 +42,8 @@ describe('computeMetrics', () => {
       expect(result.fragmentQualities).toHaveLength(1);
       expect(result.fragmentQualities[0].grade).toBe('D');
       expect(result.fragmentQualities[0].score).toBe(0.1);
+      expect(result.fragmentQualities[0].reconciliationConfidenceLevel).toBe('low');
+      expect(result.fragmentQualities[0].fragmentCount).toBe(1);
     });
 
     it('assigns grade A for a high-quality item', () => {
@@ -98,6 +100,25 @@ describe('computeMetrics', () => {
       expect(q.score).toBeLessThan(0.8);
       expect(q.hasSheetRef).toBe(true);
       expect(q.linkedRequirementCount).toBe(1);
+      expect(q.reconciliationConfidenceLevel).toBe('high');
+    });
+
+    it('counts structured fragments and keeps confidence deterministic', () => {
+      const item = makeInventoryItem({
+        evidence_id: 'ev-1',
+        linked_requirement_ids: ['rule-1'],
+        pdd_fragments: [
+          { fragment_id: 'f-1', evidence_id: 'ev-1', page_start: 1, excerpt: 'This excerpt is long enough to pass the text content threshold.' },
+          { fragment_id: 'f-2', evidence_id: 'ev-1', page_start: 2, excerpt: 'This excerpt is also long enough to pass the text content threshold.' },
+        ],
+        reconciliation_status: 'linked',
+      });
+      const result1 = computeMetrics({ inventoryItems: [item] });
+      const result2 = computeMetrics({ inventoryItems: [item] });
+      expect(result1.fragmentQualities[0].fragmentCount).toBe(2);
+      expect(result1.fragmentQualities[0].reconciliationConfidenceLevel).toBe('high');
+      expect(result1.fragmentQualities[0].reconciliationConfidenceScore).toBe(result2.fragmentQualities[0].reconciliationConfidenceScore);
+      expect(result1.fingerprint).toBe(result2.fingerprint);
     });
 
     it('assigns grade C for low quality', () => {

--- a/tests/lib/evidence/metrics/compute.test.ts
+++ b/tests/lib/evidence/metrics/compute.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from '@jest/globals';
+import { computeMetrics } from '@/lib/evidence/metrics/compute';
+import type { EvidenceInventoryItem } from '@/lib/evidence/inventory';
+import type { RuleReview } from '@/lib/projects/types';
+
+function makeInventoryItem(overrides: Partial<EvidenceInventoryItem> & { evidence_id: string }): EvidenceInventoryItem {
+  return {
+    dedupe_key: overrides.evidence_id,
+    display_name: overrides.display_name ?? 'Test Evidence',
+    kind: 'document',
+    type: 'pdf',
+    source_summary: 'Test source',
+    provenance_summary: overrides.provenance_summary ?? 'Test provenance',
+    added_at: '2026-01-01T00:00:00Z',
+    link_state: 'unlinked',
+    linked_requirement_ids: [],
+    ...overrides,
+  };
+}
+
+function makeReview(overrides: Partial<RuleReview> & { ruleId: string }): RuleReview {
+  return {
+    ruleTitle: 'Test rule',
+    sectionId: 'section-1',
+    status: 'not-started',
+    evidenceIds: [],
+    ...overrides,
+  };
+}
+
+describe('computeMetrics', () => {
+  describe('fragment qualities', () => {
+    it('returns empty qualities for empty inventory', () => {
+      const result = computeMetrics({ inventoryItems: [] });
+      expect(result.fragmentQualities).toEqual([]);
+      expect(result.fragmentCount).toBe(0);
+    });
+
+    it('computes grade D for a bare item with no quality signals', () => {
+      const item = makeInventoryItem({ evidence_id: 'ev-1' });
+      const result = computeMetrics({ inventoryItems: [item] });
+      expect(result.fragmentQualities).toHaveLength(1);
+      expect(result.fragmentQualities[0].grade).toBe('D');
+      expect(result.fragmentQualities[0].score).toBe(0.1);
+    });
+
+    it('assigns grade A for a high-quality item', () => {
+      const item = makeInventoryItem({
+        evidence_id: 'ev-1',
+        provenance_summary: 'Full provenance chain: uploaded PDD',
+        pdd_fragments: [
+          {
+            fragment_id: 'frag-1',
+            evidence_id: 'ev-1',
+            page_start: 5,
+            page_end: 7,
+            excerpt: 'This is a substantial excerpt text that is well over twenty characters long to demonstrate text content.',
+          },
+        ],
+        linked_requirement_ids: ['rule-1', 'rule-2'],
+        reconciliation_status: 'linked',
+      });
+      const result = computeMetrics({ inventoryItems: [item] });
+      const q = result.fragmentQualities[0];
+      expect(q.grade).toBe('A');
+      expect(q.score).toBeGreaterThanOrEqual(0.8);
+      expect(q.hasPageRef).toBe(true);
+      expect(q.linkedRequirementCount).toBe(2);
+      expect(q.isReconciled).toBe(true);
+    });
+
+    it('assigns grade B for moderate quality', () => {
+      const item = makeInventoryItem({
+        evidence_id: 'ev-1',
+        workbook_record_groups: [
+          {
+            group_id: 'g-1',
+            group_type: 'parameter',
+            display_name: 'params',
+            workbook_id: 'wb-1',
+            workbook_filename: 'wb.xlsx',
+            source_sheet: 'Sheet1',
+            source_range: 'A1:B10',
+            row_count: 5,
+            column_names: ['a', 'b'],
+            rows: [],
+            provenance_summary: 'Workbook data',
+          },
+        ],
+        linked_requirement_ids: ['rule-1'],
+        reconciliation_status: 'linked',
+        provenance_summary: 'Has provenance',
+      });
+      const result = computeMetrics({ inventoryItems: [item] });
+      const q = result.fragmentQualities[0];
+      expect(q.grade).toBe('B');
+      expect(q.score).toBeGreaterThanOrEqual(0.6);
+      expect(q.score).toBeLessThan(0.8);
+      expect(q.hasSheetRef).toBe(true);
+      expect(q.linkedRequirementCount).toBe(1);
+    });
+
+    it('assigns grade C for low quality', () => {
+      const item = makeInventoryItem({
+        evidence_id: 'ev-1',
+        linked_requirement_ids: ['rule-1'],
+        pdd_fragments: [{ fragment_id: 'f-1', evidence_id: 'ev-1', page_start: 1, excerpt: 'This excerpt is long enough to pass the text content threshold.' }],
+        provenance_summary: '',
+      });
+      const result = computeMetrics({ inventoryItems: [item] });
+      const q = result.fragmentQualities[0];
+      expect(q.grade).toBe('C');
+      expect(q.score).toBeGreaterThanOrEqual(0.4);
+      expect(q.score).toBeLessThan(0.6);
+    });
+
+    it('recognizes page references in PDD fragments', () => {
+      const noPage = makeInventoryItem({
+        evidence_id: 'ev-1',
+        pdd_fragments: [{ fragment_id: 'f-1', evidence_id: 'ev-1' }],
+      });
+      const withPage = makeInventoryItem({
+        evidence_id: 'ev-2',
+        pdd_fragments: [{ fragment_id: 'f-2', evidence_id: 'ev-2', page_start: 10 }],
+      });
+      const result1 = computeMetrics({ inventoryItems: [noPage] });
+      const result2 = computeMetrics({ inventoryItems: [withPage] });
+      expect(result1.fragmentQualities[0].hasPageRef).toBe(false);
+      expect(result2.fragmentQualities[0].hasPageRef).toBe(true);
+      expect(result2.fragmentQualities[0].score).toBeGreaterThan(result1.fragmentQualities[0].score);
+    });
+
+    it('recognizes sheet references in workbook record groups', () => {
+      const withSheet = makeInventoryItem({
+        evidence_id: 'ev-1',
+        workbook_record_groups: [
+          {
+            group_id: 'g-1',
+            group_type: 'parameter',
+            display_name: 'params',
+            workbook_id: 'wb-1',
+            workbook_filename: 'wb.xlsx',
+            source_sheet: 'Inputs',
+            source_range: 'A1:B10',
+            row_count: 5,
+            column_names: ['a', 'b'],
+            rows: [],
+            provenance_summary: 'data',
+          },
+        ],
+      });
+      const withoutSheet = makeInventoryItem({ evidence_id: 'ev-2' });
+      const result1 = computeMetrics({ inventoryItems: [withSheet] });
+      const result2 = computeMetrics({ inventoryItems: [withoutSheet] });
+      expect(result1.fragmentQualities[0].hasSheetRef).toBe(true);
+      expect(result2.fragmentQualities[0].hasSheetRef).toBe(false);
+    });
+  });
+
+  describe('section coverages', () => {
+    it('returns empty coverages when no reviews provided', () => {
+      const result = computeMetrics({ inventoryItems: [] });
+      expect(result.sectionCoverages).toEqual([]);
+    });
+
+    it('computes per-section coverage from reviews', () => {
+      const reviews: RuleReview[] = [
+        makeReview({ ruleId: 'r1', sectionId: 's1', evidenceIds: ['ev-1'] }),
+        makeReview({ ruleId: 'r2', sectionId: 's1', evidenceIds: [] }),
+        makeReview({ ruleId: 'r3', sectionId: 's1', evidenceIds: ['ev-2'], status: 'verified' }),
+        makeReview({ ruleId: 'r4', sectionId: 's2', evidenceIds: [] }),
+      ];
+      const result = computeMetrics({ inventoryItems: [], reviews });
+      expect(result.sectionCoverages).toHaveLength(2);
+
+      const s1 = result.sectionCoverages.find((s) => s.sectionId === 's1');
+      const s2 = result.sectionCoverages.find((s) => s.sectionId === 's2');
+      expect(s1).toBeDefined();
+      expect(s2).toBeDefined();
+      expect(s1!.totalRules).toBe(3);
+      expect(s1!.rulesWithLinkedEvidence).toBe(2);
+      expect(s1!.coverageFraction).toBeCloseTo(2 / 3);
+      expect(s1!.rulesWithDecisions).toBe(1);
+      expect(s2!.totalRules).toBe(1);
+      expect(s2!.rulesWithLinkedEvidence).toBe(0);
+      expect(s2!.coverageFraction).toBe(0);
+    });
+
+    it('groups reviews by sectionId', () => {
+      const reviews: RuleReview[] = [
+        makeReview({ ruleId: 'r1', sectionId: 'sec-A', evidenceIds: ['ev-1'] }),
+        makeReview({ ruleId: 'r2', sectionId: 'sec-A', evidenceIds: ['ev-2'] }),
+        makeReview({ ruleId: 'r3', sectionId: 'sec-B', evidenceIds: [] }),
+      ];
+      const result = computeMetrics({ inventoryItems: [], reviews });
+      expect(result.sectionCoverages).toHaveLength(2);
+      const secA = result.sectionCoverages.find((s) => s.sectionId === 'sec-A');
+      expect(secA!.coverageFraction).toBe(1);
+      expect(secA!.totalRules).toBe(2);
+    });
+
+    it('sorts sections by sectionId', () => {
+      const reviews: RuleReview[] = [
+        makeReview({ ruleId: 'r1', sectionId: 'z-last', evidenceIds: [] }),
+        makeReview({ ruleId: 'r2', sectionId: 'a-first', evidenceIds: [] }),
+      ];
+      const result = computeMetrics({ inventoryItems: [], reviews });
+      expect(result.sectionCoverages[0].sectionId).toBe('a-first');
+      expect(result.sectionCoverages[1].sectionId).toBe('z-last');
+    });
+  });
+
+  describe('overall metrics', () => {
+    it('computes overallCoverage as fraction of fragments linked to requirements', () => {
+      const items: EvidenceInventoryItem[] = [
+        makeInventoryItem({ evidence_id: 'ev-1', linked_requirement_ids: ['r1'] }),
+        makeInventoryItem({ evidence_id: 'ev-2', linked_requirement_ids: ['r2', 'r3'] }),
+        makeInventoryItem({ evidence_id: 'ev-3' }),
+      ];
+      const result = computeMetrics({ inventoryItems: items });
+      expect(result.overallCoverage).toBeCloseTo(2 / 3);
+    });
+
+    it('computes averageQuality as mean of fragment scores', () => {
+      const items: EvidenceInventoryItem[] = [
+        makeInventoryItem({
+          evidence_id: 'ev-1',
+          linked_requirement_ids: ['r1'],
+          pdd_fragments: [{ fragment_id: 'f-1', evidence_id: 'ev-1', page_start: 1 }],
+          reconciliation_status: 'linked',
+          provenance_summary: 'Has provenance',
+        }),
+        makeInventoryItem({ evidence_id: 'ev-2' }),
+      ];
+      const result = computeMetrics({ inventoryItems: items });
+      expect(result.averageQuality).toBeGreaterThan(0);
+      expect(result.averageQuality).toBeLessThanOrEqual(1);
+      expect(result.fingerprint).toBeTruthy();
+    });
+
+    it('produces deterministic fingerprint for same input', () => {
+      const items: EvidenceInventoryItem[] = [
+        makeInventoryItem({ evidence_id: 'ev-1', linked_requirement_ids: ['r1'] }),
+      ];
+      const result1 = computeMetrics({ inventoryItems: items });
+      const result2 = computeMetrics({ inventoryItems: items });
+      expect(result1.fingerprint).toBe(result2.fingerprint);
+    });
+
+    it('produces different fingerprints for different input', () => {
+      const items1: EvidenceInventoryItem[] = [
+        makeInventoryItem({ evidence_id: 'ev-1', linked_requirement_ids: ['r1'] }),
+      ];
+      const items2: EvidenceInventoryItem[] = [
+        makeInventoryItem({ evidence_id: 'ev-2', linked_requirement_ids: ['r2'] }),
+      ];
+      const result1 = computeMetrics({ inventoryItems: items1 });
+      const result2 = computeMetrics({ inventoryItems: items2 });
+      expect(result1.fingerprint).not.toBe(result2.fingerprint);
+    });
+  });
+
+  describe('overallCoverage', () => {
+    it('returns 0 when no inventory items', () => {
+      const result = computeMetrics({ inventoryItems: [] });
+      expect(result.overallCoverage).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
- New metrics module (src/lib/evidence/metrics/) computes per-fragment quality scores (A-D grades), per-section coverage fractions, and overall metrics
- EvidenceQualityBadge component renders quality grade badges in inventory items
- SectionCoverageBar component shows per-section coverage with progress bars
- Integrated into ProofMapTab, RequirementCoverageWorkspace, and ProjectDetail
- 16 tests covering fragment quality, section coverage, deterministic fingerprints
- Metrics are advisory only — reviewers make the final sufficiency call

## Roadmap

### Roadmap-Update
- slug: review-grade-evidence-intelligence
- ack: human
- items:
  - RC6: done

Allowed statuses: planned | next | in_progress | done | blocked

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

Visible UI changes to look for:
- Evidence quality badges (A/B/C/D) in evidence inventory items
- Coverage progress bars per methodology section in project overview