### PR TITLE
[codex] Build home and quick check product flow

### DIFF
--- a/src/app/m/_components/MethodDetailPane.tsx
+++ b/src/app/m/_components/MethodDetailPane.tsx
@@ -1515,7 +1515,7 @@ export default function MethodDetailPane({
               Change project
             </Link>
             <Link
-              href={linkedProjectId ? `/m?projectId=${encodeURIComponent(linkedProjectId)}` : "/m"}
+              href={linkedProjectId ? `/methods?projectId=${encodeURIComponent(linkedProjectId)}` : "/methods"}
               className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
             >
               Change methodology/version
@@ -1625,6 +1625,14 @@ export default function MethodDetailPane({
       </div>
 
       <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+        {activeVersion ? (
+          <Link
+            href={`/quick-check?method=${encodeURIComponent(method.code)}&version=${encodeURIComponent(activeVersion)}`}
+            className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:border-slate-300 hover:text-slate-900"
+          >
+            Quick check with this method
+          </Link>
+        ) : null}
         {isEvidenceMode ? (
           <Link
             href={buildVerifyHref()}

--- a/src/app/m/_components/MethodsFinder.tsx
+++ b/src/app/m/_components/MethodsFinder.tsx
@@ -97,9 +97,9 @@ export default async function MethodsFinder({
     <main className="min-h-screen bg-slate-50">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-8 md:px-8">
         <header className="flex flex-col gap-1">
-          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Method Library</h1>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Methods</h1>
           <p className="text-sm text-slate-600">
-            Select a methodology to begin review.
+            Browse methodology packs, inspect versions, and jump back into Quick Check with the method you want to test.
           </p>
         </header>
 

--- a/src/app/m/page.tsx
+++ b/src/app/m/page.tsx
@@ -1,11 +1,5 @@
-import type { Metadata } from "next";
-import MethodsFinder from "@/app/m/_components/MethodsFinder";
+import { redirect } from "next/navigation";
 
-export const metadata: Metadata = {
-  title: "Methods | app.article6",
-  description: "Methods-first inventory finder.",
-};
-
-export default function MethodsInventoryPage() {
-  return <MethodsFinder />;
+export default function LegacyMethodsPage() {
+  redirect("/methods");
 }

--- a/src/app/methods/page.tsx
+++ b/src/app/methods/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import MethodsFinder from "@/app/m/_components/MethodsFinder";
+
+export const metadata: Metadata = {
+  title: "Methods | app.article6",
+  description: "Browse carbon project methodologies and open a method review.",
+};
+
+export default function MethodsPage() {
+  return <MethodsFinder />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,62 @@
-import React from "react";
-import { Suspense } from "react";
-import ChatApp from "@/components/chat/ChatApp";
+import Link from "next/link";
 
-export default function Page() {
+export default function HomePage() {
   return (
-    <main className="min-h-screen bg-[#f9f9f9]">
-      <Suspense
-        fallback={
-          <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-12 md:px-8">
-            <div className="h-6 w-56 animate-pulse rounded-full bg-slate-200" />
-            <div className="h-4 w-full animate-pulse rounded-full bg-slate-200" />
-            <div className="h-4 w-3/4 animate-pulse rounded-full bg-slate-200" />
+    <main className="min-h-screen bg-slate-50">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-16 md:px-8 md:py-20">
+        <section className="rounded-[2rem] border border-slate-200 bg-white px-6 py-10 shadow-sm md:px-10 md:py-14">
+          <div className="max-w-3xl">
+            <h1 className="text-4xl font-semibold tracking-tight text-slate-950 md:text-5xl">
+              Review carbon project documents faster.
+            </h1>
+            <p className="mt-4 max-w-2xl text-base leading-7 text-slate-600">
+              Upload a PDD, monitoring report, or evidence file. Article6 extracts project metadata,
+              identifies the method, and helps prepare a review-ready project record.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                href="/quick-check"
+                className="inline-flex items-center rounded-full bg-black px-5 py-3 text-sm font-semibold text-white hover:bg-neutral-900"
+              >
+                Quick Check
+              </Link>
+              <Link
+                href="/projects"
+                className="inline-flex items-center rounded-full border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+              >
+                Open Projects
+              </Link>
+              <Link
+                href="/methods"
+                className="inline-flex items-center rounded-full border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+              >
+                Browse Methods
+              </Link>
+            </div>
           </div>
-        }
-      >
-        <ChatApp />
-      </Suspense>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-3">
+          <article className="rounded-[1.5rem] border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-900">Check a document</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Upload a PDD, monitoring report, or evidence file and see what Article6 can extract.
+            </p>
+          </article>
+          <article className="rounded-[1.5rem] border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-900">Create a project draft</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Use extracted metadata to start a project record with reviewer confirmation.
+            </p>
+          </article>
+          <article className="rounded-[1.5rem] border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-900">Continue review work</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Open saved projects, evidence maps, rule reviews, and exportable records.
+            </p>
+          </article>
+        </section>
+      </div>
     </main>
   );
 }

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import NewProjectForm from '@/components/projects/NewProjectForm';
 
 export const metadata: Metadata = {
-  title: 'New Project Review | app.article6',
+  title: 'New Manual Project | app.article6',
 };
 
 export default function NewProjectPage() {

--- a/src/app/quick-check/page.tsx
+++ b/src/app/quick-check/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+import ChatApp from "@/components/chat/ChatApp";
+
+export const metadata: Metadata = {
+  title: "Quick Check | app.article6",
+  description: "Upload a carbon project document and check what it can support.",
+};
+
+export default function QuickCheckPage() {
+  return (
+    <main className="min-h-screen bg-slate-50">
+      <Suspense
+        fallback={
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-12 md:px-8">
+            <div className="h-6 w-56 animate-pulse rounded-full bg-slate-200" />
+            <div className="h-4 w-full animate-pulse rounded-full bg-slate-200" />
+            <div className="h-4 w-3/4 animate-pulse rounded-full bg-slate-200" />
+          </div>
+        }
+      >
+        <ChatApp />
+      </Suspense>
+    </main>
+  );
+}

--- a/src/components/DemoNav.tsx
+++ b/src/components/DemoNav.tsx
@@ -2,27 +2,15 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-
-type DemoRoute = {
-  href: string;
-  title: string;
-};
-
-const demoRoutes: DemoRoute[] = [
-  { href: "/", title: "Quick Check" },
-  { href: "/m", title: "Methods" },
-  { href: "/projects", title: "Projects" },
-];
+import { isPrimaryNavActive, PRIMARY_NAV_ITEMS } from "@/lib/nav/primaryNav";
 
 export default function DemoNav() {
   const pathname = usePathname() ?? "/";
 
   return (
     <nav className="flex flex-wrap items-center gap-2 text-xs text-slate-600" aria-label="Primary">
-      {demoRoutes.map(route => {
-        const isActive =
-          pathname === route.href ||
-          (route.href !== "/" && pathname.startsWith(`${route.href}/`));
+      {PRIMARY_NAV_ITEMS.map((route) => {
+        const isActive = isPrimaryNavActive(pathname, route.key);
         const base = "inline-flex items-center rounded-full border px-3 py-1.5 font-medium transition";
         const appearance = isActive
           ? "border-black bg-black text-white hover:bg-neutral-900"

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -11,8 +11,7 @@ export default function ChatApp() {
   const selectedVersion = deeplink.resolved.resolvedVersion;
 
   return (
-    <div className="min-h-screen bg-[#f9f9f9]">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-4 py-10 md:px-8 md:py-16">
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-4 py-10 md:px-8 md:py-16">
         {selectedMethod || deeplinkWarnings.length ? (
           <div className="mx-auto w-full max-w-lg rounded-3xl border border-slate-200 bg-white p-4 text-sm text-slate-700 shadow-sm">
             <div className="flex flex-wrap items-center justify-between gap-2">
@@ -43,7 +42,6 @@ export default function ChatApp() {
         ) : null}
 
         <QuickCheckPanel initialMethod={selectedMethod} initialVersion={selectedVersion} />
-      </div>
     </div>
   );
 }

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowUpRight,
@@ -1760,18 +1761,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 <div className="mt-1 text-sm text-slate-600">{SUPPORTED_FORMATS_LABEL}</div>
               </div>
               <div className="flex flex-wrap items-center gap-3 text-sm">
-                <a
+                <Link
                   href="/methods"
                   className="font-medium text-slate-500 underline underline-offset-4 transition hover:text-slate-700"
                 >
                   Browse methods
-                </a>
-                <a
+                </Link>
+                <Link
                   href="/projects"
                   className="font-medium text-slate-500 underline underline-offset-4 transition hover:text-slate-700"
                 >
                   Open Projects
-                </a>
+                </Link>
               </div>
             </div>
 
@@ -1809,12 +1810,12 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             {!selectedEvidenceLabel ? (
               <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500">
                 <span>Drop in one file to extract metadata and start a review path.</span>
-                <a
+                <Link
                   href="/methods"
                   className="font-medium text-slate-700 underline underline-offset-4 transition hover:text-slate-900"
                 >
                   Run against another method
-                </a>
+                </Link>
               </div>
             ) : (
               <>
@@ -2073,12 +2074,12 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               </div>
             ) : null}
             <div className="text-center">
-              <a
+              <Link
                 href="/methods"
                 className="text-xs text-slate-500 underline underline-offset-4 transition hover:text-slate-700"
               >
                 Run against another method
-              </a>
+              </Link>
             </div>
           </div>
 
@@ -2244,12 +2245,12 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 >
                   Run against another method
                 </button>
-                <a
+                <Link
                   href="/methods"
                   className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
                 >
                   Browse methods
-                </a>
+                </Link>
               </div>
             </div>
           ) : null}
@@ -2340,12 +2341,12 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 >
                   Run against another method
                 </button>
-                <a
+                <Link
                   href="/methods"
                   className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
                 >
                   Browse methods
-                </a>
+                </Link>
               </div>
             </div>
           ) : null}

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -50,6 +50,7 @@ import { createAndStoreEvidenceAttachment } from "@/lib/proofMap/attachments";
 import { isRuleLikeId } from "@/lib/proofMap/pins";
 import { loadPins, savePins } from "@/lib/proofMap/storage";
 import type { EvidencePin, PddFragment } from "@/lib/proofMap/types";
+import { stagePendingQuickCheckProjectHandoff } from "@/lib/projects/quickCheckHandoff";
 
 type MethodInventoryRecord = {
   code: string;
@@ -138,8 +139,23 @@ const CLAIM_SUGGESTIONS = [
   "The baseline methodology is clearly justified by the evidence.",
 ];
 
+const SUPPORTED_FORMATS_LABEL = "PDF, DOCX, XLSX, GEOJSON, KML, SHP ZIP";
+
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function trimFileExtension(fileName: string): string {
+  return fileName.replace(/\.[^/.]+$/, "").trim();
+}
+
+function deriveProjectName(fileName: string): string {
+  const baseName = trimFileExtension(fileName);
+  if (!baseName) return "Project review draft";
+  return baseName
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function newPinId(): string {
@@ -540,6 +556,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [showMethodology, setShowMethodology] = useState(false);
   const [showExtractionDetails, setShowExtractionDetails] = useState(false);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
+  const [isDragActive, setIsDragActive] = useState(false);
+  const [creatingProject, setCreatingProject] = useState(false);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
     loading: false,
     analysis: null,
@@ -713,6 +731,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     (selectedUpload ? "uploaded_file" : selectedInventoryItem ? "saved_evidence" : null);
   const selectedEvidenceMeta = activeSourceMode ? sourceModeLabel(activeSourceMode) : "";
   const canRunQuickCheck = Boolean(draft.claimText.trim()) && selectedEvidenceCount === 1 && !submitting;
+  const canCreateProjectFromDocument = Boolean(selectedUpload) && !creatingProject;
   const activeResultKey =
     result && draft.methodologyId.trim() && draft.methodologyVersion.trim() && draft.matchedRequirementId?.trim()
       ? `${draft.methodologyId.trim()}@@${draft.methodologyVersion.trim()}@@${draft.matchedRequirementId.trim()}`
@@ -765,6 +784,28 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       selectedMethod: draft.methodologyId.trim(),
     };
   }, [draft.methodologyId, methodologyResolution]);
+  const projectDraftMethod = useMemo(() => {
+    if (workspaceMethodologyId && workspaceMethodologyVersion) {
+      return { code: workspaceMethodologyId, version: workspaceMethodologyVersion };
+    }
+    if (draft.methodologyId.trim() && draft.methodologyVersion.trim()) {
+      return { code: draft.methodologyId.trim(), version: draft.methodologyVersion.trim() };
+    }
+    if (methodologyResolution.status === "single") {
+      const matched = methodologyResolution.matchedMethods[0];
+      if (matched?.methodologyId && matched?.methodologyVersion) {
+        return { code: matched.methodologyId, version: matched.methodologyVersion };
+      }
+    }
+    return null;
+  }, [
+    draft.methodologyId,
+    draft.methodologyVersion,
+    methodologyResolution.matchedMethods,
+    methodologyResolution.status,
+    workspaceMethodologyId,
+    workspaceMethodologyVersion,
+  ]);
   const extractionDiagnostic = useMemo<ExtractionDiagnostic>(() => {
     if (methodologyMismatch) {
       return {
@@ -1224,6 +1265,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     if (!file) return;
 
     setSubmitting(true);
+    setIsDragActive(false);
     resetQuickCheckUi();
     setFieldErrors((current) => ({ ...current, evidence: undefined, general: undefined }));
     setRecoveryState(null);
@@ -1264,6 +1306,49 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     } finally {
       setSubmitting(false);
       if (fileRef.current) fileRef.current.value = "";
+    }
+  }
+
+  function handleDragOver(event: React.DragEvent<HTMLLabelElement>) {
+    event.preventDefault();
+    if (!submitting) setIsDragActive(true);
+  }
+
+  function handleDragLeave(event: React.DragEvent<HTMLLabelElement>) {
+    event.preventDefault();
+    setIsDragActive(false);
+  }
+
+  function handleDrop(event: React.DragEvent<HTMLLabelElement>) {
+    event.preventDefault();
+    setIsDragActive(false);
+    if (submitting) return;
+    void handleUpload(event.dataTransfer.files?.[0] ?? null);
+  }
+
+  async function handleCreateProjectFromDocument() {
+    if (!selectedUpload) return;
+    setCreatingProject(true);
+    setFieldErrors((current) => ({ ...current, general: undefined }));
+    try {
+      await stagePendingQuickCheckProjectHandoff({
+        projectName: deriveProjectName(selectedUpload.filename),
+        methodCode: projectDraftMethod?.code,
+        methodVersion: projectDraftMethod?.version,
+        description: extractionPreview
+          ? `${extractionPreview.documentType} uploaded through Quick Check.`
+          : "Document uploaded through Quick Check.",
+        attachment: selectedUpload.attachment,
+      });
+      if (typeof window !== "undefined") {
+        window.location.assign("/projects/new?handoff=quick-check-document");
+      }
+    } catch (error) {
+      setFieldErrors({
+        general: error instanceof Error ? error.message : "Failed to stage the project draft from this document.",
+      });
+    } finally {
+      setCreatingProject(false);
     }
   }
 
@@ -1654,11 +1739,13 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         <div className="flex flex-col items-center text-center">
           <div className="flex w-full items-start justify-center">
             <div className="w-full">
-              <h1 className="text-4xl font-bold tracking-tight text-slate-950">
-                Quick Check
+              <div className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Quick Check</div>
+              <h1 className="mt-3 text-4xl font-bold tracking-tight text-slate-950">
+                Check a carbon project document in minutes.
               </h1>
               <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
-                Upload evidence. Get a preliminary match in seconds.
+                Upload a PDD, monitoring report, or evidence file. Article6 extracts text,
+                detects project metadata, and checks whether the document can support a methodology review.
               </p>
             </div>
             {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" /> : null}
@@ -1666,97 +1753,68 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         </div>
 
         <div className="mt-8 grid gap-8">
-          <div>
-            <label className="grid gap-2 text-sm text-slate-700">
-              <span className="font-medium text-slate-900">Claim</span>
-              <textarea
-                value={draft.claimText}
-                onChange={(event) => {
-                  const value = event.target.value;
-                  updateDraft(
-                    (current) => {
-                      const nextMethodology = resetMethodologyForUserInput(current);
-                      return {
-                        ...current,
-                        ...nextMethodology,
-                        claimText: value,
-                        matchedRequirementId: undefined,
-                        matchedRequirementLabel: undefined,
-                        status: "draft",
-                        resultId: undefined,
-                      };
-                    },
-                    null,
-                );
-                clearDecisionState();
-              }}
-              rows={3}
-              placeholder="Example: The monitoring report covers the full reporting period."
-                className="w-full rounded-[1.25rem] border border-slate-200 bg-white p-5 text-lg leading-8 text-slate-950 outline-none transition placeholder:text-slate-300 focus:border-slate-400 focus:bg-white"
-                ref={claimRef}
-              />
-              {fieldErrors.claim ? <span className="text-sm text-rose-700">{fieldErrors.claim}</span> : null}
-            </label>
-            <div className="mt-4">
-              <div className="text-xs text-slate-400">Try an example</div>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {CLAIM_SUGGESTIONS.slice(0, 2).map((suggestion) => (
-                  <button
-                    key={suggestion}
-                    type="button"
-                    onClick={() => {
-                      updateDraft(
-                        (current) => {
-                          const nextMethodology = resetMethodologyForUserInput(current);
-                          return {
-                            ...current,
-                            ...nextMethodology,
-                            claimText: suggestion,
-                            matchedRequirementId: undefined,
-                            matchedRequirementLabel: undefined,
-                            status: "draft",
-                            resultId: undefined,
-                          };
-                        },
-                        null,
-                      );
-                      clearDecisionState();
-                    }}
-                    className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
-                  >
-                    {suggestion}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <div>
+          <div className="rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-sm md:p-6">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0">
-                <div className="text-sm font-medium text-slate-900">Evidence</div>
-                <div className="mt-1 text-sm text-slate-600">Upload one file.</div>
+                <div className="text-lg font-semibold text-slate-900">Drag and drop your project document</div>
+                <div className="mt-1 text-sm text-slate-600">{SUPPORTED_FORMATS_LABEL}</div>
               </div>
-              <input
-                ref={fileRef}
-                type="file"
-                className="hidden"
-                accept=".pdf,.png,.jpg,.jpeg,.csv,.xlsx"
-                onChange={(event) => void handleUpload(event.target.files?.[0] ?? null)}
-              />
-              <button
-                type="button"
-                onClick={() => fileRef.current?.click()}
-                className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-white px-4 py-2.5 text-sm font-semibold text-black transition hover:bg-slate-50"
-              >
-                <Upload className="h-4 w-4" />
-                Upload evidence
-              </button>
+              <div className="flex flex-wrap items-center gap-3 text-sm">
+                <a
+                  href="/methods"
+                  className="font-medium text-slate-500 underline underline-offset-4 transition hover:text-slate-700"
+                >
+                  Browse methods
+                </a>
+                <a
+                  href="/projects"
+                  className="font-medium text-slate-500 underline underline-offset-4 transition hover:text-slate-700"
+                >
+                  Open Projects
+                </a>
+              </div>
             </div>
 
+            <input
+              ref={fileRef}
+              type="file"
+              className="hidden"
+              accept=".pdf,.docx,.xlsx,.csv,.geojson,.kml,.zip,.png,.jpg,.jpeg"
+              onChange={(event) => void handleUpload(event.target.files?.[0] ?? null)}
+            />
+
+            <label
+              className={`mt-5 flex cursor-pointer flex-col items-center justify-center rounded-[1.5rem] border border-dashed px-6 py-10 text-center transition ${
+                isDragActive
+                  ? "border-slate-900 bg-slate-100"
+                  : "border-slate-300 bg-slate-50 hover:border-slate-400 hover:bg-white"
+              }`}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+            >
+              <div className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white text-slate-900 shadow-sm">
+                <Upload className="h-5 w-5" />
+              </div>
+              <div className="mt-4 text-lg font-semibold text-slate-900">Upload document</div>
+              <div className="mt-2 max-w-xl text-sm leading-6 text-slate-600">
+                You can run a quick check first or create a project draft after upload.
+              </div>
+              <div className="mt-6 inline-flex items-center gap-2 rounded-full bg-black px-5 py-3 text-sm font-semibold text-white">
+                <Upload className="h-4 w-4" />
+                Upload document
+              </div>
+            </label>
+
             {!selectedEvidenceLabel ? (
-              <div className="mt-4 rounded-[1.25rem] border border-slate-200 bg-slate-50/50 px-4 py-5 text-sm text-slate-600">
-                Drop in one file or use the upload button.
+              <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500">
+                <span>Drop in one file to extract metadata and start a review path.</span>
+                <a
+                  href="/methods"
+                  className="font-medium text-slate-700 underline underline-offset-4 transition hover:text-slate-900"
+                >
+                  Run against another method
+                </a>
               </div>
             ) : (
               <>
@@ -1912,6 +1970,71 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             {fieldErrors.evidence ? <div className="mt-3 text-sm text-rose-700">{fieldErrors.evidence}</div> : null}
           </div>
 
+          <div>
+            <label className="grid gap-2 text-sm text-slate-700">
+              <span className="font-medium text-slate-900">Claim</span>
+              <textarea
+                value={draft.claimText}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  updateDraft(
+                    (current) => {
+                      const nextMethodology = resetMethodologyForUserInput(current);
+                      return {
+                        ...current,
+                        ...nextMethodology,
+                        claimText: value,
+                        matchedRequirementId: undefined,
+                        matchedRequirementLabel: undefined,
+                        status: "draft",
+                        resultId: undefined,
+                      };
+                    },
+                    null,
+                  );
+                  clearDecisionState();
+                }}
+                rows={3}
+                placeholder="Example: The monitoring report covers the full reporting period."
+                className="w-full rounded-[1.25rem] border border-slate-200 bg-white p-5 text-lg leading-8 text-slate-950 outline-none transition placeholder:text-slate-300 focus:border-slate-400 focus:bg-white"
+                ref={claimRef}
+              />
+              {fieldErrors.claim ? <span className="text-sm text-rose-700">{fieldErrors.claim}</span> : null}
+            </label>
+            <div className="mt-4">
+              <div className="text-xs text-slate-400">Try an example</div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {CLAIM_SUGGESTIONS.slice(0, 2).map((suggestion) => (
+                  <button
+                    key={suggestion}
+                    type="button"
+                    onClick={() => {
+                      updateDraft(
+                        (current) => {
+                          const nextMethodology = resetMethodologyForUserInput(current);
+                          return {
+                            ...current,
+                            ...nextMethodology,
+                            claimText: suggestion,
+                            matchedRequirementId: undefined,
+                            matchedRequirementLabel: undefined,
+                            status: "draft",
+                            resultId: undefined,
+                          };
+                        },
+                        null,
+                      );
+                      clearDecisionState();
+                    }}
+                    className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
+                  >
+                    {suggestion}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
           <div className="grid gap-3">
             <button
               type="button"
@@ -1949,6 +2072,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 </button>
               </div>
             ) : null}
+            <div className="text-center">
+              <a
+                href="/methods"
+                className="text-xs text-slate-500 underline underline-offset-4 transition hover:text-slate-700"
+              >
+                Run against another method
+              </a>
+            </div>
           </div>
 
           {showAdvancedOptions ? (
@@ -2082,6 +2213,47 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             </div>
           ) : null}
 
+          {selectedUpload ? (
+            <div className="rounded-[1.6rem] border border-slate-200 bg-white p-5 shadow-sm">
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Next actions</div>
+              <div className="mt-2 text-sm text-slate-600">
+                Don&apos;t stop at the upload. Use the document to start a project draft, continue in a full review workspace, or compare against another method.
+              </div>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handleCreateProjectFromDocument()}
+                  disabled={!canCreateProjectFromDocument}
+                  className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
+                >
+                  {creatingProject ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                  Create project from document
+                </button>
+                <button
+                  type="button"
+                  onClick={handleContinueToWorkspace}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+                >
+                  <FolderOpen className="h-4 w-4" />
+                  Open full review
+                </button>
+                <button
+                  type="button"
+                  onClick={handleTryAnotherMethodology}
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+                >
+                  Run against another method
+                </button>
+                <a
+                  href="/methods"
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+                >
+                  Browse methods
+                </a>
+              </div>
+            </div>
+          ) : null}
+
           {matchCandidates.length ? (
             <div className="rounded-2xl border border-sky-200 bg-sky-50/80 p-4">
               <div className="flex items-start gap-3">
@@ -2143,15 +2315,37 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   {normalizedResult.extractionState.label} evidence signal
                 </span>
               </div>
-              <div className="mt-4">
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handleCreateProjectFromDocument()}
+                  disabled={!canCreateProjectFromDocument}
+                  className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
+                >
+                  {creatingProject ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                  Create project from document
+                </button>
                 <button
                   type="button"
                   onClick={handleContinueToWorkspace}
-                  className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
                 >
                   <FolderOpen className="h-4 w-4" />
                   Open full review
                 </button>
+                <button
+                  type="button"
+                  onClick={handleTryAnotherMethodology}
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+                >
+                  Run against another method
+                </button>
+                <a
+                  href="/methods"
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-300 hover:text-slate-900"
+                >
+                  Browse methods
+                </a>
               </div>
             </div>
           ) : null}

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -2,10 +2,15 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { createProject } from '@/lib/projects/storage';
+import { addProjectDocument, createProject } from '@/lib/projects/storage';
 import { projectRegistryFromMethodProgram } from '@/lib/projects/verificationReport';
 import type { ProjectRegistry, ProjectReviewMode } from '@/lib/projects/types';
 import { importMethodologyReviewIntoProject, readPendingProjectReviewHandoff } from '@/lib/projects/reviewHandoff';
+import {
+  clearPendingQuickCheckProjectHandoff,
+  readPendingQuickCheckProjectHandoff,
+  type PendingQuickCheckProjectHandoff,
+} from '@/lib/projects/quickCheckHandoff';
 
 export type MethodOption = {
   code: string;
@@ -33,8 +38,9 @@ export function groupMethodsByRegistry(methods: MethodOption[]): Array<{ registr
 export default function NewProjectForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const handoffMode = searchParams.get('handoff');
   const [methods, setMethods] = useState<MethodOption[]>([]);
-  const [reviewMode, setReviewMode] = useState<ProjectReviewMode>('methodology-linked');
+  const [reviewMode, setReviewMode] = useState<ProjectReviewMode>('manual');
   const [name, setName] = useState('');
   const [projectCode, setProjectCode] = useState('');
   const [countryLocation, setCountryLocation] = useState('');
@@ -47,6 +53,7 @@ export default function NewProjectForm() {
   const [error, setError] = useState('');
   const [handoffDetected, setHandoffDetected] = useState(false);
   const [handoffMethodLabel, setHandoffMethodLabel] = useState('');
+  const [quickCheckHandoff, setQuickCheckHandoff] = useState<PendingQuickCheckProjectHandoff | null>(null);
 
   const groupedMethods = useMemo(() => groupMethodsByRegistry(methods), [methods]);
 
@@ -58,14 +65,32 @@ export default function NewProjectForm() {
   }, []);
 
   useEffect(() => {
-    if (searchParams.get('handoff') !== 'active-review') return;
-    const handoff = readPendingProjectReviewHandoff();
+    if (handoffMode === 'active-review') {
+      const handoff = readPendingProjectReviewHandoff();
+      if (!handoff) return;
+      setHandoffDetected(true);
+      setReviewMode('methodology-linked');
+      setSelectedMethod(`${handoff.source.methodCode}@${handoff.source.methodVersion}`);
+      setHandoffMethodLabel(`${handoff.source.methodCode} ${handoff.source.methodVersion}`);
+      return;
+    }
+
+    if (handoffMode !== 'quick-check-document') return;
+    const handoff = readPendingQuickCheckProjectHandoff();
     if (!handoff) return;
-    setHandoffDetected(true);
-    setReviewMode('methodology-linked');
-    setSelectedMethod(`${handoff.source.methodCode}@${handoff.source.methodVersion}`);
-    setHandoffMethodLabel(`${handoff.source.methodCode} ${handoff.source.methodVersion}`);
-  }, [searchParams]);
+    setQuickCheckHandoff(handoff);
+    setName(handoff.projectName);
+    setReportingPeriod(handoff.reportingPeriod ?? '');
+    setAoiLabel(handoff.aoiLabel ?? '');
+    setDescription(handoff.description ?? '');
+    if (handoff.methodCode && handoff.methodVersion) {
+      setReviewMode('methodology-linked');
+      setSelectedMethod(`${handoff.methodCode}@${handoff.methodVersion}`);
+      setHandoffMethodLabel(`${handoff.methodCode} ${handoff.methodVersion}`);
+    } else {
+      setReviewMode('manual');
+    }
+  }, [handoffMode]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -87,6 +112,18 @@ export default function NewProjectForm() {
           aoiLabel: aoiLabel || undefined,
           description: description || undefined,
         });
+        if (quickCheckHandoff) {
+          addProjectDocument(project.id, {
+            fileName: quickCheckHandoff.sourceDocument.fileName,
+            mimeType: quickCheckHandoff.sourceDocument.mimeType,
+            sizeBytes: quickCheckHandoff.sourceDocument.sizeBytes,
+            contentSha256: quickCheckHandoff.sourceDocument.contentSha256,
+            contentBase64: quickCheckHandoff.sourceDocument.contentBase64,
+            extractedText: quickCheckHandoff.sourceDocument.extractedText,
+            manualFindingExtractionStatus: 'not-run',
+          });
+          clearPendingQuickCheckProjectHandoff();
+        }
         router.push(`/projects/${project.id}`);
         return;
       }
@@ -122,6 +159,18 @@ export default function NewProjectForm() {
           },
           rules,
         });
+        if (quickCheckHandoff) {
+          addProjectDocument(result.project.id, {
+            fileName: quickCheckHandoff.sourceDocument.fileName,
+            mimeType: quickCheckHandoff.sourceDocument.mimeType,
+            sizeBytes: quickCheckHandoff.sourceDocument.sizeBytes,
+            contentSha256: quickCheckHandoff.sourceDocument.contentSha256,
+            contentBase64: quickCheckHandoff.sourceDocument.contentBase64,
+            extractedText: quickCheckHandoff.sourceDocument.extractedText,
+            manualFindingExtractionStatus: 'not-run',
+          });
+          clearPendingQuickCheckProjectHandoff();
+        }
         router.push(result.href);
         return;
       }
@@ -145,6 +194,18 @@ export default function NewProjectForm() {
           sectionId: r.sectionId || '',
         })),
       });
+      if (quickCheckHandoff) {
+        addProjectDocument(project.id, {
+          fileName: quickCheckHandoff.sourceDocument.fileName,
+          mimeType: quickCheckHandoff.sourceDocument.mimeType,
+          sizeBytes: quickCheckHandoff.sourceDocument.sizeBytes,
+          contentSha256: quickCheckHandoff.sourceDocument.contentSha256,
+          contentBase64: quickCheckHandoff.sourceDocument.contentBase64,
+          extractedText: quickCheckHandoff.sourceDocument.extractedText,
+          manualFindingExtractionStatus: 'not-run',
+        });
+        clearPendingQuickCheckProjectHandoff();
+      }
 
       router.push(`/projects/${project.id}`);
     } catch {
@@ -158,9 +219,13 @@ export default function NewProjectForm() {
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-12 md:px-8">
       <div>
-        <h1 className="text-2xl font-bold text-slate-900">New Project Review</h1>
+        <h1 className="text-2xl font-bold text-slate-900">
+          {quickCheckHandoff ? 'Create project draft from document' : 'New manual project'}
+        </h1>
         <p className="mt-1 text-sm text-slate-500">
-          Create a long-lived project review workspace
+          {quickCheckHandoff
+            ? 'Confirm the project details extracted from Quick Check before opening the saved review workspace.'
+            : 'Create a review workspace without starting from a document upload.'}
         </p>
       </div>
 
@@ -171,41 +236,54 @@ export default function NewProjectForm() {
       )}
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <div>
-          <label className="mb-1 block text-sm font-semibold text-slate-700">Review Type</label>
-          <div className="grid gap-3 md:grid-cols-2">
-            <button
-              type="button"
-              disabled={handoffDetected}
-              onClick={() => setReviewMode('methodology-linked')}
-              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? 'cursor-not-allowed opacity-60' : ''} ${
-                reviewMode === 'methodology-linked'
-                  ? 'border-blue-500 bg-blue-50 text-blue-900'
-                  : 'border-slate-200 bg-white text-slate-700'
-              }`}
-            >
-              <div className="text-sm font-semibold">Methodology-linked review</div>
-              <div className="mt-1 text-xs text-slate-500">Use a selected methodology and its rule set.</div>
-            </button>
-            <button
-              type="button"
-              disabled={handoffDetected}
-              onClick={() => setReviewMode('manual')}
-              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? 'cursor-not-allowed opacity-60' : ''} ${
-                reviewMode === 'manual'
-                  ? 'border-blue-500 bg-blue-50 text-blue-900'
-                  : 'border-slate-200 bg-white text-slate-700'
-              }`}
-            >
-              <div className="text-sm font-semibold">Manual Review</div>
-              <div className="mt-1 text-xs text-slate-500">Project-level manual review / VVB findings reconstruction.</div>
-            </button>
+        {handoffDetected || quickCheckHandoff ? (
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">Review Type</label>
+            <div className="grid gap-3 md:grid-cols-2">
+              <button
+                type="button"
+                disabled={handoffDetected}
+                onClick={() => setReviewMode('methodology-linked')}
+                className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? 'cursor-not-allowed opacity-60' : ''} ${
+                  reviewMode === 'methodology-linked'
+                    ? 'border-blue-500 bg-blue-50 text-blue-900'
+                    : 'border-slate-200 bg-white text-slate-700'
+                }`}
+              >
+                <div className="text-sm font-semibold">Methodology-linked review</div>
+                <div className="mt-1 text-xs text-slate-500">Use a selected methodology and its rule set.</div>
+              </button>
+              <button
+                type="button"
+                disabled={handoffDetected}
+                onClick={() => setReviewMode('manual')}
+                className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? 'cursor-not-allowed opacity-60' : ''} ${
+                  reviewMode === 'manual'
+                    ? 'border-blue-500 bg-blue-50 text-blue-900'
+                    : 'border-slate-200 bg-white text-slate-700'
+                }`}
+              >
+                <div className="text-sm font-semibold">Manual Review</div>
+                <div className="mt-1 text-xs text-slate-500">Project-level manual review / VVB findings reconstruction.</div>
+              </button>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            Manual project setup is the fallback path when you want to create a saved review without starting in Quick Check.
+          </div>
+        )}
 
         {handoffDetected ? (
           <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
             Create a project and carry over the active review for {handoffMethodLabel}. Existing evidence links, rule reviews, reviewer notes, and draft finalization state will be imported.
+          </div>
+        ) : null}
+
+        {quickCheckHandoff ? (
+          <div className="rounded-lg border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-900">
+            {quickCheckHandoff.sourceDocument.fileName} will be attached to this project after creation.
+            {handoffMethodLabel ? ` Quick Check suggested ${handoffMethodLabel}.` : ''}
           </div>
         ) : null}
 

--- a/src/components/projects/ProjectsList.tsx
+++ b/src/components/projects/ProjectsList.tsx
@@ -30,13 +30,13 @@ export default function ProjectsList() {
           href="/projects/new"
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
         >
-          + New Project Review
+          New manual project
         </Link>
       </div>
 
       {projects.length === 0 ? (
         <div className="rounded-lg border border-dashed border-slate-300 bg-white p-12 text-center">
-          <p className="text-slate-500">No project reviews yet. Create one to start a durable review workspace.</p>
+          <p className="text-slate-500">No saved reviews yet. Start in Quick Check or create a manual project when you need a fallback.</p>
         </div>
       ) : (
         <div className="flex flex-col gap-3">

--- a/src/lib/nav/primaryNav.ts
+++ b/src/lib/nav/primaryNav.ts
@@ -1,0 +1,36 @@
+export type PrimaryNavKey = "home" | "quick-check" | "methods" | "projects";
+
+export type PrimaryNavItem = {
+  key: PrimaryNavKey;
+  href: string;
+  title: string;
+};
+
+export const PRIMARY_NAV_ITEMS: PrimaryNavItem[] = [
+  { key: "home", href: "/", title: "Home" },
+  { key: "quick-check", href: "/quick-check", title: "Quick Check" },
+  { key: "methods", href: "/methods", title: "Methods" },
+  { key: "projects", href: "/projects", title: "Projects" },
+];
+
+function isMethodsPath(pathname: string): boolean {
+  return (
+    pathname === "/methods" ||
+    pathname.startsWith("/methods/") ||
+    pathname === "/m" ||
+    pathname.startsWith("/m/")
+  );
+}
+
+function isProjectsPath(pathname: string): boolean {
+  if (pathname === "/projects") return true;
+  if (!pathname.startsWith("/projects/")) return false;
+  return pathname !== "/projects/new";
+}
+
+export function isPrimaryNavActive(pathname: string, key: PrimaryNavKey): boolean {
+  if (key === "home") return pathname === "/";
+  if (key === "quick-check") return pathname === "/quick-check";
+  if (key === "methods") return isMethodsPath(pathname);
+  return isProjectsPath(pathname);
+}

--- a/src/lib/projects/quickCheckHandoff.ts
+++ b/src/lib/projects/quickCheckHandoff.ts
@@ -1,0 +1,83 @@
+import { getAttachmentBytes } from "@/lib/proofMap/attachments";
+import type { EvidenceAttachment } from "@/lib/proofMap/types";
+
+const PENDING_QUICK_CHECK_HANDOFF_KEY = "article6:pending-quick-check-project-handoff";
+
+export type PendingQuickCheckProjectHandoff = {
+  projectName: string;
+  methodCode?: string;
+  methodVersion?: string;
+  reportingPeriod?: string;
+  aoiLabel?: string;
+  description?: string;
+  sourceDocument: {
+    fileName: string;
+    mimeType: string;
+    sizeBytes: number;
+    contentSha256?: string;
+    contentBase64?: string;
+    extractedText?: string;
+  };
+  createdAt: string;
+};
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+function arrayBufferToBase64(bytes: ArrayBuffer): string {
+  const view = new Uint8Array(bytes);
+  let binary = "";
+  for (const byte of view) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+export async function stagePendingQuickCheckProjectHandoff(input: {
+  projectName: string;
+  methodCode?: string;
+  methodVersion?: string;
+  reportingPeriod?: string;
+  aoiLabel?: string;
+  description?: string;
+  extractedText?: string;
+  attachment: EvidenceAttachment;
+}): Promise<PendingQuickCheckProjectHandoff> {
+  const bytes = await getAttachmentBytes(input.attachment.id);
+  const handoff: PendingQuickCheckProjectHandoff = {
+    projectName: input.projectName,
+    methodCode: input.methodCode,
+    methodVersion: input.methodVersion,
+    reportingPeriod: input.reportingPeriod,
+    aoiLabel: input.aoiLabel,
+    description: input.description,
+    sourceDocument: {
+      fileName: input.attachment.filename,
+      mimeType: input.attachment.mime,
+      sizeBytes: input.attachment.size,
+      contentSha256: input.attachment.sha256,
+      contentBase64: bytes ? arrayBufferToBase64(bytes) : undefined,
+      extractedText: input.extractedText,
+    },
+    createdAt: new Date().toISOString(),
+  };
+
+  getStorage()?.setItem(PENDING_QUICK_CHECK_HANDOFF_KEY, JSON.stringify(handoff));
+  return handoff;
+}
+
+export function readPendingQuickCheckProjectHandoff(): PendingQuickCheckProjectHandoff | null {
+  const raw = getStorage()?.getItem(PENDING_QUICK_CHECK_HANDOFF_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as PendingQuickCheckProjectHandoff;
+    if (!parsed?.projectName || !parsed?.sourceDocument?.fileName) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingQuickCheckProjectHandoff(): void {
+  getStorage()?.removeItem(PENDING_QUICK_CHECK_HANDOFF_KEY);
+}

--- a/src/lib/proofMap/attachments.ts
+++ b/src/lib/proofMap/attachments.ts
@@ -11,10 +11,18 @@ export const ALLOWED_EVIDENCE_ATTACHMENT_MIME_TYPES = new Set([
   "application/pdf",
   "image/jpeg",
   "image/png",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   "application/vnd.ms-excel",
   "text/csv",
   "application/csv",
+  "application/geo+json",
+  "application/json",
+  "application/vnd.google-earth.kml+xml",
+  "application/xml",
+  "text/xml",
+  "application/zip",
+  "application/x-zip-compressed",
 ]);
 
 function openDb(): Promise<IDBDatabase> {
@@ -79,8 +87,12 @@ function normalizeMime(file: File): string {
   if (lower.endsWith(".pdf")) return "application/pdf";
   if (lower.endsWith(".png")) return "image/png";
   if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".docx")) return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
   if (lower.endsWith(".xlsx")) return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
   if (lower.endsWith(".csv")) return "text/csv";
+  if (lower.endsWith(".geojson")) return "application/geo+json";
+  if (lower.endsWith(".kml")) return "application/vnd.google-earth.kml+xml";
+  if (lower.endsWith(".zip")) return "application/zip";
   return "application/octet-stream";
 }
 
@@ -100,7 +112,7 @@ export async function createAndStoreEvidenceAttachment(input: {
 
   const mime = normalizeMime(file);
   if (!ALLOWED_EVIDENCE_ATTACHMENT_MIME_TYPES.has(mime) && !isSupportedWorkbookUpload({ filename: file.name, mime })) {
-    return { ok: false, message: "Unsupported file type (allowed: pdf, jpg, png, csv, xlsx)." };
+    return { ok: false, message: "Unsupported file type (allowed: pdf, docx, xlsx, geojson, kml, shp zip, jpg, png, csv)." };
   }
 
   const bytes =

--- a/tests/app/homePage.test.tsx
+++ b/tests/app/homePage.test.tsx
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import HomePage from "@/app/page";
+
+describe("HomePage", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders the product copy and CTA targets", async () => {
+    await act(async () => {
+      root.render(<HomePage />);
+    });
+
+    expect(container.textContent).toContain("Review carbon project documents faster.");
+    const links = Array.from(container.querySelectorAll("a"));
+    expect(links.find((link) => link.textContent === "Quick Check")?.getAttribute("href")).toBe("/quick-check");
+    expect(links.find((link) => link.textContent === "Open Projects")?.getAttribute("href")).toBe("/projects");
+    expect(links.find((link) => link.textContent === "Browse Methods")?.getAttribute("href")).toBe("/methods");
+  });
+});

--- a/tests/components/chatAppQuickCheck.test.tsx
+++ b/tests/components/chatAppQuickCheck.test.tsx
@@ -7,12 +7,12 @@ import { createRoot } from "react-dom/client";
 jest.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(),
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
-  usePathname: () => "/",
+  usePathname: () => "/quick-check",
 }));
 
 import ChatApp from "@/components/chat/ChatApp";
 
-describe("ChatApp claim-first landing", () => {
+describe("ChatApp quick-check workspace", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
 
@@ -43,17 +43,19 @@ describe("ChatApp claim-first landing", () => {
     jest.clearAllMocks();
   });
 
-  it("renders the claim-first command card and removes chat from the landing page", async () => {
+  it("renders the document-first quick-check surface and keeps the evidence workflow controls", async () => {
     await act(async () => {
       root.render(<ChatApp />);
     });
 
     expect(container.textContent).toContain("Quick Check");
-    expect(container.textContent).toContain("Upload evidence. Get a preliminary match in seconds.");
-    expect(container.textContent).toContain("Evidence");
+    expect(container.textContent).toContain("Check a carbon project document in minutes.");
+    expect(container.textContent).toContain("Drag and drop your project document");
+    expect(container.textContent).toContain("Upload document");
+    expect(container.textContent).toContain("PDF, DOCX, XLSX, GEOJSON, KML, SHP ZIP");
     expect(container.textContent).toContain("Try demo check");
     expect(container.textContent).toContain("Run quick check");
-    expect(container.textContent).toContain("Upload evidence");
+    expect(container.textContent).toContain("Run against another method");
     expect(container.querySelectorAll("textarea").length).toBe(1);
     expect(container.textContent).toContain("Options");
     expect(container.textContent).not.toContain("Select saved evidence");
@@ -61,6 +63,5 @@ describe("ChatApp claim-first landing", () => {
     expect(container.textContent).not.toContain("Ask in chat instead");
     expect(container.textContent).not.toContain("Send");
     expect(container.textContent).not.toContain("Welcome to Article6");
-    expect(container.textContent).not.toContain("One claim. One file.");
   });
 });

--- a/tests/components/demoNav.test.tsx
+++ b/tests/components/demoNav.test.tsx
@@ -31,7 +31,7 @@ describe("DemoNav", () => {
     jest.clearAllMocks();
   });
 
-  it("shows Quick Check, Methods, and Projects destinations", async () => {
+  it("shows Home, Quick Check, Methods, and Projects destinations", async () => {
     pathnameState.value = "/";
     await act(async () => {
       root.render(<DemoNav />);
@@ -39,15 +39,16 @@ describe("DemoNav", () => {
 
     const links = Array.from(container.querySelectorAll("a"));
     expect(links.map((link) => link.textContent)).toEqual(
-      expect.arrayContaining(["Quick Check", "Methods", "Projects"]),
+      expect.arrayContaining(["Home", "Quick Check", "Methods", "Projects"]),
     );
-    expect(links.find((link) => link.textContent?.includes("Quick Check"))?.getAttribute("href")).toBe("/");
-    expect(links.find((link) => link.textContent?.includes("Methods"))?.getAttribute("href")).toBe("/m");
+    expect(links.find((link) => link.textContent?.includes("Home"))?.getAttribute("href")).toBe("/");
+    expect(links.find((link) => link.textContent?.includes("Quick Check"))?.getAttribute("href")).toBe("/quick-check");
+    expect(links.find((link) => link.textContent?.includes("Methods"))?.getAttribute("href")).toBe("/methods");
     expect(links.find((link) => link.textContent?.includes("Projects"))?.getAttribute("href")).toBe("/projects");
   });
 
-  it("lets the user return to Quick Check from Methods in one click", async () => {
-    pathnameState.value = "/m";
+  it("lets the user reach Quick Check from Methods in one click", async () => {
+    pathnameState.value = "/methods";
     await act(async () => {
       root.render(<DemoNav />);
     });
@@ -55,6 +56,6 @@ describe("DemoNav", () => {
     const quickCheckLink = Array.from(container.querySelectorAll("a")).find((link) =>
       link.textContent?.includes("Quick Check"),
     );
-    expect(quickCheckLink?.getAttribute("href")).toBe("/");
+    expect(quickCheckLink?.getAttribute("href")).toBe("/quick-check");
   });
 });

--- a/tests/components/projects/NewProjectForm.quickCheckHandoff.test.tsx
+++ b/tests/components/projects/NewProjectForm.quickCheckHandoff.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment jsdom
+ */
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createRoot } from 'react-dom/client';
+import { listProjects } from '@/lib/projects/storage';
+
+const pushMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+  useSearchParams: () => new URLSearchParams('handoff=quick-check-document'),
+}));
+
+const NewProjectForm = require('@/components/projects/NewProjectForm').default as typeof import('@/components/projects/NewProjectForm').default;
+
+describe('NewProjectForm quick-check handoff', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    pushMock.mockReset();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    window.localStorage.setItem('article6:pending-quick-check-project-handoff', JSON.stringify({
+      projectName: 'Kasigau Monitoring Report',
+      methodCode: 'VM0007',
+      methodVersion: 'v1-8',
+      description: 'Monitoring report uploaded through Quick Check.',
+      sourceDocument: {
+        fileName: 'kasigau-monitoring-report.pdf',
+        mimeType: 'application/pdf',
+        sizeBytes: 1024,
+        contentSha256: 'sha-123',
+        contentBase64: 'cGRm',
+      },
+      createdAt: '2026-05-25T00:00:00.000Z',
+    }));
+
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/projects/methods') {
+        return new Response(JSON.stringify({
+          methods: [
+            { code: 'VM0007', program: 'Verra/Forestry', version: 'v1-8', ruleCount: 2 },
+          ],
+        }), { status: 200 });
+      }
+      if (url === '/api/projects/method-rules?code=VM0007&version=v1-8') {
+        return new Response(JSON.stringify({
+          rules: [
+            { id: 'R-1-0001', title: 'Boundary must be documented', sectionId: 'S-1' },
+            { id: 'R-1-0002', title: 'Monitoring must be described', sectionId: 'S-2' },
+          ],
+        }), { status: 200 });
+      }
+      throw new Error(`Unhandled fetch ${url}`);
+    }) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (global as { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  it('creates a project draft from the staged document handoff and attaches the source file', async () => {
+    await act(async () => {
+      root.render(<NewProjectForm />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Create project draft from document');
+    expect(container.textContent).toContain('kasigau-monitoring-report.pdf will be attached to this project');
+
+    const submitButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Create Project Review'),
+    ) as HTMLButtonElement | undefined;
+
+    expect(submitButton).toBeDefined();
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const projects = listProjects();
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.documents).toHaveLength(1);
+    expect(projects[0]?.documents[0]?.fileName).toBe('kasigau-monitoring-report.pdf');
+  });
+});

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -885,8 +885,9 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     const pageText = container.textContent ?? "";
     expect(pageText).toContain("Quick Check");
-    expect(pageText).toContain("Upload evidence. Get a preliminary match in seconds.");
-    expect(pageText).toContain("Upload evidence");
+    expect(pageText).toContain("Check a carbon project document in minutes.");
+    expect(pageText).toContain("Drag and drop your project document");
+    expect(pageText).toContain("Upload document");
     expect(pageText).toContain("Try demo check");
     expect(pageText).toContain("Options");
     expect(pageText).not.toContain("Select saved evidence");
@@ -973,7 +974,8 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(container.textContent).toContain("Extraction signal");
     expect(container.textContent).toContain("Grounded");
     expect(container.textContent).toContain("Use match");
-    expect(container.textContent).not.toContain("Open full review");
+    expect(container.textContent).toContain("Next actions");
+    expect(container.textContent).toContain("Open full review");
     expect(container.textContent).not.toContain(QUICK_CHECK_DEMO.filename);
     expect(container.textContent).not.toContain("Match confidence");
     expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
@@ -1891,7 +1893,8 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     expect(container.textContent).toContain("Likely requirement matches");
     expect(container.textContent).toContain("Use match");
-    expect(container.textContent).not.toContain("Open full review");
+    expect(container.textContent).toContain("Next actions");
+    expect(container.textContent).toContain("Open full review");
     expect(container.textContent).toContain("monitoring-report.pdf");
     expect(container.textContent).not.toContain("The matched requirement could not be loaded.");
   });

--- a/tests/lib/primaryNav.test.ts
+++ b/tests/lib/primaryNav.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "@jest/globals";
+import { isPrimaryNavActive } from "@/lib/nav/primaryNav";
+
+describe("isPrimaryNavActive", () => {
+  it("activates Home only on /", () => {
+    expect(isPrimaryNavActive("/", "home")).toBe(true);
+    expect(isPrimaryNavActive("/", "quick-check")).toBe(false);
+    expect(isPrimaryNavActive("/", "methods")).toBe(false);
+    expect(isPrimaryNavActive("/", "projects")).toBe(false);
+  });
+
+  it("activates Quick Check only on /quick-check", () => {
+    expect(isPrimaryNavActive("/quick-check", "quick-check")).toBe(true);
+    expect(isPrimaryNavActive("/quick-check", "home")).toBe(false);
+    expect(isPrimaryNavActive("/quick-check", "methods")).toBe(false);
+    expect(isPrimaryNavActive("/quick-check", "projects")).toBe(false);
+  });
+
+  it("activates Methods on /methods and method detail routes", () => {
+    expect(isPrimaryNavActive("/methods", "methods")).toBe(true);
+    expect(isPrimaryNavActive("/m/VM0007/v/v1-8", "methods")).toBe(true);
+    expect(isPrimaryNavActive("/methods", "projects")).toBe(false);
+  });
+
+  it("activates Projects only on saved project routes", () => {
+    expect(isPrimaryNavActive("/projects", "projects")).toBe(true);
+    expect(isPrimaryNavActive("/projects/proj_123", "projects")).toBe(true);
+    expect(isPrimaryNavActive("/projects/new", "projects")).toBe(false);
+    expect(isPrimaryNavActive("/projects", "quick-check")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed
- moved the main upload and triage experience to `/quick-check`
- rebuilt `/` as a lightweight landing page with product copy and clear CTAs
- made `/methods` the canonical methods route while keeping `/m` as a compatibility redirect and preserving method detail routes
- kept `/projects` focused on saved review work and `/projects/new` as a manual fallback
- added a Quick Check document-to-project handoff so uploaded source files can seed a project draft
- fixed primary nav ownership so Home, Quick Check, Methods, and Projects cannot be active at the same time

## Why
- clarifies the product model: land -> quick check -> create or continue review
- removes route ambiguity around home, methods, projects, and manual setup
- makes the upload flow a first-class surface without duplicating it on Home

## Validation
- `tsc --noEmit`
- `node ./node_modules/jest/bin/jest.js --runInBand --forceExit tests/lib/primaryNav.test.ts tests/components/demoNav.test.tsx tests/app/homePage.test.tsx tests/components/chatAppQuickCheck.test.tsx tests/components/projects/NewProjectForm.test.tsx tests/components/projects/NewProjectForm.handoff.test.tsx tests/components/projects/NewProjectForm.quickCheckHandoff.test.tsx`