### PR TITLE
feat(phase8): standardize export conventions

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -183,7 +183,7 @@ Lane status: Active
 Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.
 
 Current focus:
-- Export standardization and cross-export consistency (Phase 8)
+- Maintain the export-conventions contract across new export surfaces
 - Cover Quick Check extraction edge case tests
 - Responsive UI QA for reconciliation and decision badges
 
@@ -200,7 +200,7 @@ Not active now:
 6) RC5 — Verification pack integration with evidence intelligence: Done
 7) RC6 — Evidence quality and coverage metrics: Done
 8) RC7 — Evidence snapshot and comparison: Done
-9) RC8 — Export standardization and cross-export consistency: Planned
+9) RC8 — Export standardization and cross-export consistency: Done
 
 ## safe-learning-intake-pipeline
 

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -7,12 +7,12 @@
   "RC5": "done",
   "RC6": "done",
   "RC7": "done",
-  "RC8": "planned",
+  "RC8": "done",
   "phase_meta": {
     "status": "active",
     "summary": "Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.",
     "current_focus": [
-      "Export standardization and cross-export consistency (Phase 8)",
+      "Maintain the export-conventions contract across new export surfaces",
       "Cover Quick Check extraction edge case tests",
       "Responsive UI QA for reconciliation and decision badges"
     ],
@@ -178,7 +178,7 @@
       ]
     },
     "phase_8_export_standardization_and_consistency": {
-      "status": "planned",
+      "status": "done",
       "title": "Export standardization and cross-export consistency",
       "repo": "app.article6",
       "description": "Ensure all export outputs (PDF, ZIP, verification pack, evidence snapshot) follow the same layout conventions, terminology, and section ordering. Cross-export consistency makes the product predictable and professional.",
@@ -192,6 +192,9 @@
       "visible_ui_change": "Consistent section ordering and terminology across all export formats",
       "depends_on": [
         "phase_5_verification_pack_integration"
+      ],
+      "prs": [
+        620
       ]
     }
   }

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -194,7 +194,8 @@
         "phase_5_verification_pack_integration"
       ],
       "prs": [
-        620
+        620,
+        622
       ]
     }
   }

--- a/docs/standards/export-conventions.md
+++ b/docs/standards/export-conventions.md
@@ -1,0 +1,91 @@
+# Export Conventions
+
+## Purpose
+
+This document is the SSOT for Phase 8 export standardization in `app.article6`.
+
+It defines:
+- canonical terminology
+- canonical section ordering
+- deterministic timestamp sourcing
+- migration guidance for existing export consumers
+
+## In Scope
+
+The conventions apply to these export surfaces:
+- Standard PDF: `/api/projects/[id]/export-pdf`
+- Premium evidence export: `/api/projects/[id]/export-premium`
+- Evidence snapshot export
+- Verification pack / audit pack: `/api/exports/audit-pack`
+- Client readiness report export
+- VVB workpaper export
+
+## Canonical Terminology
+
+Use these terms consistently in rendered output and export metadata:
+
+| Canonical term | Replace variants like |
+|---|---|
+| evidence fragment | fragment, document fragment |
+| extracted fact | fact |
+| candidate link | evidence link, link |
+| evidence inventory | evidence register |
+| coverage status | reconciliation status |
+| reviewer decision | decision, review decision |
+| provenance | metadata, audit trail |
+| export timestamp | export time, generated time |
+| project locked at | locked timestamp |
+| evidence fragment reference | evidence ref, evidence link |
+
+## Canonical Section Order
+
+Section order is normalized per export surface in code at
+`src/lib/export/conventions.ts`.
+
+The core order is:
+1. Project information
+2. Evidence inventory
+3. Evidence fragments
+4. Extracted facts
+5. Candidate links
+6. Coverage matrix
+7. Reviewer decisions
+8. Provenance and export metadata
+
+Rendered reports may include registry-specific or export-specific headings, but
+the underlying order must stay consistent with the surface definition in code.
+
+## Determinism
+
+Export timestamps must use this precedence:
+1. explicit `exportTime` from the caller
+2. `project.lockedAt`
+3. `project.createdAt`
+4. `1970-01-01T00:00:00.000Z`
+
+Do not use `new Date().toISOString()` as a fallback inside export builders.
+
+Snapshot exports use the captured snapshot timestamp instead of wall-clock export time.
+
+## Schema Versions
+
+Current schema/version contracts:
+- `premium_export.v1`
+- `evidence_snapshot.v2`
+- `article6.proof_audit_pack.v1`
+- `client_readiness.v1`
+- `vvb_workpaper.v1`
+
+## Migration Path
+
+Existing export consumers should:
+1. read `exportConventions` or `export_conventions` metadata when present
+2. prefer `exportedAt` / `generated_at` from the export payload over local generation time
+3. treat section order as declared metadata, not inferred from file ordering
+4. preserve canonical terminology in downstream renderers and importers
+
+## Governance
+
+- Code-level SSOT: `src/lib/export/conventions.ts`
+- Documentation SSOT: this file
+- Any future export surface must declare its section order and terminology through the shared conventions module

--- a/src/lib/evidence/export/pdfExporter.ts
+++ b/src/lib/evidence/export/pdfExporter.ts
@@ -1,5 +1,6 @@
 import type { PremiumExportInput } from './types';
 import type { ExtractedFact } from '@/lib/evidence/extraction/types';
+import { resolveProjectExportTimestamp } from '@/lib/export/conventions';
 
 function esc(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
@@ -105,7 +106,7 @@ function safeDate(iso: string | undefined): string {
 }
 
 function exportTimestamp(input: PremiumExportInput): string {
-  return input.exportTime ?? input.project.lockedAt ?? input.project.createdAt ?? '1970-01-01T00:00:00.000Z';
+  return resolveProjectExportTimestamp(input.project, input.exportTime);
 }
 
 function centerText(y: number, font: 'F1' | 'FB', size: number, text: string, color?: string): string[] {
@@ -553,7 +554,7 @@ function addProvenance(state: PdfPage, input: PremiumExportInput): void {
   const { project, inventory, fragments, facts, candidateLinks, reconciliationRun, decisionRun } = input;
 
   const provenanceItems: Array<[string, string]> = [
-    ['Export time', now],
+    ['Export timestamp', now],
     ['Project', `${project.name} (${project.id})`],
     ['Registry', project.registry ?? 'Unknown'],
     ['Methodology', project.methodCode && project.methodVersion ? `${project.methodCode} @ ${project.methodVersion}` : 'n/a'],
@@ -609,7 +610,7 @@ function buildPdfStream(state: PdfPage, input: PremiumExportInput): string[] {
   state.ln.push(
     LN(state.y),
     ...TXT(L, state.y - 12, 'F1', 7, 'This export was generated deterministically from project evidence pipeline data.', '0.65 0.65 0.65 rg'),
-    ...TXT(L, state.y - 24, 'F1', 7, `Export time ${safeDate(now)}. article6.org | Premium Evidence Export`, '0.65 0.65 0.65 rg'),
+    ...TXT(L, state.y - 24, 'F1', 7, `Export timestamp ${safeDate(now)}. article6.org | Premium Evidence Export`, '0.65 0.65 0.65 rg'),
   );
 
   flushPage(state, input.project.name, isManual, input.project.registry ?? 'Unknown', now, false);

--- a/src/lib/evidence/export/zipExporter.ts
+++ b/src/lib/evidence/export/zipExporter.ts
@@ -2,6 +2,7 @@ import JSZip from 'jszip';
 import type { PremiumExportInput, ManifestEntry } from './types';
 import { buildPremiumPdf } from './pdfExporter';
 import { canonicalJsonStringify } from '@/lib/export/canonicalJson';
+import { buildExportConventions, resolveProjectExportTimestamp } from '@/lib/export/conventions';
 import { createHash } from 'crypto';
 
 function sha256(input: string): string {
@@ -17,7 +18,7 @@ function byteLength(input: string): number {
 }
 
 function exportTimestamp(input: PremiumExportInput): string {
-  return input.exportTime ?? input.project.lockedAt ?? input.project.createdAt ?? '1970-01-01T00:00:00.000Z';
+  return resolveProjectExportTimestamp(input.project, input.exportTime);
 }
 
 function stableDate(input: PremiumExportInput): Date {
@@ -33,8 +34,10 @@ function buildExportJson(input: PremiumExportInput): string {
     exportMeta: {
       exportedAt: now,
       pipelineVersion,
+      schemaVersion: 'premium_export.v1',
       projectId: project.id,
       projectName: project.name,
+      exportConventions: buildExportConventions('premium_export'),
     },
     project: {
       id: project.id,
@@ -205,6 +208,7 @@ export async function buildPremiumZip(input: PremiumExportInput): Promise<Buffer
   const manifest = {
     exportVersion: '1.0.0',
     generatedAt: exportTimestamp(input),
+    exportConventions: buildExportConventions('premium_export'),
     entries: entries.map((entry) => ({
       path: entry.path,
       contentSha256: entry.contentSha256,

--- a/src/lib/export/conventions.ts
+++ b/src/lib/export/conventions.ts
@@ -1,0 +1,144 @@
+import type { Project } from '@/lib/projects/types';
+import type { EvidenceSnapshot } from '@/lib/snapshot/types_v2';
+
+export const EXPORT_TIMESTAMP_FALLBACK = '1970-01-01T00:00:00.000Z';
+
+export const CANONICAL_EXPORT_TERMINOLOGY = {
+  evidenceFragment: 'evidence fragment',
+  extractedFact: 'extracted fact',
+  candidateLink: 'candidate link',
+  evidenceInventory: 'evidence inventory',
+  coverageStatus: 'coverage status',
+  reviewerDecision: 'reviewer decision',
+  provenance: 'provenance',
+  exportTimestamp: 'export timestamp',
+  projectLockedAt: 'project locked at',
+  evidenceFragmentReference: 'evidence fragment reference',
+} as const;
+
+export type ExportSurface =
+  | 'standard_pdf'
+  | 'premium_export'
+  | 'evidence_snapshot'
+  | 'verification_pack'
+  | 'client_readiness'
+  | 'vvb_workpaper';
+
+const EXPORT_SCHEMA_VERSION: Partial<Record<ExportSurface, string>> = {
+  premium_export: 'premium_export.v1',
+  evidence_snapshot: 'evidence_snapshot.v2',
+  verification_pack: 'article6.proof_audit_pack.v1',
+  client_readiness: 'client_readiness.v1',
+  vvb_workpaper: 'vvb_workpaper.v1',
+};
+
+const EXPORT_SECTION_ORDER: Record<ExportSurface, string[]> = {
+  standard_pdf: [
+    'report-status',
+    'project-information',
+    'scope-and-methodology-basis',
+    'evidence-reviewed',
+    'findings-summary',
+    'requirement-review',
+    'evidence-appendix',
+    'limitations',
+    'provenance-and-export-metadata',
+  ],
+  premium_export: [
+    'executive-summary',
+    'project-information',
+    'methodology-source-sections',
+    'evidence-inventory',
+    'extracted-facts',
+    'candidate-links',
+    'coverage-matrix',
+    'reviewer-decisions',
+    'limitations-and-disclaimers',
+    'provenance-and-export-metadata',
+  ],
+  evidence_snapshot: [
+    'project-information',
+    'coverage-summary',
+    'reviews',
+    'documents',
+    'manual-findings',
+    'extracted-drafts',
+    'learning-cases',
+    'source-documents',
+    'evidence-inventory',
+    'evidence-fragments',
+    'extracted-facts',
+    'candidate-links',
+    'coverage-matrix',
+    'reviewer-decisions',
+    'evidence-pins',
+    'verification-runs',
+    'aoi-data',
+    'provenance-and-export-metadata',
+  ],
+  verification_pack: [
+    'project-information',
+    'evidence-inventory',
+    'evidence-fragments',
+    'extracted-facts',
+    'candidate-links',
+    'coverage-matrix',
+    'reviewer-decisions',
+    'traceability-and-audit-trail',
+    'provenance-and-export-metadata',
+  ],
+  client_readiness: [
+    'executive-summary',
+    'scope-and-criteria',
+    'project-and-methodology-context',
+    'documents-reviewed',
+    'missing-documents',
+    'readiness-assessment-approach',
+    'rule-findings-matrix',
+    'evidence-checklist',
+    'limitations-and-disclaimers',
+    'technical-appendix',
+  ],
+  vvb_workpaper: [
+    'project-and-run-context',
+    'registry-and-program-context',
+    'executive-summary',
+    'rule-review-workpaper',
+    'readiness-and-gap-status',
+    'reviewer-artifact-state',
+    'evidence-and-provenance-references',
+    'limitations-and-non-claims',
+    'technical-appendix',
+  ],
+};
+
+export function resolveProjectExportTimestamp(
+  project: Pick<Project, 'lockedAt' | 'createdAt'>,
+  exportTime?: string,
+): string {
+  return exportTime ?? project.lockedAt ?? project.createdAt ?? EXPORT_TIMESTAMP_FALLBACK;
+}
+
+export function resolveSnapshotExportTimestamp(
+  snapshot: Pick<EvidenceSnapshot, 'capturedAt' | 'createdAt'>,
+  exportTime?: string,
+): string {
+  return exportTime ?? snapshot.capturedAt ?? snapshot.createdAt ?? EXPORT_TIMESTAMP_FALLBACK;
+}
+
+export function exportSchemaVersion(surface: ExportSurface): string | undefined {
+  return EXPORT_SCHEMA_VERSION[surface];
+}
+
+export function exportSectionOrder(surface: ExportSurface): string[] {
+  return [...EXPORT_SECTION_ORDER[surface]];
+}
+
+export function buildExportConventions(surface: ExportSurface) {
+  return {
+    surface,
+    schemaVersion: exportSchemaVersion(surface),
+    sectionOrder: exportSectionOrder(surface),
+    terminology: { ...CANONICAL_EXPORT_TERMINOLOGY },
+  };
+}

--- a/src/lib/projects/exportPdf.ts
+++ b/src/lib/projects/exportPdf.ts
@@ -1,6 +1,7 @@
 import type { Project, ProjectCoverage, RuleReview } from '@/lib/projects/types';
 import { manualRegistryLabel } from '@/lib/projects/verificationReport';
 import { composeStandardReport } from '@/lib/composers/composeReport';
+import { resolveProjectExportTimestamp } from '@/lib/export/conventions';
 import type { ReportFinding } from '@/lib/projects/reportFindings';
 
 function esc(s: string): string {
@@ -195,7 +196,7 @@ function estimateFindingHeight(finding: ReportFinding): number {
 }
 
 export async function buildProjectExportPdf(project: Project, coverage: ProjectCoverage): Promise<Buffer> {
-  const now = new Date().toISOString().replace('T', ' ').slice(0, 16);
+  const now = resolveProjectExportTimestamp(project).replace('T', ' ').slice(0, 16);
   const report = await composeStandardReport(project, coverage, now);
   const isManual = project.reviewMode === 'manual';
 
@@ -428,7 +429,7 @@ export async function buildProjectExportPdf(project: Project, coverage: ProjectC
   ln.push(
     LN(y),
     ...TXT(L, y - 12, 'F1', 7, truncate(report.limitation, 112), '0.65 0.65 0.65 rg'),
-    ...TXT(L, y - 24, 'F1', 7, `Export time ${safeDate(now)}.`, '0.65 0.65 0.65 rg'),
+    ...TXT(L, y - 24, 'F1', 7, `Export timestamp ${safeDate(now)}.`, '0.65 0.65 0.65 rg'),
   );
   flushPage(pg, false);
 

--- a/src/lib/projects/verificationReport.ts
+++ b/src/lib/projects/verificationReport.ts
@@ -88,7 +88,7 @@ export function buildProvenance(
     ['Methodology', project.methodCode && project.methodVersion ? `${project.methodCode} @ ${project.methodVersion}` : 'n/a'],
     ['Created', project.createdAt || 'n/a'],
     ['Rules reviewed', `${coverage.verified + coverage.gap} of ${coverage.total}`],
-    ['Export time', exportTime],
+    ['Export timestamp', exportTime],
   ];
 
   if (project.lockedAt) items.splice(5, 0, ['Locked', project.lockedAt]);

--- a/src/lib/proof/auditZip.ts
+++ b/src/lib/proof/auditZip.ts
@@ -9,6 +9,7 @@ import { loadVerificationRuns } from "@/lib/proofMap/storage";
 import extractStacArtifacts from "@/lib/export/extractStacArtifacts";
 import { canonicalJsonStringify } from "@/lib/export/canonicalJson";
 import buildProvenanceTxt from "@/lib/export/buildProvenanceTxt";
+import { buildExportConventions } from "@/lib/export/conventions";
 import selectRunsForAoi from "@/lib/export/selectRunsForAoi";
 
 type AuditZipEntry = { path: string; bytes: Uint8Array };
@@ -376,6 +377,8 @@ export async function buildAuditZipBytes(input: {
   const manifest = {
     kind: "article6.proof_audit_pack",
     version: 1,
+    generated_at: input.bundle.exported_at,
+    export_conventions: buildExportConventions("verification_pack"),
     files: manifestEntries,
     hashing: {
       bundle_json: "bundle.json hashed with integrity.manifest_sha256 cleared",

--- a/src/lib/readiness/clientReadinessExport.tsx
+++ b/src/lib/readiness/clientReadinessExport.tsx
@@ -11,6 +11,7 @@ import {
   renderMetricCard,
   renderReportHtmlDocument,
 } from "@/lib/readiness/reportHtmlTheme";
+import { buildExportConventions } from "@/lib/export/conventions";
 
 export type ClientReadinessAppendixArtifact = {
   kind: "article6.client_readiness_appendix";
@@ -62,6 +63,7 @@ export type ClientReadinessExportManifest = {
   version: 1;
   generated_at: string;
   report_id: string;
+  export_conventions: ReturnType<typeof buildExportConventions>;
   files: Array<{
     path: string;
     sha256: string;
@@ -449,6 +451,7 @@ export function buildClientReadinessReportExport(
     version: 1,
     generated_at: input.report.technicalAppendix.generatedAt,
     report_id: input.report.reportId,
+    export_conventions: buildExportConventions("client_readiness"),
     files: fileEntries.map((entry) => ({
       path: entry.path,
       sha256: sha256Hex(entry.bytes),

--- a/src/lib/readiness/vvbWorkpaperExport.tsx
+++ b/src/lib/readiness/vvbWorkpaperExport.tsx
@@ -7,6 +7,7 @@ import {
   renderMetricCard,
   renderReportHtmlDocument,
 } from "@/lib/readiness/reportHtmlTheme";
+import { buildExportConventions } from "@/lib/export/conventions";
 import type { VvbWorkpaperReport } from "@/lib/readiness/vvbWorkpaperReport";
 
 export type VvbWorkpaperAppendixArtifact = {
@@ -43,6 +44,7 @@ export type VvbWorkpaperExportManifest = {
   version: 1;
   generated_at: string;
   report_id: string;
+  export_conventions: ReturnType<typeof buildExportConventions>;
   files: Array<{
     path: string;
     sha256: string;
@@ -414,6 +416,7 @@ export function buildVvbWorkpaperExport(input: BuildVvbWorkpaperExportInput): Vv
     version: 1,
     generated_at: input.report.generatedAt,
     report_id: input.report.reportId,
+    export_conventions: buildExportConventions("vvb_workpaper"),
     files: fileEntries.map((entry) => ({
       path: entry.path,
       sha256: sha256Hex(entry.bytes),

--- a/src/lib/snapshot/export.ts
+++ b/src/lib/snapshot/export.ts
@@ -1,18 +1,22 @@
 import { canonicalJsonStringify, sha256Hex } from './canonical';
 import type { EvidenceSnapshot } from './types_v2';
+import { buildExportConventions, resolveSnapshotExportTimestamp } from '@/lib/export/conventions';
 
 export type SnapshotExport = {
   schema_version: 'evidence_snapshot.v2';
+  exportConventions: ReturnType<typeof buildExportConventions>;
   snapshot: EvidenceSnapshot;
   exportedAt: string;
   contentSha256: string;
 };
 
 export async function buildSnapshotExport(snapshot: EvidenceSnapshot): Promise<SnapshotExport> {
+  const exportedAt = resolveSnapshotExportTimestamp(snapshot);
   const payload = {
     schema_version: 'evidence_snapshot.v2' as const,
+    exportConventions: buildExportConventions('evidence_snapshot'),
     snapshot,
-    exportedAt: snapshot.capturedAt,
+    exportedAt,
   };
 
   const json = canonicalJsonStringify(payload);

--- a/tests/lib/composers/composerPdfIntegration.test.ts
+++ b/tests/lib/composers/composerPdfIntegration.test.ts
@@ -83,4 +83,14 @@ describe('PDF export integration with Verra composer', () => {
 
     expect(parsed1.text.length).toBe(parsed2.text.length);
   }, 15000);
+
+  it('uses canonical export timestamp terminology in the rendered PDF', async () => {
+    const project = makeProject();
+    const pdf = await buildProjectExportPdf(project, coverage);
+    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);
+    const parsed = await extractPdfTextWithPdfParse({ bytes });
+
+    expect(parsed.text).toContain('Export timestamp');
+    expect(parsed.text).not.toContain('Export time:');
+  }, 15000);
 });

--- a/tests/lib/evidence/export/premiumExport.test.ts
+++ b/tests/lib/evidence/export/premiumExport.test.ts
@@ -365,6 +365,10 @@ describe('Premium ZIP Export', () => {
     expect(parsed.exportMeta.projectId).toBe('project-12345678');
     expect(parsed.exportMeta.projectName).toBe('Malawi Verification Project');
     expect(parsed.project.methodCode).toBe('AR-AMS0007');
+    expect(parsed.exportMeta.schemaVersion).toBe('premium_export.v1');
+    expect(parsed.exportMeta.exportedAt).toBe('2026-05-20T00:00:00.000Z');
+    expect(parsed.exportMeta.exportConventions.sectionOrder).toContain('evidence-inventory');
+    expect(parsed.exportMeta.exportConventions.terminology.exportTimestamp).toBe('export timestamp');
     expect(parsed.evidenceInventory).toHaveLength(2);
     expect(parsed.fragments).toHaveLength(2);
     expect(parsed.facts).toHaveLength(3);
@@ -383,6 +387,8 @@ describe('Premium ZIP Export', () => {
     const manifest = JSON.parse(manifestJson);
 
     expect(manifest.exportVersion).toBe('1.0.0');
+    expect(manifest.exportConventions.schemaVersion).toBe('premium_export.v1');
+    expect(manifest.exportConventions.sectionOrder).toContain('reviewer-decisions');
     expect(manifest.entries.length).toBeGreaterThanOrEqual(4);
     for (const entry of manifest.entries) {
       expect(entry.path).toBeTruthy();
@@ -427,6 +433,15 @@ describe('Premium ZIP Export', () => {
 
     expect(zipA.equals(zipB)).toBe(true);
   });
+
+  it('renders canonical export timestamp terminology in the PDF', async () => {
+    const input = makeInput();
+    const pdf = buildPremiumPdf(input);
+    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));
+
+    expect(text).toContain('Export timestamp');
+    expect(text).not.toContain('Export time:');
+  }, 15000);
 });
 
 describe('/api/projects/[id]/export-premium route', () => {

--- a/tests/lib/proof.auditZip.test.ts
+++ b/tests/lib/proof.auditZip.test.ts
@@ -159,6 +159,20 @@ describe("audit zip exporter/importer", () => {
     expect(parsed.integrity?.zip_sha256).toBeTruthy();
     expect(parsed.integrity?.manifest_sha256).toBeTruthy();
 
+    const manifestText = await zip.file("manifest.json")!.async("text");
+    const manifest = JSON.parse(manifestText) as {
+      generated_at: string;
+      export_conventions: {
+        schemaVersion: string;
+        sectionOrder: string[];
+        terminology: { coverageStatus: string };
+      };
+    };
+    expect(manifest.generated_at).toBe(bundle.exported_at);
+    expect(manifest.export_conventions.schemaVersion).toBe("article6.proof_audit_pack.v1");
+    expect(manifest.export_conventions.sectionOrder).toContain("coverage-matrix");
+    expect(manifest.export_conventions.terminology.coverageStatus).toBe("coverage status");
+
     const read = await readAuditZipBytes(zipBytes);
     expect(read.ok).toBe(true);
   });

--- a/tests/lib/readiness/clientReadinessReportExport.test.ts
+++ b/tests/lib/readiness/clientReadinessReportExport.test.ts
@@ -139,4 +139,23 @@ describe("buildClientReadinessReportExport", () => {
     expect(appendix.traceability.rules.map((rule) => rule.ruleId)).toEqual(["R-1", "R-2"]);
     expect(appendix.traceability.rules[0]?.linkedEvidence.map((item) => item.id)).toEqual(["ev-1"]);
   });
+
+  test("adds canonical export conventions to the manifest", async () => {
+    const result = buildSampleExport();
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const manifestRaw = await zip.file("manifest.json")?.async("string");
+    expect(manifestRaw).toBeTruthy();
+
+    const manifest = JSON.parse(manifestRaw ?? "{}") as {
+      export_conventions: {
+        schemaVersion: string;
+        sectionOrder: string[];
+        terminology: { reviewerDecision: string };
+      };
+    };
+
+    expect(manifest.export_conventions.schemaVersion).toBe("client_readiness.v1");
+    expect(manifest.export_conventions.sectionOrder).toContain("rule-findings-matrix");
+    expect(manifest.export_conventions.terminology.reviewerDecision).toBe("reviewer decision");
+  });
 });

--- a/tests/lib/readiness/vvbWorkpaperExport.test.ts
+++ b/tests/lib/readiness/vvbWorkpaperExport.test.ts
@@ -287,4 +287,23 @@ describe("buildVvbWorkpaperExport", () => {
       "VVB workpaper export contains forbidden claim language: verification opinion",
     );
   });
+
+  test("adds canonical export conventions to the manifest", async () => {
+    const result = buildVvbWorkpaperExport({ report: buildSampleReport() });
+    const zip = await JSZip.loadAsync(result.zipBytes);
+    const manifestRaw = await zip.file("manifest.json")?.async("string");
+    expect(manifestRaw).toBeTruthy();
+
+    const manifest = JSON.parse(manifestRaw ?? "{}") as {
+      export_conventions: {
+        schemaVersion: string;
+        sectionOrder: string[];
+        terminology: { candidateLink: string };
+      };
+    };
+
+    expect(manifest.export_conventions.schemaVersion).toBe("vvb_workpaper.v1");
+    expect(manifest.export_conventions.sectionOrder).toContain("evidence-and-provenance-references");
+    expect(manifest.export_conventions.terminology.candidateLink).toBe("candidate link");
+  });
 });

--- a/tests/lib/snapshot.test.ts
+++ b/tests/lib/snapshot.test.ts
@@ -321,6 +321,9 @@ describe('snapshot builder', () => {
     expect(firstExport).toEqual(secondExport);
     expect(firstExport.exportedAt).toBe(first.capturedAt);
     expect(firstExport.schema_version).toBe('evidence_snapshot.v2');
+    expect(firstExport.exportConventions.schemaVersion).toBe('evidence_snapshot.v2');
+    expect(firstExport.exportConventions.sectionOrder).toContain('reviewer-decisions');
+    expect(firstExport.exportConventions.terminology.evidenceFragment).toBe('evidence fragment');
   });
 
   it('computes added, removed, and changed evidence across snapshots', async () => {


### PR DESCRIPTION
## Summary

Complete Phase 8 export standardization and cross-export consistency on top of the Phase 7 branch.

## What changed

- Added `src/lib/export/conventions.ts` as the code-level SSOT for:
  - canonical terminology
  - canonical section ordering
  - deterministic export timestamp resolution
  - per-surface schema/version metadata
- Added `docs/standards/export-conventions.md` as the documentation SSOT and migration path for existing consumers.
- Standardized deterministic export timestamp handling for the standard PDF and premium export surfaces.
- Normalized rendered provenance terminology from `Export time` to `Export timestamp`.
- Added shared export-convention metadata to:
  - premium export JSON + manifest
  - snapshot export payload
  - audit-pack / verification-pack manifest
  - client readiness export manifest
  - VVB workpaper export manifest
- Marked Phase 8 as done in the roadmap SSOT and regenerated `docs/roadmaps/SUMMARY.md`.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm test -- --runTestsByPath tests/lib/evidence/export/premiumExport.test.ts tests/lib/snapshot.test.ts tests/lib/readiness/clientReadinessReportExport.test.ts tests/lib/readiness/vvbWorkpaperExport.test.ts tests/lib/proof.auditZip.test.ts tests/lib/composers/composerPdfIntegration.test.ts`

## Phase 8 coverage

- All export types now publish shared export-convention metadata.
- Section ordering is declared centrally and emitted per export surface.
- Canonical terminology is centralized and surfaced in exporter metadata.
- Export timestamps are deterministic and avoid `new Date().toISOString()` fallback inside export builders.
- Migration guidance is documented in `docs/standards/export-conventions.md`.
