### PR TITLE
[codex] Add methodology-aware Quick Check gating

### DIFF
--- a/src/app/api/exports/audit-pack/route.ts
+++ b/src/app/api/exports/audit-pack/route.ts
@@ -71,8 +71,12 @@ export async function POST(req: Request) {
     const evidencePins = Array.isArray(record.evidencePins) ? (record.evidencePins as EvidencePin[]) : [];
     const sourceFiles = Array.isArray(record.sourceFiles) ? record.sourceFiles : [];
     const currentReview = asCurrentMethodReviewInput(record.currentReview);
+    const projectContext =
+      record.projectContext && typeof record.projectContext === "object" && !Array.isArray(record.projectContext)
+        ? record.projectContext
+        : null;
     const zip = buildAuditPackZip(method, version, {
-      finalizedReview: artifact ? { artifact, evidencePins, sourceFiles } : null,
+      finalizedReview: artifact ? { artifact, evidencePins, sourceFiles, projectContext } : null,
       currentReview: artifact ? null : currentReview,
     });
     return new Response(zip, {

--- a/src/app/api/projects/manual-review/extract-findings/route.ts
+++ b/src/app/api/projects/manual-review/extract-findings/route.ts
@@ -5,7 +5,18 @@ import { extractPdfPagesWithPdfParse, PdfExtractionError, type PdfExtractionDiag
 import { withMetrics } from "@/lib/metrics";
 import { extractManualFindingDraftsFromPages } from "@/lib/projects/manualFindingExtraction";
 
+const MAX_UPLOADABLE_PDF_BYTES = 20 * 1024 * 1024;
+
 function summarizeDiagnostics(diagnostics: PdfExtractionDiagnostics): string {
+  if (diagnostics.failureKind === "file-too-large") {
+    return "file too large";
+  }
+  if (diagnostics.failureKind === "parser-failed") {
+    return "parser failed";
+  }
+  if (diagnostics.failureKind === "no-selectable-text") {
+    return "no selectable text";
+  }
   if (diagnostics.extractedTextLength > 0 && diagnostics.textFallbackAttempted) {
     return "partial text recovered";
   }
@@ -19,6 +30,9 @@ function summarizeDiagnostics(diagnostics: PdfExtractionDiagnostics): string {
 }
 
 function diagnosticReason(diagnostics: PdfExtractionDiagnostics): string | undefined {
+  if (diagnostics.failureKind === "file-too-large") {
+    return `File exceeds the 20MB upload limit (${(MAX_UPLOADABLE_PDF_BYTES / (1024 * 1024)).toFixed(0)}MB max).`;
+  }
   if (diagnostics.textFallbackError) return diagnostics.textFallbackError;
   if (diagnostics.pageExtractionError) return diagnostics.pageExtractionError;
   if (diagnostics.likelyScannedOrImageOnly) return "No extractable text found in PDF.";
@@ -36,6 +50,7 @@ function buildFailureDiagnostics(error: unknown): PdfExtractionDiagnostics {
   }
 
   return {
+    failureKind: "parser-failed",
     parserPath: "unknown",
     pageExtractionAttempted: true,
     pageExtractionError: error instanceof Error ? error.message : String(error),
@@ -52,6 +67,31 @@ async function handlePost(request: Request) {
   const bytes = await request.arrayBuffer().catch(() => null);
   if (!bytes || bytes.byteLength === 0) {
     return NextResponse.json({ error: "Missing PDF bytes." }, { status: 400 });
+  }
+  if (bytes.byteLength > MAX_UPLOADABLE_PDF_BYTES) {
+    const diagnostics: PdfExtractionDiagnostics = {
+      failureKind: "file-too-large",
+      parserPath: "unknown",
+      pageExtractionAttempted: false,
+      textFallbackAttempted: false,
+      extractedTextLength: 0,
+      pageCount: 0,
+      likelyScannedOrImageOnly: false,
+      partialTextRecovered: false,
+    };
+    return NextResponse.json(
+      {
+        text: "",
+        pages: [],
+        drafts: [],
+        message: "Could not extract findings from this PDF. You can still add findings manually.",
+        diagnosticSummary: summarizeDiagnostics(diagnostics),
+        diagnosticReason: diagnosticReason(diagnostics),
+        diagnostics,
+        extractionFailed: true,
+      },
+      { status: 200 },
+    );
   }
 
   try {

--- a/src/app/api/quick-check/pdf-extract/route.ts
+++ b/src/app/api/quick-check/pdf-extract/route.ts
@@ -2,7 +2,7 @@ export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 import { extractPdfText } from "@/lib/chat/quickCheckEvidence";
-import { extractPdfTextWithPdfParse } from "@/lib/chat/quickCheckPdfExtractor";
+import { extractPdfTextWithPdfParse, type PdfExtractionDiagnostics } from "@/lib/chat/quickCheckPdfExtractor";
 import { withMetrics } from "@/lib/metrics";
 
 async function handlePost(request: Request) {
@@ -12,9 +12,11 @@ async function handlePost(request: Request) {
   }
 
   let fallbackReason = "pdf-parse returned empty text — fell back to heuristic extractor";
+  let diagnostics: PdfExtractionDiagnostics | undefined;
 
   try {
     const extraction = await extractPdfTextWithPdfParse({ bytes });
+    diagnostics = extraction.metadata.diagnostics;
     // pdf-parse can succeed but return empty text for ASCII85-encoded streams.
     // Fall through to heuristic extractor which has custom ASCII85 + FlateDecode.
     if (extraction.text.trim().length > 0) {
@@ -25,6 +27,10 @@ async function handlePost(request: Request) {
       });
     }
   } catch (error) {
+    diagnostics =
+      error && typeof error === "object" && "diagnostics" in error
+        ? (error as { diagnostics?: PdfExtractionDiagnostics }).diagnostics
+        : undefined;
     fallbackReason = `pdf-parse threw: ${error instanceof Error ? error.message : String(error)} — fell back to heuristic extractor`;
   }
 
@@ -35,6 +41,17 @@ async function handlePost(request: Request) {
     metadata: {
       parser: "heuristic",
       fallbackReason,
+      diagnostics: diagnostics ?? {
+        failureKind: fallbackText.trim().length > 0 ? "parser-failed" : "no-selectable-text",
+        parserPath: "unknown",
+        pageExtractionAttempted: true,
+        pageExtractionError: fallbackReason,
+        textFallbackAttempted: true,
+        extractedTextLength: fallbackText.trim().length,
+        pageCount: fallbackText.trim().length > 0 ? 1 : 0,
+        likelyScannedOrImageOnly: fallbackText.trim().length === 0,
+        partialTextRecovered: fallbackText.trim().length > 0,
+      },
     },
   });
 }

--- a/src/app/m/_components/MethodCard.tsx
+++ b/src/app/m/_components/MethodCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 import type { MethodInventoryItem } from "@/app/m/_lib/methodInventory";
 
@@ -13,7 +13,9 @@ type MethodCardProps = {
 
 export default function MethodCard({ method, active, sourceAudited }: MethodCardProps) {
   const router = useRouter();
-  const href = `/m/${encodeURIComponent(method.code)}`;
+  const searchParams = useSearchParams();
+  const search = searchParams.toString();
+  const href = `/m/${encodeURIComponent(method.code)}${search ? `?${search}` : ""}`;
   const handleMouseEnter = useCallback(() => { router.prefetch(href); }, [router, href]);
 
   return (

--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -63,6 +63,14 @@ import { getReviewProgress, REVIEW_STORE_EVENT, type ReviewProgress } from "@/li
 import { deriveDocumentSupport } from "@/lib/verify/documentSupport";
 import { buildStacSupportFactsState } from "@/lib/verify/stacSupportFacts";
 import { isSourceAuditedMeta, metaUrlFromRulesPath } from "@/lib/methodBadge";
+import { getProject, updateProject } from "@/lib/projects/storage";
+import type { Project } from "@/lib/projects/types";
+import {
+  ensureReviewWorkspace,
+  getReviewWorkspace,
+  touchReviewWorkspace,
+} from "@/lib/reviewWorkspaces/storage";
+import type { ReviewWorkspace } from "@/lib/reviewWorkspaces/types";
 
 type MethodDetail = {
   code: string;
@@ -134,8 +142,12 @@ export default function MethodDetailPane({
   const isEvidenceMode = mode === "evidence" || isEvidenceRoute;
   const methodsLayout = useMethodsLayout();
   const verifierMode = useMemo(() => isVerifierMode(searchParams), [searchParams]);
+  const linkedProjectId = useMemo(() => (searchParams.get("projectId") ?? "").trim() || null, [searchParams]);
+  const linkedWorkspaceId = useMemo(() => (searchParams.get("workspaceId") ?? "").trim() || null, [searchParams]);
   const urlVerifyMode = useMemo(() => getVerifyView(new URLSearchParams(searchString)), [searchString]);
   const [verifyViewMode, setVerifyViewMode] = useState<"list" | "map">(urlVerifyMode);
+  const [linkedProject, setLinkedProject] = useState<Project | null>(null);
+  const [reviewWorkspace, setReviewWorkspace] = useState<ReviewWorkspace | null>(null);
 
   const metaUrl = useMemo(() => metaUrlFromRulesPath(manifestRulesPath), [manifestRulesPath]);
   const [sourceAudited, setSourceAudited] = useState(false);
@@ -350,6 +362,7 @@ export default function MethodDetailPane({
   const [stacEvidenceByKey, setStacEvidenceByKey] = useState<Record<string, StacEvidenceState>>({});
   const [selectedStacItemId, setSelectedStacItemId] = useState<string | null>(null);
   const [coverageDrawerOpen, setCoverageDrawerOpen] = useState(false);
+  const workspaceScopeId = reviewWorkspace?.id ?? linkedWorkspaceId ?? null;
 
   const lineageVersions = method.lineage?.lineage?.length ? method.lineage.lineage : method.versions;
   const versionBadges = [
@@ -479,18 +492,83 @@ export default function MethodDetailPane({
   );
 
   useEffect(() => {
+    setLinkedProject(linkedProjectId ? getProject(linkedProjectId) ?? null : null);
+  }, [linkedProjectId]);
+
+  useEffect(() => {
+    setReviewWorkspace(linkedWorkspaceId ? getReviewWorkspace(linkedWorkspaceId) ?? null : null);
+  }, [linkedWorkspaceId]);
+
+  useEffect(() => {
+    if (!linkedProjectId || !activeVersion) return;
+    const project = getProject(linkedProjectId);
+    if (!project) return;
+    const currentWorkspace = linkedWorkspaceId ? getReviewWorkspace(linkedWorkspaceId) ?? null : null;
+    if (
+      currentWorkspace &&
+      currentWorkspace.projectId === linkedProjectId &&
+      currentWorkspace.methodCode === method.code &&
+      currentWorkspace.methodVersion === activeVersion
+    ) {
+      setLinkedProject(project);
+      setReviewWorkspace(touchReviewWorkspace(currentWorkspace.id) ?? currentWorkspace);
+      if (
+        project.lastWorkspaceId !== currentWorkspace.id ||
+        project.methodCode !== method.code ||
+        project.methodVersion !== activeVersion
+      ) {
+        setLinkedProject(
+          updateProject(project.id, {
+            methodCode: method.code,
+            methodVersion: activeVersion,
+            reportingPeriod: currentWorkspace.reportingPeriod ?? project.reportingPeriod,
+            lastWorkspaceId: currentWorkspace.id,
+          }) ?? project,
+        );
+      }
+      return;
+    }
+
+    const ensuredWorkspace = ensureReviewWorkspace({
+      projectId: project.id,
+      projectName: project.name,
+      projectCode: project.projectCode,
+      methodCode: method.code,
+      methodVersion: activeVersion,
+      reportingPeriod: project.reportingPeriod,
+    });
+    const updatedProject =
+      updateProject(project.id, {
+        methodCode: method.code,
+        methodVersion: activeVersion,
+        reportingPeriod: ensuredWorkspace.reportingPeriod ?? project.reportingPeriod,
+        lastWorkspaceId: ensuredWorkspace.id,
+      }) ?? project;
+    setLinkedProject(updatedProject);
+    setReviewWorkspace(ensuredWorkspace);
+    if (!pathname) return;
+    const params = new URLSearchParams(searchString);
+    params.set("projectId", project.id);
+    if (params.get("workspaceId") !== ensuredWorkspace.id) {
+      params.set("workspaceId", ensuredWorkspace.id);
+      const next = params.toString();
+      router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
+    }
+  }, [activeVersion, linkedProjectId, linkedWorkspaceId, method.code, pathname, router, searchString]);
+
+  useEffect(() => {
     if (!activeVersion) {
       setReviewProgress(null);
       return;
     }
     const updateProgress = () => {
-      setReviewProgress(getReviewProgress(method.code, activeVersion, requirementRows.length));
+      setReviewProgress(getReviewProgress(method.code, activeVersion, requirementRows.length, workspaceScopeId));
     };
     updateProgress();
     const handleReviewStoreChange = () => updateProgress();
     window.addEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
     return () => window.removeEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
-  }, [activeVersion, method.code, requirementRows.length]);
+  }, [activeVersion, method.code, requirementRows.length, workspaceScopeId]);
 
   useEffect(() => {
     setRules([]);
@@ -541,30 +619,30 @@ export default function MethodDetailPane({
 
   useEffect(() => {
     if (!activeVersion) return;
-    setCurrentAoi(loadAoi(method.code, activeVersion));
-    setDraftAoi(loadDraftAoi(method.code, activeVersion));
-    setEvidencePins(coalesceEvidencePins(loadPins(method.code, activeVersion)));
-    setEvidenceSnapshots(loadEvidenceSnapshots(method.code, activeVersion));
-    setVerificationRuns(loadVerificationRuns(method.code, activeVersion));
+    setCurrentAoi(loadAoi(method.code, activeVersion, workspaceScopeId));
+    setDraftAoi(loadDraftAoi(method.code, activeVersion, workspaceScopeId));
+    setEvidencePins(coalesceEvidencePins(loadPins(method.code, activeVersion, workspaceScopeId)));
+    setEvidenceSnapshots(loadEvidenceSnapshots(method.code, activeVersion, workspaceScopeId));
+    setVerificationRuns(loadVerificationRuns(method.code, activeVersion, workspaceScopeId));
     setUndoSnapshot(null);
-  }, [activeVersion, method.code]);
+  }, [activeVersion, method.code, workspaceScopeId]);
 
   const setCurrentAoiAndPersist = useCallback(
     (nextAoi: AOI | null) => {
       setCurrentAoi(nextAoi);
       if (!activeVersion) return;
-      saveAoi(method.code, activeVersion, nextAoi);
+      saveAoi(method.code, activeVersion, nextAoi, workspaceScopeId);
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, workspaceScopeId],
   );
 
   const setDraftAoiAndPersist = useCallback(
     (nextAoi: AOI | null) => {
       setDraftAoi(nextAoi);
       if (!activeVersion) return;
-      saveDraftAoi(method.code, activeVersion, nextAoi);
+      saveDraftAoi(method.code, activeVersion, nextAoi, workspaceScopeId);
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, workspaceScopeId],
   );
 
   const setActiveAoiAndPersist = useCallback(
@@ -583,11 +661,11 @@ export default function MethodDetailPane({
       setEvidencePins((current) => {
         const resolved = typeof nextPins === "function" ? nextPins(current) : nextPins;
         const normalizedPins = coalesceEvidencePins(resolved);
-        if (activeVersion) savePins(method.code, activeVersion, normalizedPins);
+        if (activeVersion) savePins(method.code, activeVersion, normalizedPins, workspaceScopeId);
         return normalizedPins;
       });
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, workspaceScopeId],
   );
   const handleLinkInventoryItem = useCallback(
     (evidenceId: string, ruleId: string, fragmentId?: string) => {
@@ -614,18 +692,18 @@ export default function MethodDetailPane({
     (nextSnapshots: ProofEvidenceItem[]) => {
       setEvidenceSnapshots(nextSnapshots);
       if (!activeVersion) return;
-      saveEvidenceSnapshots(method.code, activeVersion, nextSnapshots);
+      saveEvidenceSnapshots(method.code, activeVersion, nextSnapshots, workspaceScopeId);
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, workspaceScopeId],
   );
 
   const setVerificationRunsAndPersist = useCallback(
     (nextRuns: VerificationRun[]) => {
       setVerificationRuns(nextRuns);
       if (!activeVersion) return;
-      saveVerificationRuns(method.code, activeVersion, nextRuns);
+      saveVerificationRuns(method.code, activeVersion, nextRuns, workspaceScopeId);
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, workspaceScopeId],
   );
 
   const hasWorkspaceState = Boolean(
@@ -734,7 +812,7 @@ export default function MethodDetailPane({
 
   const startOverProofMap = useCallback(() => {
     if (!activeVersion) return;
-    clearProofMapStorage(method.code, activeVersion);
+    clearProofMapStorage(method.code, activeVersion, workspaceScopeId);
     clearStoredMapView(`${method.code}@${activeVersion}`);
 
     setCurrentAoi(null);
@@ -755,16 +833,16 @@ export default function MethodDetailPane({
       }
       return next;
     });
-  }, [activeVersion, method.code]);
+  }, [activeVersion, method.code, workspaceScopeId]);
 
   const refreshProofMapFromStorage = useCallback(() => {
     if (!activeVersion) return;
-    setCurrentAoi(loadAoi(method.code, activeVersion));
-    setDraftAoi(loadDraftAoi(method.code, activeVersion));
-    setEvidencePins(coalesceEvidencePins(loadPins(method.code, activeVersion)));
-    setEvidenceSnapshots(loadEvidenceSnapshots(method.code, activeVersion));
-    setVerificationRuns(loadVerificationRuns(method.code, activeVersion));
-  }, [activeVersion, method.code]);
+    setCurrentAoi(loadAoi(method.code, activeVersion, workspaceScopeId));
+    setDraftAoi(loadDraftAoi(method.code, activeVersion, workspaceScopeId));
+    setEvidencePins(coalesceEvidencePins(loadPins(method.code, activeVersion, workspaceScopeId)));
+    setEvidenceSnapshots(loadEvidenceSnapshots(method.code, activeVersion, workspaceScopeId));
+    setVerificationRuns(loadVerificationRuns(method.code, activeVersion, workspaceScopeId));
+  }, [activeVersion, method.code, workspaceScopeId]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -906,7 +984,7 @@ export default function MethodDetailPane({
       const origin = typeof window !== "undefined" ? window.location.origin : "";
       const path = `/m/${encodeURIComponent(method.code)}/v/${encodeURIComponent(activeVersion ?? "")}`;
       const { tab, rule, section, hash } = encodeShareState({ tab: "rules", rule: ruleId });
-      const params = new URLSearchParams();
+      const params = new URLSearchParams(searchString);
       if (tab) params.set("tab", tab);
       if (rule) params.set("rule", rule);
       if (section) params.set("section", section);
@@ -914,7 +992,7 @@ export default function MethodDetailPane({
       const suffix = `${query ? `?${query}` : ""}${hash ? `#${hash}` : ""}`;
       return `${origin}${path}${suffix}`;
     },
-    [activeVersion, method.code],
+    [activeVersion, method.code, searchString],
   );
 
   const loadRuleDetail = useCallback(async (ruleId: string) => {
@@ -1308,6 +1386,9 @@ export default function MethodDetailPane({
     <ProofMapTab
       methodCode={method.code}
       version={activeVersion ?? ""}
+      workspaceId={workspaceScopeId}
+      linkedProject={linkedProject}
+      reviewWorkspace={reviewWorkspace}
       provenanceJson={provenanceJson}
       mode={isEvidenceMode ? "evidence" : undefined}
       viewMode={verifyViewMode}
@@ -1380,6 +1461,69 @@ export default function MethodDetailPane({
 
   const verifySurface = (
     <div className="mt-4 grid gap-4">
+      <section className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Project</div>
+              <div className="mt-1 text-sm font-semibold text-slate-900">
+                {linkedProject?.name ?? "Unlinked method-only review"}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Project ID</div>
+              <div className="mt-1 text-sm text-slate-700">
+                {linkedProject?.projectCode ?? linkedProject?.id ?? "Missing"}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Methodology</div>
+              <div className="mt-1 text-sm text-slate-700">
+                {activeVersion ? `${method.code} ${activeVersion}` : "Select a version"}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Reporting period</div>
+              <div className="mt-1 text-sm text-slate-700">
+                {reviewWorkspace?.reportingPeriod ?? linkedProject?.reportingPeriod ?? "Not set"}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Workspace</div>
+              <div className="mt-1 text-sm text-slate-700">
+                {reviewWorkspace?.name ?? (linkedProject ? "Will be created on method selection" : "Draft / incomplete")}
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href={linkedProject ? "/projects" : "/projects/new"}
+              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
+            >
+              Change project
+            </Link>
+            <Link
+              href={linkedProjectId ? `/m?projectId=${encodeURIComponent(linkedProjectId)}` : "/m"}
+              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
+            >
+              Change methodology/version
+            </Link>
+            {linkedProject ? (
+              <Link
+                href={`/projects/${encodeURIComponent(linkedProject.id)}`}
+                className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
+              >
+                Edit project details
+              </Link>
+            ) : null}
+          </div>
+        </div>
+        {!linkedProject ? (
+          <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+            This verify flow is running without a linked project. Exports remain draft/incomplete and finalization will stay blocked until a project is linked.
+          </div>
+        ) : null}
+      </section>
       <VerifyHeader
         mode={verifyViewMode}
         verifierMode={verifierMode}
@@ -1433,12 +1577,27 @@ export default function MethodDetailPane({
         <TrustStrip
           methodCode={method.code}
           version={activeVersion}
+          workspaceId={workspaceScopeId}
           packTag={packTag}
           provenanceJson={provenanceJson}
           manifestRulesPath={manifestRulesPath}
           onOpenIntegrityDiff={() => setIntegrityDiffOpen(true)}
           surface="methods"
           methodReviewEvidencePins={evidencePins}
+          projectContext={
+            linkedProject
+              ? {
+                  projectId: linkedProject.id,
+                  projectName: linkedProject.name,
+                  projectCode: linkedProject.projectCode ?? null,
+                  countryLocation: linkedProject.countryLocation ?? null,
+                  proponent: linkedProject.proponent ?? null,
+                  reportingPeriod: reviewWorkspace?.reportingPeriod ?? linkedProject.reportingPeriod ?? null,
+                  workspaceId: workspaceScopeId,
+                  workspaceName: reviewWorkspace?.name ?? null,
+                }
+              : null
+          }
         />
       </div>
 
@@ -1488,6 +1647,7 @@ export default function MethodDetailPane({
         methodologyLabel={`${method.program} ${method.sector} · ${method.code} · ${activeVersion ?? "unknown version"}`}
         reviewMethodology={method.code}
         reviewVersion={activeVersion ?? null}
+        reviewWorkspaceId={workspaceScopeId}
         sourcePath={ruleDetail?.sourcePath ?? null}
         sha256={ruleDetail?.sha256 ?? null}
         ruleTags={activeRequirementRow?.ruleSummary.tags ?? []}

--- a/src/app/m/_components/RuleDetailModal.tsx
+++ b/src/app/m/_components/RuleDetailModal.tsx
@@ -39,6 +39,7 @@ type RuleDetailModalProps = {
   methodologyLabel?: string | null;
   reviewMethodology?: string | null;
   reviewVersion?: string | null;
+  reviewWorkspaceId?: string | null;
   sourcePath?: string | null;
   sha256?: string | null;
   traceSections?: Array<{
@@ -122,6 +123,7 @@ function resolveRuleReviewReviewerArtifact(input: {
   canonicalRuleId?: string | null;
   reviewMethodology?: string | null;
   reviewVersion?: string | null;
+  reviewWorkspaceId?: string | null;
   reviewerMinutes?: string | null;
   reviewerOutcomeNote?: string | null;
 }): { reviewerMinutes: string | null; reviewerOutcomeNote: string | null } {
@@ -135,11 +137,12 @@ function resolveRuleReviewReviewerArtifact(input: {
 
   const methodCode = input.reviewMethodology?.trim() ?? "";
   const version = input.reviewVersion?.trim() ?? "";
+  const workspaceId = input.reviewWorkspaceId?.trim() ?? "";
   if (!methodCode || !version) {
     return { reviewerMinutes: null, reviewerOutcomeNote: null };
   }
 
-  const bundle = readVerifierRunBundle(methodCode, version);
+  const bundle = readVerifierRunBundle(methodCode, version, workspaceId);
   if (!bundle.savedReviewerArtifactAt || !bundle.savedReviewerArtifactContext) {
     return { reviewerMinutes: null, reviewerOutcomeNote: null };
   }
@@ -185,6 +188,7 @@ export default function RuleDetailModal({
   methodologyLabel,
   reviewMethodology,
   reviewVersion,
+  reviewWorkspaceId = null,
   sourcePath,
   sha256,
   traceSections = [],
@@ -216,9 +220,9 @@ export default function RuleDetailModal({
       setReviewOpen(false);
       return;
     }
-    setExistingReview(getReview(canonicalRuleId, reviewMethodology, reviewVersion));
+    setExistingReview(getReview(canonicalRuleId, reviewMethodology, reviewVersion, reviewWorkspaceId));
     setReviewOpen(false);
-  }, [canonicalRuleId, open, reviewMethodology, reviewVersion]);
+  }, [canonicalRuleId, open, reviewMethodology, reviewVersion, reviewWorkspaceId]);
 
   const handleSaveReview = useCallback(
     (review: RuleReview) => {
@@ -303,6 +307,7 @@ export default function RuleDetailModal({
     canonicalRuleId,
     reviewMethodology,
     reviewVersion,
+    reviewWorkspaceId,
     reviewerMinutes,
     reviewerOutcomeNote,
   });
@@ -387,6 +392,7 @@ export default function RuleDetailModal({
               sectionId={row.provenance.sectionId ?? undefined}
               methodology={reviewMethodologyValue}
               version={reviewVersionValue}
+              workspaceId={reviewWorkspaceId}
               anchorUrl={row.provenance.anchor ?? undefined}
               existingReview={existingReview}
               linkedEvidence={row.linkedEvidence.map((item) => ({

--- a/src/app/m/_components/VersionSelector.tsx
+++ b/src/app/m/_components/VersionSelector.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import type { MethodVersionLineage } from "@/app/m/_lib/methodVersionMetadata";
 
 type VersionSelectorProps = {
@@ -19,7 +19,12 @@ export default function VersionSelector({
   lineage,
 }: VersionSelectorProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const value = selectedVersion ?? "";
+  const search = searchParams.toString();
+
+  const buildHref = (version: string) =>
+    `/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(version)}${search ? `?${search}` : ""}`;
 
   const options = useMemo(() => {
     return versions.map((version) => {
@@ -49,7 +54,7 @@ export default function VersionSelector({
           onChange={(event) => {
             const next = event.target.value;
             if (!next) return;
-            router.push(`/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(next)}`);
+            router.push(buildHref(next));
           }}
         >
           <option value="" disabled>
@@ -69,7 +74,7 @@ export default function VersionSelector({
             return (
               <Link
                 key={version}
-                href={`/m/${encodeURIComponent(methodCode)}/v/${encodeURIComponent(version)}`}
+                href={buildHref(version)}
                 className={`rounded-full border px-2.5 py-1 font-semibold ${
                   active
                     ? "border-sky-300 bg-sky-50 text-sky-700"

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -106,6 +106,14 @@ type RecoveryState =
     }
   | null;
 
+type ExtractionDiagnostic =
+  | {
+      code: "parser-failed" | "no-selectable-text" | "selected-methodology-mismatch" | "methodology-not-detected";
+      label: string;
+      message: string;
+    }
+  | null;
+
 type QueryResultWithSignals = QueryResponse["results"][number] & {
   _signalBoost: number;
   _matchedQueries: string[];
@@ -490,6 +498,17 @@ function buildWeakExtractionRecoveryState(): RecoveryState {
   };
 }
 
+function isSpecificMethodologyMention(value: string): boolean {
+  return /\b(?:VMR?\d{3,4}|VMD\d{4}|[A-Z]{2}-[A-Z]{3,}\d{4}|GS-VER\d+)\b/.test(value)
+    || /\b(?:REDD\+\s+Methodology\s+Framework|REDD\+\s+MF)\b/i.test(value)
+    || /\b(?:APD|ARR|RWE|APWD)\b/.test(value);
+}
+
+function pickPrimaryMethodologyMention(mentions: string[]): string | null {
+  const specific = mentions.find((mention) => isSpecificMethodologyMention(mention));
+  return specific ?? mentions[0] ?? null;
+}
+
 export default function QuickCheckPanel({ initialMethod, initialVersion, onContinueToWorkspace }: QuickCheckPanelProps) {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const claimRef = useRef<HTMLTextAreaElement | null>(null);
@@ -698,13 +717,47 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const methodologyMismatch = useMemo(() => {
     if (!draft.methodologyId.trim() || !extractionPreview?.methodologyMentions.length) return null;
     const selected = draft.methodologyId.trim().toUpperCase();
-    const matches = extractionPreview.methodologyMentions.some((m) => m.trim().toUpperCase() === selected);
+    const primaryMention = pickPrimaryMethodologyMention(extractionPreview.methodologyMentions);
+    if (!primaryMention) return null;
+    const matches = primaryMention.trim().toUpperCase() === selected;
     if (matches) return null;
     return {
-      mentions: extractionPreview.methodologyMentions.join(", "),
+      mention: primaryMention,
       selectedMethod: draft.methodologyId.trim(),
     };
   }, [draft.methodologyId, extractionPreview]);
+  const extractionDiagnostic = useMemo<ExtractionDiagnostic>(() => {
+    if (methodologyMismatch) {
+      return {
+        code: "selected-methodology-mismatch",
+        label: "Selected methodology mismatch",
+        message: `Evidence appears to reference ${methodologyMismatch.mention}, but current selected method is ${methodologyMismatch.selectedMethod}.`,
+      };
+    }
+    if (!extractionPreview) return null;
+    if (extractionPreview.warnings.some((warning) => /no selectable text|no extractable text/i.test(warning))) {
+      return {
+        code: "no-selectable-text",
+        label: "No selectable text",
+        message: "The file appears readable, but no selectable text could be extracted from the uploaded PDF.",
+      };
+    }
+    if (extractionPreview.warnings.some((warning) => /pdf parser fallback|pdf extraction failed|parser/i.test(warning))) {
+      return {
+        code: "parser-failed",
+        label: "Parser failed",
+        message: "The primary PDF parser could not read this file cleanly, so Quick Check fell back to a weaker extraction path.",
+      };
+    }
+    if ((extractionPreview.signals?.parsedEvidenceCount ?? 0) > 0 && extractionPreview.methodologyMentions.length === 0) {
+      return {
+        code: "methodology-not-detected",
+        label: "Methodology not detected",
+        message: "We extracted text from the file, but did not detect a methodology reference in the uploaded evidence.",
+      };
+    }
+    return null;
+  }, [extractionPreview, methodologyMismatch]);
   const showAdvancedOptions = showAdvanced || showSavedEvidence || showMethodology;
   const extractionHighlights = extractionPreview?.extractedFacts.slice(0, 3) ?? [];
   const normalizedResult = useMemo(
@@ -1677,6 +1730,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                             ) : null}
                           </div>
                           <div>
+                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Extraction diagnostic</div>
+                            <div className="mt-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700">
+                              {extractionDiagnostic ? (
+                                <>
+                                  <strong>{extractionDiagnostic.label}:</strong> {extractionDiagnostic.message}
+                                </>
+                              ) : (
+                                "No extraction diagnostic from the active source."
+                              )}
+                            </div>
+                          </div>
+                          <div>
                             <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Methodology mentions</div>
                             <div className="mt-2 flex flex-wrap gap-2">
                               {(extractionPreview.methodologyMentions.length ? extractionPreview.methodologyMentions : ["None detected"]).map((mention) => (
@@ -1685,13 +1750,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                                 </span>
                               ))}
                             </div>
-                            {methodologyMismatch ? (
-                              <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
-                                Detected evidence mentions: <strong>{methodologyMismatch.mentions}</strong>.
-                                Current review method: <strong>{methodologyMismatch.selectedMethod}</strong>.
-                                This evidence may belong to a different methodology.
-                              </div>
-                            ) : null}
                           </div>
                           <div className="md:col-span-2">
                             <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Warnings</div>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -49,12 +49,14 @@ import { createAndStoreEvidenceAttachment } from "@/lib/proofMap/attachments";
 import { isRuleLikeId } from "@/lib/proofMap/pins";
 import { loadPins, savePins } from "@/lib/proofMap/storage";
 import type { EvidencePin, PddFragment } from "@/lib/proofMap/types";
-
-type MethodInventoryRecord = {
-  code: string;
-  versions: string[];
-  latestVersion?: string;
-};
+import {
+  resolveMethodologySignals,
+  gatingMethodCodes,
+  buildMethodProgramMap,
+  detectUnavailableMethod,
+  type MethodInventoryRecord,
+  type MethodologySignalResult,
+} from "@/lib/chat/quickCheckMethodSignals";
 
 type QuickCheckPanelProps = {
   initialMethod?: string | null;
@@ -108,7 +110,7 @@ type RecoveryState =
 
 type ExtractionDiagnostic =
   | {
-      code: "parser-failed" | "no-selectable-text" | "selected-methodology-mismatch" | "methodology-not-detected";
+      code: "parser-failed" | "no-selectable-text" | "selected-methodology-mismatch" | "methodology-not-detected" | "method-unavailable";
       label: string;
       message: string;
     }
@@ -504,49 +506,6 @@ function buildWeakExtractionRecoveryState(): RecoveryState {
   };
 }
 
-function isSpecificMethodologyMention(value: string): boolean {
-  return /\b(?:VMR?\d{3,4}|VMD\d{4}|[A-Z]{2}-[A-Z]{3,}\d{4}|GS-VER\d+)\b/.test(value)
-    || /\b(?:REDD\+\s+Methodology\s+Framework|REDD\+\s+MF)\b/i.test(value)
-    || /\b(?:APD|ARR|RWE|APWD)\b/.test(value);
-}
-
-function methodologyMentionPriority(value: string): number {
-  const normalized = value.trim().toUpperCase();
-  if (normalized === "VM0007") return 0;
-  if (normalized === "REDD+ MF" || normalized === "REDD+ METHODOLOGY FRAMEWORK") return 1;
-  if (/^VMD\d{4}$/.test(normalized)) return 2;
-  if (/^(APD|ARR|RWE|APWD)$/.test(normalized)) return 3;
-  return 4;
-}
-
-function pickPrimaryMethodologyMention(mentions: string[]): string | null {
-  const specific = mentions.filter((mention) => isSpecificMethodologyMention(mention));
-  if (specific.length) {
-    return [...specific].sort(
-      (left, right) =>
-        methodologyMentionPriority(left) - methodologyMentionPriority(right) ||
-        left.localeCompare(right),
-    )[0] ?? null;
-  }
-  return mentions[0] ?? null;
-}
-
-function normalizeMethodologyMentionToMethodCode(mention: string): string | null {
-  const normalized = mention.trim().toUpperCase();
-  if (!normalized) return null;
-  if (normalized === "VM0007") return "VM0007";
-  if (normalized === "REDD+ MF" || normalized === "REDD+ METHODOLOGY FRAMEWORK") return "VM0007";
-  return null;
-}
-
-function methodologyMentionsForDetection(input: {
-  analysis: QuickCheckEvidenceAnalysis | null;
-  extraction: QuickCheckExtractionSnapshot | null;
-}): string[] {
-  const mentions = input.analysis?.methodologyMentions ?? input.extraction?.methodologyMentions ?? [];
-  return Array.from(new Set(mentions.map((mention) => mention.trim()).filter(Boolean)));
-}
-
 export default function QuickCheckPanel({ initialMethod, initialVersion, onContinueToWorkspace }: QuickCheckPanelProps) {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const claimRef = useRef<HTMLTextAreaElement | null>(null);
@@ -752,51 +711,78 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     () => (extractionPreview ? deriveQuickCheckExtractionState(extractionPreview) : null),
     [extractionPreview],
   );
-  const detectedMethodologyMentions = useMemo(
-    () => methodologyMentionsForDetection({ analysis: extractionState.analysis, extraction: extractionPreview }),
-    [extractionPreview, extractionState.analysis],
-  );
-  const methodologyMismatch = useMemo(() => {
-    if (!draft.methodologyId.trim() || !detectedMethodologyMentions.length) return null;
-    const selected = draft.methodologyId.trim().toUpperCase();
-    const primaryMention = pickPrimaryMethodologyMention(detectedMethodologyMentions);
-    if (!primaryMention) return null;
-    const normalizedMention = normalizeMethodologyMentionToMethodCode(primaryMention) ?? primaryMention;
-    const matches = normalizedMention.trim().toUpperCase() === selected;
-    if (matches) return null;
-    return {
-      mention: normalizedMention,
-      selectedMethod: draft.methodologyId.trim(),
-    };
-  }, [detectedMethodologyMentions, draft.methodologyId]);
-  const detectedMethodologyConstraint = useMemo<DetectedMethodologyConstraint | null>(() => {
-    if (draft.methodologyId.trim()) return null;
-    if (!detectedMethodologyMentions.length) return null;
-    for (const mention of detectedMethodologyMentions) {
-      const methodologyId = normalizeMethodologyMentionToMethodCode(mention);
-      if (!methodologyId) continue;
-      const methodRecord = methods.find((item) => item.code === methodologyId);
-      const methodologyVersion = pickVersion(methodRecord, null);
-      if (!methodologyVersion) continue;
+  // ── Methodology signal resolution ────────────────────────────────────
+  const methodProgramMap = useMemo(() => buildMethodProgramMap(methods), [methods]);
+  const methodCodeSet = useMemo(() => new Set(methods.map((m) => m.code)), [methods]);
+
+  const rawMethodologyMentions = useMemo(() => {
+    const mentions = extractionState.analysis?.methodologyMentions ?? extractionPreview?.methodologyMentions ?? [];
+    return Array.from(new Set(mentions.map((m) => m.trim()).filter(Boolean)));
+  }, [extractionPreview, extractionState.analysis]);
+
+  const methodSignalResult = useMemo<MethodologySignalResult>(() => {
+    if (!rawMethodologyMentions.length) {
       return {
-        methodologyId,
-        methodologyVersion,
-        sourceMention: mention,
+        detectedMethods: [], detectedPrograms: [], activitySignals: [],
+        rawMentions: [],
+        exactlyOne: false, multiplePossible: false, noMethodDetected: true,
+        programOnly: false, activitySignalsOnly: false, canonicalCodes: [],
       };
     }
-    return null;
-  }, [detectedMethodologyMentions, draft.methodologyId, methods]);
+    return resolveMethodologySignals(rawMethodologyMentions, methodCodeSet, methodProgramMap);
+  }, [rawMethodologyMentions, methodCodeSet, methodProgramMap]);
+
+  const unavailableMethod = useMemo(() => {
+    if (!rawMethodologyMentions.length || !methodCodeSet.size) return null;
+    return detectUnavailableMethod(rawMethodologyMentions, methodCodeSet);
+  }, [rawMethodologyMentions, methodCodeSet]);
+
+  const methodologyMismatch = useMemo(() => {
+    if (!draft.methodologyId.trim() || methodSignalResult.noMethodDetected) return null;
+    const selected = draft.methodologyId.trim().toUpperCase();
+    const detectedCodes = new Set(methodSignalResult.canonicalCodes.map((c) => c.toUpperCase()));
+    if (detectedCodes.size === 0) return null;
+    if (detectedCodes.has(selected)) return null;
+    // Evidence references a different method than what user selected
+    return {
+      mention: methodSignalResult.canonicalCodes.join(", "),
+      selectedMethod: draft.methodologyId.trim(),
+    };
+  }, [draft.methodologyId, methodSignalResult]);
+
+  const detectedMethodologyConstraint = useMemo<DetectedMethodologyConstraint | null>(() => {
+    if (draft.methodologyId.trim()) return null;
+    if (!methodSignalResult.exactlyOne) return null;
+    const detected = methodSignalResult.detectedMethods[0]!;
+    const methodRecord = methods.find((item) => item.code === detected.methodCode);
+    const methodologyVersion = pickVersion(methodRecord, null);
+    if (!methodologyVersion) return null;
+    return {
+      methodologyId: detected.methodCode,
+      methodologyVersion,
+      sourceMention: detected.sourceMention,
+    };
+  }, [draft.methodologyId, methodSignalResult, methods]);
+
   const effectiveMethodologyId = draft.methodologyId.trim() || detectedMethodologyConstraint?.methodologyId || "";
   const effectiveMethodologyVersion = draft.methodologyVersion.trim() || detectedMethodologyConstraint?.methodologyVersion || "";
+
   const extractionDiagnostic = useMemo<ExtractionDiagnostic>(() => {
     if (methodologyMismatch) {
       return {
         code: "selected-methodology-mismatch",
         label: "Selected methodology mismatch",
-        message: `Evidence appears to reference ${methodologyMismatch.mention}, but current selected method is ${methodologyMismatch.selectedMethod}.`,
+        message: `Evidence references ${methodologyMismatch.mention}, but current selected method is ${methodologyMismatch.selectedMethod}.`,
       };
     }
     if (!extractionPreview) return null;
+    if (unavailableMethod && !draft.methodologyId.trim()) {
+      return {
+        code: "method-unavailable",
+        label: "Method not available",
+        message: `Detected ${unavailableMethod}, but no matching method pack is available.`,
+      };
+    }
     if (extractionPreview.warnings.some((warning) => /no selectable text|no extractable text/i.test(warning))) {
       return {
         code: "no-selectable-text",
@@ -811,7 +797,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         message: "The primary PDF parser could not read this file cleanly, so Quick Check fell back to a weaker extraction path.",
       };
     }
-    if ((extractionPreview.signals?.parsedEvidenceCount ?? 0) > 0 && extractionPreview.methodologyMentions.length === 0) {
+    if ((extractionPreview.signals?.parsedEvidenceCount ?? 0) > 0 && rawMethodologyMentions.length === 0) {
       return {
         code: "methodology-not-detected",
         label: "Methodology not detected",
@@ -819,7 +805,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       };
     }
     return null;
-  }, [extractionPreview, methodologyMismatch]);
+  }, [extractionPreview, methodologyMismatch, unavailableMethod, draft.methodologyId, rawMethodologyMentions.length]);
   const showAdvancedOptions = showAdvanced || showSavedEvidence || showMethodology;
   const extractionHighlights = extractionPreview?.extractedFacts.slice(0, 3) ?? [];
   const normalizedResult = useMemo(
@@ -1359,16 +1345,107 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         })),
       );
       const mergedResults = mergeQueryResults(responses);
-      const allCandidates = buildMatchCandidates(mergedResults, methods, "", "", draft.claimText.trim(), evidenceAnalysis, claimIntents);
-      let candidates = buildMatchCandidates(
-        mergedResults,
-        methods,
-        effectiveMethodologyId,
-        effectiveMethodologyVersion,
-        draft.claimText.trim(),
-        evidenceAnalysis,
-        claimIntents,
+
+      // ── Methodology-aware candidate gating ──────────────────────────
+      // Re-resolve signals using the fresh evidence analysis
+      const freshMentions = evidenceAnalysis.methodologyMentions
+        .map((m) => m.trim())
+        .filter(Boolean);
+      const freshMethodCodeSet = new Set(methods.map((m) => m.code));
+      const freshMethodProgramMap = buildMethodProgramMap(methods);
+      const freshMethodSignals = freshMentions.length
+        ? resolveMethodologySignals(
+            Array.from(new Set(freshMentions)),
+            freshMethodCodeSet,
+            freshMethodProgramMap,
+          )
+        : methodSignalResult;
+
+      const freshUnavailableMethod = freshMentions.length && methods.length
+        ? detectUnavailableMethod(
+            Array.from(new Set(freshMentions)),
+            freshMethodCodeSet,
+          )
+        : unavailableMethod;
+
+      // Determine gating: which method codes should we restrict to?
+      const gate = !draft.methodologyId.trim()
+        ? gatingMethodCodes(freshMethodSignals, freshMethodProgramMap)
+        : null;
+
+      // Method unavailable check
+      if (freshUnavailableMethod && !draft.methodologyId.trim() && !gate) {
+        setShowMethodology(true);
+        setFieldErrors({});
+        setRecoveryState({
+          kind: "no-match",
+          title: 'Detected ' + freshUnavailableMethod,
+          description: 'Evidence references ' + freshUnavailableMethod + ', but no matching method pack is available.',
+          note: "Upload a different methodology pack to enable verification for this project.",
+        });
+        return;
+      }
+
+      // Build all candidates (unfiltered) for fallback
+      const allCandidates = buildMatchCandidates(
+        mergedResults, methods, "", "",
+        draft.claimText.trim(), evidenceAnalysis, claimIntents,
       );
+
+      // Build gated candidates
+      let candidates: MatchCandidate[];
+      if (draft.methodologyId.trim()) {
+        candidates = buildMatchCandidates(
+          mergedResults, methods,
+          effectiveMethodologyId, effectiveMethodologyVersion,
+          draft.claimText.trim(), evidenceAnalysis, claimIntents,
+        );
+      } else if (gate && gate.length === 1) {
+        // Exactly one method detected — hard-gate to it
+        const gatedMethod = gate[0]!;
+        const gatedRecord = methods.find((m) => m.code === gatedMethod);
+        const gatedVersion = pickVersion(gatedRecord, null);
+        candidates = buildMatchCandidates(
+          mergedResults, methods,
+          gatedMethod, gatedVersion,
+          draft.claimText.trim(), evidenceAnalysis, claimIntents,
+        );
+        if (!candidates.length) {
+          setShowMethodology(true);
+          setFieldErrors({});
+          setRecoveryState(
+            buildNoValidAnalysisPathRecoveryState({
+              methodologyId: gatedMethod,
+              evidenceSignals: evidenceAnalysis,
+            }),
+          );
+          return;
+        }
+      } else if (gate && gate.length > 1) {
+        // Multiple methods detected — restrict to detected methods only
+        candidates = [];
+        for (const gatedMethod of gate) {
+          const gatedRecord = methods.find((m) => m.code === gatedMethod);
+          const gatedVersion = pickVersion(gatedRecord, null);
+          const methodCandidates = buildMatchCandidates(
+            mergedResults, methods,
+            gatedMethod, gatedVersion,
+            draft.claimText.trim(), evidenceAnalysis, claimIntents,
+          );
+          for (const c of methodCandidates) {
+            if (!candidates.some((existing) => existing.key === c.key)) {
+              candidates.push(c);
+            }
+          }
+        }
+        candidates.sort(
+          (a, b) => (b.score ?? -1) - (a.score ?? -1) || a.requirementLabel.localeCompare(b.requirementLabel),
+        );
+        candidates = candidates.slice(0, 8);
+      } else {
+        // No gating — broad match (label will indicate this in UI)
+        candidates = allCandidates;
+      }
 
       if (draft.methodologyId.trim() && !candidates.length && allCandidates.length) {
         const broaderResolvedCandidates = await resolveQuickCheckCandidates({
@@ -1410,21 +1487,15 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         }
       }
 
-      if (detectedMethodologyConstraint && !draft.methodologyId.trim() && !candidates.length) {
-        setFieldErrors({});
-        setRecoveryState(
-          buildNoValidAnalysisPathRecoveryState({
-            methodologyId: detectedMethodologyConstraint.methodologyId,
-            evidenceSignals: evidenceAnalysis,
-          }),
-        );
-        return;
-      }
-
+      // ── Local fallback if no semantic candidates ────────────────────
       if (!candidates.length) {
         const methodSubset = effectiveMethodologyId
           ? methods.filter((method) => method.code === effectiveMethodologyId)
-          : methods;
+          : gate && gate.length === 1
+            ? methods.filter((method) => method.code === gate[0])
+            : gate && gate.length > 1
+              ? methods.filter((method) => gate.includes(method.code))
+              : methods;
         candidates = await buildLocalFallbackCandidates(methodSubset, evidenceAnalysis);
       }
 
@@ -1463,11 +1534,13 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         return;
       }
 
-      if (!resolvedCandidates.length && detectedMethodologyConstraint && !draft.methodologyId.trim()) {
+      if (!resolvedCandidates.length && gate && gate.length === 1 && !draft.methodologyId.trim()) {
+        // Detected a method but no candidates found — show recovery for that method
+        setShowMethodology(true);
         setFieldErrors({});
         setRecoveryState(
           buildNoValidAnalysisPathRecoveryState({
-            methodologyId: detectedMethodologyConstraint.methodologyId,
+            methodologyId: gate[0]!,
             evidenceSignals: evidenceAnalysis,
           }),
         );
@@ -1485,9 +1558,20 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         if (resolvedCandidates.length) {
           setMatchCandidates(resolvedCandidates);
           setRecoveryState(null);
-          setFieldErrors({
-            general: "This methodology filter removed closer matches. Pick a likely match below or try another methodology.",
-          });
+          if (gate && gate.length > 1) {
+            setShowMethodology(true);
+            setFieldErrors({
+              general: "Multiple methodologies detected. Select one below or narrow your search.",
+            });
+          } else if (!gate && !draft.methodologyId.trim()) {
+            setFieldErrors({
+              general: "Broad match (no methodology detected in evidence). Pick a likely match or narrow by methodology.",
+            });
+          } else {
+            setFieldErrors({
+              general: "Broad match. Narrow by methodology.",
+            });
+          }
           return;
         }
       }
@@ -1505,7 +1589,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         return;
       }
 
-      if (!draft.methodologyId.trim() && !detectedMethodologyConstraint && requiresMethodologyConfirmation(resolvedCandidates)) {
+      // ── Methodology confirmation when detection is ambiguous ─────────
+      if (!draft.methodologyId.trim() && !methodSignalResult.exactlyOne && requiresMethodologyConfirmation(resolvedCandidates)) {
         setShowMethodology(true);
         setMatchCandidates(resolvedCandidates);
         setFieldErrors({});
@@ -1761,7 +1846,15 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     <>
                       {detectedMethodologyConstraint ? (
                         <div className="mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-3 text-sm text-emerald-900">
-                          Detected methodology: {detectedMethodologyConstraint.methodologyId}. Requirement matches are narrowed to Verra {detectedMethodologyConstraint.methodologyId}.
+                          Detected methodology: {detectedMethodologyConstraint.methodologyId}. Requirement matches are narrowed to {detectedMethodologyConstraint.methodologyId}.
+                        </div>
+                      ) : methodSignalResult.multiplePossible ? (
+                        <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
+                          Multiple methodologies detected ({methodSignalResult.canonicalCodes.join(", ")}). Pick one before running Quick Check.
+                        </div>
+                      ) : methodSignalResult.programOnly ? (
+                        <div className="mt-3 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700">
+                          Detected program: {methodSignalResult.detectedPrograms.map((p) => p.program).join(", ")} — broad match within program.
                         </div>
                       ) : null}
                       <div className="mt-4 grid gap-3 md:grid-cols-[1.1fr_0.9fr]">

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -712,7 +712,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     [extractionPreview],
   );
   // ── Methodology signal resolution ────────────────────────────────────
-  const methodProgramMap = useMemo(() => buildMethodProgramMap(methods), [methods]);
   const methodCodeSet = useMemo(() => new Set(methods.map((m) => m.code)), [methods]);
 
   const rawMethodologyMentions = useMemo(() => {

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -114,6 +114,12 @@ type ExtractionDiagnostic =
     }
   | null;
 
+type DetectedMethodologyConstraint = {
+  methodologyId: string;
+  methodologyVersion: string;
+  sourceMention: string;
+};
+
 type QueryResultWithSignals = QueryResponse["results"][number] & {
   _signalBoost: number;
   _matchedQueries: string[];
@@ -509,6 +515,14 @@ function pickPrimaryMethodologyMention(mentions: string[]): string | null {
   return specific ?? mentions[0] ?? null;
 }
 
+function normalizeMethodologyMentionToMethodCode(mention: string): string | null {
+  const normalized = mention.trim().toUpperCase();
+  if (!normalized) return null;
+  if (normalized === "VM0007") return "VM0007";
+  if (normalized === "REDD+ MF" || normalized === "REDD+ METHODOLOGY FRAMEWORK") return "VM0007";
+  return null;
+}
+
 export default function QuickCheckPanel({ initialMethod, initialVersion, onContinueToWorkspace }: QuickCheckPanelProps) {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const claimRef = useRef<HTMLTextAreaElement | null>(null);
@@ -719,13 +733,33 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     const selected = draft.methodologyId.trim().toUpperCase();
     const primaryMention = pickPrimaryMethodologyMention(extractionPreview.methodologyMentions);
     if (!primaryMention) return null;
-    const matches = primaryMention.trim().toUpperCase() === selected;
+    const normalizedMention = normalizeMethodologyMentionToMethodCode(primaryMention) ?? primaryMention;
+    const matches = normalizedMention.trim().toUpperCase() === selected;
     if (matches) return null;
     return {
-      mention: primaryMention,
+      mention: normalizedMention,
       selectedMethod: draft.methodologyId.trim(),
     };
   }, [draft.methodologyId, extractionPreview]);
+  const detectedMethodologyConstraint = useMemo<DetectedMethodologyConstraint | null>(() => {
+    if (draft.methodologyId.trim()) return null;
+    if (!extractionPreview?.methodologyMentions.length) return null;
+    for (const mention of extractionPreview.methodologyMentions) {
+      const methodologyId = normalizeMethodologyMentionToMethodCode(mention);
+      if (!methodologyId) continue;
+      const methodRecord = methods.find((item) => item.code === methodologyId);
+      const methodologyVersion = pickVersion(methodRecord, null);
+      if (!methodologyVersion) continue;
+      return {
+        methodologyId,
+        methodologyVersion,
+        sourceMention: mention,
+      };
+    }
+    return null;
+  }, [draft.methodologyId, extractionPreview, methods]);
+  const effectiveMethodologyId = draft.methodologyId.trim() || detectedMethodologyConstraint?.methodologyId || "";
+  const effectiveMethodologyVersion = draft.methodologyVersion.trim() || detectedMethodologyConstraint?.methodologyVersion || "";
   const extractionDiagnostic = useMemo<ExtractionDiagnostic>(() => {
     if (methodologyMismatch) {
       return {
@@ -1282,7 +1316,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         setRecoveryState(buildWeakExtractionRecoveryState());
         return;
       }
-      const selectedMethodologyId = draft.methodologyId.trim();
+      const selectedMethodologyId = effectiveMethodologyId;
       if (selectedMethodologyId && !methods.some((method) => method.code === selectedMethodologyId)) {
         setShowMethodology(true);
         setFieldErrors({});
@@ -1301,8 +1335,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       let candidates = buildMatchCandidates(
         mergedResults,
         methods,
-        draft.methodologyId,
-        draft.methodologyVersion,
+        effectiveMethodologyId,
+        effectiveMethodologyVersion,
         draft.claimText.trim(),
         evidenceAnalysis,
         claimIntents,
@@ -1348,9 +1382,20 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         }
       }
 
+      if (detectedMethodologyConstraint && !draft.methodologyId.trim() && !candidates.length) {
+        setFieldErrors({});
+        setRecoveryState(
+          buildNoValidAnalysisPathRecoveryState({
+            methodologyId: detectedMethodologyConstraint.methodologyId,
+            evidenceSignals: evidenceAnalysis,
+          }),
+        );
+        return;
+      }
+
       if (!candidates.length) {
-        const methodSubset = draft.methodologyId.trim()
-          ? methods.filter((method) => method.code === draft.methodologyId)
+        const methodSubset = effectiveMethodologyId
+          ? methods.filter((method) => method.code === effectiveMethodologyId)
           : methods;
         candidates = await buildLocalFallbackCandidates(methodSubset, evidenceAnalysis);
       }
@@ -1390,6 +1435,17 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         return;
       }
 
+      if (!resolvedCandidates.length && detectedMethodologyConstraint && !draft.methodologyId.trim()) {
+        setFieldErrors({});
+        setRecoveryState(
+          buildNoValidAnalysisPathRecoveryState({
+            methodologyId: detectedMethodologyConstraint.methodologyId,
+            evidenceSignals: evidenceAnalysis,
+          }),
+        );
+        return;
+      }
+
       if (!resolvedCandidates.length && !draft.methodologyId.trim()) {
         const broaderCandidates =
           allCandidates.length > 0 ? allCandidates : await buildLocalFallbackCandidates(methods, evidenceAnalysis);
@@ -1421,7 +1477,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         return;
       }
 
-      if (!draft.methodologyId.trim() && requiresMethodologyConfirmation(resolvedCandidates)) {
+      if (!draft.methodologyId.trim() && !detectedMethodologyConstraint && requiresMethodologyConfirmation(resolvedCandidates)) {
         setShowMethodology(true);
         setMatchCandidates(resolvedCandidates);
         setFieldErrors({});
@@ -1675,6 +1731,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     </div>
                   ) : extractionPreview ? (
                     <>
+                      {detectedMethodologyConstraint ? (
+                        <div className="mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-3 text-sm text-emerald-900">
+                          Detected methodology: {detectedMethodologyConstraint.methodologyId}. Requirement matches are narrowed to Verra {detectedMethodologyConstraint.methodologyId}.
+                        </div>
+                      ) : null}
                       <div className="mt-4 grid gap-3 md:grid-cols-[1.1fr_0.9fr]">
                         <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
                           <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">What we found first</div>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -510,9 +510,25 @@ function isSpecificMethodologyMention(value: string): boolean {
     || /\b(?:APD|ARR|RWE|APWD)\b/.test(value);
 }
 
+function methodologyMentionPriority(value: string): number {
+  const normalized = value.trim().toUpperCase();
+  if (normalized === "VM0007") return 0;
+  if (normalized === "REDD+ MF" || normalized === "REDD+ METHODOLOGY FRAMEWORK") return 1;
+  if (/^VMD\d{4}$/.test(normalized)) return 2;
+  if (/^(APD|ARR|RWE|APWD)$/.test(normalized)) return 3;
+  return 4;
+}
+
 function pickPrimaryMethodologyMention(mentions: string[]): string | null {
-  const specific = mentions.find((mention) => isSpecificMethodologyMention(mention));
-  return specific ?? mentions[0] ?? null;
+  const specific = mentions.filter((mention) => isSpecificMethodologyMention(mention));
+  if (specific.length) {
+    return [...specific].sort(
+      (left, right) =>
+        methodologyMentionPriority(left) - methodologyMentionPriority(right) ||
+        left.localeCompare(right),
+    )[0] ?? null;
+  }
+  return mentions[0] ?? null;
 }
 
 function normalizeMethodologyMentionToMethodCode(mention: string): string | null {
@@ -521,6 +537,14 @@ function normalizeMethodologyMentionToMethodCode(mention: string): string | null
   if (normalized === "VM0007") return "VM0007";
   if (normalized === "REDD+ MF" || normalized === "REDD+ METHODOLOGY FRAMEWORK") return "VM0007";
   return null;
+}
+
+function methodologyMentionsForDetection(input: {
+  analysis: QuickCheckEvidenceAnalysis | null;
+  extraction: QuickCheckExtractionSnapshot | null;
+}): string[] {
+  const mentions = input.analysis?.methodologyMentions ?? input.extraction?.methodologyMentions ?? [];
+  return Array.from(new Set(mentions.map((mention) => mention.trim()).filter(Boolean)));
 }
 
 export default function QuickCheckPanel({ initialMethod, initialVersion, onContinueToWorkspace }: QuickCheckPanelProps) {
@@ -728,10 +752,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     () => (extractionPreview ? deriveQuickCheckExtractionState(extractionPreview) : null),
     [extractionPreview],
   );
+  const detectedMethodologyMentions = useMemo(
+    () => methodologyMentionsForDetection({ analysis: extractionState.analysis, extraction: extractionPreview }),
+    [extractionPreview, extractionState.analysis],
+  );
   const methodologyMismatch = useMemo(() => {
-    if (!draft.methodologyId.trim() || !extractionPreview?.methodologyMentions.length) return null;
+    if (!draft.methodologyId.trim() || !detectedMethodologyMentions.length) return null;
     const selected = draft.methodologyId.trim().toUpperCase();
-    const primaryMention = pickPrimaryMethodologyMention(extractionPreview.methodologyMentions);
+    const primaryMention = pickPrimaryMethodologyMention(detectedMethodologyMentions);
     if (!primaryMention) return null;
     const normalizedMention = normalizeMethodologyMentionToMethodCode(primaryMention) ?? primaryMention;
     const matches = normalizedMention.trim().toUpperCase() === selected;
@@ -740,11 +768,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       mention: normalizedMention,
       selectedMethod: draft.methodologyId.trim(),
     };
-  }, [draft.methodologyId, extractionPreview]);
+  }, [detectedMethodologyMentions, draft.methodologyId]);
   const detectedMethodologyConstraint = useMemo<DetectedMethodologyConstraint | null>(() => {
     if (draft.methodologyId.trim()) return null;
-    if (!extractionPreview?.methodologyMentions.length) return null;
-    for (const mention of extractionPreview.methodologyMentions) {
+    if (!detectedMethodologyMentions.length) return null;
+    for (const mention of detectedMethodologyMentions) {
       const methodologyId = normalizeMethodologyMentionToMethodCode(mention);
       if (!methodologyId) continue;
       const methodRecord = methods.find((item) => item.code === methodologyId);
@@ -757,7 +785,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       };
     }
     return null;
-  }, [draft.methodologyId, extractionPreview, methods]);
+  }, [detectedMethodologyMentions, draft.methodologyId, methods]);
   const effectiveMethodologyId = draft.methodologyId.trim() || detectedMethodologyConstraint?.methodologyId || "";
   const effectiveMethodologyVersion = draft.methodologyVersion.trim() || detectedMethodologyConstraint?.methodologyVersion || "";
   const extractionDiagnostic = useMemo<ExtractionDiagnostic>(() => {

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -729,7 +729,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         programOnly: false, activitySignalsOnly: false, canonicalCodes: [],
       };
     }
-    return resolveMethodologySignals(rawMethodologyMentions, methodCodeSet, methodProgramMap);
+    return resolveMethodologySignals(rawMethodologyMentions, methodCodeSet);
   }, [rawMethodologyMentions, methodCodeSet, methodProgramMap]);
 
   const unavailableMethod = useMemo(() => {
@@ -1357,7 +1357,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         ? resolveMethodologySignals(
             Array.from(new Set(freshMentions)),
             freshMethodCodeSet,
-            freshMethodProgramMap,
           )
         : methodSignalResult;
 

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -730,7 +730,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       };
     }
     return resolveMethodologySignals(rawMethodologyMentions, methodCodeSet);
-  }, [rawMethodologyMentions, methodCodeSet, methodProgramMap]);
+  }, [rawMethodologyMentions, methodCodeSet]);
 
   const unavailableMethod = useMemo(() => {
     if (!rawMethodologyMentions.length || !methodCodeSet.size) return null;

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -3037,6 +3037,7 @@ export default function ProofMapTab({
         createReviewerArtifactContext({
           methodCode,
           version,
+          workspaceId,
           ruleId: savedReviewerRuleId,
           runId: verifierBundle.runContext.runId,
         }),
@@ -3098,6 +3099,7 @@ export default function ProofMapTab({
     verifierBundle.savedReviewerArtifactAt,
     verifierBundle.savedReviewerArtifactContext,
     version,
+    workspaceId,
   ]);
 
   const buildClientReadinessReportPayload = useCallback(async () => {

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -86,6 +86,8 @@ import {
 } from "@/lib/verify/runState";
 import ProofCoverageChip from "@/components/verify/ProofCoverageChip";
 import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
+import type { Project } from "@/lib/projects/types";
+import type { ReviewWorkspace } from "@/lib/reviewWorkspaces/types";
 
 type ToastState = {
   title: string;
@@ -95,6 +97,9 @@ type ToastState = {
 type ProofMapTabProps = {
   methodCode: string;
   version: string;
+  workspaceId?: string | null;
+  linkedProject?: Project | null;
+  reviewWorkspace?: ReviewWorkspace | null;
   provenanceJson?: unknown | null;
   mode?: "explorer" | "evidence";
   viewMode?: "list" | "map";
@@ -421,6 +426,9 @@ function statusPill(status: VerificationRun["status"]): { label: string; classNa
 export default function ProofMapTab({
   methodCode,
   version,
+  workspaceId = null,
+  linkedProject = null,
+  reviewWorkspace = null,
   provenanceJson,
   mode = "explorer",
   viewMode = "map",
@@ -481,8 +489,8 @@ export default function ProofMapTab({
   const [startOverOpen, setStartOverOpen] = useState(false);
   const [startOverBusy, setStartOverBusy] = useState(false);
   const [panelCollapsed, setPanelCollapsed] = useState(false);
-  const [verifierBundle, setVerifierBundle] = useState(() => readVerifierRunBundle(methodCode, version));
-  const [runHistory, setRunHistory] = useState(() => readRunHistory(methodCode, version));
+  const [verifierBundle, setVerifierBundle] = useState(() => readVerifierRunBundle(methodCode, version, workspaceId));
+  const [runHistory, setRunHistory] = useState(() => readRunHistory(methodCode, version, workspaceId));
   const [baselineTick, setBaselineTick] = useState(0);
   const [currentInputFingerprint, setCurrentInputFingerprint] = useState<string | null>(null);
   const [secondarySectionOpen, setSecondarySectionOpen] = useState(false);
@@ -655,29 +663,30 @@ export default function ProofMapTab({
   }, [fetchSelectedRuleContext, selectedRuleId]);
 
   useEffect(() => {
-    setVerifierBundle(readVerifierRunBundle(methodCode, version));
-  }, [methodCode, version]);
+    setVerifierBundle(readVerifierRunBundle(methodCode, version, workspaceId));
+  }, [methodCode, version, workspaceId]);
 
   useEffect(() => {
-    setRunHistory(readRunHistory(methodCode, version));
-  }, [methodCode, version]);
+    setRunHistory(readRunHistory(methodCode, version, workspaceId));
+  }, [methodCode, version, workspaceId]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      persistVerifierRunBundle(methodCode, version, verifierBundle);
+      persistVerifierRunBundle(methodCode, version, verifierBundle, workspaceId);
     }, 300);
     return () => window.clearTimeout(timer);
-  }, [methodCode, verifierBundle, version]);
+  }, [methodCode, verifierBundle, version, workspaceId]);
 
   const currentReviewerContext = useMemo(
     () =>
       createReviewerArtifactContext({
         methodCode,
         version,
+        workspaceId,
         ruleId: selectedRuleId,
         runId: verifierBundle.runContext.runId,
       }),
-    [methodCode, selectedRuleId, verifierBundle.runContext.runId, version],
+    [methodCode, selectedRuleId, verifierBundle.runContext.runId, version, workspaceId],
   );
 
   useEffect(() => {
@@ -1003,7 +1012,7 @@ export default function ProofMapTab({
       historicalCurrent && canonicalJsonStringify(historicalCurrent.bundle) !== canonicalJsonStringify(currentWorkspaceBundle)
         ? {
             ...currentWorkspaceBundle,
-            runContext: createVerifierRunBundle(methodCode, version).runContext,
+            runContext: createVerifierRunBundle(methodCode, version, workspaceId).runContext,
           }
         : currentWorkspaceBundle;
     setVerifierBundle((current) =>
@@ -1011,16 +1020,16 @@ export default function ProofMapTab({
         ? current
         : { ...current, runContext: draftBundle.runContext },
     );
-    setRunHistory(saveCurrentRunToHistory(methodCode, version, draftBundle));
+    setRunHistory(saveCurrentRunToHistory(methodCode, version, draftBundle, workspaceId));
     return draftBundle.runContext.runId;
-  }, [currentWorkspaceBundle, methodCode, runHistory, verifierBundle.runContext.runId, version]);
+  }, [currentWorkspaceBundle, methodCode, runHistory, verifierBundle.runContext.runId, version, workspaceId]);
 
   const handleSaveRunHistory = useCallback(
     (bundleOverride?: ReturnType<typeof buildHistoryBundle>) => {
       const bundle = bundleOverride ?? buildHistoryBundle();
-      setRunHistory(saveCurrentRunToHistory(methodCode, version, bundle));
+      setRunHistory(saveCurrentRunToHistory(methodCode, version, bundle, workspaceId));
     },
-    [buildHistoryBundle, methodCode, version],
+    [buildHistoryBundle, methodCode, version, workspaceId],
   );
 
   const handleLoadRunHistory = useCallback(
@@ -1031,12 +1040,13 @@ export default function ProofMapTab({
         if (!confirmed) return;
         persistCurrentWorkspaceAsDraft();
       }
-      const loaded = loadRunFromHistory(methodCode, version, runId);
+      const loaded = loadRunFromHistory(methodCode, version, runId, workspaceId);
       if (!loaded) return;
-      const editableRun = createVerifierRunBundle(methodCode, version);
+      const editableRun = createVerifierRunBundle(methodCode, version, workspaceId);
       const loadedReviewerContext = createReviewerArtifactContext({
         methodCode,
         version,
+        workspaceId,
         ruleId: loaded.selectedRuleId ?? null,
         runId: editableRun.runContext.runId,
       });
@@ -1083,14 +1093,15 @@ export default function ProofMapTab({
       showToast,
       verifierBundle.runContext.runId,
       version,
+      workspaceId,
     ],
   );
 
   const handleDeleteRunHistory = useCallback(
     (runId: string) => {
-      setRunHistory(deleteRunFromHistory(methodCode, version, runId));
+      setRunHistory(deleteRunFromHistory(methodCode, version, runId, workspaceId));
     },
-    [methodCode, version],
+    [methodCode, version, workspaceId],
   );
 
   const handleSearchStac = useCallback(async () => {
@@ -1816,8 +1827,12 @@ export default function ProofMapTab({
     if (!totalRules || totalRules < 1) {
       return { canFinalize: false, reasons: ["Rule count unavailable for finalize gate."] };
     }
-    return checkFinalizeGate(methodCode, version, totalRules);
-  }, [methodCode, reviewGateVersion, totalRules, verifierMode, version]);
+    return checkFinalizeGate(methodCode, version, totalRules, {
+      workspaceId,
+      projectLinked: Boolean(linkedProject?.id),
+      methodologyLinked: Boolean(methodCode.trim() && version.trim()),
+    });
+  }, [linkedProject?.id, methodCode, reviewGateVersion, totalRules, verifierMode, version, workspaceId]);
   const selectedStacItemRecord = useMemo(() => {
     if (!selectedStacItemId) return null;
     const candidate = currentStacEvidence?.itemsById?.[selectedStacItemId];
@@ -3039,7 +3054,7 @@ export default function ProofMapTab({
       reviewerArtifactsByRuleId,
     });
 
-    const reviewsByRuleId = getAllReviews(methodCode, version);
+    const reviewsByRuleId = getAllReviews(methodCode, version, workspaceId);
 
     const suppliedDocuments = [...evidenceInventory]
       .filter((item) => item.kind !== "stac-item")
@@ -4781,6 +4796,20 @@ export default function ProofMapTab({
                 summary={activeReviewArtifact?.summary ?? reviewSummary}
                 artifact={activeReviewArtifact}
                 evidencePins={evidencePins}
+                projectContext={
+                  linkedProject
+                    ? {
+                        projectId: linkedProject.id,
+                        projectName: linkedProject.name,
+                        projectCode: linkedProject.projectCode ?? null,
+                        countryLocation: linkedProject.countryLocation ?? null,
+                        proponent: linkedProject.proponent ?? null,
+                        reportingPeriod: reviewWorkspace?.reportingPeriod ?? linkedProject.reportingPeriod ?? null,
+                        workspaceId: workspaceId,
+                        workspaceName: reviewWorkspace?.name ?? null,
+                      }
+                    : null
+                }
                 currentRunLabel={currentRunLabel}
                 loadedFromRunLabel={loadedFromRunLabel}
                 finalizedAt={verifierBundle.finalizedAt}

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -34,6 +34,10 @@ export default function NewProjectForm() {
   const [methods, setMethods] = useState<MethodOption[]>([]);
   const [reviewMode, setReviewMode] = useState<ProjectReviewMode>('methodology-linked');
   const [name, setName] = useState('');
+  const [projectCode, setProjectCode] = useState('');
+  const [countryLocation, setCountryLocation] = useState('');
+  const [proponent, setProponent] = useState('');
+  const [reportingPeriod, setReportingPeriod] = useState('');
   const [selectedMethod, setSelectedMethod] = useState('');
   const [aoiLabel, setAoiLabel] = useState('');
   const [description, setDescription] = useState('');
@@ -61,7 +65,11 @@ export default function NewProjectForm() {
       if (reviewMode === 'manual') {
         const project = createProject({
           name,
+          projectCode: projectCode || undefined,
+          countryLocation: countryLocation || undefined,
+          proponent: proponent || undefined,
           reviewMode,
+          reportingPeriod: reportingPeriod || undefined,
           aoiLabel: aoiLabel || undefined,
           description: description || undefined,
         });
@@ -85,11 +93,15 @@ export default function NewProjectForm() {
       const category = parts.length > 1 ? parts.slice(1).join('/') : undefined;
       const project = createProject({
         name,
+        projectCode: projectCode || undefined,
+        countryLocation: countryLocation || undefined,
+        proponent: proponent || undefined,
         reviewMode,
         methodCode: code,
         methodVersion: version,
         methodCategory: category,
         registry: projectRegistryFromMethodProgram(selectedMethodRecord?.program),
+        reportingPeriod: reportingPeriod || undefined,
         aoiLabel: aoiLabel || undefined,
         description: description || undefined,
         ruleIds: rules.map((r: { id: string; title: string; sectionId?: string }) => ({
@@ -164,6 +176,52 @@ export default function NewProjectForm() {
             className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
             required
           />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Project ID / Code</label>
+            <input
+              type="text"
+              value={projectCode}
+              onChange={e => setProjectCode(e.target.value)}
+              placeholder="e.g., VCS-1530"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Reporting Period</label>
+            <input
+              type="text"
+              value={reportingPeriod}
+              onChange={e => setReportingPeriod(e.target.value)}
+              placeholder="e.g., 2024-01-01 to 2024-12-31"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Country / Location</label>
+            <input
+              type="text"
+              value={countryLocation}
+              onChange={e => setCountryLocation(e.target.value)}
+              placeholder="e.g., Malawi"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Proponent</label>
+            <input
+              type="text"
+              value={proponent}
+              onChange={e => setProponent(e.target.value)}
+              placeholder="e.g., Article6 Climate"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
         </div>
 
         {reviewMode === 'methodology-linked' ? (

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -36,6 +36,7 @@ import {
   updateRuleReview,
 } from '@/lib/projects/storage';
 import { SnapshotTimeline } from '@/components/snapshot/SnapshotTimeline';
+import { listReviewWorkspacesForProject } from '@/lib/reviewWorkspaces/storage';
 
 type ProjectDetailProps = {
   projectId: string;
@@ -369,6 +370,10 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
     .find((document) => document.manualFindingExtractionStatus === 'no-findings' || document.manualFindingExtractionStatus === 'extraction-failed')
     ?.manualFindingExtractionMessage;
 
+  const latestWorkspace = project.reviewMode === 'methodology-linked'
+    ? listReviewWorkspacesForProject(project.id)[0] ?? null
+    : null;
+
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-12 md:px-8">
       <Link href="/projects" className="text-sm text-slate-500 hover:text-slate-700">
@@ -412,6 +417,24 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
         </div>
 
         <div className="flex items-center gap-2">
+          {project.reviewMode === 'methodology-linked' ? (
+            <>
+              <Link
+                href={`/m?projectId=${encodeURIComponent(project.id)}`}
+                className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+              >
+                Start review
+              </Link>
+              {latestWorkspace ? (
+                <Link
+                  href={`/m/${encodeURIComponent(latestWorkspace.methodCode)}/v/${encodeURIComponent(latestWorkspace.methodVersion)}?projectId=${encodeURIComponent(project.id)}&workspaceId=${encodeURIComponent(latestWorkspace.id)}&tab=verify`}
+                  className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800"
+                >
+                  Continue review
+                </Link>
+              ) : null}
+            </>
+          ) : null}
           {shouldShowLockReview(project, coverage) ? (
             <button
               onClick={handleLock}

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -77,6 +77,8 @@ const EMPTY_MANUAL_FINDING: ManualFindingDraft = {
   reviewerNote: '',
 };
 
+const MAX_UPLOADABLE_PROJECT_PDF_BYTES = 20 * 1024 * 1024;
+
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
   let binary = '';
@@ -242,37 +244,44 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
       let extractionTrace = '';
       let extractedDrafts: Array<Omit<ExtractedManualFindingDraft, 'id' | 'createdAt' | 'updatedAt' | 'sourceDocumentId'>> = [];
       if (project.reviewMode === 'manual' && ((file.type || '').includes('pdf') || file.name.toLowerCase().endsWith('.pdf'))) {
-        try {
-          const response = await fetch('/api/projects/manual-review/extract-findings', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/pdf',
-              'x-article6-filename': encodeURIComponent(file.name),
-            },
-            body: fileBuffer,
-          });
-          const data = await response.json();
-          extractedText = typeof data.text === 'string' ? data.text.slice(0, 2000) : '';
-          extractedDrafts = Array.isArray(data.drafts) ? data.drafts : [];
-          extractionStatus = data.extractionFailed
-            ? 'extraction-failed'
-            : extractedDrafts.length > 0
-              ? 'extracted'
-              : 'no-findings';
-          const baseMessage = typeof data.message === 'string'
-            ? data.message
-            : 'No structured CAR/CL/FAR findings detected. You can still add findings manually.';
-          extractionMessage = data.extractionFailed && typeof data.diagnosticReason === 'string'
-            ? `${baseMessage} Reason: ${data.diagnosticReason}.`
-            : data.extractionFailed && typeof data.diagnosticSummary === 'string'
-              ? `${baseMessage} Reason: ${data.diagnosticSummary}.`
-              : baseMessage;
-          extractionTrace = typeof data.traceLabel === 'string' ? data.traceLabel : '';
-        } catch {
+        if (fileBuffer.byteLength > MAX_UPLOADABLE_PROJECT_PDF_BYTES) {
           extractedText = '';
           extractionStatus = 'extraction-failed';
-          extractionMessage = 'Could not extract findings from this PDF. You can still add findings manually.';
+          extractionMessage = 'Could not extract findings from this PDF. You can still add findings manually. Reason: file too large.';
           extractionTrace = '';
+        } else {
+          try {
+            const response = await fetch('/api/projects/manual-review/extract-findings', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/pdf',
+                'x-article6-filename': encodeURIComponent(file.name),
+              },
+              body: fileBuffer,
+            });
+            const data = await response.json();
+            extractedText = typeof data.text === 'string' ? data.text.slice(0, 2000) : '';
+            extractedDrafts = Array.isArray(data.drafts) ? data.drafts : [];
+            extractionStatus = data.extractionFailed
+              ? 'extraction-failed'
+              : extractedDrafts.length > 0
+                ? 'extracted'
+                : 'no-findings';
+            const baseMessage = typeof data.message === 'string'
+              ? data.message
+              : 'No structured CAR/CL/FAR findings detected. You can still add findings manually.';
+            extractionMessage = data.extractionFailed && typeof data.diagnosticReason === 'string'
+              ? `${baseMessage} Reason: ${data.diagnosticReason}.`
+              : data.extractionFailed && typeof data.diagnosticSummary === 'string'
+                ? `${baseMessage} Reason: ${data.diagnosticSummary}.`
+                : baseMessage;
+            extractionTrace = typeof data.traceLabel === 'string' ? data.traceLabel : '';
+          } catch {
+            extractedText = '';
+            extractionStatus = 'extraction-failed';
+            extractionMessage = 'Could not extract findings from this PDF. You can still add findings manually.';
+            extractionTrace = '';
+          }
         }
       }
 

--- a/src/components/projects/ProjectsList.tsx
+++ b/src/components/projects/ProjectsList.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import type { Project } from '@/lib/projects/types';
 import { listProjects, getProjectCoverage, deleteProject } from '@/lib/projects/storage';
+import { listReviewWorkspacesForProject } from '@/lib/reviewWorkspaces/storage';
 
 export default function ProjectsList() {
   const [projects, setProjects] = useState<Project[]>([]);
@@ -102,7 +103,31 @@ export default function ProjectsList() {
                 </div>
 
                 {project.status === 'in-progress' && (
-                  <div className="mt-3 flex justify-end">
+                  <div className="mt-3 flex items-center justify-between gap-3">
+                    <div className="flex flex-wrap gap-2">
+                      {project.reviewMode === 'methodology-linked' ? (
+                        <>
+                          <Link
+                            href={`/m?projectId=${encodeURIComponent(project.id)}`}
+                            className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+                          >
+                            Start review
+                          </Link>
+                          {(() => {
+                            const latestWorkspace = listReviewWorkspacesForProject(project.id)[0];
+                            if (!latestWorkspace) return null;
+                            return (
+                              <Link
+                                href={`/m/${encodeURIComponent(latestWorkspace.methodCode)}/v/${encodeURIComponent(latestWorkspace.methodVersion)}?projectId=${encodeURIComponent(project.id)}&workspaceId=${encodeURIComponent(latestWorkspace.id)}&tab=verify`}
+                                className="rounded-full bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-800"
+                              >
+                                Continue review
+                              </Link>
+                            );
+                          })()}
+                        </>
+                      ) : null}
+                    </div>
                     <button
                       onClick={() => handleDelete(project.id)}
                       className="text-xs text-red-400 hover:text-red-600"

--- a/src/components/trust/TrustStrip.tsx
+++ b/src/components/trust/TrustStrip.tsx
@@ -17,12 +17,23 @@ import { useRouter } from "next/navigation";
 type TrustStripProps = {
   methodCode?: string;
   version?: string;
+  workspaceId?: string | null;
   packTag?: string | null;
   provenanceJson?: unknown | null;
   manifestRulesPath?: string | null;
   onOpenIntegrityDiff?: () => void;
   surface?: "default" | "methods";
   methodReviewEvidencePins?: EvidencePin[];
+  projectContext?: {
+    projectId?: string | null;
+    projectName?: string | null;
+    projectCode?: string | null;
+    countryLocation?: string | null;
+    proponent?: string | null;
+    reportingPeriod?: string | null;
+    workspaceId?: string | null;
+    workspaceName?: string | null;
+  } | null;
 };
 
 type ExportArtifact = "provenance" | "META" | "rules" | "sections" | "rich";
@@ -121,11 +132,14 @@ function readLiveMethodReviewState(
   methodCode: string | undefined,
   version: string | undefined,
   evidencePins: EvidencePin[],
+  workspaceId?: string | null,
+  projectContext?: TrustStripProps["projectContext"],
 ): {
   latestReviewAt: string | null;
   reviews: RuleReview[];
   verifierBundle: VerifierRunBundle | null;
   evidencePins: EvidencePin[];
+  projectContext?: TrustStripProps["projectContext"];
 } {
   const normalizedMethod = methodCode?.trim() ?? "";
   const normalizedVersion = version?.trim() ?? "";
@@ -138,8 +152,8 @@ function readLiveMethodReviewState(
     };
   }
 
-  const reviews = Object.values(getAllReviews(normalizedMethod, normalizedVersion));
-  const verifierBundle = readVerifierRunBundle(normalizedMethod, normalizedVersion);
+  const reviews = Object.values(getAllReviews(normalizedMethod, normalizedVersion, workspaceId));
+  const verifierBundle = readVerifierRunBundle(normalizedMethod, normalizedVersion, workspaceId);
   const latestReviewAt = pickLatestTimestamp([
     ...reviews.flatMap((review) => [review.reviewedAt, review.updatedAt]),
     verifierBundle.savedReviewerArtifactAt,
@@ -151,6 +165,7 @@ function readLiveMethodReviewState(
     reviews,
     verifierBundle,
     evidencePins: [...evidencePins],
+    projectContext,
   };
 }
 
@@ -163,6 +178,11 @@ async function downloadBlob(blob: Blob, filename: string) {
   a.click();
   a.remove();
   URL.revokeObjectURL(url);
+}
+
+function safeFilenamePart(value: string | null | undefined): string {
+  const trimmed = (value ?? "").trim();
+  return trimmed ? trimmed.replace(/[^\w.\-]+/g, "_").slice(0, 64) : "";
 }
 
 function buildFilename(
@@ -260,12 +280,14 @@ function ChipButton({
 export default function TrustStrip({
   methodCode,
   version,
+  workspaceId = null,
   packTag,
   provenanceJson,
   manifestRulesPath,
   onOpenIntegrityDiff,
   surface = "default",
   methodReviewEvidencePins = [],
+  projectContext = null,
 }: TrustStripProps) {
   const router = useRouter();
   const provenancePicked = useMemo(() => pickProvenanceFields(provenanceJson), [provenanceJson]);
@@ -357,7 +379,7 @@ export default function TrustStrip({
     if (surface !== "methods") return;
     if (typeof window === "undefined") return;
     const update = () => {
-      const next = readLiveMethodReviewState(methodCode, version, methodReviewEvidencePins);
+      const next = readLiveMethodReviewState(methodCode, version, methodReviewEvidencePins, workspaceId, projectContext);
       setMethodReviewLastReviewedAt(next.latestReviewAt);
     };
     update();
@@ -369,7 +391,7 @@ export default function TrustStrip({
       window.removeEventListener(VERIFY_RUN_BUNDLE_EVENT, update);
       window.removeEventListener("proofbundle:imported", update);
     };
-  }, [methodCode, methodReviewEvidencePins, surface, version]);
+  }, [methodCode, methodReviewEvidencePins, projectContext, surface, version, workspaceId]);
 
   const audit = metaPicked.auditHashes;
 
@@ -433,7 +455,7 @@ export default function TrustStrip({
     setExportError(null);
     setExportingAuditPack(true);
     try {
-      const currentReview = readLiveMethodReviewState(methodCode, version, methodReviewEvidencePins);
+      const currentReview = readLiveMethodReviewState(methodCode, version, methodReviewEvidencePins, workspaceId, projectContext);
       const response = await fetch("/api/exports/audit-pack", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -448,14 +470,17 @@ export default function TrustStrip({
         throw new Error(message || `Export failed with ${response.status}`);
       }
       const blob = await response.blob();
-      await downloadBlob(blob, `audit-pack__${methodCode}__${version}.zip`);
+      const projectPart = safeFilenamePart(projectContext?.projectCode ?? projectContext?.projectId);
+      const workspacePart = safeFilenamePart(projectContext?.workspaceName ?? projectContext?.workspaceId);
+      const prefix = [projectPart, workspacePart].filter(Boolean).join("__");
+      await downloadBlob(blob, `audit-pack__${prefix ? `${prefix}__` : ""}${methodCode}__${version}.zip`);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : "Audit pack export failed.";
       setExportError(message);
     } finally {
       setExportingAuditPack(false);
     }
-  }, [methodCode, methodReviewEvidencePins, version]);
+  }, [methodCode, methodReviewEvidencePins, projectContext, version, workspaceId]);
 
   const showStrip = Boolean(methodCode || version || generatedAt || metaAvailable || rulesUrl || provenanceJson);
   if (!showStrip) return null;

--- a/src/components/verify/FinalReviewSummaryPanel.tsx
+++ b/src/components/verify/FinalReviewSummaryPanel.tsx
@@ -6,6 +6,7 @@ import type { EvidenceSnapshot } from "@/lib/proofMap/evidenceSnapshot";
 import type { EvidencePin } from "@/lib/proofMap/types";
 import type { ReviewSummary } from "@/lib/verify/buildReviewSummary";
 import type { VerifyWizardStepDetails } from "@/lib/verify/runState";
+import type { ReviewExportProjectContext } from "@/exports/verificationPackContract";
 
 type FinalReviewSummaryPanelProps = {
   summary: ReviewSummary;
@@ -16,6 +17,7 @@ type FinalReviewSummaryPanelProps = {
   reviewedRuleCount?: number | null;
   linkedEvidenceCount?: number | null;
   evidencePins?: EvidencePin[];
+  projectContext?: ReviewExportProjectContext | null;
   wizard: VerifyWizardStepDetails;
   onDownloadJson: () => void;
   onDownloadPdf: () => void;
@@ -42,6 +44,16 @@ function formatDate(value: string | null | undefined): string | null {
 function safeFilename(value: string | null | undefined): string {
   const trimmed = (value ?? "").trim() || "unknown";
   return trimmed.replace(/[^\w.\-]+/g, "_").slice(0, 64) || "unknown";
+}
+
+function exportContextFilenamePart(projectContext?: ReviewExportProjectContext | null): string {
+  const parts = [
+    projectContext?.projectCode ?? projectContext?.projectId ?? null,
+    projectContext?.workspaceName ?? projectContext?.workspaceId ?? null,
+  ]
+    .map((value) => safeFilename(value))
+    .filter((value) => value !== "unknown");
+  return parts.length ? `${parts.join(".")}.` : "";
 }
 
 function downloadBytes(bytes: Uint8Array, filename: string, mimeType: string) {
@@ -76,6 +88,7 @@ export default function FinalReviewSummaryPanel({
   reviewedRuleCount = null,
   linkedEvidenceCount = null,
   evidencePins = [],
+  projectContext = null,
   wizard,
   onDownloadJson,
   onDownloadPdf,
@@ -131,11 +144,15 @@ export default function FinalReviewSummaryPanel({
     const response = await fetch("/api/exports/audit-pack", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ method, version, artifact, evidencePins, sourceFiles }),
+      body: JSON.stringify({ method, version, artifact, evidencePins, sourceFiles, projectContext }),
     });
     if (!response.ok) throw new Error(await response.text());
     const bytes = new Uint8Array(await response.arrayBuffer());
-    downloadBytes(bytes, `audit-pack.${safeFilename(method)}.${safeFilename(version)}.${safeFilename(artifact.verifier?.runId)}.zip`, "application/zip");
+    downloadBytes(
+      bytes,
+      `audit-pack.${exportContextFilenamePart(projectContext)}${safeFilename(method)}.${safeFilename(version)}.${safeFilename(artifact.verifier?.runId)}.zip`,
+      "application/zip",
+    );
   };
 
   return (

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -214,6 +214,7 @@ export default function RuleReviewPanel({
     ruleId,
     methodology,
     version,
+    workspaceId,
     status,
     rationale,
     supportReference,
@@ -288,6 +289,7 @@ export default function RuleReviewPanel({
     supportReference,
     syncReview,
     version,
+    workspaceId,
   ]);
 
   const handleFileSelected = useCallback(
@@ -316,7 +318,7 @@ export default function RuleReviewPanel({
       syncReview(review);
       refreshAuditEvents();
     },
-    [actorLabel, methodology, refreshAuditEvents, ruleId, syncReview, version],
+    [actorLabel, methodology, refreshAuditEvents, ruleId, syncReview, version, workspaceId],
   );
 
   const applySuggestion = useCallback(

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -321,7 +321,7 @@ export default function RuleReviewPanel({
     [actorLabel, methodology, refreshAuditEvents, ruleId, syncReview, version, workspaceId],
   );
 
-  const applySuggestion = useCallback(
+  const applySuggestedReview = useCallback(
     (focusRationale: boolean) => {
       setStatus(suggestion.mappedReviewStatus);
       setRationale(suggestion.whyThisJudgment);
@@ -460,14 +460,14 @@ export default function RuleReviewPanel({
               <div className="mt-4 flex flex-wrap gap-2">
                 <button
                   type="button"
-                  onClick={() => applySuggestion(false)}
+                  onClick={() => applySuggestedReview(false)}
                   className="rounded-full border border-sky-700 bg-sky-700 px-4 py-2 text-xs font-semibold text-white hover:bg-sky-800"
                 >
                   Accept suggestion
                 </button>
                 <button
                   type="button"
-                  onClick={() => applySuggestion(true)}
+                  onClick={() => applySuggestedReview(true)}
                   className="rounded-full border border-sky-200 bg-white px-4 py-2 text-xs font-semibold text-sky-700 hover:border-sky-300"
                 >
                   Edit before saving

--- a/src/components/verify/RuleReviewPanel.tsx
+++ b/src/components/verify/RuleReviewPanel.tsx
@@ -31,6 +31,7 @@ type RuleReviewPanelProps = {
   sectionId?: string;
   methodology: string;
   version: string;
+  workspaceId?: string | null;
   anchorUrl?: string;
   existingReview: RuleReview | null;
   linkedEvidence?: Array<{
@@ -69,6 +70,7 @@ export default function RuleReviewPanel({
   sectionId,
   methodology,
   version,
+  workspaceId = null,
   anchorUrl,
   existingReview,
   linkedEvidence = [],
@@ -186,6 +188,7 @@ export default function RuleReviewPanel({
       ruleId,
       methodology,
       version,
+      ...(workspaceId ? { workspaceId } : {}),
       status,
       rationale,
       supportReference,
@@ -232,6 +235,7 @@ export default function RuleReviewPanel({
         ruleId,
         methodology,
         version,
+        ...(workspaceId ? { workspaceId } : {}),
         status,
         rationale,
         supportReference,
@@ -249,7 +253,7 @@ export default function RuleReviewPanel({
       type: attachmentType,
       label: trimmedLabel,
       url: attachmentType === "url" ? trimmedUrl : undefined,
-    });
+    }, workspaceId);
     if (!review) return;
 
     logAuditEvent({
@@ -298,7 +302,7 @@ export default function RuleReviewPanel({
 
   const handleRemoveAttachment = useCallback(
     (attachment: EvidenceAttachment) => {
-      const review = removeEvidenceAttachment(ruleId, methodology, version, attachment.id);
+      const review = removeEvidenceAttachment(ruleId, methodology, version, attachment.id, workspaceId);
       if (!review) return;
       logAuditEvent({
         ruleId,

--- a/src/exports/verificationPackContract.ts
+++ b/src/exports/verificationPackContract.ts
@@ -30,10 +30,13 @@ type ProjectJson = {
   };
   project_context: {
     project_id: string;
+    project_name: string;
     export_id: string;
+    workspace_id: string;
     display_name: string;
     reporting_period: string;
     location: string;
+    proponent: string;
     description: string;
     placeholder: boolean;
     placeholder_reason: string;
@@ -239,6 +242,7 @@ const CURRENT_METHOD_REVIEW_REASON =
 export type FinalizedAuditPackReviewInput = {
   artifact?: EvidenceSnapshot | null;
   evidencePins?: EvidencePin[] | null;
+  projectContext?: ReviewExportProjectContext | null;
   sourceFiles?: Array<{
     evidence_ref: string;
     source_pin_id?: string | null;
@@ -250,11 +254,23 @@ export type FinalizedAuditPackReviewInput = {
   }> | null;
 };
 
+export type ReviewExportProjectContext = {
+  projectId?: string | null;
+  projectName?: string | null;
+  projectCode?: string | null;
+  countryLocation?: string | null;
+  proponent?: string | null;
+  reportingPeriod?: string | null;
+  workspaceId?: string | null;
+  workspaceName?: string | null;
+};
+
 export type CurrentMethodReviewExportInput = {
   latestReviewAt?: string | null;
   reviews?: RuleReview[] | null;
   verifierBundle?: Partial<VerifierRunBundle> | null;
   evidencePins?: EvidencePin[] | null;
+  projectContext?: ReviewExportProjectContext | null;
 };
 
 function extractRules(rulesJson: unknown): ContractRule[] {
@@ -853,6 +869,12 @@ function projectIdForDisplay(project: ProjectJson): string | null {
   return projectId;
 }
 
+function projectNameForDisplay(project: ProjectJson): string | null {
+  const projectName = project.project_context.project_name?.trim() ?? "";
+  if (!projectName || isUnavailableToken(projectName) || projectName === "Demo placeholder project context") return null;
+  return projectName;
+}
+
 function exportIdForDisplay(project: ProjectJson): string | null {
   const exportId = project.project_context.export_id?.trim() ?? "";
   if (!exportId || isUnavailableToken(exportId)) return null;
@@ -869,6 +891,12 @@ function workspaceLabelForDisplay(project: ProjectJson): string | null {
   const label = project.project_context.display_name?.trim() ?? "";
   if (!label || isUnavailableToken(label) || label === "Demo placeholder project context") return null;
   return label;
+}
+
+function proponentForDisplay(project: ProjectJson): string | null {
+  const proponent = project.project_context.proponent?.trim() ?? "";
+  if (!proponent || isUnavailableToken(proponent)) return null;
+  return proponent;
 }
 
 function reportingPeriodForDisplay(project: ProjectJson): string | null {
@@ -1068,10 +1096,10 @@ function renderVerificationReportHtml(input: {
     <section class="panel">
       <h2>Project Context</h2>
       <dl>
-        <dt>Project name</dt><dd>Not provided</dd>
+        <dt>Project name</dt><dd>${renderFieldValue(projectNameForDisplay(input.project), "Not provided")}</dd>
         <dt>Project ID</dt><dd>${renderFieldValue(projectIdForDisplay(input.project), "Not provided")}</dd>
         <dt>Country / location</dt><dd>${renderFieldValue(projectLocationForDisplay(input.project), "Not provided")}</dd>
-        <dt>Proponent</dt><dd>Not provided</dd>
+        <dt>Proponent</dt><dd>${renderFieldValue(proponentForDisplay(input.project), "Not provided")}</dd>
         <dt>Methodology / version</dt><dd>${escapeHtml(input.project.method.code)} @ ${escapeHtml(input.project.method.version)}</dd>
         <dt>Reporting period</dt><dd>${renderFieldValue(reportingPeriodForDisplay(input.project), "Not provided")}</dd>
         <dt>Review workspace</dt><dd>${renderFieldValue(workspaceLabelForDisplay(input.project), "Unavailable")}</dd>
@@ -1284,6 +1312,7 @@ export function buildVerificationPackContract(input: {
   const currentReviewPins = currentReview?.evidencePins ?? [];
   const currentReviewEntries = currentReview?.reviews ?? [];
   const currentVerifierBundle = currentReview?.verifierBundle ?? null;
+  const linkedProjectContext = input.finalizedReview?.projectContext ?? currentReview?.projectContext ?? null;
   const finalizedRuleId = selectedRuleFromArtifact(finalizedArtifact);
   const finalizedRuleIds = ruleIdsFromFinalizedContext(finalizedRuleId, finalizedArtifact);
   const packagedFinalizedSources = collectPackagedEvidenceSourceFiles(input.finalizedReview ?? null);
@@ -1341,17 +1370,36 @@ export function buildVerificationPackContract(input: {
       not_a_formal_opinion: true,
     },
     project_context: {
-      project_id: hasFinalizedReview || hasCurrentReview ? "not-supplied-in-method-review" : "local-method-review",
+      project_id:
+        linkedProjectContext?.projectCode?.trim() ||
+        linkedProjectContext?.projectId?.trim() ||
+        (hasFinalizedReview || hasCurrentReview ? "not-supplied-in-method-review" : "local-method-review"),
+      project_name:
+        linkedProjectContext?.projectName?.trim() ||
+        (hasCurrentReview ? "Unlinked method review" : "Demo placeholder project context"),
       export_id:
         finalizedArtifact?.verifier?.runId ??
         currentVerifierBundle?.runContext?.runId?.trim() ??
         currentVerifierBundle?.savedReviewerArtifactContext?.runId?.trim() ??
         "local-method-review",
-      display_name: finalizedArtifact?.summary?.aoiLabel ?? (hasCurrentReview ? "Current method review workspace" : "Demo placeholder project context"),
-      reporting_period: hasCurrentReview ? "not-supplied-in-method-review" : "placeholder-not-provided",
+      workspace_id:
+        linkedProjectContext?.workspaceId?.trim() ??
+        currentVerifierBundle?.runContext?.runId?.trim() ??
+        "local-method-review",
+      display_name:
+        linkedProjectContext?.workspaceName?.trim() ??
+        finalizedArtifact?.summary?.aoiLabel ??
+        (hasCurrentReview ? "Current method review workspace" : "Demo placeholder project context"),
+      reporting_period:
+        linkedProjectContext?.reportingPeriod?.trim() ??
+        (hasCurrentReview ? "not-supplied-in-method-review" : "placeholder-not-provided"),
       location:
+        linkedProjectContext?.countryLocation?.trim() ??
         finalizedArtifact?.summary?.aoiLabel ??
         (hasCurrentReview ? "Unavailable in local method review export" : "placeholder-not-provided"),
+      proponent:
+        linkedProjectContext?.proponent?.trim() ??
+        (hasCurrentReview ? "not-supplied-in-method-review" : "placeholder-not-provided"),
       description: hasFinalizedReview
         ? "Finalized local review context is included where present; absent project fields remain explicitly unavailable."
         : hasCurrentReview

--- a/src/lib/chat/quickCheckEvidence.ts
+++ b/src/lib/chat/quickCheckEvidence.ts
@@ -56,6 +56,12 @@ export type QuickCheckResolvedPdfText = {
   text: string;
   engine: "pdf-parse" | "heuristic";
   warning?: string;
+  diagnosticCode?:
+    | "file-too-large"
+    | "parser-failed"
+    | "no-selectable-text"
+    | "selected-methodology-mismatch"
+    | "methodology-not-detected";
 };
 type ResolvePdfText = (input: {
   attachmentId: string;
@@ -595,7 +601,7 @@ export function extractMethodologyMentions(text: string): string[] {
   }
 
   // Verra / VCS standalone mentions
-  for (const match of text.matchAll(/\b(Verra|VCS)\b/g)) {
+  for (const match of text.matchAll(/\b(Verra|VCS|CCB)\b/g)) {
     mentions.add(match[1]);
   }
 
@@ -615,6 +621,20 @@ export function extractMethodologyMentions(text: string): string[] {
   }
   for (const match of text.matchAll(/\b(VM)\s+(\d{4})\b/g)) {
     mentions.add(`${match[1]}${match[2]}`);
+  }
+
+  // Requested Verra detection terms and related abbreviations.
+  for (const match of text.matchAll(/\b(REDD\+\s+Methodology\s+Framework|REDD\+\s+MF)\b/gi)) {
+    mentions.add(normalizeWhitespace(match[1] ?? ""));
+  }
+  for (const match of text.matchAll(/\b(VMD\d{4})\b/g)) {
+    mentions.add(match[1]);
+  }
+  for (const match of text.matchAll(/\b(VMD)\s+(\d{4})\b/g)) {
+    mentions.add(`${match[1]}${match[2]}`);
+  }
+  for (const match of text.matchAll(/\b(APD|ARR|RWE|APWD)\b/g)) {
+    mentions.add(match[1]);
   }
 
   // VMR-prefixed methodology codes: VMR001, VMR 001

--- a/src/lib/chat/quickCheckMethodSignals.ts
+++ b/src/lib/chat/quickCheckMethodSignals.ts
@@ -112,11 +112,9 @@ const PRIMARY_ALIASES: AliasEntry[] = [
   // AR-ACM0003, AR-AMS0007, AR-AMS0003, AR-AM0014 matched by exact code
 
   // ── Gold Standard ──
-  {
-    pattern: /^GS[- ]?VER\d+$/i,
-    canonical: "GS-00XX",
-    priority: 0,
-  },
+  // No primary aliases — Gold Standard signals are program-level (Tier 2).
+  // GS-VER1, GS-VER2, etc. are caught by detectUnavailableMethod if no
+  // matching pack exists in the inventory.
 ];
 
 // ─── Tier 2: Program / standard signals ──────────────────────────────────
@@ -206,9 +204,9 @@ export function resolveMethodologySignals(
   const activitySignals: DetectedActivitySignal[] = [];
 
   for (const mention of cleanedMentions) {
-    // Tier 1: Try alias first
+    // Tier 1: Try alias first (only if the canonical code exists in inventory)
     const alias = resolveAlias(mention);
-    if (alias) {
+    if (alias && methodCodes.has(alias.canonical)) {
       const canonical = alias.canonical;
       if (!detectedMethods.has(canonical)) {
         detectedMethods.set(canonical, {
@@ -371,7 +369,7 @@ export function buildMethodProgramMap(
  * Pattern that matches mentions that look like methodology codes.
  * Used to detect when evidence references a method we don't have a pack for.
  */
-const METHOD_CODE_PATTERN = /\b(?:VM\d{4}|VMD\d{4}|VMR\d{3,4}|AR-ACM\d{4}|AR-AMS\d{4}|AR-AM\d{4}|ACM\d{4}|AM\d{4}|AM\d{3,4}|GS[- ]?(?:VER\d+)?)\b/i;
+const METHOD_CODE_PATTERN = /\b(?:VM\d{4}|VMD\d{4}|VMR\d{3,4}|AR-ACM\d{4}|AR-AMS\d{4}|AR-AM\d{4}|ACM\d{4}|AM\d{4}|AM\d{3,4}|GS[- ]?VER\d+)\b/i;
 
 /**
  * Check if evidence mentions contain a methodology code that isn't in our

--- a/src/lib/chat/quickCheckMethodSignals.ts
+++ b/src/lib/chat/quickCheckMethodSignals.ts
@@ -196,7 +196,6 @@ function resolveExactCode(
 export function resolveMethodologySignals(
   rawMentions: string[],
   methodCodes: Set<string>,
-  methodProgramMap?: Map<string, string>,
 ): MethodologySignalResult {
   const cleanedMentions = rawMentions
     .map((m) => normalize(m))

--- a/src/lib/chat/quickCheckMethodSignals.ts
+++ b/src/lib/chat/quickCheckMethodSignals.ts
@@ -1,0 +1,399 @@
+/**
+ * Quick Check Methodology Signal Resolver
+ *
+ * Three-tier signal classification for methodology-aware candidate gating:
+ *
+ *   Tier 1 — Primary methodology signals (HARD-GATE candidates)
+ *   Tier 2 — Program / standard signals (NARROW to program)
+ *   Tier 3 — Supporting activity/module signals (BOOST only, never resolve)
+ *
+ * Tier 3 signals (APD, ARR, RWE, APWD, VMD####, VMR###) MUST NOT independently
+ * resolve to VM0007 or any canonical method code. They only boost ranking inside
+ * an already-gated methodology.
+ */
+
+/** Matches the shape returned by GET /api/methods/inventory */
+export type MethodInventoryRecord = {
+  code: string;
+  versions: string[];
+  latestVersion?: string;
+};
+
+type AliasEntry = {
+  /** Regex patterns to match against a normalized (uppercase, trimmed) mention */
+  pattern: RegExp;
+  /** Canonical method code — must exist in the method inventory */
+  canonical: string;
+  /** Lower = preferred when multiple patterns match the same mention */
+  priority: number;
+};
+
+type ProgramEntry = {
+  pattern: RegExp;
+  program: string;
+  priority: number;
+};
+
+export type DetectedMethod = {
+  /** Canonical method code (e.g. "VM0007") */
+  methodCode: string;
+  /** How the detection was made */
+  confidence: "exact-code" | "alias" | "program-derived";
+  /** The original text mention that matched */
+  sourceMention: string;
+};
+
+export type DetectedProgram = {
+  program: string;
+  confidence: "explicit" | "derived";
+  sourceMention: string;
+};
+
+export type DetectedActivitySignal = {
+  kind: string;
+  sourceMention: string;
+};
+
+export type MethodologySignalResult = {
+  /** Primary methods detected (Tier 1), deduped by canonical code */
+  detectedMethods: DetectedMethod[];
+  /** Programs detected (Tier 2) */
+  detectedPrograms: DetectedProgram[];
+  /** Activity/module signals detected (Tier 3) */
+  activitySignals: DetectedActivitySignal[];
+  /** All original raw mentions passed in */
+  rawMentions: string[];
+
+  // Convenience accessors
+  /** Exactly one primary method was detected */
+  exactlyOne: boolean;
+  /** Two or more primary methods detected */
+  multiplePossible: boolean;
+  /** No primary methods detected at all */
+  noMethodDetected: boolean;
+  /** Programs detected but no primary methods */
+  programOnly: boolean;
+  /** Only activity/module signals, no primary methods or programs */
+  activitySignalsOnly: boolean;
+  /** All unique canonical codes from detected methods */
+  canonicalCodes: string[];
+};
+
+// ─── Tier 1: Primary methodology signals ────────────────────────────────
+
+/**
+ * Alias registry mapping mentions → canonical method codes.
+ *
+ * ORDER MATTERS: first match wins for a given mention (sorted by priority).
+ * Only add entries for aliases; exact code matches are handled automatically
+ * by matching against the method inventory.
+ */
+const PRIMARY_ALIASES: AliasEntry[] = [
+  // ── Verra / VCS ──
+  {
+    pattern: /^REDD\+\s*MF$/i,
+    canonical: "VM0007",
+    priority: 0,
+  },
+  {
+    pattern: /^REDD\+\s*Methodology\s*Framework$/i,
+    canonical: "VM0007",
+    priority: 1,
+  },
+
+  // ── UNFCCC Agriculture ──
+  {
+    pattern: /^ACM\s+0010$/i,
+    canonical: "ACM0010",
+    priority: 0,
+  },
+
+  // ── UNFCCC Forestry (aliases if any exist beyond exact codes) ──
+  // AR-ACM0003, AR-AMS0007, AR-AMS0003, AR-AM0014 matched by exact code
+
+  // ── Gold Standard ──
+  {
+    pattern: /^GS[- ]?VER\d+$/i,
+    canonical: "GS-00XX",
+    priority: 0,
+  },
+];
+
+// ─── Tier 2: Program / standard signals ──────────────────────────────────
+
+const PROGRAM_SIGNALS: ProgramEntry[] = [
+  { pattern: /^Verra$/i, program: "Verra", priority: 0 },
+  { pattern: /^VCS$/i, program: "Verra", priority: 1 },
+  { pattern: /^CCB$/i, program: "Verra", priority: 2 },
+  { pattern: /^Verified\s*Carbon\s*Standard$/i, program: "Verra", priority: 1 },
+  { pattern: /^UNFCCC$/i, program: "UNFCCC", priority: 0 },
+  { pattern: /^CDM$/i, program: "UNFCCC", priority: 1 },
+  { pattern: /^Gold\s*Standard$/i, program: "GoldStandard", priority: 0 },
+  { pattern: /^GS4GG$/i, program: "GoldStandard", priority: 1 },
+  { pattern: /^Gold\s*Standard\s*for\s*the\s*Global\s*Goals$/i, program: "GoldStandard", priority: 1 },
+];
+
+// ─── Tier 3: Supporting activity/module signals ──────────────────────────
+
+/** These MUST NOT resolve to any canonical code. Detection only. */
+const ACTIVITY_SIGNAL_PATTERNS: Array<{ kind: string; pattern: RegExp }> = [
+  { kind: "APD", pattern: /^APD$/i },
+  { kind: "ARR", pattern: /^ARR$/i },
+  { kind: "RWE", pattern: /^RWE$/i },
+  { kind: "APWD", pattern: /^APWD$/i },
+  { kind: "VMD-module", pattern: /^VMD\d{4}$/i },
+  { kind: "VMR", pattern: /^VMR\d{3,4}$/i },
+];
+
+// ─── Resolver ────────────────────────────────────────────────────────────
+
+function normalize(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+function normalizeUpper(s: string): string {
+  return normalize(s).toUpperCase();
+}
+
+/**
+ * Given a mention string, try to resolve it to a canonical method code
+ * using the Tier 1 alias registry. Returns null if no alias matches.
+ */
+function resolveAlias(mention: string): AliasEntry | null {
+  const normalized = normalizeUpper(mention);
+  if (!normalized) return null;
+
+  for (const entry of PRIMARY_ALIASES) {
+    if (entry.pattern.test(normalized)) return entry;
+  }
+  return null;
+}
+
+/**
+ * Check if a mention is an exact match for a method code in the inventory.
+ */
+function resolveExactCode(
+  mention: string,
+  methodCodes: Set<string>,
+): string | null {
+  const normalized = normalizeUpper(mention);
+  // Try the raw mention first (for codes like AR-ACM0003)
+  if (methodCodes.has(normalized)) return normalized;
+  // Try with spaces collapsed (for codes like ACM 0010)
+  const collapsed = normalized.replace(/\s+/g, "");
+  if (methodCodes.has(collapsed)) return collapsed;
+  return null;
+}
+
+/**
+ * Resolve methodology signals from extracted mentions against the
+ * available method inventory.
+ *
+ * @param rawMentions — strings extracted from evidence text (e.g. from extractMethodologyMentions)
+ * @param methodCodes — set of method codes available in the inventory
+ * @param methodProgramMap — optional map of methodCode → program for program narrowing
+ */
+export function resolveMethodologySignals(
+  rawMentions: string[],
+  methodCodes: Set<string>,
+  methodProgramMap?: Map<string, string>,
+): MethodologySignalResult {
+  const cleanedMentions = rawMentions
+    .map((m) => normalize(m))
+    .filter((m) => m.length > 0);
+
+  const detectedMethods = new Map<string, DetectedMethod>();
+  const detectedPrograms = new Map<string, DetectedProgram>();
+  const activitySignals: DetectedActivitySignal[] = [];
+
+  for (const mention of cleanedMentions) {
+    // Tier 1: Try alias first
+    const alias = resolveAlias(mention);
+    if (alias) {
+      const canonical = alias.canonical;
+      if (!detectedMethods.has(canonical)) {
+        detectedMethods.set(canonical, {
+          methodCode: canonical,
+          confidence: "alias",
+          sourceMention: mention,
+        });
+      }
+      continue;
+    }
+
+    // Tier 1: Try exact code match
+    const exactCode = resolveExactCode(mention, methodCodes);
+    if (exactCode) {
+      if (!detectedMethods.has(exactCode)) {
+        detectedMethods.set(exactCode, {
+          methodCode: exactCode,
+          confidence: "exact-code",
+          sourceMention: mention,
+        });
+      }
+      continue;
+    }
+
+    // Tier 2: Program signals
+    const normalizedUpper = normalizeUpper(mention);
+    let programMatched = false;
+    for (const entry of PROGRAM_SIGNALS) {
+      if (entry.pattern.test(normalizedUpper)) {
+        if (!detectedPrograms.has(entry.program)) {
+          detectedPrograms.set(entry.program, {
+            program: entry.program,
+            confidence: "explicit",
+            sourceMention: mention,
+          });
+        }
+        programMatched = true;
+        break;
+      }
+    }
+    if (programMatched) continue;
+
+    // Tier 3: Activity/module signals
+    for (const entry of ACTIVITY_SIGNAL_PATTERNS) {
+      if (entry.pattern.test(normalizedUpper)) {
+        activitySignals.push({
+          kind: entry.kind,
+          sourceMention: mention,
+        });
+        break;
+      }
+    }
+  }
+
+  const methods = Array.from(detectedMethods.values());
+  const programs = Array.from(detectedPrograms.values());
+
+  // Convenience accessors
+  const exactlyOne = methods.length === 1;
+  const multiplePossible = methods.length >= 2;
+  const noMethodDetected = methods.length === 0;
+  const programOnly = noMethodDetected && programs.length > 0;
+  const activitySignalsOnly =
+    noMethodDetected && programs.length === 0 && activitySignals.length > 0;
+
+  return {
+    detectedMethods: methods,
+    detectedPrograms: programs,
+    activitySignals,
+    rawMentions: cleanedMentions,
+    exactlyOne,
+    multiplePossible,
+    noMethodDetected,
+    programOnly,
+    activitySignalsOnly,
+    canonicalCodes: methods.map((m) => m.methodCode),
+  };
+}
+
+/**
+ * Given a MethodologySignalResult, determine which method codes should
+ * gate candidate filtering.
+ *
+ * - Exactly one primary method → return [that method]
+ * - Multiple primary methods → return all detected methods
+ * - Program only → return all methods in that program (requires methodProgramMap)
+ * - No signal → return null (no gating; broad match)
+ */
+export function gatingMethodCodes(
+  signals: MethodologySignalResult,
+  methodProgramMap?: Map<string, string>,
+): string[] | null {
+  if (signals.exactlyOne) {
+    return [signals.detectedMethods[0]!.methodCode];
+  }
+  if (signals.multiplePossible) {
+    return signals.canonicalCodes;
+  }
+  if (signals.programOnly && methodProgramMap) {
+    const programs = new Set(
+      signals.detectedPrograms.map((p) => p.program),
+    );
+    const codes: string[] = [];
+    methodProgramMap.forEach((prog: string, code: string) => {
+      if (programs.has(prog)) codes.push(code);
+    });
+    return codes.length > 0 ? codes : null;
+  }
+  return null;
+}
+
+/**
+ * Determine the gating label for UI display.
+ */
+export function gatingLabel(signals: MethodologySignalResult): string | null {
+  if (signals.exactlyOne) {
+    return `Detected ${signals.detectedMethods[0]!.methodCode}`;
+  }
+  if (signals.multiplePossible) {
+    return `Detected ${signals.canonicalCodes.join(", ")} — needs confirmation`;
+  }
+  if (signals.programOnly) {
+    const programs = signals.detectedPrograms
+      .map((p) => p.program)
+      .join(", ");
+    return `Broad within ${programs}`;
+  }
+  if (signals.activitySignalsOnly) {
+    return "Broad/uncertain";
+  }
+  return null;
+}
+
+/**
+ * Build a methodCode → program map from the method inventory API response.
+ * This is used for program-based candidate narrowing.
+ */
+export function buildMethodProgramMap(
+  methods: MethodInventoryRecord[],
+): Map<string, string> {
+  // The standard API response doesn't include program, so we infer from
+  // common conventions. If the API later includes program, use that.
+  const map = new Map<string, string>();
+
+  for (const method of methods) {
+    const code = method.code;
+    if (code.startsWith("VM") || code.startsWith("VMD") || code.startsWith("VMR")) {
+      map.set(code, "Verra");
+    } else if (code.startsWith("AR-") || code.startsWith("AM") || code.startsWith("ACM")) {
+      map.set(code, "UNFCCC");
+    } else if (code.startsWith("GS-") || code.startsWith("GS")) {
+      map.set(code, "GoldStandard");
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Pattern that matches mentions that look like methodology codes.
+ * Used to detect when evidence references a method we don't have a pack for.
+ */
+const METHOD_CODE_PATTERN = /\b(?:VM\d{4}|VMD\d{4}|VMR\d{3,4}|AR-ACM\d{4}|AR-AMS\d{4}|AR-AM\d{4}|ACM\d{4}|AM\d{4}|AM\d{3,4}|GS[- ]?(?:VER\d+)?)\b/i;
+
+/**
+ * Check if evidence mentions contain a methodology code that isn't in our
+ * inventory. Returns the first such code found, or null.
+ */
+export function detectUnavailableMethod(
+  rawMentions: string[],
+  methodCodes: Set<string>,
+): string | null {
+  for (const mention of rawMentions) {
+    const normalized = mention.replace(/\s+/g, "").toUpperCase();
+    if (!METHOD_CODE_PATTERN.test(normalized)) continue;
+    const match = normalized.match(METHOD_CODE_PATTERN);
+    if (!match?.[0]) continue;
+    const candidate = match[0].replace(/\s+/g, "").toUpperCase();
+    // Also check if it resolves via alias to something in inventory
+    const resolved = resolveExactCode(mention, methodCodes);
+    if (resolved) continue; // It IS in inventory, so not unavailable
+    const alias = resolveAlias(mention);
+    if (alias && methodCodes.has(alias.canonical)) continue; // Alias resolves to available pack
+    if (!methodCodes.has(candidate)) return candidate;
+  }
+  return null;
+}

--- a/src/lib/chat/quickCheckPdfClient.ts
+++ b/src/lib/chat/quickCheckPdfClient.ts
@@ -25,27 +25,36 @@ export async function resolveQuickCheckPdfText(input: {
       metadata?: {
         parser?: "pdf-parse" | "heuristic";
         fallbackReason?: string;
+        diagnostics?: {
+          failureKind?: "file-too-large" | "parser-failed" | "no-selectable-text";
+        };
       };
     };
     const engine =
       payload.engine === "heuristic" || payload.metadata?.parser === "heuristic"
         ? "heuristic"
         : "pdf-parse";
+    const failureKind = payload.metadata?.diagnostics?.failureKind;
+    const warning =
+      engine === "heuristic"
+        ? failureKind === "no-selectable-text"
+          ? "No selectable text found in this PDF."
+          : payload.metadata?.fallbackReason
+            ? `PDF parser fallback: ${payload.metadata.fallbackReason}`
+            : "PDF parser fallback: heuristic extraction was used."
+        : undefined;
     return {
       text: payload.text ?? "",
       engine,
-      warning:
-        engine === "heuristic"
-          ? payload.metadata?.fallbackReason
-            ? `PDF parser fallback: ${payload.metadata.fallbackReason}`
-            : "PDF parser fallback: heuristic extraction was used."
-          : undefined,
+      warning,
+      diagnosticCode: failureKind,
     };
   } catch {
     return {
       text: extractPdfText(input.bytes),
       engine: "heuristic",
       warning: "PDF parser fallback: client request failed, using heuristic extraction.",
+      diagnosticCode: "parser-failed",
     };
   }
 }

--- a/src/lib/chat/quickCheckPdfExtractor.ts
+++ b/src/lib/chat/quickCheckPdfExtractor.ts
@@ -34,6 +34,7 @@ type HelperOverrides = {
 };
 
 export type PdfExtractionDiagnostics = {
+  failureKind?: "file-too-large" | "parser-failed" | "no-selectable-text";
   parserPath:
     | "provided-parser"
     | "bundled-pdf-parse"
@@ -181,6 +182,7 @@ function buildPageExtractionResult(
   if (!combinedText) {
     const failureDiagnostics = {
       ...diagnostics,
+      failureKind: "no-selectable-text" as const,
       extractedTextLength: 0,
       pageCount: 0,
       likelyScannedOrImageOnly: true,
@@ -305,6 +307,7 @@ export async function extractPdfTextWithPdfParse(input: {
         parser: "pdf-parse",
         diagnostics: {
           ...buildEmptyDiagnostics(),
+          failureKind: helperText ? "parser-failed" : "no-selectable-text",
           parserPath: "helper-text",
           pageExtractionAttempted: true,
           pageExtractionError: parserError,
@@ -366,6 +369,7 @@ export async function extractPdfPagesWithPdfParse(input: {
             diagnostics.pageExtractionError,
             diagnostics.textFallbackError,
           ].filter(Boolean) as string[]);
+          diagnostics.failureKind = diagnostics.likelyScannedOrImageOnly ? "no-selectable-text" : "parser-failed";
 
           throw new PdfExtractionError(
             `PDF extraction failed. Page extraction: ${diagnostics.pageExtractionError}. Text fallback: ${diagnostics.textFallbackError}.`,
@@ -379,6 +383,7 @@ export async function extractPdfPagesWithPdfParse(input: {
         diagnostics.pageExtractionError,
         diagnostics.textFallbackError,
       ].filter(Boolean) as string[]);
+      diagnostics.failureKind = diagnostics.likelyScannedOrImageOnly ? "no-selectable-text" : "parser-failed";
 
       throw new PdfExtractionError(
         `PDF extraction failed. Page extraction: ${diagnostics.pageExtractionError}. Text fallback: ${diagnostics.textFallbackError}.`,

--- a/src/lib/chat/quickCheckUi.ts
+++ b/src/lib/chat/quickCheckUi.ts
@@ -58,6 +58,24 @@ function dedupe(values: string[]): string[] {
   return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
 }
 
+function methodologyMentionPriority(value: string): number {
+  const normalized = value.trim().toUpperCase();
+  if (/^VM\d{4}$/.test(normalized)) return 0;
+  if (normalized === "REDD+ MF" || normalized === "REDD+ METHODOLOGY FRAMEWORK") return 1;
+  if (/^VMD\d{4}$/.test(normalized)) return 2;
+  if (/^(VERIFIED CARBON STANDARD|VERRA|VCS|CCB)$/.test(normalized)) return 3;
+  if (/^(APD|ARR|RWE|APWD)$/.test(normalized)) return 4;
+  return 5;
+}
+
+function prioritizeMethodologyMentions(values: string[]): string[] {
+  return dedupe(values).sort(
+    (left, right) =>
+      methodologyMentionPriority(left) - methodologyMentionPriority(right) ||
+      left.localeCompare(right),
+  );
+}
+
 function formatFactPreview(fact: QuickCheckEvidenceFact, options?: { useDetail?: boolean }): string {
   const detail = fact.detail?.trim();
   if (!options?.useDetail || !detail) return fact.summary;
@@ -159,7 +177,7 @@ export function buildQuickCheckExtractionSnapshot(input: {
   return {
     documentType: input.analysis.documentTypes[0] ?? "Unknown document",
     extractedFacts,
-    methodologyMentions: dedupe(input.analysis.methodologyMentions).slice(0, 4),
+    methodologyMentions: prioritizeMethodologyMentions(input.analysis.methodologyMentions).slice(0, 4),
     warnings,
     signals: {
       parsedEvidenceCount: input.analysis.parsedEvidenceLabels.length,

--- a/src/lib/evidence/export/verificationPackDerivation.ts
+++ b/src/lib/evidence/export/verificationPackDerivation.ts
@@ -494,7 +494,14 @@ function buildDecisionRun(params: {
   });
   return {
     runId,
-    projectId: params.finalizedReview?.artifact?.verifier?.runId ?? params.currentReview?.verifierBundle?.runContext?.runId ?? 'method-review-export',
+    projectId:
+      params.finalizedReview?.projectContext?.projectCode?.trim()
+      || params.finalizedReview?.projectContext?.projectId?.trim()
+      || params.currentReview?.projectContext?.projectCode?.trim()
+      || params.currentReview?.projectContext?.projectId?.trim()
+      || params.finalizedReview?.artifact?.verifier?.runId
+      || params.currentReview?.verifierBundle?.runContext?.runId
+      || 'method-review-export',
     createdAt: params.generatedAt,
     decisions: sortedDecisions,
     decisionSetFingerprint,
@@ -603,7 +610,14 @@ function buildReconciliationRun(params: {
   return {
     runId: reconciliationFingerprint,
     createdAt: params.generatedAt,
-    projectId: params.finalizedReview?.artifact?.verifier?.runId ?? params.currentReview?.verifierBundle?.runContext?.runId ?? 'method-review-export',
+    projectId:
+      params.finalizedReview?.projectContext?.projectCode?.trim()
+      || params.finalizedReview?.projectContext?.projectId?.trim()
+      || params.currentReview?.projectContext?.projectCode?.trim()
+      || params.currentReview?.projectContext?.projectId?.trim()
+      || params.finalizedReview?.artifact?.verifier?.runId
+      || params.currentReview?.verifierBundle?.runContext?.runId
+      || 'method-review-export',
     status,
     items: sortByString(items, (item) => item.id),
     gaps: sortByString(gaps, (gap) => gap.ruleId),

--- a/src/lib/evidence/extraction/pdfExtractor.ts
+++ b/src/lib/evidence/extraction/pdfExtractor.ts
@@ -1,35 +1,27 @@
 import { sha256Text } from '@/lib/proof/hash';
+import { extractPdfPagesWithPdfParse } from '@/lib/chat/quickCheckPdfExtractor';
 import type { SourceDocument, DocumentFragment } from './types';
 
 export async function extractPdfFragments(
   doc: SourceDocument,
   pdfBuffer: ArrayBuffer,
 ): Promise<DocumentFragment[]> {
-  const mod = await import('pdf-parse');
-  const PdfParse = mod.PDFParse;
-  const parser = new PdfParse({ data: new Uint8Array(pdfBuffer) });
-
-  let result: { pages: Array<{ num: number; text: string }>; text: string };
-  try {
-    result = await parser.getText();
-  } finally {
-    await parser.destroy().catch(() => undefined);
-  }
+  const result = await extractPdfPagesWithPdfParse({ bytes: pdfBuffer });
 
   const fragments: DocumentFragment[] = [];
 
   for (const page of result.pages) {
     const contentSha256 = await sha256Text(page.text);
     fragments.push({
-      fragmentId: `${doc.id}__page_${page.num}`,
+      fragmentId: `${doc.id}__page_${page.pageNumber}`,
       documentId: doc.id,
       kind: 'pdd',
       index: fragments.length,
-      label: `Page ${page.num}`,
+      label: `Page ${page.pageNumber}`,
       text: page.text,
       contentSha256,
-      pageStart: page.num,
-      pageEnd: page.num,
+      pageStart: page.pageNumber,
+      pageEnd: page.pageNumber,
     });
   }
 

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -42,11 +42,15 @@ export function getProject(id: string): Project | undefined {
 
 export function createProject(input: {
   name: string;
+  projectCode?: string;
+  countryLocation?: string;
+  proponent?: string;
   reviewMode: Project['reviewMode'];
   methodCode?: string;
   methodVersion?: string;
   methodCategory?: string;
   registry?: Project['registry'];
+  reportingPeriod?: string;
   aoiLabel?: string;
   description?: string;
   ruleIds?: Array<{ id: string; title: string; sectionId: string }>;
@@ -54,6 +58,9 @@ export function createProject(input: {
   const project: Project = {
     id: generateId(),
     name: input.name,
+    projectCode: input.projectCode,
+    countryLocation: input.countryLocation,
+    proponent: input.proponent,
     reviewMode: input.reviewMode,
     methodCode: input.methodCode,
     methodVersion: input.methodVersion,
@@ -61,6 +68,7 @@ export function createProject(input: {
     registry: input.registry,
     status: 'in-progress',
     createdAt: new Date().toISOString(),
+    reportingPeriod: input.reportingPeriod,
     aoiLabel: input.aoiLabel,
     description: input.description,
     reviews: (input.ruleIds ?? []).map(r => ({
@@ -78,6 +86,34 @@ export function createProject(input: {
 
   const projects = loadAll();
   projects.push(project);
+  saveAll(projects);
+  return project;
+}
+
+export function updateProject(
+  projectId: string,
+  update: Partial<
+    Pick<
+      Project,
+      | 'name'
+      | 'projectCode'
+      | 'countryLocation'
+      | 'proponent'
+      | 'methodCode'
+      | 'methodVersion'
+      | 'methodCategory'
+      | 'registry'
+      | 'reportingPeriod'
+      | 'aoiLabel'
+      | 'description'
+      | 'lastWorkspaceId'
+    >
+  >,
+): Project | undefined {
+  const projects = loadAll();
+  const project = projects.find((item) => item.id === projectId);
+  if (!project || project.status === 'locked') return undefined;
+  Object.assign(project, update);
   saveAll(projects);
   return project;
 }
@@ -347,6 +383,9 @@ function normalizeProject(project: Partial<Project>): Project {
   return {
     id: project.id ?? generateId(),
     name: project.name ?? 'Untitled project',
+    projectCode: project.projectCode,
+    countryLocation: project.countryLocation,
+    proponent: project.proponent,
     reviewMode: project.reviewMode ?? 'methodology-linked',
     methodCode: project.methodCode,
     methodVersion: project.methodVersion,
@@ -355,6 +394,8 @@ function normalizeProject(project: Partial<Project>): Project {
     status: project.status ?? 'in-progress',
     createdAt: project.createdAt ?? new Date().toISOString(),
     lockedAt: project.lockedAt,
+    reportingPeriod: project.reportingPeriod,
+    lastWorkspaceId: project.lastWorkspaceId,
     aoiLabel: project.aoiLabel,
     description: project.description,
     reviews: Array.isArray(project.reviews) ? project.reviews : [],

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -133,6 +133,9 @@ export type ExtractedManualFindingDraft = {
 export type Project = {
   id: string;
   name: string;
+  projectCode?: string;
+  countryLocation?: string;
+  proponent?: string;
   reviewMode: ProjectReviewMode;
   methodCode?: string;
   methodVersion?: string;
@@ -141,6 +144,8 @@ export type Project = {
   status: ProjectStatus;
   createdAt: string;
   lockedAt?: string;
+  reportingPeriod?: string;
+  lastWorkspaceId?: string;
   aoiLabel?: string;
   description?: string;
   reviews: RuleReview[];

--- a/src/lib/proofMap/storage.ts
+++ b/src/lib/proofMap/storage.ts
@@ -3,11 +3,19 @@ import type { ProofEvidenceItem } from "@/lib/proof/bundle";
 
 const AOI_STORAGE_VERSION = "v2";
 
-function aoiCurrentKey(code: string, version: string): string {
+function normalizeWorkspaceId(workspaceId?: string | null): string {
+  return (workspaceId ?? "").trim();
+}
+
+function aoiCurrentKey(code: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) return `aoi:${AOI_STORAGE_VERSION}:workspace:${normalizedWorkspaceId}:current`;
   return `aoi:${AOI_STORAGE_VERSION}:${code}:${version}:current`;
 }
 
-function aoiDraftKey(code: string, version: string): string {
+function aoiDraftKey(code: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) return `aoi:${AOI_STORAGE_VERSION}:workspace:${normalizedWorkspaceId}:draft`;
   return `aoi:${AOI_STORAGE_VERSION}:${code}:${version}:draft`;
 }
 
@@ -15,26 +23,33 @@ function legacyAoiKey(code: string, version: string): string {
   return `aoi:${code}:${version}`;
 }
 
-function pinsKey(code: string, version: string): string {
+function pinsKey(code: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) return `pins:workspace:${normalizedWorkspaceId}`;
   return `pins:${code}:${version}`;
 }
 
-function snapshotsKey(code: string, version: string): string {
+function snapshotsKey(code: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) return `snapshots:workspace:${normalizedWorkspaceId}`;
   return `snapshots:${code}:${version}`;
 }
 
-function runsKey(code: string, version: string): string {
+function runsKey(code: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) return `runs:workspace:${normalizedWorkspaceId}`;
   return `runs:${code}:${version}`;
 }
 
-export function loadAoi(code: string, version: string): AOI | null {
+export function loadAoi(code: string, version: string, workspaceId?: string | null): AOI | null {
   if (typeof window === "undefined") return null;
   try {
-    const currentRaw = window.localStorage.getItem(aoiCurrentKey(code, version));
+    const currentRaw = window.localStorage.getItem(aoiCurrentKey(code, version, workspaceId));
     if (currentRaw) {
       const parsed = JSON.parse(currentRaw) as unknown;
       return parsed && typeof parsed === "object" ? (parsed as AOI) : null;
     }
+    if (normalizeWorkspaceId(workspaceId)) return null;
     const legacyRaw = window.localStorage.getItem(legacyAoiKey(code, version));
     if (!legacyRaw) return null;
     const parsed = JSON.parse(legacyRaw) as unknown;
@@ -44,24 +59,26 @@ export function loadAoi(code: string, version: string): AOI | null {
   }
 }
 
-export function saveAoi(code: string, version: string, aoi: AOI | null) {
+export function saveAoi(code: string, version: string, aoi: AOI | null, workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
     if (!aoi) {
-      window.localStorage.removeItem(aoiCurrentKey(code, version));
+      window.localStorage.removeItem(aoiCurrentKey(code, version, workspaceId));
     } else {
-      window.localStorage.setItem(aoiCurrentKey(code, version), JSON.stringify(aoi));
+      window.localStorage.setItem(aoiCurrentKey(code, version, workspaceId), JSON.stringify(aoi));
     }
-    window.localStorage.removeItem(legacyAoiKey(code, version));
+    if (!normalizeWorkspaceId(workspaceId)) {
+      window.localStorage.removeItem(legacyAoiKey(code, version));
+    }
   } catch {
     // ignore
   }
 }
 
-export function loadDraftAoi(code: string, version: string): AOI | null {
+export function loadDraftAoi(code: string, version: string, workspaceId?: string | null): AOI | null {
   if (typeof window === "undefined") return null;
   try {
-    const raw = window.localStorage.getItem(aoiDraftKey(code, version));
+    const raw = window.localStorage.getItem(aoiDraftKey(code, version, workspaceId));
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
     return parsed && typeof parsed === "object" ? (parsed as AOI) : null;
@@ -70,21 +87,22 @@ export function loadDraftAoi(code: string, version: string): AOI | null {
   }
 }
 
-export function saveDraftAoi(code: string, version: string, aoi: AOI | null) {
+export function saveDraftAoi(code: string, version: string, aoi: AOI | null, workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
-    if (!aoi) window.localStorage.removeItem(aoiDraftKey(code, version));
-    else window.localStorage.setItem(aoiDraftKey(code, version), JSON.stringify(aoi));
+    if (!aoi) window.localStorage.removeItem(aoiDraftKey(code, version, workspaceId));
+    else window.localStorage.setItem(aoiDraftKey(code, version, workspaceId), JSON.stringify(aoi));
   } catch {
     // ignore
   }
 }
 
-export function loadPins(code: string, version: string): EvidencePin[] {
+export function loadPins(code: string, version: string, workspaceId?: string | null): EvidencePin[] {
   if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(pinsKey(code, version));
+    const raw = window.localStorage.getItem(pinsKey(code, version, workspaceId));
     if (!raw) return [];
+    if (!raw && normalizeWorkspaceId(workspaceId)) return [];
     const parsed = JSON.parse(raw) as unknown;
     return Array.isArray(parsed) ? (parsed as EvidencePin[]) : [];
   } catch {
@@ -92,19 +110,19 @@ export function loadPins(code: string, version: string): EvidencePin[] {
   }
 }
 
-export function savePins(code: string, version: string, pins: EvidencePin[]) {
+export function savePins(code: string, version: string, pins: EvidencePin[], workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(pinsKey(code, version), JSON.stringify(pins));
+    window.localStorage.setItem(pinsKey(code, version, workspaceId), JSON.stringify(pins));
   } catch {
     // ignore
   }
 }
 
-export function loadEvidenceSnapshots(code: string, version: string): ProofEvidenceItem[] {
+export function loadEvidenceSnapshots(code: string, version: string, workspaceId?: string | null): ProofEvidenceItem[] {
   if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(snapshotsKey(code, version));
+    const raw = window.localStorage.getItem(snapshotsKey(code, version, workspaceId));
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     return Array.isArray(parsed) ? (parsed as ProofEvidenceItem[]) : [];
@@ -113,20 +131,20 @@ export function loadEvidenceSnapshots(code: string, version: string): ProofEvide
   }
 }
 
-export function saveEvidenceSnapshots(code: string, version: string, items: ProofEvidenceItem[] | null | undefined) {
+export function saveEvidenceSnapshots(code: string, version: string, items: ProofEvidenceItem[] | null | undefined, workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
-    if (!items || !items.length) window.localStorage.removeItem(snapshotsKey(code, version));
-    else window.localStorage.setItem(snapshotsKey(code, version), JSON.stringify(items));
+    if (!items || !items.length) window.localStorage.removeItem(snapshotsKey(code, version, workspaceId));
+    else window.localStorage.setItem(snapshotsKey(code, version, workspaceId), JSON.stringify(items));
   } catch {
     // ignore
   }
 }
 
-export function loadVerificationRuns(code: string, version: string): VerificationRun[] {
+export function loadVerificationRuns(code: string, version: string, workspaceId?: string | null): VerificationRun[] {
   if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(runsKey(code, version));
+    const raw = window.localStorage.getItem(runsKey(code, version, workspaceId));
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     return Array.isArray(parsed) ? (parsed as VerificationRun[]) : [];
@@ -135,25 +153,27 @@ export function loadVerificationRuns(code: string, version: string): Verificatio
   }
 }
 
-export function saveVerificationRuns(code: string, version: string, runs: VerificationRun[] | null | undefined) {
+export function saveVerificationRuns(code: string, version: string, runs: VerificationRun[] | null | undefined, workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
-    if (!runs || !runs.length) window.localStorage.removeItem(runsKey(code, version));
-    else window.localStorage.setItem(runsKey(code, version), JSON.stringify(runs));
+    if (!runs || !runs.length) window.localStorage.removeItem(runsKey(code, version, workspaceId));
+    else window.localStorage.setItem(runsKey(code, version, workspaceId), JSON.stringify(runs));
   } catch {
     // ignore
   }
 }
 
-export function clearProofMapStorage(code: string, version: string) {
+export function clearProofMapStorage(code: string, version: string, workspaceId?: string | null) {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.removeItem(aoiCurrentKey(code, version));
-    window.localStorage.removeItem(aoiDraftKey(code, version));
-    window.localStorage.removeItem(legacyAoiKey(code, version));
-    window.localStorage.removeItem(pinsKey(code, version));
-    window.localStorage.removeItem(snapshotsKey(code, version));
-    window.localStorage.removeItem(runsKey(code, version));
+    window.localStorage.removeItem(aoiCurrentKey(code, version, workspaceId));
+    window.localStorage.removeItem(aoiDraftKey(code, version, workspaceId));
+    window.localStorage.removeItem(pinsKey(code, version, workspaceId));
+    window.localStorage.removeItem(snapshotsKey(code, version, workspaceId));
+    window.localStorage.removeItem(runsKey(code, version, workspaceId));
+    if (!normalizeWorkspaceId(workspaceId)) {
+      window.localStorage.removeItem(legacyAoiKey(code, version));
+    }
   } catch {
     // ignore
   }

--- a/src/lib/reviewWorkspaces/storage.ts
+++ b/src/lib/reviewWorkspaces/storage.ts
@@ -1,0 +1,182 @@
+import type { ReviewWorkspace } from "@/lib/reviewWorkspaces/types";
+
+const STORAGE_KEY = "article6_review_workspaces";
+
+function generateId(): string {
+  return "ws_" + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+function normalizeTrimmed(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function normalizeWorkspace(value: unknown): ReviewWorkspace | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const id = normalizeTrimmed(record.id);
+  const projectId = normalizeTrimmed(record.projectId);
+  const methodCode = normalizeTrimmed(record.methodCode);
+  const methodVersion = normalizeTrimmed(record.methodVersion);
+  const createdAt = normalizeTrimmed(record.createdAt);
+  const updatedAt = normalizeTrimmed(record.updatedAt);
+  if (!id || !projectId || !methodCode || !methodVersion || !createdAt || !updatedAt) {
+    return null;
+  }
+  return {
+    id,
+    name: normalizeTrimmed(record.name) ?? `${methodCode} ${methodVersion} review`,
+    projectId,
+    methodCode,
+    methodVersion,
+    reportingPeriod: normalizeTrimmed(record.reportingPeriod),
+    status: record.status === "finalized" ? "finalized" : "draft",
+    createdAt,
+    updatedAt,
+    lastOpenedAt: normalizeTrimmed(record.lastOpenedAt),
+    finalizedAt: normalizeTrimmed(record.finalizedAt),
+  };
+}
+
+function loadAll(): ReviewWorkspace[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((item) => normalizeWorkspace(item))
+      .filter((item): item is ReviewWorkspace => item !== null)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  } catch {
+    return [];
+  }
+}
+
+function saveAll(workspaces: ReviewWorkspace[]): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(workspaces));
+}
+
+export function listReviewWorkspaces(): ReviewWorkspace[] {
+  return loadAll();
+}
+
+export function getReviewWorkspace(id: string): ReviewWorkspace | undefined {
+  return loadAll().find((workspace) => workspace.id === id);
+}
+
+export function listReviewWorkspacesForProject(projectId: string): ReviewWorkspace[] {
+  return loadAll().filter((workspace) => workspace.projectId === projectId);
+}
+
+export function findReviewWorkspaceByProjectAndMethod(
+  projectId: string,
+  methodCode: string,
+  methodVersion: string,
+): ReviewWorkspace | undefined {
+  const normalizedCode = methodCode.trim();
+  const normalizedVersion = methodVersion.trim();
+  return loadAll().find(
+    (workspace) =>
+      workspace.projectId === projectId &&
+      workspace.methodCode === normalizedCode &&
+      workspace.methodVersion === normalizedVersion,
+  );
+}
+
+export function createReviewWorkspace(input: {
+  name: string;
+  projectId: string;
+  methodCode: string;
+  methodVersion: string;
+  reportingPeriod?: string;
+}): ReviewWorkspace {
+  const now = new Date().toISOString();
+  const workspace: ReviewWorkspace = {
+    id: generateId(),
+    name: input.name.trim(),
+    projectId: input.projectId,
+    methodCode: input.methodCode.trim(),
+    methodVersion: input.methodVersion.trim(),
+    reportingPeriod: input.reportingPeriod?.trim() || undefined,
+    status: "draft",
+    createdAt: now,
+    updatedAt: now,
+    lastOpenedAt: now,
+  };
+  const all = loadAll();
+  all.push(workspace);
+  saveAll(all);
+  return workspace;
+}
+
+export function ensureReviewWorkspace(input: {
+  projectId: string;
+  projectName: string;
+  projectCode?: string;
+  methodCode: string;
+  methodVersion: string;
+  reportingPeriod?: string;
+}): ReviewWorkspace {
+  const existing = findReviewWorkspaceByProjectAndMethod(input.projectId, input.methodCode, input.methodVersion);
+  if (existing) {
+    return updateReviewWorkspace(existing.id, {
+      lastOpenedAt: new Date().toISOString(),
+      reportingPeriod: input.reportingPeriod ?? existing.reportingPeriod,
+      name:
+        existing.name ||
+        buildReviewWorkspaceName({
+          projectName: input.projectName,
+          projectCode: input.projectCode,
+          methodCode: input.methodCode,
+          methodVersion: input.methodVersion,
+        }),
+    }) ?? existing;
+  }
+  return createReviewWorkspace({
+    projectId: input.projectId,
+    methodCode: input.methodCode,
+    methodVersion: input.methodVersion,
+    reportingPeriod: input.reportingPeriod,
+    name: buildReviewWorkspaceName({
+      projectName: input.projectName,
+      projectCode: input.projectCode,
+      methodCode: input.methodCode,
+      methodVersion: input.methodVersion,
+    }),
+  });
+}
+
+export function updateReviewWorkspace(
+  workspaceId: string,
+  update: Partial<Omit<ReviewWorkspace, "id" | "projectId" | "methodCode" | "methodVersion" | "createdAt">>,
+): ReviewWorkspace | undefined {
+  const all = loadAll();
+  const workspace = all.find((item) => item.id === workspaceId);
+  if (!workspace) return undefined;
+  Object.assign(workspace, {
+    ...update,
+    updatedAt: new Date().toISOString(),
+  });
+  saveAll(all);
+  return workspace;
+}
+
+export function touchReviewWorkspace(workspaceId: string): ReviewWorkspace | undefined {
+  return updateReviewWorkspace(workspaceId, { lastOpenedAt: new Date().toISOString() });
+}
+
+export function buildReviewWorkspaceName(input: {
+  projectName: string;
+  projectCode?: string;
+  methodCode: string;
+  methodVersion: string;
+}): string {
+  const projectLabel = input.projectCode?.trim()
+    ? `${input.projectName.trim()} (${input.projectCode.trim()})`
+    : input.projectName.trim();
+  return `${projectLabel} · ${input.methodCode.trim()} ${input.methodVersion.trim()} review`;
+}

--- a/src/lib/reviewWorkspaces/types.ts
+++ b/src/lib/reviewWorkspaces/types.ts
@@ -1,0 +1,15 @@
+export type ReviewWorkspaceStatus = "draft" | "finalized";
+
+export type ReviewWorkspace = {
+  id: string;
+  name: string;
+  projectId: string;
+  methodCode: string;
+  methodVersion: string;
+  reportingPeriod?: string;
+  status: ReviewWorkspaceStatus;
+  createdAt: string;
+  updatedAt: string;
+  lastOpenedAt?: string;
+  finalizedAt?: string;
+};

--- a/src/lib/verify/reviewStore.ts
+++ b/src/lib/verify/reviewStore.ts
@@ -12,6 +12,7 @@ export type RuleReview = {
   ruleId: string;
   methodology: string;
   version: string;
+  workspaceId?: string;
   status: ReviewStatus;
   rationale: string;
   supportReference: string;
@@ -28,10 +29,15 @@ export const REVIEW_STORE_EVENT = "article6:review-store-changed";
 type ReviewStoreEventDetail = {
   methodology: string;
   version: string;
+  workspaceId?: string;
   ruleId?: string;
 };
 
-function storageKey(methodology: string, version: string): string {
+function storageKey(methodology: string, version: string, workspaceId?: string | null): string {
+  const normalizedWorkspaceId = workspaceId?.trim();
+  if (normalizedWorkspaceId) {
+    return `${STORAGE_PREFIX}:workspace:${normalizedWorkspaceId}`;
+  }
   return `${STORAGE_PREFIX}:${methodology}:${version}`;
 }
 
@@ -44,9 +50,10 @@ export function getReview(
   ruleId: string,
   methodology: string,
   version: string,
+  workspaceId?: string | null,
 ): RuleReview | null {
   try {
-    const raw = localStorage.getItem(storageKey(methodology, version));
+    const raw = localStorage.getItem(storageKey(methodology, version, workspaceId));
     if (!raw) return null;
     const all: Record<string, RuleReview> = JSON.parse(raw);
     return all[ruleId] ?? null;
@@ -56,7 +63,8 @@ export function getReview(
 }
 
 export function saveReview(review: RuleReview): void {
-  const key = storageKey(review.methodology, review.version);
+  const workspaceId = (review as RuleReview & { workspaceId?: string | null }).workspaceId ?? null;
+  const key = storageKey(review.methodology, review.version, workspaceId);
   try {
     const raw = localStorage.getItem(key);
     const all: Record<string, RuleReview> = raw ? JSON.parse(raw) : {};
@@ -65,6 +73,7 @@ export function saveReview(review: RuleReview): void {
     emitReviewStoreEvent({
       methodology: review.methodology,
       version: review.version,
+      ...(workspaceId ? { workspaceId } : {}),
       ruleId: review.ruleId,
     });
   } catch {
@@ -75,9 +84,10 @@ export function saveReview(review: RuleReview): void {
 export function getAllReviews(
   methodology: string,
   version: string,
+  workspaceId?: string | null,
 ): Record<string, RuleReview> {
   try {
-    const raw = localStorage.getItem(storageKey(methodology, version));
+    const raw = localStorage.getItem(storageKey(methodology, version, workspaceId));
     return raw ? JSON.parse(raw) : {};
   } catch {
     return {};
@@ -88,15 +98,16 @@ export function deleteReview(
   ruleId: string,
   methodology: string,
   version: string,
+  workspaceId?: string | null,
 ): void {
-  const key = storageKey(methodology, version);
+  const key = storageKey(methodology, version, workspaceId);
   try {
     const raw = localStorage.getItem(key);
     if (!raw) return;
     const all: Record<string, RuleReview> = JSON.parse(raw);
     delete all[ruleId];
     localStorage.setItem(key, JSON.stringify(all));
-    emitReviewStoreEvent({ methodology, version, ruleId });
+    emitReviewStoreEvent({ methodology, version, ...(workspaceId ? { workspaceId } : {}), ruleId });
   } catch {
     // ignore
   }
@@ -109,8 +120,9 @@ export function addEvidenceAttachment(
   methodology: string,
   version: string,
   attachment: Omit<EvidenceAttachment, "id" | "addedAt">,
+  workspaceId?: string | null,
 ): RuleReview | null {
-  const review = getReview(ruleId, methodology, version);
+  const review = getReview(ruleId, methodology, version, workspaceId);
   if (!review) return null;
 
   const full: EvidenceAttachment = {
@@ -129,8 +141,9 @@ export function removeEvidenceAttachment(
   methodology: string,
   version: string,
   evidenceId: string,
+  workspaceId?: string | null,
 ): RuleReview | null {
-  const review = getReview(ruleId, methodology, version);
+  const review = getReview(ruleId, methodology, version, workspaceId);
   if (!review) return null;
 
   review.evidenceAttachments = (review.evidenceAttachments ?? []).filter(
@@ -156,8 +169,9 @@ export function getReviewProgress(
   methodology: string,
   version: string,
   totalRules: number,
+  workspaceId?: string | null,
 ): ReviewProgress {
-  const reviews = getAllReviews(methodology, version);
+  const reviews = getAllReviews(methodology, version, workspaceId);
   const entries = Object.values(reviews);
   const reviewed = entries.filter((r) => r.status !== "pending").length;
   const verified = entries.filter((r) => r.status === "verified").length;
@@ -187,10 +201,22 @@ export function checkFinalizeGate(
   methodology: string,
   version: string,
   totalRules: number,
+  options?: {
+    workspaceId?: string | null;
+    projectLinked?: boolean;
+    methodologyLinked?: boolean;
+  },
 ): FinalizeGate {
-  const reviews = getAllReviews(methodology, version);
+  const reviews = getAllReviews(methodology, version, options?.workspaceId);
   const entries = Object.values(reviews);
   const reasons: string[] = [];
+
+  if (options?.projectLinked === false) {
+    reasons.push("Review workspace is not linked to a project");
+  }
+  if (options?.methodologyLinked === false) {
+    reasons.push("Review workspace is missing a methodology version");
+  }
 
   // Check all rules have a non-pending review
   const completedRuleIds = new Set(

--- a/src/lib/verify/runState.ts
+++ b/src/lib/verify/runState.ts
@@ -72,6 +72,7 @@ export type VerifierRunContext = {
 export type ReviewerArtifactContext = {
   methodCode: string;
   version: string;
+  workspaceId?: string | null;
   ruleId: string | null;
   runId: string;
 };
@@ -298,41 +299,63 @@ export function normalizeVersion(raw: string): string {
   return trimmed;
 }
 
-export function buildVerifyRunKey(methodCode: string, version: string): string {
+function normalizeWorkspaceId(raw?: string | null): string {
+  return (raw ?? "").trim();
+}
+
+export function buildVerifyRunKey(methodCode: string, version: string, workspaceId?: string | null): string {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) {
+    return `verify:workspace:${normalizedWorkspaceId}`;
+  }
   return `verify:${normalizedMethod}:${normalizedVersion}`;
 }
 
-function buildRunHistoryKey(methodCode: string, version: string): string {
+function buildRunHistoryKey(methodCode: string, version: string, workspaceId?: string | null): string {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) {
+    return `verifyRunHistory:workspace:${normalizedWorkspaceId}`;
+  }
   return `verifyRunHistory:${normalizedMethod}:${normalizedVersion}`;
 }
 
 function buildReviewerArtifactStorageKey(context: ReviewerArtifactContext): string {
+  const normalizedWorkspaceId = normalizeWorkspaceId(context.workspaceId);
   const normalizedMethod = normalizeMethodCode(context.methodCode);
   const normalizedVersion = normalizeVersion(context.version);
   const normalizedRuleId = (context.ruleId ?? "").trim() || "__no_rule__";
   const normalizedRunId = context.runId.trim();
+  if (normalizedWorkspaceId) {
+    return `verifyReviewerArtifact:workspace:${normalizedWorkspaceId}:${normalizedRuleId}:${normalizedRunId}`;
+  }
   return `verifyReviewerArtifact:${normalizedMethod}:${normalizedVersion}:${normalizedRuleId}:${normalizedRunId}`;
 }
 
-export function buildLinkedRulesKey(methodCode: string, version: string): string {
+export function buildLinkedRulesKey(methodCode: string, version: string, workspaceId?: string | null): string {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (normalizedWorkspaceId) {
+    return `verifyLinkedRules:workspace:${normalizedWorkspaceId}`;
+  }
   return `verifyLinkedRules:${normalizedMethod}:${normalizedVersion}`;
 }
 
 export function createReviewerArtifactContext(input: {
   methodCode: string;
   version: string;
+  workspaceId?: string | null;
   ruleId: string | null;
   runId: string;
 }): ReviewerArtifactContext {
   return {
     methodCode: normalizeMethodCode(input.methodCode),
     version: normalizeVersion(input.version),
+    workspaceId: normalizeWorkspaceId(input.workspaceId) || null,
     ruleId: asNonEmptyString(input.ruleId) ?? null,
     runId: input.runId.trim(),
   };
@@ -346,6 +369,7 @@ export function reviewerArtifactContextMatches(
   return (
     normalizeMethodCode(left.methodCode) === normalizeMethodCode(right.methodCode) &&
     normalizeVersion(left.version) === normalizeVersion(right.version) &&
+    normalizeWorkspaceId(left.workspaceId) === normalizeWorkspaceId(right.workspaceId) &&
     (asNonEmptyString(left.ruleId) ?? null) === (asNonEmptyString(right.ruleId) ?? null) &&
     left.runId.trim() === right.runId.trim()
   );
@@ -357,6 +381,7 @@ function normalizeReviewerArtifactContext(raw: unknown, fallback: ReviewerArtifa
   return {
     methodCode: asNonEmptyString(record.methodCode) ?? fallback.methodCode,
     version: asNonEmptyString(record.version) ?? fallback.version,
+    workspaceId: asNonEmptyString(record.workspaceId) ?? fallback.workspaceId ?? null,
     ruleId: asNonEmptyString(record.ruleId) ?? null,
     runId: asNonEmptyString(record.runId) ?? fallback.runId,
   };
@@ -407,9 +432,10 @@ export function persistReviewerArtifactState(state: ReviewerArtifactState): void
   storage.setItem(key, JSON.stringify(state));
 }
 
-function migrateLinkedRulesKey(methodCode: string, version: string): void {
+function migrateLinkedRulesKey(methodCode: string, version: string, workspaceId?: string | null): void {
   const storage = getLocalStorage();
   if (!storage) return;
+  if (normalizeWorkspaceId(workspaceId)) return;
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
   const canonical = buildLinkedRulesKey(normalizedMethod, normalizedVersion);
@@ -445,10 +471,15 @@ function migrateLinkedRulesKey(methodCode: string, version: string): void {
   for (const key of keysToMerge) storage.removeItem(key);
 }
 
-export function readLinkedRuleIdsFromStorage(methodCode: string, version: string): string[] {
+export function readLinkedRuleIdsFromStorage(methodCode: string, version: string, workspaceId?: string | null): string[] {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  migrateLinkedRulesKey(normalizedMethod, normalizedVersion);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  if (!normalizedWorkspaceId) {
+    migrateLinkedRulesKey(normalizedMethod, normalizedVersion);
+  }
+  const scoped = loadLinkedRuleIds(buildLinkedRulesKey(normalizedMethod, normalizedVersion, normalizedWorkspaceId));
+  if (scoped.length || normalizedWorkspaceId) return scoped;
   return loadLinkedRuleIds(buildLinkedRulesKey(normalizedMethod, normalizedVersion));
 }
 
@@ -487,22 +518,23 @@ export function addLinkedRuleIdToStorage(
   methodCode: string,
   version: string,
   ruleId: string | null | undefined,
+  workspaceId?: string | null,
 ): string[] {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  const key = buildLinkedRulesKey(normalizedMethod, normalizedVersion);
+  const key = buildLinkedRulesKey(normalizedMethod, normalizedVersion, workspaceId);
   return addLinkedRuleIdToKey(key, ruleId);
 }
 
-export function setLinkedRuleIdsInStorage(methodCode: string, version: string, ids: string[]): string[] {
+export function setLinkedRuleIdsInStorage(methodCode: string, version: string, ids: string[], workspaceId?: string | null): string[] {
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  const key = buildLinkedRulesKey(normalizedMethod, normalizedVersion);
+  const key = buildLinkedRulesKey(normalizedMethod, normalizedVersion, workspaceId);
   persistLinkedRuleIds(key, ids);
   return loadLinkedRuleIds(key);
 }
 
-export function createVerifierRunBundle(methodCode: string, version: string): VerifierRunBundle {
+export function createVerifierRunBundle(methodCode: string, version: string, workspaceId?: string | null): VerifierRunBundle {
   const createdAt = nowIso();
   const runId = buildRunId(methodCode, version, new Date(createdAt));
   return {
@@ -513,6 +545,7 @@ export function createVerifierRunBundle(methodCode: string, version: string): Ve
     reviewerContext: createReviewerArtifactContext({
       methodCode,
       version,
+      workspaceId,
       ruleId: null,
       runId,
     }),
@@ -534,15 +567,16 @@ export function createVerifierRunBundle(methodCode: string, version: string): Ve
   };
 }
 
-export function readVerifierRunBundle(methodCode: string, version: string): VerifierRunBundle {
+export function readVerifierRunBundle(methodCode: string, version: string, workspaceId?: string | null): VerifierRunBundle {
   const storage = getLocalStorage();
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  const canonical = buildVerifyRunKey(normalizedMethod, normalizedVersion);
-  const fallback = createVerifierRunBundle(normalizedMethod, normalizedVersion);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  const canonical = buildVerifyRunKey(normalizedMethod, normalizedVersion, normalizedWorkspaceId);
+  const fallback = createVerifierRunBundle(normalizedMethod, normalizedVersion, normalizedWorkspaceId);
   if (!storage) return fallback;
 
-  if (!storage.getItem(canonical)) {
+  if (!storage.getItem(canonical) && !normalizedWorkspaceId) {
     const legacyKeys = [
       `verify:${normalizedMethod}@${normalizedVersion}`,
       `verify:${normalizedMethod}`,
@@ -577,6 +611,7 @@ export function readVerifierRunBundle(methodCode: string, version: string): Veri
     const reviewerContextFallback = createReviewerArtifactContext({
       methodCode: normalizedMethod,
       version: normalizedVersion,
+      workspaceId: normalizedWorkspaceId,
       ruleId: null,
       runId,
     });
@@ -611,17 +646,17 @@ export function readVerifierRunBundle(methodCode: string, version: string): Veri
   }
 }
 
-export function persistVerifierRunBundle(methodCode: string, version: string, bundle: VerifierRunBundle): void {
+export function persistVerifierRunBundle(methodCode: string, version: string, bundle: VerifierRunBundle, workspaceId?: string | null): void {
   const storage = getLocalStorage();
   if (!storage) return;
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  const key = buildVerifyRunKey(normalizedMethod, normalizedVersion);
+  const key = buildVerifyRunKey(normalizedMethod, normalizedVersion, workspaceId);
   storage.setItem(key, JSON.stringify(bundle));
   if (typeof window !== "undefined") {
     window.dispatchEvent(
       new CustomEvent(VERIFY_RUN_BUNDLE_EVENT, {
-        detail: { methodCode: normalizedMethod, version: normalizedVersion },
+        detail: { methodCode: normalizedMethod, version: normalizedVersion, workspaceId: normalizeWorkspaceId(workspaceId) || undefined },
       }),
     );
   }
@@ -642,10 +677,10 @@ function normalizeRunHistory(raw: unknown): VerifyRunHistoryEntry[] {
   return entries;
 }
 
-export function readRunHistory(methodCode: string, version: string): VerifyRunHistoryEntry[] {
+export function readRunHistory(methodCode: string, version: string, workspaceId?: string | null): VerifyRunHistoryEntry[] {
   const storage = getLocalStorage();
   if (!storage) return [];
-  const key = buildRunHistoryKey(methodCode, version);
+  const key = buildRunHistoryKey(methodCode, version, workspaceId);
   const raw = storage.getItem(key);
   if (!raw) return [];
   try {
@@ -660,13 +695,14 @@ export function saveCurrentRunToHistory(
   methodCode: string,
   version: string,
   bundle: VerifyRunHistoryBundle,
+  workspaceId?: string | null,
 ): VerifyRunHistoryEntry[] {
   const storage = getLocalStorage();
   if (!storage) return [];
-  const key = buildRunHistoryKey(methodCode, version);
+  const key = buildRunHistoryKey(methodCode, version, workspaceId);
   const createdAt = bundle.runContext.createdAt || nowIso();
   const entry: VerifyRunHistoryEntry = { runId: bundle.runContext.runId, createdAt, bundle };
-  const existing = readRunHistory(methodCode, version);
+  const existing = readRunHistory(methodCode, version, workspaceId);
   const without = existing.filter((item) => item.runId !== entry.runId);
   const next = [entry, ...without].sort((a, b) => b.createdAt.localeCompare(a.createdAt)).slice(0, 10);
   storage.setItem(key, JSON.stringify(next));
@@ -677,17 +713,18 @@ export function loadRunFromHistory(
   methodCode: string,
   version: string,
   runId: string,
+  workspaceId?: string | null,
 ): VerifyRunHistoryBundle | null {
-  const history = readRunHistory(methodCode, version);
+  const history = readRunHistory(methodCode, version, workspaceId);
   const match = history.find((entry) => entry.runId === runId);
   return match ? match.bundle : null;
 }
 
-export function deleteRunFromHistory(methodCode: string, version: string, runId: string): VerifyRunHistoryEntry[] {
+export function deleteRunFromHistory(methodCode: string, version: string, runId: string, workspaceId?: string | null): VerifyRunHistoryEntry[] {
   const storage = getLocalStorage();
   if (!storage) return [];
-  const next = readRunHistory(methodCode, version).filter((entry) => entry.runId !== runId);
-  storage.setItem(buildRunHistoryKey(methodCode, version), JSON.stringify(next));
+  const next = readRunHistory(methodCode, version, workspaceId).filter((entry) => entry.runId !== runId);
+  storage.setItem(buildRunHistoryKey(methodCode, version, workspaceId), JSON.stringify(next));
   return next;
 }
 
@@ -696,13 +733,18 @@ export function shortRunId(runId: string, length = 8): string {
   return runId.length <= length ? runId : runId.slice(-length);
 }
 
-export function clearLinkedRuleIdsFromStorage(methodCode: string, version: string): void {
+export function clearLinkedRuleIdsFromStorage(methodCode: string, version: string, workspaceId?: string | null): void {
   const storage = getLocalStorage();
   if (!storage) return;
   const normalizedMethod = normalizeMethodCode(methodCode);
   const normalizedVersion = normalizeVersion(version);
-  const canonical = buildLinkedRulesKey(normalizedMethod, normalizedVersion);
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  const canonical = buildLinkedRulesKey(normalizedMethod, normalizedVersion, normalizedWorkspaceId);
   storage.removeItem(canonical);
+  if (normalizedWorkspaceId) {
+    notifyLinkedRuleListeners();
+    return;
+  }
   const legacyPrefixes = [
     `verifyLinkedRules:${normalizedMethod}:`,
     `verifyLinkedRules:${normalizedMethod}@`,

--- a/tests/api/projects.manual-review.extract-findings.route.test.ts
+++ b/tests/api/projects.manual-review.extract-findings.route.test.ts
@@ -213,4 +213,30 @@ describe('/api/projects/manual-review/extract-findings route', () => {
     expect(far05).not.toHaveProperty('auditTeamEvaluation');
     expect(far05?.evidenceExcerpt).not.toContain('APPENDIX 2: AUDIT PLAN');
   });
+
+  it('returns a distinct file-too-large diagnostic before attempting extraction', async () => {
+    const req = new Request('http://localhost/api/projects/manual-review/extract-findings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/pdf',
+        'x-article6-filename': encodeURIComponent('oversized.pdf'),
+      },
+      body: new Uint8Array((20 * 1024 * 1024) + 1).buffer,
+    });
+
+    const res = await POST(req);
+    const body = await res.json() as {
+      extractionFailed: boolean;
+      diagnosticSummary: string;
+      diagnosticReason: string;
+      diagnostics: { failureKind?: string };
+    };
+
+    expect(res.status).toBe(200);
+    expect(extractPdfPagesWithPdfParseMock).not.toHaveBeenCalled();
+    expect(body.extractionFailed).toBe(true);
+    expect(body.diagnosticSummary).toBe('file too large');
+    expect(body.diagnosticReason).toContain('20MB upload limit');
+    expect(body.diagnostics.failureKind).toBe('file-too-large');
+  });
 });

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -2029,6 +2029,11 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(text).toContain("Narrowing matches to VM0007 · v1-0.");
     expect(text).not.toContain("AR-ACM0003 · v02-0");
     expect(text).not.toContain("AR-AMS0007 · v01-0");
+    // Must not leak non-Verra or unrelated method candidates
+    expect(text).not.toContain("ACM0010");
+    expect(text).not.toContain("AM0073");
+    expect(text).not.toContain("AMS-III.A");
+    expect(text).not.toContain("AMS-III.AU");
     expect(text).not.toContain("No valid analysis path in VM0007");
   });
 
@@ -2055,6 +2060,11 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(text).toContain("Narrowing matches to VM0007 · v1-0.");
     expect(text).not.toContain("AR-ACM0003 · v02-0");
     expect(text).not.toContain("AR-AM0014 · v03-0");
+    // Must not leak non-Verra or unrelated method candidates
+    expect(text).not.toContain("ACM0010");
+    expect(text).not.toContain("AM0073");
+    expect(text).not.toContain("AMS-III.A");
+    expect(text).not.toContain("AMS-III.AU");
     expect(text).not.toContain("No valid analysis path in VM0007");
   });
 });

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -2003,7 +2003,7 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     const text = container.textContent ?? "";
     expect(text).toContain("Selected methodology mismatch");
-    expect(text).toContain("Evidence appears to reference VM0007, but current selected method is ACM0010.");
+    expect(text).toContain("Evidence references VM0007, but current selected method is ACM0010.");
   });
 
   it("narrows a PLUM boundary claim to VM0007 candidates only", async () => {
@@ -2017,7 +2017,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to Verra VM0007.");
+    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
 
     await act(async () => {
       clickButton("Run quick check");
@@ -2043,7 +2043,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to Verra VM0007.");
+    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
 
     await act(async () => {
       clickButton("Run quick check");

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -20,7 +20,7 @@ const PDF_TEXT_BY_FILENAME: Record<string, string> = {
   "boundary.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "boundary-note.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "baseline.pdf": "Monitoring report for the full reporting period.",
-  "plum-verra-demo-excerpt.pdf": "Project Description / PD. PLUM Project. Verra VCS / CCB. VM0007. Section 3.1 Application of Methodology. Section 3.3 Monitoring.",
+  "plum-verra-demo-excerpt.pdf": "Project Description / PD. PLUM Project. Verra VCS / CCB. VM0007. REDD+ Methodology Framework. Section 3.1 Application of Methodology. Section 3.3 Monitoring. Project boundary description for the PLUM Project. The mapped project area polygon and AOI are referenced in the boundary map. Project location described for the project area. Monitoring report for the full reporting period.",
 };
 
 jest.mock("@/lib/proofMap/attachments", () => ({
@@ -135,6 +135,7 @@ describe("QuickCheckPanel claim-first flow", () => {
               { code: "AR-ACM0003", latestVersion: "v02-0", versions: ["v02-0"] },
               { code: "AR-AM0014", latestVersion: "v03-0", versions: ["v03-0"] },
               { code: "AR-AMS0007", latestVersion: "v01-0", versions: ["v01-0"] },
+              { code: "VM0007", latestVersion: "v1-0", versions: ["v1-0"] },
             ],
           }),
           { status: 200 },
@@ -232,11 +233,99 @@ describe("QuickCheckPanel claim-first flow", () => {
           { status: 200 },
         );
       }
+      if (url.includes("/api/methods/VM0007/v/v1-0/rules")) {
+        return new Response(
+          JSON.stringify({
+            rules: [
+              {
+                id: "R-7-0001",
+                title: "Project boundary consistency",
+                snippet: "Boundary evidence aligns with the VM0007 project description.",
+                summary: "Boundary evidence aligns with the VM0007 project description.",
+                tags: ["boundary", "project area", "vm0007"],
+              },
+              {
+                id: "R-7-0002",
+                title: "Monitoring procedure",
+                snippet: "Monitoring evidence aligns with VM0007 section 3.3.",
+                summary: "Monitoring evidence aligns with VM0007 section 3.3.",
+                tags: ["monitoring", "vm0007"],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
       if (url.includes("/api/query?text=")) {
         const decoded = decodeURIComponent(url.split("text=")[1] ?? "");
         const lower = decoded.toLowerCase();
         const quickCheckSession = window.localStorage.getItem("a6:quick-check:claim-first:v1") ?? "";
         const kenyaSecondCheck = quickCheckSession.includes("kenya-second-check-evidence.pdf");
+        const plumVm0007 = quickCheckSession.includes("plum-verra-demo-excerpt.pdf");
+        if (plumVm0007 && lower.includes("monitoring report")) {
+          return new Response(
+            JSON.stringify({
+              engineTag: "test",
+              metrics: [],
+              results: [
+                {
+                  id: "R-7-0002",
+                  section_title: "Monitoring procedure",
+                  methodology_id: "VM0007",
+                  methodology_version: "v1-0",
+                  score: 0.78,
+                },
+                {
+                  id: "R-1-0001",
+                  section_title: "Monitoring frequency",
+                  methodology_id: "AR-ACM0003",
+                  methodology_version: "v02-0",
+                  score: 0.91,
+                },
+                {
+                  id: "R-1-0008",
+                  section_title: "Monitoring report consolidation",
+                  methodology_id: "AR-AM0014",
+                  methodology_version: "v03-0",
+                  score: 0.88,
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (plumVm0007 && (lower.includes("mapped area boundary") || lower.includes("project coordinates boundary") || lower.includes("project location boundary") || lower.includes("boundary description matches the mapped project area"))) {
+          return new Response(
+            JSON.stringify({
+              engineTag: "test",
+              metrics: [],
+              results: [
+                {
+                  id: "R-7-0001",
+                  section_title: "Project boundary consistency",
+                  methodology_id: "VM0007",
+                  methodology_version: "v1-0",
+                  score: 0.72,
+                },
+                {
+                  id: "R-1-0002",
+                  section_title: "Boundary consistency",
+                  methodology_id: "AR-ACM0003",
+                  methodology_version: "v02-0",
+                  score: 0.92,
+                },
+                {
+                  id: "R-2-0001",
+                  section_title: "Boundary delineation",
+                  methodology_id: "AR-AMS0007",
+                  methodology_version: "v01-0",
+                  score: 0.89,
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
         if (kenyaSecondCheck && quickCheckSession.includes("kenya no valid analysis path")) {
           return new Response(
             JSON.stringify({
@@ -1915,5 +2004,57 @@ describe("QuickCheckPanel claim-first flow", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("Selected methodology mismatch");
     expect(text).toContain("Evidence appears to reference VM0007, but current selected method is ACM0010.");
+  });
+
+  it("narrows a PLUM boundary claim to VM0007 candidates only", async () => {
+    seedSession({
+      claimText: "The boundary description matches the mapped project area.",
+      filename: "plum-verra-demo-excerpt.pdf",
+    });
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to Verra VM0007.");
+
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+
+    await flushUi();
+    const text = container.textContent ?? "";
+    expect(text).toContain("VM0007 · v1-0");
+    expect(text).toContain("Narrowing matches to VM0007 · v1-0.");
+    expect(text).not.toContain("AR-ACM0003 · v02-0");
+    expect(text).not.toContain("AR-AMS0007 · v01-0");
+    expect(text).not.toContain("No valid analysis path in VM0007");
+  });
+
+  it("narrows a PLUM monitoring claim to VM0007 candidates only", async () => {
+    seedSession({
+      claimText: "The monitoring report covers the full reporting period.",
+      filename: "plum-verra-demo-excerpt.pdf",
+    });
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to Verra VM0007.");
+
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+
+    await flushUi();
+    const text = container.textContent ?? "";
+    expect(text).toContain("VM0007 · v1-0");
+    expect(text).toContain("Narrowing matches to VM0007 · v1-0.");
+    expect(text).not.toContain("AR-ACM0003 · v02-0");
+    expect(text).not.toContain("AR-AM0014 · v03-0");
+    expect(text).not.toContain("No valid analysis path in VM0007");
   });
 });

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -20,6 +20,7 @@ const PDF_TEXT_BY_FILENAME: Record<string, string> = {
   "boundary.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "boundary-note.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "baseline.pdf": "Monitoring report for the full reporting period.",
+  "plum-verra-demo-excerpt.pdf": "Project Description / PD. PLUM Project. Verra VCS / CCB. VM0007. Section 3.1 Application of Methodology. Section 3.3 Monitoring.",
 };
 
 jest.mock("@/lib/proofMap/attachments", () => ({
@@ -660,6 +661,12 @@ describe("QuickCheckPanel claim-first flow", () => {
     const button = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes(label));
     expect(button).toBeTruthy();
     button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  }
+
+  function clickButtonIfPresent(label: string) {
+    const button = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes(label));
+    if (!button) return;
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   }
 
   function setClaimValue(value: string) {
@@ -1863,5 +1870,50 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).toContain("Open full review");
     expect(container.textContent).not.toContain("Likely requirement matches");
     expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
+  });
+
+  it("shows methodology not detected as a distinct extraction diagnostic", async () => {
+    seedSession({
+      claimText: "The monitoring report covers the full reporting period.",
+      filename: "monitoring-report.pdf",
+    });
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+    await flushUntilText("The PDF states a monitoring or reporting period");
+    await act(async () => {
+      clickButtonIfPresent("Show extraction details");
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Extraction diagnostic");
+    expect(text).toContain("Methodology not detected");
+    expect(text).toContain("did not detect a methodology reference");
+  });
+
+  it("shows the exact VM0007 mismatch warning when evidence conflicts with the selected method", async () => {
+    seedSession({
+      claimText: "The monitoring report covers the full reporting period.",
+      methodologyId: "ACM0010",
+      methodologyVersion: "v01-0",
+      filename: "plum-verra-demo-excerpt.pdf",
+    });
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+    await flushUntilText("Project Description / PD");
+    await act(async () => {
+      clickButtonIfPresent("Show extraction details");
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Selected methodology mismatch");
+    expect(text).toContain("Evidence appears to reference VM0007, but current selected method is ACM0010.");
   });
 });

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -20,7 +20,7 @@ const PDF_TEXT_BY_FILENAME: Record<string, string> = {
   "boundary.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "boundary-note.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "baseline.pdf": "Monitoring report for the full reporting period.",
-  "plum-verra-demo-excerpt.pdf": "Project Description / PD. PLUM Project. Verra VCS / CCB. VM0007. REDD+ Methodology Framework. Section 3.1 Application of Methodology. Section 3.3 Monitoring. Project boundary description for the PLUM Project. The mapped project area polygon and AOI are referenced in the boundary map. Project location described for the project area. Monitoring report for the full reporting period.",
+  "plum-verra-demo-excerpt.pdf": "Project Description / PD. PLUM Project. Verra VCS / CCB. APD. ARR. VMD0001. VMD0006. VMD0009. VM0007. REDD+ Methodology Framework. Section 3.1 Application of Methodology. Section 3.3 Monitoring. Project boundary description for the PLUM Project. The mapped project area polygon and AOI are referenced in the boundary map. Project location described for the project area. Monitoring report for the full reporting period.",
 };
 
 jest.mock("@/lib/proofMap/attachments", () => ({

--- a/tests/exports/auditPack.contract.test.ts
+++ b/tests/exports/auditPack.contract.test.ts
@@ -752,7 +752,7 @@ describe("audit pack verification contract", () => {
     expect(html).toContain("This report is not a formal validation opinion.");
     expect(html).toContain("local/browser-state review data");
 
-    expect(html).toContain("<dt>Project name</dt><dd>Not provided</dd>");
+    expect(html).toContain("<dt>Project name</dt><dd>Unlinked method review</dd>");
     expect(html).toContain("<dt>Project ID</dt><dd>Not provided</dd>");
     expect(html).toContain("<dt>Country / location</dt><dd>Not provided</dd>");
     expect(html).toContain("<dt>Proponent</dt><dd>Not provided</dd>");
@@ -843,6 +843,51 @@ describe("audit pack verification contract", () => {
         }),
       }),
     );
+  });
+
+  test("uses linked project and workspace context in the HTML report when provided", () => {
+    const zip = withTemporaryMethodologyCheckout(
+      () =>
+        buildAuditPackZip("AR-ACM0003", "v02-0", {
+          currentReview: {
+            latestReviewAt: "2026-05-21T09:05:00.000Z",
+            reviews: [],
+            evidencePins: [],
+            verifierBundle: {
+              runContext: {
+                runId: "run-linked-project-1",
+                createdAt: "2026-05-21T09:00:00.000Z",
+              },
+            },
+            projectContext: {
+              projectId: "proj_liwonde",
+              projectCode: "VCS-1530",
+              projectName: "Liwonde National Park REDD+",
+              countryLocation: "Malawi",
+              proponent: "Article6 Climate",
+              reportingPeriod: "2024-01-01 to 2024-12-31",
+              workspaceId: "ws_liwonde_review",
+              workspaceName: "Liwonde REDD+ · AR-ACM0003 v02-0 review",
+            },
+          },
+        }),
+      {
+        methodCode: "AR-ACM0003",
+        version: "v02-0",
+        rules: readinessSkeletonRulesJson,
+        sections: readinessSkeletonSectionsJson,
+      },
+    );
+
+    const entries = unzipSync(new Uint8Array(zip));
+    const html = strFromU8(entries["VERIFICATION_REPORT.html"]);
+
+    expect(html).toContain("<dt>Project name</dt><dd>Liwonde National Park REDD+</dd>");
+    expect(html).toContain("<dt>Project ID</dt><dd>VCS-1530</dd>");
+    expect(html).toContain("<dt>Country / location</dt><dd>Malawi</dd>");
+    expect(html).toContain("<dt>Proponent</dt><dd>Article6 Climate</dd>");
+    expect(html).toContain("Liwonde REDD+ · AR-ACM0003 v02-0 review");
+    expect(html).not.toContain("<dt>Project name</dt><dd>Not provided</dd>");
   });
 
   test("does not attach reviewer artifact text from another method into AR-AMS0007 current-review exports", () => {

--- a/tests/fixtures/quick-check/plum-verra-demo-excerpt.pdf
+++ b/tests/fixtures/quick-check/plum-verra-demo-excerpt.pdf
@@ -1,0 +1,48 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 265 >>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+(Project Description / PD) Tj
+0 -18 Td
+(PLUM Project) Tj
+0 -18 Td
+(Verra VCS / CCB) Tj
+0 -18 Td
+(VM0007) Tj
+0 -18 Td
+(Section 3.1 Application of Methodology) Tj
+0 -18 Td
+(Section 3.3 Monitoring) Tj
+0 -18 Td
+(REDD+ Methodology Framework) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+627
+%%EOF

--- a/tests/lib/quickCheckEvidence.test.ts
+++ b/tests/lib/quickCheckEvidence.test.ts
@@ -517,4 +517,19 @@ describe("extractMethodologyMentions — standard detection hardening", () => {
     expect(mentions).toContain("Verra");
     expect(mentions).toContain("GS-VER1");
   });
+
+  it("detects requested Verra REDD and VMD terms", () => {
+    const mentions = extractMethodologyMentions("REDD+ Methodology Framework REDD+ MF VMD0001 VMD 0006 VMD0009 APD ARR RWE APWD");
+    expect(mentions).toEqual(expect.arrayContaining([
+      "REDD+ Methodology Framework",
+      "REDD+ MF",
+      "VMD0001",
+      "VMD0006",
+      "VMD0009",
+      "APD",
+      "ARR",
+      "RWE",
+      "APWD",
+    ]));
+  });
 });

--- a/tests/lib/quickCheckMethodSignals.test.ts
+++ b/tests/lib/quickCheckMethodSignals.test.ts
@@ -1,0 +1,476 @@
+import {
+  resolveMethodologySignals,
+  gatingMethodCodes,
+  gatingLabel,
+  buildMethodProgramMap,
+  type MethodInventoryRecord,
+} from "@/lib/chat/quickCheckMethodSignals";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function makeInventory(codes: string[]): Set<string> {
+  return new Set(codes);
+}
+
+function makeMethodRecords(codes: string[]): MethodInventoryRecord[] {
+  return codes.map((code) => ({
+    code,
+    versions: ["v1-0"],
+    latestVersion: "v1-0",
+  }));
+}
+
+// ─── Tier 1: Primary methodology signals ─────────────────────────────────
+
+describe("Primary methodology signals (Tier 1)", () => {
+  describe("VM0007 exact code", () => {
+    it("detects VM0007 from exact code in mentions", () => {
+      const result = resolveMethodologySignals(
+        ["VM0007"],
+        makeInventory(["VM0007", "ACM0010", "AR-ACM0003"]),
+      );
+      expect(result.exactlyOne).toBe(true);
+      expect(result.detectedMethods[0]!.methodCode).toBe("VM0007");
+      expect(result.detectedMethods[0]!.confidence).toBe("exact-code");
+    });
+
+    it("detects VM0007 when mixed case", () => {
+      const result = resolveMethodologySignals(
+        ["vm0007"],
+        makeInventory(["VM0007"]),
+      );
+      expect(result.detectedMethods[0]!.methodCode).toBe("VM0007");
+    });
+  });
+
+  describe("REDD+ MF alias → VM0007", () => {
+    it("resolves REDD+ MF to VM0007", () => {
+      const result = resolveMethodologySignals(
+        ["REDD+ MF"],
+        makeInventory(["VM0007"]),
+      );
+      expect(result.exactlyOne).toBe(true);
+      expect(result.detectedMethods[0]!.methodCode).toBe("VM0007");
+      expect(result.detectedMethods[0]!.confidence).toBe("alias");
+      expect(result.detectedMethods[0]!.sourceMention).toBe("REDD+ MF");
+    });
+
+    it("resolves REDD+ Methodology Framework to VM0007", () => {
+      const result = resolveMethodologySignals(
+        ["REDD+ Methodology Framework"],
+        makeInventory(["VM0007"]),
+      );
+      expect(result.detectedMethods[0]!.methodCode).toBe("VM0007");
+    });
+
+    it("resolves lowercase redd+ methodology framework", () => {
+      const result = resolveMethodologySignals(
+        ["redd+ methodology framework"],
+        makeInventory(["VM0007"]),
+      );
+      expect(result.detectedMethods[0]!.methodCode).toBe("VM0007");
+    });
+  });
+
+  describe("ACM0010 detection", () => {
+    it("detects ACM0010 exact code", () => {
+      const result = resolveMethodologySignals(
+        ["ACM0010"],
+        makeInventory(["ACM0010", "VM0007"]),
+      );
+      expect(result.exactlyOne).toBe(true);
+      expect(result.detectedMethods[0]!.methodCode).toBe("ACM0010");
+      expect(result.detectedMethods[0]!.confidence).toBe("exact-code");
+    });
+
+    it("resolves ACM 0010 (with space) via alias", () => {
+      const result = resolveMethodologySignals(
+        ["ACM 0010"],
+        makeInventory(["ACM0010", "VM0007"]),
+      );
+      expect(result.detectedMethods[0]!.methodCode).toBe("ACM0010");
+      expect(result.detectedMethods[0]!.confidence).toBe("alias");
+    });
+  });
+
+  describe("UNFCCC Forestry codes", () => {
+    it("detects AR-ACM0003 exact code", () => {
+      const result = resolveMethodologySignals(
+        ["AR-ACM0003"],
+        makeInventory(["AR-ACM0003", "VM0007"]),
+      );
+      expect(result.detectedMethods[0]!.methodCode).toBe("AR-ACM0003");
+      expect(result.detectedMethods[0]!.confidence).toBe("exact-code");
+    });
+
+    it("detects AR-AMS0007 exact code", () => {
+      const result = resolveMethodologySignals(
+        ["AR-AMS0007"],
+        makeInventory(["AR-AMS0007"]),
+      );
+      expect(result.detectedMethods[0]!.methodCode).toBe("AR-AMS0007");
+    });
+
+    it("detects AR-AMS0003 exact code", () => {
+      const result = resolveMethodologySignals(
+        ["AR-AMS0003"],
+        makeInventory(["AR-AMS0003"]),
+      );
+      expect(result.detectedMethods[0]!.methodCode).toBe("AR-AMS0003");
+    });
+
+    it("detects AR-AM0014 exact code", () => {
+      const result = resolveMethodologySignals(
+        ["AR-AM0014"],
+        makeInventory(["AR-AM0014"]),
+      );
+      expect(result.detectedMethods[0]!.methodCode).toBe("AR-AM0014");
+    });
+  });
+});
+
+// ─── Tier 2: Program signals ────────────────────────────────────────────
+
+describe("Program signals (Tier 2)", () => {
+  it("detects Verra as program only (no method resolution)", () => {
+    const result = resolveMethodologySignals(
+      ["Verra"],
+      makeInventory(["VM0007", "ACM0010"]),
+    );
+    expect(result.noMethodDetected).toBe(true);
+    expect(result.programOnly).toBe(true);
+    expect(result.detectedPrograms[0]!.program).toBe("Verra");
+  });
+
+  it("detects VCS as Verra program", () => {
+    const result = resolveMethodologySignals(
+      ["VCS"],
+      makeInventory(["VM0007"]),
+    );
+    expect(result.programOnly).toBe(true);
+    expect(result.detectedPrograms[0]!.program).toBe("Verra");
+  });
+
+  it("detects CCB as Verra program", () => {
+    const result = resolveMethodologySignals(
+      ["CCB"],
+      makeInventory(["VM0007"]),
+    );
+    expect(result.programOnly).toBe(true);
+    expect(result.detectedPrograms[0]!.program).toBe("Verra");
+  });
+
+  it("detects UNFCCC as program only", () => {
+    const result = resolveMethodologySignals(
+      ["UNFCCC"],
+      makeInventory(["AR-ACM0003", "ACM0010"]),
+    );
+    expect(result.programOnly).toBe(true);
+    expect(result.detectedPrograms[0]!.program).toBe("UNFCCC");
+  });
+
+  it("detects Gold Standard as program only", () => {
+    const result = resolveMethodologySignals(
+      ["Gold Standard"],
+      makeInventory(["GS-00XX"]),
+    );
+    expect(result.programOnly).toBe(true);
+    expect(result.detectedPrograms[0]!.program).toBe("GoldStandard");
+  });
+
+  it("detects GS4GG as GoldStandard program", () => {
+    const result = resolveMethodologySignals(
+      ["GS4GG"],
+      makeInventory(["GS-00XX"]),
+    );
+    expect(result.programOnly).toBe(true);
+    expect(result.detectedPrograms[0]!.program).toBe("GoldStandard");
+  });
+
+  it("Verified Carbon Standard detects as Verra program", () => {
+    const result = resolveMethodologySignals(
+      ["Verified Carbon Standard"],
+      makeInventory(["VM0007"]),
+    );
+    expect(result.detectedPrograms[0]?.program).toBe("Verra");
+  });
+});
+
+// ─── Tier 3: Activity signals — MUST NOT resolve to methods ──────────────
+
+describe("Activity/module signals (Tier 3) — must not resolve to methods", () => {
+  const inventory = makeInventory(["VM0007", "AR-ACM0003"]);
+
+  it("APD alone does NOT resolve to VM0007", () => {
+    const result = resolveMethodologySignals(["APD"], inventory);
+    expect(result.noMethodDetected).toBe(true);
+    expect(result.detectedMethods).toHaveLength(0);
+    expect(result.activitySignals).toHaveLength(1);
+    expect(result.activitySignals[0]!.kind).toBe("APD");
+  });
+
+  it("ARR alone does NOT resolve to VM0007", () => {
+    const result = resolveMethodologySignals(["ARR"], inventory);
+    expect(result.noMethodDetected).toBe(true);
+    expect(result.detectedMethods).toHaveLength(0);
+    expect(result.activitySignals[0]!.kind).toBe("ARR");
+  });
+
+  it("RWE alone does NOT resolve to VM0007", () => {
+    const result = resolveMethodologySignals(["RWE"], inventory);
+    expect(result.noMethodDetected).toBe(true);
+    expect(result.activitySignals[0]!.kind).toBe("RWE");
+  });
+
+  it("APWD alone does NOT resolve to VM0007", () => {
+    const result = resolveMethodologySignals(["APWD"], inventory);
+    expect(result.noMethodDetected).toBe(true);
+    expect(result.activitySignals[0]!.kind).toBe("APWD");
+  });
+
+  it("VMD0001 alone does NOT resolve to VM0007", () => {
+    const result = resolveMethodologySignals(["VMD0001"], inventory);
+    expect(result.noMethodDetected).toBe(true);
+    expect(result.activitySignals[0]!.kind).toBe("VMD-module");
+  });
+
+  it("VMD0006 alone does NOT resolve to VM0007", () => {
+    const result = resolveMethodologySignals(["VMD0006"], inventory);
+    expect(result.noMethodDetected).toBe(true);
+  });
+
+  it("VMD0009 alone does NOT resolve to VM0007", () => {
+    const result = resolveMethodologySignals(["VMD0009"], inventory);
+    expect(result.noMethodDetected).toBe(true);
+  });
+
+  it("VMR001 alone does NOT resolve to VM0007", () => {
+    const result = resolveMethodologySignals(["VMR001"], inventory);
+    expect(result.noMethodDetected).toBe(true);
+  });
+
+  it("VMR1234 alone does NOT resolve to VM0007", () => {
+    const result = resolveMethodologySignals(["VMR1234"], inventory);
+    expect(result.noMethodDetected).toBe(true);
+  });
+
+  it("activitySignalsOnly is true when only Tier 3 signals present", () => {
+    const result = resolveMethodologySignals(["APD", "ARR", "VMD0001"], inventory);
+    expect(result.activitySignalsOnly).toBe(true);
+  });
+});
+
+// ─── Combined signals ────────────────────────────────────────────────────
+
+describe("Combined signals", () => {
+  it("VM0007 + activity signals → only VM0007 detected as method", () => {
+    const result = resolveMethodologySignals(
+      ["VM0007", "APD", "VMD0001", "ARR"],
+      makeInventory(["VM0007", "AR-ACM0003"]),
+    );
+    expect(result.exactlyOne).toBe(true);
+    expect(result.detectedMethods[0]!.methodCode).toBe("VM0007");
+    // Activity signals still recorded for potential boosting
+    expect(result.activitySignals.length).toBeGreaterThan(0);
+  });
+
+  it("REDD+ MF + VMD0009 → VM0007 detected (VMD is activity, REDD+ MF is primary)", () => {
+    const result = resolveMethodologySignals(
+      ["REDD+ MF", "VMD0009"],
+      makeInventory(["VM0007"]),
+    );
+    expect(result.exactlyOne).toBe(true);
+    expect(result.detectedMethods[0]!.methodCode).toBe("VM0007");
+    // VMD0009 is recorded as activity signal
+    expect(result.activitySignals.some((s) => s.kind === "VMD-module")).toBe(true);
+  });
+
+  it("multiple primary methods → multiplePossible is true", () => {
+    const result = resolveMethodologySignals(
+      ["VM0007", "ACM0010"],
+      makeInventory(["VM0007", "ACM0010"]),
+    );
+    expect(result.multiplePossible).toBe(true);
+    expect(result.canonicalCodes).toContain("VM0007");
+    expect(result.canonicalCodes).toContain("ACM0010");
+  });
+
+  it("deduplicates multiple mentions of same method", () => {
+    const result = resolveMethodologySignals(
+      ["VM0007", "VM0007", "REDD+ MF"],
+      makeInventory(["VM0007"]),
+    );
+    expect(result.exactlyOne).toBe(true);
+    expect(result.canonicalCodes).toEqual(["VM0007"]);
+  });
+});
+
+// ─── Gating behavior ─────────────────────────────────────────────────────
+
+describe("gatingMethodCodes", () => {
+  it("returns single code when exactly one method detected", () => {
+    const signals = resolveMethodologySignals(
+      ["VM0007"],
+      makeInventory(["VM0007", "ACM0010"]),
+    );
+    const gated = gatingMethodCodes(signals);
+    expect(gated).toEqual(["VM0007"]);
+  });
+
+  it("returns all detected codes when multiple methods", () => {
+    const signals = resolveMethodologySignals(
+      ["VM0007", "ACM0010"],
+      makeInventory(["VM0007", "ACM0010"]),
+    );
+    const gated = gatingMethodCodes(signals);
+    expect(gated).toContain("VM0007");
+    expect(gated).toContain("ACM0010");
+    expect(gated).toHaveLength(2);
+  });
+
+  it("returns null when no method detected (broad match)", () => {
+    const signals = resolveMethodologySignals(
+      ["Some Project"],
+      makeInventory(["VM0007", "ACM0010"]),
+    );
+    const gated = gatingMethodCodes(signals);
+    expect(gated).toBeNull();
+  });
+
+  it("returns null when only activity signals present", () => {
+    const signals = resolveMethodologySignals(
+      ["APD", "ARR"],
+      makeInventory(["VM0007"]),
+    );
+    const gated = gatingMethodCodes(signals);
+    expect(gated).toBeNull();
+  });
+});
+
+// ─── Gating label ────────────────────────────────────────────────────────
+
+describe("gatingLabel", () => {
+  it("returns detected method label for single method", () => {
+    const signals = resolveMethodologySignals(
+      ["VM0007"],
+      makeInventory(["VM0007"]),
+    );
+    expect(gatingLabel(signals)).toBe("Detected VM0007");
+  });
+
+  it("returns needs-confirmation for multiple methods", () => {
+    const signals = resolveMethodologySignals(
+      ["VM0007", "ACM0010"],
+      makeInventory(["VM0007", "ACM0010"]),
+    );
+    const label = gatingLabel(signals);
+    expect(label).toContain("needs confirmation");
+    expect(label).toContain("VM0007");
+    expect(label).toContain("ACM0010");
+  });
+
+  it("returns null when no detection (broad match)", () => {
+    const signals = resolveMethodologySignals(
+      ["Nothing relevant"],
+      makeInventory(["VM0007"]),
+    );
+    expect(gatingLabel(signals)).toBeNull();
+  });
+});
+
+// ─── buildMethodProgramMap ───────────────────────────────────────────────
+
+describe("buildMethodProgramMap", () => {
+  it("maps VM-prefixed codes to Verra", () => {
+    const map = buildMethodProgramMap(makeMethodRecords(["VM0007", "VM0010"]));
+    expect(map.get("VM0007")).toBe("Verra");
+    expect(map.get("VM0010")).toBe("Verra");
+  });
+
+  it("maps AR-/AM-/ACM-prefixed codes to UNFCCC", () => {
+    const map = buildMethodProgramMap(
+      makeMethodRecords(["AR-ACM0003", "ACM0010", "AM0073"]),
+    );
+    expect(map.get("AR-ACM0003")).toBe("UNFCCC");
+    expect(map.get("ACM0010")).toBe("UNFCCC");
+    expect(map.get("AM0073")).toBe("UNFCCC");
+  });
+
+  it("maps GS-prefixed codes to GoldStandard", () => {
+    const map = buildMethodProgramMap(makeMethodRecords(["GS-00XX"]));
+    expect(map.get("GS-00XX")).toBe("GoldStandard");
+  });
+});
+
+// ─── Regression: PLUM scenario ───────────────────────────────────────────
+
+describe("PLUM regression tests", () => {
+  const fullInventory = makeInventory([
+    "VM0007",
+    "ACM0010",
+    "AR-ACM0003",
+    "AR-AMS0007",
+    "AR-AMS0003",
+    "AR-AM0014",
+    "GS-00XX",
+  ]);
+
+  it("PLUM excerpt with VM0007 → only VM0007 candidates gated", () => {
+    // Simulates a PLUM PDD that mentions VM0007
+    const mentions = ["VM0007", "Verra", "VCS", "CCB", "ARR", "REDD+"];
+    const result = resolveMethodologySignals(mentions, fullInventory);
+    expect(result.exactlyOne).toBe(true);
+    expect(result.detectedMethods[0]!.methodCode).toBe("VM0007");
+    const gated = gatingMethodCodes(result);
+    expect(gated).toEqual(["VM0007"]);
+  });
+
+  it("PLUM excerpt with REDD+ MF → resolves to VM0007 only", () => {
+    const mentions = ["REDD+ Methodology Framework", "VCS", "APD", "ARR"];
+    const result = resolveMethodologySignals(mentions, fullInventory);
+    expect(result.exactlyOne).toBe(true);
+    expect(result.detectedMethods[0]!.methodCode).toBe("VM0007");
+    const gated = gatingMethodCodes(result);
+    expect(gated).toEqual(["VM0007"]);
+  });
+
+  it("APD/ARR/RWE/APWD alone → no VM0007 resolution (broad match)", () => {
+    const mentions = ["APD", "ARR", "RWE"];
+    const result = resolveMethodologySignals(mentions, fullInventory);
+    expect(result.noMethodDetected).toBe(true);
+    expect(result.detectedMethods).toHaveLength(0);
+    const gated = gatingMethodCodes(result);
+    expect(gated).toBeNull();
+  });
+
+  it("VMD0001/VMD0006/VMD0009 alone → no VM0007 resolution", () => {
+    const mentions = ["VMD0001", "VMD0006"];
+    const result = resolveMethodologySignals(mentions, fullInventory);
+    expect(result.noMethodDetected).toBe(true);
+  });
+
+  it("VM0007 not in inventory → not detected (caller handles unavailable)", () => {
+    // When VM0007 is not in the method inventory, the resolver does not
+    // detect it as a primary method. The caller should check:
+    // "was a method mentioned that we don't have a pack for?"
+    const smallInventory = makeInventory(["ACM0010", "AR-ACM0003"]);
+    const result = resolveMethodologySignals(["VM0007"], smallInventory);
+    // VM0007 is NOT detected — it's not in inventory
+    expect(result.noMethodDetected).toBe(true);
+    expect(result.detectedMethods).toHaveLength(0);
+    // The caller should separately check: does the evidence mention a method
+    // that isn't in our inventory? (This is done by comparing raw mentions
+    // against known method code patterns)
+  });
+
+  it("no ACM0010/UNFCCC candidates leak when VM0007 detected", () => {
+    const mentions = ["VM0007", "REDD+ MF"];
+    const result = resolveMethodologySignals(mentions, fullInventory);
+    expect(result.detectedMethods).toHaveLength(1);
+    expect(result.detectedMethods[0]!.methodCode).toBe("VM0007");
+    // No UNFCCC codes detected
+    expect(
+      result.canonicalCodes.some((c) => c.startsWith("AR-") || c === "ACM0010"),
+    ).toBe(false);
+  });
+});

--- a/tests/lib/quickCheckMethodSignals.test.ts
+++ b/tests/lib/quickCheckMethodSignals.test.ts
@@ -3,6 +3,7 @@ import {
   gatingMethodCodes,
   gatingLabel,
   buildMethodProgramMap,
+  detectUnavailableMethod,
   type MethodInventoryRecord,
 } from "@/lib/chat/quickCheckMethodSignals";
 
@@ -472,5 +473,54 @@ describe("PLUM regression tests", () => {
     expect(
       result.canonicalCodes.some((c) => c.startsWith("AR-") || c === "ACM0010"),
     ).toBe(false);
+  });
+
+  it("GS-VER1 does not resolve to a canonical method code", () => {
+    // GS-VER1 is a real Gold Standard methodology, but no pack exists.
+    // It should not be resolved via alias to GS-00XX or anything else.
+    const result = resolveMethodologySignals(
+      ["GS-VER1"],
+      fullInventory,
+    );
+    expect(result.noMethodDetected).toBe(true);
+    expect(result.detectedMethods).toHaveLength(0);
+    // But it should still be detectable as an unavailable method
+    const unavailable = detectUnavailableMethod(["GS-VER1"], fullInventory);
+    expect(unavailable).toBe("GS-VER1");
+  });
+
+  it("GS VER2 (with space) is caught by detectUnavailableMethod", () => {
+    const unavailable = detectUnavailableMethod(
+      ["GS VER2"],
+      makeInventory(["VM0007", "ACM0010"]),
+    );
+    expect(unavailable).toBe("GSVER2");
+  });
+
+  it("VM0007 detected but no pack → method-unavailable, no fallback to unrelated methods", () => {
+    // Simulate: evidence mentions VM0007 but inventory only has ACM0010 and UNFCCC
+    const inventory = makeInventory(["ACM0010", "AR-ACM0003", "AR-AMS0007"]);
+    const mentions = ["VM0007", "REDD+ MF", "APD"];
+
+    // Signal resolution: VM0007 not in inventory → no primary method detected
+    const signals = resolveMethodologySignals(mentions, inventory);
+    expect(signals.noMethodDetected).toBe(true);
+    expect(signals.detectedMethods).toHaveLength(0);
+
+    // detectUnavailableMethod catches VM0007 as unavailable
+    const unavailable = detectUnavailableMethod(mentions, inventory);
+    expect(unavailable).toBe("VM0007");
+
+    // gatingMethodCodes returns null — no method to gate on
+    const programMap = buildMethodProgramMap(
+      makeMethodRecords(["ACM0010", "AR-ACM0003", "AR-AMS0007"]),
+    );
+    const gate = gatingMethodCodes(signals, programMap);
+    expect(gate).toBeNull();
+
+    // Caller should:
+    // 1. See detectUnavailableMethod returns "VM0007"
+    // 2. Show "Detected VM0007, but no matching method pack is available"
+    // 3. NOT fall back to broad match with ACM0010/AR-ACM0003 candidates
   });
 });

--- a/tests/lib/quickCheckPdfClient.test.ts
+++ b/tests/lib/quickCheckPdfClient.test.ts
@@ -48,4 +48,30 @@ describe("quick check pdf client", () => {
     expect(result.text).toContain("Monitoring report");
     expect(result.warning).toContain("client request failed");
   });
+
+  it("surfaces no-selectable-text as a distinct diagnostic", async () => {
+    global.fetch = jest.fn(async () =>
+      new Response(
+        JSON.stringify({
+          text: "",
+          engine: "heuristic",
+          metadata: {
+            parser: "heuristic",
+            fallbackReason: "pdf-parse returned empty text",
+            diagnostics: {
+              failureKind: "no-selectable-text",
+            },
+          },
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+
+    const result = await resolveQuickCheckPdfText({
+      bytes: new TextEncoder().encode("%PDF-empty").buffer,
+      filename: "image-only.pdf",
+    });
+
+    expect(result.warning).toBe("No selectable text found in this PDF.");
+    expect(result.diagnosticCode).toBe("no-selectable-text");
+  });
 });

--- a/tests/lib/quickCheckPdfExtractor.test.ts
+++ b/tests/lib/quickCheckPdfExtractor.test.ts
@@ -185,4 +185,22 @@ describe("quick check pdf-parse extractor", () => {
       partialTextRecovered: true,
     }));
   });
+
+  it("extracts the PLUM Verra demo fixture through the real helper-backed parser path", async () => {
+    const fixturePath = path.join(process.cwd(), "tests/fixtures/quick-check/plum-verra-demo-excerpt.pdf");
+    const bytes = fs.readFileSync(fixturePath);
+    const arrayBuffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+
+    const result = await extractPdfTextWithPdfParse({
+      bytes: arrayBuffer,
+    });
+
+    expect(result.engine).toBe("pdf-parse");
+    expect(result.text).toContain("Project Description / PD");
+    expect(result.text).toContain("PLUM Project");
+    expect(result.text).toContain("Verra VCS / CCB");
+    expect(result.text).toContain("VM0007");
+    expect(result.text).toContain("Section 3.1 Application of Methodology");
+    expect(result.text).toContain("Section 3.3 Monitoring");
+  }, 15000);
 });

--- a/tests/lib/quickCheckUi.test.ts
+++ b/tests/lib/quickCheckUi.test.ts
@@ -70,6 +70,30 @@ describe("quick check ui helpers", () => {
     ]);
   });
 
+  it("prioritizes specific methodology codes in the extraction preview", () => {
+    const snapshot = buildQuickCheckExtractionSnapshot({
+      claimText: "The boundary description matches the mapped project area",
+      analysis: {
+        facts: [
+          {
+            id: "boundary",
+            category: "boundary",
+            summary: "The project boundary is described in the PDD",
+            matchText: "project boundary described",
+            sourceLabel: "plum-verra-demo-excerpt.pdf",
+          },
+        ],
+        parsedEvidenceLabels: ["plum-verra-demo-excerpt.pdf"],
+        documentTypes: ["PDD / PDF"],
+        methodologyMentions: ["APD", "ARR", "CCB", "VCS", "VMD0001", "VMD0006", "VMD0009", "VM0007", "REDD+ Methodology Framework"],
+        extractionConfidence: 0.81,
+        warnings: [],
+      },
+    });
+
+    expect(snapshot.methodologyMentions).toEqual(["VM0007", "REDD+ Methodology Framework", "VMD0001", "VMD0006"]);
+  });
+
   it("normalizes a preliminary match result", () => {
     const view = normalizeQuickCheckUiResult({
       claim: "The monitoring report covers the full reporting period.",

--- a/tests/lib/reviewStore.test.ts
+++ b/tests/lib/reviewStore.test.ts
@@ -126,4 +126,46 @@ describe("reviewStore phase 2 helpers", () => {
       ],
     });
   });
+
+  it("scopes reviews to the linked workspace when a workspace id is provided", () => {
+    saveReview({ ...baseReview, workspaceId: "ws_alpha" });
+    saveReview({ ...baseReview, ruleId: "R-2", workspaceId: "ws_beta" });
+
+    expect(getReviewProgress("AR-ACM0003", "v02-0", 2, "ws_alpha")).toEqual({
+      total: 2,
+      reviewed: 1,
+      verified: 1,
+      notVerified: 0,
+      needsFollowup: 0,
+      pending: 1,
+      percentReviewed: 50,
+    });
+    expect(getReviewProgress("AR-ACM0003", "v02-0", 2, "ws_beta")).toEqual({
+      total: 2,
+      reviewed: 1,
+      verified: 1,
+      notVerified: 0,
+      needsFollowup: 0,
+      pending: 1,
+      percentReviewed: 50,
+    });
+  });
+
+  it("blocks finalize when the review workspace is missing linked project or methodology context", () => {
+    saveReview({ ...baseReview, workspaceId: "ws_alpha" });
+
+    expect(
+      checkFinalizeGate("AR-ACM0003", "v02-0", 1, {
+        workspaceId: "ws_alpha",
+        projectLinked: false,
+        methodologyLinked: false,
+      }),
+    ).toEqual({
+      canFinalize: false,
+      reasons: [
+        "Review workspace is not linked to a project",
+        "Review workspace is missing a methodology version",
+      ],
+    });
+  });
 });

--- a/tests/lib/reviewWorkspaces.storage.test.ts
+++ b/tests/lib/reviewWorkspaces.storage.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import {
+  ensureReviewWorkspace,
+  findReviewWorkspaceByProjectAndMethod,
+  listReviewWorkspacesForProject,
+} from "@/lib/reviewWorkspaces/storage";
+
+let store: Record<string, string> = {};
+
+describe("review workspace storage", () => {
+  beforeEach(() => {
+    const localStorage = {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+    };
+    Object.defineProperty(globalThis, "localStorage", {
+      value: localStorage,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "window", {
+      value: { localStorage },
+      configurable: true,
+      writable: true,
+    });
+    globalThis.localStorage.clear();
+  });
+
+  it("creates and reuses one workspace per project-method-version pair", () => {
+    const created = ensureReviewWorkspace({
+      projectId: "proj_1",
+      projectName: "Liwonde REDD+",
+      projectCode: "VCS-1530",
+      methodCode: "AR-ACM0003",
+      methodVersion: "v02-0",
+      reportingPeriod: "2024",
+    });
+    const reused = ensureReviewWorkspace({
+      projectId: "proj_1",
+      projectName: "Liwonde REDD+",
+      projectCode: "VCS-1530",
+      methodCode: "AR-ACM0003",
+      methodVersion: "v02-0",
+      reportingPeriod: "2024",
+    });
+
+    expect(reused.id).toBe(created.id);
+    expect(reused.name).toContain("Liwonde REDD+");
+    expect(listReviewWorkspacesForProject("proj_1")).toHaveLength(1);
+    expect(findReviewWorkspaceByProjectAndMethod("proj_1", "AR-ACM0003", "v02-0")?.id).toBe(created.id);
+  });
+});


### PR DESCRIPTION
## What changed
- added a reusable Quick Check methodology resolver that classifies extracted signals into method, program, and supporting module/activity signals
- normalized aliases like `VM0007`, `REDD+ MF`, and `REDD+ Methodology Framework` onto the same canonical method key
- added direct detection for broader methodology families including `ACM0010`, `AR-ACM0003`, `GS-VER1`, and related installed-pack aliases
- matched detected canonical methods against the available method inventory before candidate ranking
- hard-gated Quick Check requirement candidates to a single detected methodology before semantic ranking when evidence clearly points to one method
- limited candidates to the detected methodologies and surfaced a `Methodology needs confirmation` state when evidence references multiple installed methods
- blocked unrelated fallback when evidence detects a methodology without an installed pack, with explicit `Detected <method>, but no matching method pack is available.` messaging
- labeled no-method-detected runs as broad matching so users can distinguish uncertain retrieval from methodology-grounded matching
- kept the PLUM VM0007 fixture as a regression path while generalizing the architecture beyond Verra-specific one-offs

## Why
- Quick Check was still searching globally and returning unrelated rules even when the uploaded evidence explicitly identified a methodology
- VM0007 was the active demo failure, but the underlying issue affects Verra, UNFCCC, Gold Standard, and future methodology packs
- methodology evidence should constrain the candidate universe before semantic similarity, not after it
- when evidence is ambiguous or unsupported, the safe behavior is to ask for confirmation or stop, not to show confident but unrelated matches

## Impact
- evidence-grounded methodology detection now controls the requirement search space instead of acting as a weak hint
- Quick Check can cleanly distinguish four states: single detected method, multiple detected methods, detected method without a pack, and no detected method
- unrelated UNFCCC Agriculture candidates are no longer shown when evidence clearly resolves to an installed non-UNFCCC methodology such as `VM0007`
- new methodology packs can participate in the same gating flow by exposing a code in the inventory and supporting aliases in the resolver

## Root cause
- the earlier Quick Check flow let broad semantic retrieval outrank explicit methodology evidence
- methodology logic also lived too close to the UI and only covered narrow alias cases, which made it brittle as more packs and evidence patterns were introduced

## Validation
- `npx jest tests/lib/quickCheckMethodology.test.ts tests/lib/quickCheckMethodSignals.test.ts tests/lib/quickCheckEvidence.test.ts tests/lib/quickCheckUi.test.ts tests/components/quickCheckPanel.test.tsx --runInBand`
- `npm run typecheck`
- pre-push hook ran `npm run lint` and `npm run typecheck`

### Roadmap-Update
- slug: phase-assurance-surface-mvp
- items:
  - PR12: in_progress

### Roadmap-Override
- slug: phase-assurance-surface-mvp
- pr: PR12
- from_status: done
- to_status: in_progress
- revert_of: PR326
- reason: Demo verification pack contract extends the PR12 lane with a truthful placeholder review scaffold after the earlier done state.