### PR TITLE
[codex] Link projects to methodology review workspaces

### DIFF
--- a/src/app/api/exports/audit-pack/route.ts
+++ b/src/app/api/exports/audit-pack/route.ts
@@ -71,8 +71,12 @@ export async function POST(req: Request) {
     const evidencePins = Array.isArray(record.evidencePins) ? (record.evidencePins as EvidencePin[]) : [];
     const sourceFiles = Array.isArray(record.sourceFiles) ? record.sourceFiles : [];
     const currentReview = asCurrentMethodReviewInput(record.currentReview);
+    const projectContext =
+      record.projectContext && typeof record.projectContext === "object" && !Array.isArray(record.projectContext)
+        ? record.projectContext
+        : null;
     const zip = buildAuditPackZip(method, version, {
-      finalizedReview: artifact ? { artifact, evidencePins, sourceFiles } : null,
+      finalizedReview: artifact ? { artifact, evidencePins, sourceFiles, projectContext } : null,
       currentReview: artifact ? null : currentReview,
     });
     return new Response(zip, {

--- a/src/app/m/_components/MethodCard.tsx
+++ b/src/app/m/_components/MethodCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
 
@@ -13,7 +13,9 @@ type MethodCardProps = {
 
 export default function MethodCard({ method, active, sourceAudited }: MethodCardProps) {
   const router = useRouter();
-  const href = `/m/${encodeURIComponent(method.code)}`;
+  const searchParams = useSearchParams();
+  const search = searchParams.toString();
+  const href = `/m/${encodeURIComponent(method.code)}${search ? `?${search}` : ""}`;
   const handleMouseEnter = useCallback(() => { router.prefetch(href); }, [router, href]);
 
   return (

--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -63,6 +63,14 @@ import { getReviewProgress, REVIEW_STORE_EVENT, type ReviewProgress } from "@/li
 import { deriveDocumentSupport } from "@/lib/verify/documentSupport";
 import { buildStacSupportFactsState } from "@/lib/verify/stacSupportFacts";
 import { isSourceAuditedMeta, metaUrlFromRulesPath } from "@/lib/methodBadge";
+import { getProject, updateProject } from "@/lib/projects/storage";
+import type { Project } from "@/lib/projects/types";
+import {
+  ensureReviewWorkspace,
+  getReviewWorkspace,
+  touchReviewWorkspace,
+} from "@/lib/reviewWorkspaces/storage";
+import type { ReviewWorkspace } from "@/lib/reviewWorkspaces/types";
 
 type MethodDetail = {
   code: string;
@@ -134,8 +142,12 @@ export default function MethodDetailPane({
   const isEvidenceMode = mode === "evidence" || isEvidenceRoute;
   const methodsLayout = useMethodsLayout();
   const verifierMode = useMemo(() => isVerifierMode(searchParams), [searchParams]);
+  const linkedProjectId = useMemo(() => (searchParams.get("projectId") ?? "").trim() || null, [searchParams]);
+  const linkedWorkspaceId = useMemo(() => (searchParams.get("workspaceId") ?? "").trim() || null, [searchParams]);
   const urlVerifyMode = useMemo(() => getVerifyView(new URLSearchParams(searchString)), [searchString]);
   const [verifyViewMode, setVerifyViewMode] = useState<"list" | "map">(urlVerifyMode);
+  const [linkedProject, setLinkedProject] = useState<Project | null>(null);
+  const [reviewWorkspace, setReviewWorkspace] = useState<ReviewWorkspace | null>(null);
 
   const metaUrl = useMemo(() => metaUrlFromRulesPath(manifestRulesPath), [manifestRulesPath]);
   const [sourceAudited, setSourceAudited] = useState(false);
@@ -350,6 +362,7 @@ export default function MethodDetailPane({
   const [stacEvidenceByKey, setStacEvidenceByKey] = useState<Record<string, StacEvidenceState>>({});
   const [selectedStacItemId, setSelectedStacItemId] = useState<string | null>(null);
   const [coverageDrawerOpen, setCoverageDrawerOpen] = useState(false);
+  const workspaceScopeId = reviewWorkspace?.id ?? linkedWorkspaceId ?? null;
 
   const lineageVersions = method.lineage?.lineage?.length ? method.lineage.lineage : method.versions;
   const versionBadges = [
@@ -479,18 +492,83 @@ export default function MethodDetailPane({
   );
 
   useEffect(() => {
+    setLinkedProject(linkedProjectId ? getProject(linkedProjectId) ?? null : null);
+  }, [linkedProjectId]);
+
+  useEffect(() => {
+    setReviewWorkspace(linkedWorkspaceId ? getReviewWorkspace(linkedWorkspaceId) ?? null : null);
+  }, [linkedWorkspaceId]);
+
+  useEffect(() => {
+    if (!linkedProjectId || !activeVersion) return;
+    const project = getProject(linkedProjectId);
+    if (!project) return;
+    const currentWorkspace = linkedWorkspaceId ? getReviewWorkspace(linkedWorkspaceId) ?? null : null;
+    if (
+      currentWorkspace &&
+      currentWorkspace.projectId === linkedProjectId &&
+      currentWorkspace.methodCode === method.code &&
+      currentWorkspace.methodVersion === activeVersion
+    ) {
+      setLinkedProject(project);
+      setReviewWorkspace(touchReviewWorkspace(currentWorkspace.id) ?? currentWorkspace);
+      if (
+        project.lastWorkspaceId !== currentWorkspace.id ||
+        project.methodCode !== method.code ||
+        project.methodVersion !== activeVersion
+      ) {
+        setLinkedProject(
+          updateProject(project.id, {
+            methodCode: method.code,
+            methodVersion: activeVersion,
+            reportingPeriod: currentWorkspace.reportingPeriod ?? project.reportingPeriod,
+            lastWorkspaceId: currentWorkspace.id,
+          }) ?? project,
+        );
+      }
+      return;
+    }
+
+    const ensuredWorkspace = ensureReviewWorkspace({
+      projectId: project.id,
+      projectName: project.name,
+      projectCode: project.projectCode,
+      methodCode: method.code,
+      methodVersion: activeVersion,
+      reportingPeriod: project.reportingPeriod,
+    });
+    const updatedProject =
+      updateProject(project.id, {
+        methodCode: method.code,
+        methodVersion: activeVersion,
+        reportingPeriod: ensuredWorkspace.reportingPeriod ?? project.reportingPeriod,
+        lastWorkspaceId: ensuredWorkspace.id,
+      }) ?? project;
+    setLinkedProject(updatedProject);
+    setReviewWorkspace(ensuredWorkspace);
+    if (!pathname) return;
+    const params = new URLSearchParams(searchString);
+    params.set("projectId", project.id);
+    if (params.get("workspaceId") !== ensuredWorkspace.id) {
+      params.set("workspaceId", ensuredWorkspace.id);
+      const next = params.toString();
+      router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
+    }
+  }, [activeVersion, linkedProjectId, linkedWorkspaceId, method.code, pathname, router, searchString]);
+
+  useEffect(() => {
     if (!activeVersion) {
       setReviewProgress(null);
       return;
     }
     const updateProgress = () => {
-      setReviewProgress(getReviewProgress(method.code, activeVersion, requirementRows.length));
+      setReviewProgress(getReviewProgress(method.code, activeVersion, requirementRows.length, workspaceScopeId));
     };
     updateProgress();
     const handleReviewStoreChange = () => updateProgress();
     window.addEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
     return () => window.removeEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
-  }, [activeVersion, method.code, requirementRows.length]);
+  }, [activeVersion, method.code, requirementRows.length, workspaceScopeId]);
 
   useEffect(() => {
     setRules([]);
@@ -541,30 +619,30 @@ export default function MethodDetailPane({
 
   useEffect(() => {
     if (!activeVersion) return;
-    setCurrentAoi(loadAoi(method.code, activeVersion));
-    setDraftAoi(loadDraftAoi(method.code, activeVersion));
-    setEvidencePins(coalesceEvidencePins(loadPins(method.code, activeVersion)));
-    setEvidenceSnapshots(loadEvidenceSnapshots(method.code, activeVersion));
-    setVerificationRuns(loadVerificationRuns(method.code, activeVersion));
+    setCurrentAoi(loadAoi(method.code, activeVersion, workspaceScopeId));
+    setDraftAoi(loadDraftAoi(method.code, activeVersion, workspaceScopeId));
+    setEvidencePins(coalesceEvidencePins(loadPins(method.code, activeVersion, workspaceScopeId)));
+    setEvidenceSnapshots(loadEvidenceSnapshots(method.code, activeVersion, workspaceScopeId));
+    setVerificationRuns(loadVerificationRuns(method.code, activeVersion, workspaceScopeId));
     setUndoSnapshot(null);
-  }, [activeVersion, method.code]);
+  }, [activeVersion, method.code, workspaceScopeId]);
 
   const setCurrentAoiAndPersist = useCallback(
     (nextAoi: AOI | null) => {
       setCurrentAoi(nextAoi);
       if (!activeVersion) return;
-      saveAoi(method.code, activeVersion, nextAoi);
+      saveAoi(method.code, activeVersion, nextAoi, workspaceScopeId);
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, workspaceScopeId],
   );
 
   const setDraftAoiAndPersist = useCallback(
     (nextAoi: AOI | null) => {
       setDraftAoi(nextAoi);
       if (!activeVersion) return;
-      saveDraftAoi(method.code, activeVersion, nextAoi);
+      saveDraftAoi(method.code, activeVersion, nextAoi, workspaceScopeId);
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, workspaceScopeId],
   );
 
   const setActiveAoiAndPersist = useCallback(
@@ -583,11 +661,11 @@ export default function MethodDetailPane({
       setEvidencePins((current) => {
         const resolved = typeof nextPins === "function" ? nextPins(current) : nextPins;
         const normalizedPins = coalesceEvidencePins(resolved);
-        if (activeVersion) savePins(method.code, activeVersion, normalizedPins);
+        if (activeVersion) savePins(method.code, activeVersion, normalizedPins, workspaceScopeId);
         return normalizedPins;
       });
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, workspaceScopeId],
   );
   const handleLinkInventoryItem = useCallback(
     (evidenceId: string, ruleId: string, fragmentId?: string) => {
@@ -614,18 +692,18 @@ export default function MethodDetailPane({
     (nextSnapshots: ProofEvidenceItem[]) => {
       setEvidenceSnapshots(nextSnapshots);
       if (!activeVersion) return;
-      saveEvidenceSnapshots(method.code, activeVersion, nextSnapshots);
+      saveEvidenceSnapshots(method.code, activeVersion, nextSnapshots, workspaceScopeId);
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, workspaceScopeId],
   );
 
   const setVerificationRunsAndPersist = useCallback(
     (nextRuns: VerificationRun[]) => {
       setVerificationRuns(nextRuns);
       if (!activeVersion) return;
-      saveVerificationRuns(method.code, activeVersion, nextRuns);
+      saveVerificationRuns(method.code, activeVersion, nextRuns, workspaceScopeId);
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, workspaceScopeId],
   );
 
   const hasWorkspaceState = Boolean(
@@ -734,7 +812,7 @@ export default function MethodDetailPane({
 
   const startOverProofMap = useCallback(() => {
     if (!activeVersion) return;
-    clearProofMapStorage(method.code, activeVersion);
+    clearProofMapStorage(method.code, activeVersion, workspaceScopeId);
     clearStoredMapView(`${method.code}@${activeVersion}`);
 
     setCurrentAoi(null);
@@ -755,16 +833,16 @@ export default function MethodDetailPane({
       }
       return next;
     });
-  }, [activeVersion, method.code]);
+  }, [activeVersion, method.code, workspaceScopeId]);
 
   const refreshProofMapFromStorage = useCallback(() => {
     if (!activeVersion) return;
-    setCurrentAoi(loadAoi(method.code, activeVersion));
-    setDraftAoi(loadDraftAoi(method.code, activeVersion));
-    setEvidencePins(coalesceEvidencePins(loadPins(method.code, activeVersion)));
-    setEvidenceSnapshots(loadEvidenceSnapshots(method.code, activeVersion));
-    setVerificationRuns(loadVerificationRuns(method.code, activeVersion));
-  }, [activeVersion, method.code]);
+    setCurrentAoi(loadAoi(method.code, activeVersion, workspaceScopeId));
+    setDraftAoi(loadDraftAoi(method.code, activeVersion, workspaceScopeId));
+    setEvidencePins(coalesceEvidencePins(loadPins(method.code, activeVersion, workspaceScopeId)));
+    setEvidenceSnapshots(loadEvidenceSnapshots(method.code, activeVersion, workspaceScopeId));
+    setVerificationRuns(loadVerificationRuns(method.code, activeVersion, workspaceScopeId));
+  }, [activeVersion, method.code, workspaceScopeId]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -906,7 +984,7 @@ export default function MethodDetailPane({
       const origin = typeof window !== "undefined" ? window.location.origin : "";
       const path = `/m/${encodeURIComponent(method.code)}/v/${encodeURIComponent(activeVersion ?? "")}`;
       const { tab, rule, section, hash } = encodeShareState({ tab: "rules", rule: ruleId });
-      const params = new URLSearchParams();
+      const params = new URLSearchParams(searchString);
       if (tab) params.set("tab", tab);
       if (rule) params.set("rule", rule);
       if (section) params.set("section", section);
@@ -914,7 +992,7 @@ export default function MethodDetailPane({
       const suffix = `${query ? `?${query}` : ""}${hash ? `#${hash}` : ""}`;
       return `${origin}${path}${suffix}`;
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, searchString],
   );
 
   const loadRuleDetail = useCallback(async (ruleId: string) => {
@@ -1308,6 +1386,9 @@ export default function MethodDetailPane({
     <ProofMapTab
       methodCode={method.code}
       version={activeVersion ?? ""}
+      workspaceId={workspaceScopeId}
+      linkedProject={linkedProject}
+      reviewWorkspace={reviewWorkspace}
       provenanceJson={provenanceJson}
       mode={isEvidenceMode ? "evidence" : undefined}
       viewMode={verifyViewMode}
@@ -1380,6 +1461,69 @@ export default function MethodDetailPane({
 
   const verifySurface = (
     <div className="mt-4 grid gap-4">
+      <section className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Project</div>
+              <div className="mt-1 text-sm font-semibold text-slate-900">
+                {linkedProject?.name ?? "Unlinked method-only review"}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Project ID</div>
+              <div className="mt-1 text-sm text-slate-700">
+                {linkedProject?.projectCode ?? linkedProject?.id ?? "Missing"}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Methodology</div>
+              <div className="mt-1 text-sm text-slate-700">
+                {activeVersion ? `${method.code} ${activeVersion}` : "Select a version"}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Reporting period</div>
+              <div className="mt-1 text-sm text-slate-700">
+                {reviewWorkspace?.reportingPeriod ?? linkedProject?.reportingPeriod ?? "Not set"}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Workspace</div>
+              <div className="mt-1 text-sm text-slate-700">
+                {reviewWorkspace?.name ?? (linkedProject ? "Will be created on method selection" : "Draft / incomplete")}
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href={linkedProject ? "/projects" : "/projects/new"}
+              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
+            >
+              Change project
+            </Link>
+            <Link
+              href={linkedProjectId ? `/m?projectId=${encodeURIComponent(linkedProjectId)}` : "/m"}
+              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
+            >
+              Change methodology/version
+            </Link>
+            {linkedProject ? (
+              <Link
+                href={`/projects/${encodeURIComponent(linkedProject.id)}`}
+                className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
+              >
+                Edit project details
+              </Link>
+            ) : null}
+          </div>
+        </div>
+        {!linkedProject ? (
+          <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+            This verify flow is running without a linked project. Exports remain draft/incomplete and finalization will stay blocked until a project is linked.
+          </div>
+        ) : null}
+      </section>
       <VerifyHeader
         mode={verifyViewMode}
         verifierMode={verifierMode}
@@ -1433,12 +1577,27 @@ export default function MethodDetailPane({
         <TrustStrip
           methodCode={method.code}
           version={activeVersion}
+          workspaceId={workspaceScopeId}
           packTag={packTag}
           provenanceJson={provenanceJson}
           manifestRulesPath={manifestRulesPath}
           onOpenIntegrityDiff={() => setIntegrityDiffOpen(true)}
           surface="methods"
           methodReviewEvidencePins={evidencePins}
+          projectContext={
+            linkedProject
+              ? {
+                  projectId: linkedProject.id,
+                  projectName: linkedProject.name,
+                  projectCode: linkedProject.projectCode ?? null,
+                  countryLocation: linkedProject.countryLocation ?? null,
+                  proponent: linkedProject.proponent ?? null,
+                  reportingPeriod: reviewWorkspace?.reportingPeriod ?? linkedProject.reportingPeriod ?? null,
+                  workspaceId: workspaceScopeId,
+                  workspaceName: reviewWorkspace?.name ?? null,
+                }
+              : null
+          }
         />
       </div>
 
@@ -1488,6 +1647,7 @@ export default function MethodDetailPane({
         methodologyLabel={`${method.program} ${method.sector} · ${method.code} · ${activeVersion ?? "unknown version"}`}
         reviewMethodology={method.code}
         reviewVersion={activeVersion ?? null}
+        reviewWorkspaceId={workspaceScopeId}
         sourcePath={ruleDetail?.sourcePath ?? null}
         sha256={ruleDetail?.sha256 ?? null}
         ruleTags={activeRequirementRow?.ruleSummary.tags ?? []}

--- a/src/app/m/_components/RuleDetailModal.tsx
+++ b/src/app/m/_components/RuleDetailModal.tsx
@@ -39,6 +39,7 @@ type RuleDetailModalProps = {
   methodologyLabel?: string | null;
   reviewMethodology?: string | null;
   reviewVersion?: string | null;
+  reviewWorkspaceId?: string | null;
   sourcePath?: string | null;
   sha256?: string | null;
   traceSections?: Array<{
@@ -122,6 +123,7 @@ function resolveRuleReviewReviewerArtifact(input: {
   canonicalRuleId?: string | null;
   reviewMethodology?: string | null;
   reviewVersion?: string | null;
+  reviewWorkspaceId?: string | null;
   reviewerMinutes?: string | null;
   reviewerOutcomeNote?: string | null;
 }): { reviewerMinutes: string | null; reviewerOutcomeNote: string | null } {
@@ -135,11 +137,12 @@ function resolveRuleReviewReviewerArtifact(input: {
 
   const methodCode = input.reviewMethodology?.trim() ?? "";
   const version = input.reviewVersion?.trim() ?? "";
+  const workspaceId = input.reviewWorkspaceId?.trim() ?? "";
   if (!methodCode || !version) {
     return { reviewerMinutes: null, reviewerOutcomeNote: null };
   }
 
-  const bundle = readVerifierRunBundle(methodCode, version);
+  const bundle = readVerifierRunBundle(methodCode, version, workspaceId);
   if (!bundle.savedReviewerArtifactAt || !bundle.savedReviewerArtifactContext) {
     return { reviewerMinutes: null, reviewerOutcomeNote: null };
   }
@@ -185,6 +188,7 @@ export default function RuleDetailModal({
   methodologyLabel,
   reviewMethodology,
   reviewVersion,
+  reviewWorkspaceId = null,
   sourcePath,
   sha256,
   traceSections = [],
@@ -216,9 +220,9 @@ export default function RuleDetailModal({
       setReviewOpen(false);
       return;
     }
-    setExistingReview(getReview(canonicalRuleId, reviewMethodology, reviewVersion));
+    setExistingReview(getReview(canonicalRuleId, reviewMethodology, reviewVersion, reviewWorkspaceId));
     setReviewOpen(false);
-  }, [canonicalRuleId, open, reviewMethodology, reviewVersion]);
+  }, [canonicalRuleId, open, reviewMethodology, reviewVersion, reviewWorkspaceId]);
 
   const handleSaveReview = useCallback(
     (review: RuleReview) => {
@@ -303,6 +307,7 @@ export default function RuleDetailModal({
     canonicalRuleId,
     reviewMethodology,
     reviewVersion,
+    reviewWorkspaceId,
     reviewerMinutes,
     reviewerOutcomeNote,
   });
@@ -387,6 +392,7 @@ export default function RuleDetailModal({
               sectionId={row.provenance.sectionId ?? undefined}
               methodology={reviewMethodologyValue}
               version={reviewVersionValue}
+              workspaceId={reviewWorkspaceId}
               anchorUrl={row.provenance.anchor ?? undefined}
               existingReview={existingReview}
               linkedEvidence={row.linkedEvidence.map((item) => ({

--- a/src/app/m/_components/VersionSelector.tsx
+++ b/src/app/m/_components/VersionSelector.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import type { MethodVersionLineage } from "@/app/m/_lib/methodVersionMetadata";
 
 type VersionSelectorProps = {
@@ -19,7 +19,12 @@ export default function VersionSelector({
   lineage,
 }: VersionSelectorProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const value = selectedVersion ?? "";
+  const search = searchParams.toString();
+
+  const buildHref = (version: string) =>
+    `/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(version)}${search ? `?${search}` : ""}`;
 
   const options = useMemo(() => {
     return versions.map((version) => {
@@ -49,7 +54,7 @@ export default function VersionSelector({
           onChange={(event) => {
             const next = event.target.value;
             if (!next) return;
-            router.push(`/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(next)}`);
+            router.push(buildHref(next));
           }}
         >
           <option value="" disabled>
@@ -69,7 +74,7 @@ export default function VersionSelector({
             return (
               <Link
                 key={version}
-                href={`/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(version)}`}
+                href={buildHref(version)}
                 className={`rounded-full border px-2.5 py-1 font-semibold ${
                   active
                     ? "border-sky-300 bg-sky-50 text-sky-700"

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -3037,6 +3037,7 @@ export default function ProofMapTab({
         createReviewerArtifactContext({
           methodCode,
           version,
+          workspaceId,
           ruleId: savedReviewerRuleId,
           runId: verifierBundle.runContext.runId,
         }),
@@ -3098,6 +3099,7 @@ export default function ProofMapTab({
     verifierBundle.savedReviewerArtifactAt,
     verifierBundle.savedReviewerArtifactContext,
     version,
+    workspaceId,
   ]);
 
   const buildClientReadinessReportPayload = useCallback(async () => {

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -86,6 +86,8 @@ import {
 } from "@/lib/verify/runState";
 import ProofCoverageChip from "@/components/verify/ProofCoverageChip";
 import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
+import type { Project } from "@/lib/projects/types";
+import type { ReviewWorkspace } from "@/lib/reviewWorkspaces/types";
 
 type ToastState = {
   title: string;
@@ -95,6 +97,9 @@ type ToastState = {
 type ProofMapTabProps = {
   methodCode: string;
   version: string;
+  workspaceId?: string | null;
+  linkedProject?: Project | null;
+  reviewWorkspace?: ReviewWorkspace | null;
   provenanceJson?: unknown | null;
   mode?: "explorer" | "evidence";
   viewMode?: "list" | "map";
@@ -421,6 +426,9 @@ function statusPill(status: VerificationRun["status"]): { label: string; classNa
 export default function ProofMapTab({
   methodCode,
   version,
+  workspaceId = null,
+  linkedProject = null,
+  reviewWorkspace = null,
   provenanceJson,
   mode = "explorer",
   viewMode = "map",
@@ -481,8 +489,8 @@ export default function ProofMapTab({
   const [startOverOpen, setStartOverOpen] = useState(false);
   const [startOverBusy, setStartOverBusy] = useState(false);
   const [panelCollapsed, setPanelCollapsed] = useState(false);
-  const [verifierBundle, setVerifierBundle] = useState(() => readVerifierRunBundle(methodCode, version));
-  const [runHistory, setRunHistory] = useState(() => readRunHistory(methodCode, version));
+  const [verifierBundle, setVerifierBundle] = useState(() => readVerifierRunBundle(methodCode, version, workspaceId));
+  const [runHistory, setRunHistory] = useState(() => readRunHistory(methodCode, version, workspaceId));
   const [baselineTick, setBaselineTick] = useState(0);
   const [currentInputFingerprint, setCurrentInputFingerprint] = useState<string | null>(null);
   const [secondarySectionOpen, setSecondarySectionOpen] = useState(false);
@@ -655,29 +663,30 @@ export default function ProofMapTab({
   }, [fetchSelectedRuleContext, selectedRuleId]);
 
   useEffect(() => {
-    setVerifierBundle(readVerifierRunBundle(methodCode, version));
-  }, [methodCode, version]);
+    setVerifierBundle(readVerifierRunBundle(methodCode, version, workspaceId));
+  }, [methodCode, version, workspaceId]);
 
   useEffect(() => {
-    setRunHistory(readRunHistory(methodCode, version));
-  }, [methodCode, version]);
+    setRunHistory(readRunHistory(methodCode, version, workspaceId));
+  }, [methodCode, version, workspaceId]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      persistVerifierRunBundle(methodCode, version, verifierBundle);
+      persistVerifierRunBundle(methodCode, version, verifierBundle, workspaceId);
     }, 300);
     return () => window.clearTimeout(timer);
-  }, [methodCode, verifierBundle, version]);
+  }, [methodCode, verifierBundle, version, workspaceId]);
 
   const currentReviewerContext = useMemo(
     () =>
       createReviewerArtifactContext({
         methodCode,
         version,
+        workspaceId,
         ruleId: selectedRuleId,
         runId: verifierBundle.runContext.runId,
       }),
-    [methodCode, selectedRuleId, verifierBundle.runContext.runId, version],
+    [methodCode, selectedRuleId, verifierBundle.runContext.runId, version, workspaceId],
   );
 
   useEffect(() => {
@@ -1003,7 +1012,7 @@ export default function ProofMapTab({
       historicalCurrent && canonicalJsonStringify(historicalCurrent.bundle) !== canonicalJsonStringify(currentWorkspaceBundle)
         ? {
             ...currentWorkspaceBundle,
-            runContext: createVerifierRunBundle(methodCode, version).runContext,
+            runContext: createVerifierRunBundle(methodCode, version, workspaceId).runContext,
           }
         : currentWorkspaceBundle;
     setVerifierBundle((current) =>
@@ -1011,16 +1020,16 @@ export default function ProofMapTab({
         ? current
         : { ...current, runContext: draftBundle.runContext },
     );
-    setRunHistory(saveCurrentRunToHistory(methodCode, version, draftBundle));
+    setRunHistory(saveCurrentRunToHistory(methodCode, version, draftBundle, workspaceId));
     return draftBundle.runContext.runId;
-  }, [currentWorkspaceBundle, methodCode, runHistory, verifierBundle.runContext.runId, version]);
+  }, [currentWorkspaceBundle, methodCode, runHistory, verifierBundle.runContext.runId, version, workspaceId]);
 
   const handleSaveRunHistory = useCallback(
     (bundleOverride?: ReturnType<typeof buildHistoryBundle>) => {
       const bundle = bundleOverride ?? buildHistoryBundle();
-      setRunHistory(saveCurrentRunToHistory(methodCode, version, bundle));
+      setRunHistory(saveCurrentRunToHistory(methodCode, version, bundle, workspaceId));
     },
-    [buildHistoryBundle, methodCode, version],
+    [buildHistoryBundle, methodCode, version, workspaceId],
   );
 
   const handleLoadRunHistory = useCallback(
@@ -1031,12 +1040,13 @@ export default function ProofMapTab({
         if (!confirmed) return;
         persistCurrentWorkspaceAsDraft();
       }
-      const loaded = loadRunFromHistory(methodCode, version, runId);
+      const loaded = loadRunFromHistory(methodCode, version, runId, workspaceId);
       if (!loaded) return;
-      const editableRun = createVerifierRunBundle(methodCode, version);
+      const editableRun = createVerifierRunBundle(methodCode, version, workspaceId);
       const loadedReviewerContext = createReviewerArtifactContext({
         methodCode,
         version,
+        workspaceId,
         ruleId: loaded.selectedRuleId ?? null,
         runId: editableRun.runContext.runId,
       });
@@ -1083,14 +1093,15 @@ export default function ProofMapTab({
       showToast,
       verifierBundle.runContext.runId,
       version,
+      workspaceId,
     ],
   );
 
   const handleDeleteRunHistory = useCallback(
     (runId: string) => {
-      setRunHistory(deleteRunFromHistory(methodCode, version, runId));
+      setRunHistory(deleteRunFromHistory(methodCode, version, runId, workspaceId));
     },
-    [methodCode, version],
+    [methodCode, version, workspaceId],
   );
 
   const handleSearchStac = useCallback(async () => {
@@ -1816,8 +1827,12 @@ export default function ProofMapTab({
     if (!totalRules || totalRules < 1) {
       return { canFinalize: false, reasons: ["Rule count unavailable for finalize gate."] };
     }
-    return checkFinalizeGate(methodCode, version, totalRules);
-  }, [methodCode, reviewGateVersion, totalRules, verifierMode, version]);
+    return checkFinalizeGate(methodCode, version, totalRules, {
+      workspaceId,
+      projectLinked: Boolean(linkedProject?.id),
+      methodologyLinked: Boolean(methodCode.trim() && version.trim()),
+    });
+  }, [linkedProject?.id, methodCode, reviewGateVersion, totalRules, verifierMode, version, workspaceId]);
   const selectedStacItemRecord = useMemo(() => {
     if (!selectedStacItemId) return null;
     const candidate = currentStacEvidence?.itemsById?.[selectedStacItemId];
@@ -3039,7 +3054,7 @@ export default function ProofMapTab({
       reviewerArtifactsByRuleId,
     });
 
-    const reviewsByRuleId = getAllReviews(methodCode, version);
+    const reviewsByRuleId = getAllReviews(methodCode, version, workspaceId);
 
     const suppliedDocuments = [...evidenceInventory]
       .filter((item) => item.kind !== "stac-item")
@@ -4781,6 +4796,20 @@ export default function ProofMapTab({
                 summary={activeReviewArtifact?.summary ?? reviewSummary}
                 artifact={activeReviewArtifact}
                 evidencePins={evidencePins}
+                projectContext={
+                  linkedProject
+                    ? {
+                        projectId: linkedProject.id,
+                        projectName: linkedProject.name,
+                        projectCode: linkedProject.projectCode ?? null,
+                        countryLocation: linkedProject.countryLocation ?? null,
+                        proponent: linkedProject.proponent ?? null,
+                        reportingPeriod: reviewWorkspace?.reportingPeriod ?? linkedProject.reportingPeriod ?? null,
+                        workspaceId: workspaceId,
+                        workspaceName: reviewWorkspace?.name ?? null,
+                      }
+                    : null
+                }
                 currentRunLabel={currentRunLabel}
                 loadedFromRunLabel={loadedFromRunLabel}
                 finalizedAt={verifierBundle.finalizedAt}

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -34,6 +34,10 @@ export default function NewProjectForm() {
   const [methods, setMethods] = useState<MethodOption[]>([]);
   const [reviewMode, setReviewMode] = useState<ProjectReviewMode>('methodology-linked');
   const [name, setName] = useState('');
+  const [projectCode, setProjectCode] = useState('');
+  const [countryLocation, setCountryLocation] = useState('');
+  const [proponent, setProponent] = useState('');
+  const [reportingPeriod, setReportingPeriod] = useState('');
   const [selectedMethod, setSelectedMethod] = useState('');
   const [aoiLabel, setAoiLabel] = useState('');
   const [description, setDescription] = useState('');
@@ -61,7 +65,11 @@ export default function NewProjectForm() {
       if (reviewMode === 'manual') {
         const project = createProject({
           name,
+          projectCode: projectCode || undefined,
+          countryLocation: countryLocation || undefined,
+          proponent: proponent || undefined,
           reviewMode,
+          reportingPeriod: reportingPeriod || undefined,
           aoiLabel: aoiLabel || undefined,
           description: description || undefined,
         });
@@ -85,11 +93,15 @@ export default function NewProjectForm() {
       const category = parts.length > 1 ? parts.slice(1).join('/') : undefined;
       const project = createProject({
         name,
+        projectCode: projectCode || undefined,
+        countryLocation: countryLocation || undefined,
+        proponent: proponent || undefined,
         reviewMode,
         methodCode: code,
         methodVersion: version,
         methodCategory: category,
         registry: projectRegistryFromMethodProgram(selectedMethodRecord?.program),
+        reportingPeriod: reportingPeriod || undefined,
         aoiLabel: aoiLabel || undefined,
         description: description || undefined,
         ruleIds: rules.map((r: { id: string; title: string; sectionId?: string }) => ({
@@ -164,6 +176,52 @@ export default function NewProjectForm() {
             className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
             required
           />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Project ID / Code</label>
+            <input
+              type="text"
+              value={projectCode}
+              onChange={e => setProjectCode(e.target.value)}
+              placeholder="e.g., VCS-1530"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Reporting Period</label>
+            <input
+              type="text"
+              value={reportingPeriod}
+              onChange={e => setReportingPeriod(e.target.value)}
+              placeholder="e.g., 2024-01-01 to 2024-12-31"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Country / Location</label>
+            <input
+              type="text"
+              value={countryLocation}
+              onChange={e => setCountryLocation(e.target.value)}
+              placeholder="e.g., Malawi"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Proponent</label>
+            <input
+              type="text"
+              value={proponent}
+              onChange={e => setProponent(e.target.value)}
+              placeholder="e.g., Article6 Climate"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
         </div>
 
         {reviewMode === 'methodology-linked' ? (

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -36,6 +36,7 @@ import {
   updateRuleReview,
 } from '@/lib/projects/storage';
 import { SnapshotTimeline } from '@/components/snapshot/SnapshotTimeline';
+import { listReviewWorkspacesForProject } from '@/lib/reviewWorkspaces/storage';
 
 type ProjectDetailProps = {
   projectId: string;
@@ -369,6 +370,10 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
     .find((document) => document.manualFindingExtractionStatus === 'no-findings' || document.manualFindingExtractionStatus === 'extraction-failed')
     ?.manualFindingExtractionMessage;
 
+  const latestWorkspace = project.reviewMode === 'methodology-linked'
+    ? listReviewWorkspacesForProject(project.id)[0] ?? null
+    : null;
+
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-12 md:px-8">
       <Link href="/projects" className="text-sm text-slate-500 hover:text-slate-700">
@@ -412,6 +417,24 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
         </div>
 
         <div className="flex items-center gap-2">
+          {project.reviewMode === 'methodology-linked' ? (
+            <>
+              <Link
+                href={`/m?projectId=${encodeURIComponent(project.id)}`}
+                className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+              >
+                Start review
+              </Link>
+              {latestWorkspace ? (
+                <Link
+                  href={`/m/${encodeURIComponent(latestWorkspace.methodCode)}/v/${encodeURIComponent(latestWorkspace.methodVersion)}?projectId=${encodeURIComponent(project.id)}&workspaceId=${encodeURIComponent(latestWorkspace.id)}&tab=verify`}
+                  className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800"
+                >
+                  Continue review
+                </Link>
+              ) : null}
+            </>
+          ) : null}
           {shouldShowLockReview(project, coverage) ? (
             <button
               onClick={handleLock}

--- a/src/components/projects/ProjectsList.tsx
+++ b/src/components/projects/ProjectsList.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import type { Project } from '@/lib/projects/types';
 import { listProjects, getProjectCoverage, deleteProject } from '@/lib/projects/storage';
+import { listReviewWorkspacesForProject } from '@/lib/reviewWorkspaces/storage';
 
 export default function ProjectsList() {
   const [projects, setProjects] = useState<Project[]>([]);
@@ -102,7 +103,31 @@ export default function ProjectsList() {
                 </div>
 
                 {project.status === 'in-progress' && (
-                  <div className="mt-3 flex justify-end">
+                  <div className="mt-3 flex items-center justify-between gap-3">
+                    <div className="flex flex-wrap gap-2">
+                      {project.reviewMode === 'methodology-linked' ? (
+                        <>
+                          <Link
+                            href={`/m?projectId=${encodeURIComponent(project.id)}`}
+                            className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+                          >
+                            Start review
+                          </Link>
+                          {(() => {
+                            const latestWorkspace = listReviewWorkspacesForProject(project.id)[0];
+                            if (!latestWorkspace) return null;
+                            return (
+                              <Link
+                                href={`/m/${encodeURIComponent(latestWorkspace.methodCode)}/v/${encodeURIComponent(latestWorkspace.methodVersion)}?projectId=${encodeURIComponent(project.id)}&workspaceId=${encodeURIComponent(latestWorkspace.id)}&tab=verify`}
+                                className="rounded-full bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-800"
+                              >
+                                Continue review
+                              </Link>
+                            );
+                          })()}
+                        </>
+                      ) : null}
+                    </div>
                     <button
                       onClick={() => handleDelete(project.id)}
                       className="text-xs text-red-400 hover:text-red-600"

--- a/src/components/trust/TrustStrip.tsx
+++ b/src/components/trust/TrustStrip.tsx
@@ -17,12 +17,23 @@ import { useRouter } from "next/navigation";
 type TrustStripProps = {
   methodCode?: string;
   version?: string;
+  workspaceId?: string | null;
   packTag?: string | null;
   provenanceJson?: unknown | null;
   manifestRulesPath?: string | null;
   onOpenIntegrityDiff?: () => void;
   surface?: "default" | "methods";
   methodReviewEvidencePins?: EvidencePin[];
+  projectContext?: {
+    projectId?: string | null;
+    projectName?: string | null;
+    projectCode?: string | null;
+    countryLocation?: string | null;
+    proponent?: string | null;
+    reportingPeriod?: string | null;
+    workspaceId?: string | null;
+    workspaceName?: string | null;
+  } | null;
 };
 
 type ExportArtifact = "provenance" | "META" | "rules" | "sections" | "rich";
@@ -121,11 +132,14 @@ function readLiveMethodReviewState(
   methodCode: string | undefined,
   version: string | undefined,
   evidencePins: EvidencePin[],
+  workspaceId?: string | null,
+  projectContext?: TrustStripProps["projectContext"],
 ): {
   latestReviewAt: string | null;
   reviews: RuleReview[];
   verifierBundle: VerifierRunBundle | null;
   evidencePins: EvidencePin[];
+  projectContext?: TrustStripProps["projectContext"];
 } {
   const normalizedMethod = methodCode?.trim() ?? "";
   const normalizedVersion = version?.trim() ?? "";
@@ -138,8 +152,8 @@ function readLiveMethodReviewState(
     };
   }
 
-  const reviews = Object.values(getAllReviews(normalizedMethod, normalizedVersion));
-  const verifierBundle = readVerifierRunBundle(normalizedMethod, normalizedVersion);
+  const reviews = Object.values(getAllReviews(normalizedMethod, normalizedVersion, workspaceId));
+  const verifierBundle = readVerifierRunBundle(normalizedMethod, normalizedVersion, workspaceId);
   const latestReviewAt = pickLatestTimestamp([
     ...reviews.flatMap((review) => [review.reviewedAt, review.updatedAt]),
     verifierBundle.savedReviewerArtifactAt,
@@ -151,6 +165,7 @@ function readLiveMethodReviewState(
     reviews,
     verifierBundle,
     evidencePins: [...evidencePins],
+    projectContext,
   };
 }
 
@@ -163,6 +178,11 @@ async function downloadBlob(blob: Blob, filename: string) {
   a.click();
   a.remove();
   URL.revokeObjectURL(url);
+}
+
+function safeFilenamePart(value: string | null | undefined): string {
+  const trimmed = (value ?? "").trim();
+  return trimmed ? trimmed.replace(/[^\w.\-]+/g, "_").slice(0, 64) : "";
 }
 
 function buildFilename(
@@ -260,12 +280,14 @@ function ChipButton({
 export default function TrustStrip({
   methodCode,
   version,
+  workspaceId = null,
   packTag,
   provenanceJson,
   manifestRulesPath,
   onOpenIntegrityDiff,
   surface = "default",
   methodReviewEvidencePins = [],
+  projectContext = null,
 }: TrustStripProps) {
   const router = useRouter();
   const provenancePicked = useMemo(() => pickProvenanceFields(provenanceJson), [provenanceJson]);
@@ -357,7 +379,7 @@ export default function TrustStrip({
     if (surface !== "methods") return;
     if (typeof window === "undefined") return;
     const update = () => {
-      const next = readLiveMethodReviewState(methodCode, version, methodReviewEvidencePins);
+      const next = readLiveMethodReviewState(methodCode, version, methodReviewEvidencePins, workspaceId, projectContext);
       setMethodReviewLastReviewedAt(next.latestReviewAt);
     };
     update();
@@ -369,7 +391,7 @@ export default function TrustStrip({
       window.removeEventListener(VERIFY_RUN_BUNDLE_EVENT, update);
       window.removeEventListener("proofbundle:imported", update);
     };
-  }, [methodCode, methodReviewEvidencePins, surface, version]);
+  }, [methodCode, methodReviewEvidencePins, projectContext, surface, version, workspaceId]);
 
   const audit = metaPicked.auditHashes;
 
@@ -433,7 +455,7 @@ export default function TrustStrip({
     setExportError(null);
     setExportingAuditPack(true);
     try {
-      const currentReview = readLiveMethodReviewState(methodCode, version, methodReviewEvidencePins);
+      const currentReview = readLiveMethodReviewState(methodCode, version, methodReviewEvidencePins, workspaceId, projectContext);
       const response = await fetch("/api/exports/audit-pack", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -448,14 +470,17 @@ export default function TrustStrip({
         throw new Error(message || `Export failed with ${response.status}`);
       }
       const blob = await response.blob();
-      await downloadBlob(blob, `audit-pack__${methodCode}__${version}.zip`);
+      const projectPart = safeFilenamePart(projectContext?.projectCode ?? projectContext?.projectId);
+      const workspacePart = safeFilenamePart(projectContext?.workspaceName ?? projectContext?.workspaceId);
+      const prefix = [projectPart, workspacePart].filter(Boolean).join("__");
+      await downloadBlob(blob, `audit-pack__${prefix ? `${prefix}__` : ""}${methodCode}__${version}.zip`);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : "Audit pack export failed.";
       setExportError(message);
     } finally {
       setExportingAuditPack(false);
     }
-  }, [methodCode, methodReviewEvidencePins, version]);
+  }, [methodCode, methodReviewEvidencePins, projectContext, version, workspaceId]);
 
   const showStrip = Boolean(methodCode || version || generatedAt || metaAvailable || rulesUrl || provenanceJson);
   if (!showStrip) return null;

--- a/src/components/verify/FinalReviewSummaryPanel.tsx
+++ b/src/components/verify/FinalReviewSummaryPanel.tsx
@@ -6,6 +6,7 @@ import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
 import type { EvidencePin } from "@/lib/proofMap/types";
 import type { ReviewSummary } from "@/lib/verify/buildReviewSummary";
 import type { VerifyWizardStepDetails } from "@/lib/verify/runState";
+import type { ReviewExportProjectContext } from "@/exports/verificationPackContract";
 
 type FinalReviewSummaryPanelProps = {
   summary: ReviewSummary;
@@ -16,6 +17,7 @@ type FinalReviewSummaryPanelProps = {
   reviewedRuleCount?: number | null;
   linkedEvidenceCount?: number | null;
   evidencePins?: EvidencePin[];
+  projectContext?: ReviewExportProjectContext | null;
   wizard: VerifyWizardStepDetails;
   onDownloadJson: () => void;
   onDownloadPdf: () => void;
@@ -42,6 +44,16 @@ function formatDate(value: string | null | undefined): string | null {
 function safeFilename(value: string | null | undefined): string {
   const trimmed = (value ?? "").trim() || "unknown";
   return trimmed.replace(/[^\w.\-]+/g, "_").slice(0, 64) || "unknown";
+}
+
+function exportContextFilenamePart(projectContext?: ReviewExportProjectContext | null): string {
+  const parts = [
+    projectContext?.projectCode ?? projectContext?.projectId ?? null,
+    projectContext?.workspaceName ?? projectContext?.workspaceId ?? null,
+  ]
+    .map((value) => safeFilename(value))
+    .filter((value) => value !== "unknown");
+  return parts.length ? `${parts.join(".")}.` : "";
 }
 
 function downloadBytes(bytes: Uint8Array, filename: string, mimeType: string) {
@@ -76,6 +88,7 @@ export default function FinalReviewSummaryPanel({
   reviewedRuleCount = null,
   linkedEvidenceCount = null,
   evidencePins = [],
+  projectContext = null,
   wizard,
   onDownloadJson,
   onDownloadPdf,
@@ -131,11 +144,15 @@ export default function FinalReviewSummaryPanel({
     const response = await fetch("/api/exports/audit-pack", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ method, version, artifact, evidencePins, sourceFiles }),
+      body: JSON.stringify({ method, version, artifact, evidencePins, sourceFiles, projectContext }),
     });
     if (!response.ok) throw new Error(await response.text());
     const bytes = new Uint8Array(await response.arrayBuffer());
-    downloadBytes(bytes, `audit-pack.${safeFilename(method)}.${safeFilename(version)}.${safeFilename(artifact.verifier?.runId)}.zip`, "application/zip");
+    downloadBytes(
+      bytes,
+      `audit-pack.${exportContextFilenamePart(projectContext)}${safeFilename(method)}.${safeFilename(version)}.${safeFilename(artifact.verifier?.runId)}.zip`,
+      "application/zip",
+    );
   };
 
   return (

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -214,6 +214,7 @@ export default function RuleReviewPanel({
     ruleId,
     methodology,
     version,
+    workspaceId,
     status,
     rationale,
     supportReference,
@@ -288,6 +289,7 @@ export default function RuleReviewPanel({
     supportReference,
     syncReview,
     version,
+    workspaceId,
   ]);
 
   const handleFileSelected = useCallback(
@@ -316,7 +318,7 @@ export default function RuleReviewPanel({
       syncReview(review);
       refreshAuditEvents();
     },
-    [actorLabel, methodology, refreshAuditEvents, ruleId, syncReview, version],
+    [actorLabel, methodology, refreshAuditEvents, ruleId, syncReview, version, workspaceId],
   );
 
   const applySuggestion = useCallback(

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -321,7 +321,7 @@ export default function RuleReviewPanel({
     [actorLabel, methodology, refreshAuditEvents, ruleId, syncReview, version, workspaceId],
   );
 
-  const applySuggestion = useCallback(
+  const applySuggestedReview = useCallback(
     (focusRationale: boolean) => {
       setStatus(suggestion.mappedReviewStatus);
       setRationale(suggestion.whyThisJudgment);
@@ -460,14 +460,14 @@ export default function RuleReviewPanel({
               <div className="mt-4 flex flex-wrap gap-2">
                 <button
                   type="button"
-                  onClick={() => applySuggestion(false)}
+                  onClick={() => applySuggestedReview(false)}
                   className="rounded-full border border-sky-700 bg-sky-700 px-4 py-2 text-xs font-semibold text-white hover:bg-sky-800"
                 >
                   Accept suggestion
                 </button>
                 <button
                   type="button"
-                  onClick={() => applySuggestion(true)}
+                  onClick={() => applySuggestedReview(true)}
                   className="rounded-full border border-sky-200 bg-white px-4 py-2 text-xs font-semibold text-sky-700 hover:border-sky-300"
                 >
                   Edit before saving

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -31,6 +31,7 @@ type RuleReviewPanelProps = {
   sectionId?: string;
   methodology: string;
   version: string;
+  workspaceId?: string | null;
   anchorUrl?: string;
   existingReview: RuleReview | null;
   linkedEvidence?: Array<{
@@ -69,6 +70,7 @@ export default function RuleReviewPanel({
   sectionId,
   methodology,
   version,
+  workspaceId = null,
   anchorUrl,
   existingReview,
   linkedEvidence = [],
@@ -186,6 +188,7 @@ export default function RuleReviewPanel({
       ruleId,
       methodology,
       version,
+      ...(workspaceId ? { workspaceId } : {}),
       status,
       rationale,
       supportReference,
@@ -232,6 +235,7 @@ export default function RuleReviewPanel({
         ruleId,
         methodology,
         version,
+        ...(workspaceId ? { workspaceId } : {}),
         status,
         rationale,
         supportReference,
@@ -249,7 +253,7 @@ export default function RuleReviewPanel({
       type: attachmentType,
       label: trimmedLabel,
       url: attachmentType === "url" ? trimmedUrl : undefined,
-    });
+    }, workspaceId);
     if (!review) return;
 
     logAuditEvent({
@@ -298,7 +302,7 @@ export default function RuleReviewPanel({
 
   const handleRemoveAttachment = useCallback(
     (attachment: EvidenceAttachment) => {
-      const review = removeEvidenceAttachment(ruleId, methodology, version, attachment.id);
+      const review = removeEvidenceAttachment(ruleId, methodology, version, attachment.id, workspaceId);
       if (!review) return;
       logAuditEvent({
         ruleId,

--- a/src/exports/verificationPackContract.ts
+++ b/src/exports/verificationPackContract.ts
@@ -30,10 +30,13 @@ type ProjectJson = {
   };
   project_context: {
     project_id: string;
+    project_name: string;
     export_id: string;
+    workspace_id: string;
     display_name: string;
     reporting_period: string;
     location: string;
+    proponent: string;
     description: string;
     placeholder: boolean;
     placeholder_reason: string;
@@ -239,6 +242,7 @@ const CURRENT_METHOD_REVIEW_REASON =
 export type FinalizedAuditPackReviewInput = {
   artifact?: EvidenceSnapshot | null;
   evidencePins?: EvidencePin[] | null;
+  projectContext?: ReviewExportProjectContext | null;
   sourceFiles?: Array<{
     evidence_ref: string;
     source_pin_id?: string | null;
@@ -250,11 +254,23 @@ export type FinalizedAuditPackReviewInput = {
   }> | null;
 };
 
+export type ReviewExportProjectContext = {
+  projectId?: string | null;
+  projectName?: string | null;
+  projectCode?: string | null;
+  countryLocation?: string | null;
+  proponent?: string | null;
+  reportingPeriod?: string | null;
+  workspaceId?: string | null;
+  workspaceName?: string | null;
+};
+
 export type CurrentMethodReviewExportInput = {
   latestReviewAt?: string | null;
   reviews?: RuleReview[] | null;
   verifierBundle?: Partial<VerifierRunBundle> | null;
   evidencePins?: EvidencePin[] | null;
+  projectContext?: ReviewExportProjectContext | null;
 };
 
 function extractRules(rulesJson: unknown): ContractRule[] {
@@ -853,6 +869,12 @@ function projectIdForDisplay(project: ProjectJson): string | null {
   return projectId;
 }
 
+function projectNameForDisplay(project: ProjectJson): string | null {
+  const projectName = project.project_context.project_name?.trim() ?? "";
+  if (!projectName || isUnavailableToken(projectName) || projectName === "Demo placeholder project context") return null;
+  return projectName;
+}
+
 function exportIdForDisplay(project: ProjectJson): string | null {
   const exportId = project.project_context.export_id?.trim() ?? "";
   if (!exportId || isUnavailableToken(exportId)) return null;
@@ -869,6 +891,12 @@ function workspaceLabelForDisplay(project: ProjectJson): string | null {
   const label = project.project_context.display_name?.trim() ?? "";
   if (!label || isUnavailableToken(label) || label === "Demo placeholder project context") return null;
   return label;
+}
+
+function proponentForDisplay(project: ProjectJson): string | null {
+  const proponent = project.project_context.proponent?.trim() ?? "";
+  if (!proponent || isUnavailableToken(proponent)) return null;
+  return proponent;
 }
 
 function reportingPeriodForDisplay(project: ProjectJson): string | null {
@@ -1068,10 +1096,10 @@ function renderVerificationReportHtml(input: {
     <section class="panel">
       <h2>Project Context</h2>
       <dl>
-        <dt>Project name</dt><dd>Not provided</dd>
+        <dt>Project name</dt><dd>${renderFieldValue(projectNameForDisplay(input.project), "Not provided")}</dd>
         <dt>Project ID</dt><dd>${renderFieldValue(projectIdForDisplay(input.project), "Not provided")}</dd>
         <dt>Country / location</dt><dd>${renderFieldValue(projectLocationForDisplay(input.project), "Not provided")}</dd>
-        <dt>Proponent</dt><dd>Not provided</dd>
+        <dt>Proponent</dt><dd>${renderFieldValue(proponentForDisplay(input.project), "Not provided")}</dd>
         <dt>Methodology / version</dt><dd>${escapeHtml(input.project.method.code)} @ ${escapeHtml(input.project.method.version)}</dd>
         <dt>Reporting period</dt><dd>${renderFieldValue(reportingPeriodForDisplay(input.project), "Not provided")}</dd>
         <dt>Review workspace</dt><dd>${renderFieldValue(workspaceLabelForDisplay(input.project), "Unavailable")}</dd>
@@ -1284,6 +1312,7 @@ export function buildVerificationPackContract(input: {
   const currentReviewPins = currentReview?.evidencePins ?? [];
   const currentReviewEntries = currentReview?.reviews ?? [];
   const currentVerifierBundle = currentReview?.verifierBundle ?? null;
+  const linkedProjectContext = input.finalizedReview?.projectContext ?? currentReview?.projectContext ?? null;
   const finalizedRuleId = selectedRuleFromArtifact(finalizedArtifact);
   const finalizedRuleIds = ruleIdsFromFinalizedContext(finalizedRuleId, finalizedArtifact);
   const packagedFinalizedSources = collectPackagedEvidenceSourceFiles(input.finalizedReview ?? null);
@@ -1341,17 +1370,36 @@ export function buildVerificationPackContract(input: {
       not_a_formal_opinion: true,
     },
     project_context: {
-      project_id: hasFinalizedReview || hasCurrentReview ? "not-supplied-in-method-review" : "local-method-review",
+      project_id:
+        linkedProjectContext?.projectCode?.trim() ||
+        linkedProjectContext?.projectId?.trim() ||
+        (hasFinalizedReview || hasCurrentReview ? "not-supplied-in-method-review" : "local-method-review"),
+      project_name:
+        linkedProjectContext?.projectName?.trim() ||
+        (hasCurrentReview ? "Unlinked method review" : "Demo placeholder project context"),
       export_id:
         finalizedArtifact?.verifier?.runId ??
         currentVerifierBundle?.runContext?.runId?.trim() ??
         currentVerifierBundle?.savedReviewerArtifactContext?.runId?.trim() ??
         "local-method-review",
-      display_name: finalizedArtifact?.summary?.aoiLabel ?? (hasCurrentReview ? "Current method review workspace" : "Demo placeholder project context"),
-      reporting_period: hasCurrentReview ? "not-supplied-in-method-review" : "placeholder-not-provided",
+      workspace_id:
+        linkedProjectContext?.workspaceId?.trim() ??
+        currentVerifierBundle?.runContext?.runId?.trim() ??
+        "local-method-review",
+      display_name:
+        linkedProjectContext?.workspaceName?.trim() ??
+        finalizedArtifact?.summary?.aoiLabel ??
+        (hasCurrentReview ? "Current method review workspace" : "Demo placeholder project context"),
+      reporting_period:
+        linkedProjectContext?.reportingPeriod?.trim() ??
+        (hasCurrentReview ? "not-supplied-in-method-review" : "placeholder-not-provided"),
       location:
+        linkedProjectContext?.countryLocation?.trim() ??
         finalizedArtifact?.summary?.aoiLabel ??
         (hasCurrentReview ? "Unavailable in local method review export" : "placeholder-not-provided"),
+      proponent:
+        linkedProjectContext?.proponent?.trim() ??
+        (hasCurrentReview ? "not-supplied-in-method-review" : "placeholder-not-provided"),
       description: hasFinalizedReview
         ? "Finalized local review context is included where present; absent project fields remain explicitly unavailable."
         : hasCurrentReview

--- a/src/lib/evidence/export/verificationPackDerivation.ts
+++ b/src/lib/evidence/export/verificationPackDerivation.ts
@@ -494,7 +494,14 @@ function buildDecisionRun(params: {
   });
   return {
     runId,
-    projectId: params.finalizedReview?.artifact?.verifier?.runId ?? params.currentReview?.verifierBundle?.runContext?.runId ?? 'method-review-export',
+    projectId:
+      params.finalizedReview?.projectContext?.projectCode?.trim()
+      || params.finalizedReview?.projectContext?.projectId?.trim()
+      || params.currentReview?.projectContext?.projectCode?.trim()
+      || params.currentReview?.projectContext?.projectId?.trim()
+      || params.finalizedReview?.artifact?.verifier?.runId
+      || params.currentReview?.verifierBundle?.runContext?.runId
+      || 'method-review-export',
     createdAt: params.generatedAt,
     decisions: sortedDecisions,
     decisionSetFingerprint,
@@ -603,7 +610,14 @@ function buildReconciliationRun(params: {
   return {
     runId: reconciliationFingerprint,
     createdAt: params.generatedAt,
-    projectId: params.finalizedReview?.artifact?.verifier?.runId ?? params.currentReview?.verifierBundle?.runContext?.runId ?? 'method-review-export',
+    projectId:
+      params.finalizedReview?.projectContext?.projectCode?.trim()
+      || params.finalizedReview?.projectContext?.projectId?.trim()
+      || params.currentReview?.projectContext?.projectCode?.trim()
+      || params.currentReview?.projectContext?.projectId?.trim()
+      || params.finalizedReview?.artifact?.verifier?.runId
+      || params.currentReview?.verifierBundle?.runContext?.runId
+      || 'method-review-export',
     status,
     items: sortByString(items, (item) => item.id),
     gaps: sortByString(gaps, (gap) => gap.ruleId),

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -42,11 +42,15 @@ export function getProject(id: string): Project | undefined {
 
 export function createProject(input: {
   name: string;
+  projectCode?: string;
+  countryLocation?: string;
+  proponent?: string;
   reviewMode: Project['reviewMode'];
   methodCode?: string;
   methodVersion?: string;
   methodCategory?: string;
   registry?: Project['registry'];
+  reportingPeriod?: string;
   aoiLabel?: string;
   description?: string;
   ruleIds?: Array<{ id: string; title: string; sectionId: string }>;
@@ -54,6 +58,9 @@ export function createProject(input: {
   const project: Project = {
     id: generateId(),
     name: input.name,
+    projectCode: input.projectCode,
+    countryLocation: input.countryLocation,
+    proponent: input.proponent,
     reviewMode: input.reviewMode,
     methodCode: input.methodCode,
     methodVersion: input.methodVersion,
@@ -61,6 +68,7 @@ export function createProject(input: {
     registry: input.registry,
     status: 'in-progress',
     createdAt: new Date().toISOString(),
+    reportingPeriod: input.reportingPeriod,
     aoiLabel: input.aoiLabel,
     description: input.description,
     reviews: (input.ruleIds ?? []).map(r => ({
@@ -78,6 +86,34 @@ export function createProject(input: {
 
   const projects = loadAll();
   projects.push(project);
+  saveAll(projects);
+  return project;
+}
+
+export function updateProject(
+  projectId: string,
+  update: Partial<
+    Pick<
+      Project,
+      | 'name'
+      | 'projectCode'
+      | 'countryLocation'
+      | 'proponent'
+      | 'methodCode'
+      | 'methodVersion'
+      | 'methodCategory'
+      | 'registry'
+      | 'reportingPeriod'
+      | 'aoiLabel'
+      | 'description'
+      | 'lastWorkspaceId'
+    >
+  >,
+): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find((item) => item.id === projectId);
+  if (!project || project.status === 'locked') return undefined;
+  Object.assign(project, update);
   saveAll(projects);
   return project;
 }
@@ -347,6 +383,9 @@ function normalizeProject(project: Partial<Project>): Project {
   return {
     id: project.id ?? generateId(),
     name: project.name ?? 'Untitled project',
+    projectCode: project.projectCode,
+    countryLocation: project.countryLocation,
+    proponent: project.proponent,
     reviewMode: project.reviewMode ?? 'methodology-linked',
     methodCode: project.methodCode,
     methodVersion: project.methodVersion,
@@ -355,6 +394,8 @@ function normalizeProject(project: Partial<Project>): Project {
     status: project.status ?? 'in-progress',
     createdAt: project.createdAt ?? new Date().toISOString(),
     lockedAt: project.lockedAt,
+    reportingPeriod: project.reportingPeriod,
+    lastWorkspaceId: project.lastWorkspaceId,
     aoiLabel: project.aoiLabel,
     description: project.description,
     reviews: Array.isArray(project.reviews) ? project.reviews : [],

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -133,6 +133,9 @@ export type ExtractedManualFindingDraft = {
 export type Project = {
   id: string;
   name: string;
+  projectCode?: string;
+  countryLocation?: string;
+  proponent?: string;
   reviewMode: ProjectReviewMode;
   methodCode?: string;
   methodVersion?: string;
@@ -141,6 +144,8 @@ export type Project = {
   status: ProjectStatus;
   createdAt: string;
   lockedAt?: string;
+  reportingPeriod?: string;
+  lastWorkspaceId?: string;
   aoiLabel?: string;
   description?: string;
   reviews: RuleReview[];

--- a/src/lib/proofMap/storage.ts
+++ b/src/lib/proofMap/storage.ts
@@ -3,11 +3,19 @@ import type { ProofEvidenceItem } from "@/lib/proof/bundle";
 
 const AOI_STORAGE_VERSION = "v2";
 
-function aoiCurrentKey(code: string, version: string): string {
+function normalizeWorkspaceId(workspaceId?: string | null): string {
+  return (workspaceId ?? "").trim();
+}
+
+function aoiCurrentKey(code: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) return `aoi:${AOI_STORAGE_VERSION}:workspace:${normalizedWorkspaceId}:current`;
   return `aoi:${AOI_STORAGE_VERSION}:${code}:${version}:current`;
 }
 
-function aoiDraftKey(code: string, version: string): string {
+function aoiDraftKey(code: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) return `aoi:${AOI_STORAGE_VERSION}:workspace:${normalizedWorkspaceId}:draft`;
   return `aoi:${AOI_STORAGE_VERSION}:${code}:${version}:draft`;
 }
 
@@ -15,26 +23,33 @@ function legacyAoiKey(code: string, version: string): string {
   return `aoi:${code}:${version}`;
 }
 
-function pinsKey(code: string, version: string): string {
+function pinsKey(code: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) return `pins:workspace:${normalizedWorkspaceId}`;
   return `pins:${code}:${version}`;
 }
 
-function snapshotsKey(code: string, version: string): string {
+function snapshotsKey(code: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) return `snapshots:workspace:${normalizedWorkspaceId}`;
   return `snapshots:${code}:${version}`;
 }
 
-function runsKey(code: string, version: string): string {
+function runsKey(code: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) return `runs:workspace:${normalizedWorkspaceId}`;
   return `runs:${code}:${version}`;
 }
 
-export function loadAoi(code: string, version: string): AOI | null {
+export function loadAoi(code: string, version: string, workspaceId?: string | null): AOI | null {
   if (typeof window === "undefined") return null;
   try {
-    const currentRaw = window.localStorage.getItem(aoiCurrentKey(code, version));
+    const currentRaw = window.localStorage.getItem(aoiCurrentKey(code, version, workspaceId));
     if (currentRaw) {
       const parsed = JSON.parse(currentRaw) as unknown;
       return parsed && typeof parsed === "object" ? (parsed as AOI) : null;
     }
+    if (normalizeWorkspaceId(workspaceId)) return null;
     const legacyRaw = window.localStorage.getItem(legacyAoiKey(code, version));
     if (!legacyRaw) return null;
     const parsed = JSON.parse(legacyRaw) as unknown;
@@ -44,24 +59,26 @@ export function loadAoi(code: string, version: string): AOI | null {
   }
 }
 
-export function saveAoi(code: string, version: string, aoi: AOI | null) {
+export function saveAoi(code: string, version: string, aoi: AOI | null, workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
     if (!aoi) {
-      window.localStorage.removeItem(aoiCurrentKey(code, version));
+      window.localStorage.removeItem(aoiCurrentKey(code, version, workspaceId));
     } else {
-      window.localStorage.setItem(aoiCurrentKey(code, version), JSON.stringify(aoi));
+      window.localStorage.setItem(aoiCurrentKey(code, version, workspaceId), JSON.stringify(aoi));
     }
-    window.localStorage.removeItem(legacyAoiKey(code, version));
+    if (!normalizeWorkspaceId(workspaceId)) {
+      window.localStorage.removeItem(legacyAoiKey(code, version));
+    }
   } catch {
     // ignore
   }
 }
 
-export function loadDraftAoi(code: string, version: string): AOI | null {
+export function loadDraftAoi(code: string, version: string, workspaceId?: string | null): AOI | null {
   if (typeof window === "undefined") return null;
   try {
-    const raw = window.localStorage.getItem(aoiDraftKey(code, version));
+    const raw = window.localStorage.getItem(aoiDraftKey(code, version, workspaceId));
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
     return parsed && typeof parsed === "object" ? (parsed as AOI) : null;
@@ -70,21 +87,22 @@ export function loadDraftAoi(code: string, version: string): AOI | null {
   }
 }
 
-export function saveDraftAoi(code: string, version: string, aoi: AOI | null) {
+export function saveDraftAoi(code: string, version: string, aoi: AOI | null, workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
-    if (!aoi) window.localStorage.removeItem(aoiDraftKey(code, version));
-    else window.localStorage.setItem(aoiDraftKey(code, version), JSON.stringify(aoi));
+    if (!aoi) window.localStorage.removeItem(aoiDraftKey(code, version, workspaceId));
+    else window.localStorage.setItem(aoiDraftKey(code, version, workspaceId), JSON.stringify(aoi));
   } catch {
     // ignore
   }
 }
 
-export function loadPins(code: string, version: string): EvidencePin[] {
+export function loadPins(code: string, version: string, workspaceId?: string | null): EvidencePin[] {
   if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(pinsKey(code, version));
+    const raw = window.localStorage.getItem(pinsKey(code, version, workspaceId));
     if (!raw) return [];
+    if (!raw && normalizeWorkspaceId(workspaceId)) return [];
     const parsed = JSON.parse(raw) as unknown;
     return Array.isArray(parsed) ? (parsed as EvidencePin[]) : [];
   } catch {
@@ -92,19 +110,19 @@ export function loadPins(code: string, version: string): EvidencePin[] {
   }
 }
 
-export function savePins(code: string, version: string, pins: EvidencePin[]) {
+export function savePins(code: string, version: string, pins: EvidencePin[], workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(pinsKey(code, version), JSON.stringify(pins));
+    window.localStorage.setItem(pinsKey(code, version, workspaceId), JSON.stringify(pins));
   } catch {
     // ignore
   }
 }
 
-export function loadEvidenceSnapshots(code: string, version: string): ProofEvidenceItem[] {
+export function loadEvidenceSnapshots(code: string, version: string, workspaceId?: string | null): ProofEvidenceItem[] {
   if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(snapshotsKey(code, version));
+    const raw = window.localStorage.getItem(snapshotsKey(code, version, workspaceId));
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     return Array.isArray(parsed) ? (parsed as ProofEvidenceItem[]) : [];
@@ -113,20 +131,20 @@ export function loadEvidenceSnapshots(code: string, version: string): ProofEvide
   }
 }
 
-export function saveEvidenceSnapshots(code: string, version: string, items: ProofEvidenceItem[] | null | undefined) {
+export function saveEvidenceSnapshots(code: string, version: string, items: ProofEvidenceItem[] | null | undefined, workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
-    if (!items || !items.length) window.localStorage.removeItem(snapshotsKey(code, version));
-    else window.localStorage.setItem(snapshotsKey(code, version), JSON.stringify(items));
+    if (!items || !items.length) window.localStorage.removeItem(snapshotsKey(code, version, workspaceId));
+    else window.localStorage.setItem(snapshotsKey(code, version, workspaceId), JSON.stringify(items));
   } catch {
     // ignore
   }
 }
 
-export function loadVerificationRuns(code: string, version: string): VerificationRun[] {
+export function loadVerificationRuns(code: string, version: string, workspaceId?: string | null): VerificationRun[] {
   if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(runsKey(code, version));
+    const raw = window.localStorage.getItem(runsKey(code, version, workspaceId));
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     return Array.isArray(parsed) ? (parsed as VerificationRun[]) : [];
@@ -135,25 +153,27 @@ export function loadVerificationRuns(code: string, version: string): Verificatio
   }
 }
 
-export function saveVerificationRuns(code: string, version: string, runs: VerificationRun[] | null | undefined) {
+export function saveVerificationRuns(code: string, version: string, runs: VerificationRun[] | null | undefined, workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
-    if (!runs || !runs.length) window.localStorage.removeItem(runsKey(code, version));
-    else window.localStorage.setItem(runsKey(code, version), JSON.stringify(runs));
+    if (!runs || !runs.length) window.localStorage.removeItem(runsKey(code, version, workspaceId));
+    else window.localStorage.setItem(runsKey(code, version, workspaceId), JSON.stringify(runs));
   } catch {
     // ignore
   }
 }
 
-export function clearProofMapStorage(code: string, version: string) {
+export function clearProofMapStorage(code: string, version: string, workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.removeItem(aoiCurrentKey(code, version));
-    window.localStorage.removeItem(aoiDraftKey(code, version));
-    window.localStorage.removeItem(legacyAoiKey(code, version));
-    window.localStorage.removeItem(pinsKey(code, version));
-    window.localStorage.removeItem(snapshotsKey(code, version));
-    window.localStorage.removeItem(runsKey(code, version));
+    window.localStorage.removeItem(aoiCurrentKey(code, version, workspaceId));
+    window.localStorage.removeItem(aoiDraftKey(code, version, workspaceId));
+    window.localStorage.removeItem(pinsKey(code, version, workspaceId));
+    window.localStorage.removeItem(snapshotsKey(code, version, workspaceId));
+    window.localStorage.removeItem(runsKey(code, version, workspaceId));
+    if (!normalizeWorkspaceId(workspaceId)) {
+      window.localStorage.removeItem(legacyAoiKey(code, version));
+    }
   } catch {
     // ignore
   }

--- a/src/lib/reviewWorkspaces/storage.ts
+++ b/src/lib/reviewWorkspaces/storage.ts
@@ -1,0 +1,182 @@
+import type { ReviewWorkspace } from "@/lib/reviewWorkspaces/types";
+
+const STORAGE_KEY = "article6_review_workspaces";
+
+function generateId(): string {
+  return "ws_" + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+function normalizeTrimmed(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function normalizeWorkspace(value: unknown): ReviewWorkspace | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const id = normalizeTrimmed(record.id);
+  const projectId = normalizeTrimmed(record.projectId);
+  const methodCode = normalizeTrimmed(record.methodCode);
+  const methodVersion = normalizeTrimmed(record.methodVersion);
+  const createdAt = normalizeTrimmed(record.createdAt);
+  const updatedAt = normalizeTrimmed(record.updatedAt);
+  if (!id || !projectId || !methodCode || !methodVersion || !createdAt || !updatedAt) {
+    return null;
+  }
+  return {
+    id,
+    name: normalizeTrimmed(record.name) ?? `${methodCode} ${methodVersion} review`,
+    projectId,
+    methodCode,
+    methodVersion,
+    reportingPeriod: normalizeTrimmed(record.reportingPeriod),
+    status: record.status === "finalized" ? "finalized" : "draft",
+    createdAt,
+    updatedAt,
+    lastOpenedAt: normalizeTrimmed(record.lastOpenedAt),
+    finalizedAt: normalizeTrimmed(record.finalizedAt),
+  };
+}
+
+function loadAll(): ReviewWorkspace[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((item) => normalizeWorkspace(item))
+      .filter((item): item is ReviewWorkspace => item !== null)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  } catch {
+    return [];
+  }
+}
+
+function saveAll(workspaces: ReviewWorkspace[]): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(workspaces));
+}
+
+export function listReviewWorkspaces(): ReviewWorkspace[] {
+  return loadAll();
+}
+
+export function getReviewWorkspace(id: string): ReviewWorkspace | undefined {
+  return loadAll().find((workspace) => workspace.id === id);
+}
+
+export function listReviewWorkspacesForProject(projectId: string): ReviewWorkspace[] {
+  return loadAll().filter((workspace) => workspace.projectId === projectId);
+}
+
+export function findReviewWorkspaceByProjectAndMethod(
+  projectId: string,
+  methodCode: string,
+  methodVersion: string,
+): ReviewWorkspace | undefined {
+  const normalizedCode = methodCode.trim();
+  const normalizedVersion = methodVersion.trim();
+  return loadAll().find(
+    (workspace) =>
+      workspace.projectId === projectId &&
+      workspace.methodCode === normalizedCode &&
+      workspace.methodVersion === normalizedVersion,
+  );
+}
+
+export function createReviewWorkspace(input: {
+  name: string;
+  projectId: string;
+  methodCode: string;
+  methodVersion: string;
+  reportingPeriod?: string;
+}): ReviewWorkspace {
+  const now = new Date().toISOString();
+  const workspace: ReviewWorkspace = {
+    id: generateId(),
+    name: input.name.trim(),
+    projectId: input.projectId,
+    methodCode: input.methodCode.trim(),
+    methodVersion: input.methodVersion.trim(),
+    reportingPeriod: input.reportingPeriod?.trim() || undefined,
+    status: "draft",
+    createdAt: now,
+    updatedAt: now,
+    lastOpenedAt: now,
+  };
+  const all = loadAll();
+  all.push(workspace);
+  saveAll(all);
+  return workspace;
+}
+
+export function ensureReviewWorkspace(input: {
+  projectId: string;
+  projectName: string;
+  projectCode?: string;
+  methodCode: string;
+  methodVersion: string;
+  reportingPeriod?: string;
+}): ReviewWorkspace {
+  const existing = findReviewWorkspaceByProjectAndMethod(input.projectId, input.methodCode, input.methodVersion);
+  if (existing) {
+    return updateReviewWorkspace(existing.id, {
+      lastOpenedAt: new Date().toISOString(),
+      reportingPeriod: input.reportingPeriod ?? existing.reportingPeriod,
+      name:
+        existing.name ||
+        buildReviewWorkspaceName({
+          projectName: input.projectName,
+          projectCode: input.projectCode,
+          methodCode: input.methodCode,
+          methodVersion: input.methodVersion,
+        }),
+    }) ?? existing;
+  }
+  return createReviewWorkspace({
+    projectId: input.projectId,
+    methodCode: input.methodCode,
+    methodVersion: input.methodVersion,
+    reportingPeriod: input.reportingPeriod,
+    name: buildReviewWorkspaceName({
+      projectName: input.projectName,
+      projectCode: input.projectCode,
+      methodCode: input.methodCode,
+      methodVersion: input.methodVersion,
+    }),
+  });
+}
+
+export function updateReviewWorkspace(
+  workspaceId: string,
+  update: Partial<Omit<ReviewWorkspace, "id" | "projectId" | "methodCode" | "methodVersion" | "createdAt">>,
+): ReviewWorkspace | undefined {
+  const all = loadAll();
+  const workspace = all.find((item) => item.id === workspaceId);
+  if (!workspace) return undefined;
+  Object.assign(workspace, {
+    ...update,
+    updatedAt: new Date().toISOString(),
+  });
+  saveAll(all);
+  return workspace;
+}
+
+export function touchReviewWorkspace(workspaceId: string): ReviewWorkspace | undefined {
+  return updateReviewWorkspace(workspaceId, { lastOpenedAt: new Date().toISOString() });
+}
+
+export function buildReviewWorkspaceName(input: {
+  projectName: string;
+  projectCode?: string;
+  methodCode: string;
+  methodVersion: string;
+}): string {
+  const projectLabel = input.projectCode?.trim()
+    ? `${input.projectName.trim()} (${input.projectCode.trim()})`
+    : input.projectName.trim();
+  return `${projectLabel} · ${input.methodCode.trim()} ${input.methodVersion.trim()} review`;
+}

--- a/src/lib/reviewWorkspaces/types.ts
+++ b/src/lib/reviewWorkspaces/types.ts
@@ -1,0 +1,15 @@
+export type ReviewWorkspaceStatus = "draft" | "finalized";
+
+export type ReviewWorkspace = {
+  id: string;
+  name: string;
+  projectId: string;
+  methodCode: string;
+  methodVersion: string;
+  reportingPeriod?: string;
+  status: ReviewWorkspaceStatus;
+  createdAt: string;
+  updatedAt: string;
+  lastOpenedAt?: string;
+  finalizedAt?: string;
+};

--- a/src/lib/verify/reviewStore.ts
+++ b/src/lib/verify/reviewStore.ts
@@ -12,6 +12,7 @@ export type RuleReview = {
   ruleId: string;
   methodology: string;
   version: string;
+  workspaceId?: string;
   status: ReviewStatus;
   rationale: string;
   supportReference: string;
@@ -28,10 +29,15 @@ export const REVIEW_STORE_EVENT = "article6:review-store-changed";
 type ReviewStoreEventDetail = {
   methodology: string;
   version: string;
+  workspaceId?: string;
   ruleId?: string;
 };
 
-function storageKey(methodology: string, version: string): string {
+function storageKey(methodology: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = workspaceId?.trim();
+  if (normalizedWorkspaceId) {
+    return `${STORAGE_PREFIX}:workspace:${normalizedWorkspaceId}`;
+  }
   return `${STORAGE_PREFIX}:${methodology}:${version}`;
 }
 
@@ -44,9 +50,10 @@ export function getReview(
   ruleId: string,
   methodology: string,
   version: string,
+  workspaceId?: string | null,
 ): RuleReview | null {
   try {
-    const raw = localStorage.getItem(storageKey(methodology, version));
+    const raw = localStorage.getItem(storageKey(methodology, version, workspaceId));
     if (!raw) return null;
     const all: Record<string, RuleReview> = JSON.parse(raw);
     return all[ruleId] ?? null;
@@ -56,7 +63,8 @@ export function getReview(
 }
 
 export function saveReview(review: RuleReview): void {
-  const key = storageKey(review.methodology, review.version);
+  const workspaceId = (review as RuleReview & { workspaceId?: string | null }).workspaceId ?? null;
+  const key = storageKey(review.methodology, review.version, workspaceId);
   try {
     const raw = localStorage.getItem(key);
     const all: Record<string, RuleReview> = raw ? JSON.parse(raw) : {};
@@ -65,6 +73,7 @@ export function saveReview(review: RuleReview): void {
     emitReviewStoreEvent({
       methodology: review.methodology,
       version: review.version,
+      ...(workspaceId ? { workspaceId } : {}),
       ruleId: review.ruleId,
     });
   } catch {
@@ -75,9 +84,10 @@ export function saveReview(review: RuleReview): void {
 export function getAllReviews(
   methodology: string,
   version: string,
+  workspaceId?: string | null,
 ): Record<string, RuleReview> {
   try {
-    const raw = localStorage.getItem(storageKey(methodology, version));
+    const raw = localStorage.getItem(storageKey(methodology, version, workspaceId));
     return raw ? JSON.parse(raw) : {};
   } catch {
     return {};
@@ -88,15 +98,16 @@ export function deleteReview(
   ruleId: string,
   methodology: string,
   version: string,
+  workspaceId?: string | null,
 ): void {
-  const key = storageKey(methodology, version);
+  const key = storageKey(methodology, version, workspaceId);
   try {
     const raw = localStorage.getItem(key);
     if (!raw) return;
     const all: Record<string, RuleReview> = JSON.parse(raw);
     delete all[ruleId];
     localStorage.setItem(key, JSON.stringify(all));
-    emitReviewStoreEvent({ methodology, version, ruleId });
+    emitReviewStoreEvent({ methodology, version, ...(workspaceId ? { workspaceId } : {}), ruleId });
   } catch {
     // ignore
   }
@@ -109,8 +120,9 @@ export function addEvidenceAttachment(
   methodology: string,
   version: string,
   attachment: Omit<EvidenceAttachment, "id" | "addedAt">,
+  workspaceId?: string | null,
 ): RuleReview | null {
-  const review = getReview(ruleId, methodology, version);
+  const review = getReview(ruleId, methodology, version, workspaceId);
   if (!review) return null;
 
   const full: EvidenceAttachment = {
@@ -129,8 +141,9 @@ export function removeEvidenceAttachment(
   methodology: string,
   version: string,
   evidenceId: string,
+  workspaceId?: string | null,
 ): RuleReview | null {
-  const review = getReview(ruleId, methodology, version);
+  const review = getReview(ruleId, methodology, version, workspaceId);
   if (!review) return null;
 
   review.evidenceAttachments = (review.evidenceAttachments ?? []).filter(
@@ -156,8 +169,9 @@ export function getReviewProgress(
   methodology: string,
   version: string,
   totalRules: number,
+  workspaceId?: string | null,
 ): ReviewProgress {
-  const reviews = getAllReviews(methodology, version);
+  const reviews = getAllReviews(methodology, version, workspaceId);
   const entries = Object.values(reviews);
   const reviewed = entries.filter((r) => r.status !== "pending").length;
   const verified = entries.filter((r) => r.status === "verified").length;
@@ -187,10 +201,22 @@ export function checkFinalizeGate(
   methodology: string,
   version: string,
   totalRules: number,
+  options?: {
+    workspaceId?: string | null;
+    projectLinked?: boolean;
+    methodologyLinked?: boolean;
+  },
 ): FinalizeGate {
-  const reviews = getAllReviews(methodology, version);
+  const reviews = getAllReviews(methodology, version, options?.workspaceId);
   const entries = Object.values(reviews);
   const reasons: string[] = [];
+
+  if (options?.projectLinked === false) {
+    reasons.push("Review workspace is not linked to a project");
+  }
+  if (options?.methodologyLinked === false) {
+    reasons.push("Review workspace is missing a methodology version");
+  }
 
   // Check all rules have a non-pending review
   const completedRuleIds = new Set(

--- a/src/lib/verify/runState.ts
+++ b/src/lib/verify/runState.ts
@@ -72,6 +72,7 @@ export type VerifierRunContext = {
 export type ReviewerArtifactContext = {
   methodCode: string;
   version: string;
+  workspaceId?: string | null;
   ruleId: string | null;
   runId: string;
 };
@@ -298,41 +299,63 @@ export function normalizeVersion(raw: string): string {
   return trimmed;
 }
 
-export function buildVerifyRunKey(methodCode: string, version: string): string {
+function normalizeWorkspaceId(raw?: string | null): string {
+  return (raw ?? "").trim();
+}
+
+export function buildVerifyRunKey(methodCode: string, version: string, workspaceId?: string | null): string {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) {
+    return `verify:workspace:${normalizedWorkspaceId}`;
+  }
   return `verify:${normalizedMethod}:${normalizedVersion}`;
 }
 
-function buildRunHistoryKey(methodCode: string, version: string): string {
+function buildRunHistoryKey(methodCode: string, version: string, workspaceId?: string | null): string {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) {
+    return `verifyRunHistory:workspace:${normalizedWorkspaceId}`;
+  }
   return `verifyRunHistory:${normalizedMethod}:${normalizedVersion}`;
 }
 
 function buildReviewerArtifactStorageKey(context: ReviewerArtifactContext): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(context.workspaceId);
   const normalizedMethod = normalizeMethodCode(context.methodCode);
   const normalizedVersion = normalizeVersion(context.version);
   const normalizedRuleId = (context.ruleId ?? "").trim() || "__no_rule__";
   const normalizedRunId = context.runId.trim();
+  if (normalizedWorkspaceId) {
+    return `verifyReviewerArtifact:workspace:${normalizedWorkspaceId}:${normalizedRuleId}:${normalizedRunId}`;
+  }
   return `verifyReviewerArtifact:${normalizedMethod}:${normalizedVersion}:${normalizedRuleId}:${normalizedRunId}`;
 }
 
-export function buildLinkedRulesKey(methodCode: string, version: string): string {
+export function buildLinkedRulesKey(methodCode: string, version: string, workspaceId?: string | null): string {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) {
+    return `verifyLinkedRules:workspace:${normalizedWorkspaceId}`;
+  }
   return `verifyLinkedRules:${normalizedMethod}:${normalizedVersion}`;
 }
 
 export function createReviewerArtifactContext(input: {
   methodCode: string;
   version: string;
+  workspaceId?: string | null;
   ruleId: string | null;
   runId: string;
 }): ReviewerArtifactContext {
   return {
     methodCode: normalizeMethodCode(input.methodCode),
     version: normalizeVersion(input.version),
+    workspaceId: normalizeWorkspaceId(input.workspaceId) || null,
     ruleId: asNonEmptyString(input.ruleId) ?? null,
     runId: input.runId.trim(),
   };
@@ -346,6 +369,7 @@ export function reviewerArtifactContextMatches(
   return (
     normalizeMethodCode(left.methodCode) === normalizeMethodCode(right.methodCode) &&
     normalizeVersion(left.version) === normalizeVersion(right.version) &&
+    normalizeWorkspaceId(left.workspaceId) === normalizeWorkspaceId(right.workspaceId) &&
     (asNonEmptyString(left.ruleId) ?? null) === (asNonEmptyString(right.ruleId) ?? null) &&
     left.runId.trim() === right.runId.trim()
   );
@@ -357,6 +381,7 @@ function normalizeReviewerArtifactContext(raw: unknown, fallback: ReviewerArtifa
   return {
     methodCode: asNonEmptyString(record.methodCode) ?? fallback.methodCode,
     version: asNonEmptyString(record.version) ?? fallback.version,
+    workspaceId: asNonEmptyString(record.workspaceId) ?? fallback.workspaceId ?? null,
     ruleId: asNonEmptyString(record.ruleId) ?? null,
     runId: asNonEmptyString(record.runId) ?? fallback.runId,
   };
@@ -407,9 +432,10 @@ export function persistReviewerArtifactState(state: ReviewerArtifactState): void
   storage.setItem(key, JSON.stringify(state));
 }
 
-function migrateLinkedRulesKey(methodCode: string, version: string): void {
+function migrateLinkedRulesKey(methodCode: string, version: string, workspaceId?: string | null): void {
   const storage = getLocalStorage();
   if (!storage) return;
+  if (normalizeWorkspaceId(workspaceId)) return;
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
   const canonical = buildLinkedRulesKey(normalizedMethod, normalizedVersion);
@@ -445,10 +471,15 @@ function migrateLinkedRulesKey(methodCode: string, version: string): void {
   for (const key of keysToMerge) storage.removeItem(key);
 }
 
-export function readLinkedRuleIdsFromStorage(methodCode: string, version: string): string[] {
+export function readLinkedRuleIdsFromStorage(methodCode: string, version: string, workspaceId?: string | null): string[] {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  migrateLinkedRulesKey(normalizedMethod, normalizedVersion);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (!normalizedWorkspaceId) {
+    migrateLinkedRulesKey(normalizedMethod, normalizedVersion);
+  }
+  const scoped = loadLinkedRuleIds(buildLinkedRulesKey(normalizedMethod, normalizedVersion, normalizedWorkspaceId));
+  if (scoped.length || normalizedWorkspaceId) return scoped;
   return loadLinkedRuleIds(buildLinkedRulesKey(normalizedMethod, normalizedVersion));
 }
 
@@ -487,22 +518,23 @@ export function addLinkedRuleIdToStorage(
   methodCode: string,
   version: string,
   ruleId: string | null | undefined,
+  workspaceId?: string | null,
 ): string[] {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  const key = buildLinkedRulesKey(normalizedMethod, normalizedVersion);
+  const key = buildLinkedRulesKey(normalizedMethod, normalizedVersion, workspaceId);
   return addLinkedRuleIdToKey(key, ruleId);
 }
 
-export function setLinkedRuleIdsInStorage(methodCode: string, version: string, ids: string[]): string[] {
+export function setLinkedRuleIdsInStorage(methodCode: string, version: string, ids: string[], workspaceId?: string | null): string[] {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  const key = buildLinkedRulesKey(normalizedMethod, normalizedVersion);
+  const key = buildLinkedRulesKey(normalizedMethod, normalizedVersion, workspaceId);
   persistLinkedRuleIds(key, ids);
   return loadLinkedRuleIds(key);
 }
 
-export function createVerifierRunBundle(methodCode: string, version: string): VerifierRunBundle {
+export function createVerifierRunBundle(methodCode: string, version: string, workspaceId?: string | null): VerifierRunBundle {
   const createdAt = nowIso();
   const runId = buildRunId(methodCode, version, new Date(createdAt));
   return {
@@ -513,6 +545,7 @@ export function createVerifierRunBundle(methodCode: string, version: string): Ve
     reviewerContext: createReviewerArtifactContext({
       methodCode,
       version,
+      workspaceId,
       ruleId: null,
       runId,
     }),
@@ -534,15 +567,16 @@ export function createVerifierRunBundle(methodCode: string, version: string): Ve
   };
 }
 
-export function readVerifierRunBundle(methodCode: string, version: string): VerifierRunBundle {
+export function readVerifierRunBundle(methodCode: string, version: string, workspaceId?: string | null): VerifierRunBundle {
   const storage = getLocalStorage();
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  const canonical = buildVerifyRunKey(normalizedMethod, normalizedVersion);
-  const fallback = createVerifierRunBundle(normalizedMethod, normalizedVersion);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  const canonical = buildVerifyRunKey(normalizedMethod, normalizedVersion, normalizedWorkspaceId);
+  const fallback = createVerifierRunBundle(normalizedMethod, normalizedVersion, normalizedWorkspaceId);
   if (!storage) return fallback;
 
-  if (!storage.getItem(canonical)) {
+  if (!storage.getItem(canonical) && !normalizedWorkspaceId) {
     const legacyKeys = [
       `verify:${normalizedMethod}@${normalizedVersion}`,
       `verify:${normalizedMethod}`,
@@ -577,6 +611,7 @@ export function readVerifierRunBundle(methodCode: string, version: string): Veri
     const reviewerContextFallback = createReviewerArtifactContext({
       methodCode: normalizedMethod,
       version: normalizedVersion,
+      workspaceId: normalizedWorkspaceId,
       ruleId: null,
       runId,
     });
@@ -611,17 +646,17 @@ export function readVerifierRunBundle(methodCode: string, version: string): Veri
   }
 }
 
-export function persistVerifierRunBundle(methodCode: string, version: string, bundle: VerifierRunBundle): void {
+export function persistVerifierRunBundle(methodCode: string, version: string, bundle: VerifierRunBundle, workspaceId?: string | null): void {
   const storage = getLocalStorage();
   if (!storage) return;
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  const key = buildVerifyRunKey(normalizedMethod, normalizedVersion);
+  const key = buildVerifyRunKey(normalizedMethod, normalizedVersion, workspaceId);
   storage.setItem(key, JSON.stringify(bundle));
   if (typeof window !== "undefined") {
     window.dispatchEvent(
       new CustomEvent(VERIFY_RUN_BUNDLE_EVENT, {
-        detail: { methodCode: normalizedMethod, version: normalizedVersion },
+        detail: { methodCode: normalizedMethod, version: normalizedVersion, workspaceId: normalizeWorkspaceId(workspaceId) || undefined },
       }),
     );
   }
@@ -642,10 +677,10 @@ function normalizeRunHistory(raw: unknown): VerifyRunHistoryEntry[] {
   return entries;
 }
 
-export function readRunHistory(methodCode: string, version: string): VerifyRunHistoryEntry[] {
+export function readRunHistory(methodCode: string, version: string, workspaceId?: string | null): VerifyRunHistoryEntry[] {
   const storage = getLocalStorage();
   if (!storage) return [];
-  const key = buildRunHistoryKey(methodCode, version);
+  const key = buildRunHistoryKey(methodCode, version, workspaceId);
   const raw = storage.getItem(key);
   if (!raw) return [];
   try {
@@ -660,13 +695,14 @@ export function saveCurrentRunToHistory(
   methodCode: string,
   version: string,
   bundle: VerifyRunHistoryBundle,
+  workspaceId?: string | null,
 ): VerifyRunHistoryEntry[] {
   const storage = getLocalStorage();
   if (!storage) return [];
-  const key = buildRunHistoryKey(methodCode, version);
+  const key = buildRunHistoryKey(methodCode, version, workspaceId);
   const createdAt = bundle.runContext.createdAt || nowIso();
   const entry: VerifyRunHistoryEntry = { runId: bundle.runContext.runId, createdAt, bundle };
-  const existing = readRunHistory(methodCode, version);
+  const existing = readRunHistory(methodCode, version, workspaceId);
   const without = existing.filter((item) => item.runId !== entry.runId);
   const next = [entry, ...without].sort((a, b) => b.createdAt.localeCompare(a.createdAt)).slice(0, 10);
   storage.setItem(key, JSON.stringify(next));
@@ -677,17 +713,18 @@ export function loadRunFromHistory(
   methodCode: string,
   version: string,
   runId: string,
+  workspaceId?: string | null,
 ): VerifyRunHistoryBundle | null {
-  const history = readRunHistory(methodCode, version);
+  const history = readRunHistory(methodCode, version, workspaceId);
   const match = history.find((entry) => entry.runId === runId);
   return match ? match.bundle : null;
 }
 
-export function deleteRunFromHistory(methodCode: string, version: string, runId: string): VerifyRunHistoryEntry[] {
+export function deleteRunFromHistory(methodCode: string, version: string, runId: string, workspaceId?: string | null): VerifyRunHistoryEntry[] {
   const storage = getLocalStorage();
   if (!storage) return [];
-  const next = readRunHistory(methodCode, version).filter((entry) => entry.runId !== runId);
-  storage.setItem(buildRunHistoryKey(methodCode, version), JSON.stringify(next));
+  const next = readRunHistory(methodCode, version, workspaceId).filter((entry) => entry.runId !== runId);
+  storage.setItem(buildRunHistoryKey(methodCode, version, workspaceId), JSON.stringify(next));
   return next;
 }
 
@@ -696,13 +733,18 @@ export function shortRunId(runId: string, length = 8): string {
   return runId.length <= length ? runId : runId.slice(-length);
 }
 
-export function clearLinkedRuleIdsFromStorage(methodCode: string, version: string): void {
+export function clearLinkedRuleIdsFromStorage(methodCode: string, version: string, workspaceId?: string | null): void {
   const storage = getLocalStorage();
   if (!storage) return;
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  const canonical = buildLinkedRulesKey(normalizedMethod, normalizedVersion);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  const canonical = buildLinkedRulesKey(normalizedMethod, normalizedVersion, normalizedWorkspaceId);
   storage.removeItem(canonical);
+  if (normalizedWorkspaceId) {
+    notifyLinkedRuleListeners();
+    return;
+  }
   const legacyPrefixes = [
     `verifyLinkedRules:${normalizedMethod}:`,
     `verifyLinkedRules:${normalizedMethod}@`,

--- a/tests/exports/auditPack.contract.test.ts
+++ b/tests/exports/auditPack.contract.test.ts
@@ -752,7 +752,7 @@ describe("audit pack verification contract", () => {
     expect(html).toContain("This report is not a formal validation opinion.");
     expect(html).toContain("local/browser-state review data");
 
-    expect(html).toContain("<dt>Project name</dt><dd>Not provided</dd>");
+    expect(html).toContain("<dt>Project name</dt><dd>Unlinked method review</dd>");
     expect(html).toContain("<dt>Project ID</dt><dd>Not provided</dd>");
     expect(html).toContain("<dt>Country / location</dt><dd>Not provided</dd>");
     expect(html).toContain("<dt>Proponent</dt><dd>Not provided</dd>");
@@ -843,6 +843,51 @@ describe("audit pack verification contract", () => {
         }),
       }),
     );
+  });
+
+  test("uses linked project and workspace context in the HTML report when provided", () => {
+    const zip = withTemporaryMethodologyCheckout(
+      () =>
+        buildAuditPackZip("AR-ACM0003", "v02-0", {
+          currentReview: {
+            latestReviewAt: "2026-05-21T09:05:00.000Z",
+            reviews: [],
+            evidencePins: [],
+            verifierBundle: {
+              runContext: {
+                runId: "run-linked-project-1",
+                createdAt: "2026-05-21T09:00:00.000Z",
+              },
+            },
+            projectContext: {
+              projectId: "proj_liwonde",
+              projectCode: "VCS-1530",
+              projectName: "Liwonde National Park REDD+",
+              countryLocation: "Malawi",
+              proponent: "Article6 Climate",
+              reportingPeriod: "2024-01-01 to 2024-12-31",
+              workspaceId: "ws_liwonde_review",
+              workspaceName: "Liwonde REDD+ · AR-ACM0003 v02-0 review",
+            },
+          },
+        }),
+      {
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        rules: readinessSkeletonRulesJson,
+        sections: readinessSkeletonSectionsJson,
+      },
+    );
+
+    const entries = unzipSync(new Uint8Array(zip));
+    const html = strFromU8(entries["VERIFICATION_REPORT.html"]);
+
+    expect(html).toContain("<dt>Project name</dt><dd>Liwonde National Park REDD+</dd>");
+    expect(html).toContain("<dt>Project ID</dt><dd>VCS-1530</dd>");
+    expect(html).toContain("<dt>Country / location</dt><dd>Malawi</dd>");
+    expect(html).toContain("<dt>Proponent</dt><dd>Article6 Climate</dd>");
+    expect(html).toContain("Liwonde REDD+ · AR-ACM0003 v02-0 review");
+    expect(html).not.toContain("<dt>Project name</dt><dd>Not provided</dd>");
   });
 
   test("does not attach reviewer artifact text from another method into AR-AMS0007 current-review exports", () => {

--- a/tests/lib/reviewStore.test.ts
+++ b/tests/lib/reviewStore.test.ts
@@ -126,4 +126,46 @@ describe("reviewStore phase 2 helpers", () => {
       ],
     });
   });
+
+  it("scopes reviews to the linked workspace when a workspace id is provided", () => {
+    saveReview({ ...baseReview, workspaceId: "ws_alpha" });
+    saveReview({ ...baseReview, ruleId: "R-2", workspaceId: "ws_beta" });
+
+    expect(getReviewProgress("AR-ACM0003", "v02-0", 2, "ws_alpha")).toEqual({
+      total: 2,
+      reviewed: 1,
+      verified: 1,
+      notVerified: 0,
+      needsFollowup: 0,
+      pending: 1,
+      percentReviewed: 50,
+    });
+    expect(getReviewProgress("AR-ACM0003", "v02-0", 2, "ws_beta")).toEqual({
+      total: 2,
+      reviewed: 1,
+      verified: 1,
+      notVerified: 0,
+      needsFollowup: 0,
+      pending: 1,
+      percentReviewed: 50,
+    });
+  });
+
+  it("blocks finalize when the review workspace is missing linked project or methodology context", () => {
+    saveReview({ ...baseReview, workspaceId: "ws_alpha" });
+
+    expect(
+      checkFinalizeGate("AR-ACM0003", "v02-0", 1, {
+        workspaceId: "ws_alpha",
+        projectLinked: false,
+        methodologyLinked: false,
+      }),
+    ).toEqual({
+      canFinalize: false,
+      reasons: [
+        "Review workspace is not linked to a project",
+        "Review workspace is missing a methodology version",
+      ],
+    });
+  });
 });

--- a/tests/lib/reviewWorkspaces.storage.test.ts
+++ b/tests/lib/reviewWorkspaces.storage.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import {
+  ensureReviewWorkspace,
+  findReviewWorkspaceByProjectAndMethod,
+  listReviewWorkspacesForProject,
+} from "@/lib/reviewWorkspaces/storage";
+
+let store: Record<string, string> = {};
+
+describe("review workspace storage", () => {
+  beforeEach(() => {
+    const localStorage = {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+    };
+    Object.defineProperty(globalThis, "localStorage", {
+      value: localStorage,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "window", {
+      value: { localStorage },
+      configurable: true,
+      writable: true,
+    });
+    globalThis.localStorage.clear();
+  });
+
+  it("creates and reuses one workspace per project-method-version pair", () => {
+    const created = ensureReviewWorkspace({
+      projectId: "proj_1",
+      projectName: "Liwonde REDD+",
+      projectCode: "VCS-1530",
+      methodCode: "AR-ACM0003",
+      methodVersion: "v02-0",
+      reportingPeriod: "2024",
+    });
+    const reused = ensureReviewWorkspace({
+      projectId: "proj_1",
+      projectName: "Liwonde REDD+",
+      projectCode: "VCS-1530",
+      methodCode: "AR-ACM0003",
+      methodVersion: "v02-0",
+      reportingPeriod: "2024",
+    });
+
+    expect(reused.id).toBe(created.id);
+    expect(reused.name).toContain("Liwonde REDD+");
+    expect(listReviewWorkspacesForProject("proj_1")).toHaveLength(1);
+    expect(findReviewWorkspaceByProjectAndMethod("proj_1", "AR-ACM0003", "v02-0")?.id).toBe(created.id);
+  });
+});


### PR DESCRIPTION
## What changed
- introduced a first-class `ReviewWorkspace` model linking one Project to one methodology version
- threaded `projectId` and `workspaceId` through the existing verify flow, review state, run state, and proof-map persistence
- added project metadata fields needed for traceable exports: project code, country/location, proponent, reporting period, and last workspace pointer
- added `Start review` and `Continue review` actions on project surfaces and a verify context bar showing project, method/version, reporting period, and workspace
- updated finalize gating so review finalization is blocked when the workspace is not linked to both a Project and a methodology version
- updated audit-pack export inputs and HTML/report rendering so linked project/workspace context is used consistently instead of anonymous method-only placeholders

## Why
Projects, methodologies, and review state were previously split across disconnected surfaces. That made method review exports behave like anonymous workspaces and weakened traceability. This change binds review evidence, decisions, and exports to a real project + methodology workspace join.

## Reviewer impact
- reviewers can start or resume review from a project instead of guessing the correct method-only surface
- verify now carries explicit context for the linked project and active workspace
- linked exports use project/workspace metadata automatically
- unlinked method-only review remains visibly draft/incomplete and cannot be finalized as if it were a bound review workspace

## Validation
- `npm run typecheck`
- `npm test -- --runTestsByPath tests/lib/reviewStore.test.ts tests/lib/reviewWorkspaces.storage.test.ts tests/exports/auditPack.contract.test.ts`
- pre-push hook reran `next lint --max-warnings=0` and `tsc --noEmit`

## Notes
- this PR keeps the existing Verify / Rule Review workflow and layers the workspace join into that surface rather than creating a separate product area
- full-suite tests were not run in this pass; validation was targeted to the new workspace/export behavior