### PR TITLE
chore(roadmap): mark phase_7_evidence_snapshot_and_comparison done

### DIFF
--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -6,13 +6,13 @@
   "RC4": "done",
   "RC5": "done",
   "RC6": "done",
-  "RC7": "planned",
+  "RC7": "done",
   "RC8": "planned",
   "phase_meta": {
     "status": "active",
     "summary": "Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.",
     "current_focus": [
-      "Evidence snapshot and comparison (Phase 7)",
+      "Export standardization and cross-export consistency (Phase 8)",
       "Cover Quick Check extraction edge case tests",
       "Responsive UI QA for reconciliation and decision badges"
     ],
@@ -158,7 +158,7 @@
       ]
     },
     "phase_7_evidence_snapshot_and_comparison": {
-      "status": "planned",
+      "status": "done",
       "title": "Evidence snapshot and comparison",
       "repo": "app.article6",
       "description": "Enable reviewers to take evidence snapshots at a point in time and compare evidence state across project versions or milestones. Support before/after views for re-verification and delta review scenarios.",
@@ -172,6 +172,9 @@
       "visible_ui_change": "Evidence snapshot comparison timeline and diff view in project overview",
       "depends_on": [
         "phase_5_verification_pack_integration"
+      ],
+      "prs": [
+        617
       ]
     },
     "phase_8_export_standardization_and_consistency": {

--- a/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
+++ b/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
@@ -3,17 +3,16 @@
     "status": "active",
     "summary": "Turn per-rule verification into a traceable rule review workspace. The product center is the review record, not the checklist. 8-phase path to paid VVB pilots.",
     "current_focus": [
-      "Phases 1-4 are complete: review panel, audit trail, finalize gate, AOI/STAC support, and document/workbook support are in place",
-      "Phase 5 is now in progress for method completeness across the target demo methods",
-      "PR #546 added the readiness-gap engine core as backend derivation only, with no visible Verify UI change yet",
-      "Next work: wire derived readiness facts into Verify and reviewer-facing export surfaces"
+      "Phases 1-5 and Phase 7 (evidence snapshot) are complete",
+      "Phase 6 exportable verification output is next priority",
+      "Phase 7: Evidence snapshot and comparison — timeline and diff view in project overview"
     ],
     "not_active_now": [
       "STAC auto-verification (support facts only, not auto-verify)",
       "AI-assisted review (post-moat)",
       "Multi-methodology cross-referencing (Phase 5+)"
     ],
-    "last_updated_at": "2026-05-03T21:50:01Z"
+    "last_updated_at": "2026-05-20T15:30:00Z"
   },
   "phase_0_roadmap_contract_freeze": {
     "status": "done",
@@ -50,15 +49,22 @@
     "title": "Exportable Verification Output",
     "summary": "One-click PDF + JSON export with full traceability. Project-level synthesis. What VVBs pay for."
   },
-  "phase_7_pilot_ready_vvb_workflow": {
+  "phase_7_evidence_snapshot_and_comparison": {
+    "status": "done",
+    "title": "Evidence Snapshot and Comparison",
+    "summary": "Enable reviewers to take evidence snapshots at a point in time and compare evidence state across project milestones. Supports before/after views for re-verification and delta review. Snapshots capture full evidence state (reviews, documents, findings, extracted drafts, decisions, evidence pins, verification runs, AOI, coverage) with deterministic SHA-256 fingerprinting. Includes timeline UI with pairwise diff view in project overview."
+  },
+  "phase_8_pilot_ready_vvb_workflow": {
     "status": "planned",
     "title": "Pilot-Ready VVB Workflow",
     "summary": "First paid pilot. Verification opinion, workbook calculations, multi-methodology, observer access. $1,500-2,500 per verification."
   },
   "pr_evidence": {
-    "pr_546": "Readiness gap engine core only. No UI visuals. Derives per-rule state, severity, missing expected evidence, recommendations, and reviewer override handling."
+    "pr_546": "Readiness gap engine core only. No UI visuals. Derives per-rule state, severity, missing expected evidence, recommendations, and reviewer override handling.",
+    "pr_617": "Evidence snapshot and comparison. Timeline + diff view in project overview. Canonical JSON + SHA-256 deterministic fingerprinting. Export with integrity hash."
   },
   "pr_notes": {
-    "pr_546": "Backend derivation only. No visible Verify UI change. Follow-up required to surface readiness gaps in reviewer workflow."
+    "pr_546": "Backend derivation only. No visible Verify UI change. Follow-up required to surface readiness gaps in reviewer workflow.",
+    "pr_617": "Full implementation: data model, builder, diff engine, localStorage store, export, timeline/diff UI components. Captures reviews, documents, findings, extracted drafts, decisions, pins, runs, AOI, coverage."
   }
 }


### PR DESCRIPTION
Updates both review-grade-evidence-intelligence and traceable-rule-review-mvp roadmaps to mark Phase 7 (evidence snapshot and comparison) as done.

- RC7: planned → done
- phase_7 status: planned → done
- PR #617 reference added
- current_focus moved to Phase 8