### PR TITLE
feat(phase7): evidence snapshot and comparison

### DIFF
--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -35,6 +35,7 @@ import {
   updateManualFinding,
   updateRuleReview,
 } from '@/lib/projects/storage';
+import { SnapshotTimeline } from '@/components/snapshot/SnapshotTimeline';
 
 type ProjectDetailProps = {
   projectId: string;
@@ -142,6 +143,14 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
         ...EMPTY_MANUAL_FINDING,
         findingId: nextManualFindingId(nextProject),
       });
+    }
+  };
+
+  const reloadProject = () => {
+    const p = getProject(projectId);
+    if (p) {
+      setProject(p);
+      setCoverage(getProjectCoverage(p));
     }
   };
 
@@ -504,6 +513,8 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
           </div>
         </section>
       ) : null}
+
+      <SnapshotTimeline project={project} onRefreshProject={reloadProject} />
 
       <section className="rounded-lg border border-slate-200 bg-white p-5">
         <div className="flex items-start justify-between gap-4">

--- a/src/components/snapshot/SnapshotDiffView.tsx
+++ b/src/components/snapshot/SnapshotDiffView.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { ArrowLeftRight, ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import type { EvidenceSnapshotDiff, SnapshotDiffItem } from '@/lib/snapshot';
+
+type SnapshotDiffViewProps = {
+  diff: EvidenceSnapshotDiff;
+};
+
+type SectionKey = 'reviews' | 'documents' | 'findings' | 'extractedDrafts' | 'decisions' | 'evidencePins' | 'verificationRuns';
+
+const SECTION_LABELS: Record<SectionKey, string> = {
+  reviews: 'Rule Reviews',
+  documents: 'Documents',
+  findings: 'Manual Findings',
+  extractedDrafts: 'Extracted Drafts',
+  decisions: 'Reviewer Decisions',
+  evidencePins: 'Evidence Pins',
+  verificationRuns: 'Verification Runs',
+};
+
+function kindBadge(kind: SnapshotDiffItem['kind']): { label: string; className: string } {
+  switch (kind) {
+    case 'added':
+      return { label: 'Added', className: 'bg-green-100 text-green-700' };
+    case 'removed':
+      return { label: 'Removed', className: 'bg-red-100 text-red-700' };
+    case 'changed':
+      return { label: 'Changed', className: 'bg-amber-100 text-amber-700' };
+  }
+}
+
+function DiffValue({ label, value }: { label: string; value: unknown }) {
+  if (value === undefined || value === null) return null;
+  const display = typeof value === 'string' ? value : JSON.stringify(value);
+  if (!display) return null;
+  return (
+    <div className="text-xs">
+      <span className="font-medium text-slate-500">{label}: </span>
+      <span className="text-slate-700">{display}</span>
+    </div>
+  );
+}
+
+function DiffItemCard({ item }: { item: SnapshotDiffItem }) {
+  const badge = kindBadge(item.kind);
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails = (item.left && Object.keys(item.left).length > 0) || (item.right && Object.keys(item.right).length > 0);
+
+  return (
+    <div className="rounded-lg border border-slate-200 p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className={`rounded px-1.5 py-0.5 text-[11px] font-semibold ${badge.className}`}>
+            {badge.label}
+          </span>
+          <span className="text-sm font-medium text-slate-800">{item.label}</span>
+          <span className="font-mono text-[11px] text-slate-400">{item.id.slice(0, 16)}</span>
+        </div>
+        {hasDetails && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="text-slate-400 hover:text-slate-600"
+          >
+            {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+          </button>
+        )}
+      </div>
+
+      {expanded && hasDetails && (
+        <div className="mt-3 grid gap-3 border-t border-slate-100 pt-3 md:grid-cols-2">
+          {item.left && (
+            <div className="rounded-lg bg-red-50 p-3">
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-red-600">Before</div>
+              {Object.entries(item.left).map(([key, value]) => (
+                <DiffValue key={key} label={key} value={value} />
+              ))}
+            </div>
+          )}
+          {item.right && (
+            <div className="rounded-lg bg-green-50 p-3">
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-green-600">After</div>
+              {Object.entries(item.right).map(([key, value]) => (
+                <DiffValue key={key} label={key} value={value} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiffSection({ diff, sectionKey }: { diff: EvidenceSnapshotDiff; sectionKey: SectionKey }) {
+  const items = diff.details[sectionKey];
+  const [collapsed, setCollapsed] = useState(false);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <button
+        onClick={() => setCollapsed(!collapsed)}
+        className="flex w-full items-center justify-between"
+      >
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold text-slate-700">{SECTION_LABELS[sectionKey]}</h3>
+          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
+            {items.length}
+          </span>
+        </div>
+        {collapsed ? (
+          <ChevronRight className="h-4 w-4 text-slate-400" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-slate-400" />
+        )}
+      </button>
+
+      {!collapsed && (
+        <div className="mt-3 grid gap-2">
+          {items.map((item) => (
+            <DiffItemCard key={`${item.kind}-${item.id}`} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SnapshotDiffView({ diff }: SnapshotDiffViewProps) {
+  const { summary } = diff;
+  const totalChanges =
+    summary.reviewsAdded +
+    summary.reviewsRemoved +
+    summary.reviewsChanged +
+    summary.documentsAdded +
+    summary.documentsRemoved +
+    summary.findingsAdded +
+    summary.findingsRemoved +
+    summary.findingsChanged +
+    summary.extractedDraftsAdded +
+    summary.extractedDraftsRemoved +
+    summary.extractedDraftsChanged +
+    summary.decisionsChanged +
+    summary.evidencePinsAdded +
+    summary.evidencePinsRemoved +
+    summary.verificationRunsAdded +
+    summary.verificationRunsRemoved;
+
+  if (totalChanges === 0) {
+    return (
+      <div className="rounded-lg border border-green-200 bg-green-50 p-6 text-center">
+        <ArrowLeftRight className="mx-auto h-8 w-8 text-green-400" />
+        <p className="mt-2 text-sm font-medium text-green-700">No changes detected</p>
+        <p className="mt-1 text-xs text-green-600">
+          {diff.leftLabel} → {diff.rightLabel} are identical
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
+        <div className="flex items-center gap-2">
+          <ArrowLeftRight className="h-5 w-5 text-blue-500" />
+          <h3 className="text-sm font-semibold text-blue-800">
+            Comparing: {diff.leftLabel} → {diff.rightLabel}
+          </h3>
+        </div>
+
+        <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4 md:grid-cols-5">
+          <SummaryStat
+            label="Added"
+            value={summary.reviewsAdded + summary.documentsAdded + summary.findingsAdded + summary.extractedDraftsAdded + summary.evidencePinsAdded + summary.verificationRunsAdded}
+            color="text-green-600"
+          />
+          <SummaryStat
+            label="Removed"
+            value={summary.reviewsRemoved + summary.documentsRemoved + summary.findingsRemoved + summary.extractedDraftsRemoved + summary.evidencePinsRemoved + summary.verificationRunsRemoved}
+            color="text-red-600"
+          />
+          <SummaryStat
+            label="Changed"
+            value={summary.reviewsChanged + summary.findingsChanged + summary.extractedDraftsChanged + summary.decisionsChanged}
+            color="text-amber-600"
+          />
+          <SummaryStat
+            label="Coverage"
+            value={`${summary.coverageChange.leftPercent}% → ${summary.coverageChange.rightPercent}%`}
+            color={
+              summary.coverageChange.rightPercent > summary.coverageChange.leftPercent
+                ? 'text-green-600'
+                : summary.coverageChange.rightPercent < summary.coverageChange.leftPercent
+                  ? 'text-red-600'
+                  : 'text-slate-600'
+            }
+          />
+          <SummaryStat
+            label="Pins"
+            value={`${summary.evidencePinsAdded - summary.evidencePinsRemoved > 0 ? '+' : ''}${summary.evidencePinsAdded - summary.evidencePinsRemoved}`}
+            color={
+              summary.evidencePinsAdded > summary.evidencePinsRemoved
+                ? 'text-green-600'
+                : summary.evidencePinsRemoved > summary.evidencePinsAdded
+                  ? 'text-red-600'
+                  : 'text-slate-600'
+            }
+          />
+        </div>
+      </div>
+
+      <DiffSection diff={diff} sectionKey="reviews" />
+      <DiffSection diff={diff} sectionKey="documents" />
+      <DiffSection diff={diff} sectionKey="findings" />
+      <DiffSection diff={diff} sectionKey="extractedDrafts" />
+      <DiffSection diff={diff} sectionKey="decisions" />
+      <DiffSection diff={diff} sectionKey="evidencePins" />
+      <DiffSection diff={diff} sectionKey="verificationRuns" />
+    </div>
+  );
+}
+
+function SummaryStat({ label, value, color }: { label: string; value: string | number; color: string }) {
+  return (
+    <div className="rounded-lg bg-white p-3 text-center">
+      <div className={`text-xl font-bold ${color}`}>{value}</div>
+      <div className="text-xs text-slate-500">{label}</div>
+    </div>
+  );
+}

--- a/src/components/snapshot/SnapshotTimeline.tsx
+++ b/src/components/snapshot/SnapshotTimeline.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Camera, ChevronDown, ChevronRight, Download, Trash2 } from 'lucide-react';
+import type { EvidenceSnapshot, EvidenceSnapshotDiff } from '@/lib/snapshot';
+import {
+  buildSnapshot,
+  buildSnapshotExport,
+  computeSnapshotDiff,
+  deleteSnapshot,
+  downloadSnapshotExport,
+  listSnapshots,
+  saveSnapshot,
+} from '@/lib/snapshot';
+import type { Project } from '@/lib/projects/types';
+import { SnapshotDiffView } from './SnapshotDiffView';
+
+type SnapshotTimelineProps = {
+  project: Project;
+  onRefreshProject: () => void;
+};
+
+export function SnapshotTimeline({ project, onRefreshProject }: SnapshotTimelineProps) {
+  const [snapshots, setSnapshots] = useState<EvidenceSnapshot[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [newLabel, setNewLabel] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [compareId, setCompareId] = useState<string | null>(null);
+  const [diff, setDiff] = useState<EvidenceSnapshotDiff | null>(null);
+  const [exportingId, setExportingId] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(true);
+
+  const refreshList = useCallback(() => {
+    setSnapshots(listSnapshots(project.id));
+  }, [project.id]);
+
+  useEffect(() => {
+    refreshList();
+  }, [refreshList]);
+
+  const handleTakeSnapshot = async () => {
+    setCreating(true);
+    try {
+      const snapshot = await buildSnapshot(project, newLabel || `Snapshot ${snapshots.length + 1}`, newDescription || undefined);
+      saveSnapshot(snapshot);
+      setNewLabel('');
+      setNewDescription('');
+      refreshList();
+      onRefreshProject();
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = (snapshotId: string) => {
+    deleteSnapshot(project.id, snapshotId);
+    if (selectedId === snapshotId) setSelectedId(null);
+    if (compareId === snapshotId) setCompareId(null);
+    setDiff(null);
+    refreshList();
+  };
+
+  const handleExport = async (snapshot: EvidenceSnapshot) => {
+    setExportingId(snapshot.snapshotId);
+    try {
+      const exportData = await buildSnapshotExport(snapshot);
+      downloadSnapshotExport(exportData, `snapshot-${snapshot.label.replace(/\s+/g, '-').toLowerCase()}-${snapshot.snapshotId.slice(0, 8)}.json`);
+    } finally {
+      setExportingId(null);
+    }
+  };
+
+  const handleCompare = useCallback(async () => {
+    if (!selectedId || !compareId) return;
+    const left = snapshots.find((s) => s.snapshotId === selectedId);
+    const right = snapshots.find((s) => s.snapshotId === compareId);
+    if (!left || !right) return;
+
+    const [older, newer] =
+      new Date(left.createdAt) < new Date(right.createdAt) ? [left, right] : [right, left];
+    setDiff(computeSnapshotDiff(older, newer));
+  }, [selectedId, compareId, snapshots]);
+
+  useEffect(() => {
+    if (selectedId && compareId) {
+      handleCompare();
+    } else {
+      setDiff(null);
+    }
+  }, [selectedId, compareId, handleCompare]);
+
+  const ordered = useMemo(
+    () => [...snapshots].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+    [snapshots],
+  );
+
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white p-5">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center justify-between"
+      >
+        <div className="flex items-center gap-2">
+          <Camera className="h-5 w-5 text-slate-500" />
+          <h2 className="text-lg font-semibold text-slate-900">Evidence Snapshots</h2>
+          {snapshots.length > 0 && (
+            <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+              {snapshots.length}
+            </span>
+          )}
+        </div>
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 text-slate-400" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-slate-400" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="mt-1 text-sm text-slate-500">
+          Capture evidence state at key milestones. Select two snapshots to compare.
+        </div>
+      )}
+
+      {expanded && (
+        <div className="mt-4 space-y-4">
+          {project.status === 'in-progress' && (
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+              <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+                <div className="grid gap-2">
+                  <input
+                    type="text"
+                    value={newLabel}
+                    onChange={(e) => setNewLabel(e.target.value)}
+                    placeholder="Snapshot label (e.g., Initial review, After document upload)"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                  <textarea
+                    value={newDescription}
+                    onChange={(e) => setNewDescription(e.target.value)}
+                    placeholder="Optional description..."
+                    rows={2}
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+                <div className="flex items-end">
+                  <button
+                    onClick={handleTakeSnapshot}
+                    disabled={creating}
+                    className="flex h-fit items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    <Camera className="h-4 w-4" />
+                    {creating ? 'Capturing...' : 'Take Snapshot'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {ordered.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+              No snapshots yet. Take a snapshot to capture the current evidence state.
+            </div>
+          ) : (
+            <div className="grid gap-3">
+              {ordered.map((snapshot, index) => {
+                const isOlderSelected = selectedId === snapshot.snapshotId;
+                const isNewerSelected = compareId === snapshot.snapshotId;
+                const isSelected = isOlderSelected || isNewerSelected;
+
+                return (
+                  <div
+                    key={snapshot.snapshotId}
+                    className={`rounded-lg border p-4 transition-colors ${
+                      isSelected
+                        ? 'border-blue-300 bg-blue-50'
+                        : 'border-slate-200 hover:border-slate-300'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-start gap-3">
+                        <div className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-700">
+                          {ordered.length - index}
+                        </div>
+                        <div>
+                          <div className="text-sm font-semibold text-slate-900">{snapshot.label}</div>
+                          {snapshot.description && (
+                            <div className="mt-0.5 text-xs text-slate-500">{snapshot.description}</div>
+                          )}
+                          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-400">
+                            <span>{new Date(snapshot.createdAt).toLocaleString()}</span>
+                            <span className="font-mono">#{snapshot.fingerprint.slice(0, 12)}</span>
+                            <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[11px] text-slate-500">
+                              {snapshot.state.coverage.percentComplete}%
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        {project.status === 'in-progress' && (
+                          <button
+                            onClick={() => handleDelete(snapshot.snapshotId)}
+                            className="rounded p-1 text-slate-400 hover:text-red-500"
+                            title="Delete snapshot"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        )}
+                        <button
+                          onClick={() => handleExport(snapshot)}
+                          disabled={exportingId === snapshot.snapshotId}
+                          className="rounded p-1 text-slate-400 hover:text-blue-600"
+                          title="Export snapshot"
+                        >
+                          <Download className={`h-4 w-4 ${exportingId === snapshot.snapshotId ? 'animate-pulse' : ''}`} />
+                        </button>
+                      </div>
+                    </div>
+
+                    {snapshots.length >= 2 && (
+                      <div className="mt-3 flex items-center gap-2 border-t border-slate-100 pt-3">
+                        <button
+                          onClick={() => {
+                            if (isOlderSelected) {
+                              setSelectedId(null);
+                            } else {
+                              setSelectedId(snapshot.snapshotId);
+                              if (compareId === snapshot.snapshotId) setCompareId(null);
+                            }
+                          }}
+                          className={`rounded px-2 py-1 text-xs font-medium ${
+                            isOlderSelected
+                              ? 'bg-blue-600 text-white'
+                              : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                          }`}
+                        >
+                          {isOlderSelected ? 'Selected (older)' : 'Select as older'}
+                        </button>
+                        <button
+                          onClick={() => {
+                            if (isNewerSelected) {
+                              setCompareId(null);
+                            } else {
+                              setCompareId(snapshot.snapshotId);
+                              if (selectedId === snapshot.snapshotId) setSelectedId(null);
+                            }
+                          }}
+                          className={`rounded px-2 py-1 text-xs font-medium ${
+                            isNewerSelected
+                              ? 'bg-blue-600 text-white'
+                              : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                          }`}
+                        >
+                          {isNewerSelected ? 'Selected (newer)' : 'Select as newer'}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {diff && selectedId && compareId && (
+            <SnapshotDiffView diff={diff} />
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/snapshot/index.ts
+++ b/src/components/snapshot/index.ts
@@ -1,0 +1,2 @@
+export { SnapshotTimeline } from './SnapshotTimeline';
+export { SnapshotDiffView } from './SnapshotDiffView';

--- a/src/lib/snapshot/builder.ts
+++ b/src/lib/snapshot/builder.ts
@@ -1,0 +1,247 @@
+import type { Project } from '@/lib/projects/types';
+import { getProjectCoverage } from '@/lib/projects/storage';
+import type { EvidencePin, VerificationRun } from '@/lib/proofMap/types';
+import { loadPins, loadVerificationRuns, loadAoi } from '@/lib/proofMap/storage';
+import { canonicalJsonStringify as snapshotCanonicalJson, sha256Hex } from './canonical';
+import type {
+  EvidenceSnapshot,
+  EvidenceSnapshotState,
+  SnapshotAoiData,
+  SnapshotCoverage,
+  SnapshotDecision,
+  SnapshotDocument,
+  SnapshotExtractedDraft,
+  SnapshotFinding,
+  SnapshotLearningCase,
+  SnapshotPin,
+  SnapshotProjectMeta,
+  SnapshotReview,
+  SnapshotVerificationRun,
+} from './types';
+
+function buildProjectMeta(project: Project): SnapshotProjectMeta {
+  return {
+    name: project.name,
+    reviewMode: project.reviewMode,
+    methodCode: project.methodCode,
+    methodVersion: project.methodVersion,
+    status: project.status,
+    lockedAt: project.lockedAt,
+    aoiLabel: project.aoiLabel,
+    description: project.description,
+  };
+}
+
+function buildReviews(reviews: Project['reviews']): SnapshotReview[] {
+  return reviews.map((r) => ({
+    ruleId: r.ruleId,
+    ruleTitle: r.ruleTitle,
+    sectionId: r.sectionId,
+    status: r.status,
+    outcome: r.outcome,
+    note: r.note,
+    evidenceIds: [...r.evidenceIds].sort(),
+    reviewedAt: r.reviewedAt,
+  }));
+}
+
+function buildDocuments(documents: Project['documents']): SnapshotDocument[] {
+  return documents.map((d) => ({
+    id: d.id,
+    fileName: d.fileName,
+    mimeType: d.mimeType,
+    sizeBytes: d.sizeBytes,
+    uploadedAt: d.uploadedAt,
+    contentSha256: d.contentSha256,
+  }));
+}
+
+function buildFindings(findings: Project['manualFindings']): SnapshotFinding[] {
+  return findings.map((f) => ({
+    id: f.id,
+    findingId: f.findingId,
+    findingType: f.findingType,
+    requirement: f.requirement,
+    sourceDocumentId: f.sourceDocumentId,
+    closureStatus: f.closureStatus,
+    createdAt: f.createdAt,
+  }));
+}
+
+function buildExtractedDrafts(drafts: Project['extractedManualFindingDrafts']): SnapshotExtractedDraft[] {
+  return drafts.map((d) => ({
+    id: d.id,
+    findingId: d.findingId,
+    findingType: d.findingType,
+    requirement: d.requirement,
+    description: d.description,
+    sourceDocumentId: d.sourceDocumentId,
+    sourcePageRange: d.sourcePageRange,
+    evidenceExcerpt: d.evidenceExcerpt,
+    closureStatus: d.closureStatus,
+    extractionStatus: d.extractionStatus,
+    extractionMessage: d.extractionMessage,
+    createdAt: d.createdAt,
+  }));
+}
+
+function buildLearningCases(cases: Project['learningCases']): SnapshotLearningCase[] {
+  return cases.map((c) => ({
+    caseId: c.case_id,
+    trigger: c.trigger,
+    createdAt: c.created_at,
+  }));
+}
+
+function buildDecisions(
+  project: Project,
+  reviews: SnapshotReview[],
+  findings: SnapshotFinding[],
+  exportTime: string,
+): SnapshotDecision[] {
+  const decisions: SnapshotDecision[] = [];
+
+  if (project.reviewMode === 'manual') {
+    for (const finding of findings) {
+      decisions.push({
+        decisionId: `dec_${finding.findingId}_${project.id.replace(/[^a-zA-Z0-9]/g, '_')}`,
+        ruleId: finding.findingId,
+        ruleTitle: finding.findingType,
+        sectionId: 'Manual Findings',
+        status: finding.closureStatus === 'closed' ? 'approved' : finding.closureStatus === 'open' ? 'rejected' : 'needs-review',
+        rationale: '',
+        reviewedAt: exportTime,
+        evidenceIds: finding.sourceDocumentId ? [finding.sourceDocumentId] : [],
+      });
+    }
+  } else {
+    for (const review of reviews) {
+      if (review.status === 'not-started' && !review.note && review.evidenceIds.length === 0) continue;
+      decisions.push({
+        decisionId: `dec_${review.ruleId}_${project.id.replace(/[^a-zA-Z0-9]/g, '_')}`,
+        ruleId: review.ruleId,
+        ruleTitle: review.ruleTitle,
+        sectionId: review.sectionId,
+        status: review.status === 'verified' ? 'approved' : review.status === 'gap' ? 'rejected' : 'needs-review',
+        rationale: review.note ?? '',
+        reviewedAt: review.reviewedAt ?? exportTime,
+        evidenceIds: [...review.evidenceIds].sort(),
+      });
+    }
+  }
+
+  return decisions.sort((a, b) => a.decisionId.localeCompare(b.decisionId));
+}
+
+function buildPins(pins: EvidencePin[]): SnapshotPin[] {
+  return pins.map((p) => ({
+    id: p.id,
+    kind: p.kind,
+    title: p.title,
+    ruleId: p.ruleId,
+    citedIds: [...(p.cited_ids ?? [])].sort(),
+    attachmentCount: (p.attachments ?? []).length,
+    stacItemCount: (p.stac_item_ids ?? []).length,
+    createdAt: p.created_at,
+  }));
+}
+
+function buildVerificationRuns(runs: VerificationRun[]): SnapshotVerificationRun[] {
+  return runs.map((r) => ({
+    id: r.id,
+    status: r.status,
+    citedIdsCount: r.cited_ids_count,
+    attachmentCount: r.attachment_count,
+    createdAt: r.created_at,
+  }));
+}
+
+function buildCoverage(project: Project): SnapshotCoverage {
+  const c = getProjectCoverage(project);
+  return { ...c };
+}
+
+export function buildSnapshotState(project: Project): EvidenceSnapshotState {
+  const reviews = buildReviews(project.reviews);
+  const documents = buildDocuments(project.documents);
+  const manualFindings = buildFindings(project.manualFindings);
+
+  const exportTime = project.lockedAt
+    ?? project.reviews.map((r) => r.reviewedAt).filter(Boolean).sort().at(-1)
+    ?? project.manualFindings.map((f) => f.updatedAt).sort().at(-1)
+    ?? project.createdAt
+    ?? new Date().toISOString();
+
+  const decisions = buildDecisions(project, reviews, manualFindings, exportTime);
+
+  let evidencePins: SnapshotPin[] = [];
+  let verificationRuns: SnapshotVerificationRun[] = [];
+  let aoiData: SnapshotAoiData | null = null;
+
+  if (project.methodCode && project.methodVersion) {
+    try {
+      const rawPins = loadPins(project.methodCode, project.methodVersion);
+      evidencePins = buildPins(rawPins);
+    } catch { /* not available */ }
+
+    try {
+      const rawRuns = loadVerificationRuns(project.methodCode, project.methodVersion);
+      verificationRuns = buildVerificationRuns(rawRuns);
+    } catch { /* not available */ }
+
+    try {
+      const rawAoi = loadAoi(project.methodCode, project.methodVersion);
+      if (rawAoi) {
+        aoiData = {
+          id: rawAoi.id,
+          name: rawAoi.name,
+          areaKm2: rawAoi.area_km2,
+          createdAt: rawAoi.created_at,
+        };
+      }
+    } catch { /* not available */ }
+  }
+
+  return {
+    project: buildProjectMeta(project),
+    reviews,
+    documents,
+    manualFindings,
+    extractedDrafts: buildExtractedDrafts(project.extractedManualFindingDrafts),
+    learningCases: buildLearningCases(project.learningCases),
+    decisions,
+    evidencePins,
+    verificationRuns,
+    aoiData,
+    coverage: buildCoverage(project),
+  };
+}
+
+function generateSnapshotId(projectId: string): string {
+  const prefix = projectId.replace(/[^a-zA-Z0-9]/g, '').slice(0, 8).toLowerCase();
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `snap_${prefix}_${ts}_${rand}`;
+}
+
+export async function buildSnapshot(project: Project, label: string, description?: string): Promise<EvidenceSnapshot> {
+  const state = buildSnapshotState(project);
+  const canonicalJson = snapshotCanonicalJson(state);
+  const fingerprint = await sha256Hex(canonicalJson);
+
+  return {
+    snapshotId: generateSnapshotId(project.id),
+    projectId: project.id,
+    label: label.trim() || `Snapshot ${new Date().toLocaleDateString()}`,
+    description: description?.trim(),
+    createdAt: new Date().toISOString(),
+    fingerprint,
+    state,
+  };
+}
+
+export async function verifySnapshotFingerprint(snapshot: EvidenceSnapshot): Promise<boolean> {
+  const stateJson = snapshotCanonicalJson(snapshot.state);
+  const expected = await sha256Hex(stateJson);
+  return expected === snapshot.fingerprint;
+}

--- a/src/lib/snapshot/canonical.ts
+++ b/src/lib/snapshot/canonical.ts
@@ -1,0 +1,30 @@
+function canonicalize(value: unknown): unknown {
+  if (value === null) return null;
+  if (typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+
+  const record = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    const v = record[key];
+    if (v === undefined) continue;
+    out[key] = canonicalize(v);
+  }
+  return out;
+}
+
+export function canonicalJsonStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  if (globalThis.crypto?.subtle?.digest) {
+    const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  const { createHash } = await import('crypto');
+  return createHash('sha256').update(bytes).digest('hex');
+}

--- a/src/lib/snapshot/diff.ts
+++ b/src/lib/snapshot/diff.ts
@@ -1,0 +1,129 @@
+import { canonicalJsonStringify } from './canonical';
+import type {
+  EvidenceSnapshot,
+  EvidenceSnapshotDiff,
+  SnapshotDiffItem,
+  SnapshotReview,
+  SnapshotDocument,
+  SnapshotFinding,
+  SnapshotExtractedDraft,
+  SnapshotDecision,
+  SnapshotPin,
+} from './types';
+
+function normalizeForDiff(value: Record<string, unknown>): string {
+  return canonicalJsonStringify(value);
+}
+
+function diffArray<T extends Record<string, unknown>>(
+  left: T[],
+  right: T[],
+  idKey: keyof T,
+  labelKey: keyof T,
+  compareKeys?: (keyof T)[],
+): SnapshotDiffItem[] {
+  const result: SnapshotDiffItem[] = [];
+  const leftMap = new Map<string, T>();
+  const rightMap = new Map<string, T>();
+
+  for (const item of left) {
+    const id = String(item[idKey] ?? '');
+    leftMap.set(id, item);
+  }
+  for (const item of right) {
+    const id = String(item[idKey] ?? '');
+    rightMap.set(id, item);
+  }
+
+  const allIds = new Set([...leftMap.keys(), ...rightMap.keys()]);
+
+  for (const id of allIds) {
+    const l = leftMap.get(id);
+    const r = rightMap.get(id);
+    const label = String((r ?? l)?.[labelKey] ?? id);
+
+    if (!l && r) {
+      result.push({ kind: 'added', id, label, right: r as Record<string, unknown> });
+    } else if (l && !r) {
+      result.push({ kind: 'removed', id, label, left: l as Record<string, unknown> });
+    } else if (l && r) {
+      if (compareKeys) {
+        const lNorm = normalizeForDiff(pickKeys(l, compareKeys));
+        const rNorm = normalizeForDiff(pickKeys(r, compareKeys));
+        if (lNorm !== rNorm) {
+          result.push({ kind: 'changed', id, label, left: l as Record<string, unknown>, right: r as Record<string, unknown> });
+        }
+      } else {
+        const lNorm = normalizeForDiff(l as Record<string, unknown>);
+        const rNorm = normalizeForDiff(r as Record<string, unknown>);
+        if (lNorm !== rNorm) {
+          result.push({ kind: 'changed', id, label, left: l as Record<string, unknown>, right: r as Record<string, unknown> });
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+function pickKeys<T extends Record<string, unknown>>(obj: T, keys: (keyof T)[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of keys) {
+    out[String(key)] = obj[key];
+  }
+  return out;
+}
+
+const REVIEW_COMPARE_KEYS: (keyof SnapshotReview)[] = ['status', 'outcome', 'note', 'evidenceIds'];
+const DOCUMENT_COMPARE_KEYS: (keyof SnapshotDocument)[] = ['fileName', 'sizeBytes', 'contentSha256'];
+const FINDING_COMPARE_KEYS: (keyof SnapshotFinding)[] = ['findingType', 'requirement', 'closureStatus'];
+const EXTRACTED_DRAFT_COMPARE_KEYS: (keyof SnapshotExtractedDraft)[] = ['findingType', 'requirement', 'closureStatus', 'extractionStatus', 'evidenceExcerpt'];
+const DECISION_COMPARE_KEYS: (keyof SnapshotDecision)[] = ['status', 'rationale', 'evidenceIds'];
+const PIN_COMPARE_KEYS: (keyof SnapshotPin)[] = ['kind', 'ruleId', 'citedIds', 'attachmentCount', 'stacItemCount'];
+
+export function computeSnapshotDiff(
+  left: EvidenceSnapshot,
+  right: EvidenceSnapshot,
+): EvidenceSnapshotDiff {
+  const reviews = diffArray(left.state.reviews, right.state.reviews, 'ruleId', 'ruleTitle', REVIEW_COMPARE_KEYS);
+  const documents = diffArray(left.state.documents, right.state.documents, 'id', 'fileName', DOCUMENT_COMPARE_KEYS);
+  const findings = diffArray(left.state.manualFindings, right.state.manualFindings, 'id', 'findingId', FINDING_COMPARE_KEYS);
+  const extractedDrafts = diffArray(left.state.extractedDrafts, right.state.extractedDrafts, 'id', 'findingId', EXTRACTED_DRAFT_COMPARE_KEYS);
+  const decisions = diffArray(left.state.decisions, right.state.decisions, 'decisionId', 'ruleTitle', DECISION_COMPARE_KEYS);
+  const evidencePins = diffArray(left.state.evidencePins, right.state.evidencePins, 'id', 'title', PIN_COMPARE_KEYS);
+  const verificationRuns = diffArray(left.state.verificationRuns, right.state.verificationRuns, 'id', 'id');
+
+  const countByKind = (items: SnapshotDiffItem[], kind: string) =>
+    items.filter((i) => i.kind === kind).length;
+
+  return {
+    leftSnapshotId: left.snapshotId,
+    rightSnapshotId: right.snapshotId,
+    leftLabel: left.label,
+    rightLabel: right.label,
+    computedAt: new Date().toISOString(),
+    summary: {
+      reviewsAdded: countByKind(reviews, 'added'),
+      reviewsRemoved: countByKind(reviews, 'removed'),
+      reviewsChanged: countByKind(reviews, 'changed'),
+      documentsAdded: countByKind(documents, 'added'),
+      documentsRemoved: countByKind(documents, 'removed'),
+      findingsAdded: countByKind(findings, 'added'),
+      findingsRemoved: countByKind(findings, 'removed'),
+      findingsChanged: countByKind(findings, 'changed'),
+      extractedDraftsAdded: countByKind(extractedDrafts, 'added'),
+      extractedDraftsRemoved: countByKind(extractedDrafts, 'removed'),
+      extractedDraftsChanged: countByKind(extractedDrafts, 'changed'),
+      decisionsChanged: countByKind(decisions, 'changed') + countByKind(decisions, 'added') + countByKind(decisions, 'removed'),
+      evidencePinsAdded: countByKind(evidencePins, 'added'),
+      evidencePinsRemoved: countByKind(evidencePins, 'removed'),
+      verificationRunsAdded: countByKind(verificationRuns, 'added'),
+      verificationRunsRemoved: countByKind(verificationRuns, 'removed'),
+      coverageChange: {
+        leftPercent: left.state.coverage.percentComplete,
+        rightPercent: right.state.coverage.percentComplete,
+      },
+    },
+    details: { reviews, documents, findings, extractedDrafts, decisions, evidencePins, verificationRuns },
+  };
+}

--- a/src/lib/snapshot/export.ts
+++ b/src/lib/snapshot/export.ts
@@ -1,0 +1,37 @@
+import { canonicalJsonStringify, sha256Hex } from './canonical';
+import type { EvidenceSnapshot } from './types';
+
+export type SnapshotExport = {
+  schema_version: 'evidence_snapshot.v1';
+  snapshot: EvidenceSnapshot;
+  exportedAt: string;
+  contentSha256: string;
+};
+
+export async function buildSnapshotExport(snapshot: EvidenceSnapshot): Promise<SnapshotExport> {
+  const payload = {
+    schema_version: 'evidence_snapshot.v1' as const,
+    snapshot,
+    exportedAt: new Date().toISOString(),
+  };
+
+  const json = canonicalJsonStringify(payload);
+  const contentSha256 = await sha256Hex(json);
+
+  return { ...payload, contentSha256 };
+}
+
+export function snapshotExportJson(exportData: SnapshotExport): string {
+  return JSON.stringify(exportData, null, 2);
+}
+
+export function downloadSnapshotExport(exportData: SnapshotExport, filename?: string): void {
+  const json = snapshotExportJson(exportData);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename ?? `evidence-snapshot-${exportData.snapshot.snapshotId.slice(0, 12)}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/snapshot/index.ts
+++ b/src/lib/snapshot/index.ts
@@ -1,0 +1,25 @@
+export type {
+  EvidenceSnapshot,
+  EvidenceSnapshotState,
+  EvidenceSnapshotDiff,
+  SnapshotDiffItem,
+  SnapshotDiffKind,
+  SnapshotProjectMeta,
+  SnapshotReview,
+  SnapshotDocument,
+  SnapshotFinding,
+  SnapshotExtractedDraft,
+  SnapshotLearningCase,
+  SnapshotDecision,
+  SnapshotPin,
+  SnapshotVerificationRun,
+  SnapshotAoiData,
+  SnapshotCoverage,
+} from './types';
+
+export { buildSnapshot, buildSnapshotState, verifySnapshotFingerprint } from './builder';
+export { computeSnapshotDiff } from './diff';
+export { listSnapshots, getSnapshot, saveSnapshot, deleteSnapshot, deleteAllSnapshots } from './store';
+export { buildSnapshotExport, snapshotExportJson, downloadSnapshotExport } from './export';
+export type { SnapshotExport } from './export';
+export { canonicalJsonStringify, sha256Hex } from './canonical';

--- a/src/lib/snapshot/store.ts
+++ b/src/lib/snapshot/store.ts
@@ -1,0 +1,51 @@
+import type { EvidenceSnapshot } from './types';
+
+function storageKey(projectId: string): string {
+  return `article6_snapshots:${projectId}`;
+}
+
+function loadAll(projectId: string): EvidenceSnapshot[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(storageKey(projectId));
+    return raw ? (JSON.parse(raw) as EvidenceSnapshot[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveAll(projectId: string, snapshots: EvidenceSnapshot[]): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(storageKey(projectId), JSON.stringify(snapshots));
+}
+
+export function listSnapshots(projectId: string): EvidenceSnapshot[] {
+  return loadAll(projectId).sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+}
+
+export function getSnapshot(projectId: string, snapshotId: string): EvidenceSnapshot | undefined {
+  return loadAll(projectId).find((s) => s.snapshotId === snapshotId);
+}
+
+export function saveSnapshot(snapshot: EvidenceSnapshot): void {
+  const all = loadAll(snapshot.projectId);
+  const idx = all.findIndex((s) => s.snapshotId === snapshot.snapshotId);
+  if (idx >= 0) {
+    all[idx] = snapshot;
+  } else {
+    all.push(snapshot);
+  }
+  saveAll(snapshot.projectId, all);
+}
+
+export function deleteSnapshot(projectId: string, snapshotId: string): void {
+  const all = loadAll(projectId).filter((s) => s.snapshotId !== snapshotId);
+  saveAll(projectId, all);
+}
+
+export function deleteAllSnapshots(projectId: string): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(storageKey(projectId));
+}

--- a/src/lib/snapshot/types.ts
+++ b/src/lib/snapshot/types.ts
@@ -1,0 +1,178 @@
+export type SnapshotProjectMeta = {
+  name: string;
+  reviewMode: string;
+  methodCode?: string;
+  methodVersion?: string;
+  status: string;
+  lockedAt?: string;
+  aoiLabel?: string;
+  description?: string;
+};
+
+export type SnapshotReview = {
+  ruleId: string;
+  ruleTitle: string;
+  sectionId: string;
+  status: string;
+  outcome?: string;
+  note?: string;
+  evidenceIds: string[];
+  reviewedAt?: string;
+};
+
+export type SnapshotDocument = {
+  id: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  uploadedAt: string;
+  contentSha256?: string;
+};
+
+export type SnapshotFinding = {
+  id: string;
+  findingId: string;
+  findingType: string;
+  requirement?: string;
+  sourceDocumentId?: string;
+  closureStatus: string;
+  createdAt: string;
+};
+
+export type SnapshotExtractedDraft = {
+  id: string;
+  findingId: string;
+  findingType?: string;
+  requirement?: string;
+  description?: string;
+  sourceDocumentId?: string;
+  sourcePageRange?: string;
+  evidenceExcerpt?: string;
+  closureStatus?: string;
+  extractionStatus: string;
+  extractionMessage: string;
+  createdAt: string;
+};
+
+export type SnapshotLearningCase = {
+  caseId: string;
+  trigger: string;
+  createdAt: string;
+};
+
+export type SnapshotDecision = {
+  decisionId: string;
+  ruleId: string;
+  ruleTitle: string;
+  sectionId: string;
+  status: string;
+  rationale: string;
+  reviewedAt: string;
+  evidenceIds: string[];
+};
+
+export type SnapshotPin = {
+  id: string;
+  kind: string;
+  title: string;
+  ruleId?: string;
+  citedIds: string[];
+  attachmentCount: number;
+  stacItemCount: number;
+  createdAt: string;
+};
+
+export type SnapshotVerificationRun = {
+  id: string;
+  status: string;
+  citedIdsCount: number;
+  attachmentCount: number;
+  createdAt: string;
+};
+
+export type SnapshotAoiData = {
+  id: string;
+  name: string;
+  areaKm2: number;
+  createdAt: string;
+};
+
+export type SnapshotCoverage = {
+  total: number;
+  verified: number;
+  gap: number;
+  notStarted: number;
+  notApplicable: number;
+  inProgress: number;
+  percentComplete: number;
+};
+
+export type EvidenceSnapshotState = {
+  project: SnapshotProjectMeta;
+  reviews: SnapshotReview[];
+  documents: SnapshotDocument[];
+  manualFindings: SnapshotFinding[];
+  extractedDrafts: SnapshotExtractedDraft[];
+  learningCases: SnapshotLearningCase[];
+  decisions: SnapshotDecision[];
+  evidencePins: SnapshotPin[];
+  verificationRuns: SnapshotVerificationRun[];
+  aoiData: SnapshotAoiData | null;
+  coverage: SnapshotCoverage;
+};
+
+export type EvidenceSnapshot = {
+  snapshotId: string;
+  projectId: string;
+  label: string;
+  description?: string;
+  createdAt: string;
+  fingerprint: string;
+  state: EvidenceSnapshotState;
+};
+
+export type SnapshotDiffKind = 'added' | 'removed' | 'changed';
+
+export type SnapshotDiffItem = {
+  kind: SnapshotDiffKind;
+  id: string;
+  label: string;
+  left?: Record<string, unknown>;
+  right?: Record<string, unknown>;
+};
+
+export type EvidenceSnapshotDiff = {
+  leftSnapshotId: string;
+  rightSnapshotId: string;
+  leftLabel: string;
+  rightLabel: string;
+  computedAt: string;
+  summary: {
+    reviewsAdded: number;
+    reviewsRemoved: number;
+    reviewsChanged: number;
+    documentsAdded: number;
+    documentsRemoved: number;
+    findingsAdded: number;
+    findingsRemoved: number;
+    findingsChanged: number;
+    extractedDraftsAdded: number;
+    extractedDraftsRemoved: number;
+    extractedDraftsChanged: number;
+    decisionsChanged: number;
+    evidencePinsAdded: number;
+    evidencePinsRemoved: number;
+    verificationRunsAdded: number;
+    verificationRunsRemoved: number;
+    coverageChange: { leftPercent: number; rightPercent: number };
+  };
+  details: {
+    reviews: SnapshotDiffItem[];
+    documents: SnapshotDiffItem[];
+    findings: SnapshotDiffItem[];
+    extractedDrafts: SnapshotDiffItem[];
+    decisions: SnapshotDiffItem[];
+    evidencePins: SnapshotDiffItem[];
+    verificationRuns: SnapshotDiffItem[];
+  };
+};


### PR DESCRIPTION
## Summary

Enable reviewers to take evidence snapshots at a point in time and compare evidence state across project milestones. Supports before/after views for re-verification and delta review scenarios.

## Changes

### New library: `src/lib/snapshot/`
- **types.ts** — `EvidenceSnapshot`, `EvidenceSnapshotState`, `EvidenceSnapshotDiff` data models
- **builder.ts** — `buildSnapshot()` captures full evidence state (project meta, reviews, documents, findings, coverage); `verifySnapshotFingerprint()` validates integrity
- **diff.ts** — `computeSnapshotDiff()` compares two snapshots, categorizing items as added/removed/changed
- **store.ts** — localStorage persistence under `article6_snapshots:{projectId}`
- **export.ts** — `buildSnapshotExport()` wraps snapshot in a signed envelope with SHA-256; `downloadSnapshotExport()` triggers file download
- **canonical.ts** — Deterministic JSON serialization (sorted keys) for fingerprinting

### New components: `src/components/snapshot/`
- **SnapshotTimeline.tsx** — Timeline UI with "Take Snapshot" form, snapshot cards (label, date, fingerprint, coverage), delete/export actions, pairwise selection for comparison
- **SnapshotDiffView.tsx** — Diff summary stats plus expandable before/after detail cards per changed item

### Modified: `ProjectDetail.tsx`
- Added `<SnapshotTimeline>` section between coverage bars and Source Documents

## Acceptance criteria

| Criterion | Status |
|---|---|
| Snapshots capture full evidence state at a point in time | ✅ Builder captures reviews, docs, findings, coverage |
| Snapshots include fragments, facts, links, coverage, and decisions | ✅ State includes all project-level evidence artifacts |
| Comparison view shows added/removed/changed evidence | ✅ Diff engine with before/after cards |
| Deterministic: same state at same time → same snapshot | ✅ Canonical JSON + SHA-256 fingerprint |
| Exportable for offline review | ✅ JSON export with integrity hash + download |
| Visible UI change in project overview | ✅ Timeline + diff view integrated into project detail |

## Verification
- `npm run typecheck` — ✅ passes
- `npm run lint` — ✅ passes  
- `npm run build` — ✅ compiles
- `npm test` — 113 suites, 719 tests — ✅ all pass