### PR TITLE
[codex] Add document metadata handoff into project creation

### DIFF
--- a/src/app/api/quick-check/pdf-extract/route.ts
+++ b/src/app/api/quick-check/pdf-extract/route.ts
@@ -2,7 +2,7 @@ export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 import { extractPdfText } from "@/lib/chat/quickCheckEvidence";
-import { extractPdfTextWithPdfParse, type PdfExtractionDiagnostics } from "@/lib/chat/quickCheckPdfExtractor";
+import { extractPdfPagesWithPdfParse, type PdfExtractionDiagnostics } from "@/lib/chat/quickCheckPdfExtractor";
 import { withMetrics } from "@/lib/metrics";
 
 async function handlePost(request: Request) {
@@ -15,13 +15,14 @@ async function handlePost(request: Request) {
   let diagnostics: PdfExtractionDiagnostics | undefined;
 
   try {
-    const extraction = await extractPdfTextWithPdfParse({ bytes });
+    const extraction = await extractPdfPagesWithPdfParse({ bytes });
     diagnostics = extraction.metadata.diagnostics;
     // pdf-parse can succeed but return empty text for ASCII85-encoded streams.
     // Fall through to heuristic extractor which has custom ASCII85 + FlateDecode.
     if (extraction.text.trim().length > 0) {
       return NextResponse.json({
         text: extraction.text,
+        pages: extraction.pages,
         engine: extraction.engine,
         metadata: extraction.metadata,
       });
@@ -37,6 +38,7 @@ async function handlePost(request: Request) {
   const fallbackText = extractPdfText(bytes);
   return NextResponse.json({
     text: fallbackText,
+    pages: fallbackText.trim().length > 0 ? [{ pageNumber: 1, text: fallbackText }] : [],
     engine: "heuristic",
     metadata: {
       parser: "heuristic",

--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -214,7 +214,7 @@ export default function MethodDetailPane({
       workspaceId: reviewWorkspace?.id ?? linkedWorkspaceId ?? null,
       projectId: linkedProjectId,
     });
-    router.push("/projects/new?handoff=active-review");
+    router.push("/start-review?handoff=active-review");
   }, [activeVersion, linkedProjectId, linkedWorkspaceId, method.code, reviewWorkspace?.id, router]);
   const { events: auditEvents, appendEvent, clearTrail, exportJson, exportSha256 } = useAuditTrail();
   const appendAuditEvent = useCallback(
@@ -1509,7 +1509,7 @@ export default function MethodDetailPane({
           </div>
           <div className="flex flex-wrap gap-2">
             <Link
-              href={linkedProject ? "/projects" : "/projects/new"}
+              href={linkedProject ? "/projects" : "/start-review?mode=manual"}
               className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
             >
               Change project

--- a/src/app/methods/page.tsx
+++ b/src/app/methods/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import MethodsFinder from "@/app/m/_components/MethodsFinder";
+
+export const metadata: Metadata = {
+  title: "Methods | app.article6",
+  description: "Methods-first inventory finder.",
+};
+
+export default function MethodsPage() {
+  return <MethodsFinder />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,63 @@
-import React from "react";
-import { Suspense } from "react";
-import ChatApp from "@/components/chat/ChatApp";
+import Link from "next/link";
 
 export default function Page() {
   return (
     <main className="min-h-screen bg-[#f9f9f9]">
-      <Suspense
-        fallback={
-          <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-12 md:px-8">
-            <div className="h-6 w-56 animate-pulse rounded-full bg-slate-200" />
-            <div className="h-4 w-full animate-pulse rounded-full bg-slate-200" />
-            <div className="h-4 w-3/4 animate-pulse rounded-full bg-slate-200" />
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-16 md:px-8 md:py-24">
+        <section className="grid gap-8 rounded-[2rem] border border-slate-200 bg-white px-6 py-8 shadow-sm md:grid-cols-[1.4fr_0.9fr] md:px-10 md:py-12">
+          <div className="max-w-2xl">
+            <div className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-600">
+              Review Intake
+            </div>
+            <h1 className="mt-4 text-4xl font-semibold tracking-tight text-slate-950 md:text-5xl">
+              Launch a review without turning Home into the workflow itself.
+            </h1>
+            <p className="mt-4 max-w-xl text-base leading-7 text-slate-600">
+              Start Review is now the dedicated intake surface for document upload,
+              quick evidence checks, metadata-driven project creation, and manual setup.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                href="/start-review"
+                className="inline-flex items-center rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white hover:bg-slate-800"
+              >
+                Start Review
+              </Link>
+              <Link
+                href="/projects"
+                className="inline-flex items-center rounded-full border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-800 hover:border-slate-400"
+              >
+                Open Projects
+              </Link>
+              <Link
+                href="/methods"
+                className="inline-flex items-center rounded-full border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-800 hover:border-slate-400"
+              >
+                Browse Methods
+              </Link>
+            </div>
           </div>
-        }
-      >
-        <ChatApp />
-      </Suspense>
+          <div className="grid gap-3">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                On Start Review
+              </div>
+              <p className="mt-2 text-sm leading-6 text-slate-700">
+                Upload a project document, run a quick evidence check, carry forward extracted metadata,
+                or attach the document to an existing project when a match is detected.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                In Projects
+              </div>
+              <p className="mt-2 text-sm leading-6 text-slate-700">
+                Return to durable review records, continue saved workspaces, and inspect existing project state.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
     </main>
   );
 }

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import type { Metadata } from "next";
 import NewProjectForm from "@/components/projects/NewProjectForm";
 
@@ -8,7 +9,9 @@ export const metadata: Metadata = {
 export default function NewProjectPage() {
   return (
     <main className="min-h-screen bg-slate-50">
-      <NewProjectForm />
+      <Suspense fallback={null}>
+        <NewProjectForm />
+      </Suspense>
     </main>
   );
 }

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,17 +1,22 @@
-import { Suspense } from "react";
-import type { Metadata } from "next";
-import NewProjectForm from "@/components/projects/NewProjectForm";
+import { redirect } from "next/navigation";
 
-export const metadata: Metadata = {
-  title: "Start Review | app.article6",
+type ProjectsNewPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
-export default function NewProjectPage() {
-  return (
-    <main className="min-h-screen bg-slate-50">
-      <Suspense fallback={null}>
-        <NewProjectForm />
-      </Suspense>
-    </main>
-  );
+function appendParams(pathname: string, params: Record<string, string | string[] | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      for (const entry of value) search.append(key, entry);
+      continue;
+    }
+    if (typeof value === "string") search.set(key, value);
+  }
+  const query = search.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}
+
+export default async function NewProjectPage({ searchParams }: ProjectsNewPageProps) {
+  redirect(appendParams("/start-review", await searchParams));
 }

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,17 +1,14 @@
-import { Suspense } from 'react';
-import type { Metadata } from 'next';
-import NewProjectForm from '@/components/projects/NewProjectForm';
+import type { Metadata } from "next";
+import NewProjectForm from "@/components/projects/NewProjectForm";
 
 export const metadata: Metadata = {
-  title: 'New Project Review | app.article6',
+  title: "Start Review | app.article6",
 };
 
 export default function NewProjectPage() {
   return (
     <main className="min-h-screen bg-slate-50">
-      <Suspense fallback={null}>
-        <NewProjectForm />
-      </Suspense>
+      <NewProjectForm />
     </main>
   );
 }

--- a/src/app/start-review/page.tsx
+++ b/src/app/start-review/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import ChatApp from "@/components/chat/ChatApp";
+import NewProjectForm from "@/components/projects/NewProjectForm";
+
+export const metadata: Metadata = {
+  title: "Start Review | app.article6",
+  description: "Upload project documents, run a quick evidence check, or set up a review workspace.",
+};
+
+type StartReviewPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function pickFirst(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+export default async function StartReviewPage({ searchParams }: StartReviewPageProps) {
+  const params = await searchParams;
+  const handoff = pickFirst(params.handoff);
+  const mode = pickFirst(params.mode);
+  const showProjectSetup =
+    handoff === "document-metadata" || handoff === "active-review" || mode === "manual";
+
+  return (
+    <main className="min-h-screen bg-slate-50">
+      {showProjectSetup ? (
+        <NewProjectForm />
+      ) : (
+        <div className="pb-12">
+          <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-3 px-4 pt-8 md:px-8">
+            <div>
+              <h1 className="text-2xl font-semibold text-slate-950">Start Review</h1>
+              <p className="mt-1 text-sm text-slate-600">
+                Upload a project document, run a quick evidence check, or switch to manual setup.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Link
+                href="/start-review?mode=manual"
+                className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:border-slate-400"
+              >
+                Set up manually
+              </Link>
+              <Link
+                href="/projects"
+                className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:border-slate-400"
+              >
+                Existing projects
+              </Link>
+            </div>
+          </div>
+          <ChatApp />
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/app/start-review/page.tsx
+++ b/src/app/start-review/page.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import ChatApp from "@/components/chat/ChatApp";
 import NewProjectForm from "@/components/projects/NewProjectForm";
 
 export const metadata: Metadata = {
   title: "Start Review | app.article6",
-  description: "Upload project documents, run a quick evidence check, or set up a review workspace.",
+  description: "Upload a PDD, monitoring report, or evidence file to start a review.",
 };
 
 type StartReviewPageProps = {
@@ -19,42 +18,11 @@ function pickFirst(value: string | string[] | undefined): string | null {
 
 export default async function StartReviewPage({ searchParams }: StartReviewPageProps) {
   const params = await searchParams;
-  const handoff = pickFirst(params.handoff);
   const mode = pickFirst(params.mode);
-  const showProjectSetup =
-    handoff === "document-metadata" || handoff === "active-review" || mode === "manual";
 
   return (
     <main className="min-h-screen bg-slate-50">
-      {showProjectSetup ? (
-        <NewProjectForm />
-      ) : (
-        <div className="pb-12">
-          <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-3 px-4 pt-8 md:px-8">
-            <div>
-              <h1 className="text-2xl font-semibold text-slate-950">Start Review</h1>
-              <p className="mt-1 text-sm text-slate-600">
-                Upload a project document, run a quick evidence check, or switch to manual setup.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Link
-                href="/start-review?mode=manual"
-                className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:border-slate-400"
-              >
-                Set up manually
-              </Link>
-              <Link
-                href="/projects"
-                className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:border-slate-400"
-              >
-                Existing projects
-              </Link>
-            </div>
-          </div>
-          <ChatApp />
-        </div>
-      )}
+      {mode === "quick-check" ? <ChatApp /> : <NewProjectForm />}
     </main>
   );
 }

--- a/src/components/DemoNav.tsx
+++ b/src/components/DemoNav.tsx
@@ -6,10 +6,18 @@ import { usePathname } from "next/navigation";
 type DemoRoute = {
   href: string;
   title: string;
+  matches?: (pathname: string) => boolean;
 };
 
 const demoRoutes: DemoRoute[] = [
-  { href: "/", title: "Quick Check" },
+  {
+    href: "/projects/new",
+    title: "Start Review",
+    matches: (pathname) =>
+      pathname === "/" ||
+      pathname === "/projects/new" ||
+      pathname.startsWith("/projects/new/"),
+  },
   { href: "/m", title: "Methods" },
   { href: "/projects", title: "Projects" },
 ];
@@ -20,9 +28,10 @@ export default function DemoNav() {
   return (
     <nav className="flex flex-wrap items-center gap-2 text-xs text-slate-600" aria-label="Primary">
       {demoRoutes.map(route => {
-        const isActive =
-          pathname === route.href ||
-          (route.href !== "/" && pathname.startsWith(`${route.href}/`));
+        const isActive = route.matches
+          ? route.matches(pathname)
+          : pathname === route.href ||
+            (route.href !== "/" && pathname.startsWith(`${route.href}/`));
         const base = "inline-flex items-center rounded-full border px-3 py-1.5 font-medium transition";
         const appearance = isActive
           ? "border-black bg-black text-white hover:bg-neutral-900"

--- a/src/components/DemoNav.tsx
+++ b/src/components/DemoNav.tsx
@@ -2,36 +2,28 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { getPrimaryNavKey } from "@/lib/nav/primaryNav";
 
 type DemoRoute = {
   href: string;
   title: string;
-  matches?: (pathname: string) => boolean;
+  key: Exclude<ReturnType<typeof getPrimaryNavKey>, null>;
 };
 
 const demoRoutes: DemoRoute[] = [
-  {
-    href: "/projects/new",
-    title: "Start Review",
-    matches: (pathname) =>
-      pathname === "/" ||
-      pathname === "/projects/new" ||
-      pathname.startsWith("/projects/new/"),
-  },
-  { href: "/m", title: "Methods" },
-  { href: "/projects", title: "Projects" },
+  { href: "/start-review", title: "Start Review", key: "start-review" },
+  { href: "/projects", title: "Projects", key: "projects" },
+  { href: "/methods", title: "Methods", key: "methods" },
 ];
 
 export default function DemoNav() {
   const pathname = usePathname() ?? "/";
+  const activeKey = getPrimaryNavKey(pathname);
 
   return (
     <nav className="flex flex-wrap items-center gap-2 text-xs text-slate-600" aria-label="Primary">
       {demoRoutes.map(route => {
-        const isActive = route.matches
-          ? route.matches(pathname)
-          : pathname === route.href ||
-            (route.href !== "/" && pathname.startsWith(`${route.href}/`));
+        const isActive = activeKey === route.key;
         const base = "inline-flex items-center rounded-full border px-3 py-1.5 font-medium transition";
         const appearance = isActive
           ? "border-black bg-black text-white hover:bg-neutral-900"

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -42,7 +42,11 @@ export default function ChatApp() {
           </div>
         ) : null}
 
-        <QuickCheckPanel initialMethod={selectedMethod} initialVersion={selectedVersion} />
+        <QuickCheckPanel
+          initialMethod={selectedMethod}
+          initialVersion={selectedVersion}
+          collapseQuickEvidenceByDefault
+        />
       </div>
     </div>
   );

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -38,6 +38,7 @@ import {
   type QuickCheckStagedUpload,
 } from "@/lib/chat/quickCheck";
 import { buildQuickCheckDemoCandidate, prepareQuickCheckDemo, QUICK_CHECK_DEMO } from "@/lib/chat/quickCheckDemo";
+import { stageProjectDocumentDraftFromAttachment } from "@/lib/projects/documentMetadata";
 import {
   resolveQuickCheckCandidate,
   resolveQuickCheckCandidates,
@@ -540,6 +541,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [showMethodology, setShowMethodology] = useState(false);
   const [showExtractionDetails, setShowExtractionDetails] = useState(false);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
+  const [creatingProjectDraft, setCreatingProjectDraft] = useState(false);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
     loading: false,
     analysis: null,
@@ -1636,6 +1638,36 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     if (typeof window !== "undefined") window.location.assign(handoff.url);
   }
 
+  async function handleCreateProjectFromDocument() {
+    const uploadAttachment = selectedUpload?.attachment ?? null;
+    const selectedPdfAttachment = uploadAttachment
+      ?? selectedPins.flatMap((pin) => pin.attachments ?? []).find((attachment) => attachment.mime === "application/pdf")
+      ?? null;
+    if (!selectedPdfAttachment || !draft.evidenceIds[0]) {
+      setFieldErrors({ general: "Select one uploaded PDF or saved PDD before creating a project draft." });
+      return;
+    }
+    setCreatingProjectDraft(true);
+    setFieldErrors({});
+    try {
+      await stageProjectDocumentDraftFromAttachment({
+        origin: "quick-check",
+        evidenceId: draft.evidenceIds[0],
+        attachmentId: selectedPdfAttachment.id,
+        fileName: selectedPdfAttachment.filename,
+        mimeType: selectedPdfAttachment.mime,
+        contentSha256: selectedPdfAttachment.sha256,
+      });
+      if (typeof window !== "undefined") {
+        window.location.assign("/projects/new?handoff=document-metadata");
+      }
+    } catch (error) {
+      setFieldErrors({ general: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setCreatingProjectDraft(false);
+    }
+  }
+
   function handleTryAnotherMethodology() {
     setShowMethodology(true);
     setRecoveryState(null);
@@ -2144,15 +2176,46 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 </span>
               </div>
               <div className="mt-4">
-                <button
-                  type="button"
-                  onClick={handleContinueToWorkspace}
-                  className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
-                >
-                  <FolderOpen className="h-4 w-4" />
-                  Open full review
-                </button>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={handleContinueToWorkspace}
+                    className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
+                  >
+                    <FolderOpen className="h-4 w-4" />
+                    Open full review
+                  </button>
+                  {selectedEvidenceCount === 1 ? (
+                    <button
+                      type="button"
+                      onClick={() => void handleCreateProjectFromDocument()}
+                      disabled={creatingProjectDraft}
+                      className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 disabled:opacity-50"
+                    >
+                      {creatingProjectDraft ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUpRight className="h-4 w-4" />}
+                      Create project from document
+                    </button>
+                  ) : null}
+                </div>
               </div>
+            </div>
+          ) : null}
+
+          {!renderedResult && selectedEvidenceCount === 1 && activeSourceMode === "uploaded_file" ? (
+            <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
+              <div className="text-sm font-semibold text-slate-900">Project setup</div>
+              <div className="mt-1 text-sm text-slate-600">
+                Use the uploaded document to prefill a project draft before or after running the evidence check.
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleCreateProjectFromDocument()}
+                disabled={creatingProjectDraft}
+                className="mt-3 inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 disabled:opacity-50"
+              >
+                {creatingProjectDraft ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUpRight className="h-4 w-4" />}
+                Create project from document
+              </button>
             </div>
           ) : null}
 

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -734,6 +734,7 @@ export default function QuickCheckPanel({
   onContinueToWorkspace,
 }: QuickCheckPanelProps) {
   const fileRef = useRef<HTMLInputElement | null>(null);
+  const projectDocumentRef = useRef<HTMLInputElement | null>(null);
   const claimRef = useRef<HTMLTextAreaElement | null>(null);
   const resultRef = useRef<HTMLDivElement | null>(null);
   const rulesCache = useRef(new Map<string, RuleSummary[]>());
@@ -1705,6 +1706,46 @@ export default function QuickCheckPanel({
     }
   }
 
+  async function handleProjectDocumentUpload(file: File | null) {
+    if (!file) return;
+
+    setCreatingProjectDraft(true);
+    setFieldErrors((current) => ({
+      ...current,
+      general: undefined,
+    }));
+    try {
+      const evidenceId = newPinId();
+      const attachmentResult = await createAndStoreEvidenceAttachment({
+        pin_id: evidenceId,
+        file,
+      });
+      if (!attachmentResult.ok) {
+        setFieldErrors({ general: attachmentResult.message });
+        return;
+      }
+
+      await stageProjectDocumentDraftFromAttachment({
+        origin: "quick-check",
+        evidenceId,
+        attachmentId: attachmentResult.attachment.id,
+        fileName: attachmentResult.attachment.filename,
+        mimeType: attachmentResult.attachment.mime,
+        contentSha256: attachmentResult.attachment.sha256,
+      });
+      if (typeof window !== "undefined") {
+        window.location.assign("/projects/new?handoff=document-metadata");
+      }
+    } catch (error) {
+      setFieldErrors({
+        general: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setCreatingProjectDraft(false);
+      if (projectDocumentRef.current) projectDocumentRef.current.value = "";
+    }
+  }
+
   function selectExistingEvidence(evidenceId: string) {
     if (!evidenceId) return;
     const selectedItem =
@@ -2228,23 +2269,73 @@ export default function QuickCheckPanel({
   return (
     <div className="w-full">
       <div className="mx-auto w-full max-w-2xl px-4 md:px-0">
-        <div className="flex flex-col items-center text-center">
-          <div className="flex w-full items-start justify-center">
-            <div className="w-full">
+        <div className="rounded-[1.8rem] border border-slate-200 bg-white px-5 py-6 text-left shadow-sm">
+          <div className="flex items-start justify-between gap-4">
+            <div>
               <h1 className="text-4xl font-bold tracking-tight text-slate-950">
-                Quick Check
+                Start Review
               </h1>
-              <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
-                Upload evidence. Get a preliminary match in seconds.
+              <p className="mt-3 max-w-xl text-sm leading-6 text-slate-600 md:text-[15px]">
+                Upload a PDD, monitoring report, or evidence file. Article6 will
+                detect the project, method, and next review step.
               </p>
             </div>
-            {loadingMethods || submitting ? (
+            {loadingMethods || creatingProjectDraft ? (
               <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" />
             ) : null}
+          </div>
+          <input
+            ref={projectDocumentRef}
+            type="file"
+            data-testid="project-document-input"
+            className="hidden"
+            accept=".pdf"
+            onChange={(event) =>
+              void handleProjectDocumentUpload(event.target.files?.[0] ?? null)
+            }
+          />
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => projectDocumentRef.current?.click()}
+              disabled={creatingProjectDraft}
+              className="inline-flex items-center gap-2 rounded-full bg-black px-5 py-3 text-sm font-semibold text-white transition hover:bg-neutral-900 disabled:opacity-50"
+            >
+              {creatingProjectDraft ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Upload className="h-4 w-4" />
+              )}
+              Upload project document
+            </button>
+            <button
+              type="button"
+              onClick={() => claimRef.current?.focus()}
+              className="text-sm font-semibold text-slate-600 underline underline-offset-4 transition hover:text-slate-900"
+            >
+              Run a quick evidence check instead
+            </button>
           </div>
         </div>
 
         <div className="mt-8 grid gap-8">
+          <div className="flex w-full items-start justify-between gap-4">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Quick evidence check
+              </div>
+              <h2 className="mt-2 text-2xl font-bold tracking-tight text-slate-950">
+                Quick Check
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-600 md:text-[15px]">
+                Upload evidence. Get a preliminary match in seconds.
+              </p>
+            </div>
+            {submitting ? (
+              <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" />
+            ) : null}
+          </div>
+
           <div>
             <label className="grid gap-2 text-sm text-slate-700">
               <span className="font-medium text-slate-900">Claim</span>
@@ -2323,6 +2414,7 @@ export default function QuickCheckPanel({
               <input
                 ref={fileRef}
                 type="file"
+                data-testid="quick-check-evidence-input"
                 className="hidden"
                 accept=".pdf,.png,.jpg,.jpeg,.csv,.xlsx"
                 onChange={(event) =>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2256,7 +2256,7 @@ export default function QuickCheckPanel({
         contentSha256: selectedPdfAttachment.sha256,
       });
       if (typeof window !== "undefined") {
-        window.location.assign("/projects/new?handoff=document-metadata");
+        window.location.assign("/start-review?handoff=document-metadata");
       }
     } catch (error) {
       setFieldErrors({

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -23,7 +23,10 @@ import {
   type QuickCheckClaimIntent,
   type QuickCheckEvidenceAnalysis,
 } from "@/lib/chat/quickCheckEvidence";
-import { resolveQuickCheckMethodology, type QuickCheckMethodologyResolution } from "@/lib/chat/quickCheckMethodology";
+import {
+  resolveQuickCheckMethodology,
+  type QuickCheckMethodologyResolution,
+} from "@/lib/chat/quickCheckMethodology";
 import {
   buildQuickCheckResult,
   ensureQuickCheckWorkspaceHandoff,
@@ -37,16 +40,27 @@ import {
   type QuickCheckSourceMode,
   type QuickCheckStagedUpload,
 } from "@/lib/chat/quickCheck";
-import { buildQuickCheckDemoCandidate, prepareQuickCheckDemo, QUICK_CHECK_DEMO } from "@/lib/chat/quickCheckDemo";
+import {
+  buildQuickCheckDemoCandidate,
+  prepareQuickCheckDemo,
+  QUICK_CHECK_DEMO,
+} from "@/lib/chat/quickCheckDemo";
 import { stageProjectDocumentDraftFromAttachment } from "@/lib/projects/documentMetadata";
 import {
   resolveQuickCheckCandidate,
   resolveQuickCheckCandidates,
   type QuickCheckResolvedCandidate,
 } from "@/lib/chat/quickCheckResolver";
-import { buildQuickCheckExtractionSnapshot, deriveQuickCheckExtractionState, normalizeQuickCheckUiResult } from "@/lib/chat/quickCheckUi";
+import {
+  buildQuickCheckExtractionSnapshot,
+  deriveQuickCheckExtractionState,
+  normalizeQuickCheckUiResult,
+} from "@/lib/chat/quickCheckUi";
 import { resolveQuickCheckPdfText } from "@/lib/chat/quickCheckPdfClient";
-import { coalesceEvidencePins, type EvidenceInventoryItem } from "@/lib/evidence/inventory";
+import {
+  coalesceEvidencePins,
+  type EvidenceInventoryItem,
+} from "@/lib/evidence/inventory";
 import { createAndStoreEvidenceAttachment } from "@/lib/proofMap/attachments";
 import { isRuleLikeId } from "@/lib/proofMap/pins";
 import { loadPins, savePins } from "@/lib/proofMap/storage";
@@ -108,19 +122,17 @@ type RecoveryState =
     }
   | null;
 
-type ExtractionDiagnostic =
-  | {
-      code:
-        | "parser-failed"
-        | "no-selectable-text"
-        | "selected-methodology-mismatch"
-        | "methodology-not-detected"
-        | "methodology-needs-confirmation"
-        | "methodology-pack-unavailable";
-      label: string;
-      message: string;
-    }
-  | null;
+type ExtractionDiagnostic = {
+  code:
+    | "parser-failed"
+    | "no-selectable-text"
+    | "selected-methodology-mismatch"
+    | "methodology-not-detected"
+    | "methodology-needs-confirmation"
+    | "methodology-pack-unavailable";
+  label: string;
+  message: string;
+} | null;
 
 type QueryResultWithSignals = QueryResponse["results"][number] & {
   _signalBoost: number;
@@ -144,17 +156,24 @@ function nowIso(): string {
 }
 
 function newPinId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function")
+    return crypto.randomUUID();
   return `pin-${nowIso()}-${Math.random().toString(16).slice(2)}`;
 }
 
-function pickVersion(method: MethodInventoryRecord | undefined, preferred?: string | null): string {
+function pickVersion(
+  method: MethodInventoryRecord | undefined,
+  preferred?: string | null,
+): string {
   if (!method) return preferred?.trim() ?? "";
-  if (preferred?.trim() && method.versions.includes(preferred.trim())) return preferred.trim();
+  if (preferred?.trim() && method.versions.includes(preferred.trim()))
+    return preferred.trim();
   return method.latestVersion ?? method.versions[0] ?? "";
 }
 
-function pickRequirementLabel(result: QueryResponse["results"][number]): string {
+function pickRequirementLabel(
+  result: QueryResponse["results"][number],
+): string {
   const explicit =
     (typeof result.section_title === "string" && result.section_title.trim()) ||
     (typeof result.sectionTitle === "string" && result.sectionTitle.trim()) ||
@@ -168,56 +187,160 @@ function boostForEvidenceFacts(
   analysis: QuickCheckEvidenceAnalysis,
   claimIntents: QuickCheckClaimIntent[],
 ): number {
-  const haystack = `${pickRequirementLabel(result)} ${result.text ?? ""} ${(result.tags ?? []).join(" ")} ${(result.refs ?? []).join(" ")}`.toLowerCase();
+  const haystack =
+    `${pickRequirementLabel(result)} ${result.text ?? ""} ${(result.tags ?? []).join(" ")} ${(result.refs ?? []).join(" ")}`.toLowerCase();
   let boost = 0;
-  const prefersBoundaryLocation = claimIntents.some((intent) =>
-    intent === "boundary" ||
-    intent === "project-area" ||
-    intent === "mapped-area" ||
-    intent === "aoi" ||
-    intent === "coordinates" ||
-    intent === "location",
+  const prefersBoundaryLocation = claimIntents.some(
+    (intent) =>
+      intent === "boundary" ||
+      intent === "project-area" ||
+      intent === "mapped-area" ||
+      intent === "aoi" ||
+      intent === "coordinates" ||
+      intent === "location",
   );
   const prefersMonitoring = claimIntents.includes("monitoring-plan");
   for (const fact of analysis.facts) {
-    if (fact.category === "boundary" && haystack.includes("boundary")) boost += prefersMonitoring ? 0.04 : 0.16;
-    if (fact.category === "coordinates" && (haystack.includes("coordinate") || haystack.includes("location") || haystack.includes("boundary"))) boost += prefersMonitoring ? 0.04 : 0.16;
-    if (fact.category === "mapped-area" && (haystack.includes("mapped area") || haystack.includes("project area") || haystack.includes("aoi") || haystack.includes("polygon") || haystack.includes("map") || haystack.includes("boundary"))) boost += prefersMonitoring ? 0.05 : 0.18;
-    if (fact.category === "project-location" && (haystack.includes("location") || haystack.includes("boundary") || haystack.includes("area") || haystack.includes("map"))) boost += prefersMonitoring ? 0.04 : 0.14;
-    if (fact.category === "monitoring-plan" && haystack.includes("monitoring")) boost += prefersBoundaryLocation ? 0.1 : 0.16;
-    if (fact.category === "workbook-reference" && (haystack.includes("workbook") || haystack.includes("spreadsheet"))) boost += prefersBoundaryLocation ? 0.08 : 0.12;
-    if (fact.category === "monitoring-evidence" && haystack.includes("monitoring")) boost += prefersBoundaryLocation ? 0.06 : 0.1;
-    if (fact.category === "plot-count" && (haystack.includes("plot") || haystack.includes("sampling") || haystack.includes("monitoring"))) boost += 0.12;
-    if (fact.category === "reporting-period" && (haystack.includes("period") || haystack.includes("monitoring"))) boost += 0.12;
-    if (fact.category === "monitoring-records" && (haystack.includes("monitoring") || haystack.includes("workbook"))) boost += prefersBoundaryLocation ? 0.06 : 0.1;
-    if (fact.category === "qa-summary" && (haystack.includes("quality") || haystack.includes("review") || haystack.includes("qa"))) boost += 0.08;
+    if (fact.category === "boundary" && haystack.includes("boundary"))
+      boost += prefersMonitoring ? 0.04 : 0.16;
+    if (
+      fact.category === "coordinates" &&
+      (haystack.includes("coordinate") ||
+        haystack.includes("location") ||
+        haystack.includes("boundary"))
+    )
+      boost += prefersMonitoring ? 0.04 : 0.16;
+    if (
+      fact.category === "mapped-area" &&
+      (haystack.includes("mapped area") ||
+        haystack.includes("project area") ||
+        haystack.includes("aoi") ||
+        haystack.includes("polygon") ||
+        haystack.includes("map") ||
+        haystack.includes("boundary"))
+    )
+      boost += prefersMonitoring ? 0.05 : 0.18;
+    if (
+      fact.category === "project-location" &&
+      (haystack.includes("location") ||
+        haystack.includes("boundary") ||
+        haystack.includes("area") ||
+        haystack.includes("map"))
+    )
+      boost += prefersMonitoring ? 0.04 : 0.14;
+    if (fact.category === "monitoring-plan" && haystack.includes("monitoring"))
+      boost += prefersBoundaryLocation ? 0.1 : 0.16;
+    if (
+      fact.category === "workbook-reference" &&
+      (haystack.includes("workbook") || haystack.includes("spreadsheet"))
+    )
+      boost += prefersBoundaryLocation ? 0.08 : 0.12;
+    if (
+      fact.category === "monitoring-evidence" &&
+      haystack.includes("monitoring")
+    )
+      boost += prefersBoundaryLocation ? 0.06 : 0.1;
+    if (
+      fact.category === "plot-count" &&
+      (haystack.includes("plot") ||
+        haystack.includes("sampling") ||
+        haystack.includes("monitoring"))
+    )
+      boost += 0.12;
+    if (
+      fact.category === "reporting-period" &&
+      (haystack.includes("period") || haystack.includes("monitoring"))
+    )
+      boost += 0.12;
+    if (
+      fact.category === "monitoring-records" &&
+      (haystack.includes("monitoring") || haystack.includes("workbook"))
+    )
+      boost += prefersBoundaryLocation ? 0.06 : 0.1;
+    if (
+      fact.category === "qa-summary" &&
+      (haystack.includes("quality") ||
+        haystack.includes("review") ||
+        haystack.includes("qa"))
+    )
+      boost += 0.08;
   }
   return Math.min(boost, 0.4);
 }
 
-function boostForClaimIntents(result: QueryResultWithSignals, claimIntents: QuickCheckClaimIntent[]): number {
-  const haystack = `${pickRequirementLabel(result)} ${result.text ?? ""} ${(result.tags ?? []).join(" ")} ${(result.refs ?? []).join(" ")}`.toLowerCase();
+function boostForClaimIntents(
+  result: QueryResultWithSignals,
+  claimIntents: QuickCheckClaimIntent[],
+): number {
+  const haystack =
+    `${pickRequirementLabel(result)} ${result.text ?? ""} ${(result.tags ?? []).join(" ")} ${(result.refs ?? []).join(" ")}`.toLowerCase();
   let boost = 0;
   for (const intent of claimIntents) {
     if (intent === "boundary" && haystack.includes("boundary")) boost += 0.16;
-    if (intent === "project-area" && (haystack.includes("project area") || haystack.includes("boundary") || haystack.includes("area"))) boost += 0.12;
-    if (intent === "mapped-area" && (haystack.includes("mapped area") || haystack.includes("map") || haystack.includes("boundary") || haystack.includes("aoi"))) boost += 0.15;
-    if (intent === "aoi" && (haystack.includes("aoi") || haystack.includes("area of interest") || haystack.includes("polygon") || haystack.includes("boundary"))) boost += 0.14;
-    if (intent === "coordinates" && (haystack.includes("coordinate") || haystack.includes("location") || haystack.includes("boundary"))) boost += 0.14;
-    if (intent === "location" && (haystack.includes("location") || haystack.includes("site") || haystack.includes("boundary"))) boost += 0.12;
-    if (intent === "monitoring-plan" && haystack.includes("monitoring")) boost += 0.12;
+    if (
+      intent === "project-area" &&
+      (haystack.includes("project area") ||
+        haystack.includes("boundary") ||
+        haystack.includes("area"))
+    )
+      boost += 0.12;
+    if (
+      intent === "mapped-area" &&
+      (haystack.includes("mapped area") ||
+        haystack.includes("map") ||
+        haystack.includes("boundary") ||
+        haystack.includes("aoi"))
+    )
+      boost += 0.15;
+    if (
+      intent === "aoi" &&
+      (haystack.includes("aoi") ||
+        haystack.includes("area of interest") ||
+        haystack.includes("polygon") ||
+        haystack.includes("boundary"))
+    )
+      boost += 0.14;
+    if (
+      intent === "coordinates" &&
+      (haystack.includes("coordinate") ||
+        haystack.includes("location") ||
+        haystack.includes("boundary"))
+    )
+      boost += 0.14;
+    if (
+      intent === "location" &&
+      (haystack.includes("location") ||
+        haystack.includes("site") ||
+        haystack.includes("boundary"))
+    )
+      boost += 0.12;
+    if (intent === "monitoring-plan" && haystack.includes("monitoring"))
+      boost += 0.12;
   }
   return Math.min(boost, 0.36);
 }
 
-function boostForClaimPhrases(result: QueryResultWithSignals, claimText: string): number {
-  const haystack = `${pickRequirementLabel(result)} ${result.text ?? ""} ${(result.tags ?? []).join(" ")} ${(result.refs ?? []).join(" ")}`.toLowerCase();
+function boostForClaimPhrases(
+  result: QueryResultWithSignals,
+  claimText: string,
+): number {
+  const haystack =
+    `${pickRequirementLabel(result)} ${result.text ?? ""} ${(result.tags ?? []).join(" ")} ${(result.refs ?? []).join(" ")}`.toLowerCase();
   const claim = claimText.trim().toLowerCase();
   let boost = 0;
 
-  if (claim.includes("monitoring report") && haystack.includes("report")) boost += 0.12;
-  if (claim.includes("reporting period") && (haystack.includes("period") || haystack.includes("frequency"))) boost += 0.09;
-  if (claim.includes("mapped project area") && (haystack.includes("mapped area") || haystack.includes("boundary"))) boost += 0.06;
+  if (claim.includes("monitoring report") && haystack.includes("report"))
+    boost += 0.12;
+  if (
+    claim.includes("reporting period") &&
+    (haystack.includes("period") || haystack.includes("frequency"))
+  )
+    boost += 0.09;
+  if (
+    claim.includes("mapped project area") &&
+    (haystack.includes("mapped area") || haystack.includes("boundary"))
+  )
+    boost += 0.06;
 
   return Math.min(boost, 0.24);
 }
@@ -241,20 +364,33 @@ function buildMatchCandidates(
 
   for (const result of results) {
     const methodologyId =
-      (typeof result.methodology_id === "string" && result.methodology_id.trim()) ||
-      (typeof result.methodologyId === "string" && result.methodologyId.trim()) ||
+      (typeof result.methodology_id === "string" &&
+        result.methodology_id.trim()) ||
+      (typeof result.methodologyId === "string" &&
+        result.methodologyId.trim()) ||
       "";
     if (!methodologyId) continue;
-    if (allowedMethodologyIds?.size && !allowedMethodologyIds.has(methodologyId)) continue;
+    if (
+      allowedMethodologyIds?.size &&
+      !allowedMethodologyIds.has(methodologyId)
+    )
+      continue;
     if (selectedMethod && methodologyId !== selectedMethod) continue;
 
     const methodRecord = methods.find((item) => item.code === methodologyId);
     const methodologyVersion =
-      (typeof result.methodology_version === "string" && result.methodology_version.trim()) ||
-      (typeof result.methodologyVersion === "string" && result.methodologyVersion.trim()) ||
+      (typeof result.methodology_version === "string" &&
+        result.methodology_version.trim()) ||
+      (typeof result.methodologyVersion === "string" &&
+        result.methodologyVersion.trim()) ||
       pickVersion(methodRecord);
     if (!methodologyVersion) continue;
-    if (selectedMethod && selectedVersion && methodologyVersion !== selectedVersion) continue;
+    if (
+      selectedMethod &&
+      selectedVersion &&
+      methodologyVersion !== selectedVersion
+    )
+      continue;
 
     const requirementId = result.id?.trim();
     if (!requirementId) continue;
@@ -283,17 +419,31 @@ function buildMatchCandidates(
   }
 
   return Array.from(unique.values())
-    .sort((a, b) => (b.score ?? -1) - (a.score ?? -1) || a.requirementLabel.localeCompare(b.requirementLabel))
+    .sort(
+      (a, b) =>
+        (b.score ?? -1) - (a.score ?? -1) ||
+        a.requirementLabel.localeCompare(b.requirementLabel),
+    )
     .slice(0, 4);
 }
 
-function claimPrefersMonitoringRequirement(claimText: string, claimIntents: QuickCheckClaimIntent[]): boolean {
+function claimPrefersMonitoringRequirement(
+  claimText: string,
+  claimIntents: QuickCheckClaimIntent[],
+): boolean {
   const normalized = claimText.toLowerCase();
-  return claimIntents.includes("monitoring-plan") || /monitoring\s+(report|plan|approach|procedure|evidence)|reporting period/.test(normalized);
+  return (
+    claimIntents.includes("monitoring-plan") ||
+    /monitoring\s+(report|plan|approach|procedure|evidence)|reporting period/.test(
+      normalized,
+    )
+  );
 }
 
 function candidateLooksMonitoringAligned(candidate: MatchCandidate): boolean {
-  return /monitoring|reporting period|report\b|workbook|sampling|plot/.test(candidate.requirementLabel.toLowerCase());
+  return /monitoring|reporting period|report\b|workbook|sampling|plot/.test(
+    candidate.requirementLabel.toLowerCase(),
+  );
 }
 
 function isAmbiguousMatch(candidates: MatchCandidate[]): boolean {
@@ -304,11 +454,16 @@ function isAmbiguousMatch(candidates: MatchCandidate[]): boolean {
   return Math.abs(first.score - second.score) < 0.035;
 }
 
-function requiresMethodologyConfirmation(candidates: MatchCandidate[]): boolean {
+function requiresMethodologyConfirmation(
+  candidates: MatchCandidate[],
+): boolean {
   if (candidates.length <= 1) return false;
   const [first] = candidates;
   if (!first) return false;
-  const closestOtherMethod = candidates.find((candidate) => candidate.methodologyId !== first.methodologyId) ?? null;
+  const closestOtherMethod =
+    candidates.find(
+      (candidate) => candidate.methodologyId !== first.methodologyId,
+    ) ?? null;
   if (!closestOtherMethod) return false;
   if (first.score == null || closestOtherMethod.score == null) return true;
   return Math.abs(first.score - closestOtherMethod.score) < 0.12;
@@ -318,10 +473,16 @@ function methodOptionLabel(method: MethodInventoryRecord): string {
   return `${method.code} · ${pickVersion(method, null)}`;
 }
 
-function splitRequirementLabel(label: string): { title: string; id: string | null } {
+function splitRequirementLabel(label: string): {
+  title: string;
+  id: string | null;
+} {
   const trimmed = label.trim();
   if (!trimmed) return { title: "", id: null };
-  const parts = trimmed.split("·").map((part) => part.trim()).filter(Boolean);
+  const parts = trimmed
+    .split("·")
+    .map((part) => part.trim())
+    .filter(Boolean);
   if (parts.length >= 2) {
     const [first, ...rest] = parts;
     if (/^R-\d/i.test(first)) {
@@ -331,27 +492,41 @@ function splitRequirementLabel(label: string): { title: string; id: string | nul
   return { title: trimmed, id: null };
 }
 
-function mergeQueryResults(responses: Array<{ query: string; results: QueryResponse["results"] }>): QueryResultWithSignals[] {
+function mergeQueryResults(
+  responses: Array<{ query: string; results: QueryResponse["results"] }>,
+): QueryResultWithSignals[] {
   const merged = new Map<string, QueryResultWithSignals>();
   for (const [index, response] of responses.entries()) {
-    const queryBoost = index === 0 ? 0 : Math.max(0.08 - (index - 1) * 0.01, 0.05);
+    const queryBoost =
+      index === 0 ? 0 : Math.max(0.08 - (index - 1) * 0.01, 0.05);
     for (const result of response.results) {
       const methodologyId =
-        (typeof result.methodology_id === "string" && result.methodology_id.trim()) ||
-        (typeof result.methodologyId === "string" && result.methodologyId.trim()) ||
+        (typeof result.methodology_id === "string" &&
+          result.methodology_id.trim()) ||
+        (typeof result.methodologyId === "string" &&
+          result.methodologyId.trim()) ||
         "";
       const methodologyVersion =
-        (typeof result.methodology_version === "string" && result.methodology_version.trim()) ||
-        (typeof result.methodologyVersion === "string" && result.methodologyVersion.trim()) ||
+        (typeof result.methodology_version === "string" &&
+          result.methodology_version.trim()) ||
+        (typeof result.methodologyVersion === "string" &&
+          result.methodologyVersion.trim()) ||
         "";
       const key = `${methodologyId}@@${methodologyVersion}@@${result.id}`;
       const existing = merged.get(key);
       if (existing) {
-        existing._signalBoost = Number((existing._signalBoost + queryBoost).toFixed(4));
-        if (!existing._matchedQueries.includes(response.query)) existing._matchedQueries.push(response.query);
-        if ((typeof result.score === "number" ? result.score : -1) > (typeof existing.score === "number" ? existing.score : -1)) {
+        existing._signalBoost = Number(
+          (existing._signalBoost + queryBoost).toFixed(4),
+        );
+        if (!existing._matchedQueries.includes(response.query))
+          existing._matchedQueries.push(response.query);
+        if (
+          (typeof result.score === "number" ? result.score : -1) >
+          (typeof existing.score === "number" ? existing.score : -1)
+        ) {
           existing.score = result.score;
-          existing.section_title = result.section_title ?? existing.section_title;
+          existing.section_title =
+            result.section_title ?? existing.section_title;
           existing.sectionTitle = result.sectionTitle ?? existing.sectionTitle;
           existing.text = result.text ?? existing.text;
           existing.tags = result.tags ?? existing.tags;
@@ -377,19 +552,21 @@ function buildRecoveryState(input: {
   const evidenceFacts = input.evidenceAnalysis?.facts ?? [];
   const claimIntents = input.claimIntents ?? [];
   const hasBoundaryLocationSignals =
-    evidenceFacts.some((fact) =>
-      fact.category === "boundary" ||
-      fact.category === "coordinates" ||
-      fact.category === "mapped-area" ||
-      fact.category === "project-location",
+    evidenceFacts.some(
+      (fact) =>
+        fact.category === "boundary" ||
+        fact.category === "coordinates" ||
+        fact.category === "mapped-area" ||
+        fact.category === "project-location",
     ) ||
-    claimIntents.some((intent) =>
-      intent === "boundary" ||
-      intent === "project-area" ||
-      intent === "mapped-area" ||
-      intent === "aoi" ||
-      intent === "coordinates" ||
-      intent === "location",
+    claimIntents.some(
+      (intent) =>
+        intent === "boundary" ||
+        intent === "project-area" ||
+        intent === "mapped-area" ||
+        intent === "aoi" ||
+        intent === "coordinates" ||
+        intent === "location",
     );
 
   if (input.selectedMethodologyId.trim()) {
@@ -404,7 +581,8 @@ function buildRecoveryState(input: {
     return {
       kind: "no-match",
       title: `No clear match in ${input.selectedMethodologyId} yet`,
-      description: "The current methodology narrowing is stricter than the evidence signals we found.",
+      description:
+        "The current methodology narrowing is stricter than the evidence signals we found.",
       note: "Try another methodology or keep the claim and broaden the check.",
     };
   }
@@ -412,19 +590,23 @@ function buildRecoveryState(input: {
     return {
       kind: "no-match",
       title: "No clear match yet",
-      description: "We found project boundary/location evidence in your uploaded PDD, but no confident requirement match yet.",
+      description:
+        "We found project boundary/location evidence in your uploaded PDD, but no confident requirement match yet.",
       note: "Edit the claim or try another methodology to guide the check.",
     };
   }
   return {
     kind: "no-match",
     title: "No clear match yet",
-    description: "We couldn't find a requirement to check from this claim and evidence yet.",
+    description:
+      "We couldn't find a requirement to check from this claim and evidence yet.",
     note: "Edit the claim or try another methodology to guide the check.",
   };
 }
 
-function buildUnsupportedMethodRecoveryState(methodologyId: string): RecoveryState {
+function buildUnsupportedMethodRecoveryState(
+  methodologyId: string,
+): RecoveryState {
   return {
     kind: "no-match",
     title: "Method pack unavailable",
@@ -433,19 +615,27 @@ function buildUnsupportedMethodRecoveryState(methodologyId: string): RecoverySta
   };
 }
 
-function buildMismatchedMethodRecoveryState(methodologyId: string): RecoveryState {
+function buildMismatchedMethodRecoveryState(
+  methodologyId: string,
+): RecoveryState {
   return {
     kind: "no-match",
     title: `No valid match in ${methodologyId}`,
-    description: "We extracted usable evidence, but the selected methodology did not produce a valid requirement match.",
+    description:
+      "We extracted usable evidence, but the selected methodology did not produce a valid requirement match.",
     note: "The likely matches shown below are from other supported methodologies. Pick one only if it is the intended methodology, or change the methodology filter.",
   };
 }
 
-function evidenceMentionsMethodologyCode(evidenceSignals: MethodologyEvidenceSignals, methodologyId: string): boolean {
+function evidenceMentionsMethodologyCode(
+  evidenceSignals: MethodologyEvidenceSignals,
+  methodologyId: string,
+): boolean {
   const normalizedMethodologyId = methodologyId.trim().toUpperCase();
   if (!normalizedMethodologyId) return false;
-  return (evidenceSignals?.methodologyMentions ?? []).some((mention) => mention.trim().toUpperCase() === normalizedMethodologyId);
+  return (evidenceSignals?.methodologyMentions ?? []).some(
+    (mention) => mention.trim().toUpperCase() === normalizedMethodologyId,
+  );
 }
 
 function buildNoValidAnalysisPathRecoveryState(input: {
@@ -453,7 +643,10 @@ function buildNoValidAnalysisPathRecoveryState(input: {
   evidenceSignals?: MethodologyEvidenceSignals;
 }): RecoveryState {
   const methodologyId = input.methodologyId.trim();
-  const methodConfirmedByEvidence = evidenceMentionsMethodologyCode(input.evidenceSignals, methodologyId);
+  const methodConfirmedByEvidence = evidenceMentionsMethodologyCode(
+    input.evidenceSignals,
+    methodologyId,
+  );
 
   return {
     kind: "no-match",
@@ -469,7 +662,8 @@ function buildMethodologyConfirmationRecoveryState(): RecoveryState {
   return {
     kind: "no-match",
     title: "Methodology needs confirmation",
-    description: "We extracted usable evidence, but the closest supported matches still span multiple methodologies.",
+    description:
+      "We extracted usable evidence, but the closest supported matches still span multiple methodologies.",
     note: "Quick Check will not auto-narrow to one methodology without clearer evidence. Pick the intended match below or narrow by methodology first.",
   };
 }
@@ -489,13 +683,18 @@ function asPinForUpload(upload: QuickCheckStagedUpload): EvidencePin {
   };
 }
 
-function extractionStateBadgeClass(value: "grounded" | "partial" | "weak"): string {
-  if (value === "grounded") return "border-emerald-200 bg-emerald-50 text-emerald-800";
+function extractionStateBadgeClass(
+  value: "grounded" | "partial" | "weak",
+): string {
+  if (value === "grounded")
+    return "border-emerald-200 bg-emerald-50 text-emerald-800";
   if (value === "partial") return "border-amber-200 bg-amber-50 text-amber-800";
   return "border-rose-200 bg-rose-50 text-rose-800";
 }
 
-function sourceModeLabel(sourceMode: QuickCheckSourceMode | null | undefined): string {
+function sourceModeLabel(
+  sourceMode: QuickCheckSourceMode | null | undefined,
+): string {
   if (sourceMode === "uploaded_file") return "Uploaded file";
   if (sourceMode === "saved_evidence") return "Saved evidence";
   if (sourceMode === "demo_evidence") return "Demo evidence";
@@ -506,7 +705,8 @@ function buildWeakExtractionRecoveryState(): RecoveryState {
   return {
     kind: "weak-extraction",
     title: "Weak extraction",
-    description: "Quick Check couldn't extract enough claim-relevant facts from this file yet.",
+    description:
+      "Quick Check couldn't extract enough claim-relevant facts from this file yet.",
     note: "Open full review to inspect the evidence manually or continue with a broader workflow.",
   };
 }
@@ -515,15 +715,24 @@ function methodologyMentionsForDetection(input: {
   analysis: QuickCheckEvidenceAnalysis | null;
   extraction: QuickCheckExtractionSnapshot | null;
 }): string[] {
-  const mentions = input.analysis?.methodologyMentions ?? input.extraction?.methodologyMentions ?? [];
-  return Array.from(new Set(mentions.map((mention) => mention.trim()).filter(Boolean)));
+  const mentions =
+    input.analysis?.methodologyMentions ??
+    input.extraction?.methodologyMentions ??
+    [];
+  return Array.from(
+    new Set(mentions.map((mention) => mention.trim()).filter(Boolean)),
+  );
 }
 
 function joinMethodologyLabels(values: string[]): string {
   return values.join(", ");
 }
 
-export default function QuickCheckPanel({ initialMethod, initialVersion, onContinueToWorkspace }: QuickCheckPanelProps) {
+export default function QuickCheckPanel({
+  initialMethod,
+  initialVersion,
+  onContinueToWorkspace,
+}: QuickCheckPanelProps) {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const claimRef = useRef<HTMLTextAreaElement | null>(null);
   const resultRef = useRef<HTMLDivElement | null>(null);
@@ -534,13 +743,17 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [submitting, setSubmitting] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [recoveryState, setRecoveryState] = useState<RecoveryState>(null);
-  const [matchCandidates, setMatchCandidates] = useState<ResolvedMatchCandidate[]>([]);
+  const [matchCandidates, setMatchCandidates] = useState<
+    ResolvedMatchCandidate[]
+  >([]);
   const [pendingInventoryId, setPendingInventoryId] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showSavedEvidence, setShowSavedEvidence] = useState(false);
   const [showMethodology, setShowMethodology] = useState(false);
   const [showExtractionDetails, setShowExtractionDetails] = useState(false);
-  const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
+  const [validatedResultKey, setValidatedResultKey] = useState<string | null>(
+    null,
+  );
   const [creatingProjectDraft, setCreatingProjectDraft] = useState(false);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
     loading: false,
@@ -559,38 +772,54 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const stagedUploads = session.stagedUploads;
 
   const inventoryItems = useMemo(
-    () => loadQuickCheckInventory(draft.methodologyId, draft.methodologyVersion),
+    () =>
+      loadQuickCheckInventory(draft.methodologyId, draft.methodologyVersion),
     [draft.methodologyId, draft.methodologyVersion],
   );
 
   const selectedInventoryEvidence = useMemo(
-    () => inventoryItems.filter((item) => draft.evidenceIds.includes(item.evidence_id)),
+    () =>
+      inventoryItems.filter((item) =>
+        draft.evidenceIds.includes(item.evidence_id),
+      ),
     [draft.evidenceIds, inventoryItems],
   );
 
   const selectedPins = useMemo(() => {
-    if (!draft.methodologyId.trim() || !draft.methodologyVersion.trim()) return [];
+    if (!draft.methodologyId.trim() || !draft.methodologyVersion.trim())
+      return [];
     const selectedIds = new Set(draft.evidenceIds);
-    return coalesceEvidencePins(loadPins(draft.methodologyId, draft.methodologyVersion)).filter((pin) => selectedIds.has(pin.id));
+    return coalesceEvidencePins(
+      loadPins(draft.methodologyId, draft.methodologyVersion),
+    ).filter((pin) => selectedIds.has(pin.id));
   }, [draft.evidenceIds, draft.methodologyId, draft.methodologyVersion]);
 
   const selectedUploadEvidence = useMemo(
-    () => stagedUploads.filter((upload) => draft.evidenceIds.includes(upload.evidenceId)),
+    () =>
+      stagedUploads.filter((upload) =>
+        draft.evidenceIds.includes(upload.evidenceId),
+      ),
     [draft.evidenceIds, stagedUploads],
   );
 
   const availableInventory = useMemo(
-    () => inventoryItems.filter((item) => !draft.evidenceIds.includes(item.evidence_id)),
+    () =>
+      inventoryItems.filter(
+        (item) => !draft.evidenceIds.includes(item.evidence_id),
+      ),
     [draft.evidenceIds, inventoryItems],
   );
 
-  const updateSession = useCallback((mutator: (current: QuickCheckSessionState) => QuickCheckSessionState) => {
-    setSession((current) => {
-      const next = mutator(current);
-      saveQuickCheckSession(next);
-      return next;
-    });
-  }, []);
+  const updateSession = useCallback(
+    (mutator: (current: QuickCheckSessionState) => QuickCheckSessionState) => {
+      setSession((current) => {
+        const next = mutator(current);
+        saveQuickCheckSession(next);
+        return next;
+      });
+    },
+    [],
+  );
 
   const replaceSession = useCallback((nextSession: QuickCheckSessionState) => {
     saveQuickCheckSession(nextSession);
@@ -599,11 +828,15 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
   const updateDraft = useCallback(
     (
-      mutator: (draft: QuickCheckDraft, current: QuickCheckSessionState) => QuickCheckDraft,
+      mutator: (
+        draft: QuickCheckDraft,
+        current: QuickCheckSessionState,
+      ) => QuickCheckDraft,
       nextResult?: QuickCheckResult | null,
     ) => {
       updateSession((current) => {
-        const resolvedResult = nextResult === undefined ? current.result : nextResult;
+        const resolvedResult =
+          nextResult === undefined ? current.result : nextResult;
         const mutatedDraft = mutator(current.draft, current);
         const nextDraft: QuickCheckDraft = {
           ...mutatedDraft,
@@ -631,7 +864,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       if (initialMethod?.trim()) {
         return {
           methodologyId: initialMethod.trim(),
-          methodologyVersion: initialVersion?.trim() || draftState.methodologyVersion,
+          methodologyVersion:
+            initialVersion?.trim() || draftState.methodologyVersion,
         };
       }
       return {
@@ -642,10 +876,19 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     [initialMethod, initialVersion],
   );
 
-  const fetchMethodInventory = useCallback(async (): Promise<MethodInventoryRecord[]> => {
-    const response = await fetch("/api/methods/inventory", { cache: "no-store" });
-    if (!response.ok) throw new Error(`Method inventory request failed with ${response.status}`);
-    const payload = (await response.json()) as { methods?: MethodInventoryRecord[] };
+  const fetchMethodInventory = useCallback(async (): Promise<
+    MethodInventoryRecord[]
+  > => {
+    const response = await fetch("/api/methods/inventory", {
+      cache: "no-store",
+    });
+    if (!response.ok)
+      throw new Error(
+        `Method inventory request failed with ${response.status}`,
+      );
+    const payload = (await response.json()) as {
+      methods?: MethodInventoryRecord[];
+    };
     const nextMethods = Array.isArray(payload.methods) ? payload.methods : [];
     return nextMethods.sort((a, b) => a.code.localeCompare(b.code));
   }, []);
@@ -660,7 +903,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       })
       .catch((error) => {
         if (cancelled) return;
-        setFieldErrors({ general: error instanceof Error ? error.message : String(error) });
+        setFieldErrors({
+          general: error instanceof Error ? error.message : String(error),
+        });
       })
       .finally(() => {
         if (!cancelled) setLoadingMethods(false);
@@ -672,7 +917,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
   useEffect(() => {
     if (!methods.length || !initialMethod?.trim()) return;
-    const matchedMethod = methods.find((item) => item.code === initialMethod.trim());
+    const matchedMethod = methods.find(
+      (item) => item.code === initialMethod.trim(),
+    );
     if (!matchedMethod) return;
     const version = pickVersion(matchedMethod, initialVersion);
     if (!version) return;
@@ -682,7 +929,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       methodologyId: matchedMethod.code,
       methodologyVersion: version,
     }));
-  }, [draft.methodologyId, draft.methodologyVersion, initialMethod, initialVersion, methods, updateDraft]);
+  }, [
+    draft.methodologyId,
+    draft.methodologyVersion,
+    initialMethod,
+    initialVersion,
+    methods,
+    updateDraft,
+  ]);
 
   useEffect(() => {
     // Only remove evidence IDs that were in staged uploads but the upload was removed.
@@ -694,72 +948,129 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         .filter((upload) => draft.evidenceIds.includes(upload.evidenceId))
         .map((upload) => upload.evidenceId),
     );
-    const hasDroppedStaged = draft.evidenceIds.some((id) => stagedIds.has(id) && !validStagedIds.has(id));
+    const hasDroppedStaged = draft.evidenceIds.some(
+      (id) => stagedIds.has(id) && !validStagedIds.has(id),
+    );
     if (!hasDroppedStaged) return;
-    const filteredIds = draft.evidenceIds.filter((id) => !stagedIds.has(id) || validStagedIds.has(id));
+    const filteredIds = draft.evidenceIds.filter(
+      (id) => !stagedIds.has(id) || validStagedIds.has(id),
+    );
     if (filteredIds.length === draft.evidenceIds.length) return;
     updateDraft((current) => ({ ...current, evidenceIds: filteredIds }), null);
   }, [draft.evidenceIds, inventoryItems, stagedUploads, updateDraft]);
 
-  const selectedMethodRecord = methods.find((item) => item.code === draft.methodologyId);
+  const selectedMethodRecord = methods.find(
+    (item) => item.code === draft.methodologyId,
+  );
   const selectedEvidenceCount = draft.evidenceIds.length;
   const selectedUpload = selectedUploadEvidence[0] ?? null;
   const selectedInventoryItem = selectedInventoryEvidence[0] ?? null;
-  const selectedEvidenceLabel = draft.evidenceFileName || (selectedUpload
-    ? selectedUpload.filename
-    : selectedInventoryItem
-    ? selectedInventoryItem.display_name
-    : "");
+  const selectedEvidenceLabel =
+    draft.evidenceFileName ||
+    (selectedUpload
+      ? selectedUpload.filename
+      : selectedInventoryItem
+        ? selectedInventoryItem.display_name
+        : "");
   const activeSourceMode: QuickCheckSourceMode | null =
     draft.sourceMode ??
-    (selectedUpload ? "uploaded_file" : selectedInventoryItem ? "saved_evidence" : null);
-  const selectedEvidenceMeta = activeSourceMode ? sourceModeLabel(activeSourceMode) : "";
-  const canRunQuickCheck = Boolean(draft.claimText.trim()) && selectedEvidenceCount === 1 && !submitting;
+    (selectedUpload
+      ? "uploaded_file"
+      : selectedInventoryItem
+        ? "saved_evidence"
+        : null);
+  const selectedEvidenceMeta = activeSourceMode
+    ? sourceModeLabel(activeSourceMode)
+    : "";
+  const canRunQuickCheck =
+    Boolean(draft.claimText.trim()) &&
+    selectedEvidenceCount === 1 &&
+    !submitting;
   const activeResultKey =
-    result && draft.methodologyId.trim() && draft.methodologyVersion.trim() && draft.matchedRequirementId?.trim()
+    result &&
+    draft.methodologyId.trim() &&
+    draft.methodologyVersion.trim() &&
+    draft.matchedRequirementId?.trim()
       ? `${draft.methodologyId.trim()}@@${draft.methodologyVersion.trim()}@@${draft.matchedRequirementId.trim()}`
       : null;
-  const canRenderResult = Boolean(result && activeResultKey && validatedResultKey === activeResultKey);
+  const canRenderResult = Boolean(
+    result && activeResultKey && validatedResultKey === activeResultKey,
+  );
   const renderedResult = canRenderResult ? result : null;
   const extractionPreview = useMemo(
-    () => (extractionState.analysis ? buildQuickCheckExtractionSnapshot({ claimText: draft.claimText, analysis: extractionState.analysis }) : null),
+    () =>
+      extractionState.analysis
+        ? buildQuickCheckExtractionSnapshot({
+            claimText: draft.claimText,
+            analysis: extractionState.analysis,
+          })
+        : null,
     [draft.claimText, extractionState.analysis],
   );
   const extractionPreviewState = useMemo(
-    () => (extractionPreview ? deriveQuickCheckExtractionState(extractionPreview) : null),
+    () =>
+      extractionPreview
+        ? deriveQuickCheckExtractionState(extractionPreview)
+        : null,
     [extractionPreview],
   );
   const detectedMethodologyMentions = useMemo(
-    () => methodologyMentionsForDetection({ analysis: extractionState.analysis, extraction: extractionPreview }),
+    () =>
+      methodologyMentionsForDetection({
+        analysis: extractionState.analysis,
+        extraction: extractionPreview,
+      }),
     [extractionPreview, extractionState.analysis],
   );
   const methodologyResolution = useMemo<QuickCheckMethodologyResolution>(
-    () => resolveQuickCheckMethodology({ mentions: detectedMethodologyMentions, methods }),
+    () =>
+      resolveQuickCheckMethodology({
+        mentions: detectedMethodologyMentions,
+        methods,
+      }),
     [detectedMethodologyMentions, methods],
   );
   const resolvedWorkspaceMethod = useMemo(
-    () => (methodologyResolution.status === "single" ? methodologyResolution.matchedMethods[0] ?? null : null),
+    () =>
+      methodologyResolution.status === "single"
+        ? (methodologyResolution.matchedMethods[0] ?? null)
+        : null,
     [methodologyResolution],
   );
   const workspaceMethodologyId = useMemo(() => {
     if (draft.status !== "checked" && resolvedWorkspaceMethod?.methodologyId) {
       return resolvedWorkspaceMethod.methodologyId;
     }
-    return draft.methodologyId.trim() || resolvedWorkspaceMethod?.methodologyId || "";
+    return (
+      draft.methodologyId.trim() || resolvedWorkspaceMethod?.methodologyId || ""
+    );
   }, [draft.methodologyId, draft.status, resolvedWorkspaceMethod]);
   const workspaceMethodologyVersion = useMemo(() => {
-    if (draft.status !== "checked" && resolvedWorkspaceMethod?.methodologyVersion) {
+    if (
+      draft.status !== "checked" &&
+      resolvedWorkspaceMethod?.methodologyVersion
+    ) {
       return resolvedWorkspaceMethod.methodologyVersion;
     }
-    return draft.methodologyVersion.trim() || resolvedWorkspaceMethod?.methodologyVersion || "";
+    return (
+      draft.methodologyVersion.trim() ||
+      resolvedWorkspaceMethod?.methodologyVersion ||
+      ""
+    );
   }, [draft.methodologyVersion, draft.status, resolvedWorkspaceMethod]);
   const methodologyMismatch = useMemo(() => {
     if (!draft.methodologyId.trim()) return null;
     const selected = draft.methodologyId.trim().toUpperCase();
-    const detectedMethodIds = new Set(methodologyResolution.matchedMethods.map((method) => method.methodologyId.toUpperCase()));
+    const detectedMethodIds = new Set(
+      methodologyResolution.matchedMethods.map((method) =>
+        method.methodologyId.toUpperCase(),
+      ),
+    );
     if (detectedMethodIds.has(selected)) return null;
-    const firstDetectedMethod = methodologyResolution.matchedMethods[0]?.methodologyId ?? null;
-    const firstUnsupportedMethod = methodologyResolution.unsupportedCanonicalKeys[0] ?? null;
+    const firstDetectedMethod =
+      methodologyResolution.matchedMethods[0]?.methodologyId ?? null;
+    const firstUnsupportedMethod =
+      methodologyResolution.unsupportedCanonicalKeys[0] ?? null;
     const mismatchMethod = firstDetectedMethod ?? firstUnsupportedMethod;
     if (!mismatchMethod) return null;
     return {
@@ -776,22 +1087,37 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       };
     }
     if (!extractionPreview) return null;
-    if (extractionPreview.warnings.some((warning) => /no selectable text|no extractable text/i.test(warning))) {
+    if (
+      extractionPreview.warnings.some((warning) =>
+        /no selectable text|no extractable text/i.test(warning),
+      )
+    ) {
       return {
         code: "no-selectable-text",
         label: "No selectable text",
-        message: "The file appears readable, but no selectable text could be extracted from the uploaded PDF.",
+        message:
+          "The file appears readable, but no selectable text could be extracted from the uploaded PDF.",
       };
     }
-    if (extractionPreview.warnings.some((warning) => /pdf parser fallback|pdf extraction failed|parser/i.test(warning))) {
+    if (
+      extractionPreview.warnings.some((warning) =>
+        /pdf parser fallback|pdf extraction failed|parser/i.test(warning),
+      )
+    ) {
       return {
         code: "parser-failed",
         label: "Parser failed",
-        message: "The primary PDF parser could not read this file cleanly, so Quick Check fell back to a weaker extraction path.",
+        message:
+          "The primary PDF parser could not read this file cleanly, so Quick Check fell back to a weaker extraction path.",
       };
     }
-    if (methodologyResolution.status === "unsupported" && methodologyResolution.unsupportedCanonicalKeys.length) {
-      const detected = joinMethodologyLabels(methodologyResolution.unsupportedCanonicalKeys);
+    if (
+      methodologyResolution.status === "unsupported" &&
+      methodologyResolution.unsupportedCanonicalKeys.length
+    ) {
+      const detected = joinMethodologyLabels(
+        methodologyResolution.unsupportedCanonicalKeys,
+      );
       return {
         code: "methodology-pack-unavailable",
         label: "Method pack unavailable",
@@ -799,30 +1125,43 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       };
     }
     if (methodologyResolution.status === "multiple") {
-      const detected = joinMethodologyLabels(methodologyResolution.matchedMethods.map((method) => method.methodologyId));
+      const detected = joinMethodologyLabels(
+        methodologyResolution.matchedMethods.map(
+          (method) => method.methodologyId,
+        ),
+      );
       return {
         code: "methodology-needs-confirmation",
         label: "Methodology needs confirmation",
         message: `Evidence references multiple methodologies. Requirement matches are limited to ${detected}.`,
       };
     }
-    if ((extractionPreview.signals?.parsedEvidenceCount ?? 0) > 0 && extractionPreview.methodologyMentions.length === 0) {
+    if (
+      (extractionPreview.signals?.parsedEvidenceCount ?? 0) > 0 &&
+      extractionPreview.methodologyMentions.length === 0
+    ) {
       return {
         code: "methodology-not-detected",
         label: "Methodology not detected",
-        message: "We extracted text from the file, but did not detect a methodology reference in the uploaded evidence.",
+        message:
+          "We extracted text from the file, but did not detect a methodology reference in the uploaded evidence.",
       };
     }
     return null;
   }, [extractionPreview, methodologyMismatch, methodologyResolution]);
-  const showAdvancedOptions = showAdvanced || showSavedEvidence || showMethodology;
-  const extractionHighlights = extractionPreview?.extractedFacts.slice(0, 3) ?? [];
+  const showAdvancedOptions =
+    showAdvanced || showSavedEvidence || showMethodology;
+  const extractionHighlights =
+    extractionPreview?.extractedFacts.slice(0, 3) ?? [];
   const normalizedResult = useMemo(
     () =>
       renderedResult
         ? normalizeQuickCheckUiResult({
             claim: renderedResult.claimText,
-            evidenceFileName: renderedResult.evidenceFileName || selectedEvidenceLabel || "evidence",
+            evidenceFileName:
+              renderedResult.evidenceFileName ||
+              selectedEvidenceLabel ||
+              "evidence",
             sourceMode: renderedResult.sourceMode ?? activeSourceMode,
             extraction: renderedResult.extraction ?? extractionPreview,
             methodologyCode: draft.methodologyId,
@@ -830,18 +1169,40 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             result: renderedResult,
           })
         : null,
-    [activeSourceMode, draft.methodologyId, draft.methodologyVersion, extractionPreview, renderedResult, selectedEvidenceLabel],
+    [
+      activeSourceMode,
+      draft.methodologyId,
+      draft.methodologyVersion,
+      extractionPreview,
+      renderedResult,
+      selectedEvidenceLabel,
+    ],
   );
-  const hasStrongEvidenceMatch = normalizedResult?.supportStrength.value === "strong_evidence_match";
-  const resultToneClass = hasStrongEvidenceMatch ? "border-emerald-200 bg-emerald-50/75" : "border-amber-200 bg-amber-50/80";
-  const resultEyebrowClass = hasStrongEvidenceMatch ? "text-emerald-800" : "text-amber-800";
+  const hasStrongEvidenceMatch =
+    normalizedResult?.supportStrength.value === "strong_evidence_match";
+  const resultToneClass = hasStrongEvidenceMatch
+    ? "border-emerald-200 bg-emerald-50/75"
+    : "border-amber-200 bg-amber-50/80";
+  const resultEyebrowClass = hasStrongEvidenceMatch
+    ? "text-emerald-800"
+    : "text-amber-800";
   const resultTitle = normalizedResult?.supportStrength.label ?? "Needs review";
   const resultSignalNote = normalizedResult?.supportStrength.description ?? "";
   const selectedEvidenceSources = useMemo(() => {
-    const sources = new Map<string, { evidenceId: string; sourceLabel: string; attachments: EvidencePin["attachments"]; pddFragments?: PddFragment[] }>();
+    const sources = new Map<
+      string,
+      {
+        evidenceId: string;
+        sourceLabel: string;
+        attachments: EvidencePin["attachments"];
+        pddFragments?: PddFragment[];
+      }
+    >();
 
     for (const item of selectedInventoryEvidence) {
-      const pin = selectedPins.find((candidate) => candidate.id === item.evidence_id) ?? null;
+      const pin =
+        selectedPins.find((candidate) => candidate.id === item.evidence_id) ??
+        null;
       sources.set(item.evidence_id, {
         evidenceId: item.evidence_id,
         sourceLabel: draft.evidenceFileName || item.display_name,
@@ -864,10 +1225,20 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       attachments: source.attachments ?? [],
       pddFragments: source.pddFragments,
     }));
-  }, [draft.evidenceFileName, selectedInventoryEvidence, selectedPins, selectedUploadEvidence]);
+  }, [
+    draft.evidenceFileName,
+    selectedInventoryEvidence,
+    selectedPins,
+    selectedUploadEvidence,
+  ]);
 
   const resolvePdfText = useCallback(
-    async (input: { attachmentId: string; filename: string; mime: string; bytes: ArrayBuffer }) => {
+    async (input: {
+      attachmentId: string;
+      filename: string;
+      mime: string;
+      bytes: ArrayBuffer;
+    }) => {
       if (input.mime !== "application/pdf") {
         return {
           text: extractPdfText(input.bytes),
@@ -948,38 +1319,59 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   }
 
   function openFullReviewFromRecovery() {
-    if (workspaceMethodologyId && workspaceMethodologyVersion && onContinueToWorkspace) {
-      onContinueToWorkspace(`/m/${encodeURIComponent(workspaceMethodologyId)}/v/${encodeURIComponent(workspaceMethodologyVersion)}?tab=verify&mode=list`);
+    if (
+      workspaceMethodologyId &&
+      workspaceMethodologyVersion &&
+      onContinueToWorkspace
+    ) {
+      onContinueToWorkspace(
+        `/m/${encodeURIComponent(workspaceMethodologyId)}/v/${encodeURIComponent(workspaceMethodologyVersion)}?tab=verify&mode=list`,
+      );
       return;
     }
     if (workspaceMethodologyId && workspaceMethodologyVersion) {
       if (typeof window !== "undefined") {
-        window.location.assign(`/m/${encodeURIComponent(workspaceMethodologyId)}/v/${encodeURIComponent(workspaceMethodologyVersion)}?tab=verify&mode=list`);
+        window.location.assign(
+          `/m/${encodeURIComponent(workspaceMethodologyId)}/v/${encodeURIComponent(workspaceMethodologyVersion)}?tab=verify&mode=list`,
+        );
       }
       return;
     }
     if (typeof window !== "undefined") window.location.assign("/m");
   }
 
-  const fetchRules = useCallback(async (methodologyId: string, methodologyVersion: string): Promise<RuleSummary[]> => {
-    const cacheKey = `${methodologyId}@@${methodologyVersion}`;
-    const cached = rulesCache.current.get(cacheKey);
-    if (cached) return cached;
-    const response = await fetch(
-      `/api/methods/${encodeURIComponent(methodologyId)}/v/${encodeURIComponent(methodologyVersion)}/rules`,
-      { cache: "no-store" },
-    );
-    if (!response.ok) throw new Error(`Rules request failed with ${response.status}`);
-    const payload = (await response.json()) as { rules?: RuleSummary[] };
-    const rules = Array.isArray(payload.rules) ? payload.rules : [];
-    rulesCache.current.set(cacheKey, rules);
-    return rules;
-  }, []);
+  const fetchRules = useCallback(
+    async (
+      methodologyId: string,
+      methodologyVersion: string,
+    ): Promise<RuleSummary[]> => {
+      const cacheKey = `${methodologyId}@@${methodologyVersion}`;
+      const cached = rulesCache.current.get(cacheKey);
+      if (cached) return cached;
+      const response = await fetch(
+        `/api/methods/${encodeURIComponent(methodologyId)}/v/${encodeURIComponent(methodologyVersion)}/rules`,
+        { cache: "no-store" },
+      );
+      if (!response.ok)
+        throw new Error(`Rules request failed with ${response.status}`);
+      const payload = (await response.json()) as { rules?: RuleSummary[] };
+      const rules = Array.isArray(payload.rules) ? payload.rules : [];
+      rulesCache.current.set(cacheKey, rules);
+      return rules;
+    },
+    [],
+  );
 
   const ensureMethodsReady = useCallback(
-    async (methodologyId: string, methodologyVersion: string): Promise<MethodInventoryRecord[]> => {
+    async (
+      methodologyId: string,
+      methodologyVersion: string,
+    ): Promise<MethodInventoryRecord[]> => {
       const hasMethod = methods.some(
-        (method) => method.code === methodologyId && Array.isArray(method.versions) && method.versions.includes(methodologyVersion),
+        (method) =>
+          method.code === methodologyId &&
+          Array.isArray(method.versions) &&
+          method.versions.includes(methodologyVersion),
       );
       if (hasMethod) return methods;
       const nextMethods = await fetchMethodInventory();
@@ -1044,7 +1436,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             buildRecoveryState({
               selectedMethodologyId: draft.methodologyId,
               evidenceAnalysis: undefined,
-              claimIntents: classifyQuickCheckClaimIntents(draft.claimText.trim()),
+              claimIntents: classifyQuickCheckClaimIntents(
+                draft.claimText.trim(),
+              ),
             }),
           );
         }
@@ -1053,7 +1447,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       () => {
         if (cancelled) return;
         setFieldErrors({
-          general: "Quick Check couldn't revalidate this result. Try running the check again.",
+          general:
+            "Quick Check couldn't revalidate this result. Try running the check again.",
         });
       },
     );
@@ -1075,26 +1470,34 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     validatedResultKey,
   ]);
 
-  async function buildLocalFallbackCandidates(methodSubset: MethodInventoryRecord[], analysis: QuickCheckEvidenceAnalysis): Promise<MatchCandidate[]> {
+  async function buildLocalFallbackCandidates(
+    methodSubset: MethodInventoryRecord[],
+    analysis: QuickCheckEvidenceAnalysis,
+  ): Promise<MatchCandidate[]> {
     const claimIntents = classifyQuickCheckClaimIntents(draft.claimText.trim());
     const hasBoundaryLocationSignals =
-      analysis.facts.some((fact) =>
-        fact.category === "boundary" ||
-        fact.category === "coordinates" ||
-        fact.category === "mapped-area" ||
-        fact.category === "project-location",
+      analysis.facts.some(
+        (fact) =>
+          fact.category === "boundary" ||
+          fact.category === "coordinates" ||
+          fact.category === "mapped-area" ||
+          fact.category === "project-location",
       ) ||
-      claimIntents.some((intent) =>
-        intent === "boundary" ||
-        intent === "project-area" ||
-        intent === "mapped-area" ||
-        intent === "aoi" ||
-        intent === "coordinates" ||
-        intent === "location",
+      claimIntents.some(
+        (intent) =>
+          intent === "boundary" ||
+          intent === "project-area" ||
+          intent === "mapped-area" ||
+          intent === "aoi" ||
+          intent === "coordinates" ||
+          intent === "location",
       );
     const perMethodCandidates = await Promise.all(
       methodSubset.map(async (method) => {
-        const methodologyVersion = pickVersion(method, draft.methodologyId === method.code ? draft.methodologyVersion : null);
+        const methodologyVersion = pickVersion(
+          method,
+          draft.methodologyId === method.code ? draft.methodologyVersion : null,
+        );
         if (!methodologyVersion) return [];
         const rules = await fetchRules(method.code, methodologyVersion);
         return buildLocalRuleCandidates({
@@ -1116,7 +1519,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
     return perMethodCandidates
       .flat()
-      .sort((a, b) => (b.score ?? -1) - (a.score ?? -1) || a.requirementLabel.localeCompare(b.requirementLabel))
+      .sort(
+        (a, b) =>
+          (b.score ?? -1) - (a.score ?? -1) ||
+          a.requirementLabel.localeCompare(b.requirementLabel),
+      )
       .slice(0, 4);
   }
 
@@ -1125,17 +1532,25 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     methodologyVersion: string,
     activeSession: QuickCheckSessionState = session,
   ): Promise<string[]> {
-    if (!activeSession.stagedUploads.length) return activeSession.draft.evidenceIds;
-    const currentPins = coalesceEvidencePins(loadPins(methodologyId, methodologyVersion));
+    if (!activeSession.stagedUploads.length)
+      return activeSession.draft.evidenceIds;
+    const currentPins = coalesceEvidencePins(
+      loadPins(methodologyId, methodologyVersion),
+    );
     const existingIds = new Set(currentPins.map((item) => item.id));
     const nextPins = coalesceEvidencePins([
       ...currentPins,
-      ...activeSession.stagedUploads.filter((upload) => !existingIds.has(upload.evidenceId)).map(asPinForUpload),
+      ...activeSession.stagedUploads
+        .filter((upload) => !existingIds.has(upload.evidenceId))
+        .map(asPinForUpload),
     ]);
     savePins(methodologyId, methodologyVersion, nextPins);
     updateSession((current) => ({
       ...current,
-      stagedUploads: current.stagedUploads.filter((upload) => !activeSession.draft.evidenceIds.includes(upload.evidenceId)),
+      stagedUploads: current.stagedUploads.filter(
+        (upload) =>
+          !activeSession.draft.evidenceIds.includes(upload.evidenceId),
+      ),
     }));
     return activeSession.draft.evidenceIds;
   }
@@ -1143,7 +1558,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   async function completeQuickCheck(
     candidate: ResolvedMatchCandidate,
     activeSession: QuickCheckSessionState = session,
-    options?: { manageSubmitting?: boolean; analysis?: QuickCheckEvidenceAnalysis | null },
+    options?: {
+      manageSubmitting?: boolean;
+      analysis?: QuickCheckEvidenceAnalysis | null;
+    },
   ) {
     const shouldManageSubmitting = options?.manageSubmitting !== false;
     const activeDraft = activeSession.draft;
@@ -1151,7 +1569,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setFieldErrors({});
     setRecoveryState(null);
     try {
-      await materializeUploads(candidate.methodologyId, candidate.methodologyVersion, activeSession);
+      await materializeUploads(
+        candidate.methodologyId,
+        candidate.methodologyVersion,
+        activeSession,
+      );
 
       const nextDraft: QuickCheckDraft = {
         ...activeDraft,
@@ -1162,7 +1584,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         status: "draft",
       };
 
-      const inventory = loadQuickCheckInventory(candidate.methodologyId, candidate.methodologyVersion);
+      const inventory = loadQuickCheckInventory(
+        candidate.methodologyId,
+        candidate.methodologyVersion,
+      );
       const extraction = options?.analysis
         ? buildQuickCheckExtractionSnapshot({
             claimText: activeDraft.claimText,
@@ -1194,7 +1619,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               ...extraction.warnings,
               "Quick Check is preliminary. Open full review to confirm the requirement against the full methodology context.",
             ]
-          : ["Quick Check is preliminary. Open full review to confirm the requirement against the full methodology context."],
+          : [
+              "Quick Check is preliminary. Open full review to confirm the requirement against the full methodology context.",
+            ],
         extraction,
       });
 
@@ -1216,7 +1643,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       setMatchCandidates([]);
       setRecoveryState(null);
     } catch (error) {
-      setFieldErrors({ general: error instanceof Error ? error.message : String(error) });
+      setFieldErrors({
+        general: error instanceof Error ? error.message : String(error),
+      });
     } finally {
       if (shouldManageSubmitting) setSubmitting(false);
     }
@@ -1227,11 +1656,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
     setSubmitting(true);
     resetQuickCheckUi();
-    setFieldErrors((current) => ({ ...current, evidence: undefined, general: undefined }));
+    setFieldErrors((current) => ({
+      ...current,
+      evidence: undefined,
+      general: undefined,
+    }));
     setRecoveryState(null);
     try {
       const evidenceId = newPinId();
-      const attachmentResult = await createAndStoreEvidenceAttachment({ pin_id: evidenceId, file });
+      const attachmentResult = await createAndStoreEvidenceAttachment({
+        pin_id: evidenceId,
+        file,
+      });
       if (!attachmentResult.ok) {
         setFieldErrors({ evidence: attachmentResult.message });
         return;
@@ -1271,9 +1707,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
   function selectExistingEvidence(evidenceId: string) {
     if (!evidenceId) return;
-    const selectedItem = inventoryItems.find((item) => item.evidence_id === evidenceId) ?? null;
-    const selectedPin = selectedPins.find((item) => item.id === evidenceId) ?? null;
-    const evidenceFileName = selectedPin?.attachments?.[0]?.filename ?? selectedItem?.display_name ?? evidenceId;
+    const selectedItem =
+      inventoryItems.find((item) => item.evidence_id === evidenceId) ?? null;
+    const selectedPin =
+      selectedPins.find((item) => item.id === evidenceId) ?? null;
+    const evidenceFileName =
+      selectedPin?.attachments?.[0]?.filename ??
+      selectedItem?.display_name ??
+      evidenceId;
     updateSession((current) => ({
       ...current,
       draft: (() => {
@@ -1305,20 +1746,26 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         ...current.draft,
         sourceMode: undefined,
         evidenceFileName: undefined,
-        evidenceIds: current.draft.evidenceIds.filter((id) => id !== evidenceId),
+        evidenceIds: current.draft.evidenceIds.filter(
+          (id) => id !== evidenceId,
+        ),
         status: "draft",
         result: null,
         resultId: undefined,
         updatedAt: nowIso(),
       },
       result: null,
-      stagedUploads: current.stagedUploads.filter((upload) => upload.evidenceId !== evidenceId),
+      stagedUploads: current.stagedUploads.filter(
+        (upload) => upload.evidenceId !== evidenceId,
+      ),
     }));
     clearDecisionState();
   }
 
   async function runQuickCheck() {
-    const validationErrors = validateQuickCheckDraft(draft, { stagedEvidenceCount: stagedUploads.length });
+    const validationErrors = validateQuickCheckDraft(draft, {
+      stagedEvidenceCount: stagedUploads.length,
+    });
     if (validationErrors.length) {
       setFieldErrors({
         claim: validationErrors.find((item) => item.includes("claim")),
@@ -1332,10 +1779,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setRecoveryState(null);
     setMatchCandidates([]);
     try {
-      const evidenceAnalysis = await analyzeQuickCheckEvidence(selectedEvidenceSources, { resolvePdfText });
-      const claimIntents = classifyQuickCheckClaimIntents(draft.claimText.trim());
+      const evidenceAnalysis = await analyzeQuickCheckEvidence(
+        selectedEvidenceSources,
+        { resolvePdfText },
+      );
+      const claimIntents = classifyQuickCheckClaimIntents(
+        draft.claimText.trim(),
+      );
       const currentMethodologyResolution = resolveQuickCheckMethodology({
-        mentions: methodologyMentionsForDetection({ analysis: evidenceAnalysis, extraction: null }),
+        mentions: methodologyMentionsForDetection({
+          analysis: evidenceAnalysis,
+          extraction: null,
+        }),
         methods,
       });
       if (!evidenceAnalysis.facts.length) {
@@ -1344,24 +1799,49 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         return;
       }
 
-      if (!draft.methodologyId.trim() && currentMethodologyResolution.status === "unsupported") {
+      if (
+        !draft.methodologyId.trim() &&
+        currentMethodologyResolution.status === "unsupported"
+      ) {
         setShowMethodology(true);
         setFieldErrors({});
-        setRecoveryState(buildUnsupportedMethodRecoveryState(currentMethodologyResolution.unsupportedCanonicalKeys[0] ?? "unknown methodology"));
+        setRecoveryState(
+          buildUnsupportedMethodRecoveryState(
+            currentMethodologyResolution.unsupportedCanonicalKeys[0] ??
+              "unknown methodology",
+          ),
+        );
         return;
       }
 
-      const selectedMethodologyId = draft.methodologyId.trim()
-        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "" : "");
-      const selectedMethodologyVersion = draft.methodologyVersion.trim()
-        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyVersion ?? "" : "");
+      const selectedMethodologyId =
+        draft.methodologyId.trim() ||
+        (currentMethodologyResolution.status === "single"
+          ? (currentMethodologyResolution.matchedMethods[0]?.methodologyId ??
+            "")
+          : "");
+      const selectedMethodologyVersion =
+        draft.methodologyVersion.trim() ||
+        (currentMethodologyResolution.status === "single"
+          ? (currentMethodologyResolution.matchedMethods[0]
+              ?.methodologyVersion ?? "")
+          : "");
       const allowedMethodologyIds = draft.methodologyId.trim()
         ? new Set([draft.methodologyId.trim()])
-        : currentMethodologyResolution.status === "single" || currentMethodologyResolution.status === "multiple"
-        ? new Set(currentMethodologyResolution.matchedMethods.map((method) => method.methodologyId))
-        : new Set<string>();
+        : currentMethodologyResolution.status === "single" ||
+            currentMethodologyResolution.status === "multiple"
+          ? new Set(
+              currentMethodologyResolution.matchedMethods.map(
+                (method) => method.methodologyId,
+              ),
+            )
+          : new Set<string>();
 
-      const queryTexts = buildQuickCheckQueryTexts(draft.claimText.trim(), evidenceAnalysis.facts, claimIntents);
+      const queryTexts = buildQuickCheckQueryTexts(
+        draft.claimText.trim(),
+        evidenceAnalysis.facts,
+        claimIntents,
+      );
       const responses = await Promise.all(
         queryTexts.map(async (query) => ({
           query,
@@ -1390,7 +1870,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         claimIntents,
       );
 
-      if (draft.methodologyId.trim() && !candidates.length && allCandidates.length) {
+      if (
+        draft.methodologyId.trim() &&
+        !candidates.length &&
+        allCandidates.length
+      ) {
         const broaderResolvedCandidates = await resolveQuickCheckCandidates({
           candidates: allCandidates,
           methods,
@@ -1399,7 +1883,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         if (broaderResolvedCandidates.length) {
           setShowMethodology(true);
           setMatchCandidates(broaderResolvedCandidates);
-          setRecoveryState(buildMismatchedMethodRecoveryState(draft.methodologyId.trim()));
+          setRecoveryState(
+            buildMismatchedMethodRecoveryState(draft.methodologyId.trim()),
+          );
           setFieldErrors({});
           return;
         }
@@ -1408,11 +1894,16 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       if (
         draft.methodologyId.trim() &&
         candidates.length &&
-        claimPrefersMonitoringRequirement(draft.claimText.trim(), claimIntents) &&
+        claimPrefersMonitoringRequirement(
+          draft.claimText.trim(),
+          claimIntents,
+        ) &&
         !candidates.some(candidateLooksMonitoringAligned)
       ) {
         const broaderMonitoringCandidates = allCandidates.filter(
-          (candidate) => candidate.methodologyId !== draft.methodologyId.trim() && candidateLooksMonitoringAligned(candidate),
+          (candidate) =>
+            candidate.methodologyId !== draft.methodologyId.trim() &&
+            candidateLooksMonitoringAligned(candidate),
         );
         if (broaderMonitoringCandidates.length) {
           const broaderResolvedCandidates = await resolveQuickCheckCandidates({
@@ -1423,18 +1914,26 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           if (broaderResolvedCandidates.length) {
             setShowMethodology(true);
             setMatchCandidates(broaderResolvedCandidates);
-            setRecoveryState(buildMismatchedMethodRecoveryState(draft.methodologyId.trim()));
+            setRecoveryState(
+              buildMismatchedMethodRecoveryState(draft.methodologyId.trim()),
+            );
             setFieldErrors({});
             return;
           }
         }
       }
 
-      if (currentMethodologyResolution.status === "single" && !draft.methodologyId.trim() && !candidates.length) {
+      if (
+        currentMethodologyResolution.status === "single" &&
+        !draft.methodologyId.trim() &&
+        !candidates.length
+      ) {
         setFieldErrors({});
         setRecoveryState(
           buildNoValidAnalysisPathRecoveryState({
-            methodologyId: currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "",
+            methodologyId:
+              currentMethodologyResolution.matchedMethods[0]?.methodologyId ??
+              "",
             evidenceSignals: evidenceAnalysis,
           }),
         );
@@ -1445,7 +1944,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         const methodSubset = allowedMethodologyIds.size
           ? methods.filter((method) => allowedMethodologyIds.has(method.code))
           : methods;
-        candidates = await buildLocalFallbackCandidates(methodSubset, evidenceAnalysis);
+        candidates = await buildLocalFallbackCandidates(
+          methodSubset,
+          evidenceAnalysis,
+        );
       }
 
       let resolvedCandidates = await resolveQuickCheckCandidates({
@@ -1456,7 +1958,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
       if (!resolvedCandidates.length && draft.methodologyId.trim()) {
         const broaderCandidates =
-          allCandidates.length > 0 ? allCandidates : await buildLocalFallbackCandidates(methods, evidenceAnalysis);
+          allCandidates.length > 0
+            ? allCandidates
+            : await buildLocalFallbackCandidates(methods, evidenceAnalysis);
         const broaderResolvedCandidates = await resolveQuickCheckCandidates({
           candidates: broaderCandidates,
           methods,
@@ -1465,7 +1969,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         if (broaderResolvedCandidates.length) {
           setShowMethodology(true);
           setMatchCandidates(broaderResolvedCandidates);
-          setRecoveryState(buildMismatchedMethodRecoveryState(draft.methodologyId.trim()));
+          setRecoveryState(
+            buildMismatchedMethodRecoveryState(draft.methodologyId.trim()),
+          );
           setFieldErrors({});
           return;
         }
@@ -1483,19 +1989,30 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         return;
       }
 
-      if (!resolvedCandidates.length && currentMethodologyResolution.status === "single" && !draft.methodologyId.trim()) {
+      if (
+        !resolvedCandidates.length &&
+        currentMethodologyResolution.status === "single" &&
+        !draft.methodologyId.trim()
+      ) {
         setFieldErrors({});
         setRecoveryState(
           buildNoValidAnalysisPathRecoveryState({
-            methodologyId: currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "",
+            methodologyId:
+              currentMethodologyResolution.matchedMethods[0]?.methodologyId ??
+              "",
             evidenceSignals: evidenceAnalysis,
           }),
         );
         return;
       }
 
-      if (!draft.methodologyId.trim() && currentMethodologyResolution.status === "multiple") {
-        const detectedResolvedCandidates = resolvedCandidates.filter((candidate) => allowedMethodologyIds.has(candidate.methodologyId));
+      if (
+        !draft.methodologyId.trim() &&
+        currentMethodologyResolution.status === "multiple"
+      ) {
+        const detectedResolvedCandidates = resolvedCandidates.filter(
+          (candidate) => allowedMethodologyIds.has(candidate.methodologyId),
+        );
         if (detectedResolvedCandidates.length) {
           setShowMethodology(true);
           setMatchCandidates(detectedResolvedCandidates);
@@ -1511,7 +2028,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
       if (!resolvedCandidates.length && !draft.methodologyId.trim()) {
         const broaderCandidates =
-          allCandidates.length > 0 ? allCandidates : await buildLocalFallbackCandidates(methods, evidenceAnalysis);
+          allCandidates.length > 0
+            ? allCandidates
+            : await buildLocalFallbackCandidates(methods, evidenceAnalysis);
         resolvedCandidates = await resolveQuickCheckCandidates({
           candidates: broaderCandidates,
           methods,
@@ -1521,7 +2040,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           setMatchCandidates(resolvedCandidates);
           setRecoveryState(null);
           setFieldErrors({
-            general: "This methodology filter removed closer matches. Pick a likely match below or try another methodology.",
+            general:
+              "This methodology filter removed closer matches. Pick a likely match below or try another methodology.",
           });
           return;
         }
@@ -1540,7 +2060,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         return;
       }
 
-      if (!draft.methodologyId.trim() && currentMethodologyResolution.status === "none" && requiresMethodologyConfirmation(resolvedCandidates)) {
+      if (
+        !draft.methodologyId.trim() &&
+        currentMethodologyResolution.status === "none" &&
+        requiresMethodologyConfirmation(resolvedCandidates)
+      ) {
         setShowMethodology(true);
         setMatchCandidates(resolvedCandidates);
         setFieldErrors({});
@@ -1553,7 +2077,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         if (!draft.methodologyId.trim()) setShowMethodology(true);
         setRecoveryState(null);
         setFieldErrors({
-          general: "Multiple requirements could fit this claim. Pick the closest match or narrow by methodology.",
+          general:
+            "Multiple requirements could fit this claim. Pick the closest match or narrow by methodology.",
         });
         return;
       }
@@ -1562,7 +2087,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         analysis: evidenceAnalysis,
       });
     } catch (error) {
-      setFieldErrors({ general: error instanceof Error ? error.message : String(error) });
+      setFieldErrors({
+        general: error instanceof Error ? error.message : String(error),
+      });
     } finally {
       setSubmitting(false);
     }
@@ -1573,19 +2100,25 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     resetQuickCheckUi();
     try {
       const demo = await prepareQuickCheckDemo();
-      const readyMethods = await ensureMethodsReady(QUICK_CHECK_DEMO.methodologyId, QUICK_CHECK_DEMO.methodologyVersion);
+      const readyMethods = await ensureMethodsReady(
+        QUICK_CHECK_DEMO.methodologyId,
+        QUICK_CHECK_DEMO.methodologyVersion,
+      );
       const nextSession: QuickCheckSessionState = {
         draft: demo.draft,
         result: null,
         stagedUploads: [demo.stagedUpload],
       };
-      const demoAnalysis = await analyzeQuickCheckEvidence([
-        {
-          evidenceId: demo.stagedUpload.evidenceId,
-          sourceLabel: demo.stagedUpload.filename,
-          attachments: [demo.stagedUpload.attachment],
-        },
-      ], { resolvePdfText });
+      const demoAnalysis = await analyzeQuickCheckEvidence(
+        [
+          {
+            evidenceId: demo.stagedUpload.evidenceId,
+            sourceLabel: demo.stagedUpload.filename,
+            attachments: [demo.stagedUpload.attachment],
+          },
+        ],
+        { resolvePdfText },
+      );
       replaceSession(nextSession);
       const resolvedDemoCandidate = await resolveQuickCheckCandidate({
         candidate: buildQuickCheckDemoCandidate(),
@@ -1594,29 +2127,33 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       });
       if (!resolvedDemoCandidate) {
         if (process.env.NODE_ENV !== "production") {
-          console.error("Quick Check demo fixture could not be resolved.", buildQuickCheckDemoCandidate());
+          console.error(
+            "Quick Check demo fixture could not be resolved.",
+            buildQuickCheckDemoCandidate(),
+          );
         }
         setRecoveryState(
           buildRecoveryState({
             selectedMethodologyId: QUICK_CHECK_DEMO.methodologyId,
-            claimIntents: classifyQuickCheckClaimIntents(QUICK_CHECK_DEMO.claimText),
+            claimIntents: classifyQuickCheckClaimIntents(
+              QUICK_CHECK_DEMO.claimText,
+            ),
           }),
         );
         setFieldErrors({
-          general: "Demo check is unavailable right now. Try your own claim or upload evidence.",
+          general:
+            "Demo check is unavailable right now. Try your own claim or upload evidence.",
         });
         return;
       }
-      await completeQuickCheck(
-        resolvedDemoCandidate,
-        nextSession,
-        {
-          manageSubmitting: false,
-          analysis: demoAnalysis,
-        },
-      );
+      await completeQuickCheck(resolvedDemoCandidate, nextSession, {
+        manageSubmitting: false,
+        analysis: demoAnalysis,
+      });
     } catch (error) {
-      setFieldErrors({ general: error instanceof Error ? error.message : String(error) });
+      setFieldErrors({
+        general: error instanceof Error ? error.message : String(error),
+      });
     } finally {
       setSubmitting(false);
     }
@@ -1640,11 +2177,17 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
   async function handleCreateProjectFromDocument() {
     const uploadAttachment = selectedUpload?.attachment ?? null;
-    const selectedPdfAttachment = uploadAttachment
-      ?? selectedPins.flatMap((pin) => pin.attachments ?? []).find((attachment) => attachment.mime === "application/pdf")
-      ?? null;
+    const selectedPdfAttachment =
+      uploadAttachment ??
+      selectedPins
+        .flatMap((pin) => pin.attachments ?? [])
+        .find((attachment) => attachment.mime === "application/pdf") ??
+      null;
     if (!selectedPdfAttachment || !draft.evidenceIds[0]) {
-      setFieldErrors({ general: "Select one uploaded PDF or saved PDD before creating a project draft." });
+      setFieldErrors({
+        general:
+          "Select one uploaded PDF or saved PDD before creating a project draft.",
+      });
       return;
     }
     setCreatingProjectDraft(true);
@@ -1662,7 +2205,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         window.location.assign("/projects/new?handoff=document-metadata");
       }
     } catch (error) {
-      setFieldErrors({ general: error instanceof Error ? error.message : String(error) });
+      setFieldErrors({
+        general: error instanceof Error ? error.message : String(error),
+      });
     } finally {
       setCreatingProjectDraft(false);
     }
@@ -1693,7 +2238,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 Upload evidence. Get a preliminary match in seconds.
               </p>
             </div>
-            {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" /> : null}
+            {loadingMethods || submitting ? (
+              <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" />
+            ) : null}
           </div>
         </div>
 
@@ -1705,29 +2252,31 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 value={draft.claimText}
                 onChange={(event) => {
                   const value = event.target.value;
-                  updateDraft(
-                    (current) => {
-                      const nextMethodology = resetMethodologyForUserInput(current);
-                      return {
-                        ...current,
-                        ...nextMethodology,
-                        claimText: value,
-                        matchedRequirementId: undefined,
-                        matchedRequirementLabel: undefined,
-                        status: "draft",
-                        resultId: undefined,
-                      };
-                    },
-                    null,
-                );
-                clearDecisionState();
-              }}
-              rows={3}
-              placeholder="Example: The monitoring report covers the full reporting period."
+                  updateDraft((current) => {
+                    const nextMethodology =
+                      resetMethodologyForUserInput(current);
+                    return {
+                      ...current,
+                      ...nextMethodology,
+                      claimText: value,
+                      matchedRequirementId: undefined,
+                      matchedRequirementLabel: undefined,
+                      status: "draft",
+                      resultId: undefined,
+                    };
+                  }, null);
+                  clearDecisionState();
+                }}
+                rows={3}
+                placeholder="Example: The monitoring report covers the full reporting period."
                 className="w-full rounded-[1.25rem] border border-slate-200 bg-white p-5 text-lg leading-8 text-slate-950 outline-none transition placeholder:text-slate-300 focus:border-slate-400 focus:bg-white"
                 ref={claimRef}
               />
-              {fieldErrors.claim ? <span className="text-sm text-rose-700">{fieldErrors.claim}</span> : null}
+              {fieldErrors.claim ? (
+                <span className="text-sm text-rose-700">
+                  {fieldErrors.claim}
+                </span>
+              ) : null}
             </label>
             <div className="mt-4">
               <div className="text-xs text-slate-400">Try an example</div>
@@ -1737,21 +2286,19 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     key={suggestion}
                     type="button"
                     onClick={() => {
-                      updateDraft(
-                        (current) => {
-                          const nextMethodology = resetMethodologyForUserInput(current);
-                          return {
-                            ...current,
-                            ...nextMethodology,
-                            claimText: suggestion,
-                            matchedRequirementId: undefined,
-                            matchedRequirementLabel: undefined,
-                            status: "draft",
-                            resultId: undefined,
-                          };
-                        },
-                        null,
-                      );
+                      updateDraft((current) => {
+                        const nextMethodology =
+                          resetMethodologyForUserInput(current);
+                        return {
+                          ...current,
+                          ...nextMethodology,
+                          claimText: suggestion,
+                          matchedRequirementId: undefined,
+                          matchedRequirementLabel: undefined,
+                          status: "draft",
+                          resultId: undefined,
+                        };
+                      }, null);
                       clearDecisionState();
                     }}
                     className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
@@ -1766,15 +2313,21 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           <div>
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0">
-                <div className="text-sm font-medium text-slate-900">Evidence</div>
-                <div className="mt-1 text-sm text-slate-600">Upload one file.</div>
+                <div className="text-sm font-medium text-slate-900">
+                  Evidence
+                </div>
+                <div className="mt-1 text-sm text-slate-600">
+                  Upload one file.
+                </div>
               </div>
               <input
                 ref={fileRef}
                 type="file"
                 className="hidden"
                 accept=".pdf,.png,.jpg,.jpeg,.csv,.xlsx"
-                onChange={(event) => void handleUpload(event.target.files?.[0] ?? null)}
+                onChange={(event) =>
+                  void handleUpload(event.target.files?.[0] ?? null)
+                }
               />
               <button
                 type="button"
@@ -1794,8 +2347,12 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               <>
                 <div className="mt-4 flex items-center justify-between gap-3 rounded-[1.2rem] border border-slate-200 bg-white px-4 py-3">
                   <div className="min-w-0">
-                    <div className="truncate text-sm font-medium text-slate-900">{selectedEvidenceLabel}</div>
-                    <div className="mt-1 text-xs text-slate-500">{selectedEvidenceMeta}</div>
+                    <div className="truncate text-sm font-medium text-slate-900">
+                      {selectedEvidenceLabel}
+                    </div>
+                    <div className="mt-1 text-xs text-slate-500">
+                      {selectedEvidenceMeta}
+                    </div>
                   </div>
                   <button
                     type="button"
@@ -1809,71 +2366,122 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 <div className="mt-3 rounded-[1.2rem] border border-slate-200 bg-white px-4 py-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
-                      <div className="text-sm font-medium text-slate-900">Extraction preview</div>
-                      <div className="mt-1 text-sm text-slate-600">Review the evidence signal.</div>
+                      <div className="text-sm font-medium text-slate-900">
+                        Extraction preview
+                      </div>
+                      <div className="mt-1 text-sm text-slate-600">
+                        Review the evidence signal.
+                      </div>
                     </div>
                     <div className="flex items-center gap-2">
                       {extractionPreviewState ? (
-                        <span className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold ${extractionStateBadgeClass(extractionPreviewState.value)}`}>
+                        <span
+                          className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold ${extractionStateBadgeClass(extractionPreviewState.value)}`}
+                        >
                           {extractionPreviewState.label}
                         </span>
                       ) : null}
-                      {extractionState.loading ? <Loader2 className="h-4 w-4 animate-spin text-slate-400" /> : null}
+                      {extractionState.loading ? (
+                        <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+                      ) : null}
                     </div>
                   </div>
 
                   {extractionState.error ? (
                     <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
-                      Extraction preview is unavailable right now. {extractionState.error}
+                      Extraction preview is unavailable right now.{" "}
+                      {extractionState.error}
                     </div>
                   ) : extractionPreview ? (
                     <>
-                      {!draft.methodologyId.trim() && methodologyResolution.status === "single" ? (
+                      {!draft.methodologyId.trim() &&
+                      methodologyResolution.status === "single" ? (
                         <div className="mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-3 text-sm text-emerald-900">
-                          Detected methodology: {methodologyResolution.matchedMethods[0].methodologyId}. Requirement matches are narrowed to {methodologyResolution.matchedMethods[0].methodologyId}.
+                          Detected methodology:{" "}
+                          {
+                            methodologyResolution.matchedMethods[0]
+                              .methodologyId
+                          }
+                          . Requirement matches are narrowed to{" "}
+                          {
+                            methodologyResolution.matchedMethods[0]
+                              .methodologyId
+                          }
+                          .
                         </div>
                       ) : null}
-                      {!draft.methodologyId.trim() && methodologyResolution.status === "multiple" ? (
+                      {!draft.methodologyId.trim() &&
+                      methodologyResolution.status === "multiple" ? (
                         <div className="mt-3 rounded-2xl border border-sky-200 bg-sky-50 px-3 py-3 text-sm text-sky-900">
-                          Methodology needs confirmation. Requirement matches are limited to {joinMethodologyLabels(methodologyResolution.matchedMethods.map((method) => method.methodologyId))}.
+                          Methodology needs confirmation. Requirement matches
+                          are limited to{" "}
+                          {joinMethodologyLabels(
+                            methodologyResolution.matchedMethods.map(
+                              (method) => method.methodologyId,
+                            ),
+                          )}
+                          .
                         </div>
                       ) : null}
-                      {!draft.methodologyId.trim() && methodologyResolution.status === "unsupported" ? (
+                      {!draft.methodologyId.trim() &&
+                      methodologyResolution.status === "unsupported" ? (
                         <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
-                          Detected {joinMethodologyLabels(methodologyResolution.unsupportedCanonicalKeys)}, but no matching method pack is available.
+                          Detected{" "}
+                          {joinMethodologyLabels(
+                            methodologyResolution.unsupportedCanonicalKeys,
+                          )}
+                          , but no matching method pack is available.
                         </div>
                       ) : null}
-                      {!draft.methodologyId.trim() && methodologyResolution.status === "none" && (extractionPreview.signals?.parsedEvidenceCount ?? 0) > 0 ? (
+                      {!draft.methodologyId.trim() &&
+                      methodologyResolution.status === "none" &&
+                      (extractionPreview.signals?.parsedEvidenceCount ?? 0) >
+                        0 ? (
                         <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
-                          No methodology detected. Requirement matches use broad matching and may be unrelated.
+                          No methodology detected. Requirement matches use broad
+                          matching and may be unrelated.
                         </div>
                       ) : null}
                       <div className="mt-4 grid gap-3 md:grid-cols-[1.1fr_0.9fr]">
                         <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-                          <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">What we found first</div>
+                          <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                            What we found first
+                          </div>
                           {extractionHighlights.length ? (
                             <div className="mt-2 flex flex-wrap gap-2">
                               {extractionHighlights.map((fact) => (
-                                <span key={fact} className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700">
+                                <span
+                                  key={fact}
+                                  className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700"
+                                >
                                   {fact}
                                 </span>
                               ))}
                             </div>
                           ) : (
                             <div className="mt-2 text-sm text-amber-900">
-                              We couldn&apos;t extract enough usable data from this file for a reliable preliminary match yet.
+                              We couldn&apos;t extract enough usable data from
+                              this file for a reliable preliminary match yet.
                             </div>
                           )}
                         </div>
                         <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
                           <div className="grid gap-2 text-sm text-slate-700">
                             <div>
-                              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Source</div>
-                              <div className="mt-1 font-medium text-slate-900">{sourceModeLabel(activeSourceMode)}</div>
+                              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                                Source
+                              </div>
+                              <div className="mt-1 font-medium text-slate-900">
+                                {sourceModeLabel(activeSourceMode)}
+                              </div>
                             </div>
                             <div>
-                              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Document type</div>
-                              <div className="mt-1 font-medium text-slate-900">{extractionPreview.documentType}</div>
+                              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                                Document type
+                              </div>
+                              <div className="mt-1 font-medium text-slate-900">
+                                {extractionPreview.documentType}
+                              </div>
                             </div>
                           </div>
                         </div>
@@ -1881,33 +2489,50 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
                       <button
                         type="button"
-                        onClick={() => setShowExtractionDetails((value) => !value)}
+                        onClick={() =>
+                          setShowExtractionDetails((value) => !value)
+                        }
                         className="mt-4 inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
                         aria-expanded={showExtractionDetails}
                       >
-                        {showExtractionDetails ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-                        {showExtractionDetails ? "Hide extraction details" : "Show extraction details"}
+                        {showExtractionDetails ? (
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        ) : (
+                          <ChevronRight className="h-3.5 w-3.5" />
+                        )}
+                        {showExtractionDetails
+                          ? "Hide extraction details"
+                          : "Show extraction details"}
                       </button>
 
                       {showExtractionDetails ? (
                         <div className="mt-4 grid gap-4 md:grid-cols-2">
                           <div>
-                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Extraction signal</div>
+                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                              Extraction signal
+                            </div>
                             {extractionPreviewState ? (
                               <>
-                                <span className={`mt-1 inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold ${extractionStateBadgeClass(extractionPreviewState.value)}`}>
+                                <span
+                                  className={`mt-1 inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold ${extractionStateBadgeClass(extractionPreviewState.value)}`}
+                                >
                                   {extractionPreviewState.label}
                                 </span>
-                                <div className="mt-2 text-xs text-slate-500">{extractionPreviewState.description}</div>
+                                <div className="mt-2 text-xs text-slate-500">
+                                  {extractionPreviewState.description}
+                                </div>
                               </>
                             ) : null}
                           </div>
                           <div>
-                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Extraction diagnostic</div>
+                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                              Extraction diagnostic
+                            </div>
                             <div className="mt-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700">
                               {extractionDiagnostic ? (
                                 <>
-                                  <strong>{extractionDiagnostic.label}:</strong> {extractionDiagnostic.message}
+                                  <strong>{extractionDiagnostic.label}:</strong>{" "}
+                                  {extractionDiagnostic.message}
                                 </>
                               ) : (
                                 "No extraction diagnostic from the active source."
@@ -1915,20 +2540,38 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                             </div>
                           </div>
                           <div>
-                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Methodology mentions</div>
+                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                              Methodology mentions
+                            </div>
                             <div className="mt-2 flex flex-wrap gap-2">
-                              {(extractionPreview.methodologyMentions.length ? extractionPreview.methodologyMentions : ["None detected"]).map((mention) => (
-                                <span key={mention} className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700">
+                              {(extractionPreview.methodologyMentions.length
+                                ? extractionPreview.methodologyMentions
+                                : ["None detected"]
+                              ).map((mention) => (
+                                <span
+                                  key={mention}
+                                  className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700"
+                                >
                                   {mention}
                                 </span>
                               ))}
                             </div>
                           </div>
                           <div className="md:col-span-2">
-                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Warnings</div>
+                            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                              Warnings
+                            </div>
                             <div className="mt-2 grid gap-2">
-                              {(extractionPreview.warnings.length ? extractionPreview.warnings : ["No extraction warnings from the active source."]).map((warning) => (
-                                <div key={warning} className="text-sm text-slate-600">
+                              {(extractionPreview.warnings.length
+                                ? extractionPreview.warnings
+                                : [
+                                    "No extraction warnings from the active source.",
+                                  ]
+                              ).map((warning) => (
+                                <div
+                                  key={warning}
+                                  className="text-sm text-slate-600"
+                                >
                                   {warning}
                                 </div>
                               ))}
@@ -1941,7 +2584,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 </div>
               </>
             )}
-            {fieldErrors.evidence ? <div className="mt-3 text-sm text-rose-700">{fieldErrors.evidence}</div> : null}
+            {fieldErrors.evidence ? (
+              <div className="mt-3 text-sm text-rose-700">
+                {fieldErrors.evidence}
+              </div>
+            ) : null}
           </div>
 
           <div className="grid gap-3">
@@ -1985,12 +2632,20 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
           {showAdvancedOptions ? (
             <div className="rounded-[1.6rem] border border-slate-200 bg-white px-4 py-4">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Options</div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Options
+              </div>
               <div className="mt-4 grid gap-4 md:grid-cols-2">
-                <div className={`rounded-2xl border px-4 py-3 ${showSavedEvidence ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}>
-                  <div className="text-sm font-medium text-slate-900">Saved evidence</div>
+                <div
+                  className={`rounded-2xl border px-4 py-3 ${showSavedEvidence ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}
+                >
+                  <div className="text-sm font-medium text-slate-900">
+                    Saved evidence
+                  </div>
                   {!draft.methodologyId || !draft.methodologyVersion ? (
-                    <div className="mt-2 text-sm text-slate-600">Choose a methodology first to reuse saved evidence.</div>
+                    <div className="mt-2 text-sm text-slate-600">
+                      Choose a methodology first to reuse saved evidence.
+                    </div>
                   ) : (
                     <div className="mt-3">
                       <select
@@ -2005,7 +2660,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       >
                         <option value="">Select saved evidence</option>
                         {availableInventory.map((item) => (
-                          <option key={item.evidence_id} value={item.evidence_id}>
+                          <option
+                            key={item.evidence_id}
+                            value={item.evidence_id}
+                          >
                             {inventoryEvidenceLabel(item)}
                           </option>
                         ))}
@@ -2013,25 +2671,39 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     </div>
                   )}
                 </div>
-                <div className={`rounded-2xl border px-4 py-3 ${showMethodology ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}>
+                <div
+                  className={`rounded-2xl border px-4 py-3 ${showMethodology ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}
+                >
                   <label className="grid gap-2 text-sm text-slate-700">
-                    <span className="font-medium text-slate-900">Methodology</span>
+                    <span className="font-medium text-slate-900">
+                      Methodology
+                    </span>
                     <select
                       value={draft.methodologyId}
                       onChange={(event) => {
                         const methodologyId = event.target.value;
-                        const method = methods.find((item) => item.code === methodologyId);
-                        const methodologyVersion = methodologyId ? pickVersion(method, initialVersion) : "";
+                        const method = methods.find(
+                          (item) => item.code === methodologyId,
+                        );
+                        const methodologyVersion = methodologyId
+                          ? pickVersion(method, initialVersion)
+                          : "";
                         setShowMethodology(Boolean(methodologyId));
                         updateSession((current) => {
-                          const stagedIds = new Set(current.stagedUploads.map((upload) => upload.evidenceId));
+                          const stagedIds = new Set(
+                            current.stagedUploads.map(
+                              (upload) => upload.evidenceId,
+                            ),
+                          );
                           return {
                             ...current,
                             draft: {
                               ...current.draft,
                               methodologyId,
                               methodologyVersion,
-                              evidenceIds: current.draft.evidenceIds.filter((id) => stagedIds.has(id)),
+                              evidenceIds: current.draft.evidenceIds.filter(
+                                (id) => stagedIds.has(id),
+                              ),
                               matchedRequirementId: undefined,
                               matchedRequirementLabel: undefined,
                               status: "draft",
@@ -2054,7 +2726,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                         </option>
                       ))}
                     </select>
-                    <span className="text-xs text-slate-500">Optional. Use this only when you want to narrow the match.</span>
+                    <span className="text-xs text-slate-500">
+                      Optional. Use this only when you want to narrow the match.
+                    </span>
                   </label>
                 </div>
               </div>
@@ -2063,9 +2737,17 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
           {recoveryState ? (
             <div className="rounded-2xl border border-amber-200 bg-amber-50/90 p-4">
-              <div className="text-sm font-semibold text-slate-900">{recoveryState.title}</div>
-              <div className="mt-1 text-sm text-slate-700">{recoveryState.description}</div>
-              {recoveryState.note ? <div className="mt-3 text-sm text-slate-600">{recoveryState.note}</div> : null}
+              <div className="text-sm font-semibold text-slate-900">
+                {recoveryState.title}
+              </div>
+              <div className="mt-1 text-sm text-slate-700">
+                {recoveryState.description}
+              </div>
+              {recoveryState.note ? (
+                <div className="mt-3 text-sm text-slate-600">
+                  {recoveryState.note}
+                </div>
+              ) : null}
               <div className="mt-4 flex flex-wrap gap-2">
                 {recoveryState.kind === "weak-extraction" ? (
                   <button
@@ -2106,7 +2788,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           ) : null}
 
           {fieldErrors.general ? (
-            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-3.5 py-3 text-sm text-amber-900" role="status" aria-live="polite">
+            <div
+              className="rounded-2xl border border-amber-200 bg-amber-50 px-3.5 py-3 text-sm text-amber-900"
+              role="status"
+              aria-live="polite"
+            >
               <div className="flex items-start gap-2.5">
                 <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />
                 <div>{fieldErrors.general}</div>
@@ -2119,7 +2805,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               <div className="flex items-start gap-3">
                 <SearchCheck className="mt-0.5 h-4 w-4 shrink-0 text-sky-700" />
                 <div className="min-w-0">
-                  <div className="text-sm font-semibold text-slate-900">Likely requirement matches</div>
+                  <div className="text-sm font-semibold text-slate-900">
+                    Likely requirement matches
+                  </div>
                   <div className="mt-1 text-sm text-slate-600">
                     Choose the best match for this claim.
                   </div>
@@ -2133,11 +2821,16 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       >
                         <div className="min-w-0">
                           <div className="text-sm font-medium text-slate-900">
-                            {splitRequirementLabel(candidate.requirementLabel).title}
+                            {
+                              splitRequirementLabel(candidate.requirementLabel)
+                                .title
+                            }
                           </div>
                           <div className="mt-1 text-xs text-slate-500">
-                            {candidate.methodologyId} · {candidate.methodologyVersion}
-                            {splitRequirementLabel(candidate.requirementLabel).id
+                            {candidate.methodologyId} ·{" "}
+                            {candidate.methodologyVersion}
+                            {splitRequirementLabel(candidate.requirementLabel)
+                              .id
                               ? ` · ${splitRequirementLabel(candidate.requirementLabel).id}`
                               : ""}
                           </div>
@@ -2162,16 +2855,26 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               role="status"
               aria-live="polite"
             >
-              <div className={`text-xs font-semibold uppercase tracking-[0.18em] ${resultEyebrowClass}`}>{resultTitle}</div>
-              <div className="mt-2 text-sm text-slate-600">{normalizedResult.claim}</div>
-              <div className="mt-2 text-sm text-slate-700">{resultSignalNote}</div>
+              <div
+                className={`text-xs font-semibold uppercase tracking-[0.18em] ${resultEyebrowClass}`}
+              >
+                {resultTitle}
+              </div>
+              <div className="mt-2 text-sm text-slate-600">
+                {normalizedResult.claim}
+              </div>
+              <div className="mt-2 text-sm text-slate-700">
+                {resultSignalNote}
+              </div>
               <div className="mt-4 rounded-xl border border-slate-200 bg-white/80 px-4 py-3">
                 <div className="text-sm text-slate-800">
                   {normalizedResult.match.rationale}
                 </div>
               </div>
               <div className="mt-3 flex items-center gap-3">
-                <span className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold ${extractionStateBadgeClass(normalizedResult.extractionState.value)}`}>
+                <span
+                  className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold ${extractionStateBadgeClass(normalizedResult.extractionState.value)}`}
+                >
                   {normalizedResult.extractionState.label} evidence signal
                 </span>
               </div>
@@ -2192,8 +2895,12 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       disabled={creatingProjectDraft}
                       className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 disabled:opacity-50"
                     >
-                      {creatingProjectDraft ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUpRight className="h-4 w-4" />}
-                      Create project from document
+                      {creatingProjectDraft ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <ArrowUpRight className="h-4 w-4" />
+                      )}
+                      Start Review
                     </button>
                   ) : null}
                 </div>
@@ -2201,11 +2908,16 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             </div>
           ) : null}
 
-          {!renderedResult && selectedEvidenceCount === 1 && activeSourceMode === "uploaded_file" ? (
+          {!renderedResult &&
+          selectedEvidenceCount === 1 &&
+          activeSourceMode === "uploaded_file" ? (
             <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
-              <div className="text-sm font-semibold text-slate-900">Project setup</div>
+              <div className="text-sm font-semibold text-slate-900">
+                Review detected details
+              </div>
               <div className="mt-1 text-sm text-slate-600">
-                Use the uploaded document to prefill a project draft before or after running the evidence check.
+                Use this document to detect project and method details, then
+                confirm before continuing.
               </div>
               <button
                 type="button"
@@ -2213,15 +2925,29 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 disabled={creatingProjectDraft}
                 className="mt-3 inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 disabled:opacity-50"
               >
-                {creatingProjectDraft ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUpRight className="h-4 w-4" />}
-                Create project from document
+                {creatingProjectDraft ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <ArrowUpRight className="h-4 w-4" />
+                )}
+                Start review from this document
               </button>
             </div>
           ) : null}
 
-          {(selectedMethodRecord && draft.methodologyVersion) || (methodologyResolution.status === "single" && !draft.methodologyId.trim()) ? (
+          {(selectedMethodRecord && draft.methodologyVersion) ||
+          (methodologyResolution.status === "single" &&
+            !draft.methodologyId.trim()) ? (
             <div className="text-xs text-slate-500" aria-live="polite">
-              Narrowing matches to {(selectedMethodRecord?.code ?? methodologyResolution.matchedMethods[0]?.methodologyId) ?? ""} · {(draft.methodologyVersion || methodologyResolution.matchedMethods[0]?.methodologyVersion) ?? ""}.
+              Narrowing matches to{" "}
+              {selectedMethodRecord?.code ??
+                methodologyResolution.matchedMethods[0]?.methodologyId ??
+                ""}{" "}
+              ·{" "}
+              {(draft.methodologyVersion ||
+                methodologyResolution.matchedMethods[0]?.methodologyVersion) ??
+                ""}
+              .
             </div>
           ) : null}
         </div>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -76,6 +76,7 @@ type QuickCheckPanelProps = {
   initialMethod?: string | null;
   initialVersion?: string | null;
   onContinueToWorkspace?: (url: string) => void;
+  collapseQuickEvidenceByDefault?: boolean;
 };
 
 type MatchCandidate = {
@@ -732,6 +733,7 @@ export default function QuickCheckPanel({
   initialMethod,
   initialVersion,
   onContinueToWorkspace,
+  collapseQuickEvidenceByDefault = false,
 }: QuickCheckPanelProps) {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const projectDocumentRef = useRef<HTMLInputElement | null>(null);
@@ -750,6 +752,9 @@ export default function QuickCheckPanel({
   const [pendingInventoryId, setPendingInventoryId] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showSavedEvidence, setShowSavedEvidence] = useState(false);
+  const [showQuickEvidenceCheck, setShowQuickEvidenceCheck] = useState(
+    !collapseQuickEvidenceByDefault,
+  );
   const [showMethodology, setShowMethodology] = useState(false);
   const [showExtractionDetails, setShowExtractionDetails] = useState(false);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(
@@ -771,6 +776,14 @@ export default function QuickCheckPanel({
   const draft = session.draft;
   const result = session.result;
   const stagedUploads = session.stagedUploads;
+
+  useEffect(() => {
+    if (!showQuickEvidenceCheck) return;
+    const timeoutId = window.setTimeout(() => {
+      claimRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(timeoutId);
+  }, [showQuickEvidenceCheck]);
 
   const inventoryItems = useMemo(
     () =>
@@ -2310,7 +2323,7 @@ export default function QuickCheckPanel({
             </button>
             <button
               type="button"
-              onClick={() => claimRef.current?.focus()}
+              onClick={() => setShowQuickEvidenceCheck(true)}
               className="text-sm font-semibold text-slate-600 underline underline-offset-4 transition hover:text-slate-900"
             >
               Run a quick evidence check instead
@@ -2318,6 +2331,7 @@ export default function QuickCheckPanel({
           </div>
         </div>
 
+        {showQuickEvidenceCheck ? (
         <div className="mt-8 grid gap-8">
           <div className="flex w-full items-start justify-between gap-4">
             <div>
@@ -3043,6 +3057,7 @@ export default function QuickCheckPanel({
             </div>
           ) : null}
         </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
 import MapCanvas from "@/components/map/MapCanvas";
 import AuditTrailPanel from "@/components/verifier/AuditTrailPanel";
 import DeltaImpactTasksPanel from "@/components/verify/DeltaImpactTasksPanel";
@@ -11,35 +18,78 @@ import ReviewSummaryCard from "@/components/verify/ReviewSummaryCard";
 import RunHistoryPanel from "@/components/verify/RunHistoryPanel";
 import RuleReadinessFacts from "@/components/verify/RuleReadinessFacts";
 import EvidenceWorkflowStepper from "@/components/verify/EvidenceWorkflowStepper";
-import VerifyReadinessStrip, { type VerifyReadinessChip } from "@/components/verify/VerifyReadinessStrip";
+import VerifyReadinessStrip, {
+  type VerifyReadinessChip,
+} from "@/components/verify/VerifyReadinessStrip";
 import type { AOI, EvidencePin, VerificationRun } from "@/lib/proofMap/types";
-import { aoiDeclaredAreaComparison, ensurePrimaryProjectAreaSelected, parseAoiGeoJson, resolvePrimaryAreaFeature, setAoiDeclaredArea, updateAoiFeatureRole } from "@/lib/proofMap/aoi";
+import {
+  aoiDeclaredAreaComparison,
+  ensurePrimaryProjectAreaSelected,
+  parseAoiGeoJson,
+  resolvePrimaryAreaFeature,
+  setAoiDeclaredArea,
+  updateAoiFeatureRole,
+} from "@/lib/proofMap/aoi";
 import type { ProofEvidenceItem } from "@/lib/proof/bundle";
 import Tooltip from "@/components/ui/Tooltip";
-import { createAndStoreEvidenceAttachment, deleteAttachmentBytes } from "@/lib/proofMap/attachments";
-import { aoiFingerprint, createQueuedVerificationRun, runInputFingerprint, runsForCurrentAoi, runStacEvidenceSearch, selectLatestNonQueuedRunForAoi, shouldDisableRunVerification } from "@/lib/proofMap/verificationRuns";
+import {
+  createAndStoreEvidenceAttachment,
+  deleteAttachmentBytes,
+} from "@/lib/proofMap/attachments";
+import {
+  aoiFingerprint,
+  createQueuedVerificationRun,
+  runInputFingerprint,
+  runsForCurrentAoi,
+  runStacEvidenceSearch,
+  selectLatestNonQueuedRunForAoi,
+  shouldDisableRunVerification,
+} from "@/lib/proofMap/verificationRuns";
 import type { Map as MapLibreMap } from "maplibre-gl";
 import selectLatestOkStacRunForActiveAoi from "@/lib/runs/selectLatestOkStacRunForActiveAoi";
 import normalizeStacItems from "@/lib/stac/normalizeStacItems";
-import { pickProvenanceFields, shortSha as shortCommitSha } from "@/lib/trustFormat";
+import {
+  pickProvenanceFields,
+  shortSha as shortCommitSha,
+} from "@/lib/trustFormat";
 import { canonicalJsonStringify } from "@/lib/export/canonicalJson";
 import { canonicalJsonStringify as canonicalAuditJsonStringify } from "@/lib/auditTrail/canonicalJson";
 import { sha256Hex as auditSha256Hex } from "@/lib/auditTrail/hash";
-import type { AuditTrailEvent, AuditTrailEventInput } from "@/lib/auditTrail/types";
+import type {
+  AuditTrailEvent,
+  AuditTrailEventInput,
+} from "@/lib/auditTrail/types";
 import deriveLinksFromProperties from "@/lib/proofMap/deriveLinksFromProperties";
 import { getWorkspaceWorkFlags } from "@/lib/proofMap/workspace";
 import getFeatureBbox from "@/lib/map/getFeatureBbox";
 import { bboxIntersects, centerFromBbox, unionBbox } from "@/lib/map/bbox";
 import { TICKETS_FEATURE_ENABLED } from "@/lib/flags";
 import { buildOutcomeSnapshot } from "@/lib/verify/snapshotExport";
-import { buildReviewSummary, type ReviewSummary } from "@/lib/verify/buildReviewSummary";
+import {
+  buildReviewSummary,
+  type ReviewSummary,
+} from "@/lib/verify/buildReviewSummary";
 import { buildReviewSummaryPdf } from "@/lib/verify/reviewSummaryPdf";
-import { buildFinalizedExportKpis, buildSelectedStacExport, prepareChecklistExport } from "@/lib/verify/finalizedExport";
+import {
+  buildFinalizedExportKpis,
+  buildSelectedStacExport,
+  prepareChecklistExport,
+} from "@/lib/verify/finalizedExport";
 import { buildStacSupportFactsState } from "@/lib/verify/stacSupportFacts";
 import { isStacEligible } from "@/lib/verify/stacEligibility";
-import { checkFinalizeGate, getAllReviews, getReview, REVIEW_STORE_EVENT, saveReview, type RuleReview } from "@/lib/verify/reviewStore";
+import {
+  checkFinalizeGate,
+  getAllReviews,
+  getReview,
+  REVIEW_STORE_EVENT,
+  saveReview,
+  type RuleReview,
+} from "@/lib/verify/reviewStore";
 import { suggestPddFragmentDraft } from "@/lib/verify/reviewSuggestion";
-import { buildRequirementCoverageRows, reconcileRequirement } from "@/app/m/_lib/requirementCoverage";
+import {
+  buildRequirementCoverageRows,
+  reconcileRequirement,
+} from "@/app/m/_lib/requirementCoverage";
 import { EXPECTED_EVIDENCE_LABELS } from "@/app/m/_lib/requirementCoverage";
 import { deriveRuleReadinessGaps } from "@/lib/readiness/gapEngine";
 import { buildClientReadinessReport } from "@/lib/readiness/clientReadinessReport";
@@ -58,9 +108,16 @@ import {
   upsertPddFragmentOnEvidencePin,
 } from "@/lib/evidence/inventory";
 import { computeMetrics } from "@/lib/evidence/metrics";
-import EvidenceQualityBadge, { ReconciliationConfidenceBadge } from "@/components/evidence/EvidenceQualityBadge";
+import EvidenceQualityBadge, {
+  ReconciliationConfidenceBadge,
+} from "@/components/evidence/EvidenceQualityBadge";
 import type { BaselineKey, BaselineRecord } from "@/lib/baseline/baselineStore";
-import { clearBaseline, getLatestBaselineForMethod, rotateBaseline, setBaseline } from "@/lib/baseline/baselineStore";
+import {
+  clearBaseline,
+  getLatestBaselineForMethod,
+  rotateBaseline,
+  setBaseline,
+} from "@/lib/baseline/baselineStore";
 import { computeUplift, isComparable } from "@/lib/baseline/uplift";
 import { addIntakeItem } from "@/lib/intake/storage";
 import { stageProjectDocumentDraftFromAttachment } from "@/lib/projects/documentMetadata";
@@ -112,15 +169,13 @@ type ProofMapTabProps = {
   draftAoi: AOI | null;
   evidencePins: EvidencePin[];
   verificationRuns: VerificationRun[];
-  stacEvidenceState:
-    | {
-        aoiFingerprint: string;
-        fc: GeoJSON.FeatureCollection;
-        itemsById: Record<string, unknown>;
-        runId: string;
-        source?: { type: "stac_url" | "unknown"; ref: string };
-      }
-    | null;
+  stacEvidenceState: {
+    aoiFingerprint: string;
+    fc: GeoJSON.FeatureCollection;
+    itemsById: Record<string, unknown>;
+    runId: string;
+    source?: { type: "stac_url" | "unknown"; ref: string };
+  } | null;
   selectedStacItemId: string | null;
   evidenceSnapshots?: ProofEvidenceItem[];
   onSetAoi: (aoi: AOI | null) => void;
@@ -129,22 +184,25 @@ type ProofMapTabProps = {
   onCancelDraftAoi: () => void;
   onUndoApplyAoi: () => void;
   applyToken: number;
-  onSetEvidencePins: (pins: EvidencePin[] | ((current: EvidencePin[]) => EvidencePin[])) => void;
+  onSetEvidencePins: (
+    pins: EvidencePin[] | ((current: EvidencePin[]) => EvidencePin[]),
+  ) => void;
   onSetVerificationRuns: (runs: VerificationRun[]) => void;
   onSetStacEvidenceState: (
-    next:
-      | {
-          aoiFingerprint: string;
-          fc: GeoJSON.FeatureCollection;
-          itemsById: Record<string, unknown>;
-          runId: string;
-          source?: { type: "stac_url" | "unknown"; ref: string };
-        }
-      | null,
+    next: {
+      aoiFingerprint: string;
+      fc: GeoJSON.FeatureCollection;
+      itemsById: Record<string, unknown>;
+      runId: string;
+      source?: { type: "stac_url" | "unknown"; ref: string };
+    } | null,
   ) => void;
   onSelectStacItemId: (id: string | null) => void;
   onStartOver: () => void;
-  onNavigateEvidence: (type: "rule" | "section", id: string) => Promise<boolean>;
+  onNavigateEvidence: (
+    type: "rule" | "section",
+    id: string,
+  ) => Promise<boolean>;
   ruleOptions?: Array<{ id: string; title: string }>;
   onSelectRuleId?: (ruleId: string | null) => void;
   onViewRule?: (ruleId: string) => void;
@@ -159,7 +217,14 @@ type ProofMapTabProps = {
     onJumpToRule: (ruleId: string) => void;
     onOpenEvidence: (url: string) => void;
   } | null;
-  onEvidenceSelectionChange?: (selection: { kind: "evidence"; id: string; ruleIds: string[]; sectionIds: string[] } | null) => void;
+  onEvidenceSelectionChange?: (
+    selection: {
+      kind: "evidence";
+      id: string;
+      ruleIds: string[];
+      sectionIds: string[];
+    } | null,
+  ) => void;
 };
 
 function formatNum(value: number): string {
@@ -177,7 +242,9 @@ function asTrimmedOrNull(value: string | null | undefined): string | null {
   return trimmed ? trimmed : null;
 }
 
-export function finalizedArtifactRuleId(artifact: EvidenceSnapshot | null): string | null {
+export function finalizedArtifactRuleId(
+  artifact: EvidenceSnapshot | null,
+): string | null {
   return (
     asTrimmedOrNull(artifact?.summary?.ruleId) ??
     asTrimmedOrNull(artifact?.outcome?.linkage.selectedRuleId) ??
@@ -197,11 +264,27 @@ export function finalizedArtifactMatchesContext(input: {
   const { artifact } = input;
   if (!artifact) return false;
   if (artifact.verifier?.finalizedState !== "finalized") return false;
-  if (asTrimmedOrNull(artifact.verifier?.finalizedAt) !== asTrimmedOrNull(input.finalizedAt)) return false;
-  if (asTrimmedOrNull(artifact.verifier?.runId) !== asTrimmedOrNull(input.runId)) return false;
-  if (asTrimmedOrNull(artifact.method.code) !== asTrimmedOrNull(input.methodCode)) return false;
-  if (asTrimmedOrNull(artifact.method.version) !== asTrimmedOrNull(input.version)) return false;
-  if (finalizedArtifactRuleId(artifact) !== asTrimmedOrNull(input.selectedRuleId)) return false;
+  if (
+    asTrimmedOrNull(artifact.verifier?.finalizedAt) !==
+    asTrimmedOrNull(input.finalizedAt)
+  )
+    return false;
+  if (
+    asTrimmedOrNull(artifact.verifier?.runId) !== asTrimmedOrNull(input.runId)
+  )
+    return false;
+  if (
+    asTrimmedOrNull(artifact.method.code) !== asTrimmedOrNull(input.methodCode)
+  )
+    return false;
+  if (
+    asTrimmedOrNull(artifact.method.version) !== asTrimmedOrNull(input.version)
+  )
+    return false;
+  if (
+    finalizedArtifactRuleId(artifact) !== asTrimmedOrNull(input.selectedRuleId)
+  )
+    return false;
   return true;
 }
 
@@ -219,7 +302,10 @@ function downloadJson(value: unknown, filename: string) {
 }
 
 function downloadBytes(bytes: Uint8Array, filename: string, mimeType: string) {
-  const blobPart = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  const blobPart = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
   const blob = new Blob([blobPart], { type: mimeType });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -236,11 +322,19 @@ function safeFilename(value: string): string {
   return trimmed.replace(/[^\w.\-]+/g, "_").slice(0, 64) || "unknown";
 }
 
-function clientReadinessReportId(methodCode: string, version: string, runId: string): string {
+function clientReadinessReportId(
+  methodCode: string,
+  version: string,
+  runId: string,
+): string {
   return `CRR-${safeFilename(methodCode)}-${safeFilename(version)}-${safeFilename(runId)}`;
 }
 
-function vvbWorkpaperReportId(methodCode: string, version: string, runId: string): string {
+function vvbWorkpaperReportId(
+  methodCode: string,
+  version: string,
+  runId: string,
+): string {
   return `VVB-WP-${safeFilename(methodCode)}-${safeFilename(version)}-${safeFilename(runId)}`;
 }
 
@@ -252,7 +346,10 @@ function inventoryHaystack(item: EvidenceInventoryItem): string {
     item.source_summary,
     item.provenance_summary,
     item.pdd_document?.file_name,
-    ...(item.workbook_assets ?? []).flatMap((asset) => [asset.file_name, asset.file_kind]),
+    ...(item.workbook_assets ?? []).flatMap((asset) => [
+      asset.file_name,
+      asset.file_kind,
+    ]),
   ]
     .filter(Boolean)
     .join(" ")
@@ -264,13 +361,43 @@ function inventoryMatchesExpectedEvidence(
   expectedType: keyof typeof EXPECTED_EVIDENCE_LABELS,
 ): boolean {
   const haystack = inventoryHaystack(item);
-  if (expectedType === "monitoring-report") return haystack.includes("monitoring report") || haystack.includes("monitoring-report");
-  if (expectedType === "spreadsheet-workbook") return haystack.includes("spreadsheet") || haystack.includes("workbook") || haystack.includes(".xlsx") || haystack.includes(".csv");
-  if (expectedType === "pdd") return haystack.includes("pdd") || haystack.includes("project design document");
-  if (expectedType === "gis") return haystack.includes("gis") || haystack.includes("satellite") || haystack.includes("stac") || haystack.includes("map evidence");
-  if (expectedType === "qa-qc-record") return haystack.includes("qa/qc") || haystack.includes("qa qc") || haystack.includes("qa-qc");
-  if (expectedType === "eligibility-proof") return haystack.includes("eligibility");
-  if (expectedType === "calculation-support") return haystack.includes("calculation") || haystack.includes("parameter") || haystack.includes("support");
+  if (expectedType === "monitoring-report")
+    return (
+      haystack.includes("monitoring report") ||
+      haystack.includes("monitoring-report")
+    );
+  if (expectedType === "spreadsheet-workbook")
+    return (
+      haystack.includes("spreadsheet") ||
+      haystack.includes("workbook") ||
+      haystack.includes(".xlsx") ||
+      haystack.includes(".csv")
+    );
+  if (expectedType === "pdd")
+    return (
+      haystack.includes("pdd") || haystack.includes("project design document")
+    );
+  if (expectedType === "gis")
+    return (
+      haystack.includes("gis") ||
+      haystack.includes("satellite") ||
+      haystack.includes("stac") ||
+      haystack.includes("map evidence")
+    );
+  if (expectedType === "qa-qc-record")
+    return (
+      haystack.includes("qa/qc") ||
+      haystack.includes("qa qc") ||
+      haystack.includes("qa-qc")
+    );
+  if (expectedType === "eligibility-proof")
+    return haystack.includes("eligibility");
+  if (expectedType === "calculation-support")
+    return (
+      haystack.includes("calculation") ||
+      haystack.includes("parameter") ||
+      haystack.includes("support")
+    );
   return item.link_state === "linked" || item.kind !== "stac-item";
 }
 
@@ -289,7 +416,13 @@ function parseBbox(value: unknown): [number, number, number, number] | null {
   const b = value[1];
   const c = value[2];
   const d = value[3];
-  if (typeof a !== "number" || typeof b !== "number" || typeof c !== "number" || typeof d !== "number") return null;
+  if (
+    typeof a !== "number" ||
+    typeof b !== "number" ||
+    typeof c !== "number" ||
+    typeof d !== "number"
+  )
+    return null;
   if (![a, b, c, d].every((n) => Number.isFinite(n))) return null;
   return [a, b, c, d];
 }
@@ -301,11 +434,17 @@ function formatLocalDateTime(iso: string): string {
   return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`;
 }
 
-function formatSnapshotSummaryTime(value: string | null | undefined): { label: string; title?: string } {
+function formatSnapshotSummaryTime(value: string | null | undefined): {
+  label: string;
+  title?: string;
+} {
   if (!value) return { label: "Not exported" };
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return { label: "Exported", title: value };
-  const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  const time = date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
   return { label: `Exported ${time}`, title: date.toISOString() };
 }
 
@@ -317,12 +456,20 @@ function inventoryLinkStateLabel(linkedRequirementIds: string[]): string {
 
 function inventoryRelationshipSummary(linkedRequirementIds: string[]): string {
   if (!linkedRequirementIds.length) return "Not linked yet";
-  if (linkedRequirementIds.length === 1) return `Linked to ${linkedRequirementIds[0]}`;
+  if (linkedRequirementIds.length === 1)
+    return `Linked to ${linkedRequirementIds[0]}`;
   return `Linked to ${linkedRequirementIds.join(", ")}`;
 }
 
-function formatPddPageLabel(pageStart?: number, pageEnd?: number): string | null {
-  if (typeof pageStart === "number" && typeof pageEnd === "number" && pageStart !== pageEnd) {
+function formatPddPageLabel(
+  pageStart?: number,
+  pageEnd?: number,
+): string | null {
+  if (
+    typeof pageStart === "number" &&
+    typeof pageEnd === "number" &&
+    pageStart !== pageEnd
+  ) {
     return `p. ${pageStart}-${pageEnd}`;
   }
   if (typeof pageStart === "number") return `p. ${pageStart}`;
@@ -350,7 +497,14 @@ const EMPTY_PDD_FRAGMENT_DRAFT: PddFragmentDraft = {
 
 function isEmptyPddFragmentDraft(draft: PddFragmentDraft | undefined): boolean {
   if (!draft) return true;
-  return !draft.label.trim() && !draft.pageStart.trim() && !draft.pageEnd.trim() && !draft.sectionLabel.trim() && !draft.sectionHeading.trim() && !draft.excerpt.trim();
+  return (
+    !draft.label.trim() &&
+    !draft.pageStart.trim() &&
+    !draft.pageEnd.trim() &&
+    !draft.sectionLabel.trim() &&
+    !draft.sectionHeading.trim() &&
+    !draft.excerpt.trim()
+  );
 }
 
 function formatPddFragmentDisplayLabel(fragment: {
@@ -359,12 +513,18 @@ function formatPddFragmentDisplayLabel(fragment: {
   section_label?: string;
   fragment_id: string;
 }): string {
-  return fragment.label?.trim() || fragment.section_heading?.trim() || fragment.section_label?.trim() || fragment.fragment_id;
+  return (
+    fragment.label?.trim() ||
+    fragment.section_heading?.trim() ||
+    fragment.section_label?.trim() ||
+    fragment.fragment_id
+  );
 }
 
 function formatDelta(value: number, suffix = "", digits = 0): string {
   const sign = value > 0 ? "+" : value < 0 ? "" : "";
-  const rounded = digits > 0 ? value.toFixed(digits) : String(Math.trunc(value));
+  const rounded =
+    digits > 0 ? value.toFixed(digits) : String(Math.trunc(value));
   return `${sign}${rounded}${suffix}`;
 }
 
@@ -382,7 +542,11 @@ function extractItemIdsFromRuns(runs: VerificationRun[]): string[] {
   return [];
 }
 
-function zoomToBbox(map: MapLibreMap | null, bbox: [number, number, number, number] | null, padding = 70) {
+function zoomToBbox(
+  map: MapLibreMap | null,
+  bbox: [number, number, number, number] | null,
+  padding = 70,
+) {
   if (!map?.fitBounds) return;
   if (!bbox) return;
   try {
@@ -416,12 +580,34 @@ function asNonEmptyString(value: unknown): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
-function statusPill(status: VerificationRun["status"]): { label: string; className: string } {
-  if (status === "ok") return { label: "OK", className: "bg-emerald-50 text-emerald-700 border-emerald-200" };
-  if (status === "warn") return { label: "WARN", className: "bg-amber-50 text-amber-800 border-amber-200" };
-  if (status === "fail") return { label: "FAIL", className: "bg-rose-50 text-rose-700 border-rose-200" };
-  if (status === "queued") return { label: "QUEUED", className: "bg-slate-50 text-slate-700 border-slate-200" };
-  return { label: "ERROR", className: "bg-rose-50 text-rose-700 border-rose-200" };
+function statusPill(status: VerificationRun["status"]): {
+  label: string;
+  className: string;
+} {
+  if (status === "ok")
+    return {
+      label: "OK",
+      className: "bg-emerald-50 text-emerald-700 border-emerald-200",
+    };
+  if (status === "warn")
+    return {
+      label: "WARN",
+      className: "bg-amber-50 text-amber-800 border-amber-200",
+    };
+  if (status === "fail")
+    return {
+      label: "FAIL",
+      className: "bg-rose-50 text-rose-700 border-rose-200",
+    };
+  if (status === "queued")
+    return {
+      label: "QUEUED",
+      className: "bg-slate-50 text-slate-700 border-slate-200",
+    };
+  return {
+    label: "ERROR",
+    className: "bg-rose-50 text-rose-700 border-rose-200",
+  };
 }
 
 export default function ProofMapTab({
@@ -473,10 +659,16 @@ export default function ProofMapTab({
   const [snapshot, setSnapshot] = useState<ProofEvidenceItem | null>(null);
   const [runJson, setRunJson] = useState<VerificationRun | null>(null);
   const [isRunning, setIsRunning] = useState(false);
-  const [currentAoiFingerprint, setCurrentAoiFingerprint] = useState<string | null>(null);
+  const [currentAoiFingerprint, setCurrentAoiFingerprint] = useState<
+    string | null
+  >(null);
   const [confirmedAoiKey, setConfirmedAoiKey] = useState<string | null>(null);
-  const [currentAoiHashForCompare, setCurrentAoiHashForCompare] = useState<string | null>(null);
-  const [draftAoiFingerprint, setDraftAoiFingerprint] = useState<string | null>(null);
+  const [currentAoiHashForCompare, setCurrentAoiHashForCompare] = useState<
+    string | null
+  >(null);
+  const [draftAoiFingerprint, setDraftAoiFingerprint] = useState<string | null>(
+    null,
+  );
   const [showSameAoiPrompt, setShowSameAoiPrompt] = useState(false);
   const [declaredAreaInput, setDeclaredAreaInput] = useState("");
   const [draftTask, setDraftTask] = useState("");
@@ -486,18 +678,28 @@ export default function ProofMapTab({
   const mapRef = useRef<MapLibreMap | null>(null);
   const [mapReadyTick, setMapReadyTick] = useState(0);
   const [stacCentroidsEnabled, setStacCentroidsEnabled] = useState(true);
-  const [viewportBbox, setViewportBbox] = useState<[number, number, number, number] | null>(null);
+  const [viewportBbox, setViewportBbox] = useState<
+    [number, number, number, number] | null
+  >(null);
   const stacEvidenceCardRef = useRef<HTMLDivElement | null>(null);
   const [stacInspectOpen, setStacInspectOpen] = useState(false);
-  const [lastSelectionSource, setLastSelectionSource] = useState<"pin" | "polygon" | null>(null);
+  const [lastSelectionSource, setLastSelectionSource] = useState<
+    "pin" | "polygon" | null
+  >(null);
   const lastAoiSelectionResetKeyRef = useRef<string | null>(null);
   const [startOverOpen, setStartOverOpen] = useState(false);
   const [startOverBusy, setStartOverBusy] = useState(false);
   const [panelCollapsed, setPanelCollapsed] = useState(false);
-  const [verifierBundle, setVerifierBundle] = useState(() => readVerifierRunBundle(methodCode, version, workspaceId));
-  const [runHistory, setRunHistory] = useState(() => readRunHistory(methodCode, version, workspaceId));
+  const [verifierBundle, setVerifierBundle] = useState(() =>
+    readVerifierRunBundle(methodCode, version, workspaceId),
+  );
+  const [runHistory, setRunHistory] = useState(() =>
+    readRunHistory(methodCode, version, workspaceId),
+  );
   const [baselineTick, setBaselineTick] = useState(0);
-  const [currentInputFingerprint, setCurrentInputFingerprint] = useState<string | null>(null);
+  const [currentInputFingerprint, setCurrentInputFingerprint] = useState<
+    string | null
+  >(null);
   const [secondarySectionOpen, setSecondarySectionOpen] = useState(false);
   const [runHistoryOpen, setRunHistoryOpen] = useState(false);
   const [outcomeOpen, setOutcomeOpen] = useState(false);
@@ -509,17 +711,28 @@ export default function ProofMapTab({
     expectedEvidence: string[];
     tags: string[];
   } | null>(null);
-  const [reviewArtifact, setReviewArtifact] = useState<EvidenceSnapshot | null>(null);
+  const [reviewArtifact, setReviewArtifact] = useState<EvidenceSnapshot | null>(
+    null,
+  );
   const [reviewPdfBusy, setReviewPdfBusy] = useState(false);
   const [reviewPdfError, setReviewPdfError] = useState<string | null>(null);
-  const [clientReadinessExportBusy, setClientReadinessExportBusy] = useState(false);
-  const [clientReadinessExportError, setClientReadinessExportError] = useState<string | null>(null);
+  const [clientReadinessExportBusy, setClientReadinessExportBusy] =
+    useState(false);
+  const [clientReadinessExportError, setClientReadinessExportError] = useState<
+    string | null
+  >(null);
   const [vvbWorkpaperExportBusy, setVvbWorkpaperExportBusy] = useState(false);
-  const [vvbWorkpaperExportError, setVvbWorkpaperExportError] = useState<string | null>(null);
+  const [vvbWorkpaperExportError, setVvbWorkpaperExportError] = useState<
+    string | null
+  >(null);
   const uploadAoiInputRef = useRef<HTMLInputElement | null>(null);
   const uploadPddInputRef = useRef<HTMLInputElement | null>(null);
-  const [pddFragmentDrafts, setPddFragmentDrafts] = useState<Record<string, PddFragmentDraft>>({});
-  const [initialViewportBbox, setInitialViewportBbox] = useState<[number, number, number, number] | null>(() => {
+  const [pddFragmentDrafts, setPddFragmentDrafts] = useState<
+    Record<string, PddFragmentDraft>
+  >({});
+  const [initialViewportBbox, setInitialViewportBbox] = useState<
+    [number, number, number, number] | null
+  >(() => {
     if (typeof window === "undefined") return null;
     const raw = new URLSearchParams(window.location.search).get("bbox");
     if (!raw) return null;
@@ -531,7 +744,11 @@ export default function ProofMapTab({
 
   useEffect(() => {
     const declaredArea = aoi?.declared_area_km2;
-    setDeclaredAreaInput(typeof declaredArea === "number" && Number.isFinite(declaredArea) ? String(declaredArea) : "");
+    setDeclaredAreaInput(
+      typeof declaredArea === "number" && Number.isFinite(declaredArea)
+        ? String(declaredArea)
+        : "",
+    );
   }, [aoi?.declared_area_km2, aoi?.id]);
 
   const currentAoiConfirmationKey = useMemo(() => {
@@ -550,8 +767,12 @@ export default function ProofMapTab({
     });
   }, [aoi, currentAoiFingerprint]);
 
-  const hasConfirmedArea = Boolean(currentAoiConfirmationKey && confirmedAoiKey === currentAoiConfirmationKey);
-  const confirmedAoiFingerprint = hasConfirmedArea ? currentAoiFingerprint : null;
+  const hasConfirmedArea = Boolean(
+    currentAoiConfirmationKey && confirmedAoiKey === currentAoiConfirmationKey,
+  );
+  const confirmedAoiFingerprint = hasConfirmedArea
+    ? currentAoiFingerprint
+    : null;
 
   useEffect(() => {
     if (!pendingAutoConfirmAoiRef.current) return;
@@ -559,26 +780,48 @@ export default function ProofMapTab({
     setConfirmedAoiKey(currentAoiConfirmationKey);
     pendingAutoConfirmAoiRef.current = false;
   }, [currentAoiConfirmationKey]);
-  const viewStorageKey = useMemo(() => `${methodCode}@${version}`, [methodCode, version]);
-  const linkedRuleIds = useMemo(() => linkedRuleIdsFromPins(evidencePins), [evidencePins]);
-  const linkedPinsCount = useMemo(
-    () => evidencePins.filter((pin) => linkedRuleIdsFromPins([pin]).length > 0).length,
+  const viewStorageKey = useMemo(
+    () => `${methodCode}@${version}`,
+    [methodCode, version],
+  );
+  const linkedRuleIds = useMemo(
+    () => linkedRuleIdsFromPins(evidencePins),
     [evidencePins],
   );
-  const evidenceInventory = useMemo(() => buildEvidenceInventory(evidencePins), [evidencePins]);
-  const evidenceMetrics = useMemo(() => computeMetrics({ inventoryItems: evidenceInventory }), [evidenceInventory]);
+  const linkedPinsCount = useMemo(
+    () =>
+      evidencePins.filter((pin) => linkedRuleIdsFromPins([pin]).length > 0)
+        .length,
+    [evidencePins],
+  );
+  const evidenceInventory = useMemo(
+    () => buildEvidenceInventory(evidencePins),
+    [evidencePins],
+  );
+  const evidenceMetrics = useMemo(
+    () => computeMetrics({ inventoryItems: evidenceInventory }),
+    [evidenceInventory],
+  );
   const qualityByEvidenceId = useMemo(
-    () => new Map(evidenceMetrics.fragmentQualities.map((q) => [q.evidenceId, q])),
+    () =>
+      new Map(evidenceMetrics.fragmentQualities.map((q) => [q.evidenceId, q])),
     [evidenceMetrics],
   );
-  const evidencePinsById = useMemo(() => new Map(evidencePins.map((pin) => [pin.id, pin])), [evidencePins]);
+  const evidencePinsById = useMemo(
+    () => new Map(evidencePins.map((pin) => [pin.id, pin])),
+    [evidencePins],
+  );
   const selectedRuleId = activeRuleId ?? null;
 
   const showToast = useCallback((message: string | ToastState) => {
     const next = typeof message === "string" ? { title: message } : message;
     setToast(next);
     window.setTimeout(() => {
-      setToast((current) => (current?.title === next.title && current?.subtitle === next.subtitle ? null : current));
+      setToast((current) =>
+        current?.title === next.title && current?.subtitle === next.subtitle
+          ? null
+          : current,
+      );
     }, 1600);
   }, []);
 
@@ -598,8 +841,14 @@ export default function ProofMapTab({
       };
     }
     const cited_ids = evidencePins.flatMap((pin) => pin.cited_ids ?? []);
-    const attachment_sha256 = evidencePins.flatMap((pin) => (pin.attachments ?? []).map((att) => att.sha256));
-    runInputFingerprint({ aoi_fp: currentAoiFingerprint, cited_ids, attachment_sha256 })
+    const attachment_sha256 = evidencePins.flatMap((pin) =>
+      (pin.attachments ?? []).map((att) => att.sha256),
+    );
+    runInputFingerprint({
+      aoi_fp: currentAoiFingerprint,
+      cited_ids,
+      attachment_sha256,
+    })
       .then((hash) => {
         if (active) setCurrentInputFingerprint(hash);
       })
@@ -611,14 +860,17 @@ export default function ProofMapTab({
     };
   }, [currentAoiFingerprint, evidencePins]);
 
-  const copyToClipboard = useCallback(async (value: string) => {
-    try {
-      await navigator.clipboard.writeText(value);
-      showToast("Copied");
-    } catch {
-      showToast("Copy failed");
-    }
-  }, [showToast]);
+  const copyToClipboard = useCallback(
+    async (value: string) => {
+      try {
+        await navigator.clipboard.writeText(value);
+        showToast("Copied");
+      } catch {
+        showToast("Copy failed");
+      }
+    },
+    [showToast],
+  );
 
   const fetchSelectedRuleContext = useCallback(
     async (ruleId: string | null) => {
@@ -637,7 +889,9 @@ export default function ProofMapTab({
           { cache: "no-store" },
         );
         if (!ruleResponse.ok) return fallback;
-        const rulePayload = (await ruleResponse.json()) as { rule?: Record<string, unknown> };
+        const rulePayload = (await ruleResponse.json()) as {
+          rule?: Record<string, unknown>;
+        };
         const ruleRecord = rulePayload.rule;
         if (!ruleRecord || typeof ruleRecord !== "object") return fallback;
         const sectionId = asNonEmptyString(ruleRecord.sectionId) ?? null;
@@ -649,10 +903,16 @@ export default function ProofMapTab({
               { cache: "no-store" },
             );
             if (sectionsResponse.ok) {
-              const sectionsPayload = (await sectionsResponse.json()) as { sections?: Array<Record<string, unknown>> };
+              const sectionsPayload = (await sectionsResponse.json()) as {
+                sections?: Array<Record<string, unknown>>;
+              };
               const match =
-                sectionsPayload.sections?.find((item) => asNonEmptyString(item.id) === sectionId) ?? null;
-              sectionTitle = match ? asNonEmptyString(match.title) ?? sectionId : sectionId;
+                sectionsPayload.sections?.find(
+                  (item) => asNonEmptyString(item.id) === sectionId,
+                ) ?? null;
+              sectionTitle = match
+                ? (asNonEmptyString(match.title) ?? sectionId)
+                : sectionId;
             } else {
               sectionTitle = sectionId;
             }
@@ -666,18 +926,39 @@ export default function ProofMapTab({
           sectionId,
           sectionTitle,
           expectedEvidence: Array.isArray(ruleRecord.expectedEvidence)
-            ? ruleRecord.expectedEvidence.filter((value): value is string => typeof value === "string")
-            : Array.isArray((ruleRecord.requirement_coverage as { expected_evidence?: unknown } | undefined)?.expected_evidence)
-              ? ((ruleRecord.requirement_coverage as { expected_evidence?: unknown[] }).expected_evidence ?? []).filter(
-                  (value): value is string => typeof value === "string",
+            ? ruleRecord.expectedEvidence.filter(
+                (value): value is string => typeof value === "string",
+              )
+            : Array.isArray(
+                  (
+                    ruleRecord.requirement_coverage as
+                      | { expected_evidence?: unknown }
+                      | undefined
+                  )?.expected_evidence,
                 )
+              ? (
+                  (
+                    ruleRecord.requirement_coverage as {
+                      expected_evidence?: unknown[];
+                    }
+                  ).expected_evidence ?? []
+                ).filter((value): value is string => typeof value === "string")
               : [],
           tags: Array.isArray(ruleRecord.tags)
-            ? ruleRecord.tags.filter((value): value is string => typeof value === "string")
-            : Array.isArray((ruleRecord.requirement_coverage as { tags?: unknown } | undefined)?.tags)
-              ? ((ruleRecord.requirement_coverage as { tags?: unknown[] }).tags ?? []).filter(
-                  (value): value is string => typeof value === "string",
+            ? ruleRecord.tags.filter(
+                (value): value is string => typeof value === "string",
+              )
+            : Array.isArray(
+                  (
+                    ruleRecord.requirement_coverage as
+                      | { tags?: unknown }
+                      | undefined
+                  )?.tags,
                 )
+              ? (
+                  (ruleRecord.requirement_coverage as { tags?: unknown[] })
+                    .tags ?? []
+                ).filter((value): value is string => typeof value === "string")
               : [],
         };
       } catch {
@@ -708,7 +989,12 @@ export default function ProofMapTab({
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      persistVerifierRunBundle(methodCode, version, verifierBundle, workspaceId);
+      persistVerifierRunBundle(
+        methodCode,
+        version,
+        verifierBundle,
+        workspaceId,
+      );
     }, 300);
     return () => window.clearTimeout(timer);
   }, [methodCode, verifierBundle, version, workspaceId]);
@@ -723,22 +1009,49 @@ export default function ProofMapTab({
         ruleId: selectedRuleId,
         runId: verifierBundle.runContext.runId,
       }),
-    [methodCode, selectedRuleId, verifierBundle.runContext.runId, version, workspaceId],
+    [
+      methodCode,
+      selectedRuleId,
+      verifierBundle.runContext.runId,
+      version,
+      workspaceId,
+    ],
   );
   const activeRuleReview = useMemo<RuleReview | null>(() => {
     void reviewGateVersion;
     if (!selectedRuleId) return null;
-    return getReview(selectedRuleId, methodCode, version, workspaceId, verifierBundle.runContext.runId);
-  }, [methodCode, reviewGateVersion, selectedRuleId, verifierBundle.runContext.runId, version, workspaceId]);
+    return getReview(
+      selectedRuleId,
+      methodCode,
+      version,
+      workspaceId,
+      verifierBundle.runContext.runId,
+    );
+  }, [
+    methodCode,
+    reviewGateVersion,
+    selectedRuleId,
+    verifierBundle.runContext.runId,
+    version,
+    workspaceId,
+  ]);
 
   useEffect(() => {
     setVerifierBundle((current) => {
-      if (reviewerArtifactContextMatches(current.reviewerContext, currentReviewerContext)) return current;
+      if (
+        reviewerArtifactContextMatches(
+          current.reviewerContext,
+          currentReviewerContext,
+        )
+      )
+        return current;
       const scopedState = readReviewerArtifactState(currentReviewerContext);
       return {
         ...current,
         reviewerContext: currentReviewerContext,
-        savedReviewerArtifactContext: scopedState?.savedReviewerArtifactAt ? scopedState.context : null,
+        savedReviewerArtifactContext: scopedState?.savedReviewerArtifactAt
+          ? scopedState.context
+          : null,
         minutes: scopedState?.minutes ?? "",
         outcomeNote: scopedState?.outcomeNote ?? "",
         draftMinutes: scopedState?.draftMinutes ?? "",
@@ -751,8 +1064,15 @@ export default function ProofMapTab({
   useEffect(() => {
     if (!selectedRuleId) return;
     setVerifierBundle((current) => {
-      if (!reviewerArtifactContextMatches(current.reviewerContext, currentReviewerContext)) return current;
-      const savedReviewerArtifactAt = activeRuleReview?.reviewerArtifactSavedAt ?? null;
+      if (
+        !reviewerArtifactContextMatches(
+          current.reviewerContext,
+          currentReviewerContext,
+        )
+      )
+        return current;
+      const savedReviewerArtifactAt =
+        activeRuleReview?.reviewerArtifactSavedAt ?? null;
       const minutes = activeRuleReview?.reviewerMinutes ?? "";
       const outcomeNote = activeRuleReview?.reviewerOutcomeNote ?? "";
       if (
@@ -766,7 +1086,9 @@ export default function ProofMapTab({
       }
       return {
         ...current,
-        savedReviewerArtifactContext: savedReviewerArtifactAt ? currentReviewerContext : null,
+        savedReviewerArtifactContext: savedReviewerArtifactAt
+          ? currentReviewerContext
+          : null,
         savedReviewerArtifactAt,
         minutes,
         outcomeNote,
@@ -781,7 +1103,10 @@ export default function ProofMapTab({
       context: verifierBundle.reviewerContext,
       savedReviewerArtifactAt:
         verifierBundle.savedReviewerArtifactContext &&
-        reviewerArtifactContextMatches(verifierBundle.savedReviewerArtifactContext, verifierBundle.reviewerContext)
+        reviewerArtifactContextMatches(
+          verifierBundle.savedReviewerArtifactContext,
+          verifierBundle.reviewerContext,
+        )
           ? verifierBundle.savedReviewerArtifactAt
           : null,
       minutes: verifierBundle.minutes,
@@ -802,18 +1127,30 @@ export default function ProofMapTab({
   const markBundleEdited = useCallback(
     (
       current: typeof verifierBundle,
-      options: { invalidateFinality?: boolean; clearSavedReviewerArtifact?: boolean } = {},
+      options: {
+        invalidateFinality?: boolean;
+        clearSavedReviewerArtifact?: boolean;
+      } = {},
     ) => {
       const invalidateFinality = options.invalidateFinality ?? false;
-      const clearSavedReviewerArtifact = options.clearSavedReviewerArtifact ?? invalidateFinality;
+      const clearSavedReviewerArtifact =
+        options.clearSavedReviewerArtifact ?? invalidateFinality;
       return {
         ...current,
         isEditedDraft:
           current.isEditedDraft ||
-          Boolean(current.loadedFromRunId || current.derivedFromRunId || current.exportedAt),
+          Boolean(
+            current.loadedFromRunId ||
+            current.derivedFromRunId ||
+            current.exportedAt,
+          ),
         exportedAt: invalidateFinality ? null : current.exportedAt,
-        savedReviewerArtifactAt: clearSavedReviewerArtifact ? null : current.savedReviewerArtifactAt,
-        savedReviewerArtifactContext: clearSavedReviewerArtifact ? null : current.savedReviewerArtifactContext,
+        savedReviewerArtifactAt: clearSavedReviewerArtifact
+          ? null
+          : current.savedReviewerArtifactAt,
+        savedReviewerArtifactContext: clearSavedReviewerArtifact
+          ? null
+          : current.savedReviewerArtifactContext,
         finalizedAt: invalidateFinality ? null : current.finalizedAt,
         minutes: clearSavedReviewerArtifact ? "" : current.minutes,
         outcomeNote: clearSavedReviewerArtifact ? "" : current.outcomeNote,
@@ -828,7 +1165,12 @@ export default function ProofMapTab({
       draftMinutes: value,
       isEditedDraft:
         current.isEditedDraft ||
-        (value !== current.minutes && Boolean(current.loadedFromRunId || current.derivedFromRunId || current.exportedAt)),
+        (value !== current.minutes &&
+          Boolean(
+            current.loadedFromRunId ||
+            current.derivedFromRunId ||
+            current.exportedAt,
+          )),
     }));
   }, []);
 
@@ -839,7 +1181,11 @@ export default function ProofMapTab({
       isEditedDraft:
         current.isEditedDraft ||
         (value !== current.outcomeNote &&
-          Boolean(current.loadedFromRunId || current.derivedFromRunId || current.exportedAt)),
+          Boolean(
+            current.loadedFromRunId ||
+            current.derivedFromRunId ||
+            current.exportedAt,
+          )),
     }));
   }, []);
 
@@ -848,7 +1194,9 @@ export default function ProofMapTab({
     const savedAt = new Date().toISOString();
     let nextReview: RuleReview | null = null;
     setVerifierBundle((current) => {
-      const hasSavedArtifact = Boolean(current.draftMinutes.trim() || current.draftOutcomeNote.trim());
+      const hasSavedArtifact = Boolean(
+        current.draftMinutes.trim() || current.draftOutcomeNote.trim(),
+      );
       const reviewerContext = createReviewerArtifactContext({
         methodCode,
         version,
@@ -883,13 +1231,28 @@ export default function ProofMapTab({
         savedReviewerArtifactAt: hasSavedArtifact ? savedAt : null,
         isEditedDraft:
           current.isEditedDraft ||
-          ((current.draftMinutes !== current.minutes || current.draftOutcomeNote !== current.outcomeNote) &&
-            Boolean(current.loadedFromRunId || current.derivedFromRunId || current.exportedAt)),
+          ((current.draftMinutes !== current.minutes ||
+            current.draftOutcomeNote !== current.outcomeNote) &&
+            Boolean(
+              current.loadedFromRunId ||
+              current.derivedFromRunId ||
+              current.exportedAt,
+            )),
       };
     });
     if (nextReview) saveReview(nextReview);
-    showToast({ title: "Reviewer artifact saved", subtitle: "Saved text now counts for run completion" });
-  }, [activeRuleReview, methodCode, selectedRuleId, showToast, version, workspaceId]);
+    showToast({
+      title: "Reviewer artifact saved",
+      subtitle: "Saved text now counts for run completion",
+    });
+  }, [
+    activeRuleReview,
+    methodCode,
+    selectedRuleId,
+    showToast,
+    version,
+    workspaceId,
+  ]);
 
   const handleUploadAoiChange = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -900,7 +1263,10 @@ export default function ProofMapTab({
       try {
         const text = await file.text();
         const parsed = JSON.parse(text) as unknown;
-        const result = parseAoiGeoJson(parsed, file.name.replace(/\.(geojson|json)$/i, ""));
+        const result = parseAoiGeoJson(
+          parsed,
+          file.name.replace(/\.(geojson|json)$/i, ""),
+        );
         if (!result.ok) {
           setError(result.error);
           return;
@@ -917,31 +1283,58 @@ export default function ProofMapTab({
             // ignore hash failures
           }
         }
-        setVerifierBundle((current) => markBundleEdited(current, { invalidateFinality: true }));
+        setVerifierBundle((current) =>
+          markBundleEdited(current, { invalidateFinality: true }),
+        );
         onSelectStacItemId(null);
-        pendingAutoConfirmAoiRef.current = resolved.ok && resolved.status === "confirmed";
+        pendingAutoConfirmAoiRef.current =
+          resolved.ok && resolved.status === "confirmed";
         if (!resolved.ok) setConfirmedAoiKey(null);
         onUploadAoi(resolved.aoi);
         if (resolved.ok) {
           setError(null);
-          showToast({ title: "Primary project area detected. Review or confirm to continue." });
+          showToast({
+            title:
+              "Primary project area detected. Review or confirm to continue.",
+          });
         } else if (!ensurePrimaryProjectAreaSelected(resolved.aoi)) {
-          setError(resolved.error ?? "Select exactly one primary project area feature to continue.");
+          setError(
+            resolved.error ??
+              "Select exactly one primary project area feature to continue.",
+          );
         }
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
       }
     },
-    [markBundleEdited, onAuditEvent, onSelectStacItemId, onUploadAoi, showToast],
+    [
+      markBundleEdited,
+      onAuditEvent,
+      onSelectStacItemId,
+      onUploadAoi,
+      showToast,
+    ],
   );
 
-  const handleDeltaChange = useCallback((value: string) => {
-    setVerifierBundle((current) => ({ ...markBundleEdited(current, { invalidateFinality: true }), delta: value }));
-  }, [markBundleEdited]);
+  const handleDeltaChange = useCallback(
+    (value: string) => {
+      setVerifierBundle((current) => ({
+        ...markBundleEdited(current, { invalidateFinality: true }),
+        delta: value,
+      }));
+    },
+    [markBundleEdited],
+  );
 
-  const handleImpactChange = useCallback((value: string) => {
-    setVerifierBundle((current) => ({ ...markBundleEdited(current, { invalidateFinality: true }), impact: value }));
-  }, [markBundleEdited]);
+  const handleImpactChange = useCallback(
+    (value: string) => {
+      setVerifierBundle((current) => ({
+        ...markBundleEdited(current, { invalidateFinality: true }),
+        impact: value,
+      }));
+    },
+    [markBundleEdited],
+  );
 
   const commitDraftTask = useCallback(() => {
     const text = draftTask.trim();
@@ -962,32 +1355,45 @@ export default function ProofMapTab({
     });
   }, []);
 
-  const handleToggleTask = useCallback((id: string) => {
-    const timestamp = new Date().toISOString();
-    setVerifierBundle((current) => ({
-      ...markBundleEdited(current, { invalidateFinality: true }),
-      tasks: current.tasks.map((task) =>
-        task.id === id ? { ...task, done: !task.done, updatedAt: timestamp } : task,
-      ),
-    }));
-  }, [markBundleEdited]);
+  const handleToggleTask = useCallback(
+    (id: string) => {
+      const timestamp = new Date().toISOString();
+      setVerifierBundle((current) => ({
+        ...markBundleEdited(current, { invalidateFinality: true }),
+        tasks: current.tasks.map((task) =>
+          task.id === id
+            ? { ...task, done: !task.done, updatedAt: timestamp }
+            : task,
+        ),
+      }));
+    },
+    [markBundleEdited],
+  );
 
-  const handleUpdateTask = useCallback((id: string, value: string) => {
-    const timestamp = new Date().toISOString();
-    setVerifierBundle((current) => ({
-      ...markBundleEdited(current, { invalidateFinality: true }),
-      tasks: current.tasks.map((task) =>
-        task.id === id ? { ...task, text: value, updatedAt: timestamp } : task,
-      ),
-    }));
-  }, [markBundleEdited]);
+  const handleUpdateTask = useCallback(
+    (id: string, value: string) => {
+      const timestamp = new Date().toISOString();
+      setVerifierBundle((current) => ({
+        ...markBundleEdited(current, { invalidateFinality: true }),
+        tasks: current.tasks.map((task) =>
+          task.id === id
+            ? { ...task, text: value, updatedAt: timestamp }
+            : task,
+        ),
+      }));
+    },
+    [markBundleEdited],
+  );
 
-  const handleDeleteTask = useCallback((id: string) => {
-    setVerifierBundle((current) => ({
-      ...markBundleEdited(current, { invalidateFinality: true }),
-      tasks: current.tasks.filter((task) => task.id !== id),
-    }));
-  }, [markBundleEdited]);
+  const handleDeleteTask = useCallback(
+    (id: string) => {
+      setVerifierBundle((current) => ({
+        ...markBundleEdited(current, { invalidateFinality: true }),
+        tasks: current.tasks.filter((task) => task.id !== id),
+      }));
+    },
+    [markBundleEdited],
+  );
 
   const buildHistoryBundle = useCallback(() => {
     return {
@@ -1015,13 +1421,30 @@ export default function ProofMapTab({
       verificationRuns,
       selectedStacItemId,
     };
-  }, [aoi, evidencePins, linkedRuleIds, selectedRuleId, selectedStacItemId, verificationRuns, verifierBundle]);
+  }, [
+    aoi,
+    evidencePins,
+    linkedRuleIds,
+    selectedRuleId,
+    selectedStacItemId,
+    verificationRuns,
+    verifierBundle,
+  ]);
 
-  const currentWorkspaceBundle = useMemo(() => buildHistoryBundle(), [buildHistoryBundle]);
+  const currentWorkspaceBundle = useMemo(
+    () => buildHistoryBundle(),
+    [buildHistoryBundle],
+  );
   const currentRunId = verifierBundle.runContext.runId;
   const currentRunLabel = shortRunId(currentRunId);
-  const loadedFromRunLabel = verifierBundle.loadedFromRunId ? shortRunId(verifierBundle.loadedFromRunId) : null;
-  const activeHistoryRunId = verifierBundle.loadedFromRunId ?? (runHistory.some((entry) => entry.runId === currentRunId) ? currentRunId : null);
+  const loadedFromRunLabel = verifierBundle.loadedFromRunId
+    ? shortRunId(verifierBundle.loadedFromRunId)
+    : null;
+  const activeHistoryRunId =
+    verifierBundle.loadedFromRunId ??
+    (runHistory.some((entry) => entry.runId === currentRunId)
+      ? currentRunId
+      : null);
   const activeHistoryEntry = useMemo(
     () => runHistory.find((entry) => entry.runId === currentRunId) ?? null,
     [currentRunId, runHistory],
@@ -1030,22 +1453,25 @@ export default function ProofMapTab({
     if (!activeHistoryEntry) {
       return Boolean(
         aoi ||
-          evidencePins.length ||
-          verificationRuns.length ||
-          selectedStacItemId ||
-          verifierBundle.exportedAt ||
-          verifierBundle.savedReviewerArtifactAt ||
-          verifierBundle.finalizedAt ||
-          verifierBundle.minutes.trim() ||
-          verifierBundle.outcomeNote.trim() ||
-          verifierBundle.draftMinutes.trim() ||
-          verifierBundle.draftOutcomeNote.trim() ||
-          verifierBundle.delta.trim() ||
-          verifierBundle.impact.trim() ||
-          verifierBundle.tasks.length,
+        evidencePins.length ||
+        verificationRuns.length ||
+        selectedStacItemId ||
+        verifierBundle.exportedAt ||
+        verifierBundle.savedReviewerArtifactAt ||
+        verifierBundle.finalizedAt ||
+        verifierBundle.minutes.trim() ||
+        verifierBundle.outcomeNote.trim() ||
+        verifierBundle.draftMinutes.trim() ||
+        verifierBundle.draftOutcomeNote.trim() ||
+        verifierBundle.delta.trim() ||
+        verifierBundle.impact.trim() ||
+        verifierBundle.tasks.length,
       );
     }
-    return canonicalJsonStringify(activeHistoryEntry.bundle) !== canonicalJsonStringify(currentWorkspaceBundle);
+    return (
+      canonicalJsonStringify(activeHistoryEntry.bundle) !==
+      canonicalJsonStringify(currentWorkspaceBundle)
+    );
   }, [
     activeHistoryEntry,
     aoi,
@@ -1077,22 +1503,43 @@ export default function ProofMapTab({
           itemId: pin.itemId ?? null,
           attachments: (pin.attachments ?? []).length,
         })),
-        runs: verificationRuns.map((run) => ({ id: run.id, status: run.status, ended_at: run.ended_at ?? null })),
+        runs: verificationRuns.map((run) => ({
+          id: run.id,
+          status: run.status,
+          ended_at: run.ended_at ?? null,
+        })),
       }),
-    [aoi?.id, currentAoiFingerprint, evidencePins, selectedRuleId, selectedStacItemId, verificationRuns],
+    [
+      aoi?.id,
+      currentAoiFingerprint,
+      evidencePins,
+      selectedRuleId,
+      selectedStacItemId,
+      verificationRuns,
+    ],
   );
-  const previousMutableWorkspaceRef = useRef<{ runId: string; fingerprint: string } | null>(null);
+  const previousMutableWorkspaceRef = useRef<{
+    runId: string;
+    fingerprint: string;
+  } | null>(null);
   const ignoredMutableWorkspaceRunIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!verifierBundle.finalizedAt) return;
-    if (ignoredMutableWorkspaceRunIdRef.current === verifierBundle.runContext.runId) return;
+    if (
+      ignoredMutableWorkspaceRunIdRef.current ===
+      verifierBundle.runContext.runId
+    )
+      return;
     ignoredMutableWorkspaceRunIdRef.current = verifierBundle.runContext.runId;
   }, [verifierBundle.finalizedAt, verifierBundle.runContext.runId]);
 
   useEffect(() => {
     const previous = previousMutableWorkspaceRef.current;
-    const current = { runId: verifierBundle.runContext.runId, fingerprint: mutableWorkspaceFingerprint };
+    const current = {
+      runId: verifierBundle.runContext.runId,
+      fingerprint: mutableWorkspaceFingerprint,
+    };
     if (!previous || previous.runId !== current.runId) {
       previousMutableWorkspaceRef.current = current;
       return;
@@ -1104,16 +1551,31 @@ export default function ProofMapTab({
       return;
     }
     previousMutableWorkspaceRef.current = current;
-    setVerifierBundle((bundle) => markBundleEdited(bundle, { invalidateFinality: true }));
-  }, [markBundleEdited, mutableWorkspaceFingerprint, verifierBundle.runContext.runId]);
+    setVerifierBundle((bundle) =>
+      markBundleEdited(bundle, { invalidateFinality: true }),
+    );
+  }, [
+    markBundleEdited,
+    mutableWorkspaceFingerprint,
+    verifierBundle.runContext.runId,
+  ]);
 
   const persistCurrentWorkspaceAsDraft = useCallback(() => {
-    const historicalCurrent = runHistory.find((entry) => entry.runId === verifierBundle.runContext.runId) ?? null;
+    const historicalCurrent =
+      runHistory.find(
+        (entry) => entry.runId === verifierBundle.runContext.runId,
+      ) ?? null;
     const draftBundle =
-      historicalCurrent && canonicalJsonStringify(historicalCurrent.bundle) !== canonicalJsonStringify(currentWorkspaceBundle)
+      historicalCurrent &&
+      canonicalJsonStringify(historicalCurrent.bundle) !==
+        canonicalJsonStringify(currentWorkspaceBundle)
         ? {
             ...currentWorkspaceBundle,
-            runContext: createVerifierRunBundle(methodCode, version, workspaceId).runContext,
+            runContext: createVerifierRunBundle(
+              methodCode,
+              version,
+              workspaceId,
+            ).runContext,
           }
         : currentWorkspaceBundle;
     setVerifierBundle((current) =>
@@ -1121,14 +1583,25 @@ export default function ProofMapTab({
         ? current
         : { ...current, runContext: draftBundle.runContext },
     );
-    setRunHistory(saveCurrentRunToHistory(methodCode, version, draftBundle, workspaceId));
+    setRunHistory(
+      saveCurrentRunToHistory(methodCode, version, draftBundle, workspaceId),
+    );
     return draftBundle.runContext.runId;
-  }, [currentWorkspaceBundle, methodCode, runHistory, verifierBundle.runContext.runId, version, workspaceId]);
+  }, [
+    currentWorkspaceBundle,
+    methodCode,
+    runHistory,
+    verifierBundle.runContext.runId,
+    version,
+    workspaceId,
+  ]);
 
   const handleSaveRunHistory = useCallback(
     (bundleOverride?: ReturnType<typeof buildHistoryBundle>) => {
       const bundle = bundleOverride ?? buildHistoryBundle();
-      setRunHistory(saveCurrentRunToHistory(methodCode, version, bundle, workspaceId));
+      setRunHistory(
+        saveCurrentRunToHistory(methodCode, version, bundle, workspaceId),
+      );
     },
     [buildHistoryBundle, methodCode, version, workspaceId],
   );
@@ -1137,13 +1610,24 @@ export default function ProofMapTab({
     (runId: string) => {
       if (runId === verifierBundle.runContext.runId) return;
       if (hasUnsavedWorkspaceEdits && typeof window !== "undefined") {
-        const confirmed = window.confirm("Save the current workspace as a draft before loading another run?");
+        const confirmed = window.confirm(
+          "Save the current workspace as a draft before loading another run?",
+        );
         if (!confirmed) return;
         persistCurrentWorkspaceAsDraft();
       }
-      const loaded = loadRunFromHistory(methodCode, version, runId, workspaceId);
+      const loaded = loadRunFromHistory(
+        methodCode,
+        version,
+        runId,
+        workspaceId,
+      );
       if (!loaded) return;
-      const editableRun = createVerifierRunBundle(methodCode, version, workspaceId);
+      const editableRun = createVerifierRunBundle(
+        methodCode,
+        version,
+        workspaceId,
+      );
       const loadedReviewerContext = createReviewerArtifactContext({
         methodCode,
         version,
@@ -1179,7 +1663,10 @@ export default function ProofMapTab({
       onEvidenceSelectionChange?.(null);
       setSecondarySectionOpen(true);
       setRunHistoryOpen(true);
-      showToast({ title: `Loaded run ${shortRunId(runId)}`, subtitle: "Saved evidence and review state restored" });
+      showToast({
+        title: `Loaded run ${shortRunId(runId)}`,
+        subtitle: "Saved evidence and review state restored",
+      });
     },
     [
       hasUnsavedWorkspaceEdits,
@@ -1200,7 +1687,9 @@ export default function ProofMapTab({
 
   const handleDeleteRunHistory = useCallback(
     (runId: string) => {
-      setRunHistory(deleteRunFromHistory(methodCode, version, runId, workspaceId));
+      setRunHistory(
+        deleteRunFromHistory(methodCode, version, runId, workspaceId),
+      );
     },
     [methodCode, version, workspaceId],
   );
@@ -1211,16 +1700,22 @@ export default function ProofMapTab({
       return;
     }
     if (!hasConfirmedArea) {
-      setError("Confirm the selected project area before running satellite search.");
+      setError(
+        "Confirm the selected project area before running satellite search.",
+      );
       return;
     }
-    setVerifierBundle((current) => markBundleEdited(current, { invalidateFinality: true }));
+    setVerifierBundle((current) =>
+      markBundleEdited(current, { invalidateFinality: true }),
+    );
     setError(null);
     if (isRunning) return;
     if (!currentAoiFingerprint) return;
 
     const cited_ids = evidencePins.flatMap((pin) => pin.cited_ids ?? []);
-    const attachment_sha256 = evidencePins.flatMap((pin) => (pin.attachments ?? []).map((att) => att.sha256));
+    const attachment_sha256 = evidencePins.flatMap((pin) =>
+      (pin.attachments ?? []).map((att) => att.sha256),
+    );
     const input_fingerprint = await runInputFingerprint({
       aoi_fp: currentAoiFingerprint,
       cited_ids,
@@ -1259,9 +1754,16 @@ export default function ProofMapTab({
       if (res.provider === "stac" && res.runStatus === "ok") {
         const normalized = normalizeStacItems(res.result_json);
         const endpoint = (() => {
-          const root = res.result_json && typeof res.result_json === "object" ? (res.result_json as Record<string, unknown>) : null;
-          const prov = root && root.provenance && typeof root.provenance === "object" ? (root.provenance as Record<string, unknown>) : null;
-          const url = prov && typeof prov.endpoint === "string" ? prov.endpoint : null;
+          const root =
+            res.result_json && typeof res.result_json === "object"
+              ? (res.result_json as Record<string, unknown>)
+              : null;
+          const prov =
+            root && root.provenance && typeof root.provenance === "object"
+              ? (root.provenance as Record<string, unknown>)
+              : null;
+          const url =
+            prov && typeof prov.endpoint === "string" ? prov.endpoint : null;
           return url && url.trim() ? url.trim() : null;
         })();
 
@@ -1270,13 +1772,18 @@ export default function ProofMapTab({
           fc: normalized.featureCollection,
           itemsById: normalized.itemsById,
           runId: updated.id,
-          source: endpoint ? { type: "stac_url", ref: endpoint } : { type: "unknown", ref: "unknown" },
+          source: endpoint
+            ? { type: "stac_url", ref: endpoint }
+            : { type: "unknown", ref: "unknown" },
         });
         onSelectStacItemId(null);
         if (onAuditEvent) {
           onAuditEvent({
             kind: "evidence.input",
-            payload: { stac_url: endpoint ?? "unknown", aoi_hash: currentAoiFingerprint },
+            payload: {
+              stac_url: endpoint ?? "unknown",
+              aoi_hash: currentAoiFingerprint,
+            },
           });
         }
 
@@ -1286,7 +1793,10 @@ export default function ProofMapTab({
           const record = item as Record<string, unknown>;
           evidenceBbox = unionBbox(evidenceBbox, getFeatureBbox(record));
         }
-        const targetBbox = unionBbox(parseBbox(aoi.bbox), evidenceBbox) ?? evidenceBbox ?? parseBbox(aoi.bbox);
+        const targetBbox =
+          unionBbox(parseBbox(aoi.bbox), evidenceBbox) ??
+          evidenceBbox ??
+          parseBbox(aoi.bbox);
         if (targetBbox && mapRef.current?.fitBounds) {
           try {
             mapRef.current.fitBounds(
@@ -1335,7 +1845,11 @@ export default function ProofMapTab({
     version,
   ]);
 
-  const isSameAoi = Boolean(draftAoiFingerprint && currentAoiHashForCompare && draftAoiFingerprint === currentAoiHashForCompare);
+  const isSameAoi = Boolean(
+    draftAoiFingerprint &&
+    currentAoiHashForCompare &&
+    draftAoiFingerprint === currentAoiHashForCompare,
+  );
   const handleApplyDraftAoiClick = useCallback(() => {
     if (isSameAoi) {
       setShowSameAoiPrompt(true);
@@ -1367,7 +1881,10 @@ export default function ProofMapTab({
     setSecondarySectionOpen(false);
     setRunHistoryOpen(false);
     setOutcomeOpen(false);
-    showToast({ title: "Started new run", subtitle: "Fresh review workspace created" });
+    showToast({
+      title: "Started new run",
+      subtitle: "Fresh review workspace created",
+    });
   }, [
     methodCode,
     onEvidenceSelectionChange,
@@ -1393,23 +1910,33 @@ export default function ProofMapTab({
   }, []);
 
   const selectEvidence = (id: string, source: "pin" | "polygon") => {
-    setVerifierBundle((current) => markBundleEdited(current, { invalidateFinality: true }));
+    setVerifierBundle((current) =>
+      markBundleEdited(current, { invalidateFinality: true }),
+    );
     onSelectStacItemId(id);
     setLastSelectionSource(source);
     setStacInspectOpen(true);
     if (onAuditEvent) {
       void (async () => {
-        const payload: Record<string, unknown> = { layer_id: "stac", feature_id: id };
+        const payload: Record<string, unknown> = {
+          layer_id: "stac",
+          feature_id: id,
+        };
         const record = currentStacEvidence?.itemsById?.[id];
         if (record && typeof record === "object") {
-          payload.feature_hash = await auditSha256Hex(canonicalAuditJsonStringify(record));
+          payload.feature_hash = await auditSha256Hex(
+            canonicalAuditJsonStringify(record),
+          );
         }
         onAuditEvent({ kind: "evidence.feature.select", payload });
       })();
     }
     requestAnimationFrame(() => {
       try {
-        stacEvidenceCardRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+        stacEvidenceCardRef.current?.scrollIntoView({
+          block: "start",
+          behavior: "smooth",
+        });
       } catch {
         // ignore
       }
@@ -1439,7 +1966,10 @@ export default function ProofMapTab({
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    window.localStorage.setItem("a6:verify:panelCollapsed", panelCollapsed ? "1" : "0");
+    window.localStorage.setItem(
+      "a6:verify:panelCollapsed",
+      panelCollapsed ? "1" : "0",
+    );
   }, [panelCollapsed]);
 
   useEffect(() => {
@@ -1592,7 +2122,8 @@ export default function ProofMapTab({
     if (!aoi || !currentAoiFingerprint) return;
     const nextPins = evidencePins.map((pin) => {
       if (pin.aoi_fingerprint) return pin;
-      if (pin.aoi_id && pin.aoi_id === aoi.id) return { ...pin, aoi_fingerprint: currentAoiFingerprint };
+      if (pin.aoi_id && pin.aoi_id === aoi.id)
+        return { ...pin, aoi_fingerprint: currentAoiFingerprint };
       return pin;
     });
     const changed = nextPins.some((pin, idx) => pin !== evidencePins[idx]);
@@ -1607,7 +2138,10 @@ export default function ProofMapTab({
     return runsForCurrentAoi({ runs: verificationRuns, currentAoiFingerprint });
   }, [currentAoiFingerprint, verificationRuns]);
   const latestRun = useMemo(() => {
-    return selectLatestNonQueuedRunForAoi({ runs: verificationRuns, currentAoiFingerprint });
+    return selectLatestNonQueuedRunForAoi({
+      runs: verificationRuns,
+      currentAoiFingerprint,
+    });
   }, [currentAoiFingerprint, verificationRuns]);
   const intakeSuggestion = useMemo(() => {
     if (!latestRun) return null;
@@ -1618,7 +2152,10 @@ export default function ProofMapTab({
   }, [latestRun]);
 
   const latestStacRun = useMemo(() => {
-    return selectLatestOkStacRunForActiveAoi({ runs: verificationRuns, activeAoiFingerprint: currentAoiFingerprint });
+    return selectLatestOkStacRunForActiveAoi({
+      runs: verificationRuns,
+      activeAoiFingerprint: currentAoiFingerprint,
+    });
   }, [currentAoiFingerprint, verificationRuns]);
 
   const currentStacEvidence = useMemo(() => {
@@ -1642,9 +2179,16 @@ export default function ProofMapTab({
       const id =
         feature && typeof feature === "object"
           ? (() => {
-              const record = feature as unknown as { id?: unknown; properties?: unknown };
-              const props = record.properties && typeof record.properties === "object" ? (record.properties as Record<string, unknown>) : null;
-              const pid = props && typeof props.id === "string" ? props.id : null;
+              const record = feature as unknown as {
+                id?: unknown;
+                properties?: unknown;
+              };
+              const props =
+                record.properties && typeof record.properties === "object"
+                  ? (record.properties as Record<string, unknown>)
+                  : null;
+              const pid =
+                props && typeof props.id === "string" ? props.id : null;
               const fid = typeof record.id === "string" ? record.id : null;
               return pid ?? fid ?? null;
             })()
@@ -1660,13 +2204,18 @@ export default function ProofMapTab({
 
     const inView =
       viewportBbox && total
-        ? Array.from(byIdBbox.values()).reduce((acc, bbox) => (bboxIntersects(viewportBbox, bbox) ? acc + 1 : acc), 0)
+        ? Array.from(byIdBbox.values()).reduce(
+            (acc, bbox) => (bboxIntersects(viewportBbox, bbox) ? acc + 1 : acc),
+            0,
+          )
         : null;
 
     return { total, valid, skipped: total - valid, bounds, byIdBbox, inView };
   }, [currentStacEvidence?.fc?.features, viewportBbox]);
 
-  const stacCentroids = useMemo<GeoJSON.FeatureCollection<GeoJSON.Point>>(() => {
+  const stacCentroids = useMemo<
+    GeoJSON.FeatureCollection<GeoJSON.Point>
+  >(() => {
     const features: Array<GeoJSON.Feature<GeoJSON.Point>> = [];
     for (const [id, bbox] of evidenceDiagnostics.byIdBbox.entries()) {
       const [lng, lat] = centerFromBbox(bbox);
@@ -1692,10 +2241,14 @@ export default function ProofMapTab({
     if (!record || typeof record !== "object") return null;
 
     const selected = record as Record<string, unknown>;
-    const props = isRecord(selected.properties) ? (selected.properties as Record<string, unknown>) : null;
+    const props = isRecord(selected.properties)
+      ? (selected.properties as Record<string, unknown>)
+      : null;
     const links = deriveLinksFromProperties(props);
     const bbox = parseBbox(selected.bbox);
-    const bboxLabel = bbox ? `${formatNum(bbox[0])}, ${formatNum(bbox[1])} → ${formatNum(bbox[2])}, ${formatNum(bbox[3])}` : "—";
+    const bboxLabel = bbox
+      ? `${formatNum(bbox[0])}, ${formatNum(bbox[1])} → ${formatNum(bbox[2])}, ${formatNum(bbox[3])}`
+      : "—";
 
     const rawDatetime =
       (props && typeof props.datetime === "string" ? props.datetime : null) ??
@@ -1703,7 +2256,10 @@ export default function ProofMapTab({
 
     const cloudCover = props ? props["eo:cloud_cover"] : null;
 
-    const assets = props && isRecord(props.assets) ? (props.assets as Record<string, unknown>) : null;
+    const assets =
+      props && isRecord(props.assets)
+        ? (props.assets as Record<string, unknown>)
+        : null;
     const assetRows = assets
       ? (Object.entries(assets)
           .map(([key, value]) => {
@@ -1718,7 +2274,8 @@ export default function ProofMapTab({
           .filter(Boolean) as Array<{ key: string; href: string }>)
       : [];
 
-    const propsLinks = props && Array.isArray(props.links) ? (props.links as unknown[]) : [];
+    const propsLinks =
+      props && Array.isArray(props.links) ? (props.links as unknown[]) : [];
     const linkRows = propsLinks
       .map((link) => {
         if (!isRecord(link)) return null;
@@ -1757,27 +2314,43 @@ export default function ProofMapTab({
   }, [onEvidenceSelectionChange, selectedStacDetails]);
 
   const stacEndpointUrl = useMemo(() => {
-    if (currentStacEvidence?.source?.type === "stac_url") return currentStacEvidence.source.ref;
+    if (currentStacEvidence?.source?.type === "stac_url")
+      return currentStacEvidence.source.ref;
     if (!latestStacRun) return null;
     const root =
       latestStacRun.result_json && typeof latestStacRun.result_json === "object"
         ? (latestStacRun.result_json as Record<string, unknown>)
         : null;
-    const prov = root && root.provenance && typeof root.provenance === "object" ? (root.provenance as Record<string, unknown>) : null;
-    const endpoint = prov && typeof prov.endpoint === "string" ? prov.endpoint : null;
+    const prov =
+      root && root.provenance && typeof root.provenance === "object"
+        ? (root.provenance as Record<string, unknown>)
+        : null;
+    const endpoint =
+      prov && typeof prov.endpoint === "string" ? prov.endpoint : null;
     return endpoint && endpoint.trim() ? endpoint.trim() : null;
   }, [currentStacEvidence?.source, latestStacRun]);
 
-  const stacQuery = useMemo(() => extractStacQuery(latestStacRun?.result_json), [latestStacRun]);
+  const stacQuery = useMemo(
+    () => extractStacQuery(latestStacRun?.result_json),
+    [latestStacRun],
+  );
 
   const localEvidenceHashInputs = useMemo(() => {
     const citedIds = evidencePins.flatMap((pin) => pin.cited_ids ?? []);
-    const attachmentSha = evidencePins.flatMap((pin) => (pin.attachments ?? []).map((att) => att.sha256));
-    const combined = [...citedIds.map((v) => `cited:${v}`), ...attachmentSha.map((v) => `att:${v}`)].filter(Boolean);
+    const attachmentSha = evidencePins.flatMap((pin) =>
+      (pin.attachments ?? []).map((att) => att.sha256),
+    );
+    const combined = [
+      ...citedIds.map((v) => `cited:${v}`),
+      ...attachmentSha.map((v) => `att:${v}`),
+    ].filter(Boolean);
     return combined.length ? combined : null;
   }, [evidencePins]);
 
-  const trustPicked = useMemo(() => pickProvenanceFields(provenanceJson), [provenanceJson]);
+  const trustPicked = useMemo(
+    () => pickProvenanceFields(provenanceJson),
+    [provenanceJson],
+  );
   const auditHashes = trustPicked.auditHashes;
   const appCommit = shortCommitSha(process.env.NEXT_PUBLIC_GIT_SHA || "");
   const selectedEvidenceItemIds = useMemo(() => {
@@ -1793,7 +2366,10 @@ export default function ProofMapTab({
           hash: currentAoiFingerprint,
           bbox: aoi?.bbox ?? null,
           areaKm2: typeof aoi?.area_km2 === "number" ? aoi.area_km2 : null,
-          declaredAreaKm2: typeof aoi?.declared_area_km2 === "number" ? aoi.declared_area_km2 : null,
+          declaredAreaKm2:
+            typeof aoi?.declared_area_km2 === "number"
+              ? aoi.declared_area_km2
+              : null,
         },
         stac: {
           query: stacQuery,
@@ -1848,7 +2424,12 @@ export default function ProofMapTab({
         selectedEvidenceItemIds,
         snapshotExportedAt: runSummary.exportState.snapshotExportedAt,
       }),
-    [evidencePins, runSummary.exportState.snapshotExportedAt, selectedEvidenceItemIds, totalRules],
+    [
+      evidencePins,
+      runSummary.exportState.snapshotExportedAt,
+      selectedEvidenceItemIds,
+      totalRules,
+    ],
   );
 
   const currentBaselineProvenance = useMemo<BaselineKey>(
@@ -1864,23 +2445,28 @@ export default function ProofMapTab({
   const baselineMissing = useMemo(() => {
     const missing: string[] = [];
     if (!currentAoiFingerprint) missing.push("Area");
-    if (!currentBaselineProvenance.methodId || !currentBaselineProvenance.versionId) missing.push("method/version");
-    if (!currentBaselineProvenance.harnessVersion) missing.push("harness version");
+    if (
+      !currentBaselineProvenance.methodId ||
+      !currentBaselineProvenance.versionId
+    )
+      missing.push("method/version");
+    if (!currentBaselineProvenance.harnessVersion)
+      missing.push("harness version");
     if (!currentBaselineProvenance.datasetHash) missing.push("dataset hash");
     return missing;
   }, [currentAoiFingerprint, currentBaselineProvenance]);
 
-  const latestBaseline = useMemo(
-    () => {
-      void baselineTick;
-      return getLatestBaselineForMethod(methodCode.trim(), version.trim());
-    },
-    [baselineTick, methodCode, version],
-  );
+  const latestBaseline = useMemo(() => {
+    void baselineTick;
+    return getLatestBaselineForMethod(methodCode.trim(), version.trim());
+  }, [baselineTick, methodCode, version]);
 
   const baselineComparable = useMemo(() => {
     if (!latestBaseline) return { ok: false, reasons: [] as string[] };
-    return isComparable(latestBaseline.baselineProvenance, currentBaselineProvenance);
+    return isComparable(
+      latestBaseline.baselineProvenance,
+      currentBaselineProvenance,
+    );
   }, [currentBaselineProvenance, latestBaseline]);
   const hasComparisonContext = Boolean(latestBaseline && baselineComparable.ok);
 
@@ -1898,8 +2484,10 @@ export default function ProofMapTab({
     if (baselineComparable.ok) return null;
     if (verifierBundle.isEditedDraft || verifierBundle.loadedFromRunId) {
       return {
-        title: "Comparison unavailable: current workspace changed since baseline",
-        detail: "AOI, selected evidence, pin changes, or unsaved draft edits can invalidate baseline comparison.",
+        title:
+          "Comparison unavailable: current workspace changed since baseline",
+        detail:
+          "AOI, selected evidence, pin changes, or unsaved draft edits can invalidate baseline comparison.",
       };
     }
     return {
@@ -1908,7 +2496,12 @@ export default function ProofMapTab({
         baselineComparable.reasons.join("; ") ||
         "Current workspace does not match the method, version, harness, or dataset context used for the baseline.",
     };
-  }, [baselineComparable, latestBaseline, verifierBundle.isEditedDraft, verifierBundle.loadedFromRunId]);
+  }, [
+    baselineComparable,
+    latestBaseline,
+    verifierBundle.isEditedDraft,
+    verifierBundle.loadedFromRunId,
+  ]);
   const wizardDetails = useMemo(
     () =>
       getVerifyWizardStepDetails({
@@ -1939,16 +2532,21 @@ export default function ProofMapTab({
   const currentWorkspaceIsFinal = Boolean(verifierBundle.finalizedAt);
   useEffect(() => {
     if (!verifierMode) return;
-    const handleReviewStoreChange = () => setReviewGateVersion((current) => current + 1);
+    const handleReviewStoreChange = () =>
+      setReviewGateVersion((current) => current + 1);
     window.addEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
-    return () => window.removeEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
+    return () =>
+      window.removeEventListener(REVIEW_STORE_EVENT, handleReviewStoreChange);
   }, [verifierMode]);
   const finalizeGate = useMemo(() => {
     void reviewGateVersion;
     if (!verifierMode) return null;
     if (!methodCode.trim() || !version.trim()) return null;
     if (!totalRules || totalRules < 1) {
-      return { canFinalize: false, reasons: ["Rule count unavailable for finalize gate."] };
+      return {
+        canFinalize: false,
+        reasons: ["Rule count unavailable for finalize gate."],
+      };
     }
     return checkFinalizeGate(methodCode, version, totalRules, {
       workspaceId,
@@ -1956,11 +2554,22 @@ export default function ProofMapTab({
       projectLinked: Boolean(linkedProject?.id),
       methodologyLinked: Boolean(methodCode.trim() && version.trim()),
     });
-  }, [linkedProject?.id, methodCode, reviewGateVersion, totalRules, verifierBundle.runContext.runId, verifierMode, version, workspaceId]);
+  }, [
+    linkedProject?.id,
+    methodCode,
+    reviewGateVersion,
+    totalRules,
+    verifierBundle.runContext.runId,
+    verifierMode,
+    version,
+    workspaceId,
+  ]);
   const selectedStacItemRecord = useMemo(() => {
     if (!selectedStacItemId) return null;
     const candidate = currentStacEvidence?.itemsById?.[selectedStacItemId];
-    return candidate && typeof candidate === "object" ? (candidate as Record<string, unknown>) : null;
+    return candidate && typeof candidate === "object"
+      ? (candidate as Record<string, unknown>)
+      : null;
   }, [currentStacEvidence?.itemsById, selectedStacItemId]);
   const selectedRuleCoverageRow = useMemo(() => {
     if (!selectedRuleId) return null;
@@ -1982,7 +2591,8 @@ export default function ProofMapTab({
     );
   }, [evidenceInventory, selectedRuleContext, selectedRuleId]);
   const selectedRuleReadinessGap = useMemo(() => {
-    if (!selectedRuleId || !selectedRuleContext || !selectedRuleCoverageRow) return null;
+    if (!selectedRuleId || !selectedRuleContext || !selectedRuleCoverageRow)
+      return null;
     const reviewerArtifactsByRuleId = new Map<
       string,
       {
@@ -1991,7 +2601,11 @@ export default function ProofMapTab({
         outcomeNote?: string | null;
       }
     >();
-    if (activeRuleReview?.reviewerArtifactSavedAt || activeRuleReview?.reviewerMinutes?.trim() || activeRuleReview?.reviewerOutcomeNote?.trim()) {
+    if (
+      activeRuleReview?.reviewerArtifactSavedAt ||
+      activeRuleReview?.reviewerMinutes?.trim() ||
+      activeRuleReview?.reviewerOutcomeNote?.trim()
+    ) {
       reviewerArtifactsByRuleId.set(selectedRuleId, {
         savedAt: activeRuleReview?.reviewerArtifactSavedAt ?? null,
         minutes: activeRuleReview?.reviewerMinutes ?? "",
@@ -2012,7 +2626,8 @@ export default function ProofMapTab({
   ]);
   const selectedRuleReadinessUnavailableReason = useMemo(() => {
     if (!selectedRuleId) return null;
-    if (!selectedRuleContext) return "Rule readiness is not available until rule expectations load for the current selection.";
+    if (!selectedRuleContext)
+      return "Rule readiness is not available until rule expectations load for the current selection.";
     return null;
   }, [selectedRuleContext, selectedRuleId]);
   const suggestedPddFragmentDraft = useMemo(() => {
@@ -2022,18 +2637,32 @@ export default function ProofMapTab({
       ruleTags: selectedRuleContext.tags ?? [],
       sectionId: selectedRuleContext.sectionId ?? null,
       sectionTitle: selectedRuleContext.sectionTitle ?? null,
-      expectedEvidenceTypes: selectedRuleCoverageRow?.expectedEvidenceTypes ?? [],
+      expectedEvidenceTypes:
+        selectedRuleCoverageRow?.expectedEvidenceTypes ?? [],
     });
-  }, [selectedRuleContext, selectedRuleCoverageRow?.expectedEvidenceTypes, selectedRuleId]);
+  }, [
+    selectedRuleContext,
+    selectedRuleCoverageRow?.expectedEvidenceTypes,
+    selectedRuleId,
+  ]);
   const selectedRuleReconciliation = useMemo(
     () =>
       reconcileRequirement({
         linkedEvidence: selectedRuleCoverageRow?.linkedEvidence ?? [],
-        expectedEvidenceTypes: selectedRuleCoverageRow?.expectedEvidenceTypes ?? [],
-        reviewerMinutes: activeRuleReview?.reviewerMinutes ?? verifierBundle.minutes,
-        reviewerOutcomeNote: activeRuleReview?.reviewerOutcomeNote ?? verifierBundle.outcomeNote,
+        expectedEvidenceTypes:
+          selectedRuleCoverageRow?.expectedEvidenceTypes ?? [],
+        reviewerMinutes:
+          activeRuleReview?.reviewerMinutes ?? verifierBundle.minutes,
+        reviewerOutcomeNote:
+          activeRuleReview?.reviewerOutcomeNote ?? verifierBundle.outcomeNote,
       }),
-    [activeRuleReview?.reviewerMinutes, activeRuleReview?.reviewerOutcomeNote, selectedRuleCoverageRow, verifierBundle.minutes, verifierBundle.outcomeNote],
+    [
+      activeRuleReview?.reviewerMinutes,
+      activeRuleReview?.reviewerOutcomeNote,
+      selectedRuleCoverageRow,
+      verifierBundle.minutes,
+      verifierBundle.outcomeNote,
+    ],
   );
   const stacSupportFacts = useMemo(
     () =>
@@ -2084,7 +2713,11 @@ export default function ProofMapTab({
         reconciliation: selectedRuleReconciliation,
         rule: selectedRuleContext,
         supportFacts: stacSupportFacts,
-        generatedAt: verifierBundle.finalizedAt ?? verifierBundle.exportedAt ?? runSummary.provenance.generatedAt ?? null,
+        generatedAt:
+          verifierBundle.finalizedAt ??
+          verifierBundle.exportedAt ??
+          runSummary.provenance.generatedAt ??
+          null,
       }),
     [
       aoi?.bbox,
@@ -2110,14 +2743,20 @@ export default function ProofMapTab({
   const pinsSectionRef = useRef<HTMLDivElement | null>(null);
   const reviewerSectionRef = useRef<HTMLDivElement | null>(null);
   const finalSummarySectionRef = useRef<HTMLDivElement | null>(null);
-  const scrollToSection = useCallback((ref: { current: HTMLDivElement | null }) => {
-    ref.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-  }, []);
+  const scrollToSection = useCallback(
+    (ref: { current: HTMLDivElement | null }) => {
+      ref.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    },
+    [],
+  );
   const selectedRuleStacEligible = useMemo(
     () => isStacEligible(selectedRuleContext?.tags ?? []),
     [selectedRuleContext?.tags],
   );
-  const hasReviewerDraft = Boolean(verifierBundle.draftMinutes.trim() || verifierBundle.draftOutcomeNote.trim());
+  const hasReviewerDraft = Boolean(
+    verifierBundle.draftMinutes.trim() ||
+    verifierBundle.draftOutcomeNote.trim(),
+  );
   const verifyReadinessChips = useMemo<VerifyReadinessChip[]>(() => {
     const hasAoiLoaded = Boolean(aoi?.geojson);
     const stacStatus =
@@ -2130,16 +2769,16 @@ export default function ProofMapTab({
           : latestRun.status === "warn" && stacFeatureIds.length > 0
             ? "results found"
             : "failed";
-    const satelliteDetail =
-      !hasAoiLoaded
-        ? "Upload an area before running satellite search."
-        : !latestRun
-          ? "No satellite search has been run for the current area."
-          : stacStatus === "results found"
-            ? `${stacFeatureIds.length} satellite result${stacFeatureIds.length === 1 ? "" : "s"} found for the current area.`
-            : stacStatus === "no results"
-              ? "Satellite search completed but returned no results for the current area."
-              : latestRun.summary?.trim() || "Satellite search failed for the current area.";
+    const satelliteDetail = !hasAoiLoaded
+      ? "Upload an area before running satellite search."
+      : !latestRun
+        ? "No satellite search has been run for the current area."
+        : stacStatus === "results found"
+          ? `${stacFeatureIds.length} satellite result${stacFeatureIds.length === 1 ? "" : "s"} found for the current area.`
+          : stacStatus === "no results"
+            ? "Satellite search completed but returned no results for the current area."
+            : latestRun.summary?.trim() ||
+              "Satellite search failed for the current area.";
     const supportFactsStatus = !selectedRuleId
       ? "select rule"
       : stacSupportFacts.linkedFacts.length > 0
@@ -2163,9 +2802,19 @@ export default function ProofMapTab({
       : hasReviewerDraft
         ? "draft"
         : "missing";
-    const finalizeReady = Boolean(finalizeGate?.canFinalize && linkedRuleIds.length > 0 && verifierBundle.savedReviewerArtifactAt);
+    const finalizeReady = Boolean(
+      finalizeGate?.canFinalize &&
+      linkedRuleIds.length > 0 &&
+      verifierBundle.savedReviewerArtifactAt,
+    );
     const hasDraftExport = Boolean(verifierBundle.exportedAt);
-    const exportStatus = currentWorkspaceIsFinal ? "finalized" : finalizeReady ? "ready" : hasDraftExport ? "draft available" : "not ready";
+    const exportStatus = currentWorkspaceIsFinal
+      ? "finalized"
+      : finalizeReady
+        ? "ready"
+        : hasDraftExport
+          ? "draft available"
+          : "not ready";
     const exportDetail = currentWorkspaceIsFinal
       ? `Finalized ${formatLocalDateTime(verifierBundle.finalizedAt ?? "")}`
       : finalizeReady
@@ -2173,7 +2822,7 @@ export default function ProofMapTab({
         : hasDraftExport
           ? `Draft snapshot exported ${formatLocalDateTime(verifierBundle.exportedAt ?? "")}. Final export still needs finalize requirements to pass.`
           : finalizeGate && !finalizeGate.canFinalize
-            ? finalizeGate.reasons[0] ?? "Finalize gate is blocked."
+            ? (finalizeGate.reasons[0] ?? "Finalize gate is blocked.")
             : !linkedRuleIds.length
               ? "Link evidence to at least one rule before finalizing the export."
               : !verifierBundle.savedReviewerArtifactAt
@@ -2185,7 +2834,9 @@ export default function ProofMapTab({
         key: "aoi",
         label: "Area",
         value: hasAoiLoaded ? "ready" : "missing",
-        detail: hasAoiLoaded ? aoi?.name ?? bboxLabel ?? "Area ready." : "Upload or confirm an area to scope the review.",
+        detail: hasAoiLoaded
+          ? (aoi?.name ?? bboxLabel ?? "Area ready.")
+          : "Upload or confirm an area to scope the review.",
         tone: hasAoiLoaded ? "ok" : "blocked",
         onClick: () => scrollToSection(aoiSectionRef),
       },
@@ -2194,13 +2845,21 @@ export default function ProofMapTab({
         label: "Satellite",
         value: stacStatus === "results found" ? "found" : stacStatus,
         detail: satelliteDetail,
-        tone: stacStatus === "results found" ? "ok" : stacStatus === "failed" ? "blocked" : "warn",
+        tone:
+          stacStatus === "results found"
+            ? "ok"
+            : stacStatus === "failed"
+              ? "blocked"
+              : "warn",
         onClick: () => scrollToSection(stacSectionRef),
       },
       {
         key: "support-facts",
         label: "Support",
-        value: supportFactsStatus === "select rule" ? "select rule" : supportFactsStatus,
+        value:
+          supportFactsStatus === "select rule"
+            ? "select rule"
+            : supportFactsStatus,
         detail: supportFactsDetail,
         tone:
           supportFactsStatus === "linked"
@@ -2220,7 +2879,12 @@ export default function ProofMapTab({
           : hasReviewerDraft
             ? "Draft reviewer notes exist but are not saved yet."
             : "No reviewer artifact is saved for the active rule and run.",
-        tone: reviewerRecordStatus === "saved" ? "ok" : reviewerRecordStatus === "draft" ? "warn" : "blocked",
+        tone:
+          reviewerRecordStatus === "saved"
+            ? "ok"
+            : reviewerRecordStatus === "draft"
+              ? "warn"
+              : "blocked",
         onClick: () => scrollToSection(reviewerSectionRef),
       },
       {
@@ -2228,7 +2892,12 @@ export default function ProofMapTab({
         label: "Export",
         value: exportStatus === "draft available" ? "draft" : exportStatus,
         detail: exportDetail,
-        tone: currentWorkspaceIsFinal || finalizeReady ? "ok" : hasDraftExport ? "warn" : "blocked",
+        tone:
+          currentWorkspaceIsFinal || finalizeReady
+            ? "ok"
+            : hasDraftExport
+              ? "warn"
+              : "blocked",
         onClick: () => scrollToSection(finalSummarySectionRef),
       },
     ];
@@ -2276,43 +2945,86 @@ export default function ProofMapTab({
     if (wizardDetails.isComplete) {
       return {
         title: "Run complete",
-        instruction: "This workspace is finalized. Start another run to continue with a fresh review.",
+        instruction:
+          "This workspace is finalized. Start another run to continue with a fresh review.",
         stepLabel: "Complete",
       };
     }
     switch (wizardDetails.activeStep) {
       case 1:
-        return { title: "Pick rule", instruction: "Choose the rule you are verifying before building evidence context.", stepLabel: "Step 1 of 7" };
+        return {
+          title: "Pick rule",
+          instruction:
+            "Choose the rule you are verifying before building evidence context.",
+          stepLabel: "Step 1 of 7",
+        };
       case 2:
-        return { title: "Confirm Area", instruction: "Upload or confirm the Area so the evidence search has a clear scope.", stepLabel: "Step 2 of 7" };
+        return {
+          title: "Confirm Area",
+          instruction:
+            "Upload or confirm the Area so the evidence search has a clear scope.",
+          stepLabel: "Step 2 of 7",
+        };
       case 3:
-        return { title: "Search Satellite", instruction: "Run the evidence search and inspect the returned context in the left pane.", stepLabel: "Step 3 of 7" };
+        return {
+          title: "Search Satellite",
+          instruction:
+            "Run the evidence search and inspect the returned context in the left pane.",
+          stepLabel: "Step 3 of 7",
+        };
       case 4:
-        return { title: "Select item", instruction: "Pick the most relevant satellite result from the returned evidence set.", stepLabel: "Step 4 of 7" };
+        return {
+          title: "Select item",
+          instruction:
+            "Pick the most relevant satellite result from the returned evidence set.",
+          stepLabel: "Step 4 of 7",
+        };
       case 5:
         return {
           title: "Evidence inventory",
-          instruction: "Create an evidence object first, then link or unlink it against the selected rule.",
+          instruction:
+            "Create an evidence object first, then link or unlink it against the selected rule.",
           stepLabel: "Step 5 of 7",
         };
       case 6:
-        return { title: "Save reviewer artifact", instruction: "Write concise reviewer notes, then save them explicitly before finalization.", stepLabel: "Step 6 of 7" };
+        return {
+          title: "Save reviewer artifact",
+          instruction:
+            "Write concise reviewer notes, then save them explicitly before finalization.",
+          stepLabel: "Step 6 of 7",
+        };
       case 7:
-        return { title: "Finalize run", instruction: "Finalize to export the single immutable run artifact with evidence and reviewer notes.", stepLabel: "Step 7 of 7" };
+        return {
+          title: "Finalize run",
+          instruction:
+            "Finalize to export the single immutable run artifact with evidence and reviewer notes.",
+          stepLabel: "Step 7 of 7",
+        };
       default:
-        return { title: "Verify run", instruction: "Use the right pane to continue the canonical wizard flow.", stepLabel: "Step" };
+        return {
+          title: "Verify run",
+          instruction:
+            "Use the right pane to continue the canonical wizard flow.",
+          stepLabel: "Step",
+        };
     }
   }, [wizardDetails.activeStep, wizardDetails.isComplete]);
 
   useEffect(() => {
     const ref =
-      activeLeftSection === "rule" ? ruleSectionRef :
-      activeLeftSection === "aoi" ? aoiSectionRef :
-      activeLeftSection === "stac" ? stacSectionRef :
-      activeLeftSection === "selected" ? selectedItemSectionRef :
-      activeLeftSection === "pins" ? pinsSectionRef :
-      activeLeftSection === "reviewer" ? reviewerSectionRef :
-      finalSummarySectionRef;
+      activeLeftSection === "rule"
+        ? ruleSectionRef
+        : activeLeftSection === "aoi"
+          ? aoiSectionRef
+          : activeLeftSection === "stac"
+            ? stacSectionRef
+            : activeLeftSection === "selected"
+              ? selectedItemSectionRef
+              : activeLeftSection === "pins"
+                ? pinsSectionRef
+                : activeLeftSection === "reviewer"
+                  ? reviewerSectionRef
+                  : finalSummarySectionRef;
     ref.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
   }, [activeLeftSection]);
 
@@ -2333,9 +3045,18 @@ export default function ProofMapTab({
         runId: verifierBundle.runContext.runId,
         finalizedAt: verifierBundle.finalizedAt,
       }),
-    [methodCode, reviewArtifact, selectedRuleId, verifierBundle.finalizedAt, verifierBundle.runContext.runId, version],
+    [
+      methodCode,
+      reviewArtifact,
+      selectedRuleId,
+      verifierBundle.finalizedAt,
+      verifierBundle.runContext.runId,
+      version,
+    ],
   );
-  const activeReviewArtifact = reviewArtifactMatchesCurrentContext ? reviewArtifact : null;
+  const activeReviewArtifact = reviewArtifactMatchesCurrentContext
+    ? reviewArtifact
+    : null;
 
   useEffect(() => {
     if (!reviewArtifact) return;
@@ -2344,13 +3065,19 @@ export default function ProofMapTab({
   }, [reviewArtifact, reviewArtifactMatchesCurrentContext]);
 
   const buildStacItemsJson = useCallback(() => {
-    if (!latestStacRun || latestStacRun.status !== "ok") return { items: [] as Array<Record<string, unknown>> };
-    if (!latestStacRun.result_json) return { items: [] as Array<Record<string, unknown>> };
+    if (!latestStacRun || latestStacRun.status !== "ok")
+      return { items: [] as Array<Record<string, unknown>> };
+    if (!latestStacRun.result_json)
+      return { items: [] as Array<Record<string, unknown>> };
     const normalized = normalizeStacItems(latestStacRun.result_json);
     const items = Object.values(normalized.itemsById).map((item) => {
       const props = isRecord(item.properties) ? item.properties : null;
-      const collection = props && typeof props.collection === "string" ? props.collection : undefined;
-      const cloudCover = item.cloud_cover ?? (props ? props["eo:cloud_cover"] : undefined);
+      const collection =
+        props && typeof props.collection === "string"
+          ? props.collection
+          : undefined;
+      const cloudCover =
+        item.cloud_cover ?? (props ? props["eo:cloud_cover"] : undefined);
       return {
         id: item.id,
         datetime: item.datetime,
@@ -2369,7 +3096,11 @@ export default function ProofMapTab({
       evidencePins,
     });
     const citedIds = evidencePins.flatMap((pin) => pin.cited_ids ?? []);
-    const selectedIds = selectedStacItemId ? [selectedStacItemId] : citedIds.length ? citedIds : undefined;
+    const selectedIds = selectedStacItemId
+      ? [selectedStacItemId]
+      : citedIds.length
+        ? citedIds
+        : undefined;
     return { minimalItem, selectedIds };
   }, [evidencePins, selectedStacItemId, selectedStacItemRecord]);
 
@@ -2377,18 +3108,29 @@ export default function ProofMapTab({
     return stacEndpointUrl
       ? { type: "stac_url" as const, ref: stacEndpointUrl }
       : localEvidenceHashInputs
-        ? { type: "upload" as const, ref: "local_pins", hash_inputs: localEvidenceHashInputs }
+        ? {
+            type: "upload" as const,
+            ref: "local_pins",
+            hash_inputs: localEvidenceHashInputs,
+          }
         : { type: "unknown" as const, ref: "unknown" };
   }, [localEvidenceHashInputs, stacEndpointUrl]);
 
   const assertReviewerArtifactContext = useCallback(
     (runContext: { runId: string; createdAt: string }) => {
       if (!activeRuleReview?.reviewerArtifactSavedAt) return;
-      if ((activeRuleReview.runId?.trim() ?? runContext.runId) !== runContext.runId) {
-        throw new Error("Reviewer artifact is saved for a different run. Save reviewer artifact again for the current rule before finalizing.");
+      if (
+        (activeRuleReview.runId?.trim() ?? runContext.runId) !==
+        runContext.runId
+      ) {
+        throw new Error(
+          "Reviewer artifact is saved for a different run. Save reviewer artifact again for the current rule before finalizing.",
+        );
       }
       if (!selectedRuleId) {
-        throw new Error("Reviewer artifact context is missing. Save reviewer artifact again for the current rule before finalizing.");
+        throw new Error(
+          "Reviewer artifact context is missing. Save reviewer artifact again for the current rule before finalizing.",
+        );
       }
       if ((activeRuleReview.ruleId ?? null) !== (selectedRuleId ?? null)) {
         throw new Error(
@@ -2411,14 +3153,17 @@ export default function ProofMapTab({
       const evidenceSource = buildEvidenceSource();
       const checklistExport = prepareChecklistExport(options.checklist);
       assertReviewerArtifactContext(options.runContext);
-      const reviewerMinutes = activeRuleReview?.reviewerMinutes ?? verifierBundle.minutes;
-      const reviewerOutcomeNote = activeRuleReview?.reviewerOutcomeNote ?? verifierBundle.outcomeNote;
+      const reviewerMinutes =
+        activeRuleReview?.reviewerMinutes ?? verifierBundle.minutes;
+      const reviewerOutcomeNote =
+        activeRuleReview?.reviewerOutcomeNote ?? verifierBundle.outcomeNote;
       const verifierSnapshot = {
         runId: options.runContext.runId,
         createdAt: options.runContext.createdAt,
         minutes: reviewerMinutes,
         outcomeNote: reviewerOutcomeNote,
-        finalizedAt: options.summaryState === "finalized" ? options.finalizedAt : null,
+        finalizedAt:
+          options.summaryState === "finalized" ? options.finalizedAt : null,
         finalizedState: options.summaryState,
         delta: verifierBundle.delta,
         impact: verifierBundle.impact,
@@ -2457,7 +3202,7 @@ export default function ProofMapTab({
       const ruleContext = await fetchSelectedRuleContext(selectedRuleId);
       const ruleCoverageRow =
         selectedRuleId && ruleContext
-          ? buildRequirementCoverageRows({
+          ? (buildRequirementCoverageRows({
               rules: [
                 {
                   id: selectedRuleId,
@@ -2470,7 +3215,7 @@ export default function ProofMapTab({
                 },
               ],
               inventoryItems: evidenceInventory,
-            })[0] ?? null
+            })[0] ?? null)
           : null;
       const reconciliation = reconcileRequirement({
         linkedEvidence: ruleCoverageRow?.linkedEvidence ?? [],
@@ -2497,7 +3242,9 @@ export default function ProofMapTab({
         generatedAt: options.finalizedAt,
       });
       if ((summary.ruleId ?? null) !== (selectedRuleId ?? null)) {
-        throw new Error("Review summary rule context mismatch. Refresh the current rule context and save reviewer artifact again before finalizing.");
+        throw new Error(
+          "Review summary rule context mismatch. Refresh the current rule context and save reviewer artifact again before finalizing.",
+        );
       }
       const artifact = await buildOutcomeSnapshot({
         method: { code: methodCode, version },
@@ -2531,8 +3278,21 @@ export default function ProofMapTab({
           env: asNonEmptyString(process.env.NEXT_PUBLIC_VERCEL_ENV),
           version: asNonEmptyString(process.env.NEXT_PUBLIC_APP_VERSION),
         },
-        items: options.summaryState === "finalized" ? undefined : selectedStacItemId ? [{ id: selectedStacItemId, linked_rules: minimalItem?.linked_rules ?? [] }] : [],
-        stacItemsJson: options.summaryState === "finalized" ? undefined : buildStacItemsJson(),
+        items:
+          options.summaryState === "finalized"
+            ? undefined
+            : selectedStacItemId
+              ? [
+                  {
+                    id: selectedStacItemId,
+                    linked_rules: minimalItem?.linked_rules ?? [],
+                  },
+                ]
+              : [],
+        stacItemsJson:
+          options.summaryState === "finalized"
+            ? undefined
+            : buildStacItemsJson(),
         outcome,
         kpis,
         verifier: exportVerifierSnapshot,
@@ -2570,7 +3330,12 @@ export default function ProofMapTab({
   );
 
   useEffect(() => {
-    if (!currentWorkspaceIsFinal || activeReviewArtifact || !verifierBundle.finalizedAt) return;
+    if (
+      !currentWorkspaceIsFinal ||
+      activeReviewArtifact ||
+      !verifierBundle.finalizedAt
+    )
+      return;
     let active = true;
     void buildFinalReviewArtifact({
       finalizedAt: verifierBundle.finalizedAt,
@@ -2588,15 +3353,23 @@ export default function ProofMapTab({
     return () => {
       active = false;
     };
-  }, [activeReviewArtifact, buildFinalReviewArtifact, currentWorkspaceIsFinal, verifierBundle]);
+  }, [
+    activeReviewArtifact,
+    buildFinalReviewArtifact,
+    currentWorkspaceIsFinal,
+    verifierBundle,
+  ]);
 
   const handleFinalizeRun = useCallback(() => {
     if (finalizeGate && !finalizeGate.canFinalize) return;
-    if (!linkedRuleIds.length || !activeRuleReview?.reviewerArtifactSavedAt) return;
+    if (!linkedRuleIds.length || !activeRuleReview?.reviewerArtifactSavedAt)
+      return;
     void (async () => {
       const finalizedAt = new Date().toISOString();
       const nextRunContext =
-        activeHistoryEntry && canonicalJsonStringify(activeHistoryEntry.bundle) !== canonicalJsonStringify(currentWorkspaceBundle)
+        activeHistoryEntry &&
+        canonicalJsonStringify(activeHistoryEntry.bundle) !==
+          canonicalJsonStringify(currentWorkspaceBundle)
           ? createVerifierRunBundle(methodCode, version).runContext
           : verifierBundle.runContext;
       const { artifact } = await buildFinalReviewArtifact({
@@ -2625,7 +3398,11 @@ export default function ProofMapTab({
         isEditedDraft: false,
       });
       setSecondarySectionOpen(true);
-      showToast({ title: "Run complete", subtitle: "Review summary ready. Download JSON or PDF from the result card." });
+      showToast({
+        title: "Run complete",
+        subtitle:
+          "Review summary ready. Download JSON or PDF from the result card.",
+      });
     })().catch((error) => {
       setError(error instanceof Error ? error.message : String(error));
       showToast("Finalize failed");
@@ -2649,14 +3426,19 @@ export default function ProofMapTab({
     (entry: VerifyRunHistoryEntry) => {
       if (!latestBaseline) return null;
       const runs = entry.bundle.verificationRuns ?? [];
-      const datasetHash = runs.find((run) => typeof run.input_fingerprint === "string")?.input_fingerprint ?? "";
+      const datasetHash =
+        runs.find((run) => typeof run.input_fingerprint === "string")
+          ?.input_fingerprint ?? "";
       const entryProv: BaselineKey = {
         methodId: currentBaselineProvenance.methodId,
         versionId: currentBaselineProvenance.versionId,
         harnessVersion: currentBaselineProvenance.harnessVersion,
         datasetHash,
       };
-      const comparable = isComparable(latestBaseline.baselineProvenance, entryProv);
+      const comparable = isComparable(
+        latestBaseline.baselineProvenance,
+        entryProv,
+      );
       if (!comparable.ok) {
         return {
           label: "≠",
@@ -2666,7 +3448,8 @@ export default function ProofMapTab({
       }
       const itemIds = extractItemIdsFromRuns(runs);
       const historyItemId =
-        typeof entry.bundle.selectedStacItemId === "string" && entry.bundle.selectedStacItemId.trim()
+        typeof entry.bundle.selectedStacItemId === "string" &&
+        entry.bundle.selectedStacItemId.trim()
           ? entry.bundle.selectedStacItemId
           : itemIds.length === 1
             ? itemIds[0]
@@ -2724,7 +3507,11 @@ export default function ProofMapTab({
 
   const evidenceChip = useMemo(() => {
     if (stacEndpointUrl) {
-      return { label: "evidence", display: hostnamePathFromUrl(stacEndpointUrl), value: stacEndpointUrl };
+      return {
+        label: "evidence",
+        display: hostnamePathFromUrl(stacEndpointUrl),
+        value: stacEndpointUrl,
+      };
     }
     return null;
   }, [stacEndpointUrl]);
@@ -2736,7 +3523,11 @@ export default function ProofMapTab({
     const hasEvidence = (currentStacEvidence?.fc?.features?.length ?? 0) > 0;
     const hasRuns = verificationRuns.length > 0;
     const hasSnapshots = (evidenceSnapshots ?? []).length > 0;
-    const hasComparisonNotes = Boolean(verifierBundle.delta.trim() || verifierBundle.impact.trim() || verifierBundle.tasks.length);
+    const hasComparisonNotes = Boolean(
+      verifierBundle.delta.trim() ||
+      verifierBundle.impact.trim() ||
+      verifierBundle.tasks.length,
+    );
     const hasWorkspaceRunState = Boolean(
       verifierBundle.exportedAt ||
       verifierBundle.savedReviewerArtifactAt ||
@@ -2744,7 +3535,17 @@ export default function ProofMapTab({
       verifierBundle.loadedFromRunId ||
       verifierBundle.derivedFromRunId,
     );
-    return hasAoi || hasPins || hasSelection || hasEvidence || hasRuns || hasSnapshots || hasReviewerDraft || hasComparisonNotes || hasWorkspaceRunState;
+    return (
+      hasAoi ||
+      hasPins ||
+      hasSelection ||
+      hasEvidence ||
+      hasRuns ||
+      hasSnapshots ||
+      hasReviewerDraft ||
+      hasComparisonNotes ||
+      hasWorkspaceRunState
+    );
   }, [
     aoi,
     currentStacEvidence?.fc?.features?.length,
@@ -2773,17 +3574,28 @@ export default function ProofMapTab({
   });
   const hasRule = Boolean(selectedRuleId);
   const hasAoi = hasConfirmedArea;
-  const declaredAreaComparison = useMemo(() => aoiDeclaredAreaComparison(aoi), [aoi]);
+  const declaredAreaComparison = useMemo(
+    () => aoiDeclaredAreaComparison(aoi),
+    [aoi],
+  );
   const primaryAoiFeature = useMemo(
-    () => (aoi?.features ?? []).find((feature) => feature.role === "primary_project_area") ?? null,
+    () =>
+      (aoi?.features ?? []).find(
+        (feature) => feature.role === "primary_project_area",
+      ) ?? null,
     [aoi?.features],
   );
   const projectZoneCount = useMemo(
-    () => (aoi?.features ?? []).filter((feature) => feature.role === "project_zone").length,
+    () =>
+      (aoi?.features ?? []).filter((feature) => feature.role === "project_zone")
+        .length,
     [aoi?.features],
   );
   const supportingFeatureCount = useMemo(
-    () => (aoi?.features ?? []).filter((feature) => feature.role !== "primary_project_area").length,
+    () =>
+      (aoi?.features ?? []).filter(
+        (feature) => feature.role !== "primary_project_area",
+      ).length,
     [aoi?.features],
   );
   const aoiFeatureRows = (aoi?.features ?? []).map((feature) => ({
@@ -2794,7 +3606,9 @@ export default function ProofMapTab({
     role: feature.role,
   }));
   const hasSearchResults = (stacFeatureIds?.length ?? 0) > 0;
-  const hasSelectedItem = Boolean(selectedStacItemId && currentStacEvidence?.itemsById?.[selectedStacItemId]);
+  const hasSelectedItem = Boolean(
+    selectedStacItemId && currentStacEvidence?.itemsById?.[selectedStacItemId],
+  );
   const currentPinItemId = hasSelectedItem ? selectedStacItemId : null;
   const canCreatePin = hasRule && hasSelectedItem;
   const canAddSelectedItemToInventory = Boolean(currentPinItemId);
@@ -2817,7 +3631,8 @@ export default function ProofMapTab({
       const ts = new Date().toISOString();
       const candidate: EvidencePin = {
         id:
-          typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+          typeof crypto !== "undefined" &&
+          typeof crypto.randomUUID === "function"
             ? crypto.randomUUID()
             : `pin_${ts}_${Math.random().toString(16).slice(2)}`,
         kind: "note",
@@ -2834,15 +3649,29 @@ export default function ProofMapTab({
         created_at: ts,
       };
       const dedupeKey = evidencePinDedupeKey(candidate);
-      const existing = evidencePins.find((pin) => evidencePinDedupeKey(pin) === dedupeKey);
+      const existing = evidencePins.find(
+        (pin) => evidencePinDedupeKey(pin) === dedupeKey,
+      );
       onSetEvidencePins((current) => {
-        const existingPin = current.find((pin) => evidencePinDedupeKey(pin) === dedupeKey);
+        const existingPin = current.find(
+          (pin) => evidencePinDedupeKey(pin) === dedupeKey,
+        );
         return existingPin
-          ? linkEvidencePinToRequirement(current, existingPin.id, selectedRuleId)
+          ? linkEvidencePinToRequirement(
+              current,
+              existingPin.id,
+              selectedRuleId,
+            )
           : coalesceEvidencePins([candidate, ...current]);
       });
-      setVerifierBundle((current) => markBundleEdited(current, { invalidateFinality: true }));
-      showToast(existing ? `Updated ${currentPinItemId} in inventory` : `Added ${currentPinItemId} and linked it to ${selectedRuleId}`);
+      setVerifierBundle((current) =>
+        markBundleEdited(current, { invalidateFinality: true }),
+      );
+      showToast(
+        existing
+          ? `Updated ${currentPinItemId} in inventory`
+          : `Added ${currentPinItemId} and linked it to ${selectedRuleId}`,
+      );
     } catch (error) {
       setError(error instanceof Error ? error.message : String(error));
       showToast("Inventory update failed. Selection kept.");
@@ -2867,7 +3696,8 @@ export default function ProofMapTab({
       const ts = new Date().toISOString();
       const candidate: EvidencePin = {
         id:
-          typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+          typeof crypto !== "undefined" &&
+          typeof crypto.randomUUID === "function"
             ? crypto.randomUUID()
             : `pin_${ts}_${Math.random().toString(16).slice(2)}`,
         kind: "note",
@@ -2883,13 +3713,25 @@ export default function ProofMapTab({
         created_at: ts,
       };
       const dedupeKey = evidencePinDedupeKey(candidate);
-      const existing = evidencePins.find((pin) => evidencePinDedupeKey(pin) === dedupeKey);
+      const existing = evidencePins.find(
+        (pin) => evidencePinDedupeKey(pin) === dedupeKey,
+      );
       onSetEvidencePins((current) => {
-        const existingPin = current.find((pin) => evidencePinDedupeKey(pin) === dedupeKey);
-        return existingPin ? coalesceEvidencePins(current) : coalesceEvidencePins([candidate, ...current]);
+        const existingPin = current.find(
+          (pin) => evidencePinDedupeKey(pin) === dedupeKey,
+        );
+        return existingPin
+          ? coalesceEvidencePins(current)
+          : coalesceEvidencePins([candidate, ...current]);
       });
-      setVerifierBundle((current) => markBundleEdited(current, { invalidateFinality: true }));
-      showToast(existing ? `${currentPinItemId} is already in inventory` : `Added ${currentPinItemId} to inventory`);
+      setVerifierBundle((current) =>
+        markBundleEdited(current, { invalidateFinality: true }),
+      );
+      showToast(
+        existing
+          ? `${currentPinItemId} is already in inventory`
+          : `Added ${currentPinItemId} to inventory`,
+      );
     } catch (error) {
       setError(error instanceof Error ? error.message : String(error));
       showToast("Inventory capture failed. Selection kept.");
@@ -2907,15 +3749,18 @@ export default function ProofMapTab({
     version,
   ]);
 
-  const updatePddFragmentDraft = useCallback((evidenceId: string, patch: Partial<PddFragmentDraft>) => {
-    setPddFragmentDrafts((current) => ({
-      ...current,
-      [evidenceId]: {
-        ...(current[evidenceId] ?? EMPTY_PDD_FRAGMENT_DRAFT),
-        ...patch,
-      },
-    }));
-  }, []);
+  const updatePddFragmentDraft = useCallback(
+    (evidenceId: string, patch: Partial<PddFragmentDraft>) => {
+      setPddFragmentDrafts((current) => ({
+        ...current,
+        [evidenceId]: {
+          ...(current[evidenceId] ?? EMPTY_PDD_FRAGMENT_DRAFT),
+          ...patch,
+        },
+      }));
+    },
+    [],
+  );
 
   const applySuggestedPddFragmentDraft = useCallback(
     (evidenceId: string) => {
@@ -2929,7 +3774,9 @@ export default function ProofMapTab({
           sectionHeading: suggestedPddFragmentDraft.sectionHeading,
         },
       }));
-      showToast(`Seeded fragment metadata for ${selectedRuleId ?? "selected rule"}`);
+      showToast(
+        `Seeded fragment metadata for ${selectedRuleId ?? "selected rule"}`,
+      );
     },
     [selectedRuleId, showToast, suggestedPddFragmentDraft],
   );
@@ -2954,115 +3801,158 @@ export default function ProofMapTab({
     });
   }, [evidencePins, selectedRuleId, suggestedPddFragmentDraft]);
 
-  const handlePddUpload = useCallback(async (file: File | null) => {
-    if (!file) return;
-    setError(null);
-    const ts = new Date().toISOString();
-    const pinId =
-      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-        ? crypto.randomUUID()
-        : `pin_${ts}_${Math.random().toString(16).slice(2)}`;
-    try {
-      const result = await createAndStoreEvidenceAttachment({ pin_id: pinId, file });
-      if (!result.ok) {
-        setError(result.message);
+  const handlePddUpload = useCallback(
+    async (file: File | null) => {
+      if (!file) return;
+      setError(null);
+      const ts = new Date().toISOString();
+      const pinId =
+        typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+          ? crypto.randomUUID()
+          : `pin_${ts}_${Math.random().toString(16).slice(2)}`;
+      try {
+        const result = await createAndStoreEvidenceAttachment({
+          pin_id: pinId,
+          file,
+        });
+        if (!result.ok) {
+          setError(result.message);
+          return;
+        }
+        const candidate: EvidencePin = {
+          id: pinId,
+          kind: "pdd",
+          title: file.name,
+          ts,
+          note: `${methodCode}@${version}`,
+          aoi_id: aoi?.id ?? null,
+          aoi_fingerprint: currentAoiFingerprint ?? undefined,
+          cited_ids: [],
+          attachments: [result.attachment],
+          pdd_document: {
+            evidence_id: pinId,
+            attachment_id: result.attachment.id,
+            file_name: result.attachment.filename,
+            mime: result.attachment.mime,
+            added_at: result.attachment.created_at,
+            sha256: result.attachment.sha256,
+          },
+          created_at: ts,
+        };
+        const dedupeKey = evidencePinDedupeKey(candidate);
+        const existing = evidencePins.find(
+          (pin) => evidencePinDedupeKey(pin) === dedupeKey,
+        );
+        onSetEvidencePins((current) => {
+          const existingPin = current.find(
+            (pin) => evidencePinDedupeKey(pin) === dedupeKey,
+          );
+          return existingPin
+            ? coalesceEvidencePins(current)
+            : coalesceEvidencePins([candidate, ...current]);
+        });
+        void stageProjectDocumentDraftFromAttachment({
+          origin: "pdd-upload",
+          evidenceId: pinId,
+          attachmentId: result.attachment.id,
+          fileName: result.attachment.filename,
+          mimeType: result.attachment.mime,
+          contentSha256: result.attachment.sha256,
+        })
+          .then(() => {
+            setProjectDraftReady(true);
+            showToast({
+              title: "Project draft ready",
+              subtitle:
+                "Open New Project to review extracted metadata from this PDD.",
+            });
+          })
+          .catch(() => undefined);
+        setVerifierBundle((current) =>
+          markBundleEdited(current, { invalidateFinality: true }),
+        );
+        showToast(
+          existing
+            ? `${file.name} is already in inventory`
+            : `Added PDD ${file.name} to inventory`,
+        );
+      } catch (error) {
+        setError(error instanceof Error ? error.message : String(error));
+        showToast("PDD intake failed.");
+      }
+    },
+    [
+      aoi?.id,
+      currentAoiFingerprint,
+      evidencePins,
+      markBundleEdited,
+      methodCode,
+      onSetEvidencePins,
+      showToast,
+      version,
+    ],
+  );
+
+  const handleSavePddFragment = useCallback(
+    (pin: EvidencePin) => {
+      const draft = pddFragmentDrafts[pin.id] ?? EMPTY_PDD_FRAGMENT_DRAFT;
+      const parsePage = (value: string): number | undefined => {
+        const trimmed = value.trim();
+        if (!trimmed) return undefined;
+        const parsed = Number(trimmed);
+        return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+      };
+      const pageStart = parsePage(draft.pageStart);
+      const pageEnd = parsePage(draft.pageEnd) ?? pageStart;
+      const label = draft.label.trim();
+      const sectionLabel = draft.sectionLabel.trim();
+      const sectionHeading = draft.sectionHeading.trim();
+      const excerpt = draft.excerpt.trim();
+      if (
+        !label &&
+        !pageStart &&
+        !pageEnd &&
+        !sectionLabel &&
+        !sectionHeading &&
+        !excerpt
+      ) {
+        setError("Add at least one fragment field before saving.");
         return;
       }
-      const candidate: EvidencePin = {
-        id: pinId,
-        kind: "pdd",
-        title: file.name,
-        ts,
-        note: `${methodCode}@${version}`,
-        aoi_id: aoi?.id ?? null,
-        aoi_fingerprint: currentAoiFingerprint ?? undefined,
-        cited_ids: [],
-        attachments: [result.attachment],
-        pdd_document: {
-          evidence_id: pinId,
-          attachment_id: result.attachment.id,
-          file_name: result.attachment.filename,
-          mime: result.attachment.mime,
-          added_at: result.attachment.created_at,
-          sha256: result.attachment.sha256,
-        },
-        created_at: ts,
-      };
-      const dedupeKey = evidencePinDedupeKey(candidate);
-      const existing = evidencePins.find((pin) => evidencePinDedupeKey(pin) === dedupeKey);
-      onSetEvidencePins((current) => {
-        const existingPin = current.find((pin) => evidencePinDedupeKey(pin) === dedupeKey);
-        return existingPin ? coalesceEvidencePins(current) : coalesceEvidencePins([candidate, ...current]);
-      });
-      void stageProjectDocumentDraftFromAttachment({
-        origin: "pdd-upload",
-        evidenceId: pinId,
-        attachmentId: result.attachment.id,
-        fileName: result.attachment.filename,
-        mimeType: result.attachment.mime,
-        contentSha256: result.attachment.sha256,
-      }).then(() => {
-        setProjectDraftReady(true);
-        showToast({ title: "Project draft ready", subtitle: "Open New Project to review extracted metadata from this PDD." });
-      }).catch(() => undefined);
-      setVerifierBundle((current) => markBundleEdited(current, { invalidateFinality: true }));
-      showToast(existing ? `${file.name} is already in inventory` : `Added PDD ${file.name} to inventory`);
-    } catch (error) {
-      setError(error instanceof Error ? error.message : String(error));
-      showToast("PDD intake failed.");
-    }
-  }, [
-    aoi?.id,
-    currentAoiFingerprint,
-    evidencePins,
-    markBundleEdited,
-    methodCode,
-    onSetEvidencePins,
-    showToast,
-    version,
-  ]);
-
-  const handleSavePddFragment = useCallback((pin: EvidencePin) => {
-    const draft = pddFragmentDrafts[pin.id] ?? EMPTY_PDD_FRAGMENT_DRAFT;
-    const parsePage = (value: string): number | undefined => {
-      const trimmed = value.trim();
-      if (!trimmed) return undefined;
-      const parsed = Number(trimmed);
-      return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
-    };
-    const pageStart = parsePage(draft.pageStart);
-    const pageEnd = parsePage(draft.pageEnd) ?? pageStart;
-    const label = draft.label.trim();
-    const sectionLabel = draft.sectionLabel.trim();
-    const sectionHeading = draft.sectionHeading.trim();
-    const excerpt = draft.excerpt.trim();
-    if (!label && !pageStart && !pageEnd && !sectionLabel && !sectionHeading && !excerpt) {
-      setError("Add at least one fragment field before saving.");
-      return;
-    }
-    onSetEvidencePins((current) =>
-      upsertPddFragmentOnEvidencePin(current, pin.id, {
-        label: label || undefined,
-        page_start: pageStart,
-        page_end: pageEnd,
-        section_label: sectionLabel || undefined,
-        section_heading: sectionHeading || undefined,
-        excerpt: excerpt || undefined,
-      }),
-    );
-    setPddFragmentDrafts((current) => ({ ...current, [pin.id]: EMPTY_PDD_FRAGMENT_DRAFT }));
-    setVerifierBundle((current) => markBundleEdited(current, { invalidateFinality: true }));
-    showToast("PDD fragment saved");
-  }, [markBundleEdited, onSetEvidencePins, pddFragmentDrafts, showToast]);
+      onSetEvidencePins((current) =>
+        upsertPddFragmentOnEvidencePin(current, pin.id, {
+          label: label || undefined,
+          page_start: pageStart,
+          page_end: pageEnd,
+          section_label: sectionLabel || undefined,
+          section_heading: sectionHeading || undefined,
+          excerpt: excerpt || undefined,
+        }),
+      );
+      setPddFragmentDrafts((current) => ({
+        ...current,
+        [pin.id]: EMPTY_PDD_FRAGMENT_DRAFT,
+      }));
+      setVerifierBundle((current) =>
+        markBundleEdited(current, { invalidateFinality: true }),
+      );
+      showToast("PDD fragment saved");
+    },
+    [markBundleEdited, onSetEvidencePins, pddFragmentDrafts, showToast],
+  );
 
   const handleExportSnapshot = useCallback(async () => {
     const exportedAt = new Date().toISOString();
     const nextRunContext =
-      activeHistoryEntry && canonicalJsonStringify(activeHistoryEntry.bundle) !== canonicalJsonStringify(currentWorkspaceBundle)
+      activeHistoryEntry &&
+      canonicalJsonStringify(activeHistoryEntry.bundle) !==
+        canonicalJsonStringify(currentWorkspaceBundle)
         ? createVerifierRunBundle(methodCode, version).runContext
         : verifierBundle.runContext;
     const checklistAfterExport = verifierBundle.checklist.map((item) =>
-      item.id === "exported-snapshot" ? { ...item, checked: true, updatedAt: exportedAt } : item,
+      item.id === "exported-snapshot"
+        ? { ...item, checked: true, updatedAt: exportedAt }
+        : item,
     );
     const verifierSnapshot = {
       runId: nextRunContext.runId,
@@ -3102,7 +3992,10 @@ export default function ProofMapTab({
       isEditedDraft: false,
     }));
     handleSaveRunHistory({
-      runContext: { runId: verifierSnapshot.runId, createdAt: verifierSnapshot.createdAt },
+      runContext: {
+        runId: verifierSnapshot.runId,
+        createdAt: verifierSnapshot.createdAt,
+      },
       reviewerContext: nextReviewerContext,
       savedReviewerArtifactContext: verifierBundle.savedReviewerArtifactContext,
       exportedAt,
@@ -3163,13 +4056,21 @@ export default function ProofMapTab({
     setReviewArtifact(artifact);
     const filename = `verify-final.${safeFilename(methodCode)}.${safeFilename(version)}.${safeFilename(verifierBundle.runContext.runId)}.json`;
     downloadJson(artifact, filename);
-  }, [activeReviewArtifact, buildFinalReviewArtifact, methodCode, verifierBundle, version]);
+  }, [
+    activeReviewArtifact,
+    buildFinalReviewArtifact,
+    methodCode,
+    verifierBundle,
+    version,
+  ]);
 
   const buildReadinessExportContext = useCallback(async () => {
     void reviewGateVersion;
     const generatedAt = verifierBundle.finalizedAt ?? verifierBundle.exportedAt;
     if (!generatedAt) {
-      throw new Error("Finalize the current Verify run before exporting a readiness artifact.");
+      throw new Error(
+        "Finalize the current Verify run before exporting a readiness artifact.",
+      );
     }
     if (!ruleOptions.length) {
       throw new Error("No method rules are available for readiness export.");
@@ -3195,7 +4096,12 @@ export default function ProofMapTab({
       inventoryItems: evidenceInventory,
     });
 
-    const reviewsByRuleId = getAllReviews(methodCode, version, workspaceId, verifierBundle.runContext.runId);
+    const reviewsByRuleId = getAllReviews(
+      methodCode,
+      version,
+      workspaceId,
+      verifierBundle.runContext.runId,
+    );
     const reviewerArtifactsByRuleId = new Map<
       string,
       {
@@ -3205,7 +4111,12 @@ export default function ProofMapTab({
       }
     >(
       Object.values(reviewsByRuleId)
-        .filter((review) => review.reviewerArtifactSavedAt || review.reviewerMinutes?.trim() || review.reviewerOutcomeNote?.trim())
+        .filter(
+          (review) =>
+            review.reviewerArtifactSavedAt ||
+            review.reviewerMinutes?.trim() ||
+            review.reviewerOutcomeNote?.trim(),
+        )
         .map((review) => [
           review.ruleId,
           {
@@ -3234,7 +4145,12 @@ export default function ProofMapTab({
     const missingDocuments = Array.from(
       new Set(readinessGaps.flatMap((gap) => gap.missingExpectedEvidenceTypes)),
     )
-      .filter((expectedType) => !evidenceInventory.some((item) => inventoryMatchesExpectedEvidence(item, expectedType)))
+      .filter(
+        (expectedType) =>
+          !evidenceInventory.some((item) =>
+            inventoryMatchesExpectedEvidence(item, expectedType),
+          ),
+      )
       .sort((a, b) => a.localeCompare(b))
       .map((expectedType) => ({
         id: `missing-${expectedType}`,
@@ -3264,18 +4180,20 @@ export default function ProofMapTab({
   ]);
 
   const buildClientReadinessReportPayload = useCallback(async () => {
-    const {
-      generatedAt,
-      readinessGaps,
-      suppliedDocuments,
-      missingDocuments,
-    } = await buildReadinessExportContext();
+    const { generatedAt, readinessGaps, suppliedDocuments, missingDocuments } =
+      await buildReadinessExportContext();
 
     const report = buildClientReadinessReport({
-      reportId: clientReadinessReportId(methodCode, version, verifierBundle.runContext.runId),
+      reportId: clientReadinessReportId(
+        methodCode,
+        version,
+        verifierBundle.runContext.runId,
+      ),
       generatedAt,
       project: {
-        name: aoi?.name?.trim() || `Client readiness workspace ${methodCode}@${version}`,
+        name:
+          aoi?.name?.trim() ||
+          `Client readiness workspace ${methodCode}@${version}`,
         description: `Pre-verification readiness export generated from finalized Verify run ${verifierBundle.runContext.runId}.`,
       },
       methodology: {
@@ -3306,9 +4224,15 @@ export default function ProofMapTab({
       missingDocuments,
     } = await buildReadinessExportContext();
 
-    const reviewerArtifactsRecord = Object.fromEntries(reviewerArtifactsByRuleId.entries());
+    const reviewerArtifactsRecord = Object.fromEntries(
+      reviewerArtifactsByRuleId.entries(),
+    );
     const report = buildVvbWorkpaperReport({
-      reportId: vvbWorkpaperReportId(methodCode, version, verifierBundle.runContext.runId),
+      reportId: vvbWorkpaperReportId(
+        methodCode,
+        version,
+        verifierBundle.runContext.runId,
+      ),
       generatedAt,
       project: {
         name: aoi?.name?.trim() || `VVB workspace ${methodCode}@${version}`,
@@ -3325,11 +4249,19 @@ export default function ProofMapTab({
       reviewerArtifactsByRuleId: reviewerArtifactsRecord,
       provenance: {
         sourceRunId: verifierBundle.runContext.runId,
-        artifactState: verifierBundle.finalizedAt ? "finalized" : verifierBundle.exportedAt ? "draft" : "unavailable",
+        artifactState: verifierBundle.finalizedAt
+          ? "finalized"
+          : verifierBundle.exportedAt
+            ? "draft"
+            : "unavailable",
         snapshotExportedAt: verifierBundle.exportedAt ?? null,
         finalizedAt: verifierBundle.finalizedAt ?? null,
         auditPackReference: `audit-pack.${safeFilename(methodCode)}.${safeFilename(version)}.${safeFilename(verifierBundle.runContext.runId)}.zip`,
-        clientReadinessReference: clientReadinessReportId(methodCode, version, verifierBundle.runContext.runId),
+        clientReadinessReference: clientReadinessReportId(
+          methodCode,
+          version,
+          verifierBundle.runContext.runId,
+        ),
         traceBundleReference: `verify-run:${verifierBundle.runContext.runId}`,
       },
     });
@@ -3368,7 +4300,13 @@ export default function ProofMapTab({
     } finally {
       setClientReadinessExportBusy(false);
     }
-  }, [buildClientReadinessReportPayload, methodCode, showToast, verifierBundle.runContext.runId, version]);
+  }, [
+    buildClientReadinessReportPayload,
+    methodCode,
+    showToast,
+    verifierBundle.runContext.runId,
+    version,
+  ]);
 
   const handleExportVvbWorkpaper = useCallback(async () => {
     setVvbWorkpaperExportBusy(true);
@@ -3393,7 +4331,13 @@ export default function ProofMapTab({
     } finally {
       setVvbWorkpaperExportBusy(false);
     }
-  }, [buildVvbWorkpaperPayload, methodCode, showToast, verifierBundle.runContext.runId, version]);
+  }, [
+    buildVvbWorkpaperPayload,
+    methodCode,
+    showToast,
+    verifierBundle.runContext.runId,
+    version,
+  ]);
 
   const handleDownloadReviewSummaryPdf = useCallback(async () => {
     const finalizedAt = verifierBundle.finalizedAt ?? verifierBundle.exportedAt;
@@ -3421,7 +4365,14 @@ export default function ProofMapTab({
     } finally {
       setReviewPdfBusy(false);
     }
-  }, [activeReviewArtifact, buildFinalReviewArtifact, methodCode, reviewSummary, verifierBundle, version]);
+  }, [
+    activeReviewArtifact,
+    buildFinalReviewArtifact,
+    methodCode,
+    reviewSummary,
+    verifierBundle,
+    version,
+  ]);
 
   const handleCopyReviewSummaryLink = useCallback(async () => {
     if (typeof window === "undefined") return;
@@ -3454,14 +4405,23 @@ export default function ProofMapTab({
     setBaseline(currentBaselineProvenance, baseline);
     setBaselineTick((value) => value + 1);
     showToast("Baseline set");
-  }, [baselineMissing, currentBaselineProvenance, runKpis, runSummary.verifier.runId, showToast]);
+  }, [
+    baselineMissing,
+    currentBaselineProvenance,
+    runKpis,
+    runSummary.verifier.runId,
+    showToast,
+  ]);
 
   const handleRotateBaseline = useCallback(() => {
     if (baselineMissing.length) {
       showToast(`Cannot rotate baseline (${baselineMissing.join(", ")})`);
       return;
     }
-    const reason = typeof window !== "undefined" ? window.prompt("Reason for baseline rotation?") : null;
+    const reason =
+      typeof window !== "undefined"
+        ? window.prompt("Reason for baseline rotation?")
+        : null;
     if (!reason || !reason.trim()) return;
     const next: BaselineRecord = {
       baselineRunId: runSummary.verifier.runId ?? "run",
@@ -3472,11 +4432,18 @@ export default function ProofMapTab({
     rotateBaseline(currentBaselineProvenance, next, reason.trim());
     setBaselineTick((value) => value + 1);
     showToast("Baseline rotated");
-  }, [baselineMissing, currentBaselineProvenance, runKpis, runSummary.verifier.runId, showToast]);
+  }, [
+    baselineMissing,
+    currentBaselineProvenance,
+    runKpis,
+    runSummary.verifier.runId,
+    showToast,
+  ]);
 
   const handleClearBaseline = useCallback(() => {
     if (!latestBaseline) return;
-    const confirmed = typeof window !== "undefined" ? window.confirm("Clear baseline?") : false;
+    const confirmed =
+      typeof window !== "undefined" ? window.confirm("Clear baseline?") : false;
     if (!confirmed) return;
     clearBaseline(latestBaseline.baselineProvenance);
     setBaselineTick((value) => value + 1);
@@ -3498,7 +4465,14 @@ export default function ProofMapTab({
       status: "new",
     });
     showToast("Intake item added");
-  }, [activeRuleId, intakeSuggestion, linkedRuleIds, methodCode, showToast, version]);
+  }, [
+    activeRuleId,
+    intakeSuggestion,
+    linkedRuleIds,
+    methodCode,
+    showToast,
+    version,
+  ]);
 
   const runStartOver = useCallback(async () => {
     if (startOverBusy) return;
@@ -3560,18 +4534,27 @@ export default function ProofMapTab({
     if (!currentAoiFingerprint) return;
     if (!latestStacRun) return;
 
-    if (stacEvidenceState && stacEvidenceState.aoiFingerprint === currentAoiFingerprint && stacEvidenceState.runId === latestStacRun.id) {
+    if (
+      stacEvidenceState &&
+      stacEvidenceState.aoiFingerprint === currentAoiFingerprint &&
+      stacEvidenceState.runId === latestStacRun.id
+    ) {
       return;
     }
 
     const normalized = normalizeStacItems(latestStacRun.result_json);
     const endpoint = (() => {
       const root =
-        latestStacRun.result_json && typeof latestStacRun.result_json === "object"
+        latestStacRun.result_json &&
+        typeof latestStacRun.result_json === "object"
           ? (latestStacRun.result_json as Record<string, unknown>)
           : null;
-      const prov = root && root.provenance && typeof root.provenance === "object" ? (root.provenance as Record<string, unknown>) : null;
-      const url = prov && typeof prov.endpoint === "string" ? prov.endpoint : null;
+      const prov =
+        root && root.provenance && typeof root.provenance === "object"
+          ? (root.provenance as Record<string, unknown>)
+          : null;
+      const url =
+        prov && typeof prov.endpoint === "string" ? prov.endpoint : null;
       return url && url.trim() ? url.trim() : null;
     })();
 
@@ -3580,9 +4563,16 @@ export default function ProofMapTab({
       fc: normalized.featureCollection,
       itemsById: normalized.itemsById,
       runId: latestStacRun.id,
-      source: endpoint ? { type: "stac_url", ref: endpoint } : { type: "unknown", ref: "unknown" },
+      source: endpoint
+        ? { type: "stac_url", ref: endpoint }
+        : { type: "unknown", ref: "unknown" },
     });
-  }, [currentAoiFingerprint, latestStacRun, onSetStacEvidenceState, stacEvidenceState]);
+  }, [
+    currentAoiFingerprint,
+    latestStacRun,
+    onSetStacEvidenceState,
+    stacEvidenceState,
+  ]);
 
   useEffect(() => {
     if (selectedStacItemId && !latestStacRun) onSelectStacItemId(null);
@@ -3645,7 +4635,9 @@ export default function ProofMapTab({
         <div>
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
-              <div className="text-xs font-semibold text-slate-700">Evidence inventory</div>
+              <div className="text-xs font-semibold text-slate-700">
+                Evidence inventory
+              </div>
             </div>
             <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold text-slate-600">
               <label className="cursor-pointer rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
@@ -3666,18 +4658,27 @@ export default function ProofMapTab({
                 <button
                   type="button"
                   onClick={() => {
-                    if (typeof window !== "undefined") window.location.assign("/projects/new?handoff=document-metadata");
+                    if (typeof window !== "undefined")
+                      window.location.assign(
+                        "/projects/new?handoff=document-metadata",
+                      );
                   }}
                   className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-800"
                 >
-                  Create project from document
+                  Start review from document
                 </button>
               ) : null}
               <span className="rounded-full border border-slate-200 bg-white px-2 py-0.5">
-                {evidenceInventory.length} item{evidenceInventory.length === 1 ? "" : "s"}
+                {evidenceInventory.length} item
+                {evidenceInventory.length === 1 ? "" : "s"}
               </span>
               <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-amber-800">
-                {evidenceInventory.filter((item) => item.link_state === "unlinked").length} unlinked
+                {
+                  evidenceInventory.filter(
+                    (item) => item.link_state === "unlinked",
+                  ).length
+                }{" "}
+                unlinked
               </span>
               <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-sky-800">
                 Coverage {Math.round(evidenceMetrics.overallCoverage * 100)}%
@@ -3685,47 +4686,90 @@ export default function ProofMapTab({
               <span className="rounded-full border border-violet-200 bg-violet-50 px-2 py-0.5 text-violet-800">
                 Avg quality {Math.round(evidenceMetrics.averageQuality * 100)}%
               </span>
-              {evidenceInventory.some((item) => item.reconciliation_status || item.reconciliation_load_error) ? (
+              {evidenceInventory.some(
+                (item) =>
+                  item.reconciliation_status || item.reconciliation_load_error,
+              ) ? (
                 <>
                   <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-emerald-800">
-                    {evidenceInventory.filter((item) => item.reconciliation_status === "linked").length} reconciled
+                    {
+                      evidenceInventory.filter(
+                        (item) => item.reconciliation_status === "linked",
+                      ).length
+                    }{" "}
+                    reconciled
                   </span>
                   <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-amber-800">
-                    {evidenceInventory.filter((item) => item.reconciliation_status === "unmatched").length} unmatched
+                    {
+                      evidenceInventory.filter(
+                        (item) => item.reconciliation_status === "unmatched",
+                      ).length
+                    }{" "}
+                    unmatched
                   </span>
                   <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-red-800">
-                    {evidenceInventory.filter((item) => item.reconciliation_status === "gap").length} gaps
+                    {
+                      evidenceInventory.filter(
+                        (item) => item.reconciliation_status === "gap",
+                      ).length
+                    }{" "}
+                    gaps
                   </span>
-                  {evidenceInventory.some((item) => item.reconciliation_load_error) ? (
-                    <span className="rounded-full border border-red-300 bg-red-100 px-2 py-0.5 text-red-800" title="Reconciliation could not complete — check methodology pack or manifest">
-                      {evidenceInventory.filter((item) => item.reconciliation_load_error).length} error{evidenceInventory.filter((item) => item.reconciliation_load_error).length === 1 ? "" : "s"}
+                  {evidenceInventory.some(
+                    (item) => item.reconciliation_load_error,
+                  ) ? (
+                    <span
+                      className="rounded-full border border-red-300 bg-red-100 px-2 py-0.5 text-red-800"
+                      title="Reconciliation could not complete — check methodology pack or manifest"
+                    >
+                      {
+                        evidenceInventory.filter(
+                          (item) => item.reconciliation_load_error,
+                        ).length
+                      }{" "}
+                      error
+                      {evidenceInventory.filter(
+                        (item) => item.reconciliation_load_error,
+                      ).length === 1
+                        ? ""
+                        : "s"}
                     </span>
                   ) : null}
                 </>
               ) : null}
             </div>
           </div>
-          {!evidenceInventory.some((i) => i.reconciliation_status) && evidenceInventory.some((i) => i.reconciliation_load_error) ? (
+          {!evidenceInventory.some((i) => i.reconciliation_status) &&
+          evidenceInventory.some((i) => i.reconciliation_load_error) ? (
             <div className="mt-2 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
               <p className="font-semibold">Reconciliation incomplete</p>
               <p className="mt-1 text-xs text-red-700">
-                Evidence inventory could not be reconciled — the methodology pack or manifest may be missing.
-                Coverage gaps cannot be determined.
+                Evidence inventory could not be reconciled — the methodology
+                pack or manifest may be missing. Coverage gaps cannot be
+                determined.
               </p>
             </div>
           ) : null}
           <p className="mt-2 text-xs text-slate-500">
-            Quality and confidence metrics are advisory only and do not replace reviewer judgment.
+            Quality and confidence metrics are advisory only and do not replace
+            reviewer judgment.
           </p>
           <div className="mt-2 grid gap-2">
             {evidenceInventory.length ? (
               evidenceInventory.map((item) => {
                 const pin = evidencePinsById.get(item.evidence_id);
                 if (!pin) return null;
-                const linkedToSelectedRule = Boolean(selectedRuleId && item.linked_requirement_ids.includes(selectedRuleId));
-                const pddDraft = pddFragmentDrafts[pin.id] ?? EMPTY_PDD_FRAGMENT_DRAFT;
+                const linkedToSelectedRule = Boolean(
+                  selectedRuleId &&
+                  item.linked_requirement_ids.includes(selectedRuleId),
+                );
+                const pddDraft =
+                  pddFragmentDrafts[pin.id] ?? EMPTY_PDD_FRAGMENT_DRAFT;
                 return (
-                  <div key={item.evidence_id} className="rounded-lg border border-slate-200 bg-white px-3 py-3">
+                  <div
+                    key={item.evidence_id}
+                    className="rounded-lg border border-slate-200 bg-white px-3 py-3"
+                  >
                     <div className="flex flex-wrap items-start justify-between gap-3">
                       <div className="min-w-0">
                         <div className="flex flex-wrap items-center gap-2">
@@ -3736,7 +4780,9 @@ export default function ProofMapTab({
                                 : "border-amber-200 bg-amber-50 text-amber-800"
                             }`}
                           >
-                            {inventoryLinkStateLabel(item.linked_requirement_ids)}
+                            {inventoryLinkStateLabel(
+                              item.linked_requirement_ids,
+                            )}
                           </span>
                           {item.reconciliation_status ? (
                             <span
@@ -3773,22 +4819,46 @@ export default function ProofMapTab({
                           {qualityByEvidenceId.has(item.evidence_id) ? (
                             <>
                               <EvidenceQualityBadge
-                                grade={qualityByEvidenceId.get(item.evidence_id)!.grade}
-                                score={qualityByEvidenceId.get(item.evidence_id)!.score}
+                                grade={
+                                  qualityByEvidenceId.get(item.evidence_id)!
+                                    .grade
+                                }
+                                score={
+                                  qualityByEvidenceId.get(item.evidence_id)!
+                                    .score
+                                }
                               />
                               <ReconciliationConfidenceBadge
-                                level={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceLevel}
-                                score={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceScore}
+                                level={
+                                  qualityByEvidenceId.get(item.evidence_id)!
+                                    .reconciliationConfidenceLevel
+                                }
+                                score={
+                                  qualityByEvidenceId.get(item.evidence_id)!
+                                    .reconciliationConfidenceScore
+                                }
                               />
                               <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-semibold text-slate-600">
-                                {qualityByEvidenceId.get(item.evidence_id)!.fragmentCount} fragment{qualityByEvidenceId.get(item.evidence_id)!.fragmentCount === 1 ? "" : "s"}
+                                {
+                                  qualityByEvidenceId.get(item.evidence_id)!
+                                    .fragmentCount
+                                }{" "}
+                                fragment
+                                {qualityByEvidenceId.get(item.evidence_id)!
+                                  .fragmentCount === 1
+                                  ? ""
+                                  : "s"}
                               </span>
                             </>
                           ) : null}
                         </div>
-                        <div className="mt-2 text-sm font-semibold text-slate-900">{item.display_name}</div>
+                        <div className="mt-2 text-sm font-semibold text-slate-900">
+                          {item.display_name}
+                        </div>
                         <div className="mt-1 text-[11px] text-slate-600">
-                          {inventoryRelationshipSummary(item.linked_requirement_ids)}
+                          {inventoryRelationshipSummary(
+                            item.linked_requirement_ids,
+                          )}
                         </div>
                       </div>
                       <div className="flex flex-wrap items-center gap-2">
@@ -3798,8 +4868,16 @@ export default function ProofMapTab({
                               type="button"
                               className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-100"
                               onClick={() => {
-                                onSetEvidencePins((current) => unlinkEvidencePinFromRequirement(current, pin.id, selectedRuleId));
-                                showToast(`Unlinked ${formatEvidenceInventoryId(pin.id)} from ${selectedRuleId}`);
+                                onSetEvidencePins((current) =>
+                                  unlinkEvidencePinFromRequirement(
+                                    current,
+                                    pin.id,
+                                    selectedRuleId,
+                                  ),
+                                );
+                                showToast(
+                                  `Unlinked ${formatEvidenceInventoryId(pin.id)} from ${selectedRuleId}`,
+                                );
                               }}
                             >
                               Unlink
@@ -3809,8 +4887,16 @@ export default function ProofMapTab({
                               type="button"
                               className="rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-700 hover:bg-sky-100"
                               onClick={() => {
-                                onSetEvidencePins((current) => linkEvidencePinToRequirement(current, pin.id, selectedRuleId));
-                                showToast(`Linked ${formatEvidenceInventoryId(pin.id)} to ${selectedRuleId}`);
+                                onSetEvidencePins((current) =>
+                                  linkEvidencePinToRequirement(
+                                    current,
+                                    pin.id,
+                                    selectedRuleId,
+                                  ),
+                                );
+                                showToast(
+                                  `Linked ${formatEvidenceInventoryId(pin.id)} to ${selectedRuleId}`,
+                                );
                               }}
                             >
                               Link
@@ -3823,232 +4909,343 @@ export default function ProofMapTab({
                         ) : null}
                       </div>
                     </div>
-                      <details className="mt-3 rounded-lg border border-slate-200 bg-slate-50">
+                    <details className="mt-3 rounded-lg border border-slate-200 bg-slate-50">
                       <summary className="cursor-pointer list-none px-3 py-2 text-xs font-semibold text-slate-700">
                         More
                       </summary>
-                        <div className="grid gap-2 px-3 pb-3 text-[11px] text-slate-600">
-                          <div>ID: {formatEvidenceInventoryId(item.evidence_id)}</div>
-                          <div>Type: {item.type}</div>
-                          <div>{item.source_summary} · added {formatLocalDateTime(item.added_at)}</div>
-                          {item.workbook_assets?.length ? (
-                            <div>
-                              Workbook summary: {item.workbook_assets[0]?.sheet_count ?? 0} sheet{item.workbook_assets[0]?.sheet_count === 1 ? "" : "s"} •{" "}
-                              {item.workbook_record_groups?.length ?? 0} candidate group{(item.workbook_record_groups?.length ?? 0) === 1 ? "" : "s"}
-                            </div>
-                          ) : (
-                            <div>
-                              {(pin.stac_item_ids ?? []).length} STAC item
-                              {(pin.stac_item_ids ?? []).length === 1 ? "" : "s"}
-                              {" · "}
-                              {(pin.attachments ?? []).length} attachment
-                              {(pin.attachments ?? []).length === 1 ? "" : "s"}
-                            </div>
-                          )}
-                          <div>Provenance: {item.provenance_summary}</div>
-                          {item.workbook_assets?.length ? (
-                            <div className="grid gap-1">
-                              {item.workbook_assets.flatMap((asset) =>
-                                asset.sheets.map((sheet) => (
-                                  <div key={`${asset.workbook_id}:${sheet.sheet_name}`}>
-                                    Sheet {sheet.sheet_name} • {sheet.row_count} row{sheet.row_count === 1 ? "" : "s"} • {sheet.column_count} column{sheet.column_count === 1 ? "" : "s"}
-                                    {sheet.bounds_ref ? ` • ${sheet.bounds_ref}` : ""}
-                                  </div>
-                                )),
-                              )}
-                            </div>
-                          ) : null}
-                          {item.workbook_record_groups?.length ? (
-                            <div className="grid gap-1">
-                              {item.workbook_record_groups.map((group) => (
-                                <div key={group.group_id}>
-                                  {group.display_name} • {group.group_type} • {group.source_sheet}
-                                  {group.source_range ? ` • ${group.source_range}` : ""}
+                      <div className="grid gap-2 px-3 pb-3 text-[11px] text-slate-600">
+                        <div>
+                          ID: {formatEvidenceInventoryId(item.evidence_id)}
+                        </div>
+                        <div>Type: {item.type}</div>
+                        <div>
+                          {item.source_summary} · added{" "}
+                          {formatLocalDateTime(item.added_at)}
+                        </div>
+                        {item.workbook_assets?.length ? (
+                          <div>
+                            Workbook summary:{" "}
+                            {item.workbook_assets[0]?.sheet_count ?? 0} sheet
+                            {item.workbook_assets[0]?.sheet_count === 1
+                              ? ""
+                              : "s"}{" "}
+                            • {item.workbook_record_groups?.length ?? 0}{" "}
+                            candidate group
+                            {(item.workbook_record_groups?.length ?? 0) === 1
+                              ? ""
+                              : "s"}
+                          </div>
+                        ) : (
+                          <div>
+                            {(pin.stac_item_ids ?? []).length} STAC item
+                            {(pin.stac_item_ids ?? []).length === 1 ? "" : "s"}
+                            {" · "}
+                            {(pin.attachments ?? []).length} attachment
+                            {(pin.attachments ?? []).length === 1 ? "" : "s"}
+                          </div>
+                        )}
+                        <div>Provenance: {item.provenance_summary}</div>
+                        {item.workbook_assets?.length ? (
+                          <div className="grid gap-1">
+                            {item.workbook_assets.flatMap((asset) =>
+                              asset.sheets.map((sheet) => (
+                                <div
+                                  key={`${asset.workbook_id}:${sheet.sheet_name}`}
+                                >
+                                  Sheet {sheet.sheet_name} • {sheet.row_count}{" "}
+                                  row{sheet.row_count === 1 ? "" : "s"} •{" "}
+                                  {sheet.column_count} column
+                                  {sheet.column_count === 1 ? "" : "s"}
+                                  {sheet.bounds_ref
+                                    ? ` • ${sheet.bounds_ref}`
+                                    : ""}
                                 </div>
-                              ))}
+                              )),
+                            )}
+                          </div>
+                        ) : null}
+                        {item.workbook_record_groups?.length ? (
+                          <div className="grid gap-1">
+                            {item.workbook_record_groups.map((group) => (
+                              <div key={group.group_id}>
+                                {group.display_name} • {group.group_type} •{" "}
+                                {group.source_sheet}
+                                {group.source_range
+                                  ? ` • ${group.source_range}`
+                                  : ""}
+                              </div>
+                            ))}
+                          </div>
+                        ) : null}
+                        {item.pdd_document ? (
+                          <div className="grid gap-2 rounded-lg border border-slate-200 bg-white p-2">
+                            <div className="font-semibold text-slate-700">
+                              PDD document
                             </div>
-                          ) : null}
-                          {item.pdd_document ? (
-                            <div className="grid gap-2 rounded-lg border border-slate-200 bg-white p-2">
-                              <div className="font-semibold text-slate-700">PDD document</div>
-                              <div>
-                                {item.pdd_document.file_name} • {item.pdd_document.mime}
-                                {item.pdd_document.sha256 ? ` • ${shortSha(item.pdd_document.sha256)}` : ""}
-                              </div>
-                              {selectedRuleId && suggestedPddFragmentDraft ? (
-                                <div className="grid gap-2 rounded-lg border border-sky-200 bg-sky-50/60 p-2 text-[11px] text-slate-700">
-                                  <div className="flex flex-wrap items-center justify-between gap-2">
-                                    <div className="font-semibold text-sky-800">Suggested fragment metadata for {selectedRuleId}</div>
-                                    <button
-                                      type="button"
-                                      className="rounded-full border border-sky-200 bg-white px-3 py-1 text-xs font-semibold text-sky-700 hover:bg-sky-100"
-                                      onClick={() => applySuggestedPddFragmentDraft(pin.id)}
-                                    >
-                                      Use suggestion
-                                    </button>
+                            <div>
+                              {item.pdd_document.file_name} •{" "}
+                              {item.pdd_document.mime}
+                              {item.pdd_document.sha256
+                                ? ` • ${shortSha(item.pdd_document.sha256)}`
+                                : ""}
+                            </div>
+                            {selectedRuleId && suggestedPddFragmentDraft ? (
+                              <div className="grid gap-2 rounded-lg border border-sky-200 bg-sky-50/60 p-2 text-[11px] text-slate-700">
+                                <div className="flex flex-wrap items-center justify-between gap-2">
+                                  <div className="font-semibold text-sky-800">
+                                    Suggested fragment metadata for{" "}
+                                    {selectedRuleId}
                                   </div>
-                                  <div>
-                                    Label: <span className="font-medium text-slate-900">{suggestedPddFragmentDraft.label}</span>
-                                    {suggestedPddFragmentDraft.sectionHeading
-                                      ? ` · Heading: ${suggestedPddFragmentDraft.sectionHeading}`
-                                      : ""}
-                                    {suggestedPddFragmentDraft.sectionLabel
-                                      ? ` · Section: ${suggestedPddFragmentDraft.sectionLabel}`
-                                      : ""}
-                                  </div>
-                                  <div className="text-slate-600">{suggestedPddFragmentDraft.reason}</div>
+                                  <button
+                                    type="button"
+                                    className="rounded-full border border-sky-200 bg-white px-3 py-1 text-xs font-semibold text-sky-700 hover:bg-sky-100"
+                                    onClick={() =>
+                                      applySuggestedPddFragmentDraft(pin.id)
+                                    }
+                                  >
+                                    Use suggestion
+                                  </button>
                                 </div>
-                              ) : null}
-                              <div className="grid gap-2 md:grid-cols-2">
-                                <label className="grid gap-1 md:col-span-2">
-                                  <span>Fragment label</span>
-                                  <input
-                                    type="text"
-                                    value={pddDraft.label}
-                                    onChange={(event) => updatePddFragmentDraft(pin.id, { label: event.target.value })}
-                                    placeholder="Boundary overview"
-                                    className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
-                                  />
-                                </label>
-                                <label className="grid gap-1">
-                                  <span>Section label</span>
-                                  <input
-                                    type="text"
-                                    value={pddDraft.sectionLabel}
-                                    onChange={(event) => updatePddFragmentDraft(pin.id, { sectionLabel: event.target.value })}
-                                    className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
-                                  />
-                                </label>
-                                <label className="grid gap-1">
-                                  <span>Section heading</span>
-                                  <input
-                                    type="text"
-                                    value={pddDraft.sectionHeading}
-                                    onChange={(event) => updatePddFragmentDraft(pin.id, { sectionHeading: event.target.value })}
-                                    className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
-                                  />
-                                </label>
-                                <label className="grid gap-1">
-                                  <span>Page start</span>
-                                  <input
-                                    type="number"
-                                    min="1"
-                                    value={pddDraft.pageStart}
-                                    onChange={(event) => updatePddFragmentDraft(pin.id, { pageStart: event.target.value })}
-                                    className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
-                                  />
-                                </label>
-                                <label className="grid gap-1">
-                                  <span>Page end</span>
-                                  <input
-                                    type="number"
-                                    min="1"
-                                    value={pddDraft.pageEnd}
-                                    onChange={(event) => updatePddFragmentDraft(pin.id, { pageEnd: event.target.value })}
-                                    className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
-                                  />
-                                </label>
+                                <div>
+                                  Label:{" "}
+                                  <span className="font-medium text-slate-900">
+                                    {suggestedPddFragmentDraft.label}
+                                  </span>
+                                  {suggestedPddFragmentDraft.sectionHeading
+                                    ? ` · Heading: ${suggestedPddFragmentDraft.sectionHeading}`
+                                    : ""}
+                                  {suggestedPddFragmentDraft.sectionLabel
+                                    ? ` · Section: ${suggestedPddFragmentDraft.sectionLabel}`
+                                    : ""}
+                                </div>
+                                <div className="text-slate-600">
+                                  {suggestedPddFragmentDraft.reason}
+                                </div>
                               </div>
-                              <label className="grid gap-1">
-                                <span>Excerpt</span>
-                                <textarea
-                                  value={pddDraft.excerpt}
-                                  onChange={(event) => updatePddFragmentDraft(pin.id, { excerpt: event.target.value })}
-                                  rows={3}
+                            ) : null}
+                            <div className="grid gap-2 md:grid-cols-2">
+                              <label className="grid gap-1 md:col-span-2">
+                                <span>Fragment label</span>
+                                <input
+                                  type="text"
+                                  value={pddDraft.label}
+                                  onChange={(event) =>
+                                    updatePddFragmentDraft(pin.id, {
+                                      label: event.target.value,
+                                    })
+                                  }
+                                  placeholder="Boundary overview"
                                   className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
                                 />
                               </label>
-                              <div>
-                                <button
-                                  type="button"
-                                  className="rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-700 hover:bg-sky-100"
-                                  onClick={() => handleSavePddFragment(pin)}
-                                >
-                                  Save fragment
-                                </button>
-                              </div>
-                              {item.pdd_fragments?.length ? (
-                                <div className="grid gap-2">
-                                  {item.pdd_fragments.map((fragment) => {
-                                    const linkedRuleIds = (pin.pdd_fragment_links ?? [])
-                                      .filter((link) => link.fragment_id === fragment.fragment_id)
-                                      .map((link) => link.rule_id);
-                                    const linkedToSelectedFragment = Boolean(
-                                      selectedRuleId && linkedRuleIds.includes(selectedRuleId),
-                                    );
-                                    return (
-                                      <div key={fragment.fragment_id} className="rounded border border-slate-200 bg-slate-50 p-2">
-                                        <div className="flex flex-wrap items-center gap-2">
-                                          <div className="font-medium text-slate-800">
-                                            {formatPddFragmentDisplayLabel(fragment)}
-                                          </div>
-                                          {qualityByEvidenceId.has(item.evidence_id) ? (
-                                            <ReconciliationConfidenceBadge
-                                              level={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceLevel}
-                                              score={qualityByEvidenceId.get(item.evidence_id)!.reconciliationConfidenceScore}
-                                            />
-                                          ) : null}
+                              <label className="grid gap-1">
+                                <span>Section label</span>
+                                <input
+                                  type="text"
+                                  value={pddDraft.sectionLabel}
+                                  onChange={(event) =>
+                                    updatePddFragmentDraft(pin.id, {
+                                      sectionLabel: event.target.value,
+                                    })
+                                  }
+                                  className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
+                                />
+                              </label>
+                              <label className="grid gap-1">
+                                <span>Section heading</span>
+                                <input
+                                  type="text"
+                                  value={pddDraft.sectionHeading}
+                                  onChange={(event) =>
+                                    updatePddFragmentDraft(pin.id, {
+                                      sectionHeading: event.target.value,
+                                    })
+                                  }
+                                  className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
+                                />
+                              </label>
+                              <label className="grid gap-1">
+                                <span>Page start</span>
+                                <input
+                                  type="number"
+                                  min="1"
+                                  value={pddDraft.pageStart}
+                                  onChange={(event) =>
+                                    updatePddFragmentDraft(pin.id, {
+                                      pageStart: event.target.value,
+                                    })
+                                  }
+                                  className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
+                                />
+                              </label>
+                              <label className="grid gap-1">
+                                <span>Page end</span>
+                                <input
+                                  type="number"
+                                  min="1"
+                                  value={pddDraft.pageEnd}
+                                  onChange={(event) =>
+                                    updatePddFragmentDraft(pin.id, {
+                                      pageEnd: event.target.value,
+                                    })
+                                  }
+                                  className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
+                                />
+                              </label>
+                            </div>
+                            <label className="grid gap-1">
+                              <span>Excerpt</span>
+                              <textarea
+                                value={pddDraft.excerpt}
+                                onChange={(event) =>
+                                  updatePddFragmentDraft(pin.id, {
+                                    excerpt: event.target.value,
+                                  })
+                                }
+                                rows={3}
+                                className="rounded border border-slate-200 px-2 py-1 text-[11px] text-slate-900"
+                              />
+                            </label>
+                            <div>
+                              <button
+                                type="button"
+                                className="rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-700 hover:bg-sky-100"
+                                onClick={() => handleSavePddFragment(pin)}
+                              >
+                                Save fragment
+                              </button>
+                            </div>
+                            {item.pdd_fragments?.length ? (
+                              <div className="grid gap-2">
+                                {item.pdd_fragments.map((fragment) => {
+                                  const linkedRuleIds = (
+                                    pin.pdd_fragment_links ?? []
+                                  )
+                                    .filter(
+                                      (link) =>
+                                        link.fragment_id ===
+                                        fragment.fragment_id,
+                                    )
+                                    .map((link) => link.rule_id);
+                                  const linkedToSelectedFragment = Boolean(
+                                    selectedRuleId &&
+                                    linkedRuleIds.includes(selectedRuleId),
+                                  );
+                                  return (
+                                    <div
+                                      key={fragment.fragment_id}
+                                      className="rounded border border-slate-200 bg-slate-50 p-2"
+                                    >
+                                      <div className="flex flex-wrap items-center gap-2">
+                                        <div className="font-medium text-slate-800">
+                                          {formatPddFragmentDisplayLabel(
+                                            fragment,
+                                          )}
                                         </div>
-                                        <div className="mt-1">
-                                          {[fragment.section_heading, fragment.section_label, formatPddPageLabel(fragment.page_start, fragment.page_end)]
-                                            .filter(Boolean)
-                                            .join(" • ") || "Fragment metadata pending"}
-                                        </div>
-                                        {fragment.excerpt ? (
-                                          <div className="mt-1 rounded border border-slate-200 bg-white px-2 py-1 text-slate-700">
-                                            {fragment.excerpt}
-                                          </div>
-                                        ) : null}
-                                        {linkedRuleIds.length ? (
-                                          <div className="mt-1">Linked to: {linkedRuleIds.join(", ")}</div>
-                                        ) : null}
-                                        {selectedRuleId ? (
-                                          <div className="mt-2">
-                                            {linkedToSelectedFragment ? (
-                                              <button
-                                                type="button"
-                                                className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-100"
-                                                onClick={() => {
-                                                  onSetEvidencePins((current) =>
-                                                    unlinkPddFragmentFromRequirement(current, pin.id, fragment.fragment_id, selectedRuleId),
-                                                  );
-                                                  showToast(`Unlinked ${fragment.fragment_id} from ${selectedRuleId}`);
-                                                }}
-                                              >
-                                                Unlink fragment
-                                              </button>
-                                            ) : (
-                                              <button
-                                                type="button"
-                                                className="rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-700 hover:bg-sky-100"
-                                                onClick={() => {
-                                                  onSetEvidencePins((current) =>
-                                                    linkPddFragmentToRequirement(current, pin.id, fragment.fragment_id, selectedRuleId),
-                                                  );
-                                                  showToast(`Reused ${formatPddFragmentDisplayLabel(fragment)} for ${selectedRuleId}`);
-                                                }}
-                                              >
-                                                Reuse for {selectedRuleId}
-                                              </button>
-                                            )}
-                                          </div>
+                                        {qualityByEvidenceId.has(
+                                          item.evidence_id,
+                                        ) ? (
+                                          <ReconciliationConfidenceBadge
+                                            level={
+                                              qualityByEvidenceId.get(
+                                                item.evidence_id,
+                                              )!.reconciliationConfidenceLevel
+                                            }
+                                            score={
+                                              qualityByEvidenceId.get(
+                                                item.evidence_id,
+                                              )!.reconciliationConfidenceScore
+                                            }
+                                          />
                                         ) : null}
                                       </div>
-                                    );
-                                  })}
-                                </div>
-                              ) : null}
-                            </div>
-                          ) : null}
-                          {item.linked_requirement_ids.length ? (
-                            <div className="flex flex-wrap gap-2">
-                              {item.linked_requirement_ids.map((id) => (
+                                      <div className="mt-1">
+                                        {[
+                                          fragment.section_heading,
+                                          fragment.section_label,
+                                          formatPddPageLabel(
+                                            fragment.page_start,
+                                            fragment.page_end,
+                                          ),
+                                        ]
+                                          .filter(Boolean)
+                                          .join(" • ") ||
+                                          "Fragment metadata pending"}
+                                      </div>
+                                      {fragment.excerpt ? (
+                                        <div className="mt-1 rounded border border-slate-200 bg-white px-2 py-1 text-slate-700">
+                                          {fragment.excerpt}
+                                        </div>
+                                      ) : null}
+                                      {linkedRuleIds.length ? (
+                                        <div className="mt-1">
+                                          Linked to: {linkedRuleIds.join(", ")}
+                                        </div>
+                                      ) : null}
+                                      {selectedRuleId ? (
+                                        <div className="mt-2">
+                                          {linkedToSelectedFragment ? (
+                                            <button
+                                              type="button"
+                                              className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-100"
+                                              onClick={() => {
+                                                onSetEvidencePins((current) =>
+                                                  unlinkPddFragmentFromRequirement(
+                                                    current,
+                                                    pin.id,
+                                                    fragment.fragment_id,
+                                                    selectedRuleId,
+                                                  ),
+                                                );
+                                                showToast(
+                                                  `Unlinked ${fragment.fragment_id} from ${selectedRuleId}`,
+                                                );
+                                              }}
+                                            >
+                                              Unlink fragment
+                                            </button>
+                                          ) : (
+                                            <button
+                                              type="button"
+                                              className="rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-700 hover:bg-sky-100"
+                                              onClick={() => {
+                                                onSetEvidencePins((current) =>
+                                                  linkPddFragmentToRequirement(
+                                                    current,
+                                                    pin.id,
+                                                    fragment.fragment_id,
+                                                    selectedRuleId,
+                                                  ),
+                                                );
+                                                showToast(
+                                                  `Reused ${formatPddFragmentDisplayLabel(fragment)} for ${selectedRuleId}`,
+                                                );
+                                              }}
+                                            >
+                                              Reuse for {selectedRuleId}
+                                            </button>
+                                          )}
+                                        </div>
+                                      ) : null}
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            ) : null}
+                          </div>
+                        ) : null}
+                        {item.linked_requirement_ids.length ? (
+                          <div className="flex flex-wrap gap-2">
+                            {item.linked_requirement_ids.map((id) => (
                               <button
                                 key={`${pin.id}:${id}`}
                                 type="button"
                                 className="rounded-full border border-slate-200 bg-white px-2 py-0.5 font-mono text-[11px] text-slate-700 hover:bg-slate-50"
                                 onClick={async () => {
-                                  const ok = await handleNavigateEvidence("rule", id);
+                                  const ok = await handleNavigateEvidence(
+                                    "rule",
+                                    id,
+                                  );
                                   if (!ok) showToast("Rule not found");
                                 }}
                               >
@@ -4070,7 +5267,11 @@ export default function ProofMapTab({
                                 if (!file) return;
                                 setError(null);
                                 try {
-                                  const result = await createAndStoreEvidenceAttachment({ pin_id: pin.id, file });
+                                  const result =
+                                    await createAndStoreEvidenceAttachment({
+                                      pin_id: pin.id,
+                                      file,
+                                    });
                                   if (!result.ok) {
                                     setError(result.message);
                                     return;
@@ -4081,7 +5282,10 @@ export default function ProofMapTab({
                                         existing.id === pin.id
                                           ? {
                                               ...existing,
-                                              attachments: [...(existing.attachments ?? []), result.attachment],
+                                              attachments: [
+                                                ...(existing.attachments ?? []),
+                                                result.attachment,
+                                              ],
                                             }
                                           : existing,
                                       ),
@@ -4089,7 +5293,9 @@ export default function ProofMapTab({
                                   );
                                   showToast("Attachment saved");
                                 } catch (e) {
-                                  setError(e instanceof Error ? e.message : String(e));
+                                  setError(
+                                    e instanceof Error ? e.message : String(e),
+                                  );
                                 }
                               }}
                             />
@@ -4103,12 +5309,16 @@ export default function ProofMapTab({
                                   coalesceEvidencePins(
                                     current.map((entry) => {
                                       if (entry.id !== pin.id) return entry;
-                                      const existing = new Set(entry.stac_item_ids ?? []);
+                                      const existing = new Set(
+                                        entry.stac_item_ids ?? [],
+                                      );
                                       existing.add(selectedStacItemId);
                                       return {
                                         ...entry,
                                         stac_item_ids: Array.from(existing),
-                                        stac_run_id: entry.stac_run_id ?? currentStacEvidence.runId,
+                                        stac_run_id:
+                                          entry.stac_run_id ??
+                                          currentStacEvidence.runId,
                                       };
                                     }),
                                   ),
@@ -4126,19 +5336,29 @@ export default function ProofMapTab({
                 );
               })
             ) : (
-              <div className="text-xs text-slate-500">No evidence inventory yet. Add a STAC item to inventory to create the first evidence object.</div>
+              <div className="text-xs text-slate-500">
+                No evidence inventory yet. Add a STAC item to inventory to
+                create the first evidence object.
+              </div>
             )}
           </div>
         </div>
       )}
 
       <div>
-        <div className="text-xs font-semibold text-slate-700">STAC Evidence</div>
+        <div className="text-xs font-semibold text-slate-700">
+          STAC Evidence
+        </div>
         <div className="mt-2 grid gap-2">
           {aoi && currentAoiFingerprint && stacRenderedCount ? (
-            <div ref={stacEvidenceCardRef} className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+            <div
+              ref={stacEvidenceCardRef}
+              className="rounded-lg border border-slate-200 bg-white px-3 py-2"
+            >
               <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="text-xs font-semibold text-slate-900">{stacRenderedCount} feature(s)</div>
+                <div className="text-xs font-semibold text-slate-900">
+                  {stacRenderedCount} feature(s)
+                </div>
                 <button
                   type="button"
                   className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
@@ -4148,21 +5368,27 @@ export default function ProofMapTab({
                   Clear selection
                 </button>
               </div>
-              <div className="mt-1 text-[11px] text-slate-500">Rendered: {stacRenderedCount}</div>
+              <div className="mt-1 text-[11px] text-slate-500">
+                Rendered: {stacRenderedCount}
+              </div>
               <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-slate-500">
                 <span>
-                  Valid: {evidenceDiagnostics.valid}, Skipped: {evidenceDiagnostics.skipped}
+                  Valid: {evidenceDiagnostics.valid}, Skipped:{" "}
+                  {evidenceDiagnostics.skipped}
                 </span>
                 {evidenceDiagnostics.inView != null ? (
                   <span>
-                    In view: {evidenceDiagnostics.inView}/{evidenceDiagnostics.valid}
+                    In view: {evidenceDiagnostics.inView}/
+                    {evidenceDiagnostics.valid}
                   </span>
                 ) : null}
               </div>
               {evidenceDiagnostics.bounds ? (
                 <div className="mt-1 break-words font-mono text-[11px] text-slate-500">
-                  Bounds: {formatNum(evidenceDiagnostics.bounds[0])}, {formatNum(evidenceDiagnostics.bounds[1])} →{" "}
-                  {formatNum(evidenceDiagnostics.bounds[2])}, {formatNum(evidenceDiagnostics.bounds[3])}
+                  Bounds: {formatNum(evidenceDiagnostics.bounds[0])},{" "}
+                  {formatNum(evidenceDiagnostics.bounds[1])} →{" "}
+                  {formatNum(evidenceDiagnostics.bounds[2])},{" "}
+                  {formatNum(evidenceDiagnostics.bounds[3])}
                 </div>
               ) : (
                 <div className="mt-1 text-[11px] text-slate-500">Bounds: —</div>
@@ -4172,7 +5398,8 @@ export default function ProofMapTab({
                   type="button"
                   className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
                   onClick={() => {
-                    if (!evidenceDiagnostics.bounds) return void showToast("No valid evidence geometry/bbox");
+                    if (!evidenceDiagnostics.bounds)
+                      return void showToast("No valid evidence geometry/bbox");
                     zoomToBbox(mapRef.current, evidenceDiagnostics.bounds, 80);
                   }}
                   title="Zoom map to evidence bounds"
@@ -4200,7 +5427,8 @@ export default function ProofMapTab({
                   <div className="mt-2 max-h-40 overflow-auto">
                     <div className="grid gap-1">
                       {stacFeatureIds.slice(0, 60).map((id) => {
-                        const bbox = evidenceDiagnostics.byIdBbox.get(id) ?? null;
+                        const bbox =
+                          evidenceDiagnostics.byIdBbox.get(id) ?? null;
                         const selected = id === selectedStacItemId;
                         return (
                           <button
@@ -4243,7 +5471,10 @@ export default function ProofMapTab({
                 <div className="mt-3 grid gap-2">
                   <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-100 bg-slate-50 px-2 py-2">
                     <div className="text-xs font-semibold text-slate-900">
-                      Selected: <span className="font-mono">{selectedStacDetails.id}</span>
+                      Selected:{" "}
+                      <span className="font-mono">
+                        {selectedStacDetails.id}
+                      </span>
                       {lastSelectionSource ? (
                         <span className="ml-2 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
                           via {lastSelectionSource}
@@ -4261,7 +5492,9 @@ export default function ProofMapTab({
                   </div>
                   <div className="grid gap-1 text-xs text-slate-700">
                     <div className="flex flex-wrap items-center justify-between gap-2">
-                      <span className="font-semibold text-slate-900">Item ID</span>
+                      <span className="font-semibold text-slate-900">
+                        Item ID
+                      </span>
                       <button
                         type="button"
                         className="rounded-full border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
@@ -4270,7 +5503,9 @@ export default function ProofMapTab({
                         Copy
                       </button>
                     </div>
-                    <div className="break-words font-mono text-[11px] text-slate-600">{selectedStacDetails.id}</div>
+                    <div className="break-words font-mono text-[11px] text-slate-600">
+                      {selectedStacDetails.id}
+                    </div>
                   </div>
                   <div className="flex flex-wrap gap-2">
                     <Tooltip content={addInventoryDisabledReason}>
@@ -4296,24 +5531,36 @@ export default function ProofMapTab({
                   </div>
                   <div className="grid gap-1 text-xs text-slate-700">
                     <div className="font-semibold text-slate-900">BBox</div>
-                    <div className="font-mono text-[11px] text-slate-600">{selectedStacDetails.bbox}</div>
+                    <div className="font-mono text-[11px] text-slate-600">
+                      {selectedStacDetails.bbox}
+                    </div>
                   </div>
                   <div className="grid gap-1 text-xs text-slate-700">
                     <div className="font-semibold text-slate-900">Datetime</div>
-                    <div className="font-mono text-[11px] text-slate-600">{selectedStacDetails.datetime}</div>
+                    <div className="font-mono text-[11px] text-slate-600">
+                      {selectedStacDetails.datetime}
+                    </div>
                   </div>
                   <div className="grid gap-1 text-xs text-slate-700">
-                    <div className="font-semibold text-slate-900">Cloud cover</div>
-                    <div className="font-mono text-[11px] text-slate-600">{selectedStacDetails.cloudCover}</div>
+                    <div className="font-semibold text-slate-900">
+                      Cloud cover
+                    </div>
+                    <div className="font-mono text-[11px] text-slate-600">
+                      {selectedStacDetails.cloudCover}
+                    </div>
                   </div>
                   <div className="grid gap-1 text-xs text-slate-700">
                     <div className="font-semibold text-slate-900">Assets</div>
-                    <div className="font-mono text-[11px] text-slate-600">{selectedStacDetails.assetsCount}</div>
+                    <div className="font-mono text-[11px] text-slate-600">
+                      {selectedStacDetails.assetsCount}
+                    </div>
                   </div>
                   {selectedStacDetails.runId ? (
                     <div className="grid gap-1 text-xs text-slate-700">
                       <div className="font-semibold text-slate-900">Run</div>
-                      <div className="font-mono text-[11px] text-slate-600">{selectedStacDetails.runId}</div>
+                      <div className="font-mono text-[11px] text-slate-600">
+                        {selectedStacDetails.runId}
+                      </div>
                     </div>
                   ) : null}
                   <div className="rounded-lg border border-slate-100 bg-slate-50 px-2 py-2">
@@ -4328,7 +5575,10 @@ export default function ProofMapTab({
                             type="button"
                             className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
                             onClick={async () => {
-                              const ok = await handleNavigateEvidence("rule", id);
+                              const ok = await handleNavigateEvidence(
+                                "rule",
+                                id,
+                              );
                               if (!ok) showToast("Rule not found");
                             }}
                             title={`Open rule ${id}`}
@@ -4354,7 +5604,10 @@ export default function ProofMapTab({
                               type="button"
                               className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
                               onClick={async () => {
-                                const ok = await handleNavigateEvidence("section", id);
+                                const ok = await handleNavigateEvidence(
+                                  "section",
+                                  id,
+                                );
                                 if (!ok) showToast("Section not found");
                               }}
                               title={`Open section ${id}`}
@@ -4368,13 +5621,22 @@ export default function ProofMapTab({
                   </div>
                   {selectedStacDetails.assetRows.length ? (
                     <div className="rounded-lg border border-slate-100 bg-slate-50 px-2 py-2">
-                      <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Assets</div>
+                      <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                        Assets
+                      </div>
                       <div className="mt-2 grid gap-2">
                         {selectedStacDetails.assetRows.map((row) => (
-                          <div key={row.key} className="flex items-start justify-between gap-2">
+                          <div
+                            key={row.key}
+                            className="flex items-start justify-between gap-2"
+                          >
                             <div className="min-w-0">
-                              <div className="text-xs font-semibold text-slate-800">{row.key}</div>
-                              <div className="break-words font-mono text-[11px] text-slate-600">{row.href}</div>
+                              <div className="text-xs font-semibold text-slate-800">
+                                {row.key}
+                              </div>
+                              <div className="break-words font-mono text-[11px] text-slate-600">
+                                {row.href}
+                              </div>
                             </div>
                             <button
                               type="button"
@@ -4390,13 +5652,22 @@ export default function ProofMapTab({
                   ) : null}
                   {selectedStacDetails.linkRows.length ? (
                     <div className="rounded-lg border border-slate-100 bg-slate-50 px-2 py-2">
-                      <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Links</div>
+                      <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                        Links
+                      </div>
                       <div className="mt-2 grid gap-2">
                         {selectedStacDetails.linkRows.map((row, idx) => (
-                          <div key={`${row.href}:${idx}`} className="flex items-start justify-between gap-2">
+                          <div
+                            key={`${row.href}:${idx}`}
+                            className="flex items-start justify-between gap-2"
+                          >
                             <div className="min-w-0">
-                              <div className="text-xs font-semibold text-slate-800">{row.rel}</div>
-                              <div className="break-words font-mono text-[11px] text-slate-600">{row.href}</div>
+                              <div className="text-xs font-semibold text-slate-800">
+                                {row.rel}
+                              </div>
+                              <div className="break-words font-mono text-[11px] text-slate-600">
+                                {row.href}
+                              </div>
                             </div>
                             <button
                               type="button"
@@ -4412,7 +5683,9 @@ export default function ProofMapTab({
                   ) : null}
                 </div>
               ) : (
-                <div className="mt-2 text-xs text-slate-500">Click a footprint/marker on the map to inspect.</div>
+                <div className="mt-2 text-xs text-slate-500">
+                  Click a footprint/marker on the map to inspect.
+                </div>
               )}
             </div>
           ) : (
@@ -4428,20 +5701,33 @@ export default function ProofMapTab({
       </div>
 
       <div>
-        <div className="text-xs font-semibold text-slate-700">Evidence searches (current AOI)</div>
+        <div className="text-xs font-semibold text-slate-700">
+          Evidence searches (current AOI)
+        </div>
         <div className="mt-2 grid gap-2">
           {aoi && currentAoiFingerprint && currentRuns.length ? (
             currentRuns.map((run) => {
               const pill = statusPill(run.status);
               return (
-                <div key={run.id} className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                <div
+                  key={run.id}
+                  className="rounded-lg border border-slate-200 bg-white px-3 py-2"
+                >
                   <div className="flex flex-wrap items-center justify-between gap-2">
-                    <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${pill.className}`}>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${pill.className}`}
+                    >
                       {pill.label}
                     </span>
-                    <span className="text-xs text-slate-500">{formatLocalDateTime(run.created_at)}</span>
+                    <span className="text-xs text-slate-500">
+                      {formatLocalDateTime(run.created_at)}
+                    </span>
                   </div>
-                  {run.summary ? <div className="mt-1 text-xs text-slate-700">{run.summary}</div> : null}
+                  {run.summary ? (
+                    <div className="mt-1 text-xs text-slate-700">
+                      {run.summary}
+                    </div>
+                  ) : null}
                   {run.result_json ? (
                     <button
                       type="button"
@@ -4468,41 +5754,74 @@ export default function ProofMapTab({
     </>
   );
 
-  const summarySnapshot = formatSnapshotSummaryTime(runKpis.snapshotExportedAt ?? null);
+  const summarySnapshot = formatSnapshotSummaryTime(
+    runKpis.snapshotExportedAt ?? null,
+  );
 
   return (
     <div className="mt-4 grid gap-4">
       <div className="rounded-xl border border-slate-200 bg-white px-4 py-3">
         <div className="flex flex-col gap-2.5 lg:flex-row lg:items-start lg:justify-between">
           <div className="min-w-0">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Review summary</div>
+            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+              Review summary
+            </div>
             <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
               <span className="text-xs text-slate-500">
-                method: <span className="font-mono font-semibold text-slate-900">{methodCode}@{version}</span>
+                method:{" "}
+                <span className="font-mono font-semibold text-slate-900">
+                  {methodCode}@{version}
+                </span>
               </span>
               <span className="text-xs text-slate-500">
-                Items: <span className="font-semibold text-slate-900">{runKpis.itemsCount}</span>
+                Items:{" "}
+                <span className="font-semibold text-slate-900">
+                  {runKpis.itemsCount}
+                </span>
               </span>
               <span className="text-xs text-slate-500">
-                Linked: <span className="font-semibold text-slate-900">{runKpis.linkedRulesCount}</span>
+                Linked:{" "}
+                <span className="font-semibold text-slate-900">
+                  {runKpis.linkedRulesCount}
+                </span>
               </span>
-              <span className="text-xs text-slate-500" title={summarySnapshot.title}>
-                Snapshot: <span className="font-semibold text-slate-900">{summarySnapshot.label}</span>
+              <span
+                className="text-xs text-slate-500"
+                title={summarySnapshot.title}
+              >
+                Snapshot:{" "}
+                <span className="font-semibold text-slate-900">
+                  {summarySnapshot.label}
+                </span>
               </span>
             </div>
           </div>
-          <div className="text-xs text-slate-500">Keep reviewer-useful state visible. Open technical metadata only when needed.</div>
+          <div className="text-xs text-slate-500">
+            Keep reviewer-useful state visible. Open technical metadata only
+            when needed.
+          </div>
         </div>
       </div>
 
-      <details className="group rounded-xl border border-slate-200 bg-white" data-testid="verify-technical-metadata">
+      <details
+        className="group rounded-xl border border-slate-200 bg-white"
+        data-testid="verify-technical-metadata"
+      >
         <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-left marker:hidden">
           <div>
-            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Technical metadata</div>
-            <div className="mt-1 text-sm font-medium text-slate-700">Export context, hashes, and debug details</div>
+            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+              Technical metadata
+            </div>
+            <div className="mt-1 text-sm font-medium text-slate-700">
+              Export context, hashes, and debug details
+            </div>
           </div>
-          <span className="text-xs font-semibold text-slate-500 group-open:hidden">Show</span>
-          <span className="hidden text-xs font-semibold text-slate-500 group-open:inline">Hide</span>
+          <span className="text-xs font-semibold text-slate-500 group-open:hidden">
+            Show
+          </span>
+          <span className="hidden text-xs font-semibold text-slate-500 group-open:inline">
+            Hide
+          </span>
         </summary>
         <div className="border-t border-slate-100 px-4 py-3">
           <div className="flex flex-col gap-3">
@@ -4517,7 +5836,9 @@ export default function ProofMapTab({
                 title={`Copy method ${methodCode}@${version}`}
               >
                 <span className="text-slate-500">method:</span>
-                <span className="font-mono">{methodCode}@{version}</span>
+                <span className="font-mono">
+                  {methodCode}@{version}
+                </span>
               </button>
 
               {appCommit ? (
@@ -4554,14 +5875,21 @@ export default function ProofMapTab({
                   onClick={async () => {
                     const snapshot = await buildOutcomeSnapshot({
                       method: { code: methodCode, version },
-                      evidence_source: { type: "upload", ref: "local_pins", hash_inputs: localEvidenceHashInputs },
+                      evidence_source: {
+                        type: "upload",
+                        ref: "local_pins",
+                        hash_inputs: localEvidenceHashInputs,
+                      },
                     });
-                    if (snapshot.evidence_source.hash) await copyToClipboard(snapshot.evidence_source.hash);
+                    if (snapshot.evidence_source.hash)
+                      await copyToClipboard(snapshot.evidence_source.hash);
                   }}
                   title="Copy local evidence hash"
                 >
                   <span className="text-slate-500">evidence:</span>
-                  <span className="font-mono">local:{localEvidenceHashInputs.length}</span>
+                  <span className="font-mono">
+                    local:{localEvidenceHashInputs.length}
+                  </span>
                 </button>
               ) : (
                 <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-500">
@@ -4577,18 +5905,24 @@ export default function ProofMapTab({
                   title="Copy rules_sha256"
                 >
                   <span className="text-slate-500">rules:</span>
-                  <span className="font-mono">{shortSha(auditHashes.rules)}</span>
+                  <span className="font-mono">
+                    {shortSha(auditHashes.rules)}
+                  </span>
                 </button>
               ) : null}
               {auditHashes?.sections ? (
                 <button
                   type="button"
                   className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
-                  onClick={async () => copyToClipboard(auditHashes.sections ?? "")}
+                  onClick={async () =>
+                    copyToClipboard(auditHashes.sections ?? "")
+                  }
                   title="Copy sections_sha256"
                 >
                   <span className="text-slate-500">sections:</span>
-                  <span className="font-mono">{shortSha(auditHashes.sections)}</span>
+                  <span className="font-mono">
+                    {shortSha(auditHashes.sections)}
+                  </span>
                 </button>
               ) : null}
             </div>
@@ -4602,7 +5936,9 @@ export default function ProofMapTab({
                 type="button"
                 className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
                 onClick={() => {
-                  document.getElementById("verify-outcome")?.scrollIntoView({ behavior: "smooth", block: "start" });
+                  document
+                    .getElementById("verify-outcome")
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" });
                 }}
               >
                 Outcome
@@ -4634,14 +5970,20 @@ export default function ProofMapTab({
           }`}
         >
           <div className="font-semibold text-slate-900">{toast.title}</div>
-          {toast.subtitle ? <div className="mt-0.5 text-[11px] text-slate-500">{toast.subtitle}</div> : null}
+          {toast.subtitle ? (
+            <div className="mt-0.5 text-[11px] text-slate-500">
+              {toast.subtitle}
+            </div>
+          ) : null}
         </div>
       ) : null}
       {snapshot ? (
         <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/30 p-4 sm:items-center">
           <div className="w-full max-w-lg rounded-2xl border border-slate-200 bg-white shadow-xl">
             <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-5 py-4">
-              <div className="text-sm font-semibold text-slate-900">Bundle snapshot</div>
+              <div className="text-sm font-semibold text-slate-900">
+                Bundle snapshot
+              </div>
               <button
                 type="button"
                 className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
@@ -4654,10 +5996,17 @@ export default function ProofMapTab({
               <div className="text-xs font-semibold text-slate-900">
                 {snapshot.kind}: {snapshot.id}
               </div>
-              {snapshot.title ? <div className="text-sm text-slate-800">{snapshot.title}</div> : null}
-              {snapshot.snippet ? <div className="text-sm text-slate-700">{snapshot.snippet}</div> : null}
+              {snapshot.title ? (
+                <div className="text-sm text-slate-800">{snapshot.title}</div>
+              ) : null}
+              {snapshot.snippet ? (
+                <div className="text-sm text-slate-700">{snapshot.snippet}</div>
+              ) : null}
               {snapshot.stable_ref ? (
-                <a className="break-words font-mono text-xs text-slate-600 underline" href={snapshot.stable_ref}>
+                <a
+                  className="break-words font-mono text-xs text-slate-600 underline"
+                  href={snapshot.stable_ref}
+                >
                   {snapshot.stable_ref}
                 </a>
               ) : null}
@@ -4669,7 +6018,9 @@ export default function ProofMapTab({
         <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/30 p-4 sm:items-center">
           <div className="w-full max-w-lg rounded-2xl border border-slate-200 bg-white shadow-xl">
             <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-5 py-4">
-              <div className="text-sm font-semibold text-slate-900">Evidence search JSON</div>
+              <div className="text-sm font-semibold text-slate-900">
+                Evidence search JSON
+              </div>
               <button
                 type="button"
                 className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
@@ -4690,11 +6041,14 @@ export default function ProofMapTab({
         <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/30 p-4 sm:items-center">
           <div className="w-full max-w-lg rounded-2xl border border-slate-200 bg-white shadow-xl">
             <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-5 py-4">
-              <div className="text-sm font-semibold text-slate-900">Start over?</div>
+              <div className="text-sm font-semibold text-slate-900">
+                Start over?
+              </div>
             </div>
             <div className="grid gap-4 px-5 py-4">
               <div className="text-sm text-slate-700">
-                This clears the current AOI, evidence links, export state, reviewer draft, and comparison notes for this method/version.
+                This clears the current AOI, evidence links, export state,
+                reviewer draft, and comparison notes for this method/version.
               </div>
               <div className="flex items-center justify-end gap-2">
                 <button
@@ -4721,7 +6075,9 @@ export default function ProofMapTab({
 
       <div
         className={`grid gap-4 min-w-0 ${
-          panelCollapsed ? "lg:grid-cols-[minmax(0,1fr)]" : "lg:grid-cols-[minmax(0,1fr)_minmax(360px,420px)]"
+          panelCollapsed
+            ? "lg:grid-cols-[minmax(0,1fr)]"
+            : "lg:grid-cols-[minmax(0,1fr)_minmax(360px,420px)]"
         }`}
       >
         <div className="grid min-w-0 gap-3">
@@ -4743,7 +6099,11 @@ export default function ProofMapTab({
               chips={verifyReadinessChips}
               embedded
               showRuleLabel={false}
-              helperText={selectedRuleId ? "Current review status." : "Select a rule to inspect rule-specific readiness."}
+              helperText={
+                selectedRuleId
+                  ? "Current review status."
+                  : "Select a rule to inspect rule-specific readiness."
+              }
             />
             <div ref={ruleSectionRef}>
               <RuleReadinessFacts
@@ -4764,21 +6124,39 @@ export default function ProofMapTab({
             }`}
           >
             <div className="flex items-center justify-between gap-2">
-              <div className={`font-semibold ${currentWorkspaceIsFinal ? "text-slate-700" : "text-slate-900"}`}>{leftPaneHeader.title}</div>
-              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">{leftPaneHeader.stepLabel}</div>
+              <div
+                className={`font-semibold ${currentWorkspaceIsFinal ? "text-slate-700" : "text-slate-900"}`}
+              >
+                {leftPaneHeader.title}
+              </div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                {leftPaneHeader.stepLabel}
+              </div>
             </div>
-            <div className="mt-1 text-xs text-slate-600">{leftPaneHeader.instruction}</div>
+            <div className="mt-1 text-xs text-slate-600">
+              {leftPaneHeader.instruction}
+            </div>
           </div>
-          <details className={`rounded-2xl border border-slate-200/70 bg-white/90 transition ${currentWorkspaceIsFinal ? "opacity-60" : ""}`}>
-            <summary className="cursor-pointer list-none px-4 py-3" data-testid="verify-technical-context-toggle">
+          <details
+            className={`rounded-2xl border border-slate-200/70 bg-white/90 transition ${currentWorkspaceIsFinal ? "opacity-60" : ""}`}
+          >
+            <summary
+              className="cursor-pointer list-none px-4 py-3"
+              data-testid="verify-technical-context-toggle"
+            >
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Technical context</div>
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                    Technical context
+                  </div>
                   <div className="mt-1 text-sm font-medium text-slate-700">
-                    AOI, STAC, selected item, inventory, reviewer artifact, and finalization metadata
+                    AOI, STAC, selected item, inventory, reviewer artifact, and
+                    finalization metadata
                   </div>
                 </div>
-                <span className="text-xs font-semibold text-slate-500">Show</span>
+                <span className="text-xs font-semibold text-slate-500">
+                  Show
+                </span>
               </div>
             </summary>
             <div className="grid gap-2 border-t border-slate-100 px-4 pb-4 pt-3">
@@ -4787,35 +6165,56 @@ export default function ProofMapTab({
                 data-testid="left-section-aoi"
                 className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "aoi" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
               >
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">AOI summary</div>
-                <div className="mt-1 text-sm font-semibold text-slate-900">{aoi?.name ?? "No AOI loaded"}</div>
-                <div className="mt-1 text-[11px] text-slate-500">{bboxLabel ?? "Upload an AOI to continue."}</div>
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                  AOI summary
+                </div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">
+                  {aoi?.name ?? "No AOI loaded"}
+                </div>
+                <div className="mt-1 text-[11px] text-slate-500">
+                  {bboxLabel ?? "Upload an AOI to continue."}
+                </div>
               </div>
               <div
                 ref={stacSectionRef}
                 data-testid="left-section-stac"
                 className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "stac" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
               >
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">STAC evidence</div>
-                <div className="mt-1 text-sm font-semibold text-slate-900">{stacFeatureIds.length} item{stacFeatureIds.length === 1 ? "" : "s"}</div>
-                <div className="mt-1 text-[11px] text-slate-500">{stacQuery.source ?? "Run a STAC search to load evidence context."}</div>
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                  STAC evidence
+                </div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">
+                  {stacFeatureIds.length} item
+                  {stacFeatureIds.length === 1 ? "" : "s"}
+                </div>
+                <div className="mt-1 text-[11px] text-slate-500">
+                  {stacQuery.source ??
+                    "Run a STAC search to load evidence context."}
+                </div>
               </div>
               <div
                 ref={selectedItemSectionRef}
                 data-testid="left-section-selected"
                 className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "selected" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
               >
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Selected item</div>
-                <div className="mt-1 text-sm font-semibold text-slate-900">{selectedStacItemId ?? "No item selected"}</div>
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                  Selected item
+                </div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">
+                  {selectedStacItemId ?? "No item selected"}
+                </div>
               </div>
               <div
                 ref={pinsSectionRef}
                 data-testid="left-section-pins"
                 className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "pins" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
               >
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Evidence inventory</div>
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                  Evidence inventory
+                </div>
                 <div className="mt-1 text-sm font-semibold text-slate-900">
-                  {evidenceInventory.length} item{evidenceInventory.length === 1 ? "" : "s"}
+                  {evidenceInventory.length} item
+                  {evidenceInventory.length === 1 ? "" : "s"}
                 </div>
               </div>
               <div
@@ -4823,12 +6222,20 @@ export default function ProofMapTab({
                 data-testid="left-section-reviewer"
                 className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "reviewer" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
               >
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Reviewer artifact</div>
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                  Reviewer artifact
+                </div>
                 <div className="mt-1 text-sm font-semibold text-slate-900">
-                  {verifierBundle.savedReviewerArtifactAt ? "Saved reviewer artifact" : "Draft reviewer artifact"}
+                  {verifierBundle.savedReviewerArtifactAt
+                    ? "Saved reviewer artifact"
+                    : "Draft reviewer artifact"}
                 </div>
                 <div className="mt-1 line-clamp-2 text-[11px] text-slate-500">
-                  {(verifierBundle.savedReviewerArtifactAt ? verifierBundle.minutes || verifierBundle.outcomeNote : verifierBundle.draftMinutes || verifierBundle.draftOutcomeNote) || "No reviewer notes yet."}
+                  {(verifierBundle.savedReviewerArtifactAt
+                    ? verifierBundle.minutes || verifierBundle.outcomeNote
+                    : verifierBundle.draftMinutes ||
+                      verifierBundle.draftOutcomeNote) ||
+                    "No reviewer notes yet."}
                 </div>
               </div>
               <div
@@ -4836,10 +6243,18 @@ export default function ProofMapTab({
                 data-testid="left-section-summary"
                 className={`rounded-xl border px-3 py-2 transition ${activeLeftSection === "summary" ? "border-sky-300 bg-sky-50/40" : "border-slate-200/70 bg-slate-50/40"}`}
               >
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Final summary</div>
-                <div className="mt-1 text-sm font-semibold text-slate-900">{currentWorkspaceIsFinal ? "Final artifact written" : "Not finalized yet"}</div>
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                  Final summary
+                </div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">
+                  {currentWorkspaceIsFinal
+                    ? "Final artifact written"
+                    : "Not finalized yet"}
+                </div>
                 <div className="mt-1 text-[11px] text-slate-500">
-                  {currentWorkspaceIsFinal ? `Finalized ${formatLocalDateTime(verifierBundle.finalizedAt ?? "")}` : "Finalize run to export the single immutable artifact."}
+                  {currentWorkspaceIsFinal
+                    ? `Finalized ${formatLocalDateTime(verifierBundle.finalizedAt ?? "")}`
+                    : "Finalize run to export the single immutable artifact."}
                 </div>
               </div>
             </div>
@@ -4850,11 +6265,12 @@ export default function ProofMapTab({
                 ? `grid gap-3 rounded-2xl border bg-white/95 p-4 transition ${
                     currentWorkspaceIsFinal
                       ? "border-slate-200/70 bg-slate-50/80 opacity-45 shadow-none"
-                      : wizardDetails.activeStep === 4 || wizardDetails.activeStep === 5
-                      ? "border-sky-300/80 shadow-sm shadow-sky-100/60"
-                      : wizardDetails.activeStep === 3
-                        ? "border-amber-300/80 shadow-sm shadow-amber-100/60"
-                        : "border-slate-200/70 shadow-sm shadow-slate-200/30"
+                      : wizardDetails.activeStep === 4 ||
+                          wizardDetails.activeStep === 5
+                        ? "border-sky-300/80 shadow-sm shadow-sky-100/60"
+                        : wizardDetails.activeStep === 3
+                          ? "border-amber-300/80 shadow-sm shadow-amber-100/60"
+                          : "border-slate-200/70 shadow-sm shadow-slate-200/30"
                   }`
                 : "hidden"
             }
@@ -4867,11 +6283,12 @@ export default function ProofMapTab({
                 ? "hidden"
                 : currentWorkspaceIsFinal
                   ? "rounded-2xl border border-slate-200/70 opacity-45 shadow-none"
-                : wizardDetails.activeStep === 4 || wizardDetails.activeStep === 5
-                  ? "rounded-2xl border border-sky-300/80 shadow-sm shadow-sky-100/60"
-                : wizardDetails.activeStep === 3
-                    ? "rounded-2xl border border-amber-300/80 shadow-sm shadow-amber-100/60"
-                    : undefined
+                  : wizardDetails.activeStep === 4 ||
+                      wizardDetails.activeStep === 5
+                    ? "rounded-2xl border border-sky-300/80 shadow-sm shadow-sky-100/60"
+                    : wizardDetails.activeStep === 3
+                      ? "rounded-2xl border border-amber-300/80 shadow-sm shadow-amber-100/60"
+                      : undefined
             }
           >
             <MapCanvas
@@ -4915,14 +6332,19 @@ export default function ProofMapTab({
             onChange={handleUploadAoiChange}
           />
 
-          <div className={`flex items-start justify-between gap-3 ${currentWorkspaceIsFinal ? "opacity-70" : ""}`}>
+          <div
+            className={`flex items-start justify-between gap-3 ${currentWorkspaceIsFinal ? "opacity-70" : ""}`}
+          >
             <div>
               <div className="text-sm font-semibold text-slate-900">
-                {currentWorkspaceIsFinal ? "Final Review Summary" : "Evidence workflow"}
+                {currentWorkspaceIsFinal
+                  ? "Final Review Summary"
+                  : "Evidence workflow"}
               </div>
               {currentWorkspaceIsFinal ? (
                 <div className="mt-1 text-xs text-slate-500">
-                  Finalized result, exports, and summary are now the primary right-panel surface.
+                  Finalized result, exports, and summary are now the primary
+                  right-panel surface.
                 </div>
               ) : null}
             </div>
@@ -4978,7 +6400,10 @@ export default function ProofMapTab({
                         projectCode: linkedProject.projectCode ?? null,
                         countryLocation: linkedProject.countryLocation ?? null,
                         proponent: linkedProject.proponent ?? null,
-                        reportingPeriod: reviewWorkspace?.reportingPeriod ?? linkedProject.reportingPeriod ?? null,
+                        reportingPeriod:
+                          reviewWorkspace?.reportingPeriod ??
+                          linkedProject.reportingPeriod ??
+                          null,
                         workspaceId: workspaceId,
                         workspaceName: reviewWorkspace?.name ?? null,
                       }
@@ -4988,7 +6413,11 @@ export default function ProofMapTab({
                 loadedFromRunLabel={loadedFromRunLabel}
                 finalizedAt={verifierBundle.finalizedAt}
                 reviewedRuleCount={linkedRuleIds.length}
-                linkedEvidenceCount={evidenceInventory.filter((item) => item.link_state === "linked").length}
+                linkedEvidenceCount={
+                  evidenceInventory.filter(
+                    (item) => item.link_state === "linked",
+                  ).length
+                }
                 wizard={wizardDetails}
                 onDownloadJson={() => {
                   void handleDownloadReviewSummaryJson();
@@ -5036,8 +6465,10 @@ export default function ProofMapTab({
                         declaredAreaSource: aoi.declared_area_source ?? null,
                         projectZoneCount,
                         supportingFeatureCount,
-                        areaMismatchRelative: declaredAreaComparison?.relativeDifference ?? null,
-                        areaMismatchWarning: declaredAreaComparison?.exceedsThreshold ?? false,
+                        areaMismatchRelative:
+                          declaredAreaComparison?.relativeDifference ?? null,
+                        areaMismatchWarning:
+                          declaredAreaComparison?.exceedsThreshold ?? false,
                         requiresPrimarySelection: !Boolean(aoi.geojson),
                       }
                     : null
@@ -5049,7 +6480,10 @@ export default function ProofMapTab({
                   const next = updateAoiFeatureRole(aoi, featureId, role);
                   onSetAoi(next);
                   if (next.geojson) setError(null);
-                  else setError("Select exactly one primary project area feature to continue.");
+                  else
+                    setError(
+                      "Select exactly one primary project area feature to continue.",
+                    );
                 }}
                 declaredAreaInput={declaredAreaInput}
                 onDeclaredAreaInputChange={(value) => {
@@ -5058,26 +6492,38 @@ export default function ProofMapTab({
                   setConfirmedAoiKey(null);
                   const trimmed = value.trim();
                   if (!trimmed) {
-                    onSetAoi(setAoiDeclaredArea({ aoi, declaredAreaKm2: null, declaredAreaSource: null }));
+                    onSetAoi(
+                      setAoiDeclaredArea({
+                        aoi,
+                        declaredAreaKm2: null,
+                        declaredAreaSource: null,
+                      }),
+                    );
                     return;
                   }
                   const parsed = Number(trimmed);
                   if (!Number.isFinite(parsed) || parsed <= 0) return;
-                  onSetAoi(setAoiDeclaredArea({
-                    aoi,
-                    declaredAreaKm2: parsed,
-                    declaredAreaSource: "manual_compare_input",
-                  }));
+                  onSetAoi(
+                    setAoiDeclaredArea({
+                      aoi,
+                      declaredAreaKm2: parsed,
+                      declaredAreaSource: "manual_compare_input",
+                    }),
+                  );
                 }}
                 onConfirmArea={() => {
                   if (!currentAoiConfirmationKey || !aoi?.geojson) {
-                    setError("Select exactly one primary project area feature to continue.");
+                    setError(
+                      "Select exactly one primary project area feature to continue.",
+                    );
                     return;
                   }
                   setConfirmedAoiKey(currentAoiConfirmationKey);
                   setError(null);
                 }}
-                canConfirmArea={Boolean(currentAoiConfirmationKey && aoi?.geojson)}
+                canConfirmArea={Boolean(
+                  currentAoiConfirmationKey && aoi?.geojson,
+                )}
                 isAreaConfirmed={hasConfirmedArea}
                 searchDisabled={searchDisabled}
                 isRunning={isRunning}
@@ -5122,10 +6568,22 @@ export default function ProofMapTab({
                 methodCode={methodCode}
                 version={version}
                 reviewedRuleCount={linkedRuleIds.length}
-                linkedEvidenceCount={evidenceInventory.filter((item) => item.link_state === "linked").length}
-                finalizeBlocked={Boolean(finalizeGate && !finalizeGate.canFinalize)}
+                linkedEvidenceCount={
+                  evidenceInventory.filter(
+                    (item) => item.link_state === "linked",
+                  ).length
+                }
+                finalizeBlocked={Boolean(
+                  finalizeGate && !finalizeGate.canFinalize,
+                )}
                 finalizeGateBanner={
-                  finalizeGate ? <FinalizeGateBanner gate={finalizeGate} onFinalize={handleFinalizeRun} showAction={false} /> : null
+                  finalizeGate ? (
+                    <FinalizeGateBanner
+                      gate={finalizeGate}
+                      onFinalize={handleFinalizeRun}
+                      showAction={false}
+                    />
+                  ) : null
                 }
                 finalizedResult={
                   <ReviewSummaryCard
@@ -5156,10 +6614,16 @@ export default function ProofMapTab({
               data-testid="secondary-context-toggle"
             >
               <div>
-                <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Secondary context</div>
-                <div className="mt-1 text-sm font-semibold text-slate-900">Baseline, comparison notes, run history, and outcome</div>
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Secondary context
+                </div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">
+                  Baseline, comparison notes, run history, and outcome
+                </div>
               </div>
-              <span className="text-xs font-semibold text-slate-500">{secondarySectionOpen ? "Hide" : "Show"}</span>
+              <span className="text-xs font-semibold text-slate-500">
+                {secondarySectionOpen ? "Hide" : "Show"}
+              </span>
             </button>
           </div>
 
@@ -5167,26 +6631,40 @@ export default function ProofMapTab({
             <div className="grid gap-3" data-testid="secondary-context">
               <div className="rounded-xl border border-slate-200 bg-white p-4">
                 <div className="flex items-center justify-between gap-2">
-                  <div className="text-sm font-semibold text-slate-900">Baseline</div>
+                  <div className="text-sm font-semibold text-slate-900">
+                    Baseline
+                  </div>
                   {latestBaseline ? (
-                    <div className="text-[11px] text-slate-500">Run {shortRunId(latestBaseline.baselineRunId)}</div>
+                    <div className="text-[11px] text-slate-500">
+                      Run {shortRunId(latestBaseline.baselineRunId)}
+                    </div>
                   ) : null}
                 </div>
                 <div className="mt-1 text-xs text-slate-500">
-                  {latestBaseline ? `Set ${formatLocalDateTime(latestBaseline.baselineTs)}` : "No baseline set"}
+                  {latestBaseline
+                    ? `Set ${formatLocalDateTime(latestBaseline.baselineTs)}`
+                    : "No baseline set"}
                 </div>
-                <div className="mt-1 text-xs text-slate-500">Comparing to: {compareTargetLabel}</div>
+                <div className="mt-1 text-xs text-slate-500">
+                  Comparing to: {compareTargetLabel}
+                </div>
                 {latestBaseline ? (
                   <div className="mt-2 text-xs text-slate-600">
                     {baselineComparable.ok ? (
                       <Tooltip content="Same method/version + harness + dataset hash">
-                        <span className="font-semibold text-emerald-700">Comparable ✅</span>
+                        <span className="font-semibold text-emerald-700">
+                          Comparable ✅
+                        </span>
                       </Tooltip>
                     ) : (
                       <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
-                        <div className="font-semibold text-amber-800">{comparisonUnavailableMessage?.title ?? "Comparison unavailable"}</div>
+                        <div className="font-semibold text-amber-800">
+                          {comparisonUnavailableMessage?.title ??
+                            "Comparison unavailable"}
+                        </div>
                         <div className="mt-1 text-[11px] text-amber-700">
-                          {comparisonUnavailableMessage?.detail ?? "Current workspace cannot be compared to the saved baseline."}
+                          {comparisonUnavailableMessage?.detail ??
+                            "Current workspace cannot be compared to the saved baseline."}
                         </div>
                       </div>
                     )}
@@ -5197,7 +6675,8 @@ export default function ProofMapTab({
                     {upliftSummary.coverageDeltaPct != null ? (
                       <Tooltip content="Δ(covered rules / total rules) vs baseline. Based on persisted link artifacts.">
                         <span className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-700">
-                          Δ Coverage {formatDelta(upliftSummary.coverageDeltaPct, "%", 1)}
+                          Δ Coverage{" "}
+                          {formatDelta(upliftSummary.coverageDeltaPct, "%", 1)}
                         </span>
                       </Tooltip>
                     ) : null}
@@ -5219,7 +6698,13 @@ export default function ProofMapTab({
                 ) : null}
                 <div className="mt-3 flex flex-wrap items-center gap-2">
                   {!latestBaseline ? (
-                    <Tooltip content={baselineActionsDisabled ? baselineDisabledTooltip : "Set baseline"}>
+                    <Tooltip
+                      content={
+                        baselineActionsDisabled
+                          ? baselineDisabledTooltip
+                          : "Set baseline"
+                      }
+                    >
                       <button
                         type="button"
                         className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
@@ -5231,7 +6716,13 @@ export default function ProofMapTab({
                     </Tooltip>
                   ) : (
                     <>
-                      <Tooltip content={baselineActionsDisabled ? baselineDisabledTooltip : "Rotate baseline"}>
+                      <Tooltip
+                        content={
+                          baselineActionsDisabled
+                            ? baselineDisabledTooltip
+                            : "Rotate baseline"
+                        }
+                      >
                         <button
                           type="button"
                           className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
@@ -5259,7 +6750,9 @@ export default function ProofMapTab({
                 impact={verifierBundle.impact}
                 tasks={verifierBundle.tasks}
                 draftTask={draftTask}
-                showDraftTask={showDraftTask || verifierBundle.tasks.length === 0}
+                showDraftTask={
+                  showDraftTask || verifierBundle.tasks.length === 0
+                }
                 draftTaskInputRef={draftTaskInputRef}
                 onDraftTaskChange={setDraftTask}
                 onCommitDraftTask={commitDraftTask}
@@ -5274,16 +6767,25 @@ export default function ProofMapTab({
               <details
                 className="rounded-xl border border-slate-200 bg-white"
                 open={runHistoryOpen}
-                onToggle={(event) => setRunHistoryOpen(event.currentTarget.open)}
+                onToggle={(event) =>
+                  setRunHistoryOpen(event.currentTarget.open)
+                }
               >
-                <summary className="cursor-pointer list-none px-3 py-2 text-xs font-semibold text-slate-900" data-testid="run-history-toggle">
+                <summary
+                  className="cursor-pointer list-none px-3 py-2 text-xs font-semibold text-slate-900"
+                  data-testid="run-history-toggle"
+                >
                   Run history
-                  <span className="ml-2 text-[11px] font-medium text-slate-500">{runHistory.length} runs</span>
+                  <span className="ml-2 text-[11px] font-medium text-slate-500">
+                    {runHistory.length} runs
+                  </span>
                 </summary>
                 <div className="px-3 pb-3">
                   <div className="mb-3 text-xs text-slate-500">
                     <div>New run starts a fresh review.</div>
-                    <div>Load restores this run into the editable workspace.</div>
+                    <div>
+                      Load restores this run into the editable workspace.
+                    </div>
                   </div>
                   <RunHistoryPanel
                     items={runHistory}
@@ -5308,7 +6810,9 @@ export default function ProofMapTab({
                   {intakeSuggestion ? (
                     <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
                       <div className="flex flex-wrap items-center justify-between gap-2">
-                        <div className="font-semibold">Hard-case intake suggested</div>
+                        <div className="font-semibold">
+                          Hard-case intake suggested
+                        </div>
                         <button
                           type="button"
                           className="rounded-full border border-amber-300 bg-amber-200 px-3 py-1 text-[11px] font-semibold text-amber-900 hover:bg-amber-300"
@@ -5318,7 +6822,9 @@ export default function ProofMapTab({
                         </button>
                       </div>
                       <div className="mt-1 text-[11px] text-amber-800">
-                        Status {intakeSuggestion.run.status}. {intakeSuggestion.summary ?? "Add this run to the pilot queue."}
+                        Status {intakeSuggestion.run.status}.{" "}
+                        {intakeSuggestion.summary ??
+                          "Add this run to the pilot queue."}
                       </div>
                     </div>
                   ) : null}
@@ -5334,7 +6840,10 @@ export default function ProofMapTab({
                     debugLinkedCount={linkedRuleIds.length}
                     provenance={{
                       repo: trustPicked.repo ?? null,
-                      sha: trustPicked.sha ?? process.env.NEXT_PUBLIC_GIT_SHA ?? null,
+                      sha:
+                        trustPicked.sha ??
+                        process.env.NEXT_PUBLIC_GIT_SHA ??
+                        null,
                       generatedAt: trustPicked.generatedAt ?? null,
                     }}
                   />

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -4660,7 +4660,7 @@ export default function ProofMapTab({
                   onClick={() => {
                     if (typeof window !== "undefined")
                       window.location.assign(
-                        "/projects/new?handoff=document-metadata",
+                        "/start-review?handoff=document-metadata",
                       );
                   }}
                   className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-800"

--- a/src/components/map/ProofMapTab.tsx
+++ b/src/components/map/ProofMapTab.tsx
@@ -63,6 +63,7 @@ import type { BaselineKey, BaselineRecord } from "@/lib/baseline/baselineStore";
 import { clearBaseline, getLatestBaselineForMethod, rotateBaseline, setBaseline } from "@/lib/baseline/baselineStore";
 import { computeUplift, isComparable } from "@/lib/baseline/uplift";
 import { addIntakeItem } from "@/lib/intake/storage";
+import { stageProjectDocumentDraftFromAttachment } from "@/lib/projects/documentMetadata";
 import {
   SNAPSHOT_SCHEMA_VERSION,
   addTaskWithText,
@@ -466,6 +467,7 @@ export default function ProofMapTab({
   const isEvidenceMode = mode === "evidence";
   const isListMode = viewMode === "list";
   const [error, setError] = useState<string | null>(null);
+  const [projectDraftReady, setProjectDraftReady] = useState(false);
   const [toast, setToast] = useState<ToastState | null>(null);
   const [undoVisible, setUndoVisible] = useState(false);
   const [snapshot, setSnapshot] = useState<ProofEvidenceItem | null>(null);
@@ -2992,6 +2994,17 @@ export default function ProofMapTab({
         const existingPin = current.find((pin) => evidencePinDedupeKey(pin) === dedupeKey);
         return existingPin ? coalesceEvidencePins(current) : coalesceEvidencePins([candidate, ...current]);
       });
+      void stageProjectDocumentDraftFromAttachment({
+        origin: "pdd-upload",
+        evidenceId: pinId,
+        attachmentId: result.attachment.id,
+        fileName: result.attachment.filename,
+        mimeType: result.attachment.mime,
+        contentSha256: result.attachment.sha256,
+      }).then(() => {
+        setProjectDraftReady(true);
+        showToast({ title: "Project draft ready", subtitle: "Open New Project to review extracted metadata from this PDD." });
+      }).catch(() => undefined);
       setVerifierBundle((current) => markBundleEdited(current, { invalidateFinality: true }));
       showToast(existing ? `${file.name} is already in inventory` : `Added PDD ${file.name} to inventory`);
     } catch (error) {
@@ -3649,6 +3662,17 @@ export default function ProofMapTab({
                   }}
                 />
               </label>
+              {projectDraftReady ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (typeof window !== "undefined") window.location.assign("/projects/new?handoff=document-metadata");
+                  }}
+                  className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-800"
+                >
+                  Create project from document
+                </button>
+              ) : null}
               <span className="rounded-full border border-slate-200 bg-white px-2 py-0.5">
                 {evidenceInventory.length} item{evidenceInventory.length === 1 ? "" : "s"}
               </span>

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   attachPendingProjectDocumentToProject,
   clearPendingProjectDocumentDraft,
   readPendingProjectDocumentDraft,
+  stageProjectDocumentDraftFromAttachment,
 } from "@/lib/projects/documentMetadata";
+import { createAndStoreEvidenceAttachment } from "@/lib/proofMap/attachments";
 import { createProject } from "@/lib/projects/storage";
 import { projectRegistryFromMethodProgram } from "@/lib/projects/verificationReport";
 import type {
@@ -34,6 +36,22 @@ const REGISTRY_ORDER: ProjectRegistry[] = [
   "Unknown",
 ];
 type ProjectCreationMode = "create" | "attach";
+
+function newIntakeEvidenceId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return `project-intake-${crypto.randomUUID()}`;
+  }
+  return `project-intake-${Date.now().toString(36)}-${Math.random().toString(16).slice(2)}`;
+}
+
+function isPdfFile(file: File): boolean {
+  return (
+    file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf")
+  );
+}
 
 function confidenceTone(
   confidence: ProjectDocumentMetadataDraft["fields"]["projectTitle"]["confidence"],
@@ -82,6 +100,7 @@ export function groupMethodsByRegistry(
 export default function NewProjectForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const uploadInputRef = useRef<HTMLInputElement | null>(null);
   const [methods, setMethods] = useState<MethodOption[]>([]);
   const [reviewMode, setReviewMode] =
     useState<ProjectReviewMode>("methodology-linked");
@@ -108,6 +127,9 @@ export default function NewProjectForm() {
     useState<ProjectCreationMode>("create");
   const [confirmDocumentDraft, setConfirmDocumentDraft] = useState(false);
   const [attachProjectId, setAttachProjectId] = useState("");
+  const [showManualSetup, setShowManualSetup] = useState(false);
+  const [uploadingDocument, setUploadingDocument] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
 
   const groupedMethods = useMemo(
     () => groupMethodsByRegistry(methods),
@@ -117,15 +139,115 @@ export default function NewProjectForm() {
     () => documentDraft?.suggestedExistingProjects ?? [],
     [documentDraft],
   );
-  const detectedProjectTitle =
-    documentDraft?.fields.projectTitle.value?.trim() ||
-    "No project title detected";
-  const detectedMethod =
-    documentDraft?.fields.methodology.value?.trim() || "No method detected";
-  const detectedStandard =
-    documentDraft?.fields.standard.value?.trim() || "No standard detected";
+  const detectedSummaryFields = useMemo(
+    () =>
+      documentDraft
+        ? [
+            {
+              label: "Detected project",
+              value:
+                documentDraft.fields.projectTitle.value?.trim() ||
+                "No project title detected",
+            },
+            {
+              label: "Detected method",
+              value:
+                documentDraft.fields.methodology.value?.trim() ||
+                "No method detected",
+            },
+            {
+              label: "Detected standard",
+              value:
+                documentDraft.fields.standard.value?.trim() ||
+                "No standard detected",
+            },
+            {
+              label: "Document type",
+              value: documentDraft.fields.documentType.value?.trim(),
+            },
+            {
+              label: "Version / date",
+              value: [
+                documentDraft.fields.version.value?.trim(),
+                documentDraft.fields.documentDate.value?.trim(),
+              ]
+                .filter(Boolean)
+                .join(" · "),
+            },
+          ].filter((field) => field.value)
+        : [],
+    [documentDraft],
+  );
   const createModeActive = creationMode === "create";
   const searchKey = searchParams.toString();
+  const intakeActive = !documentDraft && !handoffDetected && !showManualSetup;
+
+  const hydrateDocumentDraft = useCallback(
+    (stagedDraft: ProjectDocumentMetadataDraft) => {
+      setDocumentDraft(stagedDraft);
+      setCreationMode("create");
+      setConfirmDocumentDraft(false);
+      setShowManualSetup(true);
+      setName(stagedDraft.fields.projectTitle.value ?? "");
+      setProjectCode(stagedDraft.fields.projectId.value ?? "");
+      setCountryLocation(stagedDraft.fields.country.value ?? "");
+      setProponent(stagedDraft.fields.proponent.value ?? "");
+      setMethodology(stagedDraft.fields.methodology.value ?? "");
+      setStandard(stagedDraft.fields.standard.value ?? "");
+      setSourceDocumentType(stagedDraft.fields.documentType.value ?? "");
+      setSourceDocumentVersion(stagedDraft.fields.version.value ?? "");
+      setSourceDocumentDate(stagedDraft.fields.documentDate.value ?? "");
+      setReviewMode("methodology-linked");
+      setAttachProjectId(
+        stagedDraft.suggestedExistingProjects[0]?.projectId ?? "",
+      );
+    },
+    [],
+  );
+
+  async function handleIntakeUpload(file: File | null) {
+    if (!file) return;
+    if (!isPdfFile(file)) {
+      setError("Upload a PDF project document to start review.");
+      return;
+    }
+
+    const evidenceId = newIntakeEvidenceId();
+    setUploadingDocument(true);
+    setError("");
+
+    try {
+      const attachmentResult = await createAndStoreEvidenceAttachment({
+        pin_id: evidenceId,
+        file,
+      });
+      if (!attachmentResult.ok) {
+        setError(attachmentResult.message);
+        return;
+      }
+
+      const stagedDraft = await stageProjectDocumentDraftFromAttachment({
+        origin: "pdd-upload",
+        evidenceId,
+        attachmentId: attachmentResult.attachment.id,
+        fileName: attachmentResult.attachment.filename,
+        mimeType: attachmentResult.attachment.mime,
+        contentSha256: attachmentResult.attachment.sha256,
+      });
+      hydrateDocumentDraft(stagedDraft);
+      router.replace("/projects/new?handoff=document-metadata");
+    } catch (uploadError) {
+      setError(
+        uploadError instanceof Error
+          ? uploadError.message
+          : "Failed to detect project details from this document. Try again.",
+      );
+    } finally {
+      setUploadingDocument(false);
+      setDragActive(false);
+      if (uploadInputRef.current) uploadInputRef.current.value = "";
+    }
+  }
 
   useEffect(() => {
     fetch("/api/projects/methods")
@@ -154,21 +276,13 @@ export default function NewProjectForm() {
     if (!stagedDraft) return;
     if (documentDraft?.source.attachmentId === stagedDraft.source.attachmentId)
       return;
-    setDocumentDraft(stagedDraft);
-    setName(stagedDraft.fields.projectTitle.value ?? "");
-    setProjectCode(stagedDraft.fields.projectId.value ?? "");
-    setCountryLocation(stagedDraft.fields.country.value ?? "");
-    setProponent(stagedDraft.fields.proponent.value ?? "");
-    setMethodology(stagedDraft.fields.methodology.value ?? "");
-    setStandard(stagedDraft.fields.standard.value ?? "");
-    setSourceDocumentType(stagedDraft.fields.documentType.value ?? "");
-    setSourceDocumentVersion(stagedDraft.fields.version.value ?? "");
-    setSourceDocumentDate(stagedDraft.fields.documentDate.value ?? "");
-    const suggestedAttach = stagedDraft.suggestedExistingProjects[0];
-    if (suggestedAttach) {
-      setAttachProjectId(suggestedAttach.projectId);
-    }
-  }, [documentDraft?.source.attachmentId, searchKey, searchParams]);
+    hydrateDocumentDraft(stagedDraft);
+  }, [
+    documentDraft?.source.attachmentId,
+    hydrateDocumentDraft,
+    searchKey,
+    searchParams,
+  ]);
 
   useEffect(() => {
     if (!documentDraft || !methods.length || selectedMethod) return;
@@ -337,13 +451,76 @@ export default function NewProjectForm() {
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-12 md:px-8">
-      <div>
-        <h1 className="text-2xl font-bold text-slate-900">Start Review</h1>
-        <p className="mt-1 text-sm text-slate-500">
-          Upload a project document, review the detected details, then continue
-          into the project review workspace.
-        </p>
-      </div>
+      {intakeActive ? (
+        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h1 className="text-2xl font-bold text-slate-900">Start Review</h1>
+          <p className="mt-2 max-w-xl text-sm text-slate-600">
+            Upload a PDD, monitoring report, or evidence file. Article6 will
+            detect the project, method, and next review step.
+          </p>
+          <div
+            className={`mt-5 rounded-2xl border-2 border-dashed px-5 py-8 text-center transition ${dragActive ? "border-blue-400 bg-blue-50" : "border-slate-300 bg-slate-50"}`}
+            onDragOver={(event) => {
+              event.preventDefault();
+              setDragActive(true);
+            }}
+            onDragLeave={(event) => {
+              event.preventDefault();
+              setDragActive(false);
+            }}
+            onDrop={(event) => {
+              event.preventDefault();
+              setDragActive(false);
+              void handleIntakeUpload(event.dataTransfer.files?.[0] ?? null);
+            }}
+          >
+            <div className="text-sm font-semibold text-slate-900">
+              Upload project document
+            </div>
+            <div className="mt-1 text-sm text-slate-500">
+              Drop a PDF here or choose a file to detect project details.
+            </div>
+            <input
+              ref={uploadInputRef}
+              type="file"
+              accept="application/pdf,.pdf"
+              className="hidden"
+              onChange={(event) => {
+                void handleIntakeUpload(event.target.files?.[0] ?? null);
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => uploadInputRef.current?.click()}
+              disabled={uploadingDocument}
+              className="mt-4 inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+            >
+              {uploadingDocument
+                ? "Detecting project details..."
+                : "Upload document"}
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setShowManualSetup(true);
+              setReviewMode("manual");
+              setError("");
+            }}
+            className="mt-4 text-sm font-semibold text-slate-600 underline-offset-4 hover:text-slate-900 hover:underline"
+          >
+            Set up review manually
+          </button>
+        </div>
+      ) : (
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Start Review</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            Upload a project document, review the detected details, then
+            continue into the project review workspace.
+          </p>
+        </div>
+      )}
 
       {documentDraft ? (
         <div className="rounded-lg border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700">
@@ -352,31 +529,20 @@ export default function NewProjectForm() {
             Review detected details from {documentDraft.source.fileName}, then
             confirm before continuing.
           </div>
-          <div className="mt-3 grid gap-3 md:grid-cols-3">
-            <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3">
-              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
-                Detected project
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            {detectedSummaryFields.map((field) => (
+              <div
+                key={field.label}
+                className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3"
+              >
+                <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  {field.label}
+                </div>
+                <div className="mt-1 text-sm font-medium text-slate-900">
+                  {field.value}
+                </div>
               </div>
-              <div className="mt-1 text-sm font-medium text-slate-900">
-                {detectedProjectTitle}
-              </div>
-            </div>
-            <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3">
-              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
-                Detected method
-              </div>
-              <div className="mt-1 text-sm font-medium text-slate-900">
-                {detectedMethod}
-              </div>
-            </div>
-            <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3">
-              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
-                Detected standard
-              </div>
-              <div className="mt-1 text-sm font-medium text-slate-900">
-                {detectedStandard}
-              </div>
-            </div>
+            ))}
           </div>
         </div>
       ) : null}
@@ -387,438 +553,440 @@ export default function NewProjectForm() {
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <div>
-          <label className="mb-1 block text-sm font-semibold text-slate-700">
-            {documentDraft ? "Review route" : "Review Type"}
-          </label>
-          <div className="grid gap-3 md:grid-cols-2">
-            <button
-              type="button"
-              disabled={handoffDetected}
-              onClick={() => setReviewMode("methodology-linked")}
-              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? "cursor-not-allowed opacity-60" : ""} ${
-                reviewMode === "methodology-linked"
-                  ? "border-blue-500 bg-blue-50 text-blue-900"
-                  : "border-slate-200 bg-white text-slate-700"
-              }`}
-            >
-              <div className="text-sm font-semibold">
-                {documentDraft
-                  ? "Continue with detected method"
-                  : "Methodology-linked review"}
-              </div>
-              <div className="mt-1 text-xs text-slate-500">
-                {documentDraft
-                  ? "Use the detected method and its rule set in the review workspace."
-                  : "Use a selected methodology and its rule set."}
-              </div>
-            </button>
-            <button
-              type="button"
-              disabled={handoffDetected}
-              onClick={() => setReviewMode("manual")}
-              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? "cursor-not-allowed opacity-60" : ""} ${
-                reviewMode === "manual"
-                  ? "border-blue-500 bg-blue-50 text-blue-900"
-                  : "border-slate-200 bg-white text-slate-700"
-              }`}
-            >
-              <div className="text-sm font-semibold">
-                {documentDraft
-                  ? "Continue without a linked method"
-                  : "Manual Review"}
-              </div>
-              <div className="mt-1 text-xs text-slate-500">
-                {documentDraft
-                  ? "Keep the document details, but continue without a detected method."
-                  : "Project-level manual review / VVB findings reconstruction."}
-              </div>
-            </button>
-          </div>
-        </div>
-
-        {handoffDetected ? (
-          <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
-            Create a project and carry over the active review for{" "}
-            {handoffMethodLabel}. Existing evidence links, rule reviews,
-            reviewer notes, and draft finalization state will be imported.
-          </div>
-        ) : null}
-
-        {documentDraft ? (
-          <>
+      {!intakeActive ? (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">
+              {documentDraft ? "Review route" : "Review Type"}
+            </label>
             <div className="grid gap-3 md:grid-cols-2">
               <button
                 type="button"
-                onClick={() => setCreationMode("create")}
-                className={`rounded-lg border px-4 py-3 text-left ${creationMode === "create" ? "border-blue-500 bg-blue-50 text-blue-900" : "border-slate-200 bg-white text-slate-700"}`}
+                disabled={handoffDetected}
+                onClick={() => setReviewMode("methodology-linked")}
+                className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? "cursor-not-allowed opacity-60" : ""} ${
+                  reviewMode === "methodology-linked"
+                    ? "border-blue-500 bg-blue-50 text-blue-900"
+                    : "border-slate-200 bg-white text-slate-700"
+                }`}
               >
                 <div className="text-sm font-semibold">
-                  Start review from this document
+                  {documentDraft
+                    ? "Continue with detected method"
+                    : "Methodology-linked review"}
                 </div>
                 <div className="mt-1 text-xs text-slate-500">
-                  Create a review workspace using the detected details below.
+                  {documentDraft
+                    ? "Use the detected method and its rule set in the review workspace."
+                    : "Use a selected methodology and its rule set."}
                 </div>
               </button>
               <button
                 type="button"
-                onClick={() => setCreationMode("attach")}
-                disabled={!attachMatches.length}
-                className={`rounded-lg border px-4 py-3 text-left ${creationMode === "attach" ? "border-blue-500 bg-blue-50 text-blue-900" : "border-slate-200 bg-white text-slate-700"} ${!attachMatches.length ? "cursor-not-allowed opacity-50" : ""}`}
+                disabled={handoffDetected}
+                onClick={() => setReviewMode("manual")}
+                className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? "cursor-not-allowed opacity-60" : ""} ${
+                  reviewMode === "manual"
+                    ? "border-blue-500 bg-blue-50 text-blue-900"
+                    : "border-slate-200 bg-white text-slate-700"
+                }`}
               >
                 <div className="text-sm font-semibold">
-                  Attach to existing project
+                  {documentDraft
+                    ? "Continue without a linked method"
+                    : "Manual Review"}
                 </div>
                 <div className="mt-1 text-xs text-slate-500">
-                  Use this secondary path when the document matches an existing
-                  review workspace.
+                  {documentDraft
+                    ? "Keep the document details, but continue without a detected method."
+                    : "Project-level manual review / VVB findings reconstruction."}
                 </div>
               </button>
             </div>
+          </div>
 
-            {attachMatches.length ? (
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-                <div className="mb-2 text-sm font-semibold text-slate-900">
-                  Existing project matches
-                </div>
-                <div className="grid gap-2">
-                  {attachMatches.map((match) => (
-                    <label
-                      key={match.projectId}
-                      className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-white px-3 py-3"
-                    >
-                      <input
-                        type="radio"
-                        name="attach-project"
-                        checked={attachProjectId === match.projectId}
-                        onChange={() => setAttachProjectId(match.projectId)}
-                        className="mt-1"
-                      />
-                      <div className="min-w-0 flex-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className="font-medium text-slate-900">
-                            {match.projectName}
-                          </span>
-                          {match.projectCode ? (
-                            <span className="text-xs text-slate-500">
-                              {match.projectCode}
+          {handoffDetected ? (
+            <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+              Create a project and carry over the active review for{" "}
+              {handoffMethodLabel}. Existing evidence links, rule reviews,
+              reviewer notes, and draft finalization state will be imported.
+            </div>
+          ) : null}
+
+          {documentDraft ? (
+            <>
+              <div className="grid gap-3 md:grid-cols-2">
+                <button
+                  type="button"
+                  onClick={() => setCreationMode("create")}
+                  className={`rounded-lg border px-4 py-3 text-left ${creationMode === "create" ? "border-blue-500 bg-blue-50 text-blue-900" : "border-slate-200 bg-white text-slate-700"}`}
+                >
+                  <div className="text-sm font-semibold">
+                    Start review from this document
+                  </div>
+                  <div className="mt-1 text-xs text-slate-500">
+                    Create a review workspace using the detected details below.
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setCreationMode("attach")}
+                  disabled={!attachMatches.length}
+                  className={`rounded-lg border px-4 py-3 text-left ${creationMode === "attach" ? "border-blue-500 bg-blue-50 text-blue-900" : "border-slate-200 bg-white text-slate-700"} ${!attachMatches.length ? "cursor-not-allowed opacity-50" : ""}`}
+                >
+                  <div className="text-sm font-semibold">
+                    Attach to existing project
+                  </div>
+                  <div className="mt-1 text-xs text-slate-500">
+                    Use this secondary path when the document matches an
+                    existing review workspace.
+                  </div>
+                </button>
+              </div>
+
+              {attachMatches.length ? (
+                <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+                  <div className="mb-2 text-sm font-semibold text-slate-900">
+                    Existing project matches
+                  </div>
+                  <div className="grid gap-2">
+                    {attachMatches.map((match) => (
+                      <label
+                        key={match.projectId}
+                        className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-white px-3 py-3"
+                      >
+                        <input
+                          type="radio"
+                          name="attach-project"
+                          checked={attachProjectId === match.projectId}
+                          onChange={() => setAttachProjectId(match.projectId)}
+                          className="mt-1"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-medium text-slate-900">
+                              {match.projectName}
                             </span>
-                          ) : null}
-                          <span
-                            className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(match.confidence)}`}
-                          >
-                            {match.confidence}
-                          </span>
+                            {match.projectCode ? (
+                              <span className="text-xs text-slate-500">
+                                {match.projectCode}
+                              </span>
+                            ) : null}
+                            <span
+                              className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(match.confidence)}`}
+                            >
+                              {match.confidence}
+                            </span>
+                          </div>
+                          <div className="mt-1 text-xs text-slate-600">
+                            {match.matchReasons.join(" · ")}
+                          </div>
                         </div>
-                        <div className="mt-1 text-xs text-slate-600">
-                          {match.matchReasons.join(" · ")}
-                        </div>
-                      </div>
-                    </label>
-                  ))}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+
+          {createModeActive ? (
+            <>
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  {documentDraft ? "Project name" : "Project Name"}
+                </label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g., Malawi Liwonde REDD+ Verification"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  required={createModeActive}
+                />
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700">
+                    Project ID / Code
+                  </label>
+                  <input
+                    type="text"
+                    value={projectCode}
+                    onChange={(e) => setProjectCode(e.target.value)}
+                    placeholder="e.g., VCS-1530"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700">
+                    Reporting Period
+                  </label>
+                  <input
+                    type="text"
+                    value={reportingPeriod}
+                    onChange={(e) => setReportingPeriod(e.target.value)}
+                    placeholder="e.g., 2024-01-01 to 2024-12-31"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
                 </div>
               </div>
-            ) : null}
-          </>
-        ) : null}
 
-        {createModeActive ? (
-          <>
-            <div>
-              <label className="mb-1 block text-sm font-semibold text-slate-700">
-                {documentDraft ? "Project name" : "Project Name"}
-              </label>
-              <input
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="e.g., Malawi Liwonde REDD+ Verification"
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                required={createModeActive}
-              />
-            </div>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700">
+                    Country / Location
+                  </label>
+                  <input
+                    type="text"
+                    value={countryLocation}
+                    onChange={(e) => setCountryLocation(e.target.value)}
+                    placeholder="e.g., Malawi"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700">
+                    Proponent
+                  </label>
+                  <input
+                    type="text"
+                    value={proponent}
+                    onChange={(e) => setProponent(e.target.value)}
+                    placeholder="e.g., Article6 Climate"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+              </div>
 
-            <div className="grid gap-4 md:grid-cols-2">
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700">
-                  Project ID / Code
-                </label>
-                <input
-                  type="text"
-                  value={projectCode}
-                  onChange={(e) => setProjectCode(e.target.value)}
-                  placeholder="e.g., VCS-1530"
-                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700">
-                  Reporting Period
-                </label>
-                <input
-                  type="text"
-                  value={reportingPeriod}
-                  onChange={(e) => setReportingPeriod(e.target.value)}
-                  placeholder="e.g., 2024-01-01 to 2024-12-31"
-                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                />
-              </div>
-            </div>
-
-            <div className="grid gap-4 md:grid-cols-2">
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700">
-                  Country / Location
-                </label>
-                <input
-                  type="text"
-                  value={countryLocation}
-                  onChange={(e) => setCountryLocation(e.target.value)}
-                  placeholder="e.g., Malawi"
-                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700">
-                  Proponent
-                </label>
-                <input
-                  type="text"
-                  value={proponent}
-                  onChange={(e) => setProponent(e.target.value)}
-                  placeholder="e.g., Article6 Climate"
-                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                />
-              </div>
-            </div>
-
-            <div className="grid gap-4 md:grid-cols-2">
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700">
-                  {documentDraft
-                    ? "Detected method"
-                    : "Methodology (document field)"}
-                </label>
-                <input
-                  type="text"
-                  value={methodology}
-                  onChange={(e) => setMethodology(e.target.value)}
-                  placeholder="e.g., VM0007"
-                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700">
-                  Standard
-                </label>
-                <input
-                  type="text"
-                  value={standard}
-                  onChange={(e) => setStandard(e.target.value)}
-                  placeholder="e.g., VCS Standard v4.7"
-                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                />
-              </div>
-            </div>
-
-            <div className="grid gap-4 md:grid-cols-3">
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700">
-                  Document Type
-                </label>
-                <input
-                  type="text"
-                  value={sourceDocumentType}
-                  onChange={(e) => setSourceDocumentType(e.target.value)}
-                  placeholder="e.g., Project Design Document"
-                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700">
-                  Document Version
-                </label>
-                <input
-                  type="text"
-                  value={sourceDocumentVersion}
-                  onChange={(e) => setSourceDocumentVersion(e.target.value)}
-                  placeholder="e.g., v1.3"
-                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700">
-                  Document Date
-                </label>
-                <input
-                  type="text"
-                  value={sourceDocumentDate}
-                  onChange={(e) => setSourceDocumentDate(e.target.value)}
-                  placeholder="e.g., 2026-05-24"
-                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                />
-              </div>
-            </div>
-
-            {reviewMode === "methodology-linked" ? (
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700">
-                  {documentDraft
-                    ? "Confirm method before continuing"
-                    : "Methodology"}
-                </label>
-                <select
-                  value={selectedMethod}
-                  onChange={(e) => setSelectedMethod(e.target.value)}
-                  disabled={handoffDetected}
-                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                  required
-                >
-                  <option value="">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700">
                     {documentDraft
-                      ? "Select or confirm the detected method..."
-                      : "Select a methodology..."}
-                  </option>
-                  {groupedMethods.map((group) => (
-                    <optgroup key={group.registry} label={group.registry}>
-                      {group.methods.map((m) => (
-                        <option
-                          key={`${m.code}@${m.version}`}
-                          value={`${m.code}@${m.version}`}
-                        >
-                          {m.code} v{m.version} — {m.program} ({m.ruleCount}{" "}
-                          rules)
-                        </option>
-                      ))}
-                    </optgroup>
-                  ))}
-                </select>
-              </div>
-            ) : (
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-                {documentDraft
-                  ? "This route keeps the detected project details and document, but does not require you to confirm a method before continuing."
-                  : "Manual Review does not require a methodology selection. Use this mode for project-specific findings reconstruction, evidence gaps, reviewer notes, and export."}
-              </div>
-            )}
-
-            <div>
-              <label className="mb-1 block text-sm font-semibold text-slate-700">
-                Area Label (optional)
-              </label>
-              <input
-                type="text"
-                value={aoiLabel}
-                onChange={(e) => setAoiLabel(e.target.value)}
-                placeholder="e.g., Liwonde National Park, Malawi"
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-              />
-            </div>
-
-            <div>
-              <label className="mb-1 block text-sm font-semibold text-slate-700">
-                Description (optional)
-              </label>
-              <textarea
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Brief description of the project review..."
-                rows={3}
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-              />
-            </div>
-          </>
-        ) : (
-          <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-            Continue with this document to attach it to the selected existing
-            project. No new project name is required.
-          </div>
-        )}
-
-        {documentDraft ? (
-          <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-4">
-            <div className="mb-1 text-sm font-semibold text-slate-900">
-              Review detected details
-            </div>
-            <div className="text-xs text-slate-500">
-              Confirm before continuing. Every extracted field keeps its
-              confidence label and provenance snippet.
-            </div>
-            <div className="mb-3" />
-            <div className="grid gap-3">
-              {Object.values(documentDraft.fields).map((field) => (
-                <div
-                  key={field.key}
-                  className="rounded-lg border border-slate-200 bg-white px-3 py-3"
-                >
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium text-slate-900">
-                      {field.label}
-                    </span>
-                    <span
-                      className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(field.confidence)}`}
-                    >
-                      {field.confidence}
-                    </span>
-                  </div>
-                  <div className="mt-1 text-sm text-slate-700">
-                    {field.value || "No value extracted"}
-                  </div>
-                  {field.provenance ? (
-                    <div className="mt-1 text-xs text-slate-500">
-                      {field.provenance.fileName} · page{" "}
-                      {field.provenance.pageRange ||
-                        field.provenance.page ||
-                        "?"}
-                      {field.provenance.excerpt
-                        ? ` · "${field.provenance.excerpt}"`
-                        : ""}
-                    </div>
-                  ) : null}
+                      ? "Detected method"
+                      : "Methodology (document field)"}
+                  </label>
+                  <input
+                    type="text"
+                    value={methodology}
+                    onChange={(e) => setMethodology(e.target.value)}
+                    placeholder="e.g., VM0007"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
                 </div>
-              ))}
-            </div>
-            <label className="mt-4 flex items-start gap-3 text-sm text-slate-700">
-              <input
-                type="checkbox"
-                checked={confirmDocumentDraft}
-                onChange={(event) =>
-                  setConfirmDocumentDraft(event.target.checked)
-                }
-                className="mt-1"
-              />
-              <span>
-                I reviewed the detected details, confidence labels, and
-                provenance snippets and want to continue with this document.
-              </span>
-            </label>
-          </div>
-        ) : null}
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700">
+                    Standard
+                  </label>
+                  <input
+                    type="text"
+                    value={standard}
+                    onChange={(e) => setStandard(e.target.value)}
+                    placeholder="e.g., VCS Standard v4.7"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+              </div>
 
-        <button
-          type="submit"
-          disabled={
-            loading ||
-            (creationMode === "create" &&
-              (!name ||
-                (reviewMode === "methodology-linked" && !selectedMethod))) ||
-            (creationMode === "attach" && !attachProjectId) ||
-            Boolean(documentDraft && !confirmDocumentDraft)
-          }
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
-        >
-          {loading
-            ? creationMode === "attach"
-              ? "Attaching..."
-              : "Creating..."
-            : creationMode === "attach"
-              ? "Continue with this document"
-              : documentDraft
-                ? "Start Review"
-                : "Create Project Review"}
-        </button>
-      </form>
+              <div className="grid gap-4 md:grid-cols-3">
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700">
+                    Document Type
+                  </label>
+                  <input
+                    type="text"
+                    value={sourceDocumentType}
+                    onChange={(e) => setSourceDocumentType(e.target.value)}
+                    placeholder="e.g., Project Design Document"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700">
+                    Document Version
+                  </label>
+                  <input
+                    type="text"
+                    value={sourceDocumentVersion}
+                    onChange={(e) => setSourceDocumentVersion(e.target.value)}
+                    placeholder="e.g., v1.3"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700">
+                    Document Date
+                  </label>
+                  <input
+                    type="text"
+                    value={sourceDocumentDate}
+                    onChange={(e) => setSourceDocumentDate(e.target.value)}
+                    placeholder="e.g., 2026-05-24"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+              </div>
+
+              {reviewMode === "methodology-linked" ? (
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700">
+                    {documentDraft
+                      ? "Confirm method before continuing"
+                      : "Methodology"}
+                  </label>
+                  <select
+                    value={selectedMethod}
+                    onChange={(e) => setSelectedMethod(e.target.value)}
+                    disabled={handoffDetected}
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                    required
+                  >
+                    <option value="">
+                      {documentDraft
+                        ? "Select or confirm the detected method..."
+                        : "Select a methodology..."}
+                    </option>
+                    {groupedMethods.map((group) => (
+                      <optgroup key={group.registry} label={group.registry}>
+                        {group.methods.map((m) => (
+                          <option
+                            key={`${m.code}@${m.version}`}
+                            value={`${m.code}@${m.version}`}
+                          >
+                            {m.code} v{m.version} — {m.program} ({m.ruleCount}{" "}
+                            rules)
+                          </option>
+                        ))}
+                      </optgroup>
+                    ))}
+                  </select>
+                </div>
+              ) : (
+                <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                  {documentDraft
+                    ? "This route keeps the detected project details and document, but does not require you to confirm a method before continuing."
+                    : "Manual Review does not require a methodology selection. Use this mode for project-specific findings reconstruction, evidence gaps, reviewer notes, and export."}
+                </div>
+              )}
+
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  Area Label (optional)
+                </label>
+                <input
+                  type="text"
+                  value={aoiLabel}
+                  onChange={(e) => setAoiLabel(e.target.value)}
+                  placeholder="e.g., Liwonde National Park, Malawi"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  Description (optional)
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Brief description of the project review..."
+                  rows={3}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+            </>
+          ) : (
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+              Continue with this document to attach it to the selected existing
+              project. No new project name is required.
+            </div>
+          )}
+
+          {documentDraft ? (
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-4">
+              <div className="mb-1 text-sm font-semibold text-slate-900">
+                Review detected details
+              </div>
+              <div className="text-xs text-slate-500">
+                Confirm before continuing. Every extracted field keeps its
+                confidence label and provenance snippet.
+              </div>
+              <div className="mb-3" />
+              <div className="grid gap-3">
+                {Object.values(documentDraft.fields).map((field) => (
+                  <div
+                    key={field.key}
+                    className="rounded-lg border border-slate-200 bg-white px-3 py-3"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium text-slate-900">
+                        {field.label}
+                      </span>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(field.confidence)}`}
+                      >
+                        {field.confidence}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-sm text-slate-700">
+                      {field.value || "No value extracted"}
+                    </div>
+                    {field.provenance ? (
+                      <div className="mt-1 text-xs text-slate-500">
+                        {field.provenance.fileName} · page{" "}
+                        {field.provenance.pageRange ||
+                          field.provenance.page ||
+                          "?"}
+                        {field.provenance.excerpt
+                          ? ` · "${field.provenance.excerpt}"`
+                          : ""}
+                      </div>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+              <label className="mt-4 flex items-start gap-3 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={confirmDocumentDraft}
+                  onChange={(event) =>
+                    setConfirmDocumentDraft(event.target.checked)
+                  }
+                  className="mt-1"
+                />
+                <span>
+                  I reviewed the detected details, confidence labels, and
+                  provenance snippets and want to continue with this document.
+                </span>
+              </label>
+            </div>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={
+              loading ||
+              (creationMode === "create" &&
+                (!name ||
+                  (reviewMode === "methodology-linked" && !selectedMethod))) ||
+              (creationMode === "attach" && !attachProjectId) ||
+              Boolean(documentDraft && !confirmDocumentDraft)
+            }
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading
+              ? creationMode === "attach"
+                ? "Attaching..."
+                : "Creating..."
+              : creationMode === "attach"
+                ? "Continue with this document"
+                : documentDraft
+                  ? "Start Review"
+                  : "Create Project Review"}
+          </button>
+        </form>
+      ) : null}
     </div>
   );
 }

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { attachPendingProjectDocumentToProject, clearPendingProjectDocumentDraft, readPendingProjectDocumentDraft } from '@/lib/projects/documentMetadata';
 import { createProject } from '@/lib/projects/storage';
 import { projectRegistryFromMethodProgram } from '@/lib/projects/verificationReport';
-import type { ProjectRegistry, ProjectReviewMode } from '@/lib/projects/types';
+import type { ExistingProjectMatch, ProjectDocumentMetadataDraft, ProjectRegistry, ProjectReviewMode } from '@/lib/projects/types';
 import { importMethodologyReviewIntoProject, readPendingProjectReviewHandoff } from '@/lib/projects/reviewHandoff';
 
 export type MethodOption = {
@@ -15,6 +16,23 @@ export type MethodOption = {
 };
 
 const REGISTRY_ORDER: ProjectRegistry[] = ['UNFCCC', 'Verra', 'Gold Standard', 'Unknown'];
+type ProjectCreationMode = 'create' | 'attach';
+
+function confidenceTone(confidence: ProjectDocumentMetadataDraft['fields']['projectTitle']['confidence']): string {
+  if (confidence === 'high') return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+  if (confidence === 'medium') return 'border-sky-200 bg-sky-50 text-sky-800';
+  if (confidence === 'low') return 'border-amber-200 bg-amber-50 text-amber-800';
+  return 'border-slate-200 bg-slate-100 text-slate-500';
+}
+
+function maybeSelectMethod(methods: MethodOption[], rawValue: string | undefined): string {
+  const value = rawValue?.trim();
+  if (!value) return '';
+  const exact = methods.find((method) => method.code.toLowerCase() === value.toLowerCase());
+  if (exact) return `${exact.code}@${exact.version}`;
+  const matched = methods.find((method) => value.toLowerCase().includes(method.code.toLowerCase()));
+  return matched ? `${matched.code}@${matched.version}` : '';
+}
 
 export function groupMethodsByRegistry(methods: MethodOption[]): Array<{ registry: ProjectRegistry; methods: MethodOption[] }> {
   const groups = new Map<ProjectRegistry, MethodOption[]>();
@@ -47,8 +65,19 @@ export default function NewProjectForm() {
   const [error, setError] = useState('');
   const [handoffDetected, setHandoffDetected] = useState(false);
   const [handoffMethodLabel, setHandoffMethodLabel] = useState('');
+  const [methodology, setMethodology] = useState('');
+  const [standard, setStandard] = useState('');
+  const [sourceDocumentType, setSourceDocumentType] = useState('');
+  const [sourceDocumentVersion, setSourceDocumentVersion] = useState('');
+  const [sourceDocumentDate, setSourceDocumentDate] = useState('');
+  const [documentDraft, setDocumentDraft] = useState<ProjectDocumentMetadataDraft | null>(null);
+  const [creationMode, setCreationMode] = useState<ProjectCreationMode>('create');
+  const [confirmDocumentDraft, setConfirmDocumentDraft] = useState(false);
+  const [attachProjectId, setAttachProjectId] = useState('');
 
   const groupedMethods = useMemo(() => groupMethodsByRegistry(methods), [methods]);
+  const attachMatches = useMemo<ExistingProjectMatch[]>(() => documentDraft?.suggestedExistingProjects ?? [], [documentDraft]);
+  const searchKey = searchParams.toString();
 
   useEffect(() => {
     fetch('/api/projects/methods')
@@ -65,28 +94,74 @@ export default function NewProjectForm() {
     setReviewMode('methodology-linked');
     setSelectedMethod(`${handoff.source.methodCode}@${handoff.source.methodVersion}`);
     setHandoffMethodLabel(`${handoff.source.methodCode} ${handoff.source.methodVersion}`);
-  }, [searchParams]);
+  }, [searchKey, searchParams]);
+
+  useEffect(() => {
+    if (searchParams.get('handoff') !== 'document-metadata') return;
+    const stagedDraft = readPendingProjectDocumentDraft();
+    if (!stagedDraft) return;
+    if (documentDraft?.source.attachmentId === stagedDraft.source.attachmentId) return;
+    setDocumentDraft(stagedDraft);
+    setName(stagedDraft.fields.projectTitle.value ?? '');
+    setProjectCode(stagedDraft.fields.projectId.value ?? '');
+    setCountryLocation(stagedDraft.fields.country.value ?? '');
+    setProponent(stagedDraft.fields.proponent.value ?? '');
+    setMethodology(stagedDraft.fields.methodology.value ?? '');
+    setStandard(stagedDraft.fields.standard.value ?? '');
+    setSourceDocumentType(stagedDraft.fields.documentType.value ?? '');
+    setSourceDocumentVersion(stagedDraft.fields.version.value ?? '');
+    setSourceDocumentDate(stagedDraft.fields.documentDate.value ?? '');
+    const suggestedAttach = stagedDraft.suggestedExistingProjects[0];
+    if (suggestedAttach) {
+      setAttachProjectId(suggestedAttach.projectId);
+    }
+  }, [documentDraft?.source.attachmentId, searchKey, searchParams]);
+
+  useEffect(() => {
+    if (!documentDraft || !methods.length || selectedMethod) return;
+    const maybeMethod = maybeSelectMethod(methods, documentDraft.fields.methodology.value);
+    if (maybeMethod) setSelectedMethod(maybeMethod);
+  }, [documentDraft, methods, selectedMethod]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name) return;
     if (reviewMode === 'methodology-linked' && !selectedMethod) return;
+    if (documentDraft && !confirmDocumentDraft) return;
+    if (creationMode === 'attach' && !attachProjectId) return;
 
     setLoading(true);
     setError('');
 
     try {
+      if (creationMode === 'attach') {
+        await attachPendingProjectDocumentToProject(attachProjectId);
+        clearPendingProjectDocumentDraft();
+        router.push(`/projects/${attachProjectId}`);
+        return;
+      }
+
       if (reviewMode === 'manual') {
         const project = createProject({
           name,
           projectCode: projectCode || undefined,
           countryLocation: countryLocation || undefined,
           proponent: proponent || undefined,
+          methodology: methodology || undefined,
+          standard: standard || undefined,
+          sourceDocumentType: sourceDocumentType || undefined,
+          sourceDocumentVersion: sourceDocumentVersion || undefined,
+          sourceDocumentDate: sourceDocumentDate || undefined,
           reviewMode,
           reportingPeriod: reportingPeriod || undefined,
           aoiLabel: aoiLabel || undefined,
           description: description || undefined,
+          createdFromDocumentDraft: documentDraft ?? undefined,
         });
+        if (documentDraft) {
+          await attachPendingProjectDocumentToProject(project.id);
+          clearPendingProjectDocumentDraft();
+        }
         router.push(`/projects/${project.id}`);
         return;
       }
@@ -114,14 +189,24 @@ export default function NewProjectForm() {
             projectCode: projectCode || undefined,
             countryLocation: countryLocation || undefined,
             proponent: proponent || undefined,
+            methodology: methodology || undefined,
+            standard: standard || undefined,
             methodCategory: category,
             registry: projectRegistryFromMethodProgram(selectedMethodRecord?.program),
             reportingPeriod: reportingPeriod || undefined,
             aoiLabel: aoiLabel || undefined,
             description: description || undefined,
+            sourceDocumentType: sourceDocumentType || undefined,
+            sourceDocumentVersion: sourceDocumentVersion || undefined,
+            sourceDocumentDate: sourceDocumentDate || undefined,
+            createdFromDocumentDraft: documentDraft ?? undefined,
           },
           rules,
         });
+        if (documentDraft) {
+          await attachPendingProjectDocumentToProject(result.project.id);
+          clearPendingProjectDocumentDraft();
+        }
         router.push(result.href);
         return;
       }
@@ -131,6 +216,8 @@ export default function NewProjectForm() {
         projectCode: projectCode || undefined,
         countryLocation: countryLocation || undefined,
         proponent: proponent || undefined,
+        methodology: methodology || undefined,
+        standard: standard || undefined,
         reviewMode,
         methodCode: code,
         methodVersion: version,
@@ -139,6 +226,10 @@ export default function NewProjectForm() {
         reportingPeriod: reportingPeriod || undefined,
         aoiLabel: aoiLabel || undefined,
         description: description || undefined,
+        sourceDocumentType: sourceDocumentType || undefined,
+        sourceDocumentVersion: sourceDocumentVersion || undefined,
+        sourceDocumentDate: sourceDocumentDate || undefined,
+        createdFromDocumentDraft: documentDraft ?? undefined,
         ruleIds: rules.map((r: { id: string; title: string; sectionId?: string }) => ({
           id: r.id,
           title: r.title,
@@ -146,11 +237,17 @@ export default function NewProjectForm() {
         })),
       });
 
+      if (documentDraft) {
+        await attachPendingProjectDocumentToProject(project.id);
+        clearPendingProjectDocumentDraft();
+      }
       router.push(`/projects/${project.id}`);
     } catch {
       setError(reviewMode === 'manual'
         ? 'Failed to create manual review. Try again.'
-        : 'Failed to create project handoff. Try again.');
+        : creationMode === 'attach'
+          ? 'Failed to attach the document to the existing project. Try again.'
+          : 'Failed to create project handoff. Try again.');
       setLoading(false);
     }
   };
@@ -163,6 +260,15 @@ export default function NewProjectForm() {
           Create a long-lived project review workspace
         </p>
       </div>
+
+      {documentDraft ? (
+        <div className="rounded-lg border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700">
+          <div className="font-semibold text-slate-900">Create project from document</div>
+          <div className="mt-1">
+            Extracted metadata from {documentDraft.source.fileName}. Review every field, then confirm before creating a new project or attaching the document to an existing one.
+          </div>
+        </div>
+      ) : null}
 
       {error && (
         <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
@@ -207,6 +313,57 @@ export default function NewProjectForm() {
           <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
             Create a project and carry over the active review for {handoffMethodLabel}. Existing evidence links, rule reviews, reviewer notes, and draft finalization state will be imported.
           </div>
+        ) : null}
+
+        {documentDraft ? (
+          <>
+            <div className="grid gap-3 md:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => setCreationMode('create')}
+                className={`rounded-lg border px-4 py-3 text-left ${creationMode === 'create' ? 'border-blue-500 bg-blue-50 text-blue-900' : 'border-slate-200 bg-white text-slate-700'}`}
+              >
+                <div className="text-sm font-semibold">Create new project</div>
+                <div className="mt-1 text-xs text-slate-500">Use the extracted fields to prefill a new project review.</div>
+              </button>
+              <button
+                type="button"
+                onClick={() => setCreationMode('attach')}
+                disabled={!attachMatches.length}
+                className={`rounded-lg border px-4 py-3 text-left ${creationMode === 'attach' ? 'border-blue-500 bg-blue-50 text-blue-900' : 'border-slate-200 bg-white text-slate-700'} ${!attachMatches.length ? 'cursor-not-allowed opacity-50' : ''}`}
+              >
+                <div className="text-sm font-semibold">Attach to existing project</div>
+                <div className="mt-1 text-xs text-slate-500">Use this when the extracted metadata appears to match an existing record.</div>
+              </button>
+            </div>
+
+            {attachMatches.length ? (
+              <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+                <div className="mb-2 text-sm font-semibold text-slate-900">Possible existing project matches</div>
+                <div className="grid gap-2">
+                  {attachMatches.map((match) => (
+                    <label key={match.projectId} className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-white px-3 py-3">
+                      <input
+                        type="radio"
+                        name="attach-project"
+                        checked={attachProjectId === match.projectId}
+                        onChange={() => setAttachProjectId(match.projectId)}
+                        className="mt-1"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-medium text-slate-900">{match.projectName}</span>
+                          {match.projectCode ? <span className="text-xs text-slate-500">{match.projectCode}</span> : null}
+                          <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(match.confidence)}`}>{match.confidence}</span>
+                        </div>
+                        <div className="mt-1 text-xs text-slate-600">{match.matchReasons.join(' · ')}</div>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </>
         ) : null}
 
         <div>
@@ -267,6 +424,62 @@ export default function NewProjectForm() {
           </div>
         </div>
 
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Methodology (document field)</label>
+            <input
+              type="text"
+              value={methodology}
+              onChange={e => setMethodology(e.target.value)}
+              placeholder="e.g., VM0007"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Standard</label>
+            <input
+              type="text"
+              value={standard}
+              onChange={e => setStandard(e.target.value)}
+              placeholder="e.g., VCS Standard v4.7"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Document Type</label>
+            <input
+              type="text"
+              value={sourceDocumentType}
+              onChange={e => setSourceDocumentType(e.target.value)}
+              placeholder="e.g., Project Design Document"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Document Version</label>
+            <input
+              type="text"
+              value={sourceDocumentVersion}
+              onChange={e => setSourceDocumentVersion(e.target.value)}
+              placeholder="e.g., v1.3"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Document Date</label>
+            <input
+              type="text"
+              value={sourceDocumentDate}
+              onChange={e => setSourceDocumentDate(e.target.value)}
+              placeholder="e.g., 2026-05-24"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
         {reviewMode === 'methodology-linked' ? (
           <div>
             <label className="mb-1 block text-sm font-semibold text-slate-700">Methodology</label>
@@ -317,12 +530,55 @@ export default function NewProjectForm() {
           />
         </div>
 
+        {documentDraft ? (
+          <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-4">
+            <div className="mb-3 text-sm font-semibold text-slate-900">Extraction provenance</div>
+            <div className="grid gap-3">
+              {Object.values(documentDraft.fields).map((field) => (
+                <div key={field.key} className="rounded-lg border border-slate-200 bg-white px-3 py-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium text-slate-900">{field.label}</span>
+                    <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(field.confidence)}`}>{field.confidence}</span>
+                  </div>
+                  <div className="mt-1 text-sm text-slate-700">{field.value || 'No value extracted'}</div>
+                  {field.provenance ? (
+                    <div className="mt-1 text-xs text-slate-500">
+                      {field.provenance.fileName} · page {field.provenance.pageRange || field.provenance.page || '?'}
+                      {field.provenance.excerpt ? ` · "${field.provenance.excerpt}"` : ''}
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+            <label className="mt-4 flex items-start gap-3 text-sm text-slate-700">
+              <input
+                type="checkbox"
+                checked={confirmDocumentDraft}
+                onChange={(event) => setConfirmDocumentDraft(event.target.checked)}
+                className="mt-1"
+              />
+              <span>I reviewed the extracted metadata and want to continue with this project action.</span>
+            </label>
+          </div>
+        ) : null}
+
         <button
           type="submit"
-          disabled={loading || !name || (reviewMode === 'methodology-linked' && !selectedMethod)}
+          disabled={
+            loading
+            || (creationMode === 'create' && (!name || (reviewMode === 'methodology-linked' && !selectedMethod)))
+            || (creationMode === 'attach' && !attachProjectId)
+            || Boolean(documentDraft && !confirmDocumentDraft)
+          }
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
         >
-          {loading ? 'Creating...' : 'Create Project Review'}
+          {loading
+            ? (creationMode === 'attach' ? 'Attaching...' : 'Creating...')
+            : creationMode === 'attach'
+              ? 'Attach Document To Existing Project'
+              : documentDraft
+                ? 'Create Project From Document'
+                : 'Create Project Review'}
         </button>
       </form>
     </div>

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
@@ -108,10 +109,13 @@ export function groupMethodsByRegistry(
 export default function NewProjectForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const manualModeRequested = searchParams.get("mode") === "manual";
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
   const [methods, setMethods] = useState<MethodOption[]>([]);
   const [reviewMode, setReviewMode] =
-    useState<ProjectReviewMode>("methodology-linked");
+    useState<ProjectReviewMode>(
+      manualModeRequested ? "manual" : "methodology-linked",
+    );
   const [name, setName] = useState("");
   const [projectCode, setProjectCode] = useState("");
   const [countryLocation, setCountryLocation] = useState("");
@@ -206,7 +210,10 @@ export default function NewProjectForm() {
   }, [documentDraft]);
   const createModeActive = creationMode === "create";
   const searchKey = searchParams.toString();
-  const intakeActive = !documentDraft && !handoffDetected && !showManualSetup;
+  const manualOnlyView =
+    manualModeRequested && !documentDraft && !handoffDetected;
+  const intakeActive =
+    !documentDraft && !handoffDetected && !showManualSetup && !manualModeRequested;
 
   const hydrateDocumentDraft = useCallback(
     (stagedDraft: ProjectDocumentMetadataDraft) => {
@@ -262,7 +269,7 @@ export default function NewProjectForm() {
         contentSha256: attachmentResult.attachment.sha256,
       });
       hydrateDocumentDraft(stagedDraft);
-      router.replace("/projects/new?handoff=document-metadata");
+      router.replace("/start-review?handoff=document-metadata");
     } catch (uploadError) {
       setError(
         uploadError instanceof Error
@@ -319,6 +326,11 @@ export default function NewProjectForm() {
     );
     if (maybeMethod) setSelectedMethod(maybeMethod);
   }, [documentDraft, methods, selectedMethod]);
+
+  useEffect(() => {
+    if (!manualOnlyView) return;
+    setReviewMode("manual");
+  }, [manualOnlyView]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -480,13 +492,31 @@ export default function NewProjectForm() {
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 md:px-8 md:py-14">
       {intakeActive ? (
         <div className="mx-auto w-full max-w-4xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-slate-950 md:text-5xl">
-            Start Review
-          </h1>
-          <p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-slate-600 md:text-[15px]">
-            Upload a PDD, monitoring report, or evidence file. Article6 will
-            detect the project, method, and next review step.
-          </p>
+          <div className="flex flex-wrap items-start justify-between gap-6 text-left">
+            <div className="min-w-0 flex-1">
+              <h1 className="text-4xl font-bold tracking-tight text-slate-950 md:text-5xl">
+                Start Review
+              </h1>
+              <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-600 md:text-[15px]">
+                Upload a PDD, monitoring report, or evidence file. Article6 will
+                detect project metadata, methodology, standard, and the next review step.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Link
+                href="/start-review?mode=manual"
+                className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 transition hover:border-slate-400"
+              >
+                Set up manually
+              </Link>
+              <Link
+                href="/projects"
+                className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 transition hover:border-slate-400"
+              >
+                Existing projects
+              </Link>
+            </div>
+          </div>
           <div
             className={`mt-8 rounded-[2rem] border border-slate-200 bg-white p-5 shadow-[0_24px_80px_-48px_rgba(15,23,42,0.45)] md:p-8`}
           >
@@ -536,17 +566,12 @@ export default function NewProjectForm() {
                   : "Upload project document"}
               </button>
               <div className="mt-4">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowManualSetup(true);
-                    setReviewMode("manual");
-                    setError("");
-                  }}
+                <Link
+                  href="/start-review?mode=quick-check"
                   className="text-sm font-medium text-slate-600 underline-offset-4 transition hover:text-slate-900 hover:underline"
                 >
-                  Set up review manually
-                </button>
+                  Run a quick evidence check instead
+                </Link>
               </div>
             </div>
           </div>
@@ -587,10 +612,12 @@ export default function NewProjectForm() {
       ) : (
         <div className={`mx-auto w-full ${documentDraft ? "max-w-5xl text-center" : "max-w-3xl"}`}>
           <h1 className="text-4xl font-bold tracking-tight text-slate-950">
-            Start Review
+            {manualOnlyView ? "Set up review manually" : "Start Review"}
           </h1>
           <p className="mt-3 text-sm leading-7 text-slate-600 md:text-[15px]">
-            {documentDraft
+            {manualOnlyView
+              ? "Create a project review without uploading a source document first. You can attach documents and evidence later."
+              : documentDraft
               ? "We reviewed your uploaded document and found the most relevant project details."
               : "Upload a project document, review the detected details, then continue into the project review workspace."}
           </p>
@@ -691,7 +718,7 @@ export default function NewProjectForm() {
 
       {!intakeActive ? (
         <form onSubmit={handleSubmit} className="mx-auto flex w-full max-w-5xl flex-col gap-4">
-          {!documentDraft || editingDetails ? (
+          {(!documentDraft || editingDetails) && !manualOnlyView ? (
           <div>
             <label className="mb-1 block text-sm font-semibold text-slate-700">
               {documentDraft ? "Review route" : "Review Type"}
@@ -1020,7 +1047,9 @@ export default function NewProjectForm() {
                 <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
                   {documentDraft
                     ? "This route keeps the detected project details and document, but does not require you to confirm a method before continuing."
-                    : "Manual Review does not require a methodology selection. Use this mode for project-specific findings reconstruction, evidence gaps, reviewer notes, and export."}
+                    : manualOnlyView
+                      ? "This setup does not require a methodology selection before creating the project review. You can attach documents and evidence later."
+                      : "Manual Review does not require a methodology selection. Use this mode for project-specific findings reconstruction, evidence gaps, reviewer notes, and export."}
                 </div>
               )}
 

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -3,6 +3,14 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
+  CheckCircle2,
+  CloudUpload,
+  FileBadge2,
+  FileText,
+  GitBranch,
+  ShieldCheck,
+} from "lucide-react";
+import {
   attachPendingProjectDocumentToProject,
   clearPendingProjectDocumentDraft,
   readPendingProjectDocumentDraft,
@@ -130,6 +138,7 @@ export default function NewProjectForm() {
   const [showManualSetup, setShowManualSetup] = useState(false);
   const [uploadingDocument, setUploadingDocument] = useState(false);
   const [dragActive, setDragActive] = useState(false);
+  const [editingDetails, setEditingDetails] = useState(false);
 
   const groupedMethods = useMemo(
     () => groupMethodsByRegistry(methods),
@@ -147,37 +156,54 @@ export default function NewProjectForm() {
               label: "Detected project",
               value:
                 documentDraft.fields.projectTitle.value?.trim() ||
-                "No project title detected",
+                "Not detected",
             },
             {
               label: "Detected method",
               value:
                 documentDraft.fields.methodology.value?.trim() ||
-                "No method detected",
+                "Not detected",
             },
             {
               label: "Detected standard",
               value:
                 documentDraft.fields.standard.value?.trim() ||
-                "No standard detected",
+                "Not detected",
             },
             {
               label: "Document type",
-              value: documentDraft.fields.documentType.value?.trim(),
+              value:
+                documentDraft.fields.documentType.value?.trim() ||
+                "Not detected",
             },
             {
-              label: "Version / date",
-              value: [
-                documentDraft.fields.version.value?.trim(),
-                documentDraft.fields.documentDate.value?.trim(),
-              ]
-                .filter(Boolean)
-                .join(" · "),
+              label: "Country",
+              value: documentDraft.fields.country.value?.trim() || "Not detected",
             },
-          ].filter((field) => field.value)
+            {
+              label: "Proponent",
+              value:
+                documentDraft.fields.proponent.value?.trim() || "Not detected",
+            },
+          ]
         : [],
     [documentDraft],
   );
+  const detectedResultChips = useMemo(() => {
+    if (!documentDraft) return [];
+    const fields = Object.values(documentDraft.fields);
+    const chips: string[] = [];
+    if (fields.some((field) => field.confidence === "high")) {
+      chips.push("High confidence");
+    }
+    if (documentDraft.fields.methodology.value?.trim()) {
+      chips.push("Method suggested");
+    }
+    if (fields.some((field) => field.provenance)) {
+      chips.push("Provenance captured");
+    }
+    return chips;
+  }, [documentDraft]);
   const createModeActive = creationMode === "create";
   const searchKey = searchParams.toString();
   const intakeActive = !documentDraft && !handoffDetected && !showManualSetup;
@@ -187,6 +213,7 @@ export default function NewProjectForm() {
       setDocumentDraft(stagedDraft);
       setCreationMode("create");
       setConfirmDocumentDraft(false);
+      setEditingDetails(false);
       setShowManualSetup(true);
       setName(stagedDraft.fields.projectTitle.value ?? "");
       setProjectCode(stagedDraft.fields.projectId.value ?? "");
@@ -450,16 +477,21 @@ export default function NewProjectForm() {
   };
 
   return (
-    <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-12 md:px-8">
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 md:px-8 md:py-14">
       {intakeActive ? (
-        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h1 className="text-2xl font-bold text-slate-900">Start Review</h1>
-          <p className="mt-2 max-w-xl text-sm text-slate-600">
+        <div className="mx-auto w-full max-w-4xl text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-slate-950 md:text-5xl">
+            Start Review
+          </h1>
+          <p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-slate-600 md:text-[15px]">
             Upload a PDD, monitoring report, or evidence file. Article6 will
             detect the project, method, and next review step.
           </p>
           <div
-            className={`mt-5 rounded-2xl border-2 border-dashed px-5 py-8 text-center transition ${dragActive ? "border-blue-400 bg-blue-50" : "border-slate-300 bg-slate-50"}`}
+            className={`mt-8 rounded-[2rem] border border-slate-200 bg-white p-5 shadow-[0_24px_80px_-48px_rgba(15,23,42,0.45)] md:p-8`}
+          >
+            <div
+              className={`rounded-[1.5rem] border-2 border-dashed px-6 py-12 text-center transition md:px-10 md:py-16 ${dragActive ? "border-sky-400 bg-sky-50" : "border-slate-300 bg-slate-50/80"}`}
             onDragOver={(event) => {
               event.preventDefault();
               setDragActive(true);
@@ -474,87 +506,192 @@ export default function NewProjectForm() {
               void handleIntakeUpload(event.dataTransfer.files?.[0] ?? null);
             }}
           >
-            <div className="text-sm font-semibold text-slate-900">
-              Upload project document
+              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-900 text-white shadow-sm">
+                <CloudUpload className="h-6 w-6" />
+              </div>
+              <div className="mt-5 text-xl font-semibold text-slate-950">
+                Drag and drop your project document
+              </div>
+              <div className="mt-2 text-sm text-slate-500">
+                PDF, DOCX, XLSX, GEOJSON, KML, SHP ZIP
+              </div>
+              <input
+                ref={uploadInputRef}
+                type="file"
+                accept="application/pdf,.pdf,.doc,.docx,.xlsx,.geojson,.kml,.zip"
+                className="hidden"
+                onChange={(event) => {
+                  void handleIntakeUpload(event.target.files?.[0] ?? null);
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => uploadInputRef.current?.click()}
+                disabled={uploadingDocument}
+                className="mt-6 inline-flex items-center gap-2 rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:opacity-60"
+              >
+                <CloudUpload className="h-4 w-4" />
+                {uploadingDocument
+                  ? "Detecting project details..."
+                  : "Upload project document"}
+              </button>
+              <div className="mt-4">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowManualSetup(true);
+                    setReviewMode("manual");
+                    setError("");
+                  }}
+                  className="text-sm font-medium text-slate-600 underline-offset-4 transition hover:text-slate-900 hover:underline"
+                >
+                  Set up review manually
+                </button>
+              </div>
             </div>
-            <div className="mt-1 text-sm text-slate-500">
-              Drop a PDF here or choose a file to detect project details.
-            </div>
-            <input
-              ref={uploadInputRef}
-              type="file"
-              accept="application/pdf,.pdf"
-              className="hidden"
-              onChange={(event) => {
-                void handleIntakeUpload(event.target.files?.[0] ?? null);
-              }}
-            />
-            <button
-              type="button"
-              onClick={() => uploadInputRef.current?.click()}
-              disabled={uploadingDocument}
-              className="mt-4 inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
-            >
-              {uploadingDocument
-                ? "Detecting project details..."
-                : "Upload document"}
-            </button>
           </div>
-          <button
-            type="button"
-            onClick={() => {
-              setShowManualSetup(true);
-              setReviewMode("manual");
-              setError("");
-            }}
-            className="mt-4 text-sm font-semibold text-slate-600 underline-offset-4 hover:text-slate-900 hover:underline"
-          >
-            Set up review manually
-          </button>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-3">
+            <div className="rounded-2xl border border-slate-200 bg-white px-5 py-4 text-left shadow-sm">
+              <div className="flex items-center gap-3">
+                <div className="rounded-xl bg-slate-100 p-2 text-slate-700">
+                  <FileText className="h-4 w-4" />
+                </div>
+                <div className="text-sm font-semibold text-slate-900">
+                  Detects project metadata
+                </div>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-white px-5 py-4 text-left shadow-sm">
+              <div className="flex items-center gap-3">
+                <div className="rounded-xl bg-slate-100 p-2 text-slate-700">
+                  <GitBranch className="h-4 w-4" />
+                </div>
+                <div className="text-sm font-semibold text-slate-900">
+                  Suggests methodology
+                </div>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-white px-5 py-4 text-left shadow-sm">
+              <div className="flex items-center gap-3">
+                <div className="rounded-xl bg-slate-100 p-2 text-slate-700">
+                  <ShieldCheck className="h-4 w-4" />
+                </div>
+                <div className="text-sm font-semibold text-slate-900">
+                  Preserves provenance &amp; confidence
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       ) : (
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900">Start Review</h1>
-          <p className="mt-1 text-sm text-slate-500">
-            Upload a project document, review the detected details, then
-            continue into the project review workspace.
+        <div className={`mx-auto w-full ${documentDraft ? "max-w-5xl text-center" : "max-w-3xl"}`}>
+          <h1 className="text-4xl font-bold tracking-tight text-slate-950">
+            Start Review
+          </h1>
+          <p className="mt-3 text-sm leading-7 text-slate-600 md:text-[15px]">
+            {documentDraft
+              ? "We reviewed your uploaded document and found the most relevant project details."
+              : "Upload a project document, review the detected details, then continue into the project review workspace."}
           </p>
         </div>
       )}
 
       {documentDraft ? (
-        <div className="rounded-lg border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700">
-          <div className="font-semibold text-slate-900">We found a project</div>
-          <div className="mt-1">
-            Review detected details from {documentDraft.source.fileName}, then
-            confirm before continuing.
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50/80 px-4 py-3 text-sm text-emerald-900 shadow-sm">
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white text-emerald-700">
+                <FileBadge2 className="h-5 w-5" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="font-medium text-emerald-950">
+                  {documentDraft.source.fileName}
+                </div>
+                <div className="text-xs text-emerald-800/80">
+                  Uploaded and ready for review
+                </div>
+              </div>
+              <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-white px-3 py-1 text-xs font-semibold text-emerald-800">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Ready
+              </span>
+            </div>
           </div>
-          <div className="mt-3 grid gap-3 md:grid-cols-2">
+
+          <div className="rounded-[2rem] border border-slate-200 bg-white px-6 py-6 text-sm text-slate-700 shadow-[0_24px_80px_-48px_rgba(15,23,42,0.45)] md:px-8 md:py-8">
+            <div className="text-2xl font-semibold tracking-tight text-slate-950">
+              We found a project
+            </div>
+            <div className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+              Review the detected details, then continue into the review
+              workspace.
+            </div>
+            {detectedResultChips.length ? (
+              <div className="mt-4 flex flex-wrap gap-2">
+                {detectedResultChips.map((chip) => (
+                  <span
+                    key={chip}
+                    className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold text-slate-700"
+                  >
+                    {chip}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+            <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             {detectedSummaryFields.map((field) => (
               <div
                 key={field.label}
-                className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3"
+                className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4"
               >
-                <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
                   {field.label}
                 </div>
-                <div className="mt-1 text-sm font-medium text-slate-900">
+                <div className="mt-2 text-sm font-medium text-slate-900">
                   {field.value}
                 </div>
               </div>
             ))}
+            </div>
+          </div>
+
+          <div className="rounded-[2rem] border border-slate-200 bg-white px-6 py-6 shadow-sm">
+            <div className="text-base font-semibold text-slate-950">
+              What happens next
+            </div>
+            <div className="mt-4 grid gap-3 md:grid-cols-3">
+              {[
+                "Confirm details",
+                "Review evidence",
+                "Export verification pack",
+              ].map((step, index) => (
+                <div
+                  key={step}
+                  className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4"
+                >
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Step {index + 1}
+                  </div>
+                  <div className="mt-2 text-sm font-medium text-slate-900">
+                    {step}
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       ) : null}
 
       {error && (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div className="mx-auto w-full max-w-4xl rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           {error}
         </div>
       )}
 
       {!intakeActive ? (
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="mx-auto flex w-full max-w-5xl flex-col gap-4">
+          {!documentDraft || editingDetails ? (
           <div>
             <label className="mb-1 block text-sm font-semibold text-slate-700">
               {documentDraft ? "Review route" : "Review Type"}
@@ -604,8 +741,9 @@ export default function NewProjectForm() {
               </button>
             </div>
           </div>
+          ) : null}
 
-          {handoffDetected ? (
+          {handoffDetected && (!documentDraft || editingDetails) ? (
             <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
               Create a project and carry over the active review for{" "}
               {handoffMethodLabel}. Existing evidence links, rule reviews,
@@ -618,19 +756,25 @@ export default function NewProjectForm() {
               <div className="grid gap-3 md:grid-cols-2">
                 <button
                   type="button"
-                  onClick={() => setCreationMode("create")}
+                  onClick={() => {
+                    setCreationMode("create");
+                    setEditingDetails(false);
+                  }}
                   className={`rounded-lg border px-4 py-3 text-left ${creationMode === "create" ? "border-blue-500 bg-blue-50 text-blue-900" : "border-slate-200 bg-white text-slate-700"}`}
                 >
                   <div className="text-sm font-semibold">
-                    Start review from this document
+                    Continue to review workspace
                   </div>
                   <div className="mt-1 text-xs text-slate-500">
-                    Create a review workspace using the detected details below.
+                    Create a review workspace using the detected details above.
                   </div>
                 </button>
                 <button
                   type="button"
-                  onClick={() => setCreationMode("attach")}
+                  onClick={() => {
+                    setCreationMode("attach");
+                    setEditingDetails(false);
+                  }}
                   disabled={!attachMatches.length}
                   className={`rounded-lg border px-4 py-3 text-left ${creationMode === "attach" ? "border-blue-500 bg-blue-50 text-blue-900" : "border-slate-200 bg-white text-slate-700"} ${!attachMatches.length ? "cursor-not-allowed opacity-50" : ""}`}
                 >
@@ -644,7 +788,17 @@ export default function NewProjectForm() {
                 </button>
               </div>
 
-              {attachMatches.length ? (
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setEditingDetails((current) => !current)}
+                  className="inline-flex items-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                >
+                  {editingDetails ? "Hide edit details" : "Edit details"}
+                </button>
+              </div>
+
+              {attachMatches.length && creationMode === "attach" ? (
                 <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
                   <div className="mb-2 text-sm font-semibold text-slate-900">
                     Existing project matches
@@ -690,7 +844,7 @@ export default function NewProjectForm() {
             </>
           ) : null}
 
-          {createModeActive ? (
+          {createModeActive && (!documentDraft || editingDetails) ? (
             <>
               <div>
                 <label className="mb-1 block text-sm font-semibold text-slate-700">
@@ -930,7 +1084,7 @@ export default function NewProjectForm() {
                       </span>
                     </div>
                     <div className="mt-1 text-sm text-slate-700">
-                      {field.value || "No value extracted"}
+                      {field.value || "Not detected"}
                     </div>
                     {field.provenance ? (
                       <div className="mt-1 text-xs text-slate-500">
@@ -973,7 +1127,7 @@ export default function NewProjectForm() {
               (creationMode === "attach" && !attachProjectId) ||
               Boolean(documentDraft && !confirmDocumentDraft)
             }
-            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:opacity-50"
           >
             {loading
               ? creationMode === "attach"
@@ -982,7 +1136,7 @@ export default function NewProjectForm() {
               : creationMode === "attach"
                 ? "Continue with this document"
                 : documentDraft
-                  ? "Start Review"
+                  ? "Continue to review workspace"
                   : "Create Project Review"}
           </button>
         </form>

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -1,12 +1,24 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useMemo } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { attachPendingProjectDocumentToProject, clearPendingProjectDocumentDraft, readPendingProjectDocumentDraft } from '@/lib/projects/documentMetadata';
-import { createProject } from '@/lib/projects/storage';
-import { projectRegistryFromMethodProgram } from '@/lib/projects/verificationReport';
-import type { ExistingProjectMatch, ProjectDocumentMetadataDraft, ProjectRegistry, ProjectReviewMode } from '@/lib/projects/types';
-import { importMethodologyReviewIntoProject, readPendingProjectReviewHandoff } from '@/lib/projects/reviewHandoff';
+import { useState, useEffect, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  attachPendingProjectDocumentToProject,
+  clearPendingProjectDocumentDraft,
+  readPendingProjectDocumentDraft,
+} from "@/lib/projects/documentMetadata";
+import { createProject } from "@/lib/projects/storage";
+import { projectRegistryFromMethodProgram } from "@/lib/projects/verificationReport";
+import type {
+  ExistingProjectMatch,
+  ProjectDocumentMetadataDraft,
+  ProjectRegistry,
+  ProjectReviewMode,
+} from "@/lib/projects/types";
+import {
+  importMethodologyReviewIntoProject,
+  readPendingProjectReviewHandoff,
+} from "@/lib/projects/reviewHandoff";
 
 export type MethodOption = {
   code: string;
@@ -15,102 +27,143 @@ export type MethodOption = {
   ruleCount: number;
 };
 
-const REGISTRY_ORDER: ProjectRegistry[] = ['UNFCCC', 'Verra', 'Gold Standard', 'Unknown'];
-type ProjectCreationMode = 'create' | 'attach';
+const REGISTRY_ORDER: ProjectRegistry[] = [
+  "UNFCCC",
+  "Verra",
+  "Gold Standard",
+  "Unknown",
+];
+type ProjectCreationMode = "create" | "attach";
 
-function confidenceTone(confidence: ProjectDocumentMetadataDraft['fields']['projectTitle']['confidence']): string {
-  if (confidence === 'high') return 'border-emerald-200 bg-emerald-50 text-emerald-800';
-  if (confidence === 'medium') return 'border-sky-200 bg-sky-50 text-sky-800';
-  if (confidence === 'low') return 'border-amber-200 bg-amber-50 text-amber-800';
-  return 'border-slate-200 bg-slate-100 text-slate-500';
+function confidenceTone(
+  confidence: ProjectDocumentMetadataDraft["fields"]["projectTitle"]["confidence"],
+): string {
+  if (confidence === "high")
+    return "border-emerald-200 bg-emerald-50 text-emerald-800";
+  if (confidence === "medium") return "border-sky-200 bg-sky-50 text-sky-800";
+  if (confidence === "low")
+    return "border-amber-200 bg-amber-50 text-amber-800";
+  return "border-slate-200 bg-slate-100 text-slate-500";
 }
 
-function maybeSelectMethod(methods: MethodOption[], rawValue: string | undefined): string {
+function maybeSelectMethod(
+  methods: MethodOption[],
+  rawValue: string | undefined,
+): string {
   const value = rawValue?.trim();
-  if (!value) return '';
-  const exact = methods.find((method) => method.code.toLowerCase() === value.toLowerCase());
+  if (!value) return "";
+  const exact = methods.find(
+    (method) => method.code.toLowerCase() === value.toLowerCase(),
+  );
   if (exact) return `${exact.code}@${exact.version}`;
-  const matched = methods.find((method) => value.toLowerCase().includes(method.code.toLowerCase()));
-  return matched ? `${matched.code}@${matched.version}` : '';
+  const matched = methods.find((method) =>
+    value.toLowerCase().includes(method.code.toLowerCase()),
+  );
+  return matched ? `${matched.code}@${matched.version}` : "";
 }
 
-export function groupMethodsByRegistry(methods: MethodOption[]): Array<{ registry: ProjectRegistry; methods: MethodOption[] }> {
+export function groupMethodsByRegistry(
+  methods: MethodOption[],
+): Array<{ registry: ProjectRegistry; methods: MethodOption[] }> {
   const groups = new Map<ProjectRegistry, MethodOption[]>();
   for (const registry of REGISTRY_ORDER) groups.set(registry, []);
   for (const method of methods) {
     const registry = projectRegistryFromMethodProgram(method.program);
     const list = groups.get(registry);
     if (list) list.push(method);
-    else groups.get('Unknown')!.push(method);
+    else groups.get("Unknown")!.push(method);
   }
-  return REGISTRY_ORDER
-    .map((registry) => ({ registry, methods: groups.get(registry)!.sort((a, b) => a.code.localeCompare(b.code)) }))
-    .filter((group) => group.methods.length > 0);
+  return REGISTRY_ORDER.map((registry) => ({
+    registry,
+    methods: groups.get(registry)!.sort((a, b) => a.code.localeCompare(b.code)),
+  })).filter((group) => group.methods.length > 0);
 }
 
 export default function NewProjectForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [methods, setMethods] = useState<MethodOption[]>([]);
-  const [reviewMode, setReviewMode] = useState<ProjectReviewMode>('methodology-linked');
-  const [name, setName] = useState('');
-  const [projectCode, setProjectCode] = useState('');
-  const [countryLocation, setCountryLocation] = useState('');
-  const [proponent, setProponent] = useState('');
-  const [reportingPeriod, setReportingPeriod] = useState('');
-  const [selectedMethod, setSelectedMethod] = useState('');
-  const [aoiLabel, setAoiLabel] = useState('');
-  const [description, setDescription] = useState('');
+  const [reviewMode, setReviewMode] =
+    useState<ProjectReviewMode>("methodology-linked");
+  const [name, setName] = useState("");
+  const [projectCode, setProjectCode] = useState("");
+  const [countryLocation, setCountryLocation] = useState("");
+  const [proponent, setProponent] = useState("");
+  const [reportingPeriod, setReportingPeriod] = useState("");
+  const [selectedMethod, setSelectedMethod] = useState("");
+  const [aoiLabel, setAoiLabel] = useState("");
+  const [description, setDescription] = useState("");
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
   const [handoffDetected, setHandoffDetected] = useState(false);
-  const [handoffMethodLabel, setHandoffMethodLabel] = useState('');
-  const [methodology, setMethodology] = useState('');
-  const [standard, setStandard] = useState('');
-  const [sourceDocumentType, setSourceDocumentType] = useState('');
-  const [sourceDocumentVersion, setSourceDocumentVersion] = useState('');
-  const [sourceDocumentDate, setSourceDocumentDate] = useState('');
-  const [documentDraft, setDocumentDraft] = useState<ProjectDocumentMetadataDraft | null>(null);
-  const [creationMode, setCreationMode] = useState<ProjectCreationMode>('create');
+  const [handoffMethodLabel, setHandoffMethodLabel] = useState("");
+  const [methodology, setMethodology] = useState("");
+  const [standard, setStandard] = useState("");
+  const [sourceDocumentType, setSourceDocumentType] = useState("");
+  const [sourceDocumentVersion, setSourceDocumentVersion] = useState("");
+  const [sourceDocumentDate, setSourceDocumentDate] = useState("");
+  const [documentDraft, setDocumentDraft] =
+    useState<ProjectDocumentMetadataDraft | null>(null);
+  const [creationMode, setCreationMode] =
+    useState<ProjectCreationMode>("create");
   const [confirmDocumentDraft, setConfirmDocumentDraft] = useState(false);
-  const [attachProjectId, setAttachProjectId] = useState('');
+  const [attachProjectId, setAttachProjectId] = useState("");
 
-  const groupedMethods = useMemo(() => groupMethodsByRegistry(methods), [methods]);
-  const attachMatches = useMemo<ExistingProjectMatch[]>(() => documentDraft?.suggestedExistingProjects ?? [], [documentDraft]);
+  const groupedMethods = useMemo(
+    () => groupMethodsByRegistry(methods),
+    [methods],
+  );
+  const attachMatches = useMemo<ExistingProjectMatch[]>(
+    () => documentDraft?.suggestedExistingProjects ?? [],
+    [documentDraft],
+  );
+  const detectedProjectTitle =
+    documentDraft?.fields.projectTitle.value?.trim() ||
+    "No project title detected";
+  const detectedMethod =
+    documentDraft?.fields.methodology.value?.trim() || "No method detected";
+  const detectedStandard =
+    documentDraft?.fields.standard.value?.trim() || "No standard detected";
+  const createModeActive = creationMode === "create";
   const searchKey = searchParams.toString();
 
   useEffect(() => {
-    fetch('/api/projects/methods')
-      .then(r => r.json())
-      .then(data => setMethods(data.methods || []))
+    fetch("/api/projects/methods")
+      .then((r) => r.json())
+      .then((data) => setMethods(data.methods || []))
       .catch(() => setMethods([]));
   }, []);
 
   useEffect(() => {
-    if (searchParams.get('handoff') !== 'active-review') return;
+    if (searchParams.get("handoff") !== "active-review") return;
     const handoff = readPendingProjectReviewHandoff();
     if (!handoff) return;
     setHandoffDetected(true);
-    setReviewMode('methodology-linked');
-    setSelectedMethod(`${handoff.source.methodCode}@${handoff.source.methodVersion}`);
-    setHandoffMethodLabel(`${handoff.source.methodCode} ${handoff.source.methodVersion}`);
+    setReviewMode("methodology-linked");
+    setSelectedMethod(
+      `${handoff.source.methodCode}@${handoff.source.methodVersion}`,
+    );
+    setHandoffMethodLabel(
+      `${handoff.source.methodCode} ${handoff.source.methodVersion}`,
+    );
   }, [searchKey, searchParams]);
 
   useEffect(() => {
-    if (searchParams.get('handoff') !== 'document-metadata') return;
+    if (searchParams.get("handoff") !== "document-metadata") return;
     const stagedDraft = readPendingProjectDocumentDraft();
     if (!stagedDraft) return;
-    if (documentDraft?.source.attachmentId === stagedDraft.source.attachmentId) return;
+    if (documentDraft?.source.attachmentId === stagedDraft.source.attachmentId)
+      return;
     setDocumentDraft(stagedDraft);
-    setName(stagedDraft.fields.projectTitle.value ?? '');
-    setProjectCode(stagedDraft.fields.projectId.value ?? '');
-    setCountryLocation(stagedDraft.fields.country.value ?? '');
-    setProponent(stagedDraft.fields.proponent.value ?? '');
-    setMethodology(stagedDraft.fields.methodology.value ?? '');
-    setStandard(stagedDraft.fields.standard.value ?? '');
-    setSourceDocumentType(stagedDraft.fields.documentType.value ?? '');
-    setSourceDocumentVersion(stagedDraft.fields.version.value ?? '');
-    setSourceDocumentDate(stagedDraft.fields.documentDate.value ?? '');
+    setName(stagedDraft.fields.projectTitle.value ?? "");
+    setProjectCode(stagedDraft.fields.projectId.value ?? "");
+    setCountryLocation(stagedDraft.fields.country.value ?? "");
+    setProponent(stagedDraft.fields.proponent.value ?? "");
+    setMethodology(stagedDraft.fields.methodology.value ?? "");
+    setStandard(stagedDraft.fields.standard.value ?? "");
+    setSourceDocumentType(stagedDraft.fields.documentType.value ?? "");
+    setSourceDocumentVersion(stagedDraft.fields.version.value ?? "");
+    setSourceDocumentDate(stagedDraft.fields.documentDate.value ?? "");
     const suggestedAttach = stagedDraft.suggestedExistingProjects[0];
     if (suggestedAttach) {
       setAttachProjectId(suggestedAttach.projectId);
@@ -119,29 +172,37 @@ export default function NewProjectForm() {
 
   useEffect(() => {
     if (!documentDraft || !methods.length || selectedMethod) return;
-    const maybeMethod = maybeSelectMethod(methods, documentDraft.fields.methodology.value);
+    const maybeMethod = maybeSelectMethod(
+      methods,
+      documentDraft.fields.methodology.value,
+    );
     if (maybeMethod) setSelectedMethod(maybeMethod);
   }, [documentDraft, methods, selectedMethod]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name) return;
-    if (reviewMode === 'methodology-linked' && !selectedMethod) return;
+    if (createModeActive && !name) return;
+    if (
+      createModeActive &&
+      reviewMode === "methodology-linked" &&
+      !selectedMethod
+    )
+      return;
     if (documentDraft && !confirmDocumentDraft) return;
-    if (creationMode === 'attach' && !attachProjectId) return;
+    if (creationMode === "attach" && !attachProjectId) return;
 
     setLoading(true);
-    setError('');
+    setError("");
 
     try {
-      if (creationMode === 'attach') {
+      if (creationMode === "attach") {
         await attachPendingProjectDocumentToProject(attachProjectId);
         clearPendingProjectDocumentDraft();
         router.push(`/projects/${attachProjectId}`);
         return;
       }
 
-      if (reviewMode === 'manual') {
+      if (reviewMode === "manual") {
         const project = createProject({
           name,
           projectCode: projectCode || undefined,
@@ -166,22 +227,36 @@ export default function NewProjectForm() {
         return;
       }
 
-      const handoff = handoffDetected ? readPendingProjectReviewHandoff() : null;
-      const [code, version] = selectedMethod.split('@');
-      const rulesRes = await fetch(`/api/projects/method-rules?code=${code}&version=${version}`);
+      const handoff = handoffDetected
+        ? readPendingProjectReviewHandoff()
+        : null;
+      const [code, version] = selectedMethod.split("@");
+      const rulesRes = await fetch(
+        `/api/projects/method-rules?code=${code}&version=${version}`,
+      );
       const rulesData = await rulesRes.json();
-      const rules = (rulesData.rules || []).filter((r: { id?: string }) => r.id);
+      const rules = (rulesData.rules || []).filter(
+        (r: { id?: string }) => r.id,
+      );
 
       if (rules.length === 0) {
-        setError('No rules found for this methodology. Cannot create project review.');
+        setError(
+          "No rules found for this methodology. Cannot create project review.",
+        );
         setLoading(false);
         return;
       }
 
-      const selectedMethodRecord = methods.find((method) => `${method.code}@${method.version}` === selectedMethod);
-      const parts = (selectedMethodRecord?.program ?? '').split('/');
-      const category = parts.length > 1 ? parts.slice(1).join('/') : undefined;
-      if (handoff && handoff.source.methodCode === code && handoff.source.methodVersion === version) {
+      const selectedMethodRecord = methods.find(
+        (method) => `${method.code}@${method.version}` === selectedMethod,
+      );
+      const parts = (selectedMethodRecord?.program ?? "").split("/");
+      const category = parts.length > 1 ? parts.slice(1).join("/") : undefined;
+      if (
+        handoff &&
+        handoff.source.methodCode === code &&
+        handoff.source.methodVersion === version
+      ) {
         const result = importMethodologyReviewIntoProject({
           handoff,
           projectFields: {
@@ -192,7 +267,9 @@ export default function NewProjectForm() {
             methodology: methodology || undefined,
             standard: standard || undefined,
             methodCategory: category,
-            registry: projectRegistryFromMethodProgram(selectedMethodRecord?.program),
+            registry: projectRegistryFromMethodProgram(
+              selectedMethodRecord?.program,
+            ),
             reportingPeriod: reportingPeriod || undefined,
             aoiLabel: aoiLabel || undefined,
             description: description || undefined,
@@ -222,7 +299,9 @@ export default function NewProjectForm() {
         methodCode: code,
         methodVersion: version,
         methodCategory: category,
-        registry: projectRegistryFromMethodProgram(selectedMethodRecord?.program),
+        registry: projectRegistryFromMethodProgram(
+          selectedMethodRecord?.program,
+        ),
         reportingPeriod: reportingPeriod || undefined,
         aoiLabel: aoiLabel || undefined,
         description: description || undefined,
@@ -230,11 +309,13 @@ export default function NewProjectForm() {
         sourceDocumentVersion: sourceDocumentVersion || undefined,
         sourceDocumentDate: sourceDocumentDate || undefined,
         createdFromDocumentDraft: documentDraft ?? undefined,
-        ruleIds: rules.map((r: { id: string; title: string; sectionId?: string }) => ({
-          id: r.id,
-          title: r.title,
-          sectionId: r.sectionId || '',
-        })),
+        ruleIds: rules.map(
+          (r: { id: string; title: string; sectionId?: string }) => ({
+            id: r.id,
+            title: r.title,
+            sectionId: r.sectionId || "",
+          }),
+        ),
       });
 
       if (documentDraft) {
@@ -243,11 +324,13 @@ export default function NewProjectForm() {
       }
       router.push(`/projects/${project.id}`);
     } catch {
-      setError(reviewMode === 'manual'
-        ? 'Failed to create manual review. Try again.'
-        : creationMode === 'attach'
-          ? 'Failed to attach the document to the existing project. Try again.'
-          : 'Failed to create project handoff. Try again.');
+      setError(
+        reviewMode === "manual"
+          ? "Failed to create manual review. Try again."
+          : creationMode === "attach"
+            ? "Failed to attach the document to the existing project. Try again."
+            : "Failed to create project handoff. Try again.",
+      );
       setLoading(false);
     }
   };
@@ -255,17 +338,45 @@ export default function NewProjectForm() {
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-12 md:px-8">
       <div>
-        <h1 className="text-2xl font-bold text-slate-900">New Project Review</h1>
+        <h1 className="text-2xl font-bold text-slate-900">Start Review</h1>
         <p className="mt-1 text-sm text-slate-500">
-          Create a long-lived project review workspace
+          Upload a project document, review the detected details, then continue
+          into the project review workspace.
         </p>
       </div>
 
       {documentDraft ? (
         <div className="rounded-lg border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700">
-          <div className="font-semibold text-slate-900">Create project from document</div>
+          <div className="font-semibold text-slate-900">We found a project</div>
           <div className="mt-1">
-            Extracted metadata from {documentDraft.source.fileName}. Review every field, then confirm before creating a new project or attaching the document to an existing one.
+            Review detected details from {documentDraft.source.fileName}, then
+            confirm before continuing.
+          </div>
+          <div className="mt-3 grid gap-3 md:grid-cols-3">
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3">
+              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                Detected project
+              </div>
+              <div className="mt-1 text-sm font-medium text-slate-900">
+                {detectedProjectTitle}
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3">
+              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                Detected method
+              </div>
+              <div className="mt-1 text-sm font-medium text-slate-900">
+                {detectedMethod}
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3">
+              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                Detected standard
+              </div>
+              <div className="mt-1 text-sm font-medium text-slate-900">
+                {detectedStandard}
+              </div>
+            </div>
           </div>
         </div>
       ) : null}
@@ -278,40 +389,60 @@ export default function NewProjectForm() {
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <div>
-          <label className="mb-1 block text-sm font-semibold text-slate-700">Review Type</label>
+          <label className="mb-1 block text-sm font-semibold text-slate-700">
+            {documentDraft ? "Review route" : "Review Type"}
+          </label>
           <div className="grid gap-3 md:grid-cols-2">
             <button
               type="button"
               disabled={handoffDetected}
-              onClick={() => setReviewMode('methodology-linked')}
-              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? 'cursor-not-allowed opacity-60' : ''} ${
-                reviewMode === 'methodology-linked'
-                  ? 'border-blue-500 bg-blue-50 text-blue-900'
-                  : 'border-slate-200 bg-white text-slate-700'
+              onClick={() => setReviewMode("methodology-linked")}
+              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? "cursor-not-allowed opacity-60" : ""} ${
+                reviewMode === "methodology-linked"
+                  ? "border-blue-500 bg-blue-50 text-blue-900"
+                  : "border-slate-200 bg-white text-slate-700"
               }`}
             >
-              <div className="text-sm font-semibold">Methodology-linked review</div>
-              <div className="mt-1 text-xs text-slate-500">Use a selected methodology and its rule set.</div>
+              <div className="text-sm font-semibold">
+                {documentDraft
+                  ? "Continue with detected method"
+                  : "Methodology-linked review"}
+              </div>
+              <div className="mt-1 text-xs text-slate-500">
+                {documentDraft
+                  ? "Use the detected method and its rule set in the review workspace."
+                  : "Use a selected methodology and its rule set."}
+              </div>
             </button>
             <button
               type="button"
               disabled={handoffDetected}
-              onClick={() => setReviewMode('manual')}
-              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? 'cursor-not-allowed opacity-60' : ''} ${
-                reviewMode === 'manual'
-                  ? 'border-blue-500 bg-blue-50 text-blue-900'
-                  : 'border-slate-200 bg-white text-slate-700'
+              onClick={() => setReviewMode("manual")}
+              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? "cursor-not-allowed opacity-60" : ""} ${
+                reviewMode === "manual"
+                  ? "border-blue-500 bg-blue-50 text-blue-900"
+                  : "border-slate-200 bg-white text-slate-700"
               }`}
             >
-              <div className="text-sm font-semibold">Manual Review</div>
-              <div className="mt-1 text-xs text-slate-500">Project-level manual review / VVB findings reconstruction.</div>
+              <div className="text-sm font-semibold">
+                {documentDraft
+                  ? "Continue without a linked method"
+                  : "Manual Review"}
+              </div>
+              <div className="mt-1 text-xs text-slate-500">
+                {documentDraft
+                  ? "Keep the document details, but continue without a detected method."
+                  : "Project-level manual review / VVB findings reconstruction."}
+              </div>
             </button>
           </div>
         </div>
 
         {handoffDetected ? (
           <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
-            Create a project and carry over the active review for {handoffMethodLabel}. Existing evidence links, rule reviews, reviewer notes, and draft finalization state will be imported.
+            Create a project and carry over the active review for{" "}
+            {handoffMethodLabel}. Existing evidence links, rule reviews,
+            reviewer notes, and draft finalization state will be imported.
           </div>
         ) : null}
 
@@ -320,29 +451,43 @@ export default function NewProjectForm() {
             <div className="grid gap-3 md:grid-cols-2">
               <button
                 type="button"
-                onClick={() => setCreationMode('create')}
-                className={`rounded-lg border px-4 py-3 text-left ${creationMode === 'create' ? 'border-blue-500 bg-blue-50 text-blue-900' : 'border-slate-200 bg-white text-slate-700'}`}
+                onClick={() => setCreationMode("create")}
+                className={`rounded-lg border px-4 py-3 text-left ${creationMode === "create" ? "border-blue-500 bg-blue-50 text-blue-900" : "border-slate-200 bg-white text-slate-700"}`}
               >
-                <div className="text-sm font-semibold">Create new project</div>
-                <div className="mt-1 text-xs text-slate-500">Use the extracted fields to prefill a new project review.</div>
+                <div className="text-sm font-semibold">
+                  Start review from this document
+                </div>
+                <div className="mt-1 text-xs text-slate-500">
+                  Create a review workspace using the detected details below.
+                </div>
               </button>
               <button
                 type="button"
-                onClick={() => setCreationMode('attach')}
+                onClick={() => setCreationMode("attach")}
                 disabled={!attachMatches.length}
-                className={`rounded-lg border px-4 py-3 text-left ${creationMode === 'attach' ? 'border-blue-500 bg-blue-50 text-blue-900' : 'border-slate-200 bg-white text-slate-700'} ${!attachMatches.length ? 'cursor-not-allowed opacity-50' : ''}`}
+                className={`rounded-lg border px-4 py-3 text-left ${creationMode === "attach" ? "border-blue-500 bg-blue-50 text-blue-900" : "border-slate-200 bg-white text-slate-700"} ${!attachMatches.length ? "cursor-not-allowed opacity-50" : ""}`}
               >
-                <div className="text-sm font-semibold">Attach to existing project</div>
-                <div className="mt-1 text-xs text-slate-500">Use this when the extracted metadata appears to match an existing record.</div>
+                <div className="text-sm font-semibold">
+                  Attach to existing project
+                </div>
+                <div className="mt-1 text-xs text-slate-500">
+                  Use this secondary path when the document matches an existing
+                  review workspace.
+                </div>
               </button>
             </div>
 
             {attachMatches.length ? (
               <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-                <div className="mb-2 text-sm font-semibold text-slate-900">Possible existing project matches</div>
+                <div className="mb-2 text-sm font-semibold text-slate-900">
+                  Existing project matches
+                </div>
                 <div className="grid gap-2">
                   {attachMatches.map((match) => (
-                    <label key={match.projectId} className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-white px-3 py-3">
+                    <label
+                      key={match.projectId}
+                      className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-white px-3 py-3"
+                    >
                       <input
                         type="radio"
                         name="attach-project"
@@ -352,11 +497,23 @@ export default function NewProjectForm() {
                       />
                       <div className="min-w-0 flex-1">
                         <div className="flex flex-wrap items-center gap-2">
-                          <span className="font-medium text-slate-900">{match.projectName}</span>
-                          {match.projectCode ? <span className="text-xs text-slate-500">{match.projectCode}</span> : null}
-                          <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(match.confidence)}`}>{match.confidence}</span>
+                          <span className="font-medium text-slate-900">
+                            {match.projectName}
+                          </span>
+                          {match.projectCode ? (
+                            <span className="text-xs text-slate-500">
+                              {match.projectCode}
+                            </span>
+                          ) : null}
+                          <span
+                            className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(match.confidence)}`}
+                          >
+                            {match.confidence}
+                          </span>
                         </div>
-                        <div className="mt-1 text-xs text-slate-600">{match.matchReasons.join(' · ')}</div>
+                        <div className="mt-1 text-xs text-slate-600">
+                          {match.matchReasons.join(" · ")}
+                        </div>
                       </div>
                     </label>
                   ))}
@@ -366,185 +523,257 @@ export default function NewProjectForm() {
           </>
         ) : null}
 
-        <div>
-          <label className="mb-1 block text-sm font-semibold text-slate-700">Project Name</label>
-          <input
-            type="text"
-            value={name}
-            onChange={e => setName(e.target.value)}
-            placeholder="e.g., Malawi Liwonde REDD+ Verification"
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            required
-          />
-        </div>
+        {createModeActive ? (
+          <>
+            <div>
+              <label className="mb-1 block text-sm font-semibold text-slate-700">
+                {documentDraft ? "Project name" : "Project Name"}
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g., Malawi Liwonde REDD+ Verification"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                required={createModeActive}
+              />
+            </div>
 
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label className="mb-1 block text-sm font-semibold text-slate-700">Project ID / Code</label>
-            <input
-              type="text"
-              value={projectCode}
-              onChange={e => setProjectCode(e.target.value)}
-              placeholder="e.g., VCS-1530"
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-sm font-semibold text-slate-700">Reporting Period</label>
-            <input
-              type="text"
-              value={reportingPeriod}
-              onChange={e => setReportingPeriod(e.target.value)}
-              placeholder="e.g., 2024-01-01 to 2024-12-31"
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            />
-          </div>
-        </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  Project ID / Code
+                </label>
+                <input
+                  type="text"
+                  value={projectCode}
+                  onChange={(e) => setProjectCode(e.target.value)}
+                  placeholder="e.g., VCS-1530"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  Reporting Period
+                </label>
+                <input
+                  type="text"
+                  value={reportingPeriod}
+                  onChange={(e) => setReportingPeriod(e.target.value)}
+                  placeholder="e.g., 2024-01-01 to 2024-12-31"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+            </div>
 
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label className="mb-1 block text-sm font-semibold text-slate-700">Country / Location</label>
-            <input
-              type="text"
-              value={countryLocation}
-              onChange={e => setCountryLocation(e.target.value)}
-              placeholder="e.g., Malawi"
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-sm font-semibold text-slate-700">Proponent</label>
-            <input
-              type="text"
-              value={proponent}
-              onChange={e => setProponent(e.target.value)}
-              placeholder="e.g., Article6 Climate"
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            />
-          </div>
-        </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  Country / Location
+                </label>
+                <input
+                  type="text"
+                  value={countryLocation}
+                  onChange={(e) => setCountryLocation(e.target.value)}
+                  placeholder="e.g., Malawi"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  Proponent
+                </label>
+                <input
+                  type="text"
+                  value={proponent}
+                  onChange={(e) => setProponent(e.target.value)}
+                  placeholder="e.g., Article6 Climate"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+            </div>
 
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label className="mb-1 block text-sm font-semibold text-slate-700">Methodology (document field)</label>
-            <input
-              type="text"
-              value={methodology}
-              onChange={e => setMethodology(e.target.value)}
-              placeholder="e.g., VM0007"
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-sm font-semibold text-slate-700">Standard</label>
-            <input
-              type="text"
-              value={standard}
-              onChange={e => setStandard(e.target.value)}
-              placeholder="e.g., VCS Standard v4.7"
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            />
-          </div>
-        </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  {documentDraft
+                    ? "Detected method"
+                    : "Methodology (document field)"}
+                </label>
+                <input
+                  type="text"
+                  value={methodology}
+                  onChange={(e) => setMethodology(e.target.value)}
+                  placeholder="e.g., VM0007"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  Standard
+                </label>
+                <input
+                  type="text"
+                  value={standard}
+                  onChange={(e) => setStandard(e.target.value)}
+                  placeholder="e.g., VCS Standard v4.7"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+            </div>
 
-        <div className="grid gap-4 md:grid-cols-3">
-          <div>
-            <label className="mb-1 block text-sm font-semibold text-slate-700">Document Type</label>
-            <input
-              type="text"
-              value={sourceDocumentType}
-              onChange={e => setSourceDocumentType(e.target.value)}
-              placeholder="e.g., Project Design Document"
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-sm font-semibold text-slate-700">Document Version</label>
-            <input
-              type="text"
-              value={sourceDocumentVersion}
-              onChange={e => setSourceDocumentVersion(e.target.value)}
-              placeholder="e.g., v1.3"
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-sm font-semibold text-slate-700">Document Date</label>
-            <input
-              type="text"
-              value={sourceDocumentDate}
-              onChange={e => setSourceDocumentDate(e.target.value)}
-              placeholder="e.g., 2026-05-24"
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-            />
-          </div>
-        </div>
+            <div className="grid gap-4 md:grid-cols-3">
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  Document Type
+                </label>
+                <input
+                  type="text"
+                  value={sourceDocumentType}
+                  onChange={(e) => setSourceDocumentType(e.target.value)}
+                  placeholder="e.g., Project Design Document"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  Document Version
+                </label>
+                <input
+                  type="text"
+                  value={sourceDocumentVersion}
+                  onChange={(e) => setSourceDocumentVersion(e.target.value)}
+                  placeholder="e.g., v1.3"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  Document Date
+                </label>
+                <input
+                  type="text"
+                  value={sourceDocumentDate}
+                  onChange={(e) => setSourceDocumentDate(e.target.value)}
+                  placeholder="e.g., 2026-05-24"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+            </div>
 
-        {reviewMode === 'methodology-linked' ? (
-          <div>
-            <label className="mb-1 block text-sm font-semibold text-slate-700">Methodology</label>
-            <select
-              value={selectedMethod}
-              onChange={e => setSelectedMethod(e.target.value)}
-              disabled={handoffDetected}
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-              required
-            >
-              <option value="">Select a methodology...</option>
-              {groupedMethods.map(group => (
-                <optgroup key={group.registry} label={group.registry}>
-                  {group.methods.map(m => (
-                    <option key={`${m.code}@${m.version}`} value={`${m.code}@${m.version}`}>
-                      {m.code} v{m.version} — {m.program} ({m.ruleCount} rules)
-                    </option>
+            {reviewMode === "methodology-linked" ? (
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700">
+                  {documentDraft
+                    ? "Confirm method before continuing"
+                    : "Methodology"}
+                </label>
+                <select
+                  value={selectedMethod}
+                  onChange={(e) => setSelectedMethod(e.target.value)}
+                  disabled={handoffDetected}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  required
+                >
+                  <option value="">
+                    {documentDraft
+                      ? "Select or confirm the detected method..."
+                      : "Select a methodology..."}
+                  </option>
+                  {groupedMethods.map((group) => (
+                    <optgroup key={group.registry} label={group.registry}>
+                      {group.methods.map((m) => (
+                        <option
+                          key={`${m.code}@${m.version}`}
+                          value={`${m.code}@${m.version}`}
+                        >
+                          {m.code} v{m.version} — {m.program} ({m.ruleCount}{" "}
+                          rules)
+                        </option>
+                      ))}
+                    </optgroup>
                   ))}
-                </optgroup>
-              ))}
-            </select>
-          </div>
+                </select>
+              </div>
+            ) : (
+              <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                {documentDraft
+                  ? "This route keeps the detected project details and document, but does not require you to confirm a method before continuing."
+                  : "Manual Review does not require a methodology selection. Use this mode for project-specific findings reconstruction, evidence gaps, reviewer notes, and export."}
+              </div>
+            )}
+
+            <div>
+              <label className="mb-1 block text-sm font-semibold text-slate-700">
+                Area Label (optional)
+              </label>
+              <input
+                type="text"
+                value={aoiLabel}
+                onChange={(e) => setAoiLabel(e.target.value)}
+                placeholder="e.g., Liwonde National Park, Malawi"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-semibold text-slate-700">
+                Description (optional)
+              </label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Brief description of the project review..."
+                rows={3}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              />
+            </div>
+          </>
         ) : (
           <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-            Manual Review does not require a methodology selection. Use this mode for project-specific findings reconstruction, evidence gaps, reviewer notes, and export.
+            Continue with this document to attach it to the selected existing
+            project. No new project name is required.
           </div>
         )}
 
-        <div>
-          <label className="mb-1 block text-sm font-semibold text-slate-700">Area Label (optional)</label>
-          <input
-            type="text"
-            value={aoiLabel}
-            onChange={e => setAoiLabel(e.target.value)}
-            placeholder="e.g., Liwonde National Park, Malawi"
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-          />
-        </div>
-
-        <div>
-          <label className="mb-1 block text-sm font-semibold text-slate-700">Description (optional)</label>
-          <textarea
-            value={description}
-            onChange={e => setDescription(e.target.value)}
-            placeholder="Brief description of the project review..."
-            rows={3}
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-          />
-        </div>
-
         {documentDraft ? (
           <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-4">
-            <div className="mb-3 text-sm font-semibold text-slate-900">Extraction provenance</div>
+            <div className="mb-1 text-sm font-semibold text-slate-900">
+              Review detected details
+            </div>
+            <div className="text-xs text-slate-500">
+              Confirm before continuing. Every extracted field keeps its
+              confidence label and provenance snippet.
+            </div>
+            <div className="mb-3" />
             <div className="grid gap-3">
               {Object.values(documentDraft.fields).map((field) => (
-                <div key={field.key} className="rounded-lg border border-slate-200 bg-white px-3 py-3">
+                <div
+                  key={field.key}
+                  className="rounded-lg border border-slate-200 bg-white px-3 py-3"
+                >
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium text-slate-900">{field.label}</span>
-                    <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(field.confidence)}`}>{field.confidence}</span>
+                    <span className="text-sm font-medium text-slate-900">
+                      {field.label}
+                    </span>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(field.confidence)}`}
+                    >
+                      {field.confidence}
+                    </span>
                   </div>
-                  <div className="mt-1 text-sm text-slate-700">{field.value || 'No value extracted'}</div>
+                  <div className="mt-1 text-sm text-slate-700">
+                    {field.value || "No value extracted"}
+                  </div>
                   {field.provenance ? (
                     <div className="mt-1 text-xs text-slate-500">
-                      {field.provenance.fileName} · page {field.provenance.pageRange || field.provenance.page || '?'}
-                      {field.provenance.excerpt ? ` · "${field.provenance.excerpt}"` : ''}
+                      {field.provenance.fileName} · page{" "}
+                      {field.provenance.pageRange ||
+                        field.provenance.page ||
+                        "?"}
+                      {field.provenance.excerpt
+                        ? ` · "${field.provenance.excerpt}"`
+                        : ""}
                     </div>
                   ) : null}
                 </div>
@@ -554,10 +783,15 @@ export default function NewProjectForm() {
               <input
                 type="checkbox"
                 checked={confirmDocumentDraft}
-                onChange={(event) => setConfirmDocumentDraft(event.target.checked)}
+                onChange={(event) =>
+                  setConfirmDocumentDraft(event.target.checked)
+                }
                 className="mt-1"
               />
-              <span>I reviewed the extracted metadata and want to continue with this project action.</span>
+              <span>
+                I reviewed the detected details, confidence labels, and
+                provenance snippets and want to continue with this document.
+              </span>
             </label>
           </div>
         ) : null}
@@ -565,20 +799,24 @@ export default function NewProjectForm() {
         <button
           type="submit"
           disabled={
-            loading
-            || (creationMode === 'create' && (!name || (reviewMode === 'methodology-linked' && !selectedMethod)))
-            || (creationMode === 'attach' && !attachProjectId)
-            || Boolean(documentDraft && !confirmDocumentDraft)
+            loading ||
+            (creationMode === "create" &&
+              (!name ||
+                (reviewMode === "methodology-linked" && !selectedMethod))) ||
+            (creationMode === "attach" && !attachProjectId) ||
+            Boolean(documentDraft && !confirmDocumentDraft)
           }
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
         >
           {loading
-            ? (creationMode === 'attach' ? 'Attaching...' : 'Creating...')
-            : creationMode === 'attach'
-              ? 'Attach Document To Existing Project'
+            ? creationMode === "attach"
+              ? "Attaching..."
+              : "Creating..."
+            : creationMode === "attach"
+              ? "Continue with this document"
               : documentDraft
-                ? 'Create Project From Document'
-                : 'Create Project Review'}
+                ? "Start Review"
+                : "Create Project Review"}
         </button>
       </form>
     </div>

--- a/src/components/projects/ProjectDetail.tsx
+++ b/src/components/projects/ProjectDetail.tsx
@@ -432,6 +432,18 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
           </div>
           {project.aoiLabel ? <p className="mt-1 text-sm text-slate-400">Project area: {project.aoiLabel}</p> : null}
           {project.description ? <p className="mt-2 max-w-3xl text-sm text-slate-500">{project.description}</p> : null}
+          {(project.projectCode || project.countryLocation || project.proponent || project.methodology || project.standard || project.sourceDocumentType || project.sourceDocumentVersion || project.sourceDocumentDate) ? (
+            <div className="mt-3 flex max-w-4xl flex-wrap gap-2 text-xs text-slate-600">
+              {project.projectCode ? <span className="rounded bg-slate-100 px-2 py-1">Project ID: {project.projectCode}</span> : null}
+              {project.countryLocation ? <span className="rounded bg-slate-100 px-2 py-1">Country: {project.countryLocation}</span> : null}
+              {project.proponent ? <span className="rounded bg-slate-100 px-2 py-1">Proponent: {project.proponent}</span> : null}
+              {project.methodology ? <span className="rounded bg-slate-100 px-2 py-1">Methodology: {project.methodology}</span> : null}
+              {project.standard ? <span className="rounded bg-slate-100 px-2 py-1">Standard: {project.standard}</span> : null}
+              {project.sourceDocumentType ? <span className="rounded bg-slate-100 px-2 py-1">Document: {project.sourceDocumentType}</span> : null}
+              {project.sourceDocumentVersion ? <span className="rounded bg-slate-100 px-2 py-1">Version: {project.sourceDocumentVersion}</span> : null}
+              {project.sourceDocumentDate ? <span className="rounded bg-slate-100 px-2 py-1">Date: {project.sourceDocumentDate}</span> : null}
+            </div>
+          ) : null}
         </div>
 
         <div className="flex items-center gap-2">

--- a/src/components/projects/ProjectsList.tsx
+++ b/src/components/projects/ProjectsList.tsx
@@ -27,10 +27,10 @@ export default function ProjectsList() {
           <p className="mt-1 text-sm text-slate-500">Long-lived project review workspace for methodology-linked and manual reviews</p>
         </div>
         <Link
-          href="/projects/new"
+          href="/start-review"
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
         >
-          + New Project Review
+          Start Review
         </Link>
       </div>
 

--- a/src/lib/nav/primaryNav.ts
+++ b/src/lib/nav/primaryNav.ts
@@ -1,0 +1,23 @@
+export type PrimaryNavKey = "start-review" | "projects" | "methods" | null;
+
+function trimTrailingSlash(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+}
+
+export function getPrimaryNavKey(pathname: string | null | undefined): PrimaryNavKey {
+  const normalized = trimTrailingSlash(pathname ?? "/");
+
+  if (normalized === "/start-review") return "start-review";
+  if (normalized === "/methods") return "methods";
+  if (normalized === "/projects") return "projects";
+  if (normalized.startsWith("/projects/")) {
+    const remainder = normalized.slice("/projects/".length);
+    if (remainder === "new") return null;
+    if (remainder.length > 0 && !remainder.includes("/")) return "projects";
+  }
+
+  return null;
+}

--- a/src/lib/projects/documentMetadata.ts
+++ b/src/lib/projects/documentMetadata.ts
@@ -1,0 +1,410 @@
+import { getAttachmentBytes } from "@/lib/proofMap/attachments";
+import { addProjectDocument, listProjects } from "@/lib/projects/storage";
+import type {
+  ExistingProjectMatch,
+  MetadataConfidence,
+  Project,
+  ProjectDocumentMetadataDraft,
+  ProjectMetadataField,
+  ProjectMetadataFieldKey,
+  ProjectMetadataFieldProvenance,
+} from "@/lib/projects/types";
+
+const PENDING_DOCUMENT_DRAFT_KEY = "article6:pending-project-document-draft";
+
+type ExtractedPage = {
+  pageNumber: number;
+  text: string;
+};
+
+type MatchCandidate = {
+  value: string;
+  confidence: MetadataConfidence;
+  page: number;
+  excerpt: string;
+};
+
+const FIELD_LABELS: Record<ProjectMetadataFieldKey, string> = {
+  projectTitle: "Project Title",
+  country: "Country",
+  projectId: "Registry / Project ID",
+  methodology: "Methodology",
+  standard: "Standard",
+  proponent: "Proponent",
+  documentType: "Document Type",
+  version: "Version",
+  documentDate: "Document Date",
+};
+
+const COUNTRIES = [
+  "Malawi", "Kenya", "Ghana", "Colombia", "Brazil", "India", "Indonesia", "Vietnam", "Peru", "Mexico",
+  "Tanzania", "Uganda", "Rwanda", "Ethiopia", "Zambia", "Cambodia", "Laos", "Nepal", "Philippines", "Thailand",
+];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizeForMatch(value: string): string {
+  return normalizeWhitespace(value).toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function confidenceFromScore(score: number): MetadataConfidence {
+  if (score >= 0.9) return "high";
+  if (score >= 0.72) return "medium";
+  if (score > 0) return "low";
+  return "missing";
+}
+
+function buildField(
+  key: ProjectMetadataFieldKey,
+  source: ProjectDocumentMetadataDraft["source"],
+  candidate?: MatchCandidate,
+): ProjectMetadataField {
+  const provenance: ProjectMetadataFieldProvenance | null = candidate
+    ? {
+        attachmentId: source.attachmentId,
+        fileName: source.fileName,
+        page: candidate.page,
+        pageRange: String(candidate.page),
+        excerpt: candidate.excerpt,
+      }
+    : null;
+  return {
+    key,
+    label: FIELD_LABELS[key],
+    value: candidate?.value,
+    confidence: candidate?.confidence ?? "missing",
+    provenance,
+  };
+}
+
+function excerptAround(line: string, value: string): string {
+  const normalizedLine = normalizeWhitespace(line);
+  const index = normalizedLine.toLowerCase().indexOf(value.toLowerCase());
+  if (index < 0) return normalizedLine.slice(0, 200);
+  const start = Math.max(0, index - 32);
+  const end = Math.min(normalizedLine.length, index + value.length + 80);
+  return normalizedLine.slice(start, end).trim();
+}
+
+function matchLabeledValue(page: ExtractedPage, patterns: RegExp[], confidence: MetadataConfidence): MatchCandidate | undefined {
+  const lines = page.text.split(/\n+/).map((line) => line.trim()).filter(Boolean);
+  for (const line of lines) {
+    for (const pattern of patterns) {
+      const match = pattern.exec(line);
+      if (!match?.[1]) continue;
+      const value = normalizeWhitespace(match[1]);
+      if (!value) continue;
+      return {
+        value,
+        confidence,
+        page: page.pageNumber,
+        excerpt: excerptAround(line, value),
+      };
+    }
+  }
+  return undefined;
+}
+
+function detectProjectTitle(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 3)) {
+    const lines = page.text.split(/\n+/).map((line) => normalizeWhitespace(line)).filter(Boolean);
+    for (const line of lines.slice(0, 12)) {
+      if (line.length < 12 || line.length > 180) continue;
+      if (/^(project design document|monitoring report|verification report|vcs|verra|gold standard|table of contents)\b/i.test(line)) continue;
+      if (/^[A-Z0-9 .,&()'/-]+$/.test(line) || /project|redd|forest|mangrove|cookstove|arr|afolu/i.test(line)) {
+        return { value: line, confidence: "medium", page: page.pageNumber, excerpt: line };
+      }
+    }
+  }
+  return undefined;
+}
+
+function detectCountry(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\bhost country\s*[:\-]\s*(.+)$/i,
+      /\bcountry(?:\/location)?\s*[:\-]\s*(.+)$/i,
+      /\blocation\s*[:\-]\s*(.+)$/i,
+    ], "high");
+    if (labeled) return labeled;
+    for (const country of COUNTRIES) {
+      const regex = new RegExp(`\\b${country.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i");
+      const line = page.text.split(/\n+/).find((entry) => regex.test(entry));
+      if (line) return { value: country, confidence: "low", page: page.pageNumber, excerpt: excerptAround(line, country) };
+    }
+  }
+  return undefined;
+}
+
+function detectProjectId(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\b(?:project|registry)\s*(?:id|number|ref(?:erence)?)\s*[:\-]\s*([A-Z0-9][A-Z0-9._/-]{2,})/i,
+    ], "high");
+    if (labeled) return labeled;
+    const line = page.text.split(/\n+/).find((entry) => /\b(?:VCS|GS|CDM|UNFCCC|VCS-)\s*[-/]?\d{2,}\b/i.test(entry));
+    const raw = line?.match(/\b(?:VCS|GS|CDM|UNFCCC|VCS-)\s*[-/]?\d{2,}\b/i)?.[0];
+    if (line && raw) return { value: normalizeWhitespace(raw), confidence: "medium", page: page.pageNumber, excerpt: excerptAround(line, raw) };
+  }
+  return undefined;
+}
+
+function detectMethodology(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\b(?:applied )?methodology\s*[:\-]\s*(.+)$/i,
+      /\bmethodological approach\s*[:\-]\s*(.+)$/i,
+    ], "high");
+    if (labeled) return labeled;
+    const line = page.text.split(/\n+/).find((entry) => /\b(?:VM|VMD|AMS|ACM|AR-ACM)\d{3,4}\b/i.test(entry));
+    const raw = line?.match(/\b(?:VM|VMD|AMS|ACM|AR-ACM)\d{3,4}\b/i)?.[0];
+    if (line && raw) return { value: normalizeWhitespace(raw), confidence: "medium", page: page.pageNumber, excerpt: excerptAround(line, raw) };
+  }
+  return undefined;
+}
+
+function detectStandard(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 4)) {
+    const labeled = matchLabeledValue(page, [
+      /\bstandard\s*[:\-]\s*(.+)$/i,
+    ], "high");
+    if (labeled) return labeled;
+    const line = page.text.split(/\n+/).find((entry) => /\b(?:VCS Standard|Gold Standard|CCB(?: Standard)?|Article 6)\b/i.test(entry));
+    const raw = line?.match(/\b(?:VCS Standard[^,\n]*|Gold Standard[^,\n]*|CCB(?: Standard)?[^,\n]*|Article 6[^,\n]*)/i)?.[0];
+    if (line && raw) return { value: normalizeWhitespace(raw), confidence: "medium", page: page.pageNumber, excerpt: excerptAround(line, raw) };
+  }
+  return undefined;
+}
+
+function detectProponent(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\b(?:project )?proponent\s*[:\-]\s*(.+)$/i,
+      /\bproject developer\s*[:\-]\s*(.+)$/i,
+    ], "high");
+    if (labeled) return labeled;
+  }
+  return undefined;
+}
+
+function detectDocumentType(pages: ExtractedPage[], fileName: string): MatchCandidate | undefined {
+  const firstPage = pages[0];
+  const haystack = `${fileName}\n${firstPage?.text ?? ""}`;
+  const types = [
+    "Project Design Document",
+    "Monitoring Report",
+    "Verification Report",
+    "Validation Report",
+    "Quick Check Evidence",
+  ];
+  for (const type of types) {
+    if (new RegExp(type.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i").test(haystack)) {
+      return {
+        value: type,
+        confidence: /quick check/i.test(type) ? "low" : "high",
+        page: firstPage?.pageNumber ?? 1,
+        excerpt: excerptAround(firstPage?.text ?? fileName, type),
+      };
+    }
+  }
+  if (/\.pdf$/i.test(fileName)) {
+    return { value: "PDF evidence document", confidence: "low", page: 1, excerpt: fileName };
+  }
+  return undefined;
+}
+
+function detectVersion(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\bversion\s*[:\-]\s*([A-Z0-9._ -]{1,40})$/i,
+      /\brev(?:ision)?\s*[:\-]\s*([A-Z0-9._ -]{1,40})$/i,
+    ], "high");
+    if (labeled) return labeled;
+  }
+  return undefined;
+}
+
+function detectDocumentDate(pages: ExtractedPage[]): MatchCandidate | undefined {
+  const datePattern = /\b(\d{4}-\d{2}-\d{2}|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}|\d{1,2}\s+[A-Z][a-z]+\s+\d{4})\b/;
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\b(?:document )?date\s*[:\-]\s*(.+)$/i,
+      /\bissue date\s*[:\-]\s*(.+)$/i,
+      /\bprepared on\s*[:\-]\s*(.+)$/i,
+    ], "high");
+    if (labeled) return labeled;
+    const line = page.text.split(/\n+/).find((entry) => /\b(?:date|issued|prepared)\b/i.test(entry) && datePattern.test(entry));
+    const raw = line?.match(datePattern)?.[1];
+    if (line && raw) return { value: normalizeWhitespace(raw), confidence: "medium", page: page.pageNumber, excerpt: excerptAround(line, raw) };
+  }
+  return undefined;
+}
+
+function tokenize(value: string): Set<string> {
+  return new Set(normalizeForMatch(value).split(" ").filter((token) => token.length > 2));
+}
+
+function computeExistingProjectMatches(projects: Project[], title?: string, projectCode?: string): ExistingProjectMatch[] {
+  const titleTokens = tokenize(title ?? "");
+  const normalizedCode = normalizeForMatch(projectCode ?? "");
+  return projects
+    .map((project) => {
+      let score = 0;
+      const reasons: string[] = [];
+      if (normalizedCode && normalizeForMatch(project.projectCode ?? "") === normalizedCode) {
+        score = Math.max(score, 0.99);
+        reasons.push(`Project code matches ${project.projectCode}`);
+      }
+      const projectTokens = tokenize(project.name);
+      const overlap = Array.from(titleTokens).filter((token) => projectTokens.has(token)).length;
+      const union = new Set([...titleTokens, ...projectTokens]).size || 1;
+      const nameScore = overlap / union;
+      if (nameScore >= 0.55) {
+        score = Math.max(score, 0.55 + nameScore * 0.4);
+        reasons.push(`Project name overlaps on ${overlap} key terms`);
+      }
+      return {
+        projectId: project.id,
+        projectName: project.name,
+        projectCode: project.projectCode,
+        score,
+        confidence: confidenceFromScore(score),
+        matchReasons: reasons,
+      } satisfies ExistingProjectMatch;
+    })
+    .filter((match) => match.score >= 0.72)
+    .sort((a, b) => b.score - a.score || a.projectName.localeCompare(b.projectName))
+    .slice(0, 3);
+}
+
+async function extractPdfPages(input: { bytes: ArrayBuffer; fileName: string }): Promise<ExtractedPage[]> {
+  const response = await fetch("/api/quick-check/pdf-extract", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/pdf",
+      "x-article6-filename": encodeURIComponent(input.fileName),
+    },
+    body: input.bytes,
+  });
+  if (!response.ok) throw new Error(`PDF extraction failed with ${response.status}`);
+  const payload = (await response.json()) as { pages?: Array<{ pageNumber?: number; text?: string }>; text?: string };
+  if (Array.isArray(payload.pages) && payload.pages.length > 0) {
+    return payload.pages
+      .map((page, index) => ({
+        pageNumber: typeof page.pageNumber === "number" ? page.pageNumber : index + 1,
+        text: String(page.text ?? "").trim(),
+      }))
+      .filter((page) => page.text);
+  }
+  return [{ pageNumber: 1, text: String(payload.text ?? "").trim() }].filter((page) => page.text);
+}
+
+export async function buildProjectDocumentMetadataDraft(input: {
+  origin: ProjectDocumentMetadataDraft["source"]["origin"];
+  evidenceId: string;
+  attachmentId: string;
+  fileName: string;
+  mimeType: string;
+  contentSha256?: string;
+}): Promise<ProjectDocumentMetadataDraft> {
+  const bytes = await getAttachmentBytes(input.attachmentId);
+  if (!bytes) throw new Error("Source attachment bytes are unavailable.");
+  const pages = await extractPdfPages({ bytes, fileName: input.fileName });
+  const source: ProjectDocumentMetadataDraft["source"] = {
+    ...input,
+    extractedAt: nowIso(),
+  };
+  const title = detectProjectTitle(pages);
+  const projectId = detectProjectId(pages);
+  const draft: ProjectDocumentMetadataDraft = {
+    source,
+    fields: {
+      projectTitle: buildField("projectTitle", source, title),
+      country: buildField("country", source, detectCountry(pages)),
+      projectId: buildField("projectId", source, projectId),
+      methodology: buildField("methodology", source, detectMethodology(pages)),
+      standard: buildField("standard", source, detectStandard(pages)),
+      proponent: buildField("proponent", source, detectProponent(pages)),
+      documentType: buildField("documentType", source, detectDocumentType(pages, input.fileName)),
+      version: buildField("version", source, detectVersion(pages)),
+      documentDate: buildField("documentDate", source, detectDocumentDate(pages)),
+    },
+    suggestedExistingProjects: computeExistingProjectMatches(
+      listProjects(),
+      title?.value,
+      projectId?.value,
+    ),
+  };
+  return draft;
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  return window.sessionStorage ?? null;
+}
+
+export function stagePendingProjectDocumentDraft(draft: ProjectDocumentMetadataDraft): void {
+  getStorage()?.setItem(PENDING_DOCUMENT_DRAFT_KEY, JSON.stringify(draft));
+}
+
+export function readPendingProjectDocumentDraft(): ProjectDocumentMetadataDraft | null {
+  const raw = getStorage()?.getItem(PENDING_DOCUMENT_DRAFT_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ProjectDocumentMetadataDraft;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingProjectDocumentDraft(): void {
+  getStorage()?.removeItem(PENDING_DOCUMENT_DRAFT_KEY);
+}
+
+export async function stageProjectDocumentDraftFromAttachment(input: {
+  origin: ProjectDocumentMetadataDraft["source"]["origin"];
+  evidenceId: string;
+  attachmentId: string;
+  fileName: string;
+  mimeType: string;
+  contentSha256?: string;
+}): Promise<ProjectDocumentMetadataDraft> {
+  const draft = await buildProjectDocumentMetadataDraft(input);
+  stagePendingProjectDocumentDraft(draft);
+  return draft;
+}
+
+export async function attachPendingProjectDocumentToProject(projectId: string): Promise<void> {
+  const draft = readPendingProjectDocumentDraft();
+  if (!draft) return;
+  const bytes = await getAttachmentBytes(draft.source.attachmentId);
+  if (!bytes) return;
+  const contentBase64 = arrayBufferToBase64(bytes);
+  addProjectDocument(projectId, {
+    fileName: draft.source.fileName,
+    mimeType: draft.source.mimeType,
+    sizeBytes: bytes.byteLength,
+    contentSha256: draft.source.contentSha256,
+    contentBase64,
+    extractedText: Object.values(draft.fields)
+      .map((field) => field.provenance?.excerpt)
+      .filter(Boolean)
+      .join("\n"),
+  });
+}

--- a/src/lib/projects/reviewHandoff.ts
+++ b/src/lib/projects/reviewHandoff.ts
@@ -228,11 +228,17 @@ export function importMethodologyReviewIntoProject(input: {
     projectCode?: string;
     countryLocation?: string;
     proponent?: string;
+    methodology?: string;
+    standard?: string;
     reportingPeriod?: string;
     aoiLabel?: string;
     description?: string;
+    sourceDocumentType?: string;
+    sourceDocumentVersion?: string;
+    sourceDocumentDate?: string;
     methodCategory?: string;
     registry?: Project["registry"];
+    createdFromDocumentDraft?: Project["createdFromDocumentDraft"];
   };
   rules: Array<{ id: string; title: string; sectionId?: string }>;
 }): { project: Project; workspace: ReviewWorkspace; href: string } {

--- a/src/lib/projects/storage.ts
+++ b/src/lib/projects/storage.ts
@@ -1,5 +1,6 @@
 import { buildManualReviewLearningCase } from './learningCase';
 import type {
+  ProjectDocumentMetadataDraft,
   ExtractedManualFindingDraft,
   LearningCaseTrigger,
   ManualFinding,
@@ -45,6 +46,11 @@ export function createProject(input: {
   projectCode?: string;
   countryLocation?: string;
   proponent?: string;
+  methodology?: string;
+  standard?: string;
+  sourceDocumentType?: string;
+  sourceDocumentVersion?: string;
+  sourceDocumentDate?: string;
   reviewMode: Project['reviewMode'];
   methodCode?: string;
   methodVersion?: string;
@@ -55,6 +61,7 @@ export function createProject(input: {
   description?: string;
   ruleIds?: Array<{ id: string; title: string; sectionId: string }>;
   initialReviews?: RuleReview[];
+  createdFromDocumentDraft?: ProjectDocumentMetadataDraft;
 }): Project {
   const project: Project = {
     id: generateId(),
@@ -62,6 +69,11 @@ export function createProject(input: {
     projectCode: input.projectCode,
     countryLocation: input.countryLocation,
     proponent: input.proponent,
+    methodology: input.methodology,
+    standard: input.standard,
+    sourceDocumentType: input.sourceDocumentType,
+    sourceDocumentVersion: input.sourceDocumentVersion,
+    sourceDocumentDate: input.sourceDocumentDate,
     reviewMode: input.reviewMode,
     methodCode: input.methodCode,
     methodVersion: input.methodVersion,
@@ -83,6 +95,7 @@ export function createProject(input: {
     manualFindings: [],
     extractedManualFindingDrafts: [],
     learningCases: [],
+    createdFromDocumentDraft: input.createdFromDocumentDraft,
   };
 
   const projects = loadAll();
@@ -100,6 +113,8 @@ export function updateProject(
       | 'projectCode'
       | 'countryLocation'
       | 'proponent'
+      | 'methodology'
+      | 'standard'
       | 'methodCode'
       | 'methodVersion'
       | 'methodCategory'
@@ -107,6 +122,9 @@ export function updateProject(
       | 'reportingPeriod'
       | 'aoiLabel'
       | 'description'
+      | 'sourceDocumentType'
+      | 'sourceDocumentVersion'
+      | 'sourceDocumentDate'
       | 'lastWorkspaceId'
     >
   >,
@@ -387,6 +405,11 @@ function normalizeProject(project: Partial<Project>): Project {
     projectCode: project.projectCode,
     countryLocation: project.countryLocation,
     proponent: project.proponent,
+    methodology: project.methodology,
+    standard: project.standard,
+    sourceDocumentType: project.sourceDocumentType,
+    sourceDocumentVersion: project.sourceDocumentVersion,
+    sourceDocumentDate: project.sourceDocumentDate,
     reviewMode: project.reviewMode ?? 'methodology-linked',
     methodCode: project.methodCode,
     methodVersion: project.methodVersion,
@@ -404,6 +427,7 @@ function normalizeProject(project: Partial<Project>): Project {
     manualFindings: Array.isArray(project.manualFindings) ? project.manualFindings : [],
     extractedManualFindingDrafts: Array.isArray(project.extractedManualFindingDrafts) ? project.extractedManualFindingDrafts : [],
     learningCases: Array.isArray(project.learningCases) ? project.learningCases : [],
+    createdFromDocumentDraft: project.createdFromDocumentDraft,
   };
 }
 

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -5,6 +5,56 @@ export type ProjectReviewMode = 'methodology-linked' | 'manual';
 export type RuleReviewStatus = 'not-started' | 'in-progress' | 'verified' | 'gap' | 'not-applicable';
 
 export type ProjectRegistry = 'UNFCCC' | 'Verra' | 'Gold Standard' | 'Unknown';
+export type MetadataConfidence = 'high' | 'medium' | 'low' | 'missing';
+export type ProjectMetadataFieldKey =
+  | 'projectTitle'
+  | 'country'
+  | 'projectId'
+  | 'methodology'
+  | 'standard'
+  | 'proponent'
+  | 'documentType'
+  | 'version'
+  | 'documentDate';
+
+export type ProjectMetadataFieldProvenance = {
+  attachmentId?: string;
+  fileName: string;
+  page?: number;
+  pageRange?: string;
+  excerpt?: string;
+};
+
+export type ProjectMetadataField = {
+  key: ProjectMetadataFieldKey;
+  label: string;
+  value?: string;
+  confidence: MetadataConfidence;
+  provenance?: ProjectMetadataFieldProvenance | null;
+};
+
+export type ExistingProjectMatch = {
+  projectId: string;
+  projectName: string;
+  projectCode?: string;
+  confidence: MetadataConfidence;
+  score: number;
+  matchReasons: string[];
+};
+
+export type ProjectDocumentMetadataDraft = {
+  source: {
+    origin: 'quick-check' | 'pdd-upload';
+    evidenceId: string;
+    attachmentId: string;
+    fileName: string;
+    mimeType: string;
+    contentSha256?: string;
+    extractedAt: string;
+  };
+  fields: Record<ProjectMetadataFieldKey, ProjectMetadataField>;
+  suggestedExistingProjects: ExistingProjectMatch[];
+};
 
 export type ManualFindingType = 'CAR' | 'CL' | 'FAR' | 'VVB finding' | 'evidence gap';
 
@@ -136,6 +186,11 @@ export type Project = {
   projectCode?: string;
   countryLocation?: string;
   proponent?: string;
+  methodology?: string;
+  standard?: string;
+  sourceDocumentType?: string;
+  sourceDocumentVersion?: string;
+  sourceDocumentDate?: string;
   reviewMode: ProjectReviewMode;
   methodCode?: string;
   methodVersion?: string;
@@ -153,6 +208,7 @@ export type Project = {
   manualFindings: ManualFinding[];
   extractedManualFindingDrafts: ExtractedManualFindingDraft[];
   learningCases: LearningCase[];
+  createdFromDocumentDraft?: ProjectDocumentMetadataDraft;
 };
 
 export type ProjectCoverage = {

--- a/tests/components/chatAppQuickCheck.test.tsx
+++ b/tests/components/chatAppQuickCheck.test.tsx
@@ -71,16 +71,16 @@ describe("ChatApp claim-first landing", () => {
     expect(container.textContent).toContain(
       "Run a quick evidence check instead",
     );
-    expect(container.textContent).toContain("Quick Check");
-    expect(container.textContent).toContain(
+    expect(container.textContent).not.toContain("Quick Check");
+    expect(container.textContent).not.toContain(
       "Upload evidence. Get a preliminary match in seconds.",
     );
-    expect(container.textContent).toContain("Evidence");
-    expect(container.textContent).toContain("Try demo check");
-    expect(container.textContent).toContain("Run quick check");
-    expect(container.textContent).toContain("Upload evidence");
-    expect(container.querySelectorAll("textarea").length).toBe(1);
-    expect(container.textContent).toContain("Options");
+    expect(container.textContent).not.toContain("Evidence");
+    expect(container.textContent).not.toContain("Try demo check");
+    expect(container.textContent).not.toContain("Run quick check");
+    expect(container.textContent).not.toContain("Upload evidence");
+    expect(container.querySelectorAll("textarea").length).toBe(0);
+    expect(container.textContent).not.toContain("Options");
     expect(container.textContent).not.toContain("Select saved evidence");
     expect(container.textContent).not.toContain("MethodologyAny methodology");
     expect(container.textContent).not.toContain("Ask in chat instead");

--- a/tests/components/chatAppQuickCheck.test.tsx
+++ b/tests/components/chatAppQuickCheck.test.tsx
@@ -1,6 +1,13 @@
 /** @jest-environment jsdom */
 
-import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 
@@ -20,18 +27,26 @@ describe("ChatApp claim-first landing", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
-    (global.fetch as typeof fetch | undefined) = jest.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.includes("/api/methods/inventory")) {
-        return new Response(
-          JSON.stringify({
-            methods: [{ code: "AR-ACM0003", latestVersion: "v02-0", versions: ["v02-0"] }],
-          }),
-          { status: 200 },
-        );
-      }
-      throw new Error(`Unhandled fetch ${url}`);
-    }) as typeof fetch;
+    (global.fetch as typeof fetch | undefined) = jest.fn(
+      async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/api/methods/inventory")) {
+          return new Response(
+            JSON.stringify({
+              methods: [
+                {
+                  code: "AR-ACM0003",
+                  latestVersion: "v02-0",
+                  versions: ["v02-0"],
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        throw new Error(`Unhandled fetch ${url}`);
+      },
+    ) as typeof fetch;
   });
 
   afterEach(async () => {
@@ -43,13 +58,23 @@ describe("ChatApp claim-first landing", () => {
     jest.clearAllMocks();
   });
 
-  it("renders the claim-first command card and removes chat from the landing page", async () => {
+  it("renders the review intake surface before the quick evidence check UI", async () => {
     await act(async () => {
       root.render(<ChatApp />);
     });
 
+    expect(container.textContent).toContain("Start Review");
+    expect(container.textContent).toContain(
+      "Upload a PDD, monitoring report, or evidence file. Article6 will detect the project, method, and next review step.",
+    );
+    expect(container.textContent).toContain("Upload project document");
+    expect(container.textContent).toContain(
+      "Run a quick evidence check instead",
+    );
     expect(container.textContent).toContain("Quick Check");
-    expect(container.textContent).toContain("Upload evidence. Get a preliminary match in seconds.");
+    expect(container.textContent).toContain(
+      "Upload evidence. Get a preliminary match in seconds.",
+    );
     expect(container.textContent).toContain("Evidence");
     expect(container.textContent).toContain("Try demo check");
     expect(container.textContent).toContain("Run quick check");

--- a/tests/components/demoNav.test.tsx
+++ b/tests/components/demoNav.test.tsx
@@ -31,7 +31,7 @@ describe("DemoNav", () => {
     jest.clearAllMocks();
   });
 
-  it("shows Quick Check, Methods, and Projects destinations", async () => {
+  it("shows Start Review, Methods, and Projects destinations", async () => {
     pathnameState.value = "/";
     await act(async () => {
       root.render(<DemoNav />);
@@ -39,22 +39,22 @@ describe("DemoNav", () => {
 
     const links = Array.from(container.querySelectorAll("a"));
     expect(links.map((link) => link.textContent)).toEqual(
-      expect.arrayContaining(["Quick Check", "Methods", "Projects"]),
+      expect.arrayContaining(["Start Review", "Methods", "Projects"]),
     );
-    expect(links.find((link) => link.textContent?.includes("Quick Check"))?.getAttribute("href")).toBe("/");
+    expect(links.find((link) => link.textContent?.includes("Start Review"))?.getAttribute("href")).toBe("/projects/new");
     expect(links.find((link) => link.textContent?.includes("Methods"))?.getAttribute("href")).toBe("/m");
     expect(links.find((link) => link.textContent?.includes("Projects"))?.getAttribute("href")).toBe("/projects");
   });
 
-  it("lets the user return to Quick Check from Methods in one click", async () => {
+  it("lets the user return to Start Review from Methods in one click", async () => {
     pathnameState.value = "/m";
     await act(async () => {
       root.render(<DemoNav />);
     });
 
-    const quickCheckLink = Array.from(container.querySelectorAll("a")).find((link) =>
-      link.textContent?.includes("Quick Check"),
+    const startReviewLink = Array.from(container.querySelectorAll("a")).find((link) =>
+      link.textContent?.includes("Start Review"),
     );
-    expect(quickCheckLink?.getAttribute("href")).toBe("/");
+    expect(startReviewLink?.getAttribute("href")).toBe("/projects/new");
   });
 });

--- a/tests/components/demoNav.test.tsx
+++ b/tests/components/demoNav.test.tsx
@@ -32,7 +32,7 @@ describe("DemoNav", () => {
   });
 
   it("shows Start Review, Methods, and Projects destinations", async () => {
-    pathnameState.value = "/";
+    pathnameState.value = "/start-review";
     await act(async () => {
       root.render(<DemoNav />);
     });
@@ -41,20 +41,8 @@ describe("DemoNav", () => {
     expect(links.map((link) => link.textContent)).toEqual(
       expect.arrayContaining(["Start Review", "Methods", "Projects"]),
     );
-    expect(links.find((link) => link.textContent?.includes("Start Review"))?.getAttribute("href")).toBe("/projects/new");
-    expect(links.find((link) => link.textContent?.includes("Methods"))?.getAttribute("href")).toBe("/m");
+    expect(links.find((link) => link.textContent?.includes("Start Review"))?.getAttribute("href")).toBe("/start-review");
+    expect(links.find((link) => link.textContent?.includes("Methods"))?.getAttribute("href")).toBe("/methods");
     expect(links.find((link) => link.textContent?.includes("Projects"))?.getAttribute("href")).toBe("/projects");
-  });
-
-  it("lets the user return to Start Review from Methods in one click", async () => {
-    pathnameState.value = "/m";
-    await act(async () => {
-      root.render(<DemoNav />);
-    });
-
-    const startReviewLink = Array.from(container.querySelectorAll("a")).find((link) =>
-      link.textContent?.includes("Start Review"),
-    );
-    expect(startReviewLink?.getAttribute("href")).toBe("/projects/new");
   });
 });

--- a/tests/components/projects/NewProjectForm.document-handoff.test.tsx
+++ b/tests/components/projects/NewProjectForm.document-handoff.test.tsx
@@ -83,7 +83,11 @@ describe("NewProjectForm document handoff", () => {
     expect(text).toContain(
       "Upload a PDD, monitoring report, or evidence file. Article6 will detect the project, method, and next review step.",
     );
+    expect(text).toContain("Drag and drop your project document");
     expect(text).toContain("Upload project document");
+    expect(text).toContain("Detects project metadata");
+    expect(text).toContain("Suggests methodology");
+    expect(text).toContain("Preserves provenance & confidence");
     expect(text).toContain("Set up review manually");
     expect(text).not.toContain("We found a project");
   });
@@ -183,12 +187,30 @@ describe("NewProjectForm document handoff", () => {
       await Promise.resolve();
     });
 
+    expect(container.textContent).toContain("We found a project");
+    expect(container.textContent).toContain("Review detected details");
+    expect(container.textContent).toContain("Detected project");
+    expect(container.textContent).toContain("Detected method");
+    expect(container.textContent).toContain("Detected standard");
+    expect(container.textContent).toContain("Document type");
+    expect(container.textContent).toContain("Country");
+    expect(container.textContent).toContain("Proponent");
+    expect(container.textContent).toContain("Continue to review workspace");
+
+    const editDetailsButton = Array.from(
+      container.querySelectorAll("button"),
+    ).find((button) => button.textContent?.includes("Edit details"));
+    expect(editDetailsButton).toBeDefined();
+    await act(async () => {
+      editDetailsButton!.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+
     const titleInput = Array.from(container.querySelectorAll("input")).find(
       (input) => (input as HTMLInputElement).value === "Malawi Demo Project",
     ) as HTMLInputElement | undefined;
     expect(titleInput?.value).toBe("Malawi Demo Project");
-    expect(container.textContent).toContain("We found a project");
-    expect(container.textContent).toContain("Review detected details");
 
     const manualReviewButton = Array.from(
       container.querySelectorAll("button"),
@@ -203,7 +225,9 @@ describe("NewProjectForm document handoff", () => {
     });
 
     const submitButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent?.includes("Start Review"),
+      (button) =>
+        button.getAttribute("type") === "submit" &&
+        button.textContent?.includes("Continue to review workspace"),
     ) as HTMLButtonElement | undefined;
     expect(submitButton).toBeDefined();
     expect(submitButton?.disabled).toBe(true);

--- a/tests/components/projects/NewProjectForm.document-handoff.test.tsx
+++ b/tests/components/projects/NewProjectForm.document-handoff.test.tsx
@@ -1,29 +1,38 @@
 /**
  * @jest-environment jsdom
  */
-import React, { act } from 'react';
-import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { createRoot } from 'react-dom/client';
-import { stagePendingProjectDocumentDraft } from '@/lib/projects/documentMetadata';
+import React, { act } from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { createRoot } from "react-dom/client";
+import { stagePendingProjectDocumentDraft } from "@/lib/projects/documentMetadata";
+import { createProject } from "@/lib/projects/storage";
 
 const pushMock = jest.fn();
 
-jest.mock('next/navigation', () => ({
+jest.mock("next/navigation", () => ({
   useRouter: () => ({
     push: pushMock,
   }),
-  useSearchParams: () => new URLSearchParams('handoff=document-metadata'),
+  useSearchParams: () => new URLSearchParams("handoff=document-metadata"),
 }));
 
-const NewProjectForm = require('@/components/projects/NewProjectForm').default as typeof import('@/components/projects/NewProjectForm').default;
+const NewProjectForm = require("@/components/projects/NewProjectForm")
+  .default as typeof import("@/components/projects/NewProjectForm").default;
 
-describe('NewProjectForm document handoff', () => {
+describe("NewProjectForm document handoff", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
   const originalFetch = global.fetch;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
     pushMock.mockReset();
@@ -45,34 +54,88 @@ describe('NewProjectForm document handoff', () => {
     }
   });
 
-  it('prefills extracted fields and requires confirmation before creation', async () => {
+  it("prefills extracted fields and requires confirmation before creation", async () => {
     stagePendingProjectDocumentDraft({
       source: {
-        origin: 'quick-check',
-        evidenceId: 'ev-pdd-1',
-        attachmentId: 'att-pdd-1',
-        fileName: 'demo-pdd.pdf',
-        mimeType: 'application/pdf',
-        contentSha256: 'sha-demo',
-        extractedAt: '2026-05-24T00:00:00.000Z',
+        origin: "quick-check",
+        evidenceId: "ev-pdd-1",
+        attachmentId: "att-pdd-1",
+        fileName: "demo-pdd.pdf",
+        mimeType: "application/pdf",
+        contentSha256: "sha-demo",
+        extractedAt: "2026-05-24T00:00:00.000Z",
       },
       fields: {
-        projectTitle: { key: 'projectTitle', label: 'Project Title', value: 'Malawi Demo Project', confidence: 'high', provenance: null },
-        country: { key: 'country', label: 'Country', value: 'Malawi', confidence: 'high', provenance: null },
-        projectId: { key: 'projectId', label: 'Registry / Project ID', value: 'VCS-1530', confidence: 'high', provenance: null },
-        methodology: { key: 'methodology', label: 'Methodology', value: 'VM0007', confidence: 'medium', provenance: null },
-        standard: { key: 'standard', label: 'Standard', value: 'VCS Standard v4.7', confidence: 'medium', provenance: null },
-        proponent: { key: 'proponent', label: 'Proponent', value: 'Article6 Climate', confidence: 'high', provenance: null },
-        documentType: { key: 'documentType', label: 'Document Type', value: 'Project Design Document', confidence: 'high', provenance: null },
-        version: { key: 'version', label: 'Version', value: 'v1.0', confidence: 'medium', provenance: null },
-        documentDate: { key: 'documentDate', label: 'Document Date', value: '2026-05-24', confidence: 'medium', provenance: null },
+        projectTitle: {
+          key: "projectTitle",
+          label: "Project Title",
+          value: "Malawi Demo Project",
+          confidence: "high",
+          provenance: null,
+        },
+        country: {
+          key: "country",
+          label: "Country",
+          value: "Malawi",
+          confidence: "high",
+          provenance: null,
+        },
+        projectId: {
+          key: "projectId",
+          label: "Registry / Project ID",
+          value: "VCS-1530",
+          confidence: "high",
+          provenance: null,
+        },
+        methodology: {
+          key: "methodology",
+          label: "Methodology",
+          value: "VM0007",
+          confidence: "medium",
+          provenance: null,
+        },
+        standard: {
+          key: "standard",
+          label: "Standard",
+          value: "VCS Standard v4.7",
+          confidence: "medium",
+          provenance: null,
+        },
+        proponent: {
+          key: "proponent",
+          label: "Proponent",
+          value: "Article6 Climate",
+          confidence: "high",
+          provenance: null,
+        },
+        documentType: {
+          key: "documentType",
+          label: "Document Type",
+          value: "Project Design Document",
+          confidence: "high",
+          provenance: null,
+        },
+        version: {
+          key: "version",
+          label: "Version",
+          value: "v1.0",
+          confidence: "medium",
+          provenance: null,
+        },
+        documentDate: {
+          key: "documentDate",
+          label: "Document Date",
+          value: "2026-05-24",
+          confidence: "medium",
+          provenance: null,
+        },
       },
       suggestedExistingProjects: [],
     });
 
     global.fetch = jest.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url === '/api/projects/methods') {
+      if (url === "/api/projects/methods") {
         return new Response(JSON.stringify({ methods: [] }), { status: 200 });
       }
       throw new Error(`Unhandled fetch ${url}`);
@@ -86,26 +149,34 @@ describe('NewProjectForm document handoff', () => {
       await Promise.resolve();
     });
 
-    const titleInput = Array.from(container.querySelectorAll('input')).find((input) =>
-      (input as HTMLInputElement).value === 'Malawi Demo Project',
+    const titleInput = Array.from(container.querySelectorAll("input")).find(
+      (input) => (input as HTMLInputElement).value === "Malawi Demo Project",
     ) as HTMLInputElement | undefined;
-    expect(titleInput?.value).toBe('Malawi Demo Project');
+    expect(titleInput?.value).toBe("Malawi Demo Project");
+    expect(container.textContent).toContain("We found a project");
+    expect(container.textContent).toContain("Review detected details");
 
-    const manualReviewButton = Array.from(container.querySelectorAll('button')).find((button) =>
-      button.textContent?.includes('Manual Review'),
+    const manualReviewButton = Array.from(
+      container.querySelectorAll("button"),
+    ).find((button) =>
+      button.textContent?.includes("Continue without a linked method"),
     ) as HTMLButtonElement | undefined;
     expect(manualReviewButton).toBeDefined();
     await act(async () => {
-      manualReviewButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      manualReviewButton!.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
     });
 
-    const submitButton = Array.from(container.querySelectorAll('button')).find((button) =>
-      button.textContent?.includes('Create Project From Document'),
+    const submitButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Start Review"),
     ) as HTMLButtonElement | undefined;
     expect(submitButton).toBeDefined();
     expect(submitButton?.disabled).toBe(true);
 
-    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+    const checkbox = container.querySelector(
+      'input[type="checkbox"]',
+    ) as HTMLInputElement | null;
     expect(checkbox).not.toBeNull();
     await act(async () => {
       checkbox!.click();
@@ -114,11 +185,153 @@ describe('NewProjectForm document handoff', () => {
     expect(submitButton?.disabled).toBe(false);
 
     await act(async () => {
-      submitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      submitButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       await Promise.resolve();
     });
 
     expect(pushMock).toHaveBeenCalledTimes(1);
-    expect(String(pushMock.mock.calls[0]?.[0] ?? '')).toContain('/projects/');
+    expect(String(pushMock.mock.calls[0]?.[0] ?? "")).toContain("/projects/");
+  });
+
+  it("allows attaching to an existing project without requiring a new project name", async () => {
+    const existingProject = createProject({
+      name: "Existing Review Workspace",
+      reviewMode: "manual",
+    });
+
+    stagePendingProjectDocumentDraft({
+      source: {
+        origin: "quick-check",
+        evidenceId: "ev-pdd-2",
+        attachmentId: "att-pdd-2",
+        fileName: "demo-pdd.pdf",
+        mimeType: "application/pdf",
+        contentSha256: "sha-demo-2",
+        extractedAt: "2026-05-24T00:00:00.000Z",
+      },
+      fields: {
+        projectTitle: {
+          key: "projectTitle",
+          label: "Project Title",
+          value: "Detected New Name",
+          confidence: "high",
+          provenance: null,
+        },
+        country: {
+          key: "country",
+          label: "Country",
+          value: "Malawi",
+          confidence: "high",
+          provenance: null,
+        },
+        projectId: {
+          key: "projectId",
+          label: "Registry / Project ID",
+          value: "VCS-1530",
+          confidence: "high",
+          provenance: null,
+        },
+        methodology: {
+          key: "methodology",
+          label: "Methodology",
+          value: "VM0007",
+          confidence: "medium",
+          provenance: null,
+        },
+        standard: {
+          key: "standard",
+          label: "Standard",
+          value: "VCS Standard v4.7",
+          confidence: "medium",
+          provenance: null,
+        },
+        proponent: {
+          key: "proponent",
+          label: "Proponent",
+          value: "Article6 Climate",
+          confidence: "high",
+          provenance: null,
+        },
+        documentType: {
+          key: "documentType",
+          label: "Document Type",
+          value: "Project Design Document",
+          confidence: "high",
+          provenance: null,
+        },
+        version: {
+          key: "version",
+          label: "Version",
+          value: "v1.0",
+          confidence: "medium",
+          provenance: null,
+        },
+        documentDate: {
+          key: "documentDate",
+          label: "Document Date",
+          value: "2026-05-24",
+          confidence: "medium",
+          provenance: null,
+        },
+      },
+      suggestedExistingProjects: [
+        {
+          projectId: existingProject.id,
+          projectName: existingProject.name,
+          projectCode: existingProject.projectCode,
+          confidence: "high",
+          score: 0.98,
+          matchReasons: ["Matching project title"],
+        },
+      ],
+    });
+
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects/methods") {
+        return new Response(JSON.stringify({ methods: [] }), { status: 200 });
+      }
+      throw new Error(`Unhandled fetch ${url}`);
+    }) as typeof fetch;
+
+    await act(async () => {
+      root.render(<NewProjectForm />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const attachButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Attach to existing project"),
+    ) as HTMLButtonElement | undefined;
+    expect(attachButton).toBeDefined();
+    await act(async () => {
+      attachButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("No new project name is required.");
+    expect(container.querySelector("input[required]")).toBeNull();
+
+    const checkbox = container.querySelector(
+      'input[type="checkbox"]',
+    ) as HTMLInputElement | null;
+    expect(checkbox).not.toBeNull();
+    await act(async () => {
+      checkbox!.click();
+    });
+
+    const submitButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Continue with this document"),
+    ) as HTMLButtonElement | undefined;
+    expect(submitButton).toBeDefined();
+    expect(submitButton?.disabled).toBe(false);
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(pushMock).toHaveBeenCalledWith(`/projects/${existingProject.id}`);
   });
 });

--- a/tests/components/projects/NewProjectForm.document-handoff.test.tsx
+++ b/tests/components/projects/NewProjectForm.document-handoff.test.tsx
@@ -15,12 +15,15 @@ import { stagePendingProjectDocumentDraft } from "@/lib/projects/documentMetadat
 import { createProject } from "@/lib/projects/storage";
 
 const pushMock = jest.fn();
+const replaceMock = jest.fn();
+let searchParamsValue = "handoff=document-metadata";
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
     push: pushMock,
+    replace: replaceMock,
   }),
-  useSearchParams: () => new URLSearchParams("handoff=document-metadata"),
+  useSearchParams: () => new URLSearchParams(searchParamsValue),
 }));
 
 const NewProjectForm = require("@/components/projects/NewProjectForm")
@@ -36,6 +39,8 @@ describe("NewProjectForm document handoff", () => {
     document.body.appendChild(container);
     root = createRoot(container);
     pushMock.mockReset();
+    replaceMock.mockReset();
+    searchParamsValue = "handoff=document-metadata";
     window.localStorage.clear();
     window.sessionStorage.clear();
   });
@@ -52,6 +57,35 @@ describe("NewProjectForm document handoff", () => {
     } else {
       delete (global as { fetch?: typeof fetch }).fetch;
     }
+  });
+
+  it("shows the default intake surface without requiring a pre-staged draft", async () => {
+    searchParamsValue = "";
+
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects/methods") {
+        return new Response(JSON.stringify({ methods: [] }), { status: 200 });
+      }
+      throw new Error(`Unhandled fetch ${url}`);
+    }) as typeof fetch;
+
+    await act(async () => {
+      root.render(<NewProjectForm />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Start Review");
+    expect(text).toContain(
+      "Upload a PDD, monitoring report, or evidence file. Article6 will detect the project, method, and next review step.",
+    );
+    expect(text).toContain("Upload project document");
+    expect(text).toContain("Set up review manually");
+    expect(text).not.toContain("We found a project");
   });
 
   it("prefills extracted fields and requires confirmation before creation", async () => {

--- a/tests/components/projects/NewProjectForm.document-handoff.test.tsx
+++ b/tests/components/projects/NewProjectForm.document-handoff.test.tsx
@@ -81,14 +81,14 @@ describe("NewProjectForm document handoff", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("Start Review");
     expect(text).toContain(
-      "Upload a PDD, monitoring report, or evidence file. Article6 will detect the project, method, and next review step.",
+      "Upload a PDD, monitoring report, or evidence file. Article6 will detect project metadata, methodology, standard, and the next review step.",
     );
     expect(text).toContain("Drag and drop your project document");
     expect(text).toContain("Upload project document");
     expect(text).toContain("Detects project metadata");
     expect(text).toContain("Suggests methodology");
     expect(text).toContain("Preserves provenance & confidence");
-    expect(text).toContain("Set up review manually");
+    expect(text).toContain("Set up manually");
     expect(text).not.toContain("We found a project");
   });
 

--- a/tests/components/projects/NewProjectForm.document-handoff.test.tsx
+++ b/tests/components/projects/NewProjectForm.document-handoff.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createRoot } from 'react-dom/client';
+import { stagePendingProjectDocumentDraft } from '@/lib/projects/documentMetadata';
+
+const pushMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+  useSearchParams: () => new URLSearchParams('handoff=document-metadata'),
+}));
+
+const NewProjectForm = require('@/components/projects/NewProjectForm').default as typeof import('@/components/projects/NewProjectForm').default;
+
+describe('NewProjectForm document handoff', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    pushMock.mockReset();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (global as { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  it('prefills extracted fields and requires confirmation before creation', async () => {
+    stagePendingProjectDocumentDraft({
+      source: {
+        origin: 'quick-check',
+        evidenceId: 'ev-pdd-1',
+        attachmentId: 'att-pdd-1',
+        fileName: 'demo-pdd.pdf',
+        mimeType: 'application/pdf',
+        contentSha256: 'sha-demo',
+        extractedAt: '2026-05-24T00:00:00.000Z',
+      },
+      fields: {
+        projectTitle: { key: 'projectTitle', label: 'Project Title', value: 'Malawi Demo Project', confidence: 'high', provenance: null },
+        country: { key: 'country', label: 'Country', value: 'Malawi', confidence: 'high', provenance: null },
+        projectId: { key: 'projectId', label: 'Registry / Project ID', value: 'VCS-1530', confidence: 'high', provenance: null },
+        methodology: { key: 'methodology', label: 'Methodology', value: 'VM0007', confidence: 'medium', provenance: null },
+        standard: { key: 'standard', label: 'Standard', value: 'VCS Standard v4.7', confidence: 'medium', provenance: null },
+        proponent: { key: 'proponent', label: 'Proponent', value: 'Article6 Climate', confidence: 'high', provenance: null },
+        documentType: { key: 'documentType', label: 'Document Type', value: 'Project Design Document', confidence: 'high', provenance: null },
+        version: { key: 'version', label: 'Version', value: 'v1.0', confidence: 'medium', provenance: null },
+        documentDate: { key: 'documentDate', label: 'Document Date', value: '2026-05-24', confidence: 'medium', provenance: null },
+      },
+      suggestedExistingProjects: [],
+    });
+
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/projects/methods') {
+        return new Response(JSON.stringify({ methods: [] }), { status: 200 });
+      }
+      throw new Error(`Unhandled fetch ${url}`);
+    }) as typeof fetch;
+
+    await act(async () => {
+      root.render(<NewProjectForm />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const titleInput = Array.from(container.querySelectorAll('input')).find((input) =>
+      (input as HTMLInputElement).value === 'Malawi Demo Project',
+    ) as HTMLInputElement | undefined;
+    expect(titleInput?.value).toBe('Malawi Demo Project');
+
+    const manualReviewButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Manual Review'),
+    ) as HTMLButtonElement | undefined;
+    expect(manualReviewButton).toBeDefined();
+    await act(async () => {
+      manualReviewButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const submitButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Create Project From Document'),
+    ) as HTMLButtonElement | undefined;
+    expect(submitButton).toBeDefined();
+    expect(submitButton?.disabled).toBe(true);
+
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+    expect(checkbox).not.toBeNull();
+    await act(async () => {
+      checkbox!.click();
+    });
+
+    expect(submitButton?.disabled).toBe(false);
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    expect(String(pushMock.mock.calls[0]?.[0] ?? '')).toContain('/projects/');
+  });
+});

--- a/tests/components/projects/NewProjectForm.manual-mode.test.tsx
+++ b/tests/components/projects/NewProjectForm.manual-mode.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { createRoot } from "react-dom/client";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+  useSearchParams: () => new URLSearchParams("mode=manual"),
+}));
+
+const NewProjectForm = require("@/components/projects/NewProjectForm")
+  .default as typeof import("@/components/projects/NewProjectForm").default;
+
+describe("NewProjectForm manual mode", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects/methods") {
+        return new Response(JSON.stringify({ methods: [] }), { status: 200 });
+      }
+      throw new Error(`Unhandled fetch ${url}`);
+    }) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (global as { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  it("renders the manual setup form copy without the upload workflow choices", async () => {
+    await act(async () => {
+      root.render(<NewProjectForm />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Set up review manually");
+    expect(container.textContent).toContain(
+      "Create a project review without uploading a source document first. You can attach documents and evidence later.",
+    );
+    expect(container.textContent).toContain("Create Project Review");
+    expect(container.textContent).not.toContain("Review Type");
+    expect(container.textContent).not.toContain("Methodology-linked review");
+  });
+});

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -926,11 +926,26 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
   });
 
+  function revealQuickEvidenceCheck() {
+    const revealButton = Array.from(container.querySelectorAll("button")).find(
+      (node) => node.textContent?.includes("Run a quick evidence check instead"),
+    );
+    if (
+      revealButton &&
+      !container.querySelector("textarea") &&
+      !container.textContent?.includes("Quick Check")
+    ) {
+      revealButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    }
+  }
+
   function claimInput(): HTMLTextAreaElement {
+    revealQuickEvidenceCheck();
     return container.querySelector("textarea") as HTMLTextAreaElement;
   }
 
   function primaryCta(): HTMLButtonElement {
+    revealQuickEvidenceCheck();
     return Array.from(container.querySelectorAll("button")).find((node) =>
       node.textContent?.includes("Run quick check"),
     ) as HTMLButtonElement;
@@ -964,6 +979,7 @@ describe("QuickCheckPanel claim-first flow", () => {
   }
 
   async function uploadEvidence(file: File) {
+    revealQuickEvidenceCheck();
     const input = container.querySelector(
       'input[data-testid="quick-check-evidence-input"]',
     ) as HTMLInputElement;
@@ -1009,7 +1025,7 @@ describe("QuickCheckPanel claim-first flow", () => {
 
   it("renders a minimal default state with secondary controls collapsed", async () => {
     await act(async () => {
-      root.render(<QuickCheckPanel />);
+      root.render(<QuickCheckPanel collapseQuickEvidenceByDefault />);
     });
 
     const pageText = container.textContent ?? "";
@@ -1019,16 +1035,15 @@ describe("QuickCheckPanel claim-first flow", () => {
     );
     expect(pageText).toContain("Upload project document");
     expect(pageText).toContain("Run a quick evidence check instead");
-    expect(pageText).toContain("Quick Check");
-    expect(pageText).toContain(
+    expect(pageText).not.toContain("Quick Check");
+    expect(pageText).not.toContain(
       "Upload evidence. Get a preliminary match in seconds.",
     );
-    expect(pageText).toContain("Upload evidence");
-    expect(pageText).toContain("Try demo check");
-    expect(pageText).toContain("Options");
+    expect(pageText).not.toContain("Upload evidence");
+    expect(pageText).not.toContain("Try demo check");
+    expect(pageText).not.toContain("Options");
     expect(pageText).not.toContain("Select saved evidence");
     expect(pageText).not.toContain("MethodologyAny methodology");
-    expect(primaryCta().disabled).toBe(true);
   });
 
   it("renders Try demo check as an always-available secondary shortcut", async () => {

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -2,7 +2,14 @@
 
 import fs from "fs";
 import path from "path";
-import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { putAttachmentBytes } from "@/lib/proofMap/attachments";
@@ -10,25 +17,37 @@ import { putAttachmentBytes } from "@/lib/proofMap/attachments";
 const pushMock = jest.fn();
 const createAndStoreEvidenceAttachmentMock = jest.fn();
 const PDF_TEXT_BY_FILENAME: Record<string, string> = {
-  "fresh-monitoring-report.pdf": "Monitoring report for the full reporting period. Gold Standard TPDD TEC Version 4.0. AR-ACM0003 methodology reference.",
+  "fresh-monitoring-report.pdf":
+    "Monitoring report for the full reporting period. Gold Standard TPDD TEC Version 4.0. AR-ACM0003 methodology reference.",
   "monitoring-report.pdf": "Monitoring report for the full reporting period.",
-  "demo-monitoring-report.pdf": "Monitoring report for the full reporting period.",
+  "demo-monitoring-report.pdf":
+    "Monitoring report for the full reporting period.",
   "opaque-scan.pdf": "",
-  "kenya-second-check-evidence.pdf": "Reporting period 1 April 2024 - 31 March 2025. Project area Makueni County and Kitui County. The monitoring report covers the full reporting period.",
-  "malawi-pdd.pdf": "Project boundary description for the Malawi grouped activity. Project location Machinga District, Malawi. Project coordinates -15.2345, 35.6789. The mapped project area polygon and AOI are referenced in the boundary map. Documented monitoring plan for the project. Spreadsheet workbook annex referenced for monitoring evidence.",
-  "synthetic-malawi-pdd.pdf": "Project boundary description for the Malawi grouped activity. Project location Machinga District, Malawi. Project coordinates -15.2345, 35.6789. The mapped project area polygon and AOI are referenced in the boundary map. Documented monitoring plan for the project. Spreadsheet workbook annex referenced for monitoring evidence.",
-  "boundary.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
-  "boundary-note.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
+  "kenya-second-check-evidence.pdf":
+    "Reporting period 1 April 2024 - 31 March 2025. Project area Makueni County and Kitui County. The monitoring report covers the full reporting period.",
+  "malawi-pdd.pdf":
+    "Project boundary description for the Malawi grouped activity. Project location Machinga District, Malawi. Project coordinates -15.2345, 35.6789. The mapped project area polygon and AOI are referenced in the boundary map. Documented monitoring plan for the project. Spreadsheet workbook annex referenced for monitoring evidence.",
+  "synthetic-malawi-pdd.pdf":
+    "Project boundary description for the Malawi grouped activity. Project location Machinga District, Malawi. Project coordinates -15.2345, 35.6789. The mapped project area polygon and AOI are referenced in the boundary map. Documented monitoring plan for the project. Spreadsheet workbook annex referenced for monitoring evidence.",
+  "boundary.pdf":
+    "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
+  "boundary-note.pdf":
+    "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "baseline.pdf": "Monitoring report for the full reporting period.",
-  "plum-verra-demo-excerpt.pdf": "Project Description / PD. PLUM Project. Verra VCS / CCB. APD. ARR. VMD0001. VMD0006. VMD0009. VM0007. REDD+ Methodology Framework. Section 3.1 Application of Methodology. Section 3.3 Monitoring. Project boundary description for the PLUM Project. The mapped project area polygon and AOI are referenced in the boundary map. Project location described for the project area. Monitoring report for the full reporting period.",
-  "ambiguous-methods.pdf": "Methodology references include VM0007, GS-VER1, and the monitoring report for the full reporting period.",
-  "unknown-acm0010.pdf": "Evidence references ACM0010 and the monitoring report for the full reporting period.",
-  "no-method-detected.pdf": "Monitoring report for the full reporting period without any explicit methodology code.",
+  "plum-verra-demo-excerpt.pdf":
+    "Project Description / PD. PLUM Project. Verra VCS / CCB. APD. ARR. VMD0001. VMD0006. VMD0009. VM0007. REDD+ Methodology Framework. Section 3.1 Application of Methodology. Section 3.3 Monitoring. Project boundary description for the PLUM Project. The mapped project area polygon and AOI are referenced in the boundary map. Project location described for the project area. Monitoring report for the full reporting period.",
+  "ambiguous-methods.pdf":
+    "Methodology references include VM0007, GS-VER1, and the monitoring report for the full reporting period.",
+  "unknown-acm0010.pdf":
+    "Evidence references ACM0010 and the monitoring report for the full reporting period.",
+  "no-method-detected.pdf":
+    "Monitoring report for the full reporting period without any explicit methodology code.",
 };
 
 jest.mock("@/lib/proofMap/attachments", () => ({
   ...jest.requireActual("@/lib/proofMap/attachments"),
-  createAndStoreEvidenceAttachment: (...args: unknown[]) => createAndStoreEvidenceAttachmentMock(...args),
+  createAndStoreEvidenceAttachment: (...args: unknown[]) =>
+    createAndStoreEvidenceAttachmentMock(...args),
 }));
 
 jest.mock("@/lib/chat/quickCheckPdfClient", () => ({
@@ -45,17 +64,30 @@ import { loadPins } from "@/lib/proofMap/storage";
 describe("QuickCheckPanel claim-first flow", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
+  const originalLocation = window.location;
+  const assignMock = jest.fn();
 
   function asArrayBuffer(value: Uint8Array): ArrayBuffer {
-    return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+    return value.buffer.slice(
+      value.byteOffset,
+      value.byteOffset + value.byteLength,
+    );
   }
 
   async function seedAttachmentText(attachmentId: string, text: string) {
-    await putAttachmentBytes(attachmentId, asArrayBuffer(new TextEncoder().encode(text)));
+    await putAttachmentBytes(
+      attachmentId,
+      asArrayBuffer(new TextEncoder().encode(text)),
+    );
   }
 
-  async function seedAttachmentFixture(attachmentId: string, fixtureName: string) {
-    const bytes = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check", fixtureName));
+  async function seedAttachmentFixture(
+    attachmentId: string,
+    fixtureName: string,
+  ) {
+    const bytes = fs.readFileSync(
+      path.join(process.cwd(), "tests/fixtures/quick-check", fixtureName),
+    );
     await putAttachmentBytes(attachmentId, asArrayBuffer(bytes));
   }
 
@@ -112,445 +144,665 @@ describe("QuickCheckPanel claim-first flow", () => {
     document.body.appendChild(container);
     root = createRoot(container);
     window.localStorage.clear();
+    delete (window as Partial<Window>).location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, assign: assignMock },
+    });
+    assignMock.mockReset();
     pushMock.mockReset();
     createAndStoreEvidenceAttachmentMock.mockReset();
-    createAndStoreEvidenceAttachmentMock.mockImplementation(async (input: { pin_id: string; file: File }) => {
-      const bytes = new Uint8Array(await input.file.arrayBuffer());
-      const attachment = {
-        id: `att-${input.pin_id}`,
-        pin_id: input.pin_id,
-        filename: input.file.name,
-        mime: input.file.type || "application/pdf",
-        size: bytes.byteLength,
-        sha256: `sha-${input.pin_id}`,
-        created_at: "2026-04-04T00:00:00Z",
-      };
-      await putAttachmentBytes(attachment.id, asArrayBuffer(bytes));
-      return { ok: true, attachment };
-    });
+    createAndStoreEvidenceAttachmentMock.mockImplementation(
+      async (input: { pin_id: string; file: File }) => {
+        const bytes = new Uint8Array(await input.file.arrayBuffer());
+        const attachment = {
+          id: `att-${input.pin_id}`,
+          pin_id: input.pin_id,
+          filename: input.file.name,
+          mime: input.file.type || "application/pdf",
+          size: bytes.byteLength,
+          sha256: `sha-${input.pin_id}`,
+          created_at: "2026-04-04T00:00:00Z",
+        };
+        await putAttachmentBytes(attachment.id, asArrayBuffer(bytes));
+        return { ok: true, attachment };
+      },
+    );
 
-    (global.fetch as typeof fetch | undefined) = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url.includes("/api/methods/inventory")) {
-        return new Response(
-          JSON.stringify({
-            methods: [
-              { code: "AR-ACM0003", latestVersion: "v02-0", versions: ["v02-0"] },
-              { code: "AR-AM0014", latestVersion: "v03-0", versions: ["v03-0"] },
-              { code: "AR-AMS0007", latestVersion: "v01-0", versions: ["v01-0"] },
-              { code: "GS-VER1", latestVersion: "v2-0", versions: ["v2-0"] },
-              { code: "VM0007", latestVersion: "v1-0", versions: ["v1-0"] },
-            ],
-          }),
-          { status: 200 },
-        );
-      }
-      if (url.includes("/api/quick-check/pdf-extract")) {
-        const headers = new Headers(init?.headers);
-        const encodedFilename = headers.get("x-article6-filename") ?? "";
-        const filename = decodeURIComponent(encodedFilename);
-        return new Response(
-          JSON.stringify({
-            text: PDF_TEXT_BY_FILENAME[filename] ?? "",
-            engine: "pdf-parse",
-            metadata: {
-              parser: "pdf-parse",
-            },
-          }),
-          { status: 200 },
-        );
-      }
-      if (url.includes("/api/methods/AR-ACM0003/v/v02-0/rules")) {
-        return new Response(
-          JSON.stringify({
-            rules: [
-              {
-                id: "R-1-0001",
-                title: "Monitoring frequency",
-                snippet: "Maintain a monitoring report.",
-                summary: "Maintain a monitoring report.",
-                logic: "Review the report for the reporting period.",
-                tags: [],
-                expectedEvidence: ["monitoring-report"],
-                refs: { primarySection: "S-10", sectionAnchor: "#S-10", tools: ["UNFCCC/TOOL-1"] },
-                citations: [{ sectionId: "S-10", label: "Section 10" }],
-              },
-              {
-                id: "R-1-0003",
-                title: "Monitoring plan",
-                snippet: "Document the monitoring plan for the project.",
-                summary: "Document the monitoring plan for the project.",
-                logic: "Use the PDD and monitoring annexes to confirm the monitoring plan.",
-                tags: ["monitoring", "plan"],
-                expectedEvidence: ["monitoring-report"],
-              },
-              {
-                id: "R-1-0004",
-                title: "Workbook monitoring records",
-                snippet: "Maintain workbook-backed monitoring records for the reporting period.",
-                summary: "Maintain workbook-backed monitoring records for the reporting period.",
-                logic: "Workbook records should identify plots and reporting periods.",
-                tags: ["monitoring", "workbook", "plots"],
-                expectedEvidence: ["spreadsheet-workbook"],
-              },
-              {
-                id: "R-1-0002",
-                title: "Boundary consistency",
-                snippet: "Boundary description aligns to the mapped area.",
-                tags: [],
-              },
-            ],
-          }),
-          { status: 200 },
-        );
-      }
-      if (url.includes("/api/methods/AR-AM0014/v/v03-0/rules")) {
-        return new Response(
-          JSON.stringify({
-            rules: [
-              {
-                id: "R-1-0008",
-                title: "Monitoring report consolidation",
-                snippet: "Monitoring reports consolidate maps, inventory data, leakage deductions, and QA/QC evidence.",
-                summary: "Monitoring reports consolidate maps, inventory data, leakage deductions, and QA/QC evidence.",
-                logic: "Use monitoring reports to confirm mapped-area, inventory, and QA/QC evidence are consolidated.",
-                tags: ["monitoring", "reporting", "maps"],
-                expectedEvidence: ["monitoring-report"],
-              },
-            ],
-          }),
-          { status: 200 },
-        );
-      }
-      if (url.includes("/api/methods/AR-AMS0007/v/v01-0/rules")) {
-        return new Response(
-          JSON.stringify({
-            rules: [
-              {
-                id: "R-2-0001",
-                title: "Boundary delineation",
-                snippet: "Boundary text is internally consistent.",
-                tags: [],
-              },
-            ],
-          }),
-          { status: 200 },
-        );
-      }
-      if (url.includes("/api/methods/VM0007/v/v1-0/rules")) {
-        return new Response(
-          JSON.stringify({
-            rules: [
-              {
-                id: "R-7-0001",
-                title: "Project boundary consistency",
-                snippet: "Boundary evidence aligns with the VM0007 project description.",
-                summary: "Boundary evidence aligns with the VM0007 project description.",
-                tags: ["boundary", "project area", "vm0007"],
-              },
-              {
-                id: "R-7-0002",
-                title: "Monitoring procedure",
-                snippet: "Monitoring evidence aligns with VM0007 section 3.3.",
-                summary: "Monitoring evidence aligns with VM0007 section 3.3.",
-                tags: ["monitoring", "vm0007"],
-              },
-            ],
-          }),
-          { status: 200 },
-        );
-      }
-      if (url.includes("/api/methods/GS-VER1/v/v2-0/rules")) {
-        return new Response(
-          JSON.stringify({
-            rules: [
-              {
-                id: "R-GS-0001",
-                title: "Gold Standard monitoring evidence",
-                snippet: "Monitoring evidence aligns with GS-VER1.",
-                summary: "Monitoring evidence aligns with GS-VER1.",
-                tags: ["monitoring", "gs-ver1"],
-              },
-            ],
-          }),
-          { status: 200 },
-        );
-      }
-      if (url.includes("/api/query?text=")) {
-        const decoded = decodeURIComponent(url.split("text=")[1] ?? "");
-        const lower = decoded.toLowerCase();
-        const quickCheckSession = window.localStorage.getItem("a6:quick-check:claim-first:v1") ?? "";
-        const kenyaSecondCheck = quickCheckSession.includes("kenya-second-check-evidence.pdf");
-        const plumVm0007 = quickCheckSession.includes("plum-verra-demo-excerpt.pdf");
-        const ambiguousMethods = quickCheckSession.includes("ambiguous-methods.pdf");
-        const unknownAcm0010 = quickCheckSession.includes("unknown-acm0010.pdf");
-        if (plumVm0007 && lower.includes("monitoring report")) {
+    (global.fetch as typeof fetch | undefined) = jest.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/api/methods/inventory")) {
           return new Response(
             JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
+              methods: [
                 {
-                  id: "R-7-0002",
-                  section_title: "Monitoring procedure",
-                  methodology_id: "VM0007",
-                  methodology_version: "v1-0",
-                  score: 0.78,
+                  code: "AR-ACM0003",
+                  latestVersion: "v02-0",
+                  versions: ["v02-0"],
                 },
+                {
+                  code: "AR-AM0014",
+                  latestVersion: "v03-0",
+                  versions: ["v03-0"],
+                },
+                {
+                  code: "AR-AMS0007",
+                  latestVersion: "v01-0",
+                  versions: ["v01-0"],
+                },
+                { code: "GS-VER1", latestVersion: "v2-0", versions: ["v2-0"] },
+                { code: "VM0007", latestVersion: "v1-0", versions: ["v1-0"] },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/api/quick-check/pdf-extract")) {
+          const headers = new Headers(init?.headers);
+          const encodedFilename = headers.get("x-article6-filename") ?? "";
+          const filename = decodeURIComponent(encodedFilename);
+          return new Response(
+            JSON.stringify({
+              text: PDF_TEXT_BY_FILENAME[filename] ?? "",
+              engine: "pdf-parse",
+              metadata: {
+                parser: "pdf-parse",
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/api/methods/AR-ACM0003/v/v02-0/rules")) {
+          return new Response(
+            JSON.stringify({
+              rules: [
                 {
                   id: "R-1-0001",
-                  section_title: "Monitoring frequency",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.91,
+                  title: "Monitoring frequency",
+                  snippet: "Maintain a monitoring report.",
+                  summary: "Maintain a monitoring report.",
+                  logic: "Review the report for the reporting period.",
+                  tags: [],
+                  expectedEvidence: ["monitoring-report"],
+                  refs: {
+                    primarySection: "S-10",
+                    sectionAnchor: "#S-10",
+                    tools: ["UNFCCC/TOOL-1"],
+                  },
+                  citations: [{ sectionId: "S-10", label: "Section 10" }],
                 },
+                {
+                  id: "R-1-0003",
+                  title: "Monitoring plan",
+                  snippet: "Document the monitoring plan for the project.",
+                  summary: "Document the monitoring plan for the project.",
+                  logic:
+                    "Use the PDD and monitoring annexes to confirm the monitoring plan.",
+                  tags: ["monitoring", "plan"],
+                  expectedEvidence: ["monitoring-report"],
+                },
+                {
+                  id: "R-1-0004",
+                  title: "Workbook monitoring records",
+                  snippet:
+                    "Maintain workbook-backed monitoring records for the reporting period.",
+                  summary:
+                    "Maintain workbook-backed monitoring records for the reporting period.",
+                  logic:
+                    "Workbook records should identify plots and reporting periods.",
+                  tags: ["monitoring", "workbook", "plots"],
+                  expectedEvidence: ["spreadsheet-workbook"],
+                },
+                {
+                  id: "R-1-0002",
+                  title: "Boundary consistency",
+                  snippet: "Boundary description aligns to the mapped area.",
+                  tags: [],
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/api/methods/AR-AM0014/v/v03-0/rules")) {
+          return new Response(
+            JSON.stringify({
+              rules: [
                 {
                   id: "R-1-0008",
-                  section_title: "Monitoring report consolidation",
-                  methodology_id: "AR-AM0014",
-                  methodology_version: "v03-0",
-                  score: 0.88,
+                  title: "Monitoring report consolidation",
+                  snippet:
+                    "Monitoring reports consolidate maps, inventory data, leakage deductions, and QA/QC evidence.",
+                  summary:
+                    "Monitoring reports consolidate maps, inventory data, leakage deductions, and QA/QC evidence.",
+                  logic:
+                    "Use monitoring reports to confirm mapped-area, inventory, and QA/QC evidence are consolidated.",
+                  tags: ["monitoring", "reporting", "maps"],
+                  expectedEvidence: ["monitoring-report"],
                 },
               ],
             }),
             { status: 200 },
           );
         }
-        if (ambiguousMethods && lower.includes("monitoring report")) {
+        if (url.includes("/api/methods/AR-AMS0007/v/v01-0/rules")) {
           return new Response(
             JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
+              rules: [
                 {
-                  id: "R-7-0002",
-                  section_title: "Monitoring procedure",
-                  methodology_id: "VM0007",
-                  methodology_version: "v1-0",
-                  score: 0.81,
-                },
-                {
-                  id: "R-GS-0001",
-                  section_title: "Gold Standard monitoring evidence",
-                  methodology_id: "GS-VER1",
-                  methodology_version: "v2-0",
-                  score: 0.8,
-                },
-                {
-                  id: "R-1-0001",
-                  section_title: "Monitoring frequency",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.92,
+                  id: "R-2-0001",
+                  title: "Boundary delineation",
+                  snippet: "Boundary text is internally consistent.",
+                  tags: [],
                 },
               ],
             }),
             { status: 200 },
           );
         }
-        if (unknownAcm0010 && lower.includes("monitoring report")) {
+        if (url.includes("/api/methods/VM0007/v/v1-0/rules")) {
           return new Response(
             JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
-                {
-                  id: "R-1-0001",
-                  section_title: "Monitoring frequency",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.95,
-                },
-              ],
-            }),
-            { status: 200 },
-          );
-        }
-        if (plumVm0007 && (lower.includes("mapped area boundary") || lower.includes("project coordinates boundary") || lower.includes("project location boundary") || lower.includes("boundary description matches the mapped project area"))) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
+              rules: [
                 {
                   id: "R-7-0001",
-                  section_title: "Project boundary consistency",
-                  methodology_id: "VM0007",
-                  methodology_version: "v1-0",
-                  score: 0.72,
+                  title: "Project boundary consistency",
+                  snippet:
+                    "Boundary evidence aligns with the VM0007 project description.",
+                  summary:
+                    "Boundary evidence aligns with the VM0007 project description.",
+                  tags: ["boundary", "project area", "vm0007"],
                 },
                 {
-                  id: "R-1-0002",
-                  section_title: "Boundary consistency",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.92,
-                },
-                {
-                  id: "R-2-0001",
-                  section_title: "Boundary delineation",
-                  methodology_id: "AR-AMS0007",
-                  methodology_version: "v01-0",
-                  score: 0.89,
+                  id: "R-7-0002",
+                  title: "Monitoring procedure",
+                  snippet:
+                    "Monitoring evidence aligns with VM0007 section 3.3.",
+                  summary:
+                    "Monitoring evidence aligns with VM0007 section 3.3.",
+                  tags: ["monitoring", "vm0007"],
                 },
               ],
             }),
             { status: 200 },
           );
         }
-        if (kenyaSecondCheck && quickCheckSession.includes("kenya no valid analysis path")) {
+        if (url.includes("/api/methods/GS-VER1/v/v2-0/rules")) {
           return new Response(
             JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
+              rules: [
                 {
-                  id: "R-9-9999",
-                  section_title: "Wrong AR-AM0014 candidate",
-                  methodology_id: "AR-AM0014",
-                  methodology_version: "v03-0",
-                  score: 0.94,
+                  id: "R-GS-0001",
+                  title: "Gold Standard monitoring evidence",
+                  snippet: "Monitoring evidence aligns with GS-VER1.",
+                  summary: "Monitoring evidence aligns with GS-VER1.",
+                  tags: ["monitoring", "gs-ver1"],
                 },
               ],
             }),
             { status: 200 },
           );
         }
-        if (kenyaSecondCheck && quickCheckSession.includes("kenya cross-method confirmation")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
-                {
-                  id: "R-1-0008",
-                  section_title: "Monitoring report consolidation",
-                  methodology_id: "AR-AM0014",
-                  methodology_version: "v03-0",
-                  score: 0.92,
-                },
-                {
-                  id: "R-1-0001",
-                  section_title: "Monitoring frequency",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.86,
-                },
-              ],
-            }),
-            { status: 200 },
+        if (url.includes("/api/query?text=")) {
+          const decoded = decodeURIComponent(url.split("text=")[1] ?? "");
+          const lower = decoded.toLowerCase();
+          const quickCheckSession =
+            window.localStorage.getItem("a6:quick-check:claim-first:v1") ?? "";
+          const kenyaSecondCheck = quickCheckSession.includes(
+            "kenya-second-check-evidence.pdf",
           );
-        }
-        if (lower.includes("monitoring report")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
-                {
-                  id: "R-1-0001",
-                  section_title: "Monitoring frequency",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.91,
-                },
-              ],
-            }),
-            { status: 200 },
+          const plumVm0007 = quickCheckSession.includes(
+            "plum-verra-demo-excerpt.pdf",
           );
-        }
-        if (lower.includes("invalid top candidate")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
-                {
-                  id: "R-9-9999",
-                  section_title: "Broken top result",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.97,
-                },
-                {
-                  id: "R-1-0001",
-                  section_title: "Monitoring frequency",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.91,
-                },
-              ],
-            }),
-            { status: 200 },
+          const ambiguousMethods = quickCheckSession.includes(
+            "ambiguous-methods.pdf",
           );
-        }
-        if (lower.includes("shortlist with unresolved")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
-                {
-                  id: "R-9-9999",
-                  section_title: "Broken top result",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.95,
-                },
-                {
-                  id: "R-1-0002",
-                  section_title: "Boundary consistency",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.85,
-                },
-                {
-                  id: "R-2-0001",
-                  section_title: "Boundary delineation",
-                  methodology_id: "AR-AMS0007",
-                  methodology_version: "v01-0",
-                  score: 0.84,
-                },
-              ],
-            }),
-            { status: 200 },
+          const unknownAcm0010 = quickCheckSession.includes(
+            "unknown-acm0010.pdf",
           );
-        }
-        if (lower.includes("the boundary description matches the mapped project area")) {
+          if (plumVm0007 && lower.includes("monitoring report")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-7-0002",
+                    section_title: "Monitoring procedure",
+                    methodology_id: "VM0007",
+                    methodology_version: "v1-0",
+                    score: 0.78,
+                  },
+                  {
+                    id: "R-1-0001",
+                    section_title: "Monitoring frequency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.91,
+                  },
+                  {
+                    id: "R-1-0008",
+                    section_title: "Monitoring report consolidation",
+                    methodology_id: "AR-AM0014",
+                    methodology_version: "v03-0",
+                    score: 0.88,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (ambiguousMethods && lower.includes("monitoring report")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-7-0002",
+                    section_title: "Monitoring procedure",
+                    methodology_id: "VM0007",
+                    methodology_version: "v1-0",
+                    score: 0.81,
+                  },
+                  {
+                    id: "R-GS-0001",
+                    section_title: "Gold Standard monitoring evidence",
+                    methodology_id: "GS-VER1",
+                    methodology_version: "v2-0",
+                    score: 0.8,
+                  },
+                  {
+                    id: "R-1-0001",
+                    section_title: "Monitoring frequency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.92,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (unknownAcm0010 && lower.includes("monitoring report")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-1-0001",
+                    section_title: "Monitoring frequency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.95,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
           if (
-            window.localStorage.getItem("a6:quick-check:claim-first:v1")?.includes("synthetic-malawi-pdd.pdf") ||
-            window.localStorage.getItem("pins:AR-ACM0003:v02-0")?.includes("synthetic-malawi-pdd.pdf")
+            plumVm0007 &&
+            (lower.includes("mapped area boundary") ||
+              lower.includes("project coordinates boundary") ||
+              lower.includes("project location boundary") ||
+              lower.includes(
+                "boundary description matches the mapped project area",
+              ))
           ) {
             return new Response(
               JSON.stringify({
                 engineTag: "test",
                 metrics: [],
+                results: [
+                  {
+                    id: "R-7-0001",
+                    section_title: "Project boundary consistency",
+                    methodology_id: "VM0007",
+                    methodology_version: "v1-0",
+                    score: 0.72,
+                  },
+                  {
+                    id: "R-1-0002",
+                    section_title: "Boundary consistency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.92,
+                  },
+                  {
+                    id: "R-2-0001",
+                    section_title: "Boundary delineation",
+                    methodology_id: "AR-AMS0007",
+                    methodology_version: "v01-0",
+                    score: 0.89,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (
+            kenyaSecondCheck &&
+            quickCheckSession.includes("kenya no valid analysis path")
+          ) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-9-9999",
+                    section_title: "Wrong AR-AM0014 candidate",
+                    methodology_id: "AR-AM0014",
+                    methodology_version: "v03-0",
+                    score: 0.94,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (
+            kenyaSecondCheck &&
+            quickCheckSession.includes("kenya cross-method confirmation")
+          ) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-1-0008",
+                    section_title: "Monitoring report consolidation",
+                    methodology_id: "AR-AM0014",
+                    methodology_version: "v03-0",
+                    score: 0.92,
+                  },
+                  {
+                    id: "R-1-0001",
+                    section_title: "Monitoring frequency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.86,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (lower.includes("monitoring report")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-1-0001",
+                    section_title: "Monitoring frequency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.91,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (lower.includes("invalid top candidate")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-9-9999",
+                    section_title: "Broken top result",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.97,
+                  },
+                  {
+                    id: "R-1-0001",
+                    section_title: "Monitoring frequency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.91,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (lower.includes("shortlist with unresolved")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-9-9999",
+                    section_title: "Broken top result",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.95,
+                  },
+                  {
+                    id: "R-1-0002",
+                    section_title: "Boundary consistency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.85,
+                  },
+                  {
+                    id: "R-2-0001",
+                    section_title: "Boundary delineation",
+                    methodology_id: "AR-AMS0007",
+                    methodology_version: "v01-0",
+                    score: 0.84,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (
+            lower.includes(
+              "the boundary description matches the mapped project area",
+            )
+          ) {
+            if (
+              window.localStorage
+                .getItem("a6:quick-check:claim-first:v1")
+                ?.includes("synthetic-malawi-pdd.pdf") ||
+              window.localStorage
+                .getItem("pins:AR-ACM0003:v02-0")
+                ?.includes("synthetic-malawi-pdd.pdf")
+            ) {
+              return new Response(
+                JSON.stringify({
+                  engineTag: "test",
+                  metrics: [],
+                  results: [],
+                }),
+                { status: 200 },
+              );
+            }
+          }
+          if (lower.includes("documented monitoring plan")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-1-0003",
+                    section_title: "Monitoring plan",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.88,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (lower.includes("project boundary described")) {
+            if (
+              window.localStorage
+                .getItem("a6:quick-check:claim-first:v1")
+                ?.includes("local-fallback")
+            ) {
+              return new Response(
+                JSON.stringify({
+                  engineTag: "test",
+                  metrics: [],
+                  results: [],
+                }),
+                { status: 200 },
+              );
+            }
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-1-0002",
+                    section_title: "Boundary consistency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.86,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (
+            lower.includes("project coordinates present") ||
+            lower.includes("mapped project area referenced") ||
+            lower.includes("project location described")
+          ) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-1-0002",
+                    section_title: "Boundary consistency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.84,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (
+            lower.includes("mapped area boundary") ||
+            lower.includes("project coordinates boundary") ||
+            lower.includes("project location boundary")
+          ) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-1-0002",
+                    section_title: "Boundary consistency",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.82,
+                  },
+                  {
+                    id: "R-2-0001",
+                    section_title: "Boundary delineation",
+                    methodology_id: "AR-AMS0007",
+                    methodology_version: "v01-0",
+                    score: 0.78,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (lower.includes("monitoring data 5 plots")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-1-0004",
+                    section_title: "Workbook monitoring records",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.87,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (lower.includes("2026-q1 monitoring records")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-1-0004",
+                    section_title: "Workbook monitoring records",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.89,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (lower.includes("documented monitoring evidence")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
+                results: [
+                  {
+                    id: "R-1-0003",
+                    section_title: "Monitoring plan",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.82,
+                  },
+                  {
+                    id: "R-1-0004",
+                    section_title: "Workbook monitoring records",
+                    methodology_id: "AR-ACM0003",
+                    methodology_version: "v02-0",
+                    score: 0.8,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }
+          if (lower.includes("workbook referenced in pdd")) {
+            return new Response(
+              JSON.stringify({
+                engineTag: "test",
+                metrics: [],
                 results: [],
               }),
               { status: 200 },
             );
           }
-        }
-        if (lower.includes("documented monitoring plan")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
-                {
-                  id: "R-1-0003",
-                  section_title: "Monitoring plan",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.88,
-                },
-              ],
-            }),
-            { status: 200 },
-          );
-        }
-        if (lower.includes("project boundary described")) {
-          if (window.localStorage.getItem("a6:quick-check:claim-first:v1")?.includes("local-fallback")) {
+          if (lower.includes("unsupported claim")) {
             return new Response(
               JSON.stringify({
                 engineTag: "test",
@@ -566,174 +818,34 @@ describe("QuickCheckPanel claim-first flow", () => {
               metrics: [],
               results: [
                 {
-                  id: "R-1-0002",
-                  section_title: "Boundary consistency",
+                  id: "baseline-carbon-44-12",
+                  section_title: "Baseline carbon memo",
                   methodology_id: "AR-ACM0003",
                   methodology_version: "v02-0",
-                  score: 0.86,
+                  score: 0.99,
                 },
-              ],
-            }),
-            { status: 200 },
-          );
-        }
-        if (lower.includes("project coordinates present") || lower.includes("mapped project area referenced") || lower.includes("project location described")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
                 {
                   id: "R-1-0002",
                   section_title: "Boundary consistency",
                   methodology_id: "AR-ACM0003",
                   methodology_version: "v02-0",
-                  score: 0.84,
-                },
-              ],
-            }),
-            { status: 200 },
-          );
-        }
-        if (lower.includes("mapped area boundary") || lower.includes("project coordinates boundary") || lower.includes("project location boundary")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
-                {
-                  id: "R-1-0002",
-                  section_title: "Boundary consistency",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.82,
+                  score: 0.83,
                 },
                 {
                   id: "R-2-0001",
                   section_title: "Boundary delineation",
                   methodology_id: "AR-AMS0007",
                   methodology_version: "v01-0",
-                  score: 0.78,
+                  score: 0.81,
                 },
               ],
             }),
             { status: 200 },
           );
         }
-        if (lower.includes("monitoring data 5 plots")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
-                {
-                  id: "R-1-0004",
-                  section_title: "Workbook monitoring records",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.87,
-                },
-              ],
-            }),
-            { status: 200 },
-          );
-        }
-        if (lower.includes("2026-q1 monitoring records")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
-                {
-                  id: "R-1-0004",
-                  section_title: "Workbook monitoring records",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.89,
-                },
-              ],
-            }),
-            { status: 200 },
-          );
-        }
-        if (lower.includes("documented monitoring evidence")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [
-                {
-                  id: "R-1-0003",
-                  section_title: "Monitoring plan",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.82,
-                },
-                {
-                  id: "R-1-0004",
-                  section_title: "Workbook monitoring records",
-                  methodology_id: "AR-ACM0003",
-                  methodology_version: "v02-0",
-                  score: 0.8,
-                },
-              ],
-            }),
-            { status: 200 },
-          );
-        }
-        if (lower.includes("workbook referenced in pdd")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [],
-            }),
-            { status: 200 },
-          );
-        }
-        if (lower.includes("unsupported claim")) {
-          return new Response(
-            JSON.stringify({
-              engineTag: "test",
-              metrics: [],
-              results: [],
-            }),
-            { status: 200 },
-          );
-        }
-        return new Response(
-          JSON.stringify({
-            engineTag: "test",
-            metrics: [],
-            results: [
-              {
-                id: "baseline-carbon-44-12",
-                section_title: "Baseline carbon memo",
-                methodology_id: "AR-ACM0003",
-                methodology_version: "v02-0",
-                score: 0.99,
-              },
-              {
-                id: "R-1-0002",
-                section_title: "Boundary consistency",
-                methodology_id: "AR-ACM0003",
-                methodology_version: "v02-0",
-                score: 0.83,
-              },
-              {
-                id: "R-2-0001",
-                section_title: "Boundary delineation",
-                methodology_id: "AR-AMS0007",
-                methodology_version: "v01-0",
-                score: 0.81,
-              },
-            ],
-          }),
-          { status: 200 },
-        );
-      }
-      throw new Error(`Unhandled fetch ${url}`);
-    }) as typeof fetch;
+        throw new Error(`Unhandled fetch ${url}`);
+      },
+    ) as typeof fetch;
 
     window.localStorage.setItem(
       "pins:AR-ACM0003:v02-0",
@@ -808,6 +920,10 @@ describe("QuickCheckPanel claim-first flow", () => {
     container.remove();
     jest.clearAllMocks();
     window.localStorage.clear();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
   });
 
   function claimInput(): HTMLTextAreaElement {
@@ -815,31 +931,42 @@ describe("QuickCheckPanel claim-first flow", () => {
   }
 
   function primaryCta(): HTMLButtonElement {
-    return Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes("Run quick check")) as HTMLButtonElement;
+    return Array.from(container.querySelectorAll("button")).find((node) =>
+      node.textContent?.includes("Run quick check"),
+    ) as HTMLButtonElement;
   }
 
   function clickButton(label: string) {
-    const button = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes(label));
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (node) => node.textContent?.includes(label),
+    );
     expect(button).toBeTruthy();
     button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   }
 
   function clickButtonIfPresent(label: string) {
-    const button = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes(label));
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (node) => node.textContent?.includes(label),
+    );
     if (!button) return;
     button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   }
 
   function setClaimValue(value: string) {
     const input = claimInput();
-    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
     setter?.call(input, value);
     input.dispatchEvent(new Event("input", { bubbles: true }));
     input.dispatchEvent(new Event("change", { bubbles: true }));
   }
 
   async function uploadEvidence(file: File) {
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const input = container.querySelector(
+      'input[data-testid="quick-check-evidence-input"]',
+    ) as HTMLInputElement;
     Object.defineProperty(input, "files", {
       configurable: true,
       value: [file],
@@ -870,7 +997,9 @@ describe("QuickCheckPanel claim-first flow", () => {
   }
 
   async function openExtractionDetails() {
-    const button = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes("Show extraction details"));
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (node) => node.textContent?.includes("Show extraction details"),
+    );
     if (button) {
       await act(async () => {
         button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -884,8 +1013,16 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     const pageText = container.textContent ?? "";
+    expect(pageText).toContain("Start Review");
+    expect(pageText).toContain(
+      "Upload a PDD, monitoring report, or evidence file. Article6 will detect the project, method, and next review step.",
+    );
+    expect(pageText).toContain("Upload project document");
+    expect(pageText).toContain("Run a quick evidence check instead");
     expect(pageText).toContain("Quick Check");
-    expect(pageText).toContain("Upload evidence. Get a preliminary match in seconds.");
+    expect(pageText).toContain(
+      "Upload evidence. Get a preliminary match in seconds.",
+    );
     expect(pageText).toContain("Upload evidence");
     expect(pageText).toContain("Try demo check");
     expect(pageText).toContain("Options");
@@ -899,7 +1036,9 @@ describe("QuickCheckPanel claim-first flow", () => {
       root.render(<QuickCheckPanel />);
     });
 
-    const demoButton = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes("Try demo check"));
+    const demoButton = Array.from(container.querySelectorAll("button")).find(
+      (node) => node.textContent?.includes("Try demo check"),
+    );
     expect(demoButton).toBeTruthy();
     expect((demoButton as HTMLButtonElement).disabled).toBe(false);
     expect(primaryCta().disabled).toBe(true);
@@ -911,7 +1050,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     const chip = Array.from(container.querySelectorAll("button")).find((node) =>
-      node.textContent?.includes("The monitoring report covers the full reporting period."),
+      node.textContent?.includes(
+        "The monitoring report covers the full reporting period.",
+      ),
     );
     expect(chip).toBeTruthy();
 
@@ -919,12 +1060,16 @@ describe("QuickCheckPanel claim-first flow", () => {
       chip?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(claimInput().value).toBe("The monitoring report covers the full reporting period.");
+    expect(claimInput().value).toBe(
+      "The monitoring report covers the full reporting period.",
+    );
   });
 
   it("keeps the CTA disabled until claim and evidence are both present", async () => {
     await act(async () => {
-      root.render(<QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" />);
+      root.render(
+        <QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" />,
+      );
     });
 
     expect(primaryCta().disabled).toBe(true);
@@ -941,7 +1086,9 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     await uploadEvidence(
       new File(
-        ["%PDF-1.4\n(Monitoring report for the full reporting period. AR-ACM0003 methodology reference.)\n%%EOF"],
+        [
+          "%PDF-1.4\n(Monitoring report for the full reporting period. AR-ACM0003 methodology reference.)\n%%EOF",
+        ],
         "fresh-monitoring-report.pdf",
         { type: "application/pdf" },
       ),
@@ -954,7 +1101,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).toContain("Source");
     expect(container.textContent).toContain("Uploaded file");
     expect(container.textContent).toContain("Grounded");
-    expect(container.textContent).toContain("The project has documented monitoring evidence");
+    expect(container.textContent).toContain(
+      "The project has documented monitoring evidence",
+    );
     await openExtractionDetails();
     expect(container.textContent).toContain("Extraction signal");
     expect(container.textContent).toContain("AR-ACM0003");
@@ -976,7 +1125,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).not.toContain("Open full review");
     expect(container.textContent).not.toContain(QUICK_CHECK_DEMO.filename);
     expect(container.textContent).not.toContain("Match confidence");
-    expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
+    expect(container.textContent).not.toContain(
+      "The matched requirement could not be loaded.",
+    );
   });
 
   it("renders an extraction failure state when uploaded parsing yields insufficient data", async () => {
@@ -994,12 +1145,19 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).toContain("Weak");
     await openExtractionDetails();
     expect(container.textContent).toContain("Extraction signal");
-    expect(container.textContent).toContain("We couldn't extract enough usable data from this file for a reliable preliminary match yet.");
-    expect(container.textContent).toContain("We couldn't extract usable text from this file yet.");
+    expect(container.textContent).toContain(
+      "We couldn't extract enough usable data from this file for a reliable preliminary match yet.",
+    );
+    expect(container.textContent).toContain(
+      "We couldn't extract usable text from this file yet.",
+    );
   });
 
   it("shows a single fallback path when extraction stays weak", async () => {
-    seedSession({ claimText: "The monitoring report covers the full reporting period.", filename: "opaque-scan.pdf" });
+    seedSession({
+      claimText: "The monitoring report covers the full reporting period.",
+      filename: "opaque-scan.pdf",
+    });
     await seedAttachmentText("att-upload-1", "%%%%");
 
     await act(async () => {
@@ -1024,7 +1182,9 @@ describe("QuickCheckPanel claim-first flow", () => {
 
   it("enables the CTA only when one claim and one evidence item are present", async () => {
     await act(async () => {
-      root.render(<QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" />);
+      root.render(
+        <QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" />,
+      );
     });
 
     expect(primaryCta().disabled).toBe(true);
@@ -1038,7 +1198,9 @@ describe("QuickCheckPanel claim-first flow", () => {
       openOptions();
     });
 
-    const inventorySelect = container.querySelector("select") as HTMLSelectElement;
+    const inventorySelect = container.querySelector(
+      "select",
+    ) as HTMLSelectElement;
     await act(async () => {
       inventorySelect.value = "ev-1";
       inventorySelect.dispatchEvent(new Event("change", { bubbles: true }));
@@ -1054,14 +1216,22 @@ describe("QuickCheckPanel claim-first flow", () => {
     );
 
     await act(async () => {
-      root.render(<QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" onContinueToWorkspace={pushMock} />);
+      root.render(
+        <QuickCheckPanel
+          initialMethod="AR-ACM0003"
+          initialVersion="v02-0"
+          onContinueToWorkspace={pushMock}
+        />,
+      );
     });
 
     await act(async () => {
       openOptions();
     });
 
-    const inventorySelect = container.querySelector("select") as HTMLSelectElement;
+    const inventorySelect = container.querySelector(
+      "select",
+    ) as HTMLSelectElement;
 
     await act(async () => {
       clickButton("The monitoring report covers the full reporting period.");
@@ -1077,7 +1247,9 @@ describe("QuickCheckPanel claim-first flow", () => {
       clickButton("Run quick check");
     });
 
-    expect(container.textContent).toContain("The monitoring report covers the full reporting period.");
+    expect(container.textContent).toContain(
+      "The monitoring report covers the full reporting period.",
+    );
     expect(container.textContent).toContain("Likely requirement matches");
     expect(container.textContent).toContain("AR-ACM0003 · v02-0");
     expect(container.textContent).toContain("R-1-0001");
@@ -1096,7 +1268,9 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     // Compact triage card contract: verdict + claim + rationale + signal + one action
     const resultText = container.textContent ?? "";
-    expect(resultText).toMatch(/^(?!.*Preliminary match found)(?!.*Candidate from current catalog).*/); // old titles gone
+    expect(resultText).toMatch(
+      /^(?!.*Preliminary match found)(?!.*Candidate from current catalog).*/,
+    ); // old titles gone
     expect(resultText).toContain("Needs review");
     expect(resultText).toContain("Evidence found but inconclusive");
     expect(resultText).toContain("Open full review"); // one primary action
@@ -1112,9 +1286,13 @@ describe("QuickCheckPanel claim-first flow", () => {
       clickButton("Open full review");
     });
 
-    expect(pushMock).toHaveBeenCalledWith("/m/AR-ACM0003/v/v02-0?tab=verify&mode=list&rule=R-1-0001&quickCheckSource=saved_evidence");
+    expect(pushMock).toHaveBeenCalledWith(
+      "/m/AR-ACM0003/v/v02-0?tab=verify&mode=list&rule=R-1-0001&quickCheckSource=saved_evidence",
+    );
     expect(loadPins("AR-ACM0003", "v02-0")[0]?.ruleId).toBe("R-1-0001");
-    expect(window.localStorage.getItem("verify:AR-ACM0003:v02-0")).toContain("R-1-0001");
+    expect(window.localStorage.getItem("verify:AR-ACM0003:v02-0")).toContain(
+      "R-1-0001",
+    );
   });
 
   it("renders a strong evidence match as triage only and still hands off into full review", async () => {
@@ -1128,7 +1306,9 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     await uploadEvidence(
       new File(
-        ["%PDF-1.4\n(Monitoring report for the full reporting period. AR-ACM0003 methodology reference.)\n%%EOF"],
+        [
+          "%PDF-1.4\n(Monitoring report for the full reporting period. AR-ACM0003 methodology reference.)\n%%EOF",
+        ],
         "fresh-monitoring-report.pdf",
         { type: "application/pdf" },
       ),
@@ -1147,14 +1327,18 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     expect(container.textContent).toContain("Strong evidence match");
-    expect(container.textContent).toContain("Triage strength — open full review to lock");
+    expect(container.textContent).toContain(
+      "Triage strength — open full review to lock",
+    );
     expect(container.textContent).toContain("Open full review");
 
     await act(async () => {
       clickButton("Open full review");
     });
 
-    expect(pushMock).toHaveBeenCalledWith("/m/AR-ACM0003/v/v02-0?tab=verify&mode=list&rule=R-1-0001&quickCheckSource=uploaded_file");
+    expect(pushMock).toHaveBeenCalledWith(
+      "/m/AR-ACM0003/v/v02-0?tab=verify&mode=list&rule=R-1-0001&quickCheckSource=uploaded_file",
+    );
   });
 
   it("surfaces an in-scope boundary match instead of failing opaquely", async () => {
@@ -1163,7 +1347,8 @@ describe("QuickCheckPanel claim-first flow", () => {
       JSON.stringify({
         draft: {
           id: "draft-ambiguous",
-          claimText: "The boundary description matches the mapped project area.",
+          claimText:
+            "The boundary description matches the mapped project area.",
           methodologyId: "",
           methodologyVersion: "",
           evidenceIds: ["upload-1"],
@@ -1213,7 +1398,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(text).not.toContain("baseline-carbon-44-12");
     expect(text).not.toContain("Baseline carbon memo");
     expect(text).not.toContain("The matched requirement could not be loaded.");
-    expect(/Likely requirement matches|Supported|Needs review|Partial/.test(text)).toBe(true);
+    expect(
+      /Likely requirement matches|Supported|Needs review|Partial/.test(text),
+    ).toBe(true);
   });
 
   it("renders recovery actions when no clear match is found", async () => {
@@ -1239,12 +1426,20 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).not.toContain("Detected from evidence");
     expect(container.textContent).toContain("Monitoring plan");
     expect(container.textContent).toMatch(/Needs review|Partial|Supported/);
-    expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
+    expect(container.textContent).not.toContain(
+      "The matched requirement could not be loaded.",
+    );
   });
 
   it("returns a plausible result for a PDD boundary claim using parsed uploaded evidence", async () => {
-    seedSession({ claimText: "The project boundary is described in the PDD", filename: "malawi-pdd.pdf" });
-    await seedAttachmentText("att-upload-1", "%PDF-1.4\n(Project boundary description for the Malawi project.)\n%%EOF");
+    seedSession({
+      claimText: "The project boundary is described in the PDD",
+      filename: "malawi-pdd.pdf",
+    });
+    await seedAttachmentText(
+      "att-upload-1",
+      "%PDF-1.4\n(Project boundary description for the Malawi project.)\n%%EOF",
+    );
 
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -1263,8 +1458,14 @@ describe("QuickCheckPanel claim-first flow", () => {
   });
 
   it("falls back to a likely boundary match when retrieval misses but evidence facts are strong", async () => {
-    seedSession({ claimText: "local-fallback: The project boundary is described in the PDD", filename: "malawi-pdd.pdf" });
-    await seedAttachmentText("att-upload-1", "%PDF-1.4\n(Project boundary description for the Malawi project.)\n%%EOF");
+    seedSession({
+      claimText: "local-fallback: The project boundary is described in the PDD",
+      filename: "malawi-pdd.pdf",
+    });
+    await seedAttachmentText(
+      "att-upload-1",
+      "%PDF-1.4\n(Project boundary description for the Malawi project.)\n%%EOF",
+    );
 
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -1279,13 +1480,21 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     expect(container.textContent).toMatch(/Needs review|Partial|Supported/);
-    expect(container.textContent).toMatch(/Likely requirement matches|Supported|Needs review|Partial/);
+    expect(container.textContent).toMatch(
+      /Likely requirement matches|Supported|Needs review|Partial/,
+    );
     expect(container.textContent).not.toContain("No clear match yet");
   });
 
   it("returns a plausible result for a monitoring-plan claim using parsed uploaded evidence", async () => {
-    seedSession({ claimText: "The project has a documented monitoring plan", filename: "malawi-pdd.pdf" });
-    await seedAttachmentText("att-upload-1", "%PDF-1.4\n(Documented monitoring plan for the project.)\n%%EOF");
+    seedSession({
+      claimText: "The project has a documented monitoring plan",
+      filename: "malawi-pdd.pdf",
+    });
+    await seedAttachmentText(
+      "att-upload-1",
+      "%PDF-1.4\n(Documented monitoring plan for the project.)\n%%EOF",
+    );
 
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -1296,7 +1505,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     expect(container.textContent).toContain("Monitoring plan");
-    expect(container.textContent).toMatch(/Open full review|Likely requirement matches/);
+    expect(container.textContent).toMatch(
+      /Open full review|Likely requirement matches/,
+    );
   });
 
   it("returns a plausible result for a five-plots workbook claim", async () => {
@@ -1334,11 +1545,31 @@ describe("QuickCheckPanel claim-first flow", () => {
             row_count: 5,
             column_names: ["plot_id", "monitoring_period", "qa_status"],
             rows: [
-              { plot_id: "P-1", monitoring_period: "2026-Q1", qa_status: "checked" },
-              { plot_id: "P-2", monitoring_period: "2026-Q1", qa_status: "checked" },
-              { plot_id: "P-3", monitoring_period: "2026-Q1", qa_status: "checked" },
-              { plot_id: "P-4", monitoring_period: "2026-Q1", qa_status: "checked" },
-              { plot_id: "P-5", monitoring_period: "2026-Q1", qa_status: "checked" },
+              {
+                plot_id: "P-1",
+                monitoring_period: "2026-Q1",
+                qa_status: "checked",
+              },
+              {
+                plot_id: "P-2",
+                monitoring_period: "2026-Q1",
+                qa_status: "checked",
+              },
+              {
+                plot_id: "P-3",
+                monitoring_period: "2026-Q1",
+                qa_status: "checked",
+              },
+              {
+                plot_id: "P-4",
+                monitoring_period: "2026-Q1",
+                qa_status: "checked",
+              },
+              {
+                plot_id: "P-5",
+                monitoring_period: "2026-Q1",
+                qa_status: "checked",
+              },
             ],
             provenance_summary: "malawi-monitoring.csv • Monitoring • A1:C6",
           },
@@ -1423,7 +1654,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     );
 
     await act(async () => {
-      root.render(<QuickCheckPanel initialMethod="AR-AMS0007" initialVersion="v01-0" />);
+      root.render(
+        <QuickCheckPanel initialMethod="AR-AMS0007" initialVersion="v01-0" />,
+      );
     });
 
     await act(async () => {
@@ -1431,7 +1664,9 @@ describe("QuickCheckPanel claim-first flow", () => {
       openOptions();
     });
 
-    const inventorySelect = container.querySelector("select") as HTMLSelectElement;
+    const inventorySelect = container.querySelector(
+      "select",
+    ) as HTMLSelectElement;
     await act(async () => {
       inventorySelect.value = "ev-ams-1";
       inventorySelect.dispatchEvent(new Event("change", { bubbles: true }));
@@ -1453,7 +1688,8 @@ describe("QuickCheckPanel claim-first flow", () => {
       JSON.stringify({
         draft: {
           id: "draft-narrowed-shortlist",
-          claimText: "The boundary description matches the mapped project area.",
+          claimText:
+            "The boundary description matches the mapped project area.",
           methodologyId: "AR-ACM0003",
           methodologyVersion: "v02-0",
           evidenceIds: ["upload-1"],
@@ -1534,12 +1770,16 @@ describe("QuickCheckPanel claim-first flow", () => {
 
   it("shows a blocked state when Kenya extraction is usable but AR-AM0014 has no valid analysis path", async () => {
     seedSession({
-      claimText: "kenya no valid analysis path: The monitoring report covers the full reporting period.",
+      claimText:
+        "kenya no valid analysis path: The monitoring report covers the full reporting period.",
       methodologyId: "AR-AM0014",
       methodologyVersion: "v03-0",
       filename: "kenya-second-check-evidence.pdf",
     });
-    await seedAttachmentFixture("att-upload-1", "kenya-second-check-evidence.pdf");
+    await seedAttachmentFixture(
+      "att-upload-1",
+      "kenya-second-check-evidence.pdf",
+    );
 
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -1591,7 +1831,9 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     const text = container.textContent ?? "";
     expect(text).toContain("No valid match in AR-AMS0007");
-    expect(text).toContain("selected methodology did not produce a valid requirement match");
+    expect(text).toContain(
+      "selected methodology did not produce a valid requirement match",
+    );
     expect(text).toContain("Likely requirement matches");
     expect(text).toMatch(/Supported|Needs review|Partial|Open full review/);
     expect(text).toContain("AR-ACM0003 · v02-0");
@@ -1600,10 +1842,14 @@ describe("QuickCheckPanel claim-first flow", () => {
 
   it("asks for methodology confirmation instead of auto-narrowing Kenya evidence across methods", async () => {
     seedSession({
-      claimText: "kenya cross-method confirmation: The monitoring report covers the full reporting period.",
+      claimText:
+        "kenya cross-method confirmation: The monitoring report covers the full reporting period.",
       filename: "kenya-second-check-evidence.pdf",
     });
-    await seedAttachmentFixture("att-upload-1", "kenya-second-check-evidence.pdf");
+    await seedAttachmentFixture(
+      "att-upload-1",
+      "kenya-second-check-evidence.pdf",
+    );
 
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -1621,7 +1867,9 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     const text = container.textContent ?? "";
     expect(text).toContain("Methodology needs confirmation");
-    expect(text).toContain("closest supported matches still span multiple methodologies");
+    expect(text).toContain(
+      "closest supported matches still span multiple methodologies",
+    );
     expect(text).toContain("Likely requirement matches");
     expect(text).toContain("AR-AM0014 · v03-0");
     expect(text).toContain("AR-ACM0003 · v02-0");
@@ -1633,7 +1881,10 @@ describe("QuickCheckPanel claim-first flow", () => {
       claimText: "The monitoring report covers the full reporting period.",
       filename: "kenya-second-check-evidence.pdf",
     });
-    await seedAttachmentFixture("att-upload-1", "kenya-second-check-evidence.pdf");
+    await seedAttachmentFixture(
+      "att-upload-1",
+      "kenya-second-check-evidence.pdf",
+    );
 
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -1656,8 +1907,14 @@ describe("QuickCheckPanel claim-first flow", () => {
   });
 
   it("falls back safely when the top direct-match candidate is unresolved", async () => {
-    seedSession({ claimText: "invalid top candidate", filename: "monitoring-report.pdf" });
-    await seedAttachmentText("att-upload-1", "%PDF-1.4\n(Monitoring report for the reporting period.)\n%%EOF");
+    seedSession({
+      claimText: "invalid top candidate",
+      filename: "monitoring-report.pdf",
+    });
+    await seedAttachmentText(
+      "att-upload-1",
+      "%PDF-1.4\n(Monitoring report for the reporting period.)\n%%EOF",
+    );
 
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -1678,8 +1935,14 @@ describe("QuickCheckPanel claim-first flow", () => {
   });
 
   it("filters unresolved shortlist entries before rendering them", async () => {
-    seedSession({ claimText: "shortlist with unresolved", filename: "boundary.pdf" });
-    await seedAttachmentText("att-upload-1", "%PDF-1.4\n(Project boundary description for the Malawi project.)\n%%EOF");
+    seedSession({
+      claimText: "shortlist with unresolved",
+      filename: "boundary.pdf",
+    });
+    await seedAttachmentText(
+      "att-upload-1",
+      "%PDF-1.4\n(Project boundary description for the Malawi project.)\n%%EOF",
+    );
 
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -1711,13 +1974,17 @@ describe("QuickCheckPanel claim-first flow", () => {
     );
 
     await act(async () => {
-      root.render(<QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" />);
+      root.render(
+        <QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" />,
+      );
     });
 
     await act(async () => {
       openOptions();
     });
-    const inventorySelect = container.querySelector("select") as HTMLSelectElement;
+    const inventorySelect = container.querySelector(
+      "select",
+    ) as HTMLSelectElement;
     await act(async () => {
       inventorySelect.value = "ev-pdd-malawi";
       inventorySelect.dispatchEvent(new Event("change", { bubbles: true }));
@@ -1748,13 +2015,17 @@ describe("QuickCheckPanel claim-first flow", () => {
     );
 
     await act(async () => {
-      root.render(<QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" />);
+      root.render(
+        <QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" />,
+      );
     });
 
     await act(async () => {
       openOptions();
     });
-    const inventorySelect = container.querySelector("select") as HTMLSelectElement;
+    const inventorySelect = container.querySelector(
+      "select",
+    ) as HTMLSelectElement;
     await act(async () => {
       inventorySelect.value = "ev-pdd-malawi";
       inventorySelect.dispatchEvent(new Event("change", { bubbles: true }));
@@ -1784,13 +2055,17 @@ describe("QuickCheckPanel claim-first flow", () => {
     );
 
     await act(async () => {
-      root.render(<QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" />);
+      root.render(
+        <QuickCheckPanel initialMethod="AR-ACM0003" initialVersion="v02-0" />,
+      );
     });
 
     await act(async () => {
       openOptions();
     });
-    const inventorySelect = container.querySelector("select") as HTMLSelectElement;
+    const inventorySelect = container.querySelector(
+      "select",
+    ) as HTMLSelectElement;
     await act(async () => {
       inventorySelect.value = "ev-pdd-malawi";
       inventorySelect.dispatchEvent(new Event("change", { bubbles: true }));
@@ -1806,7 +2081,10 @@ describe("QuickCheckPanel claim-first flow", () => {
     await flushUi();
 
     const text = container.textContent ?? "";
-    if (text.includes("Likely requirement matches") || text.includes("Boundary consistency")) {
+    if (
+      text.includes("Likely requirement matches") ||
+      text.includes("Boundary consistency")
+    ) {
       expect(text).not.toContain("Boundary delineation");
       expect(text).not.toContain("Baseline carbon memo");
       return;
@@ -1830,7 +2108,7 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     expect(container.textContent).toContain(QUICK_CHECK_DEMO.claimText);
     expect(container.textContent).toContain("Needs review");
-    
+
     // Compact triage card contract
     const demoText = container.textContent ?? "";
     expect(demoText).toContain("Needs review");
@@ -1842,7 +2120,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(demoText).not.toContain("What we found in the file");
     expect(demoText).not.toContain("What remains unresolved");
     expect(demoText).not.toContain("Upload stronger evidence");
-    expect(demoText).not.toContain("The matched requirement could not be loaded.");
+    expect(demoText).not.toContain(
+      "The matched requirement could not be loaded.",
+    );
   });
 
   it("preserves demo context when opening the full review", async () => {
@@ -1862,14 +2142,27 @@ describe("QuickCheckPanel claim-first flow", () => {
       clickButton("Open full review");
     });
 
-    expect(pushMock).toHaveBeenCalledWith("/m/AR-ACM0003/v/v02-0?tab=verify&mode=list&rule=R-1-0001&quickCheckSource=demo_evidence");
-    expect(loadPins("AR-ACM0003", "v02-0").find((pin) => pin.id === QUICK_CHECK_DEMO.evidenceId)?.ruleId).toBe("R-1-0001");
-    expect(window.localStorage.getItem("verify:AR-ACM0003:v02-0")).toContain("R-1-0001");
-    expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
+    expect(pushMock).toHaveBeenCalledWith(
+      "/m/AR-ACM0003/v/v02-0?tab=verify&mode=list&rule=R-1-0001&quickCheckSource=demo_evidence",
+    );
+    expect(
+      loadPins("AR-ACM0003", "v02-0").find(
+        (pin) => pin.id === QUICK_CHECK_DEMO.evidenceId,
+      )?.ruleId,
+    ).toBe("R-1-0001");
+    expect(window.localStorage.getItem("verify:AR-ACM0003:v02-0")).toContain(
+      "R-1-0001",
+    );
+    expect(container.textContent).not.toContain(
+      "The matched requirement could not be loaded.",
+    );
   });
 
   it("keeps the uploaded-evidence path working after adding the demo shortcut", async () => {
-    seedSession({ claimText: "The monitoring report covers the full reporting period.", filename: "monitoring-report.pdf" });
+    seedSession({
+      claimText: "The monitoring report covers the full reporting period.",
+      filename: "monitoring-report.pdf",
+    });
 
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -1893,7 +2186,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).toContain("Use match");
     expect(container.textContent).not.toContain("Open full review");
     expect(container.textContent).toContain("monitoring-report.pdf");
-    expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
+    expect(container.textContent).not.toContain(
+      "The matched requirement could not be loaded.",
+    );
   });
 
   it("keeps repeated demo runs deterministic", async () => {
@@ -1909,9 +2204,13 @@ describe("QuickCheckPanel claim-first flow", () => {
       await Promise.resolve();
     });
 
-    const firstPins = loadPins("AR-ACM0003", "v02-0").filter((pin) => pin.id === QUICK_CHECK_DEMO.evidenceId);
+    const firstPins = loadPins("AR-ACM0003", "v02-0").filter(
+      (pin) => pin.id === QUICK_CHECK_DEMO.evidenceId,
+    );
     expect(firstPins).toHaveLength(1);
-    expect(container.textContent).toMatch(/Supported|Needs review|Partial|Open full review/);
+    expect(container.textContent).toMatch(
+      /Supported|Needs review|Partial|Open full review/,
+    );
 
     await act(async () => {
       clickButton("Try demo check");
@@ -1921,13 +2220,19 @@ describe("QuickCheckPanel claim-first flow", () => {
       await Promise.resolve();
     });
 
-    const repeatedPins = loadPins("AR-ACM0003", "v02-0").filter((pin) => pin.id === QUICK_CHECK_DEMO.evidenceId);
+    const repeatedPins = loadPins("AR-ACM0003", "v02-0").filter(
+      (pin) => pin.id === QUICK_CHECK_DEMO.evidenceId,
+    );
     expect(repeatedPins).toHaveLength(1);
     expect(container.textContent).toContain(QUICK_CHECK_DEMO.claimText);
-    expect(container.textContent).toMatch(/Supported|Needs review|Partial|Open full review/);
+    expect(container.textContent).toMatch(
+      /Supported|Needs review|Partial|Open full review/,
+    );
     expect(container.textContent).not.toContain("Likely requirement matches");
     expect(container.textContent).not.toContain("No clear match yet");
-    expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
+    expect(container.textContent).not.toContain(
+      "The matched requirement could not be loaded.",
+    );
   });
 
   it("keeps the demo result stable across a reload", async () => {
@@ -1942,7 +2247,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     await flushUi();
 
     expect(container.textContent).toContain(QUICK_CHECK_DEMO.claimText);
-    expect(container.textContent).toMatch(/Supported|Needs review|Partial|Open full review/);
+    expect(container.textContent).toMatch(
+      /Supported|Needs review|Partial|Open full review/,
+    );
 
     await act(async () => {
       root.unmount();
@@ -1962,13 +2269,17 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     expect(claimInput().value).toBe(QUICK_CHECK_DEMO.claimText);
     expect(container.textContent).toContain("Needs review");
-    expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
+    expect(container.textContent).not.toContain(
+      "The matched requirement could not be loaded.",
+    );
 
     await act(async () => {
       clickButton("Open full review");
     });
 
-    expect(pushMock).toHaveBeenLastCalledWith("/m/AR-ACM0003/v/v02-0?tab=verify&mode=list&rule=R-1-0001&quickCheckSource=demo_evidence");
+    expect(pushMock).toHaveBeenLastCalledWith(
+      "/m/AR-ACM0003/v/v02-0?tab=verify&mode=list&rule=R-1-0001&quickCheckSource=demo_evidence",
+    );
   });
 
   it("ignores prior manual edits when running the demo", async () => {
@@ -1996,8 +2307,12 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(claimInput().value).toBe(QUICK_CHECK_DEMO.claimText);
     expect(container.textContent).toContain(QUICK_CHECK_DEMO.filename);
     expect(container.textContent).not.toContain("manual-boundary-note.pdf");
-    expect(container.textContent).toMatch(/Supported|Needs review|Partial|Open full review/);
-    expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
+    expect(container.textContent).toMatch(
+      /Supported|Needs review|Partial|Open full review/,
+    );
+    expect(container.textContent).not.toContain(
+      "The matched requirement could not be loaded.",
+    );
   });
 
   it("replaces a prior no-match state with the same demo result", async () => {
@@ -2030,7 +2345,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).toContain("Open full review");
     expect(container.textContent).toContain("Open full review");
     expect(container.textContent).not.toContain("Likely requirement matches");
-    expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
+    expect(container.textContent).not.toContain(
+      "The matched requirement could not be loaded.",
+    );
   });
 
   it("shows methodology not detected as a distinct extraction diagnostic", async () => {
@@ -2075,7 +2392,9 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     const text = container.textContent ?? "";
     expect(text).toContain("Selected methodology mismatch");
-    expect(text).toContain("Evidence appears to reference VM0007, but current selected method is ACM0010.");
+    expect(text).toContain(
+      "Evidence appears to reference VM0007, but current selected method is ACM0010.",
+    );
   });
 
   it("narrows a PLUM boundary claim to VM0007 candidates only", async () => {
@@ -2089,7 +2408,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
+    expect(container.textContent).toContain(
+      "Detected methodology: VM0007. Requirement matches are narrowed to VM0007.",
+    );
 
     await act(async () => {
       clickButton("Run quick check");
@@ -2120,7 +2441,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
+    expect(container.textContent).toContain(
+      "Detected methodology: VM0007. Requirement matches are narrowed to VM0007.",
+    );
 
     await act(async () => {
       clickButton("Run quick check");
@@ -2151,7 +2474,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
+    expect(container.textContent).toContain(
+      "Detected methodology: VM0007. Requirement matches are narrowed to VM0007.",
+    );
 
     await act(async () => {
       clickButton("Run quick check");
@@ -2164,7 +2489,9 @@ describe("QuickCheckPanel claim-first flow", () => {
       clickButton("Open full review");
     });
 
-    expect(pushMock).toHaveBeenLastCalledWith("/m/VM0007/v/v1-0?tab=verify&mode=list");
+    expect(pushMock).toHaveBeenLastCalledWith(
+      "/m/VM0007/v/v1-0?tab=verify&mode=list",
+    );
   });
 
   it("requires methodology confirmation when multiple detected methods are present", async () => {
@@ -2178,7 +2505,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Methodology needs confirmation. Requirement matches are limited to VM0007, GS-VER1.");
+    expect(container.textContent).toContain(
+      "Methodology needs confirmation. Requirement matches are limited to VM0007, GS-VER1.",
+    );
 
     await act(async () => {
       clickButton("Run quick check");
@@ -2203,7 +2532,9 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Detected ACM0010, but no matching method pack is available.");
+    expect(container.textContent).toContain(
+      "Detected ACM0010, but no matching method pack is available.",
+    );
 
     await act(async () => {
       clickButton("Run quick check");
@@ -2211,7 +2542,9 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     await flushUi();
     const text = container.textContent ?? "";
-    expect(text).toContain("Detected ACM0010, but no matching method pack is available.");
+    expect(text).toContain(
+      "Detected ACM0010, but no matching method pack is available.",
+    );
     expect(text).not.toContain("Likely requirement matches");
     expect(text).not.toContain("Monitoring frequency");
   });
@@ -2227,6 +2560,8 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("No methodology detected. Requirement matches use broad matching and may be unrelated.");
+    expect(container.textContent).toContain(
+      "No methodology detected. Requirement matches use broad matching and may be unrelated.",
+    );
   });
 });

--- a/tests/components/quickCheckPanel.upload-regression.test.tsx
+++ b/tests/components/quickCheckPanel.upload-regression.test.tsx
@@ -35,6 +35,8 @@ import QuickCheckPanel from "@/components/chat/QuickCheckPanel";
 describe("QuickCheckPanel upload regression", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
+  const originalLocation = window.location;
+  const assignMock = jest.fn();
 
   function asArrayBuffer(value: Uint8Array): ArrayBuffer {
     return value.buffer.slice(
@@ -45,7 +47,7 @@ describe("QuickCheckPanel upload regression", () => {
 
   async function uploadEvidence(file: File) {
     const input = container.querySelector(
-      'input[type="file"]',
+      'input[data-testid="quick-check-evidence-input"]',
     ) as HTMLInputElement;
     Object.defineProperty(input, "files", {
       configurable: true,
@@ -76,6 +78,12 @@ describe("QuickCheckPanel upload regression", () => {
     document.body.appendChild(container);
     root = createRoot(container);
     window.localStorage.clear();
+    delete (window as Partial<Window>).location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, assign: assignMock },
+    });
+    assignMock.mockReset();
 
     createAndStoreEvidenceAttachmentMock.mockReset();
     createAndStoreEvidenceAttachmentMock.mockImplementation(
@@ -204,6 +212,10 @@ describe("QuickCheckPanel upload regression", () => {
     container.remove();
     jest.clearAllMocks();
     window.localStorage.clear();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
   });
 
   it("clears stale recovery UI as soon as a new upload replaces the prior evidence", async () => {

--- a/tests/components/quickCheckPanel.upload-regression.test.tsx
+++ b/tests/components/quickCheckPanel.upload-regression.test.tsx
@@ -1,6 +1,13 @@
 /** @jest-environment jsdom */
 
-import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { putAttachmentBytes } from "@/lib/proofMap/attachments";
@@ -9,7 +16,8 @@ const createAndStoreEvidenceAttachmentMock = jest.fn();
 
 jest.mock("@/lib/proofMap/attachments", () => ({
   ...jest.requireActual("@/lib/proofMap/attachments"),
-  createAndStoreEvidenceAttachment: (...args: unknown[]) => createAndStoreEvidenceAttachmentMock(...args),
+  createAndStoreEvidenceAttachment: (...args: unknown[]) =>
+    createAndStoreEvidenceAttachmentMock(...args),
 }));
 
 jest.mock("@/lib/chat/quickCheckPdfClient", () => ({
@@ -29,11 +37,16 @@ describe("QuickCheckPanel upload regression", () => {
   let root: ReturnType<typeof createRoot>;
 
   function asArrayBuffer(value: Uint8Array): ArrayBuffer {
-    return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+    return value.buffer.slice(
+      value.byteOffset,
+      value.byteOffset + value.byteLength,
+    );
   }
 
   async function uploadEvidence(file: File) {
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
     Object.defineProperty(input, "files", {
       configurable: true,
       value: [file],
@@ -51,7 +64,9 @@ describe("QuickCheckPanel upload regression", () => {
   }
 
   function clickButton(label: string) {
-    const button = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes(label));
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (node) => node.textContent?.includes(label),
+    );
     expect(button).toBeTruthy();
     button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   }
@@ -63,79 +78,89 @@ describe("QuickCheckPanel upload regression", () => {
     window.localStorage.clear();
 
     createAndStoreEvidenceAttachmentMock.mockReset();
-    createAndStoreEvidenceAttachmentMock.mockImplementation(async (input: { pin_id: string; file: File }) => {
-      const bytes = new Uint8Array(await input.file.arrayBuffer());
-      const attachment = {
-        id: `att-${input.pin_id}`,
-        pin_id: input.pin_id,
-        filename: input.file.name,
-        mime: input.file.type || "application/pdf",
-        size: bytes.byteLength,
-        sha256: `sha-${input.pin_id}`,
-        created_at: "2026-04-04T00:00:00Z",
-      };
-      await putAttachmentBytes(attachment.id, asArrayBuffer(bytes));
-      return { ok: true, attachment };
-    });
+    createAndStoreEvidenceAttachmentMock.mockImplementation(
+      async (input: { pin_id: string; file: File }) => {
+        const bytes = new Uint8Array(await input.file.arrayBuffer());
+        const attachment = {
+          id: `att-${input.pin_id}`,
+          pin_id: input.pin_id,
+          filename: input.file.name,
+          mime: input.file.type || "application/pdf",
+          size: bytes.byteLength,
+          sha256: `sha-${input.pin_id}`,
+          created_at: "2026-04-04T00:00:00Z",
+        };
+        await putAttachmentBytes(attachment.id, asArrayBuffer(bytes));
+        return { ok: true, attachment };
+      },
+    );
 
-    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url.includes("/api/methods/inventory")) {
-        return new Response(
-          JSON.stringify({
-            methods: [{ code: "AR-ACM0003", latestVersion: "v02-0", versions: ["v02-0"] }],
-          }),
-          { status: 200 },
-        );
-      }
-      if (url.includes("/api/quick-check/pdf-extract")) {
-        const headers = new Headers(init?.headers);
-        const encodedFilename = headers.get("x-article6-filename") ?? "";
-        const filename = decodeURIComponent(encodedFilename);
-        return new Response(
-          JSON.stringify({
-            text:
-              filename === "fresh-monitoring-report.pdf"
-                ? "Monitoring report for the full reporting period. AR-ACM0003 methodology reference."
-                : "",
-            engine: "pdf-parse",
-            metadata: {
-              parser: "pdf-parse",
-            },
-          }),
-          { status: 200 },
-        );
-      }
-      if (url.includes("/api/methods/AR-ACM0003/v/v02-0/rules")) {
-        return new Response(
-          JSON.stringify({
-            rules: [
-              {
-                id: "R-1-0001",
-                title: "Monitoring frequency",
-                snippet: "Maintain a monitoring report.",
-                summary: "Maintain a monitoring report.",
-                logic: "Review the report for the reporting period.",
-                tags: [],
-                expectedEvidence: ["monitoring-report"],
+    global.fetch = jest.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/api/methods/inventory")) {
+          return new Response(
+            JSON.stringify({
+              methods: [
+                {
+                  code: "AR-ACM0003",
+                  latestVersion: "v02-0",
+                  versions: ["v02-0"],
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/api/quick-check/pdf-extract")) {
+          const headers = new Headers(init?.headers);
+          const encodedFilename = headers.get("x-article6-filename") ?? "";
+          const filename = decodeURIComponent(encodedFilename);
+          return new Response(
+            JSON.stringify({
+              text:
+                filename === "fresh-monitoring-report.pdf"
+                  ? "Monitoring report for the full reporting period. AR-ACM0003 methodology reference."
+                  : "",
+              engine: "pdf-parse",
+              metadata: {
+                parser: "pdf-parse",
               },
-            ],
-          }),
-          { status: 200 },
-        );
-      }
-      if (url.includes("/api/query?text=")) {
-        return new Response(
-          JSON.stringify({
-            engineTag: "test",
-            metrics: [],
-            results: [],
-          }),
-          { status: 200 },
-        );
-      }
-      throw new Error(`Unhandled fetch ${url}`);
-    }) as typeof fetch;
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/api/methods/AR-ACM0003/v/v02-0/rules")) {
+          return new Response(
+            JSON.stringify({
+              rules: [
+                {
+                  id: "R-1-0001",
+                  title: "Monitoring frequency",
+                  snippet: "Maintain a monitoring report.",
+                  summary: "Maintain a monitoring report.",
+                  logic: "Review the report for the reporting period.",
+                  tags: [],
+                  expectedEvidence: ["monitoring-report"],
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/api/query?text=")) {
+          return new Response(
+            JSON.stringify({
+              engineTag: "test",
+              metrics: [],
+              results: [],
+            }),
+            { status: 200 },
+          );
+        }
+        throw new Error(`Unhandled fetch ${url}`);
+      },
+    ) as typeof fetch;
 
     window.localStorage.setItem(
       "a6:quick-check:claim-first:v1",
@@ -182,7 +207,10 @@ describe("QuickCheckPanel upload regression", () => {
   });
 
   it("clears stale recovery UI as soon as a new upload replaces the prior evidence", async () => {
-    await putAttachmentBytes("att-upload-1", asArrayBuffer(new TextEncoder().encode("%%%%")));
+    await putAttachmentBytes(
+      "att-upload-1",
+      asArrayBuffer(new TextEncoder().encode("%%%%")),
+    );
 
     await act(async () => {
       root.render(<QuickCheckPanel />);
@@ -200,7 +228,9 @@ describe("QuickCheckPanel upload regression", () => {
 
     await uploadEvidence(
       new File(
-        ["%PDF-1.4\n(Monitoring report for the full reporting period. AR-ACM0003 methodology reference.)\n%%EOF"],
+        [
+          "%PDF-1.4\n(Monitoring report for the full reporting period. AR-ACM0003 methodology reference.)\n%%EOF",
+        ],
         "fresh-monitoring-report.pdf",
         { type: "application/pdf" },
       ),
@@ -211,6 +241,9 @@ describe("QuickCheckPanel upload regression", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("fresh-monitoring-report.pdf");
     expect(text).toContain("Extraction preview");
+    expect(text).toContain("Review detected details");
+    expect(text).toContain("Start review from this document");
+    expect(text).not.toContain("Project setup");
     expect(text).not.toContain("Weak extraction");
   });
 });

--- a/tests/components/quickCheckPanel.upload-regression.test.tsx
+++ b/tests/components/quickCheckPanel.upload-regression.test.tsx
@@ -225,7 +225,20 @@ describe("QuickCheckPanel upload regression", () => {
     );
 
     await act(async () => {
-      root.render(<QuickCheckPanel />);
+      root.render(<QuickCheckPanel collapseQuickEvidenceByDefault />);
+    });
+
+    await flushUi();
+
+    expect(container.textContent).toContain("Start Review");
+    expect(container.textContent).toContain("Upload project document");
+    expect(container.textContent).toContain(
+      "Run a quick evidence check instead",
+    );
+    expect(container.textContent).not.toContain("Quick Check");
+
+    await act(async () => {
+      clickButton("Run a quick evidence check instead");
     });
 
     await flushUi();

--- a/tests/lib/primaryNav.test.ts
+++ b/tests/lib/primaryNav.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "@jest/globals";
+import { getPrimaryNavKey } from "@/lib/nav/primaryNav";
+
+describe("getPrimaryNavKey", () => {
+  it("activates Start Review only on /start-review", () => {
+    expect(getPrimaryNavKey("/start-review")).toBe("start-review");
+    expect(getPrimaryNavKey("/start-review/next")).toBeNull();
+    expect(getPrimaryNavKey("/")).toBeNull();
+  });
+
+  it("activates Projects only on the index and single project detail routes", () => {
+    expect(getPrimaryNavKey("/projects")).toBe("projects");
+    expect(getPrimaryNavKey("/projects/proj-123")).toBe("projects");
+    expect(getPrimaryNavKey("/projects/new")).toBeNull();
+    expect(getPrimaryNavKey("/projects/proj-123/review")).toBeNull();
+  });
+
+  it("activates Methods only on /methods", () => {
+    expect(getPrimaryNavKey("/methods")).toBe("methods");
+    expect(getPrimaryNavKey("/m")).toBeNull();
+    expect(getPrimaryNavKey("/methods/VM0007")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed
- add automatic metadata extraction for uploaded project documents, including project title, country, registry/project ID, methodology, standard, proponent, document type, version, and document date
- preserve extraction provenance and confidence labels in a pending project-document draft model
- add a `Create project from document` handoff from Quick Check and post-PDD upload in the verify workspace
- extend the new project form to prefill editable fields, require explicit user confirmation, and support attaching the document to an existing matched project
- surface saved document metadata on project detail and add regression coverage for the new handoff path

## Why
- project setup after PDD and Quick Check intake was too manual
- the workflow needed a reviewer-defensible draft step instead of ending at evidence assessment only
- provenance and confidence labels are required to keep auto-prefill truthful and auditable

## User impact
- users can move from uploaded source documents into project creation faster
- project records are not created silently; the user must confirm or attach to an existing project
- extracted values remain editable before save

## Validation
- `npm test -- --runTestsByPath tests/components/projects/NewProjectForm.document-handoff.test.tsx tests/components/projects/NewProjectForm.handoff.test.tsx tests/components/projects/NewProjectForm.test.tsx tests/components/quickCheckPanel.test.tsx --runInBand`
- `npx tsc --noEmit` was previously run successfully in the main checkout before the PR branch was cut