### PR TITLE
[codex] Add rule evidence copilot suggestions

### DIFF
--- a/src/app/m/_components/RuleDetailModal.tsx
+++ b/src/app/m/_components/RuleDetailModal.tsx
@@ -401,9 +401,11 @@ export default function RuleDetailModal({
               ruleNotes={ruleNotes?.trim() || row.ruleSummary.notes || null}
               ruleWhen={renderedWhen ?? null}
               expectedEvidence={row.expectedEvidenceTypes.map((type) => EXPECTED_EVIDENCE_LABELS[type] ?? type)}
+              expectedEvidenceTypes={row.expectedEvidenceTypes}
               sourcePath={sourcePath ?? null}
               sha256={sha256 ?? null}
               ruleTags={ruleTags}
+              linkedEvidenceDetails={row.linkedEvidence}
               stacSupportState={stacSupportState}
               documentSupport={documentSupport}
               onSave={handleSaveReview}

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -38,6 +38,7 @@ import { buildFinalizedExportKpis, buildSelectedStacExport, prepareChecklistExpo
 import { buildStacSupportFactsState } from "@/lib/verify/stacSupportFacts";
 import { isStacEligible } from "@/lib/verify/stacEligibility";
 import { checkFinalizeGate, getAllReviews, REVIEW_STORE_EVENT } from "@/lib/verify/reviewStore";
+import { suggestPddFragmentDraft } from "@/lib/verify/reviewSuggestion";
 import { buildRequirementCoverageRows, reconcileRequirement } from "@/app/m/_lib/requirementCoverage";
 import { EXPECTED_EVIDENCE_LABELS } from "@/app/m/_lib/requirementCoverage";
 import { deriveRuleReadinessGaps } from "@/lib/readiness/gapEngine";
@@ -340,6 +341,11 @@ const EMPTY_PDD_FRAGMENT_DRAFT: PddFragmentDraft = {
   sectionHeading: "",
   excerpt: "",
 };
+
+function isEmptyPddFragmentDraft(draft: PddFragmentDraft | undefined): boolean {
+  if (!draft) return true;
+  return !draft.label.trim() && !draft.pageStart.trim() && !draft.pageEnd.trim() && !draft.sectionLabel.trim() && !draft.sectionHeading.trim() && !draft.excerpt.trim();
+}
 
 function formatPddFragmentDisplayLabel(fragment: {
   label?: string;
@@ -1872,6 +1878,16 @@ export default function ProofMapTab({
     if (!selectedRuleContext) return "Rule readiness is not available until rule expectations load for the current selection.";
     return null;
   }, [selectedRuleContext, selectedRuleId]);
+  const suggestedPddFragmentDraft = useMemo(() => {
+    if (!selectedRuleId || !selectedRuleContext?.text) return null;
+    return suggestPddFragmentDraft({
+      ruleText: selectedRuleContext.text,
+      ruleTags: selectedRuleContext.tags ?? [],
+      sectionId: selectedRuleContext.sectionId ?? null,
+      sectionTitle: selectedRuleContext.sectionTitle ?? null,
+      expectedEvidenceTypes: selectedRuleCoverageRow?.expectedEvidenceTypes ?? [],
+    });
+  }, [selectedRuleContext, selectedRuleCoverageRow?.expectedEvidenceTypes, selectedRuleId]);
   const selectedRuleReconciliation = useMemo(
     () =>
       reconcileRequirement({
@@ -2722,6 +2738,43 @@ export default function ProofMapTab({
       },
     }));
   }, []);
+
+  const applySuggestedPddFragmentDraft = useCallback(
+    (evidenceId: string) => {
+      if (!suggestedPddFragmentDraft) return;
+      setPddFragmentDrafts((current) => ({
+        ...current,
+        [evidenceId]: {
+          ...(current[evidenceId] ?? EMPTY_PDD_FRAGMENT_DRAFT),
+          label: suggestedPddFragmentDraft.label,
+          sectionLabel: suggestedPddFragmentDraft.sectionLabel,
+          sectionHeading: suggestedPddFragmentDraft.sectionHeading,
+        },
+      }));
+      showToast(`Seeded fragment metadata for ${selectedRuleId ?? "selected rule"}`);
+    },
+    [selectedRuleId, showToast, suggestedPddFragmentDraft],
+  );
+
+  useEffect(() => {
+    if (!selectedRuleId || !suggestedPddFragmentDraft) return;
+    setPddFragmentDrafts((current) => {
+      let changed = false;
+      const next = { ...current };
+      for (const pin of evidencePins) {
+        if (!pin.pdd_document) continue;
+        if (!isEmptyPddFragmentDraft(current[pin.id])) continue;
+        next[pin.id] = {
+          ...EMPTY_PDD_FRAGMENT_DRAFT,
+          label: suggestedPddFragmentDraft.label,
+          sectionLabel: suggestedPddFragmentDraft.sectionLabel,
+          sectionHeading: suggestedPddFragmentDraft.sectionHeading,
+        };
+        changed = true;
+      }
+      return changed ? next : current;
+    });
+  }, [evidencePins, selectedRuleId, suggestedPddFragmentDraft]);
 
   const handlePddUpload = useCallback(async (file: File | null) => {
     if (!file) return;
@@ -3633,6 +3686,30 @@ export default function ProofMapTab({
                                 {item.pdd_document.file_name} • {item.pdd_document.mime}
                                 {item.pdd_document.sha256 ? ` • ${shortSha(item.pdd_document.sha256)}` : ""}
                               </div>
+                              {selectedRuleId && suggestedPddFragmentDraft ? (
+                                <div className="grid gap-2 rounded-lg border border-sky-200 bg-sky-50/60 p-2 text-[11px] text-slate-700">
+                                  <div className="flex flex-wrap items-center justify-between gap-2">
+                                    <div className="font-semibold text-sky-800">Suggested fragment metadata for {selectedRuleId}</div>
+                                    <button
+                                      type="button"
+                                      className="rounded-full border border-sky-200 bg-white px-3 py-1 text-xs font-semibold text-sky-700 hover:bg-sky-100"
+                                      onClick={() => applySuggestedPddFragmentDraft(pin.id)}
+                                    >
+                                      Use suggestion
+                                    </button>
+                                  </div>
+                                  <div>
+                                    Label: <span className="font-medium text-slate-900">{suggestedPddFragmentDraft.label}</span>
+                                    {suggestedPddFragmentDraft.sectionHeading
+                                      ? ` · Heading: ${suggestedPddFragmentDraft.sectionHeading}`
+                                      : ""}
+                                    {suggestedPddFragmentDraft.sectionLabel
+                                      ? ` · Section: ${suggestedPddFragmentDraft.sectionLabel}`
+                                      : ""}
+                                  </div>
+                                  <div className="text-slate-600">{suggestedPddFragmentDraft.reason}</div>
+                                </div>
+                              ) : null}
                               <div className="grid gap-2 md:grid-cols-2">
                                 <label className="grid gap-1 md:col-span-2">
                                   <span>Fragment label</span>

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+  RequirementCoverageExpectedEvidenceType,
+  RequirementCoverageLinkedEvidence,
+} from "@/app/m/_lib/requirementCoverage";
 import {
   addEvidenceAttachment,
   removeEvidenceAttachment,
@@ -16,6 +20,7 @@ import {
 import { getAuditTrailForRule, logAuditEvent, type AuditEvent } from "@/lib/verify/auditTrail";
 import { isStacEligible, stacEligibilityReason } from "@/lib/verify/stacEligibility";
 import type { StacSupportFactsState } from "@/lib/verify/stacSupportFacts";
+import { buildReviewSuggestion, suggestedOutcomeLabel } from "@/lib/verify/reviewSuggestion";
 import StacSupportSection from "@/components/verify/StacSupportSection";
 import DocumentSupportSection from "@/components/verify/DocumentSupportSection";
 import type { DocumentSupportEntry } from "@/lib/verify/documentSupport";
@@ -40,9 +45,11 @@ type RuleReviewPanelProps = {
   ruleNotes?: string | null;
   ruleWhen?: string[] | null;
   expectedEvidence?: string[];
+  expectedEvidenceTypes?: RequirementCoverageExpectedEvidenceType[];
   sourcePath?: string | null;
   sha256?: string | null;
   ruleTags?: string[];
+  linkedEvidenceDetails?: RequirementCoverageLinkedEvidence[];
   stacSupportState?: StacSupportFactsState | null;
   documentSupport?: DocumentSupportEntry[];
   onSave: (review: RuleReview) => void;
@@ -70,9 +77,11 @@ export default function RuleReviewPanel({
   ruleNotes,
   ruleWhen,
   expectedEvidence = [],
+  expectedEvidenceTypes = [],
   sourcePath,
   sha256,
   ruleTags = [],
+  linkedEvidenceDetails = [],
   stacSupportState = null,
   documentSupport = [],
   onSave,
@@ -101,8 +110,22 @@ export default function RuleReviewPanel({
   );
   const [errors, setErrors] = useState<string[]>([]);
   const [saved, setSaved] = useState(false);
+  const [suggestionDismissed, setSuggestionDismissed] = useState(false);
   const stacEligible = isStacEligible(ruleTags);
   const stacReason = stacEligibilityReason(ruleTags);
+  const suggestion = useMemo(
+    () =>
+      buildReviewSuggestion({
+        ruleId,
+        ruleText,
+        ruleTags,
+        expectedEvidenceTypes,
+        linkedEvidence: linkedEvidenceDetails,
+        documentSupport,
+        stacSupportState,
+      }),
+    [documentSupport, expectedEvidenceTypes, linkedEvidenceDetails, ruleId, ruleTags, ruleText, stacSupportState],
+  );
   const reviewExplanation = useMemo(() => {
     switch (status) {
       case "verified":
@@ -140,6 +163,11 @@ export default function RuleReviewPanel({
     }
   }, [status]);
   const actorLabel = existingReview?.reviewedBy?.trim() || "local-reviewer";
+  const suggestionVisible = !suggestionDismissed;
+
+  useEffect(() => {
+    setSuggestionDismissed(false);
+  }, [ruleId, methodology, version]);
 
   const refreshAuditEvents = useCallback(() => {
     setAuditEvents(getAuditTrailForRule(ruleId, methodology, version).slice(-5).reverse());
@@ -287,6 +315,24 @@ export default function RuleReviewPanel({
     [actorLabel, methodology, refreshAuditEvents, ruleId, syncReview, version],
   );
 
+  const applySuggestion = useCallback(
+    (focusRationale: boolean) => {
+      setStatus(suggestion.mappedReviewStatus);
+      setRationale(suggestion.whyThisJudgment);
+      setSupportReference(suggestion.supportingTrace);
+      setSuggestionDismissed(false);
+      setErrors([]);
+      if (focusRationale && typeof document !== "undefined") {
+        window.setTimeout(() => {
+          const field = document.querySelector<HTMLTextAreaElement>(`textarea[data-rule-rationale="${ruleId}"]`);
+          field?.focus();
+          field?.setSelectionRange(field.value.length, field.value.length);
+        }, 0);
+      }
+    },
+    [ruleId, suggestion],
+  );
+
   return (
     <section className="rounded-[24px] border border-slate-200 bg-white shadow-sm">
       <div className="border-b border-slate-100 px-5 py-4">
@@ -326,6 +372,131 @@ export default function RuleReviewPanel({
 
       <div className="grid gap-6 px-5 py-5 lg:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
         <div className="space-y-5">
+          {suggestionVisible ? (
+            <section className="rounded-[20px] border border-sky-200 bg-sky-50/80 px-4 py-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-700">
+                    Suggested review
+                  </div>
+                  <div className="mt-1 text-sm text-slate-700">
+                    Machine suggestion only. Reviewer acceptance and save are still required before finalization.
+                  </div>
+                </div>
+                <div className="rounded-full border border-sky-200 bg-white px-3 py-1 text-xs font-semibold text-sky-700">
+                  {suggestedOutcomeLabel(suggestion.suggestedOutcome)}
+                </div>
+              </div>
+
+              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                <div className="rounded-2xl border border-sky-100 bg-white px-3 py-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                    Suggested fragment
+                  </div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">
+                    {suggestion.suggestedFragment?.label ?? "No strong fragment match found"}
+                  </div>
+                  {suggestion.suggestedFragment?.detail ? (
+                    <div className="mt-1 text-xs text-slate-500">{suggestion.suggestedFragment.detail}</div>
+                  ) : null}
+                </div>
+                <div className="rounded-2xl border border-sky-100 bg-white px-3 py-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                    Suggested evidence attachment
+                  </div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">
+                    {suggestion.suggestedEvidence?.label ?? "No strong evidence attachment match found"}
+                  </div>
+                  {suggestion.suggestedEvidence?.detail ? (
+                    <div className="mt-1 text-xs text-slate-500">{suggestion.suggestedEvidence.detail}</div>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="mt-3 rounded-2xl border border-sky-100 bg-white px-3 py-3">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Missing expected evidence
+                </div>
+                {suggestion.missingExpectedEvidence.length ? (
+                  <ul className="mt-2 grid gap-1 text-sm text-slate-700">
+                    {suggestion.missingExpectedEvidence.map((item) => (
+                      <li key={item}>• {item}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div className="mt-1 text-sm text-slate-600">No obvious expected-evidence gap detected from the current linked record.</div>
+                )}
+              </div>
+
+              <div className="mt-3 grid gap-3">
+                <div className="rounded-2xl border border-sky-100 bg-white px-3 py-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                    Draft Why this judgment
+                  </div>
+                  <div className="mt-1 text-sm leading-6 text-slate-700">{suggestion.whyThisJudgment}</div>
+                </div>
+                <div className="rounded-2xl border border-sky-100 bg-white px-3 py-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                    Draft Supporting trace
+                  </div>
+                  <div className="mt-1 text-sm leading-6 text-slate-700">
+                    {suggestion.supportingTrace || "No trace string generated from the current evidence context."}
+                  </div>
+                </div>
+                <div className="rounded-2xl border border-sky-100 bg-white px-3 py-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                    Why this was suggested
+                  </div>
+                  <div className="mt-1 text-sm leading-6 text-slate-700">{suggestion.reason}</div>
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => applySuggestion(false)}
+                  className="rounded-full border border-sky-700 bg-sky-700 px-4 py-2 text-xs font-semibold text-white hover:bg-sky-800"
+                >
+                  Accept suggestion
+                </button>
+                <button
+                  type="button"
+                  onClick={() => applySuggestion(true)}
+                  className="rounded-full border border-sky-200 bg-white px-4 py-2 text-xs font-semibold text-sky-700 hover:border-sky-300"
+                >
+                  Edit before saving
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSuggestionDismissed(true)}
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-700 hover:border-slate-300"
+                >
+                  Reject suggestion / mark manually
+                </button>
+              </div>
+            </section>
+          ) : (
+            <section className="rounded-[20px] border border-slate-200 bg-slate-50 px-4 py-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                    Suggested review
+                  </div>
+                  <div className="mt-1 text-sm text-slate-600">
+                    Suggestion dismissed for manual review. Unaccepted suggestions are not saved or exported.
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setSuggestionDismissed(false)}
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-700 hover:border-slate-300"
+                >
+                  Restore suggestion
+                </button>
+              </div>
+            </section>
+          )}
+
           <section className="space-y-3">
             <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
               Current judgment
@@ -368,6 +539,7 @@ export default function RuleReviewPanel({
               <textarea
                 value={rationale}
                 onChange={(e) => setRationale(e.target.value)}
+                data-rule-rationale={ruleId}
                 placeholder="State the reviewer’s reason in plain language."
                 rows={4}
                 className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-900 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-400"

--- a/src/lib/verify/reviewSuggestion.ts
+++ b/src/lib/verify/reviewSuggestion.ts
@@ -26,6 +26,13 @@ export type ReviewSuggestion = {
   reason: string;
 };
 
+export type SuggestedPddFragmentDraft = {
+  label: string;
+  sectionLabel: string;
+  sectionHeading: string;
+  reason: string;
+};
+
 export type BuildReviewSuggestionInput = {
   ruleId: string;
   ruleText: string;
@@ -452,4 +459,60 @@ export function suggestedOutcomeLabel(outcome: SuggestedReviewOutcome): string {
     case "not_applicable":
       return "Not applicable";
   }
+}
+
+export function suggestPddFragmentDraft(input: {
+  ruleText: string;
+  ruleTags?: string[];
+  sectionId?: string | null;
+  sectionTitle?: string | null;
+  expectedEvidenceTypes?: RequirementCoverageExpectedEvidenceType[];
+}): SuggestedPddFragmentDraft {
+  const intents = ruleIntentCategories({
+    ruleText: input.ruleText,
+    ruleTags: input.ruleTags ?? [],
+    expectedEvidenceTypes: input.expectedEvidenceTypes ?? [],
+  });
+  const normalizedSectionTitle = input.sectionTitle?.trim() ?? "";
+  const normalizedSectionId = input.sectionId?.trim() ?? "";
+  const sectionHeading =
+    normalizedSectionTitle ||
+    (intents.includes("boundary")
+      ? "Project boundary"
+      : intents.includes("baseline")
+        ? "Baseline scenario"
+        : intents.includes("uncertainty")
+          ? "Monitoring plan"
+          : intents.includes("monitoring")
+            ? "Monitoring plan"
+            : intents.includes("eligibility")
+              ? "Eligibility evidence"
+              : intents.includes("qa_qc")
+                ? "QA/QC procedure"
+                : intents.includes("calculation")
+                  ? "Calculation support"
+                  : "Rule support excerpt");
+  const label =
+    intents.includes("boundary")
+      ? normalizedSectionTitle || "Boundary overview"
+      : intents.includes("baseline")
+        ? normalizedSectionTitle || "Baseline scenario"
+        : intents.includes("uncertainty")
+          ? normalizedSectionTitle || "Monitoring plan"
+          : intents.includes("monitoring")
+            ? normalizedSectionTitle || "Monitoring plan"
+            : intents.includes("eligibility")
+              ? normalizedSectionTitle || "Eligibility evidence"
+              : intents.includes("qa_qc")
+                ? normalizedSectionTitle || "QA/QC support"
+                : intents.includes("calculation")
+                  ? normalizedSectionTitle || "Calculation support"
+                  : normalizedSectionTitle || "Rule support excerpt";
+
+  return {
+    label,
+    sectionLabel: normalizedSectionId,
+    sectionHeading,
+    reason: `Suggested from the selected rule intent${normalizedSectionTitle ? ` and methodology section ${normalizedSectionTitle}` : ""}. Source excerpt still needs reviewer confirmation from the PDD.`,
+  };
 }

--- a/src/lib/verify/reviewSuggestion.ts
+++ b/src/lib/verify/reviewSuggestion.ts
@@ -1,0 +1,455 @@
+import type {
+  RequirementCoverageExpectedEvidenceType,
+  RequirementCoverageLinkedEvidence,
+} from "@/app/m/_lib/requirementCoverage";
+import { EXPECTED_EVIDENCE_LABELS } from "@/app/m/_lib/requirementCoverage";
+import type { DocumentSupportEntry } from "@/lib/verify/documentSupport";
+import type { StacSupportFactsState } from "@/lib/verify/stacSupportFacts";
+import type { ReviewStatus } from "@/lib/verify/reviewStore";
+
+export type SuggestedReviewOutcome = "supported" | "partial" | "gap" | "not_applicable";
+
+export type ReviewSuggestionTrace = {
+  id: string;
+  label: string;
+  detail?: string;
+};
+
+export type ReviewSuggestion = {
+  suggestedOutcome: SuggestedReviewOutcome;
+  mappedReviewStatus: ReviewStatus;
+  suggestedFragment: ReviewSuggestionTrace | null;
+  suggestedEvidence: ReviewSuggestionTrace | null;
+  missingExpectedEvidence: string[];
+  whyThisJudgment: string;
+  supportingTrace: string;
+  reason: string;
+};
+
+export type BuildReviewSuggestionInput = {
+  ruleId: string;
+  ruleText: string;
+  ruleTags?: string[];
+  expectedEvidenceTypes?: RequirementCoverageExpectedEvidenceType[];
+  linkedEvidence?: RequirementCoverageLinkedEvidence[];
+  documentSupport?: DocumentSupportEntry[];
+  stacSupportState?: StacSupportFactsState | null;
+};
+
+type IntentCategory =
+  | "baseline"
+  | "monitoring"
+  | "boundary"
+  | "uncertainty"
+  | "eligibility"
+  | "qa_qc"
+  | "calculation"
+  | "general";
+
+type ScoredMatch<T> = {
+  item: T;
+  score: number;
+};
+
+const INTENT_HINTS: Record<IntentCategory, string[]> = {
+  baseline: ["baseline", "without project", "without-project", "land use", "land-use", "scenario"],
+  monitoring: ["monitoring", "sampling", "variable", "variables", "parameter", "workbook", "reporting period"],
+  boundary: ["location", "boundary", "aoi", "coordinates", "coordinate", "geospatial", "gis", "polygon", "map"],
+  uncertainty: ["uncertainty", "confidence", "90%", "sampling error", "sampling uncertainty", "precision", "tool 12"],
+  eligibility: ["eligibility", "eligible", "land title", "proof", "ownership"],
+  qa_qc: ["qa/qc", "qa qc", "qa-qc", "quality control", "quality assurance"],
+  calculation: ["calculation", "equation", "deduction", "deductions", "worksheet", "formula"],
+  general: [],
+};
+
+const UNCERTAINTY_EXPECTED_EVIDENCE = [
+  "uncertainty worksheet",
+  "sampling calculation",
+  "90% confidence result",
+  "Tool 12 deduction record, if threshold exceeded",
+] as const;
+
+function uniqSorted(values: string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+function toLowerJoined(values: Array<string | null | undefined>): string {
+  return values.filter(Boolean).join(" ").toLowerCase();
+}
+
+function ruleIntentCategories(input: {
+  ruleText: string;
+  ruleTags: string[];
+  expectedEvidenceTypes: RequirementCoverageExpectedEvidenceType[];
+}): IntentCategory[] {
+  const haystack = toLowerJoined([input.ruleText, ...input.ruleTags, ...input.expectedEvidenceTypes]);
+  const matched = new Set<IntentCategory>();
+  for (const [category, hints] of Object.entries(INTENT_HINTS) as Array<[IntentCategory, string[]]>) {
+    if (hints.some((hint) => haystack.includes(hint))) matched.add(category);
+  }
+  if (matched.has("uncertainty")) matched.add("calculation");
+  if (matched.has("boundary")) matched.add("monitoring");
+  if (matched.size === 0) matched.add("general");
+  return Array.from(matched);
+}
+
+function scoreTextMatch(text: string, needles: string[]): number {
+  let score = 0;
+  for (const needle of needles) {
+    if (!needle) continue;
+    if (text.includes(needle)) score += needle.length > 6 ? 3 : 2;
+  }
+  return score;
+}
+
+function evidenceHintsForExpectedType(type: RequirementCoverageExpectedEvidenceType): string[] {
+  switch (type) {
+    case "monitoring-report":
+      return ["monitoring report", "monitoring plan", "report", "monitoring"];
+    case "spreadsheet-workbook":
+      return ["workbook", "spreadsheet", "sheet", "tab", "sampling log"];
+    case "pdd":
+      return ["pdd", "project design document"];
+    case "gis":
+      return ["aoi", "boundary", "map", "gis", "coordinate", "polygon", "stac"];
+    case "qa-qc-record":
+      return ["qa/qc", "qa qc", "quality control", "quality assurance"];
+    case "eligibility-proof":
+      return ["eligibility", "eligible", "land title", "ownership"];
+    case "calculation-support":
+      return ["calculation", "worksheet", "tool 12", "deduction", "confidence", "uncertainty"];
+    case "other":
+      return ["evidence", "support"];
+  }
+}
+
+function scoreLinkedEvidence(
+  item: RequirementCoverageLinkedEvidence,
+  intents: IntentCategory[],
+  expectedEvidenceTypes: RequirementCoverageExpectedEvidenceType[],
+): number {
+  const haystack = toLowerJoined([
+    item.title,
+    item.type,
+    item.documentLabel,
+    item.provenanceSummary,
+    item.fragmentLabel,
+    item.sectionLabel,
+    item.sectionHeading,
+    item.excerpt,
+  ]);
+  let score = 0;
+  for (const intent of intents) {
+    score += scoreTextMatch(haystack, INTENT_HINTS[intent]);
+  }
+  for (const expectedType of expectedEvidenceTypes) {
+    score += scoreTextMatch(haystack, evidenceHintsForExpectedType(expectedType));
+  }
+  if (item.fragmentId) score += 2;
+  if (item.evidenceId) score += 1;
+  if (item.type.toLowerCase().includes("pdd")) score += 1;
+  return score;
+}
+
+function scoreDocumentSupport(
+  item: DocumentSupportEntry,
+  intents: IntentCategory[],
+  expectedEvidenceTypes: RequirementCoverageExpectedEvidenceType[],
+): number {
+  const haystack = toLowerJoined([item.title, item.source, item.provenance, item.excerpt]);
+  let score = 0;
+  for (const intent of intents) {
+    score += scoreTextMatch(haystack, INTENT_HINTS[intent]);
+  }
+  for (const expectedType of expectedEvidenceTypes) {
+    score += scoreTextMatch(haystack, evidenceHintsForExpectedType(expectedType));
+  }
+  if (item.kind === "workbook_value") score += 3;
+  if (item.kind === "pdd_excerpt") score += 2;
+  return score;
+}
+
+function pickBestLinkedEvidence(
+  linkedEvidence: RequirementCoverageLinkedEvidence[],
+  intents: IntentCategory[],
+  expectedEvidenceTypes: RequirementCoverageExpectedEvidenceType[],
+): ScoredMatch<RequirementCoverageLinkedEvidence> | null {
+  const scored = linkedEvidence
+    .map((item) => ({ item, score: scoreLinkedEvidence(item, intents, expectedEvidenceTypes) }))
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score || a.item.title.localeCompare(b.item.title));
+  return scored[0] ?? null;
+}
+
+function pickBestFragment(
+  documentSupport: DocumentSupportEntry[],
+  linkedEvidence: RequirementCoverageLinkedEvidence[],
+  intents: IntentCategory[],
+  expectedEvidenceTypes: RequirementCoverageExpectedEvidenceType[],
+): ScoredMatch<DocumentSupportEntry | RequirementCoverageLinkedEvidence> | null {
+  const supportMatches = documentSupport
+    .filter((item) => item.kind === "pdd_excerpt" || item.kind === "workbook_value")
+    .map((item) => ({ item, score: scoreDocumentSupport(item, intents, expectedEvidenceTypes) }));
+  const linkedFragmentMatches = linkedEvidence
+    .filter((item) => Boolean(item.fragmentId))
+    .map((item) => ({ item, score: scoreLinkedEvidence(item, intents, expectedEvidenceTypes) + 1 }));
+  return [...supportMatches, ...linkedFragmentMatches]
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    [0] ?? null;
+}
+
+function linkedEvidenceMatchesExpectedType(
+  linkedEvidence: RequirementCoverageLinkedEvidence[],
+  expectedType: RequirementCoverageExpectedEvidenceType,
+): boolean {
+  const hints = evidenceHintsForExpectedType(expectedType);
+  return linkedEvidence.some((item) =>
+    scoreTextMatch(
+      toLowerJoined([
+        item.title,
+        item.type,
+        item.documentLabel,
+        item.provenanceSummary,
+        item.fragmentLabel,
+        item.sectionLabel,
+        item.sectionHeading,
+        item.excerpt,
+      ]),
+      hints,
+    ) > 0,
+  );
+}
+
+function missingExpectedEvidenceLabels(
+  expectedEvidenceTypes: RequirementCoverageExpectedEvidenceType[],
+  linkedEvidence: RequirementCoverageLinkedEvidence[],
+  intents: IntentCategory[],
+): string[] {
+  const missing = expectedEvidenceTypes
+    .filter((type) => !linkedEvidenceMatchesExpectedType(linkedEvidence, type))
+    .map((type) => EXPECTED_EVIDENCE_LABELS[type] ?? type);
+
+  if (intents.includes("uncertainty")) {
+    const uncertaintyEvidence = linkedEvidence
+      .map((item) =>
+        toLowerJoined([
+          item.title,
+          item.type,
+          item.documentLabel,
+          item.provenanceSummary,
+          item.fragmentLabel,
+          item.sectionLabel,
+          item.sectionHeading,
+          item.excerpt,
+        ]),
+      )
+      .join(" ");
+    for (const label of UNCERTAINTY_EXPECTED_EVIDENCE) {
+      const needle = label.toLowerCase().replace(", if threshold exceeded", "");
+      if (!uncertaintyEvidence.includes(needle)) missing.push(label);
+    }
+  }
+
+  return uniqSorted(missing);
+}
+
+function isWeakEvidenceOnly(
+  bestEvidence: RequirementCoverageLinkedEvidence | null,
+  linkedEvidence: RequirementCoverageLinkedEvidence[],
+  intents: IntentCategory[],
+): boolean {
+  if (!bestEvidence) return true;
+  const haystack = toLowerJoined([
+    bestEvidence.title,
+    bestEvidence.type,
+    bestEvidence.documentLabel,
+    bestEvidence.provenanceSummary,
+    bestEvidence.fragmentLabel,
+    bestEvidence.sectionLabel,
+    bestEvidence.sectionHeading,
+    bestEvidence.excerpt,
+  ]);
+  const hasWorkbookOrCalculation = linkedEvidence.some((item) => {
+    const text = toLowerJoined([item.title, item.type, item.documentLabel, item.provenanceSummary, item.excerpt]);
+    return /workbook|spreadsheet|calculation|worksheet|sampling log|tool 12|confidence/.test(text);
+  });
+  if (intents.includes("uncertainty")) {
+    return !hasWorkbookOrCalculation;
+  }
+  return /monitoring plan|pdd|project design document/.test(haystack) && !hasWorkbookOrCalculation;
+}
+
+function chooseOutcome(input: {
+  intents: IntentCategory[];
+  linkedEvidence: RequirementCoverageLinkedEvidence[];
+  missingExpectedEvidence: string[];
+  weakEvidenceOnly: boolean;
+}): SuggestedReviewOutcome {
+  if (!input.linkedEvidence.length) return "gap";
+  if (input.intents.includes("uncertainty") && input.weakEvidenceOnly) return "partial";
+  if (input.missingExpectedEvidence.length > 0) {
+    return input.linkedEvidence.length > 0 ? "partial" : "gap";
+  }
+  if (input.weakEvidenceOnly) return "partial";
+  return "supported";
+}
+
+function mapOutcomeToReviewStatus(outcome: SuggestedReviewOutcome): ReviewStatus {
+  switch (outcome) {
+    case "supported":
+      return "verified";
+    case "gap":
+      return "not_verified";
+    case "partial":
+    case "not_applicable":
+      return "needs_followup";
+  }
+}
+
+function buildSupportingTrace(input: {
+  fragment: ReviewSuggestionTrace | null;
+  evidence: ReviewSuggestionTrace | null;
+  stacSupportState?: StacSupportFactsState | null;
+}): string {
+  const parts: string[] = [];
+  if (input.fragment) parts.push(`Fragment: ${input.fragment.label}${input.fragment.detail ? ` (${input.fragment.detail})` : ""}`);
+  if (input.evidence) parts.push(`Evidence: ${input.evidence.label}${input.evidence.detail ? ` (${input.evidence.detail})` : ""}`);
+  const linkedScene = input.stacSupportState?.linkedFacts[0];
+  if (linkedScene) {
+    const sceneDetail = [linkedScene.collection, linkedScene.datetime].filter(Boolean).join(" · ");
+    parts.push(`AOI/STAC: ${linkedScene.id}${sceneDetail ? ` (${sceneDetail})` : ""}`);
+  }
+  return parts.join("; ");
+}
+
+function buildReason(input: {
+  intents: IntentCategory[];
+  expectedEvidenceTypes: RequirementCoverageExpectedEvidenceType[];
+  bestEvidence: RequirementCoverageLinkedEvidence | null;
+  missingExpectedEvidence: string[];
+}): string {
+  const intentLabel = input.intents
+    .filter((intent) => intent !== "general")
+    .map((intent) => intent.replace("_", "/"))
+    .join(", ");
+  const evidenceTypeLabel = input.expectedEvidenceTypes.map((type) => EXPECTED_EVIDENCE_LABELS[type] ?? type).join(", ");
+  const parts = [
+    intentLabel ? `Matched rule intent to ${intentLabel}.` : "Matched rule text to available evidence context.",
+  ];
+  if (evidenceTypeLabel) parts.push(`Expected evidence types considered: ${evidenceTypeLabel}.`);
+  if (input.bestEvidence) parts.push(`Best available evidence is ${input.bestEvidence.title}.`);
+  if (input.missingExpectedEvidence.length) {
+    parts.push(`Missing expected evidence: ${input.missingExpectedEvidence.join(", ")}.`);
+  }
+  return parts.join(" ");
+}
+
+function labelForFragment(item: DocumentSupportEntry | RequirementCoverageLinkedEvidence): ReviewSuggestionTrace {
+  if ("kind" in item) {
+    return {
+      id: item.id,
+      label: item.title,
+      detail: item.provenance,
+    };
+  }
+  return {
+    id: item.fragmentId ?? item.id,
+    label: item.fragmentLabel ?? item.title,
+    detail: item.provenanceSummary ?? item.documentLabel,
+  };
+}
+
+function labelForEvidence(item: RequirementCoverageLinkedEvidence | null): ReviewSuggestionTrace | null {
+  if (!item) return null;
+  return {
+    id: item.evidenceId ?? item.id,
+    label: item.documentLabel ?? item.title,
+    detail: item.provenanceSummary ?? item.type,
+  };
+}
+
+function buildJudgment(input: {
+  outcome: SuggestedReviewOutcome;
+  bestEvidence: RequirementCoverageLinkedEvidence | null;
+  fragment: ReviewSuggestionTrace | null;
+  missingExpectedEvidence: string[];
+  intents: IntentCategory[];
+}): string {
+  const evidenceDescription = input.bestEvidence
+    ? input.bestEvidence.documentLabel ?? input.bestEvidence.title
+    : "No linked evidence";
+  if (input.outcome === "supported") {
+    return `${evidenceDescription} appears to address this rule and no expected evidence gap is obvious from the current linked record. Reviewer confirmation is still required before finalizing.`;
+  }
+  if (input.outcome === "gap") {
+    return `${evidenceDescription} does not currently demonstrate this rule. Missing support remains: ${input.missingExpectedEvidence.join(", ") || "linked evidence"}.`;
+  }
+  if (input.intents.includes("uncertainty")) {
+    return `${evidenceDescription}${input.fragment ? `, including ${input.fragment.label},` : ""} describes monitoring or sampling context, but it does not prove the uncertainty calculation, 90% confidence result, or any Tool 12 adjustment.`;
+  }
+  return `${evidenceDescription}${input.fragment ? `, including ${input.fragment.label},` : ""} is relevant to this rule, but the current linked record is still incomplete. Missing support remains: ${input.missingExpectedEvidence.join(", ") || "additional corroborating evidence"}.`;
+}
+
+export function buildReviewSuggestion(input: BuildReviewSuggestionInput): ReviewSuggestion {
+  const expectedEvidenceTypes = input.expectedEvidenceTypes ?? [];
+  const linkedEvidence = input.linkedEvidence ?? [];
+  const documentSupport = input.documentSupport ?? [];
+  const intents = ruleIntentCategories({
+    ruleText: input.ruleText,
+    ruleTags: input.ruleTags ?? [],
+    expectedEvidenceTypes,
+  });
+  const bestEvidenceMatch = pickBestLinkedEvidence(linkedEvidence, intents, expectedEvidenceTypes);
+  const bestEvidence = bestEvidenceMatch?.item ?? null;
+  const fragmentMatch = pickBestFragment(documentSupport, linkedEvidence, intents, expectedEvidenceTypes);
+  const fragment = fragmentMatch ? labelForFragment(fragmentMatch.item) : null;
+  const missingExpectedEvidence = missingExpectedEvidenceLabels(expectedEvidenceTypes, linkedEvidence, intents);
+  const weakEvidenceOnly = isWeakEvidenceOnly(bestEvidence, linkedEvidence, intents);
+  const suggestedOutcome = chooseOutcome({
+    intents,
+    linkedEvidence,
+    missingExpectedEvidence,
+    weakEvidenceOnly,
+  });
+  const suggestedEvidence = labelForEvidence(bestEvidence);
+  const supportingTrace = buildSupportingTrace({
+    fragment,
+    evidence: suggestedEvidence,
+    stacSupportState: input.stacSupportState,
+  });
+  return {
+    suggestedOutcome,
+    mappedReviewStatus: mapOutcomeToReviewStatus(suggestedOutcome),
+    suggestedFragment: fragment,
+    suggestedEvidence,
+    missingExpectedEvidence,
+    whyThisJudgment: buildJudgment({
+      outcome: suggestedOutcome,
+      bestEvidence,
+      fragment,
+      missingExpectedEvidence,
+      intents,
+    }),
+    supportingTrace,
+    reason: buildReason({
+      intents,
+      expectedEvidenceTypes,
+      bestEvidence,
+      missingExpectedEvidence,
+    }),
+  };
+}
+
+export function suggestedOutcomeLabel(outcome: SuggestedReviewOutcome): string {
+  switch (outcome) {
+    case "supported":
+      return "Supported";
+    case "partial":
+      return "Partially supported";
+    case "gap":
+      return "Gap";
+    case "not_applicable":
+      return "Not applicable";
+  }
+}

--- a/tests/components/ruleReviewPanel.test.tsx
+++ b/tests/components/ruleReviewPanel.test.tsx
@@ -1,0 +1,196 @@
+/** @jest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import RuleReviewPanel from "@/components/verify/RuleReviewPanel";
+import { getReview, type RuleReview } from "@/lib/verify/reviewStore";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  } as Storage;
+})();
+
+function dispatchClick(element: Element | null) {
+  if (!element) throw new Error("Expected element to exist");
+  act(() => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+function dispatchInput(element: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const prototype = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, "value");
+  act(() => {
+    descriptor?.set?.call(element, value);
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+describe("RuleReviewPanel suggested review", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const onSave = jest.fn<(review: RuleReview) => void>();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: localStorageMock,
+      configurable: true,
+      writable: true,
+    });
+    globalThis.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    onSave.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("accepts a suggestion by populating review fields without auto-saving", async () => {
+    await act(async () => {
+      root.render(
+        <RuleReviewPanel
+          ruleId="R-1-0007"
+          ruleText="Sampling uncertainty kept below 10% at 90% confidence or conservatively adjusted using Tool 12."
+          sectionId="S-10"
+          methodology="AR-ACM0003"
+          version="v02-0"
+          existingReview={null}
+          expectedEvidence={["Monitoring report", "Spreadsheet workbook", "Calculation support"]}
+          expectedEvidenceTypes={["monitoring-report", "spreadsheet-workbook", "calculation-support"]}
+          ruleTags={["uncertainty", "monitoring", "sampling"]}
+          linkedEvidence={[
+            {
+              id: "frag-d1",
+              title: "D.1 Monitoring plan",
+              type: "PDD",
+              meta: "project-design.pdf · p. 37",
+              excerpt: "Sampling procedures and monitoring variables are described.",
+            },
+          ]}
+          linkedEvidenceDetails={[
+            {
+              id: "frag-d1",
+              title: "D.1 Monitoring plan",
+              type: "PDD",
+              source: "inventory",
+              evidenceId: "ev-pdd",
+              fragmentId: "frag-d1",
+              fragmentLabel: "D.1 Monitoring plan",
+              documentLabel: "project-design.pdf",
+              provenanceSummary: "project-design.pdf • D.1 Monitoring plan • p. 37",
+              sectionHeading: "Monitoring plan",
+              excerpt: "Sampling procedures and monitoring variables are described.",
+            },
+          ]}
+          documentSupport={[
+            {
+              id: "frag-d1",
+              kind: "pdd_excerpt",
+              source: "project-design.pdf",
+              title: "D.1 Monitoring plan",
+              provenance: "project-design.pdf · D.1 Monitoring plan · p. 37",
+              excerpt: "Sampling procedures and monitoring variables are described.",
+              ruleLinked: true,
+            },
+          ]}
+          onSave={onSave}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Suggested review");
+    expect(container.textContent).toContain("Partially supported");
+    expect(container.textContent).toContain("uncertainty worksheet");
+
+    dispatchClick(Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Accept suggestion")) ?? null);
+
+    const rationale = container.querySelector('textarea[data-rule-rationale="R-1-0007"]') as HTMLTextAreaElement | null;
+    const supportReference = container.querySelector('input[placeholder*="Cite the best supporting trace"]') as HTMLInputElement | null;
+
+    expect(rationale?.value).toContain("does not prove the uncertainty calculation");
+    expect(supportReference?.value).toContain("Fragment: D.1 Monitoring plan");
+    expect(getReview("R-1-0007", "AR-ACM0003", "v02-0")).toBeNull();
+  });
+
+  it("keeps unaccepted suggestions out of finalized review state and only saves reviewer-confirmed edits", async () => {
+    await act(async () => {
+      root.render(
+        <RuleReviewPanel
+          ruleId="R-1-0007"
+          ruleText="Sampling uncertainty kept below 10% at 90% confidence or conservatively adjusted using Tool 12."
+          methodology="AR-ACM0003"
+          version="v02-0"
+          existingReview={null}
+          expectedEvidenceTypes={["monitoring-report", "spreadsheet-workbook", "calculation-support"]}
+          ruleTags={["uncertainty", "monitoring", "sampling"]}
+          linkedEvidenceDetails={[
+            {
+              id: "frag-d1",
+              title: "D.1 Monitoring plan",
+              type: "PDD",
+              source: "inventory",
+              fragmentId: "frag-d1",
+              fragmentLabel: "D.1 Monitoring plan",
+              documentLabel: "project-design.pdf",
+              provenanceSummary: "project-design.pdf • D.1 Monitoring plan • p. 37",
+              excerpt: "Sampling procedures and monitoring variables are described.",
+            },
+          ]}
+          onSave={onSave}
+        />,
+      );
+    });
+
+    dispatchClick(Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Reject suggestion")) ?? null);
+    expect(container.textContent).toContain("Unaccepted suggestions are not saved or exported.");
+
+    dispatchClick(
+      Array.from(container.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Needs Follow-up"),
+      ) ?? null,
+    );
+
+    const rationale = container.querySelector('textarea[data-rule-rationale="R-1-0007"]') as HTMLTextAreaElement;
+    const supportReference = container.querySelector('input[placeholder*="Cite the best supporting trace"]') as HTMLInputElement;
+    dispatchInput(rationale, "Reviewer confirmed the uncertainty worksheet is still missing.");
+    dispatchInput(supportReference, "Manual trace: project-design.pdf · D.1 Monitoring plan");
+
+    dispatchClick(Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "Save review") ?? null);
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0]?.[0]).toMatchObject({
+      ruleId: "R-1-0007",
+      status: "needs_followup",
+      rationale: "Reviewer confirmed the uncertainty worksheet is still missing.",
+      supportReference: "Manual trace: project-design.pdf · D.1 Monitoring plan",
+    });
+  });
+});

--- a/tests/lib/reviewSuggestion.test.ts
+++ b/tests/lib/reviewSuggestion.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "@jest/globals";
+import type {
+  RequirementCoverageExpectedEvidenceType,
+  RequirementCoverageLinkedEvidence,
+} from "@/app/m/_lib/requirementCoverage";
+import type { DocumentSupportEntry } from "@/lib/verify/documentSupport";
+import { buildReviewSuggestion } from "@/lib/verify/reviewSuggestion";
+
+function buildSuggestion(input: {
+  ruleId?: string;
+  ruleText: string;
+  ruleTags?: string[];
+  expectedEvidenceTypes?: RequirementCoverageExpectedEvidenceType[];
+  linkedEvidence?: RequirementCoverageLinkedEvidence[];
+  documentSupport?: DocumentSupportEntry[];
+}) {
+  return buildReviewSuggestion({
+    ruleId: input.ruleId ?? "R-1",
+    ruleText: input.ruleText,
+    ruleTags: input.ruleTags ?? [],
+    expectedEvidenceTypes: input.expectedEvidenceTypes ?? [],
+    linkedEvidence: input.linkedEvidence ?? [],
+    documentSupport: input.documentSupport ?? [],
+    stacSupportState: null,
+  });
+}
+
+describe("buildReviewSuggestion", () => {
+  it("suggests the best matching baseline fragment from rule text", () => {
+    const suggestion = buildSuggestion({
+      ruleText: "Baseline land use must be documented for the without-project scenario.",
+      ruleTags: ["baseline", "land-use"],
+      expectedEvidenceTypes: ["pdd"],
+      linkedEvidence: [
+        {
+          id: "ev-boundary",
+          title: "Boundary map",
+          type: "GIS map evidence",
+          source: "inventory",
+        },
+      ],
+      documentSupport: [
+        {
+          id: "frag-baseline",
+          kind: "pdd_excerpt",
+          source: "project-design.pdf",
+          title: "B.4 Baseline scenario",
+          provenance: "project-design.pdf · B.4 Baseline scenario · p. 14",
+          excerpt: "Baseline land use is cropland in the without-project case.",
+          ruleLinked: true,
+        },
+        {
+          id: "frag-monitoring",
+          kind: "pdd_excerpt",
+          source: "project-design.pdf",
+          title: "D.1 Monitoring plan",
+          provenance: "project-design.pdf · D.1 Monitoring plan · p. 40",
+          excerpt: "Monitoring variables are described here.",
+          ruleLinked: true,
+        },
+      ],
+    });
+
+    expect(suggestion.suggestedFragment?.label).toBe("B.4 Baseline scenario");
+    expect(suggestion.reason).toContain("baseline");
+  });
+
+  it("surfaces expected evidence gaps clearly", () => {
+    const suggestion = buildSuggestion({
+      ruleText: "Monitoring parameters must be evidenced with a report and workbook.",
+      ruleTags: ["monitoring", "workbook"],
+      expectedEvidenceTypes: ["monitoring-report", "spreadsheet-workbook"],
+      linkedEvidence: [
+        {
+          id: "ev-report",
+          title: "Monitoring report",
+          type: "monitoring-report",
+          source: "inventory",
+        },
+      ],
+    });
+
+    expect(suggestion.suggestedOutcome).toBe("partial");
+    expect(suggestion.missingExpectedEvidence).toEqual(["Spreadsheet workbook"]);
+  });
+
+  it("keeps weak PDD-only evidence as partial instead of supported", () => {
+    const suggestion = buildSuggestion({
+      ruleText: "Monitoring variables must be recorded in the workbook for each sampling period.",
+      ruleTags: ["monitoring", "workbook"],
+      expectedEvidenceTypes: ["spreadsheet-workbook"],
+      linkedEvidence: [
+        {
+          id: "ev-pdd-frag",
+          title: "D.1 Monitoring plan",
+          type: "PDD",
+          source: "inventory",
+          evidenceId: "ev-pdd",
+          fragmentId: "frag-d1",
+          fragmentLabel: "D.1 Monitoring plan",
+          documentLabel: "project-design.pdf",
+          provenanceSummary: "project-design.pdf • D.1 Monitoring plan • p. 37",
+          excerpt: "The monitoring plan describes variables and reporting frequency.",
+        },
+      ],
+    });
+
+    expect(suggestion.suggestedOutcome).toBe("partial");
+    expect(suggestion.mappedReviewStatus).toBe("needs_followup");
+    expect(suggestion.whyThisJudgment).toContain("still incomplete");
+  });
+
+  it("handles R-1-0007 uncertainty rules conservatively when only the monitoring plan exists", () => {
+    const suggestion = buildSuggestion({
+      ruleId: "R-1-0007",
+      ruleText: "Sampling uncertainty kept below 10% at 90% confidence or conservatively adjusted using Tool 12.",
+      ruleTags: ["uncertainty", "monitoring", "sampling"],
+      expectedEvidenceTypes: ["monitoring-report", "calculation-support", "spreadsheet-workbook"],
+      linkedEvidence: [
+        {
+          id: "ev-pdd-frag",
+          title: "D.1 Monitoring plan",
+          type: "PDD",
+          source: "inventory",
+          evidenceId: "ev-pdd",
+          fragmentId: "frag-d1",
+          fragmentLabel: "D.1 Monitoring plan",
+          documentLabel: "project-design.pdf",
+          provenanceSummary: "project-design.pdf • D.1 Monitoring plan • p. 37",
+          sectionHeading: "Monitoring plan",
+          excerpt: "Sampling procedures and monitoring variables are described for the reporting period.",
+        },
+      ],
+      documentSupport: [
+        {
+          id: "frag-d1",
+          kind: "pdd_excerpt",
+          source: "project-design.pdf",
+          title: "D.1 Monitoring plan",
+          provenance: "project-design.pdf · D.1 Monitoring plan · p. 37",
+          excerpt: "Sampling procedures and monitoring variables are described for the reporting period.",
+          ruleLinked: true,
+        },
+      ],
+    });
+
+    expect(suggestion.suggestedOutcome).toBe("partial");
+    expect(suggestion.suggestedFragment?.label).toBe("D.1 Monitoring plan");
+    expect(suggestion.missingExpectedEvidence).toEqual(
+      expect.arrayContaining([
+        "90% confidence result",
+        "Tool 12 deduction record, if threshold exceeded",
+        "Spreadsheet workbook",
+        "uncertainty worksheet",
+        "sampling calculation",
+      ]),
+    );
+    expect(suggestion.whyThisJudgment).toContain("does not prove the uncertainty calculation");
+  });
+});


### PR DESCRIPTION
## What changed
- add a rule review suggestion engine that scores rule intent against linked fragments, evidence attachments, expected evidence metadata, and support context
- add a `Suggested review` panel inside the existing rule review flow
- let reviewers accept the suggestion to populate the current review fields, edit it before saving, or dismiss it and proceed manually
- add conservative uncertainty handling for rules like `R-1-0007` so monitoring-plan-only evidence stays `Partial`/follow-up instead of becoming fully supported
- add targeted tests for suggestion selection, gap detection, weak-evidence downgrades, the uncertainty case, and the reviewer-accept flow

## Why
Reviewers currently have to infer the likely fragment, evidence item, missing expected evidence, and outcome manually for each rule. This change reduces that guessing while preserving the review boundary: machine suggestions can help draft the judgment, but they do not become review state until a human explicitly accepts/edits and saves.

## Reviewer impact
- selecting a rule now shows a suggested review panel with:
  - suggested outcome
  - suggested fragment
  - suggested evidence attachment
  - missing expected evidence
  - draft why-this-judgment text
  - draft supporting trace
  - reason for the suggestion
- `Accept suggestion` and `Edit before saving` populate the existing review fields
- dismissing the suggestion keeps the reviewer on a manual path
- finalize/export behavior remains tied to saved reviewer-confirmed review records only

## Root cause addressed
The existing flow had rule review storage and finalize gating, but no structured copilot layer to connect rule intent to the most relevant support already in the workspace. As a result, the UI offered support context but not a concrete, review-safe recommendation.

## Validation
- `npm test -- --runTestsByPath tests/lib/reviewSuggestion.test.ts tests/components/ruleReviewPanel.test.tsx tests/lib/reviewStore.test.ts tests/lib/finalizedExport.test.ts`
- `npm run typecheck`
- pre-push hooks also reran `npm run lint` and `npm run typecheck`

## Notes
- suggestions are computed-only UI state until the reviewer saves a review
- unaccepted suggestions are not exported as final review judgments
- this PR is scoped to the current rule review surface; it does not add a separate product surface