### PR TITLE
Preserve methodology review state on project handoff

### DIFF
--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -65,6 +65,7 @@ import { buildStacSupportFactsState } from "@/lib/verify/stacSupportFacts";
 import { isSourceAuditedMeta, metaUrlFromRulesPath } from "@/lib/methodBadge";
 import { getProject, updateProject } from "@/lib/projects/storage";
 import type { Project } from "@/lib/projects/types";
+import { stagePendingProjectReviewHandoff } from "@/lib/projects/reviewHandoff";
 import {
   ensureReviewWorkspace,
   getReviewWorkspace,
@@ -205,6 +206,16 @@ export default function MethodDetailPane({
     },
     [method.code, methodBasePath, searchString],
   );
+  const handleCreateProjectHandoff = useCallback(() => {
+    if (!activeVersion) return;
+    stagePendingProjectReviewHandoff({
+      methodCode: method.code,
+      methodVersion: activeVersion,
+      workspaceId: reviewWorkspace?.id ?? linkedWorkspaceId ?? null,
+      projectId: linkedProjectId,
+    });
+    router.push("/projects/new?handoff=active-review");
+  }, [activeVersion, linkedProjectId, linkedWorkspaceId, method.code, reviewWorkspace?.id, router]);
   const { events: auditEvents, appendEvent, clearTrail, exportJson, exportSha256 } = useAuditTrail();
   const appendAuditEvent = useCallback(
     (input: AuditTrailEventInput) => {
@@ -1520,8 +1531,19 @@ export default function MethodDetailPane({
           </div>
         </div>
         {!linkedProject ? (
-          <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
-            This verify flow is running without a linked project. Exports remain draft/incomplete and finalization will stay blocked until a project is linked.
+          <div className="mt-3 flex flex-col gap-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-3 text-xs text-amber-900 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              This verify flow is running without a linked project. Exports remain draft/incomplete and finalization will stay blocked until a project is linked.
+            </div>
+            {activeVersion ? (
+              <button
+                type="button"
+                onClick={handleCreateProjectHandoff}
+                className="rounded-full border border-amber-300 bg-white px-3 py-1.5 text-xs font-semibold text-amber-900 shadow-sm hover:border-amber-400"
+              >
+                Create project and carry over this review
+              </button>
+            ) : null}
           </div>
         ) : null}
       </section>

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import NewProjectForm from '@/components/projects/NewProjectForm';
 
@@ -8,7 +9,9 @@ export const metadata: Metadata = {
 export default function NewProjectPage() {
   return (
     <main className="min-h-screen bg-slate-50">
-      <NewProjectForm />
+      <Suspense fallback={null}>
+        <NewProjectForm />
+      </Suspense>
     </main>
   );
 }

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { createProject } from '@/lib/projects/storage';
 import { projectRegistryFromMethodProgram } from '@/lib/projects/verificationReport';
 import type { ProjectRegistry, ProjectReviewMode } from '@/lib/projects/types';
+import { importMethodologyReviewIntoProject, readPendingProjectReviewHandoff } from '@/lib/projects/reviewHandoff';
 
 export type MethodOption = {
   code: string;
@@ -31,6 +32,7 @@ export function groupMethodsByRegistry(methods: MethodOption[]): Array<{ registr
 
 export default function NewProjectForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [methods, setMethods] = useState<MethodOption[]>([]);
   const [reviewMode, setReviewMode] = useState<ProjectReviewMode>('methodology-linked');
   const [name, setName] = useState('');
@@ -43,6 +45,8 @@ export default function NewProjectForm() {
   const [description, setDescription] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [handoffDetected, setHandoffDetected] = useState(false);
+  const [handoffMethodLabel, setHandoffMethodLabel] = useState('');
 
   const groupedMethods = useMemo(() => groupMethodsByRegistry(methods), [methods]);
 
@@ -52,6 +56,16 @@ export default function NewProjectForm() {
       .then(data => setMethods(data.methods || []))
       .catch(() => setMethods([]));
   }, []);
+
+  useEffect(() => {
+    if (searchParams.get('handoff') !== 'active-review') return;
+    const handoff = readPendingProjectReviewHandoff();
+    if (!handoff) return;
+    setHandoffDetected(true);
+    setReviewMode('methodology-linked');
+    setSelectedMethod(`${handoff.source.methodCode}@${handoff.source.methodVersion}`);
+    setHandoffMethodLabel(`${handoff.source.methodCode} ${handoff.source.methodVersion}`);
+  }, [searchParams]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -77,6 +91,7 @@ export default function NewProjectForm() {
         return;
       }
 
+      const handoff = handoffDetected ? readPendingProjectReviewHandoff() : null;
       const [code, version] = selectedMethod.split('@');
       const rulesRes = await fetch(`/api/projects/method-rules?code=${code}&version=${version}`);
       const rulesData = await rulesRes.json();
@@ -91,6 +106,26 @@ export default function NewProjectForm() {
       const selectedMethodRecord = methods.find((method) => `${method.code}@${method.version}` === selectedMethod);
       const parts = (selectedMethodRecord?.program ?? '').split('/');
       const category = parts.length > 1 ? parts.slice(1).join('/') : undefined;
+      if (handoff && handoff.source.methodCode === code && handoff.source.methodVersion === version) {
+        const result = importMethodologyReviewIntoProject({
+          handoff,
+          projectFields: {
+            name,
+            projectCode: projectCode || undefined,
+            countryLocation: countryLocation || undefined,
+            proponent: proponent || undefined,
+            methodCategory: category,
+            registry: projectRegistryFromMethodProgram(selectedMethodRecord?.program),
+            reportingPeriod: reportingPeriod || undefined,
+            aoiLabel: aoiLabel || undefined,
+            description: description || undefined,
+          },
+          rules,
+        });
+        router.push(result.href);
+        return;
+      }
+
       const project = createProject({
         name,
         projectCode: projectCode || undefined,
@@ -115,7 +150,7 @@ export default function NewProjectForm() {
     } catch {
       setError(reviewMode === 'manual'
         ? 'Failed to create manual review. Try again.'
-        : 'Failed to load methodology rules. Try again.');
+        : 'Failed to create project handoff. Try again.');
       setLoading(false);
     }
   };
@@ -141,8 +176,9 @@ export default function NewProjectForm() {
           <div className="grid gap-3 md:grid-cols-2">
             <button
               type="button"
+              disabled={handoffDetected}
               onClick={() => setReviewMode('methodology-linked')}
-              className={`rounded-lg border px-4 py-3 text-left ${
+              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? 'cursor-not-allowed opacity-60' : ''} ${
                 reviewMode === 'methodology-linked'
                   ? 'border-blue-500 bg-blue-50 text-blue-900'
                   : 'border-slate-200 bg-white text-slate-700'
@@ -153,8 +189,9 @@ export default function NewProjectForm() {
             </button>
             <button
               type="button"
+              disabled={handoffDetected}
               onClick={() => setReviewMode('manual')}
-              className={`rounded-lg border px-4 py-3 text-left ${
+              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? 'cursor-not-allowed opacity-60' : ''} ${
                 reviewMode === 'manual'
                   ? 'border-blue-500 bg-blue-50 text-blue-900'
                   : 'border-slate-200 bg-white text-slate-700'
@@ -165,6 +202,12 @@ export default function NewProjectForm() {
             </button>
           </div>
         </div>
+
+        {handoffDetected ? (
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+            Create a project and carry over the active review for {handoffMethodLabel}. Existing evidence links, rule reviews, reviewer notes, and draft finalization state will be imported.
+          </div>
+        ) : null}
 
         <div>
           <label className="mb-1 block text-sm font-semibold text-slate-700">Project Name</label>
@@ -230,6 +273,7 @@ export default function NewProjectForm() {
             <select
               value={selectedMethod}
               onChange={e => setSelectedMethod(e.target.value)}
+              disabled={handoffDetected}
               className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
               required
             >

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -15,6 +15,7 @@ import type {
   RuleReview,
 } from '@/lib/projects/types';
 import { resolveProjectRegistry } from '@/lib/projects/verificationReport';
+import { buildProjectReviewHref } from '@/lib/projects/reviewHandoff';
 import { computeMetrics } from '@/lib/evidence/metrics';
 import { SectionCoverageBar } from '@/components/evidence/EvidenceQualityBadge';
 import {
@@ -382,6 +383,14 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
   const latestWorkspace = project.reviewMode === 'methodology-linked'
     ? listReviewWorkspacesForProject(project.id)[0] ?? null
     : null;
+  const startReviewHref = project.reviewMode === 'methodology-linked' && project.methodCode && project.methodVersion
+    ? buildProjectReviewHref({
+        methodCode: project.methodCode,
+        methodVersion: project.methodVersion,
+        projectId: project.id,
+        workspaceId: latestWorkspace?.id ?? project.lastWorkspaceId ?? null,
+      })
+    : `/m?projectId=${encodeURIComponent(project.id)}`;
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-12 md:px-8">
@@ -429,14 +438,19 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
           {project.reviewMode === 'methodology-linked' ? (
             <>
               <Link
-                href={`/m?projectId=${encodeURIComponent(project.id)}`}
+                href={startReviewHref}
                 className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
               >
                 Start review
               </Link>
               {latestWorkspace ? (
                 <Link
-                  href={`/m/${encodeURIComponent(latestWorkspace.methodCode)}/v/${encodeURIComponent(latestWorkspace.methodVersion)}?projectId=${encodeURIComponent(project.id)}&workspaceId=${encodeURIComponent(latestWorkspace.id)}&tab=verify`}
+                  href={buildProjectReviewHref({
+                    methodCode: latestWorkspace.methodCode,
+                    methodVersion: latestWorkspace.methodVersion,
+                    projectId: project.id,
+                    workspaceId: latestWorkspace.id,
+                  })}
                   className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800"
                 >
                   Continue review

--- a/src/components/projects/ProjectsList.tsx
+++ b/src/components/projects/ProjectsList.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import type { Project } from '@/lib/projects/types';
 import { listProjects, getProjectCoverage, deleteProject } from '@/lib/projects/storage';
 import { listReviewWorkspacesForProject } from '@/lib/reviewWorkspaces/storage';
+import { buildProjectReviewHref } from '@/lib/projects/reviewHandoff';
 
 export default function ProjectsList() {
   const [projects, setProjects] = useState<Project[]>([]);
@@ -41,6 +42,17 @@ export default function ProjectsList() {
         <div className="flex flex-col gap-3">
           {projects.map(project => {
             const coverage = getProjectCoverage(project);
+            const latestWorkspace = project.reviewMode === 'methodology-linked'
+              ? listReviewWorkspacesForProject(project.id)[0] ?? null
+              : null;
+            const startReviewHref = project.reviewMode === 'methodology-linked' && project.methodCode && project.methodVersion
+              ? buildProjectReviewHref({
+                  methodCode: project.methodCode,
+                  methodVersion: project.methodVersion,
+                  projectId: project.id,
+                  workspaceId: latestWorkspace?.id ?? project.lastWorkspaceId ?? null,
+                })
+              : `/m?projectId=${encodeURIComponent(project.id)}`;
             return (
               <div
                 key={project.id}
@@ -108,17 +120,21 @@ export default function ProjectsList() {
                       {project.reviewMode === 'methodology-linked' ? (
                         <>
                           <Link
-                            href={`/m?projectId=${encodeURIComponent(project.id)}`}
+                            href={startReviewHref}
                             className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
                           >
                             Start review
                           </Link>
                           {(() => {
-                            const latestWorkspace = listReviewWorkspacesForProject(project.id)[0];
                             if (!latestWorkspace) return null;
                             return (
                               <Link
-                                href={`/m/${encodeURIComponent(latestWorkspace.methodCode)}/v/${encodeURIComponent(latestWorkspace.methodVersion)}?projectId=${encodeURIComponent(project.id)}&workspaceId=${encodeURIComponent(latestWorkspace.id)}&tab=verify`}
+                                href={buildProjectReviewHref({
+                                  methodCode: latestWorkspace.methodCode,
+                                  methodVersion: latestWorkspace.methodVersion,
+                                  projectId: project.id,
+                                  workspaceId: latestWorkspace.id,
+                                })}
                                 className="rounded-full bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-800"
                               >
                                 Continue review

--- a/src/lib/projects/reviewHandoff.ts
+++ b/src/lib/projects/reviewHandoff.ts
@@ -1,0 +1,325 @@
+import { getReview, getAllReviews, saveReview, type RuleReview as CanonicalRuleReview } from "@/lib/verify/reviewStore";
+import {
+  buildLinkedRulesKey,
+  createReviewerArtifactContext,
+  persistLinkedRuleIds,
+  persistReviewerArtifactState,
+  persistVerifierRunBundle,
+  readLinkedRuleIdsFromStorage,
+  readReviewerArtifactState,
+  readRunHistory,
+  readVerifierRunBundle,
+  type ReviewerArtifactState,
+  type VerifierRunBundle,
+  type VerifyRunHistoryEntry,
+} from "@/lib/verify/runState";
+import {
+  loadAoi,
+  loadDraftAoi,
+  loadEvidenceSnapshots,
+  loadPins,
+  loadVerificationRuns,
+  saveAoi,
+  saveDraftAoi,
+  saveEvidenceSnapshots,
+  savePins,
+  saveVerificationRuns,
+} from "@/lib/proofMap/storage";
+import type { AOI, EvidencePin, VerificationRun } from "@/lib/proofMap/types";
+import type { ProofEvidenceItem } from "@/lib/proof/bundle";
+import { createProject, updateProject } from "@/lib/projects/storage";
+import type { Project, RuleReview, RuleReviewStatus } from "@/lib/projects/types";
+import { ensureReviewWorkspace } from "@/lib/reviewWorkspaces/storage";
+import type { ReviewWorkspace } from "@/lib/reviewWorkspaces/types";
+
+const PENDING_HANDOFF_KEY = "article6:pending-project-review-handoff";
+
+type SourceScope = {
+  methodCode: string;
+  methodVersion: string;
+  workspaceId?: string | null;
+  projectId?: string | null;
+};
+
+export type PendingProjectReviewHandoff = {
+  source: SourceScope;
+  currentAoi: AOI | null;
+  draftAoi: AOI | null;
+  evidencePins: EvidencePin[];
+  evidenceSnapshots: ProofEvidenceItem[];
+  verificationRuns: VerificationRun[];
+  verifierBundle: VerifierRunBundle;
+  runHistory: VerifyRunHistoryEntry[];
+  linkedRuleIds: string[];
+  reviews: Record<string, CanonicalRuleReview>;
+  reviewerArtifacts: ReviewerArtifactState[];
+  stagedAt: string;
+};
+
+export function buildProjectReviewHref(input: {
+  methodCode: string;
+  methodVersion: string;
+  projectId: string;
+  workspaceId?: string | null;
+}): string {
+  const params = new URLSearchParams();
+  params.set("projectId", input.projectId);
+  if (input.workspaceId?.trim()) params.set("workspaceId", input.workspaceId.trim());
+  params.set("tab", "verify");
+  return `/m/${encodeURIComponent(input.methodCode)}/v/${encodeURIComponent(input.methodVersion)}?${params.toString()}`;
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  return window.sessionStorage ?? null;
+}
+
+function toProjectStatus(status: CanonicalRuleReview["status"]): RuleReviewStatus {
+  switch (status) {
+    case "verified":
+      return "verified";
+    case "not_verified":
+      return "gap";
+    case "needs_followup":
+      return "in-progress";
+    case "pending":
+    default:
+      return "not-started";
+  }
+}
+
+function deriveEvidenceIdsForRule(ruleId: string, evidencePins: EvidencePin[]): string[] {
+  const linked = new Set<string>();
+  for (const pin of evidencePins) {
+    const hasDirectRule = pin.ruleId === ruleId;
+    const hasCitedRule = (pin.cited_ids ?? []).includes(ruleId);
+    const fragmentLinks = pin.pdd_fragment_links?.filter((link) => link.rule_id === ruleId) ?? [];
+    if (!hasDirectRule && !hasCitedRule && fragmentLinks.length === 0) continue;
+    linked.add(pin.id);
+    for (const fragmentLink of fragmentLinks) linked.add(fragmentLink.fragment_id);
+  }
+  return Array.from(linked).sort((a, b) => a.localeCompare(b));
+}
+
+function buildInitialProjectReviews(input: {
+  rules: Array<{ id: string; title: string; sectionId?: string }>;
+  reviews: Record<string, CanonicalRuleReview>;
+  evidencePins: EvidencePin[];
+}): RuleReview[] {
+  const latestByRule = new Map<string, CanonicalRuleReview>();
+  for (const review of Object.values(input.reviews)) {
+    const current = latestByRule.get(review.ruleId);
+    if (!current || current.updatedAt.localeCompare(review.updatedAt) < 0) {
+      latestByRule.set(review.ruleId, review);
+    }
+  }
+  return input.rules.map((rule) => {
+    const canonical = latestByRule.get(rule.id);
+    if (!canonical) {
+      return {
+        ruleId: rule.id,
+        ruleTitle: rule.title,
+        sectionId: rule.sectionId ?? "",
+        status: "not-started",
+        evidenceIds: [],
+      };
+    }
+    return {
+      ruleId: rule.id,
+      ruleTitle: rule.title,
+      sectionId: rule.sectionId ?? "",
+      status: toProjectStatus(canonical.status),
+      outcome:
+        canonical.status === "verified"
+          ? "pass"
+          : canonical.status === "not_verified"
+            ? "fail"
+            : canonical.status === "needs_followup"
+              ? "partial"
+              : undefined,
+      note: canonical.rationale || canonical.reviewerOutcomeNote || undefined,
+      evidenceIds: deriveEvidenceIdsForRule(rule.id, input.evidencePins),
+      reviewedAt: canonical.reviewedAt,
+    };
+  });
+}
+
+function cloneVerifierBundle(bundle: VerifierRunBundle, workspaceId: string): VerifierRunBundle {
+  return {
+    ...bundle,
+    reviewerContext: { ...bundle.reviewerContext, workspaceId },
+    savedReviewerArtifactContext: bundle.savedReviewerArtifactContext
+      ? { ...bundle.savedReviewerArtifactContext, workspaceId }
+      : null,
+  };
+}
+
+function persistRunHistory(methodCode: string, methodVersion: string, entries: VerifyRunHistoryEntry[], workspaceId: string): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(`verifyRunHistory:workspace:${workspaceId}`, JSON.stringify(entries));
+}
+
+function collectReviewerArtifacts(input: {
+  source: SourceScope;
+  verifierBundle: VerifierRunBundle;
+  reviews: Record<string, CanonicalRuleReview>;
+}): ReviewerArtifactState[] {
+  const artifacts: ReviewerArtifactState[] = [];
+  const bundleArtifact = readReviewerArtifactState(input.verifierBundle.reviewerContext);
+  if (bundleArtifact) artifacts.push(bundleArtifact);
+  for (const review of Object.values(input.reviews)) {
+    const context = createReviewerArtifactContext({
+      methodCode: input.source.methodCode,
+      version: input.source.methodVersion,
+      workspaceId: input.source.workspaceId,
+      ruleId: review.ruleId,
+      runId: review.runId ?? input.verifierBundle.runContext.runId,
+    });
+    const artifact = readReviewerArtifactState(context);
+    if (artifact) artifacts.push(artifact);
+  }
+  return artifacts;
+}
+
+export function stagePendingProjectReviewHandoff(source: SourceScope): PendingProjectReviewHandoff | null {
+  if (typeof window === "undefined") return null;
+  const reviews =
+    getAllReviews(source.methodCode, source.methodVersion, source.workspaceId, readVerifierRunBundle(source.methodCode, source.methodVersion, source.workspaceId).runContext.runId);
+  const fallbackReviews = Object.keys(reviews).length
+    ? reviews
+    : getAllReviews(source.methodCode, source.methodVersion, source.workspaceId);
+  const verifierBundle = readVerifierRunBundle(source.methodCode, source.methodVersion, source.workspaceId);
+  const handoff: PendingProjectReviewHandoff = {
+    source,
+    currentAoi: loadAoi(source.methodCode, source.methodVersion, source.workspaceId),
+    draftAoi: loadDraftAoi(source.methodCode, source.methodVersion, source.workspaceId),
+    evidencePins: loadPins(source.methodCode, source.methodVersion, source.workspaceId),
+    evidenceSnapshots: loadEvidenceSnapshots(source.methodCode, source.methodVersion, source.workspaceId),
+    verificationRuns: loadVerificationRuns(source.methodCode, source.methodVersion, source.workspaceId),
+    verifierBundle,
+    runHistory: readRunHistory(source.methodCode, source.methodVersion, source.workspaceId),
+    linkedRuleIds: readLinkedRuleIdsFromStorage(source.methodCode, source.methodVersion, source.workspaceId),
+    reviews: fallbackReviews,
+    reviewerArtifacts: collectReviewerArtifacts({ source, verifierBundle, reviews: fallbackReviews }),
+    stagedAt: new Date().toISOString(),
+  };
+  getStorage()?.setItem(PENDING_HANDOFF_KEY, JSON.stringify(handoff));
+  return handoff;
+}
+
+export function readPendingProjectReviewHandoff(): PendingProjectReviewHandoff | null {
+  const raw = getStorage()?.getItem(PENDING_HANDOFF_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as PendingProjectReviewHandoff;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingProjectReviewHandoff(): void {
+  getStorage()?.removeItem(PENDING_HANDOFF_KEY);
+}
+
+export function importMethodologyReviewIntoProject(input: {
+  handoff: PendingProjectReviewHandoff;
+  projectFields: {
+    name: string;
+    projectCode?: string;
+    countryLocation?: string;
+    proponent?: string;
+    reportingPeriod?: string;
+    aoiLabel?: string;
+    description?: string;
+    methodCategory?: string;
+    registry?: Project["registry"];
+  };
+  rules: Array<{ id: string; title: string; sectionId?: string }>;
+}): { project: Project; workspace: ReviewWorkspace; href: string } {
+  const methodCode = input.handoff.source.methodCode;
+  const methodVersion = input.handoff.source.methodVersion;
+  const initialReviews = buildInitialProjectReviews({
+    rules: input.rules,
+    reviews: input.handoff.reviews,
+    evidencePins: input.handoff.evidencePins,
+  });
+
+  const project = createProject({
+    ...input.projectFields,
+    reviewMode: "methodology-linked",
+    methodCode,
+    methodVersion,
+    ruleIds: input.rules.map((rule) => ({
+      id: rule.id,
+      title: rule.title,
+      sectionId: rule.sectionId ?? "",
+    })),
+    initialReviews,
+  });
+
+  const workspace = ensureReviewWorkspace({
+    projectId: project.id,
+    projectName: project.name,
+    projectCode: project.projectCode,
+    methodCode,
+    methodVersion,
+    reportingPeriod: input.projectFields.reportingPeriod,
+  });
+
+  updateProject(project.id, {
+    methodCode,
+    methodVersion,
+    reportingPeriod: workspace.reportingPeriod ?? input.projectFields.reportingPeriod,
+    lastWorkspaceId: workspace.id,
+  });
+
+  saveAoi(methodCode, methodVersion, input.handoff.currentAoi, workspace.id);
+  saveDraftAoi(methodCode, methodVersion, input.handoff.draftAoi, workspace.id);
+  savePins(methodCode, methodVersion, input.handoff.evidencePins, workspace.id);
+  saveEvidenceSnapshots(methodCode, methodVersion, input.handoff.evidenceSnapshots, workspace.id);
+  saveVerificationRuns(methodCode, methodVersion, input.handoff.verificationRuns, workspace.id);
+  persistLinkedRuleIds(buildLinkedRulesKey(methodCode, methodVersion, workspace.id), input.handoff.linkedRuleIds);
+  persistVerifierRunBundle(methodCode, methodVersion, cloneVerifierBundle(input.handoff.verifierBundle, workspace.id), workspace.id);
+  persistRunHistory(methodCode, methodVersion, input.handoff.runHistory, workspace.id);
+
+  for (const review of Object.values(input.handoff.reviews)) {
+    saveReview({ ...review, workspaceId: workspace.id });
+  }
+  for (const artifact of input.handoff.reviewerArtifacts) {
+    persistReviewerArtifactState({
+      ...artifact,
+      context: { ...artifact.context, workspaceId: workspace.id },
+    });
+  }
+
+  clearPendingProjectReviewHandoff();
+
+  return {
+    project: updateProject(project.id, { lastWorkspaceId: workspace.id }) ?? project,
+    workspace,
+    href: buildProjectReviewHref({
+      methodCode,
+      methodVersion,
+      projectId: project.id,
+      workspaceId: workspace.id,
+    }),
+  };
+}
+
+export function getImportedReviewForRule(input: {
+  handoff: PendingProjectReviewHandoff;
+  ruleId: string;
+}): CanonicalRuleReview | null {
+  const currentRunId = input.handoff.verifierBundle.runContext.runId;
+  return (
+    getReview(
+      input.ruleId,
+      input.handoff.source.methodCode,
+      input.handoff.source.methodVersion,
+      input.handoff.source.workspaceId,
+      currentRunId,
+    ) ??
+    Object.values(input.handoff.reviews).find((review) => review.ruleId === input.ruleId) ??
+    null
+  );
+}

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -54,6 +54,7 @@ export function createProject(input: {
   aoiLabel?: string;
   description?: string;
   ruleIds?: Array<{ id: string; title: string; sectionId: string }>;
+  initialReviews?: RuleReview[];
 }): Project {
   const project: Project = {
     id: generateId(),
@@ -71,7 +72,7 @@ export function createProject(input: {
     reportingPeriod: input.reportingPeriod,
     aoiLabel: input.aoiLabel,
     description: input.description,
-    reviews: (input.ruleIds ?? []).map(r => ({
+    reviews: input.initialReviews ?? (input.ruleIds ?? []).map(r => ({
       ruleId: r.id,
       ruleTitle: r.title,
       sectionId: r.sectionId,

--- a/tests/components/projects/NewProjectForm.handoff.test.tsx
+++ b/tests/components/projects/NewProjectForm.handoff.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createRoot } from 'react-dom/client';
+import { saveReview } from '@/lib/verify/reviewStore';
+import { persistVerifierRunBundle, readVerifierRunBundle } from '@/lib/verify/runState';
+import { stagePendingProjectReviewHandoff } from '@/lib/projects/reviewHandoff';
+
+const pushMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+  useSearchParams: () => new URLSearchParams('handoff=active-review'),
+}));
+
+const NewProjectForm = require('@/components/projects/NewProjectForm').default as typeof import('@/components/projects/NewProjectForm').default;
+
+describe('NewProjectForm handoff', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    pushMock.mockReset();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (global as { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  it('creates a project from an active methodology review and routes directly back to the VM0007 verify workspace', async () => {
+    const methodCode = 'VM0007';
+    const methodVersion = 'v1-8';
+    const bundle = readVerifierRunBundle(methodCode, methodVersion);
+    persistVerifierRunBundle(methodCode, methodVersion, {
+      ...bundle,
+      draftMinutes: 'Draft reviewer minutes carried into the project.',
+      draftOutcomeNote: 'Outcome note carried into the project.',
+    });
+    saveReview({
+      ruleId: 'R-1-0001',
+      methodology: methodCode,
+      version: methodVersion,
+      runId: bundle.runContext.runId,
+      status: 'verified',
+      rationale: 'Boundary evidence already reviewed.',
+      supportReference: 'Boundary map',
+      evidenceAttachments: [],
+      reviewedBy: 'reviewer@app.article6',
+      reviewedAt: '2026-05-24T00:03:00.000Z',
+      updatedAt: '2026-05-24T00:03:00.000Z',
+      reviewerArtifactSavedAt: '2026-05-24T00:04:00.000Z',
+      reviewerMinutes: 'Draft reviewer minutes carried into the project.',
+      reviewerOutcomeNote: 'Outcome note carried into the project.',
+    });
+    stagePendingProjectReviewHandoff({ methodCode, methodVersion });
+
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/projects/methods') {
+        return new Response(JSON.stringify({
+          methods: [
+            { code: 'VM0007', program: 'Verra/Forestry', version: 'v1-8', ruleCount: 2 },
+          ],
+        }), { status: 200 });
+      }
+      if (url === '/api/projects/method-rules?code=VM0007&version=v1-8') {
+        return new Response(JSON.stringify({
+          rules: [
+            { id: 'R-1-0001', title: 'Boundary must be documented', sectionId: 'S-1' },
+            { id: 'R-1-0002', title: 'Monitoring must be described', sectionId: 'S-2' },
+          ],
+        }), { status: 200 });
+      }
+      throw new Error(`Unhandled fetch ${url}`);
+    }) as typeof fetch;
+
+    await act(async () => {
+      root.render(<NewProjectForm />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const nameInput = container.querySelector('input[required]') as HTMLInputElement | null;
+    expect(nameInput).not.toBeNull();
+    await act(async () => {
+      const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      setValue?.call(nameInput!, 'PLUM Project Review');
+      nameInput!.dispatchEvent(new Event('change', { bubbles: true }));
+      nameInput!.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const submitButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Create Project Review'),
+    ) as HTMLButtonElement | undefined;
+    expect(submitButton).toBeDefined();
+    expect(submitButton?.disabled).toBe(false);
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const href = pushMock.mock.calls[0]?.[0] ?? '';
+    expect(href).toContain('/m/VM0007/v/v1-8?');
+    expect(href).toContain('projectId=');
+    expect(href).toContain('workspaceId=');
+    expect(href).toContain('tab=verify');
+    expect(href).not.toContain('ACM0010');
+    expect(href).not.toBe('/m');
+  });
+});

--- a/tests/components/projects/projectReviewRouting.test.tsx
+++ b/tests/components/projects/projectReviewRouting.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import ProjectsList from '@/components/projects/ProjectsList';
+import type { Project } from '@/lib/projects/types';
+import type { ReviewWorkspace } from '@/lib/reviewWorkspaces/types';
+
+function writeProjects(projects: Project[]) {
+  window.localStorage.setItem('article6_projects', JSON.stringify(projects));
+}
+
+function writeWorkspaces(workspaces: ReviewWorkspace[]) {
+  window.localStorage.setItem('article6_review_workspaces', JSON.stringify(workspaces));
+}
+
+describe('project review routing', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it('uses the project methodology workspace for Start review and does not show 0% when imported rule reviews already exist', async () => {
+    writeProjects([
+      {
+        id: 'proj-vm0007',
+        name: 'PLUM Project Review',
+        projectCode: 'VCS-1530',
+        reviewMode: 'methodology-linked',
+        methodCode: 'VM0007',
+        methodVersion: 'v1-8',
+        registry: 'Verra',
+        status: 'in-progress',
+        createdAt: '2026-05-24T00:00:00.000Z',
+        lastWorkspaceId: 'ws-vm0007',
+        reviews: [
+          {
+            ruleId: 'R-1-0001',
+            ruleTitle: 'Boundary must be documented',
+            sectionId: 'S-1',
+            status: 'verified',
+            evidenceIds: ['pin-boundary'],
+            reviewedAt: '2026-05-24T00:02:00.000Z',
+          },
+          {
+            ruleId: 'R-1-0002',
+            ruleTitle: 'Monitoring must be described',
+            sectionId: 'S-2',
+            status: 'not-started',
+            evidenceIds: [],
+          },
+        ],
+        documents: [],
+        manualFindings: [],
+        extractedManualFindingDrafts: [],
+        learningCases: [],
+      },
+    ]);
+    writeWorkspaces([
+      {
+        id: 'ws-vm0007',
+        name: 'PLUM Project Review · VM0007 v1-8 review',
+        projectId: 'proj-vm0007',
+        methodCode: 'VM0007',
+        methodVersion: 'v1-8',
+        status: 'draft',
+        createdAt: '2026-05-24T00:00:00.000Z',
+        updatedAt: '2026-05-24T00:00:00.000Z',
+      },
+    ]);
+
+    await act(async () => {
+      root.render(<ProjectsList />);
+    });
+
+    const percentageDisplay = Array.from(container.querySelectorAll('div')).find((node) => node.textContent?.trim() === '50%');
+    expect(percentageDisplay).toBeTruthy();
+
+    const anchors = Array.from(container.querySelectorAll('a'));
+    const startReview = anchors.find((anchor) => anchor.textContent?.trim() === 'Start review');
+    expect(startReview?.getAttribute('href')).toBe('/m/VM0007/v/v1-8?projectId=proj-vm0007&workspaceId=ws-vm0007&tab=verify');
+    expect(startReview?.getAttribute('href')).not.toContain('ACM0010');
+    expect(startReview?.getAttribute('href')).not.toBe('/m?projectId=proj-vm0007');
+  });
+});

--- a/tests/lib/projects.reviewHandoff.test.ts
+++ b/tests/lib/projects.reviewHandoff.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { getProject, getProjectCoverage } from '@/lib/projects/storage';
+import {
+  importMethodologyReviewIntoProject,
+  readPendingProjectReviewHandoff,
+  stagePendingProjectReviewHandoff,
+} from '@/lib/projects/reviewHandoff';
+import { savePins } from '@/lib/proofMap/storage';
+import type { EvidencePin } from '@/lib/proofMap/types';
+import { saveReview } from '@/lib/verify/reviewStore';
+import {
+  createReviewerArtifactContext,
+  persistLinkedRuleIds,
+  persistReviewerArtifactState,
+  persistVerifierRunBundle,
+  readReviewerArtifactState,
+  readVerifierRunBundle,
+  buildLinkedRulesKey,
+} from '@/lib/verify/runState';
+
+describe('project review handoff', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it('imports existing VM0007 methodology review work into the created project workspace', () => {
+    const methodCode = 'VM0007';
+    const methodVersion = 'v1-8';
+    const sourceBundle = readVerifierRunBundle(methodCode, methodVersion);
+    const sourceContext = createReviewerArtifactContext({
+      methodCode,
+      version: methodVersion,
+      ruleId: 'R-1-0001',
+      runId: sourceBundle.runContext.runId,
+    });
+    const sourcePins: EvidencePin[] = [
+      {
+        id: 'pin-boundary',
+        kind: 'pdd',
+        title: 'PLUM boundary evidence',
+        cited_ids: ['R-1-0001'],
+        created_at: '2026-05-24T00:00:00.000Z',
+        pdd_fragment_links: [
+          {
+            fragment_id: 'frag-boundary',
+            rule_id: 'R-1-0001',
+            linked_at: '2026-05-24T00:01:00.000Z',
+          },
+        ],
+      },
+    ];
+
+    savePins(methodCode, methodVersion, sourcePins);
+    persistLinkedRuleIds(buildLinkedRulesKey(methodCode, methodVersion), ['R-1-0001']);
+    persistVerifierRunBundle(
+      methodCode,
+      methodVersion,
+      {
+        ...sourceBundle,
+        draftMinutes: 'Saved reviewer minutes for VM0007 before project creation.',
+        draftOutcomeNote: 'Verified with caveats before project creation.',
+        minutes: 'Saved reviewer minutes for VM0007 before project creation.',
+        outcomeNote: 'Verified with caveats before project creation.',
+        savedReviewerArtifactAt: '2026-05-24T00:04:00.000Z',
+        savedReviewerArtifactContext: sourceContext,
+        reviewerContext: sourceContext,
+      },
+    );
+    persistReviewerArtifactState({
+      context: sourceContext,
+      savedReviewerArtifactAt: '2026-05-24T00:04:00.000Z',
+      minutes: 'Saved reviewer minutes for VM0007 before project creation.',
+      outcomeNote: 'Verified with caveats before project creation.',
+      draftMinutes: 'Saved reviewer minutes for VM0007 before project creation.',
+      draftOutcomeNote: 'Verified with caveats before project creation.',
+    });
+    saveReview({
+      ruleId: 'R-1-0001',
+      methodology: methodCode,
+      version: methodVersion,
+      runId: sourceBundle.runContext.runId,
+      status: 'verified',
+      rationale: 'Document evidence supports the boundary claim.',
+      supportReference: 'PDD boundary map fragment',
+      evidenceAttachments: [],
+      reviewedBy: 'reviewer@app.article6',
+      reviewedAt: '2026-05-24T00:03:00.000Z',
+      updatedAt: '2026-05-24T00:03:00.000Z',
+      reviewerArtifactSavedAt: '2026-05-24T00:04:00.000Z',
+      reviewerMinutes: 'Saved reviewer minutes for VM0007 before project creation.',
+      reviewerOutcomeNote: 'Verified with caveats before project creation.',
+    });
+
+    const staged = stagePendingProjectReviewHandoff({ methodCode, methodVersion });
+    expect(staged).not.toBeNull();
+    expect(readPendingProjectReviewHandoff()?.source.methodCode).toBe('VM0007');
+
+    const result = importMethodologyReviewIntoProject({
+      handoff: staged!,
+      projectFields: {
+        name: 'PLUM Project Review',
+        projectCode: 'VCS-1530',
+        reportingPeriod: '2024',
+        registry: 'Verra',
+      },
+      rules: [
+        { id: 'R-1-0001', title: 'Boundary must be documented', sectionId: 'S-1' },
+        { id: 'R-1-0002', title: 'Monitoring must be described', sectionId: 'S-2' },
+      ],
+    });
+
+    expect(result.href).toContain('/m/VM0007/v/v1-8?');
+    expect(result.href).toContain(`projectId=${encodeURIComponent(result.project.id)}`);
+    expect(result.href).toContain(`workspaceId=${encodeURIComponent(result.workspace.id)}`);
+    expect(result.href).toContain('tab=verify');
+
+    const importedProject = getProject(result.project.id);
+    expect(importedProject).toBeDefined();
+    const coverage = getProjectCoverage(importedProject!);
+    expect(coverage.percentComplete).toBeGreaterThan(0);
+    expect(importedProject?.reviews.find((review) => review.ruleId === 'R-1-0001')?.status).toBe('verified');
+
+    const importedBundle = readVerifierRunBundle(methodCode, methodVersion, result.workspace.id);
+    expect(importedBundle.draftMinutes).toBe('Saved reviewer minutes for VM0007 before project creation.');
+    expect(importedBundle.draftOutcomeNote).toBe('Verified with caveats before project creation.');
+
+    const importedArtifact = readReviewerArtifactState({
+      ...sourceContext,
+      workspaceId: result.workspace.id,
+    });
+    expect(importedArtifact?.minutes).toBe('Saved reviewer minutes for VM0007 before project creation.');
+    expect(importedArtifact?.outcomeNote).toBe('Verified with caveats before project creation.');
+  });
+});


### PR DESCRIPTION
## WHAT

- Fix project review handoff after methodology work already exists.
- When a user creates a project from an active methodology review, preserve and import:
  - methodology code/version
  - projectId/workspaceId
  - uploaded evidence
  - evidence pins
  - saved fragments
  - rule reviews
  - reviewer minutes
  - outcome notes
  - finalization draft state
- After project creation, route directly to:
  - `/m/VM0007/v/v1-8?projectId=<projectId>&tab=verify`
  - not generic `/m`
  - not default ACM0010
- Add a visible handoff action:
  - `Create project and carry over this review`
- Add regression coverage proving:
  - VM0007 review work exists before project creation
  - project creation imports that work
  - project dashboard does not show 0% if rules were already reviewed
  - Start review opens VM0007 v1-8, not ACM0010
  - existing reviewer artifacts remain visible after project creation

## WHY

- PR #630 improves AOI upload and review-run support, but it does not solve the critical project handoff bug.
- Users must not lose methodology review work after creating a project.
- A paying reviewer will not redo evidence links, fragments, and judgments just because the workflow upgrades into a project workspace.
- Project creation should preserve review continuity, not reset the review.

### Roadmap-Update
- slug: phase-assurance-surface-mvp
- ack: human
- PR12: in_progress

Allowed statuses: planned | next | in_progress | done | blocked

### Roadmap-Override
- slug: phase-assurance-surface-mvp
- pr: PR12
- from_status: done
- to_status: in_progress
- revert_of: PR326
- reason: Demo verification pack contract extends the PR12 lane with a truthful placeholder review scaffold after the earlier done state.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>