### PR TITLE
feat(phase8): export standardization and cross-export consistency

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -183,9 +183,7 @@ Lane status: Active
 Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.
 
 Current focus:
-- Evidence snapshot and comparison (Phase 7)
-- Cover Quick Check extraction edge case tests
-- Responsive UI QA for reconciliation and decision badges
+- Export standardization and cross-export consistency (Phase 8)
 
 Not active now:
 - Refactoring extraction or export code — documentation and planning only in RC0-RC1
@@ -199,8 +197,8 @@ Not active now:
 5) RC4 — Premium PDF/ZIP export with full provenance: Done
 6) RC5 — Verification pack integration with evidence intelligence: Done
 7) RC6 — Evidence quality and coverage metrics: Done
-8) RC7 — Evidence snapshot and comparison: Planned
-9) RC8 — Export standardization and cross-export consistency: Planned
+8) RC7 — Evidence snapshot and comparison: Done
+9) RC8 — Export standardization and cross-export consistency: In progress
 
 ## safe-learning-intake-pipeline
 
@@ -254,10 +252,9 @@ Lane status: Active
 Turn per-rule verification into a traceable rule review workspace. The product center is the review record, not the checklist. 8-phase path to paid VVB pilots.
 
 Current focus:
-- Phases 1-4 are complete: review panel, audit trail, finalize gate, AOI/STAC support, and document/workbook support are in place
-- Phase 5 is now in progress for method completeness across the target demo methods
-- PR #546 added the readiness-gap engine core as backend derivation only, with no visible Verify UI change yet
-- Next work: wire derived readiness facts into Verify and reviewer-facing export surfaces
+- Phases 1-5 and Phase 7 (evidence snapshot) are complete
+- Phase 6 exportable verification output is next priority
+- Phase 7: Evidence snapshot and comparison — timeline and diff view in project overview
 
 Not active now:
 - STAC auto-verification (support facts only, not auto-verify)

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -12,9 +12,7 @@
     "status": "active",
     "summary": "Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.",
     "current_focus": [
-      "Evidence snapshot and comparison (Phase 7)",
-      "Cover Quick Check extraction edge case tests",
-      "Responsive UI QA for reconciliation and decision badges"
+      "Export standardization and cross-export consistency (Phase 8)"
     ],
     "not_active_now": [
       "Refactoring extraction or export code — documentation and planning only in RC0-RC1",
@@ -158,7 +156,7 @@
       ]
     },
     "phase_7_evidence_snapshot_and_comparison": {
-      "status": "planned",
+      "status": "done",
       "title": "Evidence snapshot and comparison",
       "repo": "app.article6",
       "description": "Enable reviewers to take evidence snapshots at a point in time and compare evidence state across project versions or milestones. Support before/after views for re-verification and delta review scenarios.",
@@ -172,6 +170,9 @@
       "visible_ui_change": "Evidence snapshot comparison timeline and diff view in project overview",
       "depends_on": [
         "phase_5_verification_pack_integration"
+      ],
+      "prs": [
+        617
       ]
     },
     "phase_8_export_standardization_and_consistency": {

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -6,7 +6,7 @@
   "RC4": "done",
   "RC5": "done",
   "RC6": "done",
-  "RC7": "planned",
+  "RC7": "done",
   "RC8": "planned",
   "phase_meta": {
     "status": "active",

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -176,7 +176,7 @@
       ]
     },
     "phase_8_export_standardization_and_consistency": {
-      "status": "planned",
+      "status": "in_progress",
       "title": "Export standardization and cross-export consistency",
       "repo": "app.article6",
       "description": "Ensure all export outputs (PDF, ZIP, verification pack, evidence snapshot) follow the same layout conventions, terminology, and section ordering. Cross-export consistency makes the product predictable and professional.",
@@ -190,6 +190,9 @@
       "visible_ui_change": "Consistent section ordering and terminology across all export formats",
       "depends_on": [
         "phase_5_verification_pack_integration"
+      ],
+      "prs": [
+        620
       ]
     }
   }

--- a/docs/standards/export-conventions.md
+++ b/docs/standards/export-conventions.md
@@ -1,0 +1,155 @@
+# Export Conventions
+
+## Purpose
+
+Define cross-export conventions for section ordering, terminology, and determinism. All export outputs must follow this convention unless explicitly documented otherwise.
+
+## Scope
+
+This convention applies to the five export outputs:
+- Standard PDF (`/api/projects/[id]/export-pdf`)
+- Premium PDF (`/api/projects/[id]/export-premium?format=pdf`)
+- Premium ZIP / Verification Pack (`/api/projects/[id]/export-premium?format=zip`)
+- Evidence Snapshot (JSON export)
+- VVB Workpaper (audit pack route)
+- Client Readiness Report
+
+## Canonical Section Order
+
+All exports must arrange sections in the following canonical order:
+
+| Order | Section ID          | Section Title                | Present in               |
+|-------|---------------------|------------------------------|--------------------------|
+| 1     | `report-status`     | Report Status                | Standard PDF, Premium    |
+| 2     | `project-info`      | Project Information          | Standard PDF, Premium    |
+| 3     | `scope`             | Scope / Methodology Basis    | Standard PDF, Premium    |
+| 4     | `evidence-reviewed` | Evidence Reviewed            | Standard PDF, Premium    |
+| 5     | `findings-summary`  | Findings Summary             | Standard PDF             |
+| 6     | `requirement-review`| Requirement Review           | Standard PDF, Premium    |
+| 7     | `evidence-appendix` | Evidence Appendix            | Standard PDF             |
+| 8     | `reviewer-decisions`| Reviewer Decisions           | Premium                  |
+| 9     | `limitations`       | Limitations and Disclaimers  | Standard PDF, Premium    |
+| 10    | `provenance`        | Provenance and Export Metadata | Standard PDF, Premium  |
+| 11    | `coverage-matrix`   | Coverage Matrix              | Premium                  |
+
+### Registry-specific overrides
+
+When the `project.registry` is known, the sections may be relabeled to match registry conventions, but the order must remain canonical. For example:
+
+- **UNFCCC**: Section 1 → "REPORT STATUS", Section 2 → "PROJECT AND METHODOLOGY IDENTIFICATION", Section 3 → "VERIFICATION SCOPE"
+- **Verra / Gold Standard / Generic**: Section 1 → "REPORT STATUS", Section 2 → "PROJECT AND STANDARD", Section 3 → "METHODOLOGY BASIS"
+
+This maps the canonical order to registry-specific terminology while preserving structure.
+
+### Registry-specific section mapping
+
+| Canonical ID            | UNFCCC label                     | Generic / Verra / GS label    | Premium label            |
+|-------------------------|----------------------------------|-------------------------------|--------------------------|
+| `report-status`         | REPORT STATUS                    | REPORT STATUS                 | Executive Summary        |
+| `project-info`          | PROJECT AND METHODOLOGY IDENTIFICATION | PROJECT AND STANDARD      | Project Information      |
+| `scope`                 | VERIFICATION SCOPE               | METHODOLOGY BASIS             | Methodology Sections     |
+| `evidence-reviewed`     | MEANS OF VERIFICATION            | EVIDENCE REVIEWED             | Evidence Inventory       |
+| `findings-summary`      | FINDINGS SUMMARY                 | (merged into REQUIREMENT REVIEW) | Extracted Facts      |
+| `requirement-review`    | REQUIREMENT FINDINGS             | REQUIREMENT REVIEW             | Reviewer Decisions       |
+| `evidence-appendix`     | EVIDENCE APPENDIX                | (omitted for generic)          | (omitted for premium)    |
+| `reviewer-decisions`    | (omitted for UNFCCC)             | REVIEWER NOTES                 | Reviewer Decisions       |
+| `limitations`           | LIMITATIONS                      | (merged into provenence section) | Limitations           |
+| `provenance`            | PROVENANCE                       | PROVENANCE AND EXPORT METADATA | Provenance Chain         |
+| `coverage-matrix`       | (omitted for standard)           | (omitted for standard)         | Coverage Matrix          |
+
+### Manual review (VVB) section order
+
+Manual review exports follow a separate convention:
+
+| Order | Section ID          | Section Title                  |
+|-------|---------------------|---------------------------------|
+| 1     | `report-limitation` | Report Limitation               |
+| 2     | `outcome`           | Outcome                         |
+| 3     | `project-metadata`  | Project Metadata                |
+| 4     | `findings-summary`  | Findings Summary                |
+| 5     | `finding-details`   | Finding Details                 |
+| 6     | `provenance`        | Provenance and Limitations      |
+
+## Canonical Terminology
+
+### Artifact naming
+
+| Canonical term              | Also known as                  | Status          |
+|-----------------------------|--------------------------------|-----------------|
+| evidence fragment           | DocumentFragment, fragment     | **USE THIS**    |
+| extracted fact              | fact                           | **USE THIS**    |
+| candidate link              | link, evidence link            | **USE THIS**    |
+| evidence inventory          | evidence register              | **USE THIS**    |
+| coverage status             | reconciliation status          | **USE THIS**    |
+| reviewer decision           | decision, review decision      | **USE THIS**    |
+| provenance                  | metadata, audit trail          | **USE THIS**    |
+| export timestamp            | export time, generated time    | **USE THIS**    |
+| project locked at           | locked timestamp               | **USE THIS**    |
+| evidence fragment reference | evidence ref, evidence link    | **USE THIS**    |
+
+### Field names
+
+| Canonical field              | Must use                       |
+|------------------------------|--------------------------------|
+| `exportedAt`                 | ISO-8601 timestamp of export   |
+| `createdAt`                  | ISO-8601 creation timestamp    |
+| `lockedAt`                   | ISO-8601 lock timestamp        |
+| `generatedAt`                | ISO-8601 generation timestamp  |
+| `schema_version`             | `evidence_snapshot.v1`         |
+| `pipeline_version`           | semantic version               |
+| `contentSha256`              | SHA-256 hex of content         |
+
+### Labels in rendered output
+
+| Context                      | Label                           |
+|------------------------------|---------------------------------|
+| Cover page timestamp         | "Generated {timestamp}"         |
+| Provenance export timestamp  | "Export timestamp"              |
+| Provenance locked timestamp  | "Locked"                        |
+| Evidence references in findings | "Evidence references"        |
+
+## Determinism
+
+### Timestamp sourcing
+
+All export timestamps must follow this precedence:
+
+1. `exportTime` parameter (if provided by caller — allows deterministic override)
+2. `project.lockedAt` (if the project is locked)
+3. `project.createdAt` (fallback to creation time)
+4. `'1970-01-01T00:00:00.000Z'` (last-resort fallback, never `new Date().toISOString()`)
+
+### Schema versions
+
+All exports must use a stable `schema_version` string that changes only when the schema changes. Current versions:
+
+| Export              | Schema version               |
+|---------------------|------------------------------|
+| Standard PDF        | (no schema version header)   |
+| Premium PDF         | (embedded in metadata)       |
+| Premium ZIP         | `premium_export.v1`          |
+| Evidence Snapshot   | `evidence_snapshot.v1`       |
+| VVB Workpaper       | `vvb_workpaper.v1`           |
+| Client Readiness    | `client_readiness.v1`        |
+
+### Content hashing
+
+Export content hashes must use SHA-256 of the canonical JSON representation of the payload (excluding the hash itself).
+
+## Migration
+
+### From current state
+
+| File                              | Required change                                              |
+|-----------------------------------|--------------------------------------------------------------|
+| `src/lib/projects/exportPdf.ts`   | Replace `new Date().toISOString()` with project timestamp     |
+| `src/lib/snapshot/export.ts`      | Replace `new Date().toISOString()` with snapshot `createdAt`  |
+| `src/lib/evidence/export/pdfExporter.ts` | Replace `new Date().toISOString()` fallback with project timestamp |
+| `src/lib/evidence/export/zipExporter.ts` | Verify timestamp precedence matches convention            |
+| `src/lib/snapshot/builder.ts`     | `createdAt` uses current time (acceptable for a create operation) |
+
+## Governance
+
+- This document is the single source of truth for export conventions.
+- Changes require a roadmap phase update and must be reflected in all five export outputs.
+- New export outputs must follow these conventions unless explicitly exempted.

--- a/src/lib/evidence/export/pdfExporter.ts
+++ b/src/lib/evidence/export/pdfExporter.ts
@@ -549,11 +549,11 @@ function addLimitations(state: PdfPage): void {
 
 function addProvenance(state: PdfPage, input: PremiumExportInput): void {
   sec(state, 'PROVENANCE CHAIN');
-  const now = input.exportTime ?? new Date().toISOString();
+  const now = exportTimestamp(input);
   const { project, inventory, fragments, facts, candidateLinks, reconciliationRun, decisionRun } = input;
 
   const provenanceItems: Array<[string, string]> = [
-    ['Export time', now],
+    ['Export timestamp', now],
     ['Project', `${project.name} (${project.id})`],
     ['Registry', project.registry ?? 'Unknown'],
     ['Methodology', project.methodCode && project.methodVersion ? `${project.methodCode} @ ${project.methodVersion}` : 'n/a'],
@@ -609,7 +609,7 @@ function buildPdfStream(state: PdfPage, input: PremiumExportInput): string[] {
   state.ln.push(
     LN(state.y),
     ...TXT(L, state.y - 12, 'F1', 7, 'This export was generated deterministically from project evidence pipeline data.', '0.65 0.65 0.65 rg'),
-    ...TXT(L, state.y - 24, 'F1', 7, `Export time ${safeDate(now)}. article6.org | Premium Evidence Export`, '0.65 0.65 0.65 rg'),
+    ...TXT(L, state.y - 24, 'F1', 7, `Export timestamp ${safeDate(now)}. article6.org | Premium Evidence Export`, '0.65 0.65 0.65 rg'),
   );
 
   flushPage(state, input.project.name, isManual, input.project.registry ?? 'Unknown', now, false);

--- a/src/lib/evidence/export/zipExporter.ts
+++ b/src/lib/evidence/export/zipExporter.ts
@@ -26,7 +26,7 @@ function stableDate(input: PremiumExportInput): Date {
 
 function buildExportJson(input: PremiumExportInput): string {
   const { project, coverage, inventory, sources, fragments, facts, candidateLinks, reconciliationRun, decisionRun } = input;
-  const now = input.exportTime ?? new Date().toISOString();
+  const now = exportTimestamp(input);
   const pipelineVersion = input.pipelineVersion ?? '1.0.0';
 
   const data = {

--- a/src/lib/projects/exportPdf.ts
+++ b/src/lib/projects/exportPdf.ts
@@ -195,7 +195,7 @@ function estimateFindingHeight(finding: ReportFinding): number {
 }
 
 export async function buildProjectExportPdf(project: Project, coverage: ProjectCoverage): Promise<Buffer> {
-  const now = new Date().toISOString().replace('T', ' ').slice(0, 16);
+  const now = (project.lockedAt ?? project.createdAt ?? '1970-01-01T00:00:00.000Z').replace('T', ' ').slice(0, 16);
   const report = await composeStandardReport(project, coverage, now);
   const isManual = project.reviewMode === 'manual';
 
@@ -428,7 +428,7 @@ export async function buildProjectExportPdf(project: Project, coverage: ProjectC
   ln.push(
     LN(y),
     ...TXT(L, y - 12, 'F1', 7, truncate(report.limitation, 112), '0.65 0.65 0.65 rg'),
-    ...TXT(L, y - 24, 'F1', 7, `Export time ${safeDate(now)}.`, '0.65 0.65 0.65 rg'),
+    ...TXT(L, y - 24, 'F1', 7, `Export timestamp ${safeDate(now)}.`, '0.65 0.65 0.65 rg'),
   );
   flushPage(pg, false);
 

--- a/src/lib/projects/verificationReport.ts
+++ b/src/lib/projects/verificationReport.ts
@@ -88,7 +88,7 @@ export function buildProvenance(
     ['Methodology', project.methodCode && project.methodVersion ? `${project.methodCode} @ ${project.methodVersion}` : 'n/a'],
     ['Created', project.createdAt || 'n/a'],
     ['Rules reviewed', `${coverage.verified + coverage.gap} of ${coverage.total}`],
-    ['Export time', exportTime],
+    ['Export timestamp', exportTime],
   ];
 
   if (project.lockedAt) items.splice(5, 0, ['Locked', project.lockedAt]);

--- a/src/lib/snapshot/export.ts
+++ b/src/lib/snapshot/export.ts
@@ -12,7 +12,7 @@ export async function buildSnapshotExport(snapshot: EvidenceSnapshot): Promise<S
   const payload = {
     schema_version: 'evidence_snapshot.v1' as const,
     snapshot,
-    exportedAt: new Date().toISOString(),
+    exportedAt: snapshot.createdAt,
   };
 
   const json = canonicalJsonStringify(payload);


### PR DESCRIPTION
## Summary

Phase 8: Export standardization and cross-export consistency across all app.article6 export outputs.

## Changes

### New documentation
- **docs/standards/export-conventions.md** — Single source of truth for canonical section ordering, terminology, and determinism rules across all five export outputs (Standard PDF, Premium PDF, Premium ZIP, Evidence Snapshot, VVB Workpaper, Client Readiness Report).

### Determinism fixes
- **Standard PDF** — replaced `new Date().toISOString()` with `project.lockedAt ?? project.createdAt` for reproducible exports
- **Snapshot export** — replaced `new Date().toISOString()` with `snapshot.createdAt` for deterministic `exportedAt`
- **Premium PDF** — replaced `input.exportTime ?? new Date().toISOString()` with `exportTimestamp(input)` (which falls back through exportTime → lockedAt → createdAt)
- **ZIP export** — same fix as Premium PDF

### Terminology alignment
- Unified `Export time` → `Export timestamp` across all rendered output in:
  - `verificationReport.ts` (provenance section)
  - `exportPdf.ts` (footer)
  - `pdfExporter.ts` (provenance section and footer)

### Roadmap updates
- Phase 7 → `done`, RC7 → `done`, current_focus → Phase 8

## Verification
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` (113 suites, 719 tests) ✅