### PR TITLE
feat: split Quick Check into claim-to-requirement-match and review-question-answering paths

### DIFF
--- a/src/app/api/quick-check/pdf-extract/route.ts
+++ b/src/app/api/quick-check/pdf-extract/route.ts
@@ -2,7 +2,7 @@ export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 import { extractPdfText } from "@/lib/chat/quickCheckEvidence";
-import { extractPdfTextWithPdfParse, type PdfExtractionDiagnostics } from "@/lib/chat/quickCheckPdfExtractor";
+import { extractPdfPagesWithPdfParse, type PdfExtractionDiagnostics } from "@/lib/chat/quickCheckPdfExtractor";
 import { withMetrics } from "@/lib/metrics";
 
 async function handlePost(request: Request) {
@@ -15,13 +15,14 @@ async function handlePost(request: Request) {
   let diagnostics: PdfExtractionDiagnostics | undefined;
 
   try {
-    const extraction = await extractPdfTextWithPdfParse({ bytes });
+    const extraction = await extractPdfPagesWithPdfParse({ bytes });
     diagnostics = extraction.metadata.diagnostics;
     // pdf-parse can succeed but return empty text for ASCII85-encoded streams.
     // Fall through to heuristic extractor which has custom ASCII85 + FlateDecode.
     if (extraction.text.trim().length > 0) {
       return NextResponse.json({
         text: extraction.text,
+        pages: extraction.pages,
         engine: extraction.engine,
         metadata: extraction.metadata,
       });
@@ -37,6 +38,7 @@ async function handlePost(request: Request) {
   const fallbackText = extractPdfText(bytes);
   return NextResponse.json({
     text: fallbackText,
+    pages: fallbackText.trim().length > 0 ? [{ pageNumber: 1, text: fallbackText }] : [],
     engine: "heuristic",
     metadata: {
       parser: "heuristic",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,22 @@
-import React from "react";
-import { Suspense } from "react";
-import ChatApp from "@/components/chat/ChatApp";
+import Link from "next/link";
 
 export default function Page() {
   return (
-    <main className="min-h-screen bg-[#f9f9f9]">
-      <Suspense
-        fallback={
-          <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-12 md:px-8">
-            <div className="h-6 w-56 animate-pulse rounded-full bg-slate-200" />
-            <div className="h-4 w-full animate-pulse rounded-full bg-slate-200" />
-            <div className="h-4 w-3/4 animate-pulse rounded-full bg-slate-200" />
-          </div>
-        }
-      >
-        <ChatApp />
-      </Suspense>
+    <main className="flex min-h-screen items-center justify-center bg-[#f9f9f9] px-4 py-16 md:px-8">
+      <section className="mx-auto flex w-full max-w-3xl flex-col items-center text-center">
+        <h1 className="max-w-2xl text-4xl font-semibold tracking-tight text-slate-950 md:text-6xl">
+          Know what is missing before verification
+        </h1>
+        <p className="mt-6 max-w-2xl text-base leading-7 text-slate-600 md:text-lg">
+          Upload a project document. Article6 checks it against carbon methodology requirements and shows missing evidence, weak support, and the next fixes before you spend money on formal review.
+        </p>
+        <Link
+          href="/start-review"
+          className="mt-10 inline-flex items-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+        >
+          Start Quick Check
+        </Link>
+      </section>
     </main>
   );
 }

--- a/src/app/start-review/page.tsx
+++ b/src/app/start-review/page.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import ChatApp from '@/components/chat/ChatApp';
 import NewProjectForm from '@/components/projects/NewProjectForm';
 
 export const metadata: Metadata = {
   title: 'Quick Check | app.article6',
-  description: 'Run a first document scan to identify methodology fit and readiness gaps.',
+  description: 'Upload a project document. Article6 will detect the project details, identify the likely methodology, and prepare the next readiness step.',
 };
 
 type StartReviewPageProps = {
@@ -20,9 +19,8 @@ function pickFirst(value: string | string[] | undefined): string | null {
 export default async function StartReviewPage({ searchParams }: StartReviewPageProps) {
   const params = await searchParams;
   const handoff = pickFirst(params.handoff);
-  const mode = pickFirst(params.mode);
   const showProjectSetup =
-    handoff === 'document-metadata' || handoff === 'active-review' || mode === 'manual';
+    handoff === 'document-metadata' || handoff === 'active-review';
 
   return (
     <main className="min-h-screen bg-slate-50">
@@ -30,19 +28,13 @@ export default async function StartReviewPage({ searchParams }: StartReviewPageP
         <NewProjectForm />
       ) : (
         <div className="pb-12">
-          <div className="mx-auto flex w-full max-w-6xl items-start justify-between gap-6 px-4 pt-8 md:px-8">
+          <div className="mx-auto flex w-full max-w-6xl items-start gap-6 px-4 pt-8 md:px-8">
             <div>
               <h1 className="text-2xl font-semibold text-slate-950">Quick Check</h1>
               <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
-                Upload a project document first. Article6 will detect project details, identify the methodology when possible, and prepare the next readiness step.
+                Upload a project document. Article6 will detect the project details, identify the likely methodology, and prepare the next readiness step.
               </p>
             </div>
-            <Link
-              href="/start-review?mode=manual"
-              className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:border-slate-400"
-            >
-              Set up manually
-            </Link>
           </div>
           <ChatApp surface="start-review" />
         </div>

--- a/src/app/start-review/page.tsx
+++ b/src/app/start-review/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import ChatApp from '@/components/chat/ChatApp';
+import NewProjectForm from '@/components/projects/NewProjectForm';
+
+export const metadata: Metadata = {
+  title: 'Quick Check | app.article6',
+  description: 'Run a first document scan to identify methodology fit and readiness gaps.',
+};
+
+type StartReviewPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function pickFirst(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+export default async function StartReviewPage({ searchParams }: StartReviewPageProps) {
+  const params = await searchParams;
+  const handoff = pickFirst(params.handoff);
+  const mode = pickFirst(params.mode);
+  const showProjectSetup =
+    handoff === 'document-metadata' || handoff === 'active-review' || mode === 'manual';
+
+  return (
+    <main className="min-h-screen bg-slate-50">
+      {showProjectSetup ? (
+        <NewProjectForm />
+      ) : (
+        <div className="pb-12">
+          <div className="mx-auto flex w-full max-w-6xl items-start justify-between gap-6 px-4 pt-8 md:px-8">
+            <div>
+              <h1 className="text-2xl font-semibold text-slate-950">Quick Check</h1>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                Upload a project document first. Article6 will detect project details, identify the methodology when possible, and prepare the next readiness step.
+              </p>
+            </div>
+            <Link
+              href="/start-review?mode=manual"
+              className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:border-slate-400"
+            >
+              Set up manually
+            </Link>
+          </div>
+          <ChatApp surface="start-review" />
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/components/DemoNav.tsx
+++ b/src/components/DemoNav.tsx
@@ -9,7 +9,7 @@ type DemoRoute = {
 };
 
 const demoRoutes: DemoRoute[] = [
-  { href: "/", title: "Quick Check" },
+  { href: "/start-review", title: "Quick Check" },
   { href: "/m", title: "Methods" },
   { href: "/projects", title: "Projects" },
 ];

--- a/src/components/chat/ChatApp.tsx
+++ b/src/components/chat/ChatApp.tsx
@@ -4,7 +4,11 @@ import { Loader2 } from "lucide-react";
 import QuickCheckPanel from "./QuickCheckPanel";
 import useDeeplinkMethodVersion from "@/hooks/useDeeplinkMethodVersion";
 
-export default function ChatApp() {
+type ChatAppProps = {
+  surface?: "quick-check" | "start-review";
+};
+
+export default function ChatApp({ surface = "quick-check" }: ChatAppProps) {
   const deeplink = useDeeplinkMethodVersion();
   const deeplinkWarnings = deeplink.resolved.warnings;
   const selectedMethod = deeplink.resolved.method;
@@ -42,7 +46,11 @@ export default function ChatApp() {
           </div>
         ) : null}
 
-        <QuickCheckPanel initialMethod={selectedMethod} initialVersion={selectedVersion} />
+        <QuickCheckPanel
+          surface={surface}
+          initialMethod={selectedMethod}
+          initialVersion={selectedVersion}
+        />
       </div>
     </div>
   );

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1279,6 +1279,25 @@ export default function QuickCheckPanel({
           },
         ],
       }));
+
+      if (surface === "start-review") {
+        void stageProjectDocumentDraftFromAttachment({
+          origin: "quick-check",
+          evidenceId,
+          attachmentId: attachmentResult.attachment.id,
+          fileName: attachmentResult.attachment.filename,
+          mimeType: attachmentResult.attachment.mime,
+          contentSha256: attachmentResult.attachment.sha256,
+        })
+          .then(() => {
+            if (typeof window !== "undefined") {
+              window.location.assign("/start-review?handoff=document-metadata");
+            }
+          })
+          .catch((error) => {
+            setFieldErrors({ general: error instanceof Error ? error.message : String(error) });
+          });
+      }
     } finally {
       setSubmitting(false);
       if (fileRef.current) fileRef.current.value = "";
@@ -1725,26 +1744,24 @@ export default function QuickCheckPanel({
   return (
     <div className="w-full">
       <div className="mx-auto w-full max-w-2xl px-4 md:px-0">
-        <div className="flex flex-col items-center text-center">
-          <div className="flex w-full items-start justify-center">
-            <div className="w-full">
-              <h1 className="text-4xl font-bold tracking-tight text-slate-950">
-                Quick Check
-              </h1>
-              <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
-                {surface === "start-review"
-                  ? "Start with the project document."
-                  : "Assess a carbon project document fast."}
-              </p>
-              <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-slate-500 md:text-[15px]">
-                {surface === "start-review"
-                  ? "Upload one file. Article6 extracts the signal, detects the method when possible, and prepares the next readiness step."
-                  : "Upload one file. We extract the signal, detect the method, and tell you if it can support review."}
-              </p>
+        {surface !== "start-review" ? (
+          <div className="flex flex-col items-center text-center">
+            <div className="flex w-full items-start justify-center">
+              <div className="w-full">
+                <h1 className="text-4xl font-bold tracking-tight text-slate-950">
+                  Quick Check
+                </h1>
+                <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
+                  Assess a carbon project document fast.
+                </p>
+                <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-slate-500 md:text-[15px]">
+                  Upload one file. We extract the signal, detect the method, and tell you if it can support review.
+                </p>
+              </div>
+              {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" /> : null}
             </div>
-            {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" /> : null}
           </div>
-        </div>
+        ) : null}
 
         <div className="mt-8 grid gap-8">
           <div>
@@ -1787,10 +1804,10 @@ export default function QuickCheckPanel({
                     <Upload className="h-6 w-6" />
                   </div>
                   <div className="mt-4 text-base font-medium text-slate-900">
-                    Start with the file
+                    {surface === "start-review" ? "Start with the project file" : "Start with the file"}
                   </div>
                   <div className="mt-2 text-sm text-slate-600">
-                    Upload first. Then confirm method and question.
+                    {surface === "start-review" ? "Upload a PDD, monitoring report, or evidence file." : "Upload first. Then confirm method and question."}
                   </div>
                 </div>
               ) : (
@@ -1948,158 +1965,164 @@ export default function QuickCheckPanel({
             {fieldErrors.evidence ? <div className="mt-3 text-sm text-rose-700">{fieldErrors.evidence}</div> : null}
           </div>
 
-          <div className={`rounded-[1.6rem] border px-4 py-4 ${showMethodology ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}>
-            <label className="grid gap-2 text-sm text-slate-700">
-              <span className="font-medium text-slate-900">Methodology</span>
-              <select
-                value={draft.methodologyId}
-                onChange={(event) => {
-                  const methodologyId = event.target.value;
-                  const method = methods.find((item) => item.code === methodologyId);
-                  const methodologyVersion = methodologyId ? pickVersion(method, initialVersion) : "";
-                  setShowMethodology(Boolean(methodologyId));
-                  updateSession((current) => {
-                    const stagedIds = new Set(current.stagedUploads.map((upload) => upload.evidenceId));
-                    return {
-                      ...current,
-                      draft: {
-                        ...current.draft,
-                        methodologyId,
-                        methodologyVersion,
-                        evidenceIds: current.draft.evidenceIds.filter((id) => stagedIds.has(id)),
-                        matchedRequirementId: undefined,
-                        matchedRequirementLabel: undefined,
-                        status: "draft",
-                        result: null,
-                        resultId: undefined,
-                        updatedAt: nowIso(),
-                      },
-                      result: null,
-                    };
-                  });
-                  setPendingInventoryId("");
-                  clearDecisionState();
-                }}
-                className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-slate-400 focus:bg-white"
-              >
-                <option value="">Any methodology</option>
-                {methods.map((method) => (
-                  <option key={method.code} value={method.code}>
-                    {methodOptionLabel(method)}
-                  </option>
-                ))}
-              </select>
-              <span className="text-xs text-slate-500">
-                Confirm or narrow the method.
-              </span>
-            </label>
-          </div>
-
-          <div className="rounded-[1.6rem] border border-slate-200 bg-white px-4 py-4">
-            <label className="grid gap-2 text-sm text-slate-700">
-              <span className="font-medium text-slate-900">Review question</span>
-              <span className="text-xs text-slate-500">
-                Optional. Leave blank for a general check.
-              </span>
-              <textarea
-                value={draft.claimText}
-                onChange={(event) => {
-                  const value = event.target.value;
-                  updateDraft(
-                    (current) => {
-                      const nextMethodology = resetMethodologyForUserInput(current);
+          {surface !== "start-review" ? (
+            <div className={`rounded-[1.6rem] border px-4 py-4 ${showMethodology ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}>
+              <label className="grid gap-2 text-sm text-slate-700">
+                <span className="font-medium text-slate-900">Methodology</span>
+                <select
+                  value={draft.methodologyId}
+                  onChange={(event) => {
+                    const methodologyId = event.target.value;
+                    const method = methods.find((item) => item.code === methodologyId);
+                    const methodologyVersion = methodologyId ? pickVersion(method, initialVersion) : "";
+                    setShowMethodology(Boolean(methodologyId));
+                    updateSession((current) => {
+                      const stagedIds = new Set(current.stagedUploads.map((upload) => upload.evidenceId));
                       return {
                         ...current,
-                        ...nextMethodology,
-                        claimText: value,
-                        matchedRequirementId: undefined,
-                        matchedRequirementLabel: undefined,
-                        status: "draft",
-                        resultId: undefined,
-                      };
-                    },
-                    null,
-                  );
-                  clearDecisionState();
-                }}
-                rows={4}
-                placeholder="Does this file support the selected methodology?"
-                className="w-full rounded-[1.25rem] border border-slate-200 bg-slate-50 p-4 text-base leading-7 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white"
-                ref={claimRef}
-              />
-              {fieldErrors.claim ? <span className="text-sm text-rose-700">{fieldErrors.claim}</span> : null}
-            </label>
-            <div className="mt-4">
-              <div className="text-xs text-slate-400">Try an example</div>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {CLAIM_SUGGESTIONS.slice(0, 2).map((suggestion) => (
-                  <button
-                    key={suggestion}
-                    type="button"
-                    onClick={() => {
-                      updateDraft(
-                        (current) => {
-                          const nextMethodology = resetMethodologyForUserInput(current);
-                          return {
-                            ...current,
-                            ...nextMethodology,
-                            claimText: suggestion,
-                            matchedRequirementId: undefined,
-                            matchedRequirementLabel: undefined,
-                            status: "draft",
-                            resultId: undefined,
-                          };
+                        draft: {
+                          ...current.draft,
+                          methodologyId,
+                          methodologyVersion,
+                          evidenceIds: current.draft.evidenceIds.filter((id) => stagedIds.has(id)),
+                          matchedRequirementId: undefined,
+                          matchedRequirementLabel: undefined,
+                          status: "draft",
+                          result: null,
+                          resultId: undefined,
+                          updatedAt: nowIso(),
                         },
-                        null,
-                      );
-                      clearDecisionState();
-                    }}
-                    className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
-                  >
-                    {suggestion}
-                  </button>
-                ))}
+                        result: null,
+                      };
+                    });
+                    setPendingInventoryId("");
+                    clearDecisionState();
+                  }}
+                  className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-slate-400 focus:bg-white"
+                >
+                  <option value="">Any methodology</option>
+                  {methods.map((method) => (
+                    <option key={method.code} value={method.code}>
+                      {methodOptionLabel(method)}
+                    </option>
+                  ))}
+                </select>
+                <span className="text-xs text-slate-500">
+                  Confirm or narrow the method.
+                </span>
+              </label>
+            </div>
+          ) : null}
+
+          {surface !== "start-review" ? (
+            <div className="rounded-[1.6rem] border border-slate-200 bg-white px-4 py-4">
+              <label className="grid gap-2 text-sm text-slate-700">
+                <span className="font-medium text-slate-900">Review question</span>
+                <span className="text-xs text-slate-500">
+                  Optional. Leave blank for a general check.
+                </span>
+                <textarea
+                  value={draft.claimText}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    updateDraft(
+                      (current) => {
+                        const nextMethodology = resetMethodologyForUserInput(current);
+                        return {
+                          ...current,
+                          ...nextMethodology,
+                          claimText: value,
+                          matchedRequirementId: undefined,
+                          matchedRequirementLabel: undefined,
+                          status: "draft",
+                          resultId: undefined,
+                        };
+                      },
+                      null,
+                    );
+                    clearDecisionState();
+                  }}
+                  rows={4}
+                  placeholder="Does this file support the selected methodology?"
+                  className="w-full rounded-[1.25rem] border border-slate-200 bg-slate-50 p-4 text-base leading-7 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white"
+                  ref={claimRef}
+                />
+                {fieldErrors.claim ? <span className="text-sm text-rose-700">{fieldErrors.claim}</span> : null}
+              </label>
+              <div className="mt-4">
+                <div className="text-xs text-slate-400">Try an example</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {CLAIM_SUGGESTIONS.slice(0, 2).map((suggestion) => (
+                    <button
+                      key={suggestion}
+                      type="button"
+                      onClick={() => {
+                        updateDraft(
+                          (current) => {
+                            const nextMethodology = resetMethodologyForUserInput(current);
+                            return {
+                              ...current,
+                              ...nextMethodology,
+                              claimText: suggestion,
+                              matchedRequirementId: undefined,
+                              matchedRequirementLabel: undefined,
+                              status: "draft",
+                              resultId: undefined,
+                            };
+                          },
+                          null,
+                        );
+                        clearDecisionState();
+                      }}
+                      className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
+                    >
+                      {suggestion}
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
-          </div>
+          ) : null}
 
-          <div className="grid gap-3">
-            <button
-              type="button"
-              disabled={!canRunQuickCheck}
-              onClick={() => void runQuickCheck()}
-              className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-black px-5 py-3.5 text-sm font-semibold text-white transition hover:bg-neutral-900 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
-            >
-              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-              Run Quick Check
-            </button>
-            {process.env.NODE_ENV !== "production" && surface !== "start-review" ? (
-              <div className="flex flex-wrap items-center justify-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => void handleTryDemoCheck()}
-                  disabled={submitting}
-                  className="text-xs text-slate-400 underline underline-offset-4 transition hover:text-slate-600 disabled:cursor-not-allowed disabled:text-slate-300"
-                >
-                  Try demo check
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const nextValue = !showAdvancedOptions;
-                    setShowAdvanced(nextValue);
-                    if (!nextValue) {
-                      setShowSavedEvidence(false);
-                    }
-                  }}
-                  className="text-xs text-slate-400 underline underline-offset-4 transition hover:text-slate-600"
-                  aria-expanded={showAdvancedOptions}
-                >
-                  Options
-                </button>
-              </div>
-            ) : null}
-          </div>
+          {surface !== "start-review" ? (
+            <div className="grid gap-3">
+              <button
+                type="button"
+                disabled={!canRunQuickCheck}
+                onClick={() => void runQuickCheck()}
+                className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-black px-5 py-3.5 text-sm font-semibold text-white transition hover:bg-neutral-900 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
+              >
+                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                Run Quick Check
+              </button>
+              {process.env.NODE_ENV !== "production" ? (
+                <div className="flex flex-wrap items-center justify-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void handleTryDemoCheck()}
+                    disabled={submitting}
+                    className="text-xs text-slate-400 underline underline-offset-4 transition hover:text-slate-600 disabled:cursor-not-allowed disabled:text-slate-300"
+                  >
+                    Try demo check
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const nextValue = !showAdvancedOptions;
+                      setShowAdvanced(nextValue);
+                      if (!nextValue) {
+                        setShowSavedEvidence(false);
+                      }
+                    }}
+                    className="text-xs text-slate-400 underline underline-offset-4 transition hover:text-slate-600"
+                    aria-expanded={showAdvancedOptions}
+                  >
+                    Options
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
           
           {showAdvancedOptions ? (
             <div className="rounded-[1.6rem] border border-slate-200 bg-white px-4 py-4">
@@ -2135,7 +2158,7 @@ export default function QuickCheckPanel({
             </div>
           ) : null}
 
-          {recoveryState ? (
+          {surface !== "start-review" && recoveryState ? (
             <div className="rounded-2xl border border-amber-200 bg-amber-50/90 p-4">
               <div className="text-sm font-semibold text-slate-900">{recoveryState.title}</div>
               <div className="mt-1 text-sm text-slate-700">{recoveryState.description}</div>
@@ -2188,7 +2211,7 @@ export default function QuickCheckPanel({
             </div>
           ) : null}
 
-          {matchCandidates.length ? (
+          {surface !== "start-review" && matchCandidates.length ? (
             <div className="rounded-2xl border border-sky-200 bg-sky-50/80 p-4">
               <div className="flex items-start gap-3">
                 <SearchCheck className="mt-0.5 h-4 w-4 shrink-0 text-sky-700" />
@@ -2228,7 +2251,7 @@ export default function QuickCheckPanel({
             </div>
           ) : null}
 
-          {renderedResult && normalizedResult?.match ? (
+          {surface !== "start-review" && renderedResult && normalizedResult?.match ? (
             <div
               ref={resultRef}
               tabIndex={-1}
@@ -2256,13 +2279,13 @@ export default function QuickCheckPanel({
                   className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
                 >
                   <FolderOpen className="h-4 w-4" />
-                  {surface === "start-review" ? "Continue to project details" : "Open full review"}
+                  Open full review
                 </button>
               </div>
             </div>
           ) : null}
 
-          {(selectedMethodRecord && draft.methodologyVersion) || (methodologyResolution.status === "single" && !draft.methodologyId.trim()) ? (
+          {surface !== "start-review" && ((selectedMethodRecord && draft.methodologyVersion) || (methodologyResolution.status === "single" && !draft.methodologyId.trim())) ? (
             <div className="text-xs text-slate-500" aria-live="polite">
               Narrowing matches to {(selectedMethodRecord?.code ?? methodologyResolution.matchedMethods[0]?.methodologyId) ?? ""} · {(draft.methodologyVersion || methodologyResolution.matchedMethods[0]?.methodologyVersion) ?? ""}.
             </div>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -50,6 +50,7 @@ import { createAndStoreEvidenceAttachment } from "@/lib/proofMap/attachments";
 import { isRuleLikeId } from "@/lib/proofMap/pins";
 import { loadPins, savePins } from "@/lib/proofMap/storage";
 import type { EvidencePin, PddFragment } from "@/lib/proofMap/types";
+import { stageProjectDocumentDraftFromAttachment } from "@/lib/projects/documentMetadata";
 
 type MethodInventoryRecord = {
   code: string;
@@ -58,6 +59,7 @@ type MethodInventoryRecord = {
 };
 
 type QuickCheckPanelProps = {
+  surface?: "quick-check" | "start-review";
   initialMethod?: string | null;
   initialVersion?: string | null;
   onContinueToWorkspace?: (url: string) => void;
@@ -530,7 +532,12 @@ function joinMethodologyLabels(values: string[]): string {
   return values.join(", ");
 }
 
-export default function QuickCheckPanel({ initialMethod, initialVersion, onContinueToWorkspace }: QuickCheckPanelProps) {
+export default function QuickCheckPanel({
+  surface = "quick-check",
+  initialMethod,
+  initialVersion,
+  onContinueToWorkspace,
+}: QuickCheckPanelProps) {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const claimRef = useRef<HTMLTextAreaElement | null>(null);
   const resultRef = useRef<HTMLDivElement | null>(null);
@@ -1659,6 +1666,35 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   }
 
   function handleContinueToWorkspace() {
+    if (surface === "start-review") {
+      const upload = selectedUploadEvidence[0] ?? null;
+      if (!upload) {
+        setFieldErrors({ general: "Upload a project document to continue into readiness setup." });
+        return;
+      }
+      setSubmitting(true);
+      void stageProjectDocumentDraftFromAttachment({
+        origin: "quick-check",
+        evidenceId: upload.evidenceId,
+        attachmentId: upload.attachment.id,
+        fileName: upload.filename,
+        mimeType: upload.mime,
+        contentSha256: upload.attachment.sha256,
+      })
+        .then(() => {
+          if (typeof window !== "undefined") {
+            window.location.assign("/start-review?handoff=document-metadata");
+          }
+        })
+        .catch((error) => {
+          setFieldErrors({ general: error instanceof Error ? error.message : String(error) });
+        })
+        .finally(() => {
+          setSubmitting(false);
+        });
+      return;
+    }
+
     const handoff = ensureQuickCheckWorkspaceHandoff({
       ...draft,
       methodologyId: workspaceMethodologyId,
@@ -1696,10 +1732,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 Quick Check
               </h1>
               <p className="mt-3 text-sm leading-6 text-slate-600 md:text-[15px]">
-                Assess a carbon project document fast.
+                {surface === "start-review"
+                  ? "Start with the project document."
+                  : "Assess a carbon project document fast."}
               </p>
               <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-slate-500 md:text-[15px]">
-                Upload one file. We extract the signal, detect the method, and tell you if it can support review.
+                {surface === "start-review"
+                  ? "Upload one file. Article6 extracts the signal, detects the method when possible, and prepares the next readiness step."
+                  : "Upload one file. We extract the signal, detect the method, and tell you if it can support review."}
               </p>
             </div>
             {loadingMethods || submitting ? <Loader2 className="mt-1 h-5 w-5 animate-spin text-slate-400" /> : null}
@@ -2033,7 +2073,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
               Run Quick Check
             </button>
-            {process.env.NODE_ENV !== "production" ? (
+            {process.env.NODE_ENV !== "production" && surface !== "start-review" ? (
               <div className="flex flex-wrap items-center justify-center gap-2">
                 <button
                   type="button"
@@ -2216,7 +2256,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
                 >
                   <FolderOpen className="h-4 w-4" />
-                  Open full review
+                  {surface === "start-review" ? "Continue to project details" : "Open full review"}
                 </button>
               </div>
             </div>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -51,6 +51,12 @@ import { isRuleLikeId } from "@/lib/proofMap/pins";
 import { loadPins, savePins } from "@/lib/proofMap/storage";
 import type { EvidencePin, PddFragment } from "@/lib/proofMap/types";
 import { stageProjectDocumentDraftFromAttachment } from "@/lib/projects/documentMetadata";
+import {
+  buildReviewQuestionResult,
+  detectReviewPath,
+  reviewAreaLabel,
+  type ReviewQuestionResult,
+} from "@/lib/chat/quickCheckReviewQuestion";
 
 type MethodInventoryRecord = {
   code: string;
@@ -555,6 +561,7 @@ export default function QuickCheckPanel({
   const [showMethodology, setShowMethodology] = useState(false);
   const [isDragActive, setIsDragActive] = useState(false);
   const [showExtractionDetails, setShowExtractionDetails] = useState(false);
+  const [reviewQuestionResult, setReviewQuestionResult] = useState<ReviewQuestionResult | null>(null);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
     loading: false,
@@ -951,6 +958,7 @@ export default function QuickCheckPanel({
     setRecoveryState(null);
     setMatchCandidates([]);
     setValidatedResultKey(null);
+    setReviewQuestionResult(null);
   }
 
   function resetQuickCheckUi() {
@@ -1412,6 +1420,25 @@ export default function QuickCheckPanel({
         setRecoveryState(buildUnsupportedMethodRecoveryState(currentMethodologyResolution.unsupportedCanonicalKeys[0] ?? "unknown methodology"));
         return;
       }
+
+      const resolvedMethodologyId = draft.methodologyId.trim()
+        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "" : "");
+
+      if (detectReviewPath(effectiveClaimText) === "review_question_answering") {
+        const questionResult = buildReviewQuestionResult({
+          claimText: effectiveClaimText,
+          methodologyId: resolvedMethodologyId,
+          methodologyVersion: draft.methodologyVersion.trim()
+            || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyVersion ?? "" : ""),
+        });
+        setReviewQuestionResult(questionResult);
+        setRecoveryState(null);
+        setFieldErrors({});
+        setSubmitting(false);
+        return;
+      }
+
+      setReviewQuestionResult(null);
 
       const selectedMethodologyId = draft.methodologyId.trim()
         || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "" : "");
@@ -2123,7 +2150,58 @@ export default function QuickCheckPanel({
               ) : null}
             </div>
           ) : null}
-          
+
+          {reviewQuestionResult ? (
+            <div className="rounded-[1.6rem] border border-sky-200 bg-sky-50/80 p-5">
+              <div className="flex items-start gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-800">Review question</div>
+                  <div className="mt-2 text-sm text-slate-600">{draft.claimText}</div>
+                  <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Review area</div>
+                      <div className="mt-1 text-sm font-medium text-slate-900">{reviewAreaLabel(reviewQuestionResult.reviewArea)}</div>
+                    </div>
+                    {reviewQuestionResult.methodologyId ? (
+                      <div>
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Methodology</div>
+                        <div className="mt-1 text-sm font-medium text-slate-900">{reviewQuestionResult.methodologyId} · {reviewQuestionResult.methodologyVersion || "—"}</div>
+                      </div>
+                    ) : null}
+                  </div>
+                  {reviewQuestionResult.relevantSections.length > 0 ? (
+                    <div className="mt-4">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Relevant PDD sections</div>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {reviewQuestionResult.relevantSections.map((section) => (
+                          <span key={section} className="rounded-full border border-sky-200 bg-white px-3 py-1.5 text-sm font-medium text-sky-900">
+                            Section {section}
+                          </span>
+                        ))}
+                      </div>
+                      <p className="mt-2 text-xs text-slate-500">
+                        Open the full review to inspect these sections in the uploaded document.
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
+                      No methodology-specific section routing is available yet. Check the methodology document directly.
+                    </div>
+                  )}
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setReviewQuestionResult(null)}
+                      className="rounded-full border border-sky-200 bg-white px-4 py-2 text-sm font-medium text-sky-800 transition hover:border-sky-300"
+                    >
+                      Return to requirement match
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : null}
+
           {showAdvancedOptions ? (
             <div className="rounded-[1.6rem] border border-slate-200 bg-white px-4 py-4">
               <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Options</div>

--- a/src/components/projects/NewProjectForm.tsx
+++ b/src/components/projects/NewProjectForm.tsx
@@ -1,11 +1,25 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useMemo } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { createProject } from '@/lib/projects/storage';
-import { projectRegistryFromMethodProgram } from '@/lib/projects/verificationReport';
-import type { ProjectRegistry, ProjectReviewMode } from '@/lib/projects/types';
-import { importMethodologyReviewIntoProject, readPendingProjectReviewHandoff } from '@/lib/projects/reviewHandoff';
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  attachPendingProjectDocumentToProject,
+  clearPendingProjectDocumentDraft,
+  readPendingProjectDocumentDraft,
+} from "@/lib/projects/documentMetadata";
+import { createProject, updateProject } from "@/lib/projects/storage";
+import { projectRegistryFromMethodProgram } from "@/lib/projects/verificationReport";
+import type {
+  ProjectDocumentMetadataDraft,
+  ProjectRegistry,
+  ProjectReviewMode,
+} from "@/lib/projects/types";
+import {
+  buildProjectReviewHref,
+  importMethodologyReviewIntoProject,
+  readPendingProjectReviewHandoff,
+} from "@/lib/projects/reviewHandoff";
+import { ensureReviewWorkspace } from "@/lib/reviewWorkspaces/storage";
 
 export type MethodOption = {
   code: string;
@@ -14,7 +28,25 @@ export type MethodOption = {
   ruleCount: number;
 };
 
-const REGISTRY_ORDER: ProjectRegistry[] = ['UNFCCC', 'Verra', 'Gold Standard', 'Unknown'];
+const REGISTRY_ORDER: ProjectRegistry[] = ["UNFCCC", "Verra", "Gold Standard", "Unknown"];
+
+function confidenceTone(
+  confidence: ProjectDocumentMetadataDraft["fields"]["projectTitle"]["confidence"],
+): string {
+  if (confidence === "high") return "border-emerald-200 bg-emerald-50 text-emerald-800";
+  if (confidence === "medium") return "border-sky-200 bg-sky-50 text-sky-800";
+  if (confidence === "low") return "border-amber-200 bg-amber-50 text-amber-800";
+  return "border-slate-200 bg-slate-100 text-slate-500";
+}
+
+function maybeSelectMethod(methods: MethodOption[], rawValue: string | undefined): string {
+  const value = rawValue?.trim();
+  if (!value) return "";
+  const exact = methods.find((method) => method.code.toLowerCase() === value.toLowerCase());
+  if (exact) return `${exact.code}@${exact.version}`;
+  const matched = methods.find((method) => value.toLowerCase().includes(method.code.toLowerCase()));
+  return matched ? `${matched.code}@${matched.version}` : "";
+}
 
 export function groupMethodsByRegistry(methods: MethodOption[]): Array<{ registry: ProjectRegistry; methods: MethodOption[] }> {
   const groups = new Map<ProjectRegistry, MethodOption[]>();
@@ -33,50 +65,89 @@ export function groupMethodsByRegistry(methods: MethodOption[]): Array<{ registr
 export default function NewProjectForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const manualModeRequested = searchParams.get("mode") === "manual";
   const [methods, setMethods] = useState<MethodOption[]>([]);
-  const [reviewMode, setReviewMode] = useState<ProjectReviewMode>('methodology-linked');
-  const [name, setName] = useState('');
-  const [projectCode, setProjectCode] = useState('');
-  const [countryLocation, setCountryLocation] = useState('');
-  const [proponent, setProponent] = useState('');
-  const [reportingPeriod, setReportingPeriod] = useState('');
-  const [selectedMethod, setSelectedMethod] = useState('');
-  const [aoiLabel, setAoiLabel] = useState('');
-  const [description, setDescription] = useState('');
+  const [reviewMode, setReviewMode] = useState<ProjectReviewMode>(manualModeRequested ? "manual" : "methodology-linked");
+  const [name, setName] = useState("");
+  const [projectCode, setProjectCode] = useState("");
+  const [countryLocation, setCountryLocation] = useState("");
+  const [proponent, setProponent] = useState("");
+  const [reportingPeriod, setReportingPeriod] = useState("");
+  const [selectedMethod, setSelectedMethod] = useState("");
+  const [aoiLabel, setAoiLabel] = useState("");
+  const [description, setDescription] = useState("");
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
   const [handoffDetected, setHandoffDetected] = useState(false);
-  const [handoffMethodLabel, setHandoffMethodLabel] = useState('');
+  const [handoffMethodLabel, setHandoffMethodLabel] = useState("");
+  const [documentDraft, setDocumentDraft] = useState<ProjectDocumentMetadataDraft | null>(null);
+  const [confirmDocumentDraft, setConfirmDocumentDraft] = useState(false);
 
   const groupedMethods = useMemo(() => groupMethodsByRegistry(methods), [methods]);
+  const searchKey = searchParams.toString();
+  const manualOnlyView = manualModeRequested && !documentDraft && !handoffDetected;
+  const metadataFields = documentDraft ? [
+    documentDraft.fields.projectTitle,
+    documentDraft.fields.projectId,
+    documentDraft.fields.country,
+    documentDraft.fields.proponent,
+    documentDraft.fields.methodology,
+    documentDraft.fields.standard,
+    documentDraft.fields.documentType,
+    documentDraft.fields.documentDate,
+  ] : [];
 
   useEffect(() => {
-    fetch('/api/projects/methods')
+    fetch("/api/projects/methods")
       .then(r => r.json())
       .then(data => setMethods(data.methods || []))
       .catch(() => setMethods([]));
   }, []);
 
   useEffect(() => {
-    if (searchParams.get('handoff') !== 'active-review') return;
+    if (searchParams.get("handoff") !== "active-review") return;
     const handoff = readPendingProjectReviewHandoff();
     if (!handoff) return;
     setHandoffDetected(true);
-    setReviewMode('methodology-linked');
+    setReviewMode("methodology-linked");
     setSelectedMethod(`${handoff.source.methodCode}@${handoff.source.methodVersion}`);
     setHandoffMethodLabel(`${handoff.source.methodCode} ${handoff.source.methodVersion}`);
-  }, [searchParams]);
+  }, [searchKey, searchParams]);
+
+  useEffect(() => {
+    if (searchParams.get("handoff") !== "document-metadata") return;
+    const stagedDraft = readPendingProjectDocumentDraft();
+    if (!stagedDraft) return;
+    if (documentDraft?.source.attachmentId === stagedDraft.source.attachmentId) return;
+    setDocumentDraft(stagedDraft);
+    setName(stagedDraft.fields.projectTitle.value ?? "");
+    setProjectCode(stagedDraft.fields.projectId.value ?? "");
+    setCountryLocation(stagedDraft.fields.country.value ?? "");
+    setProponent(stagedDraft.fields.proponent.value ?? "");
+  }, [documentDraft?.source.attachmentId, searchKey, searchParams]);
+
+  useEffect(() => {
+    if (!documentDraft || !methods.length || selectedMethod) return;
+    const maybeMethod = maybeSelectMethod(methods, documentDraft.fields.methodology.value);
+    if (maybeMethod) setSelectedMethod(maybeMethod);
+  }, [documentDraft, methods, selectedMethod]);
+
+  useEffect(() => {
+    if (!manualOnlyView) return;
+    setReviewMode("manual");
+  }, [manualOnlyView]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name) return;
-    if (reviewMode === 'methodology-linked' && !selectedMethod) return;
+    if (reviewMode === "methodology-linked" && !selectedMethod) return;
+    if (documentDraft && !confirmDocumentDraft) return;
 
     setLoading(true);
-    setError('');
+    setError("");
 
     try {
-      if (reviewMode === 'manual') {
+      if (reviewMode === "manual") {
         const project = createProject({
           name,
           projectCode: projectCode || undefined,
@@ -87,24 +158,28 @@ export default function NewProjectForm() {
           aoiLabel: aoiLabel || undefined,
           description: description || undefined,
         });
+        if (documentDraft) {
+          await attachPendingProjectDocumentToProject(project.id);
+          clearPendingProjectDocumentDraft();
+        }
         router.push(`/projects/${project.id}`);
         return;
       }
 
       const handoff = handoffDetected ? readPendingProjectReviewHandoff() : null;
-      const [code, version] = selectedMethod.split('@');
+      const [code, version] = selectedMethod.split("@");
       const rulesRes = await fetch(`/api/projects/method-rules?code=${code}&version=${version}`);
       const rulesData = await rulesRes.json();
       const rules = (rulesData.rules || []).filter((r: { id?: string }) => r.id);
 
       if (rules.length === 0) {
-        setError('No rules found for this methodology. Cannot create project review.');
+        setError("No rules found for this methodology. Cannot create project review.");
         setLoading(false);
         return;
       }
 
       const selectedMethodRecord = methods.find((method) => `${method.code}@${method.version}` === selectedMethod);
-      const parts = (selectedMethodRecord?.program ?? '').split('/');
+      const parts = (selectedMethodRecord?.program ?? "").split("/");
       const category = parts.length > 1 ? parts.slice(1).join('/') : undefined;
       if (handoff && handoff.source.methodCode === code && handoff.source.methodVersion === version) {
         const result = importMethodologyReviewIntoProject({
@@ -122,6 +197,10 @@ export default function NewProjectForm() {
           },
           rules,
         });
+        if (documentDraft) {
+          await attachPendingProjectDocumentToProject(result.project.id);
+          clearPendingProjectDocumentDraft();
+        }
         router.push(result.href);
         return;
       }
@@ -142,15 +221,36 @@ export default function NewProjectForm() {
         ruleIds: rules.map((r: { id: string; title: string; sectionId?: string }) => ({
           id: r.id,
           title: r.title,
-          sectionId: r.sectionId || '',
+          sectionId: r.sectionId || "",
         })),
       });
-
-      router.push(`/projects/${project.id}`);
-    } catch {
-      setError(reviewMode === 'manual'
-        ? 'Failed to create manual review. Try again.'
-        : 'Failed to create project handoff. Try again.');
+      const workspace = ensureReviewWorkspace({
+        projectId: project.id,
+        projectName: project.name,
+        projectCode: project.projectCode,
+        methodCode: code,
+        methodVersion: version,
+        reportingPeriod: project.reportingPeriod,
+      });
+      updateProject(project.id, { lastWorkspaceId: workspace.id });
+      if (documentDraft) {
+        await attachPendingProjectDocumentToProject(project.id);
+        clearPendingProjectDocumentDraft();
+      }
+      router.push(buildProjectReviewHref({
+        methodCode: code,
+        methodVersion: version,
+        projectId: project.id,
+        workspaceId: workspace.id,
+      }));
+    } catch (caughtError) {
+      setError(
+        caughtError instanceof Error && caughtError.message
+          ? caughtError.message
+          : reviewMode === "manual"
+            ? "Failed to create manual review. Try again."
+            : "Failed to create project handoff. Try again.",
+      );
       setLoading(false);
     }
   };
@@ -158,11 +258,45 @@ export default function NewProjectForm() {
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-12 md:px-8">
       <div>
-        <h1 className="text-2xl font-bold text-slate-900">New Project Review</h1>
+        <h1 className="text-2xl font-bold text-slate-900">
+          {manualOnlyView ? "Set up review manually" : documentDraft ? "Confirm Project Details" : "New Project Review"}
+        </h1>
         <p className="mt-1 text-sm text-slate-500">
-          Create a long-lived project review workspace
+          {manualOnlyView
+            ? "Create a project review without uploading a source document first. You can attach documents and evidence later."
+            : documentDraft
+              ? "Article6 detected project details from your document. Confirm them, then create the readiness workspace."
+              : "Create a long-lived project review workspace"}
         </p>
       </div>
+
+      {documentDraft ? (
+        <div className="rounded-lg border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700">
+          <div className="font-semibold text-slate-900">Detected from {documentDraft.source.fileName}</div>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            {metadataFields.map((field) => (
+              <div key={field.key} className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                    {field.label}
+                  </div>
+                  <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${confidenceTone(field.confidence)}`}>
+                    {field.confidence}
+                  </span>
+                </div>
+                <div className="mt-1 text-sm font-medium text-slate-900">
+                  {field.value?.trim() || "Not detected"}
+                </div>
+                {field.provenance?.excerpt ? (
+                  <div className="mt-2 text-xs leading-5 text-slate-500">
+                    {field.provenance.excerpt}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
 
       {error && (
         <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
@@ -171,37 +305,53 @@ export default function NewProjectForm() {
       )}
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <div>
-          <label className="mb-1 block text-sm font-semibold text-slate-700">Review Type</label>
-          <div className="grid gap-3 md:grid-cols-2">
-            <button
-              type="button"
-              disabled={handoffDetected}
-              onClick={() => setReviewMode('methodology-linked')}
-              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? 'cursor-not-allowed opacity-60' : ''} ${
-                reviewMode === 'methodology-linked'
-                  ? 'border-blue-500 bg-blue-50 text-blue-900'
-                  : 'border-slate-200 bg-white text-slate-700'
-              }`}
-            >
-              <div className="text-sm font-semibold">Methodology-linked review</div>
-              <div className="mt-1 text-xs text-slate-500">Use a selected methodology and its rule set.</div>
-            </button>
-            <button
-              type="button"
-              disabled={handoffDetected}
-              onClick={() => setReviewMode('manual')}
-              className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? 'cursor-not-allowed opacity-60' : ''} ${
-                reviewMode === 'manual'
-                  ? 'border-blue-500 bg-blue-50 text-blue-900'
-                  : 'border-slate-200 bg-white text-slate-700'
-              }`}
-            >
-              <div className="text-sm font-semibold">Manual Review</div>
-              <div className="mt-1 text-xs text-slate-500">Project-level manual review / VVB findings reconstruction.</div>
-            </button>
+        {!manualOnlyView ? (
+          <div>
+            <label className="mb-1 block text-sm font-semibold text-slate-700">
+              {documentDraft ? "Review route" : "Review Type"}
+            </label>
+            <div className="grid gap-3 md:grid-cols-2">
+              <button
+                type="button"
+                disabled={handoffDetected}
+                onClick={() => setReviewMode("methodology-linked")}
+                className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? "cursor-not-allowed opacity-60" : ""} ${
+                  reviewMode === "methodology-linked"
+                    ? "border-blue-500 bg-blue-50 text-blue-900"
+                    : "border-slate-200 bg-white text-slate-700"
+                }`}
+              >
+                <div className="text-sm font-semibold">
+                  {documentDraft ? "Continue with detected method" : "Methodology-linked review"}
+                </div>
+                <div className="mt-1 text-xs text-slate-500">
+                  {documentDraft
+                    ? "Create a readiness workspace using the detected or selected methodology."
+                    : "Use a selected methodology and its rule set."}
+                </div>
+              </button>
+              <button
+                type="button"
+                disabled={handoffDetected}
+                onClick={() => setReviewMode("manual")}
+                className={`rounded-lg border px-4 py-3 text-left ${handoffDetected ? "cursor-not-allowed opacity-60" : ""} ${
+                  reviewMode === "manual"
+                    ? "border-blue-500 bg-blue-50 text-blue-900"
+                    : "border-slate-200 bg-white text-slate-700"
+                }`}
+              >
+                <div className="text-sm font-semibold">
+                  {documentDraft ? "Continue without a linked method" : "Manual Review"}
+                </div>
+                <div className="mt-1 text-xs text-slate-500">
+                  {documentDraft
+                    ? "Use this only if detection is wrong or you need a manual workspace."
+                    : "Project-level manual review / VVB findings reconstruction."}
+                </div>
+              </button>
+            </div>
           </div>
-        </div>
+        ) : null}
 
         {handoffDetected ? (
           <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
@@ -267,7 +417,7 @@ export default function NewProjectForm() {
           </div>
         </div>
 
-        {reviewMode === 'methodology-linked' ? (
+        {reviewMode === "methodology-linked" ? (
           <div>
             <label className="mb-1 block text-sm font-semibold text-slate-700">Methodology</label>
             <select
@@ -288,6 +438,15 @@ export default function NewProjectForm() {
                 </optgroup>
               ))}
             </select>
+            {documentDraft?.fields.methodology.value ? (
+              <p className="mt-2 text-xs text-slate-500">
+                Detected in document: {documentDraft.fields.methodology.value}
+              </p>
+            ) : documentDraft ? (
+              <p className="mt-2 text-xs text-slate-500">
+                No method was detected. Select one manually to continue into the readiness workspace.
+              </p>
+            ) : null}
           </div>
         ) : (
           <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
@@ -317,12 +476,30 @@ export default function NewProjectForm() {
           />
         </div>
 
+        {documentDraft ? (
+          <label className="flex items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+            <input
+              type="checkbox"
+              checked={confirmDocumentDraft}
+              onChange={(event) => setConfirmDocumentDraft(event.target.checked)}
+              className="mt-1"
+            />
+            <span>
+              I confirmed these project details and want to continue into the readiness workspace.
+            </span>
+          </label>
+        ) : null}
+
         <button
           type="submit"
-          disabled={loading || !name || (reviewMode === 'methodology-linked' && !selectedMethod)}
+          disabled={loading || !name || (reviewMode === "methodology-linked" && !selectedMethod) || Boolean(documentDraft && !confirmDocumentDraft)}
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
         >
-          {loading ? 'Creating...' : 'Create Project Review'}
+          {loading
+            ? "Creating..."
+            : documentDraft && reviewMode === "methodology-linked"
+              ? "Create Readiness Workspace"
+              : "Create Project Review"}
         </button>
       </form>
     </div>

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,0 +1,97 @@
+export type ReviewArea =
+  | "baseline"
+  | "boundary"
+  | "deviations"
+  | "leakage"
+  | "monitoring"
+  | "right_of_use"
+  | "general";
+
+export type QuickCheckPath = "claim_to_requirement_match" | "review_question_answering";
+
+export type ReviewQuestionResult = {
+  path: QuickCheckPath;
+  reviewArea: ReviewArea;
+  methodologyId: string;
+  methodologyVersion: string;
+  relevantSections: string[];
+  sectionContent: Record<string, string>;
+};
+
+const BROAD_QUESTION_PATTERNS: RegExp[] = [
+  /^does\s+this\s+pdd\s+justify/i,
+  /^does\s+this\s+pdd\s+explain/i,
+  /^does\s+this\s+pdd\s+disclose/i,
+  /^does\s+this\s+pdd\s+support/i,
+];
+
+const VM0007_SECTION_ROUTES: Record<ReviewArea, string[]> = {
+  baseline: ["2.4", "2.5", "1.10"],
+  boundary: ["2.3", "1.9"],
+  deviations: ["2.6"],
+  leakage: ["1.13", "3.3"],
+  monitoring: ["4"],
+  right_of_use: ["1.11", "1.12.1"],
+  general: [],
+};
+
+const REVIEW_AREA_LABELS: Record<ReviewArea, string> = {
+  baseline: "Baseline scenario",
+  boundary: "Project boundary",
+  deviations: "Deviations from methodology",
+  leakage: "Leakage",
+  monitoring: "Monitoring approach",
+  right_of_use: "Right of use / land tenure",
+  general: "General review",
+};
+
+export function detectReviewPath(claimText: string): QuickCheckPath {
+  const normalized = claimText.trim();
+  if (!normalized) return "claim_to_requirement_match";
+  const isBroadQuestion = BROAD_QUESTION_PATTERNS.some((pattern) => pattern.test(normalized));
+  if (isBroadQuestion) return "review_question_answering";
+  return "claim_to_requirement_match";
+}
+
+export function classifyReviewArea(claimText: string): ReviewArea {
+  const normalized = claimText.trim().toLowerCase();
+  if (/justify|baseline|scenario/i.test(normalized)) return "baseline";
+  if (/boundary|area\s+of|spatial|geographic|polygon/i.test(normalized)) return "boundary";
+  if (/deviations|departure|variance|deviation/i.test(normalized)) return "deviations";
+  if (/leakage|displacement/i.test(normalized)) return "leakage";
+  if (/monitoring|sampling|plot|measur/i.test(normalized)) return "monitoring";
+  if (/right of use|land tenure|carbon right|entitlement/i.test(normalized)) return "right_of_use";
+  return "general";
+}
+
+export function resolveReviewSections(
+  methodologyId: string,
+  reviewArea: ReviewArea,
+): string[] {
+  const normalizedMethod = methodologyId.trim().toUpperCase();
+  if (normalizedMethod === "VM0007") {
+    return VM0007_SECTION_ROUTES[reviewArea] ?? [];
+  }
+  return [];
+}
+
+export function reviewAreaLabel(area: ReviewArea): string {
+  return REVIEW_AREA_LABELS[area];
+}
+
+export function buildReviewQuestionResult(input: {
+  claimText: string;
+  methodologyId: string;
+  methodologyVersion: string;
+}): ReviewQuestionResult {
+  const reviewArea = classifyReviewArea(input.claimText);
+  const relevantSections = resolveReviewSections(input.methodologyId, reviewArea);
+  return {
+    path: "review_question_answering",
+    reviewArea,
+    methodologyId: input.methodologyId,
+    methodologyVersion: input.methodologyVersion,
+    relevantSections,
+    sectionContent: {},
+  };
+}

--- a/src/lib/projects/documentMetadata.ts
+++ b/src/lib/projects/documentMetadata.ts
@@ -1,0 +1,417 @@
+import { getAttachmentBytes } from '@/lib/proofMap/attachments';
+import { addProjectDocument, listProjects } from '@/lib/projects/storage';
+import type {
+  ExistingProjectMatch,
+  MetadataConfidence,
+  Project,
+  ProjectDocumentMetadataDraft,
+  ProjectMetadataField,
+  ProjectMetadataFieldKey,
+  ProjectMetadataFieldProvenance,
+} from '@/lib/projects/types';
+
+const PENDING_DOCUMENT_DRAFT_KEY = 'article6:pending-project-document-draft';
+
+type ExtractedPage = {
+  pageNumber: number;
+  text: string;
+};
+
+type MatchCandidate = {
+  value: string;
+  confidence: MetadataConfidence;
+  page: number;
+  excerpt: string;
+};
+
+const FIELD_LABELS: Record<ProjectMetadataFieldKey, string> = {
+  projectTitle: 'Project Title',
+  country: 'Country',
+  projectId: 'Registry / Project ID',
+  methodology: 'Methodology',
+  standard: 'Standard',
+  proponent: 'Proponent',
+  documentType: 'Document Type',
+  version: 'Version',
+  documentDate: 'Document Date',
+};
+
+const COUNTRIES = [
+  'Malawi', 'Kenya', 'Ghana', 'Colombia', 'Brazil', 'India', 'Indonesia', 'Vietnam', 'Peru', 'Mexico',
+  'Tanzania', 'Uganda', 'Rwanda', 'Ethiopia', 'Zambia', 'Cambodia', 'Laos', 'Nepal', 'Philippines', 'Thailand',
+];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeForMatch(value: string): string {
+  return normalizeWhitespace(value).toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+function confidenceFromScore(score: number): MetadataConfidence {
+  if (score >= 0.9) return 'high';
+  if (score >= 0.72) return 'medium';
+  if (score > 0) return 'low';
+  return 'missing';
+}
+
+function buildField(
+  key: ProjectMetadataFieldKey,
+  source: ProjectDocumentMetadataDraft['source'],
+  candidate?: MatchCandidate,
+): ProjectMetadataField {
+  const provenance: ProjectMetadataFieldProvenance | null = candidate
+    ? {
+        attachmentId: source.attachmentId,
+        fileName: source.fileName,
+        page: candidate.page,
+        pageRange: String(candidate.page),
+        excerpt: candidate.excerpt,
+      }
+    : null;
+  return {
+    key,
+    label: FIELD_LABELS[key],
+    value: candidate?.value,
+    confidence: candidate?.confidence ?? 'missing',
+    provenance,
+  };
+}
+
+function excerptAround(line: string, value: string): string {
+  const normalizedLine = normalizeWhitespace(line);
+  const index = normalizedLine.toLowerCase().indexOf(value.toLowerCase());
+  if (index < 0) return normalizedLine.slice(0, 200);
+  const start = Math.max(0, index - 32);
+  const end = Math.min(normalizedLine.length, index + value.length + 80);
+  return normalizedLine.slice(start, end).trim();
+}
+
+function matchLabeledValue(page: ExtractedPage, patterns: RegExp[], confidence: MetadataConfidence): MatchCandidate | undefined {
+  const lines = page.text.split(/\n+/).map((line) => line.trim()).filter(Boolean);
+  for (const line of lines) {
+    for (const pattern of patterns) {
+      const match = pattern.exec(line);
+      if (!match?.[1]) continue;
+      const value = normalizeWhitespace(match[1]);
+      if (!value) continue;
+      return {
+        value,
+        confidence,
+        page: page.pageNumber,
+        excerpt: excerptAround(line, value),
+      };
+    }
+  }
+  return undefined;
+}
+
+function detectProjectTitle(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 3)) {
+    const lines = page.text.split(/\n+/).map((line) => normalizeWhitespace(line)).filter(Boolean);
+    for (const line of lines.slice(0, 12)) {
+      if (line.length < 12 || line.length > 180) continue;
+      if (/^(project design document|monitoring report|verification report|vcs|verra|gold standard|table of contents)\b/i.test(line)) continue;
+      if (/^[A-Z0-9 .,&()'/-]+$/.test(line) || /project|redd|forest|mangrove|cookstove|arr|afolu/i.test(line)) {
+        return { value: line, confidence: 'medium', page: page.pageNumber, excerpt: line };
+      }
+    }
+  }
+  return undefined;
+}
+
+function detectCountry(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\bhost country\s*[:\-]\s*(.+)$/i,
+      /\bcountry(?:\/location)?\s*[:\-]\s*(.+)$/i,
+      /\blocation\s*[:\-]\s*(.+)$/i,
+    ], 'high');
+    if (labeled) return labeled;
+    for (const country of COUNTRIES) {
+      const regex = new RegExp(`\\b${country.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i');
+      const line = page.text.split(/\n+/).find((entry) => regex.test(entry));
+      if (line) return { value: country, confidence: 'low', page: page.pageNumber, excerpt: excerptAround(line, country) };
+    }
+  }
+  return undefined;
+}
+
+function detectProjectId(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\b(?:project|registry)\s*(?:id|number|ref(?:erence)?)\s*[:\-]\s*([A-Z0-9][A-Z0-9._/-]{2,})/i,
+    ], 'high');
+    if (labeled) return labeled;
+    const line = page.text.split(/\n+/).find((entry) => /\b(?:VCS|GS|CDM|UNFCCC|VCS-)\s*[-/]?\d{2,}\b/i.test(entry));
+    const raw = line?.match(/\b(?:VCS|GS|CDM|UNFCCC|VCS-)\s*[-/]?\d{2,}\b/i)?.[0];
+    if (line && raw) return { value: normalizeWhitespace(raw), confidence: 'medium', page: page.pageNumber, excerpt: excerptAround(line, raw) };
+  }
+  return undefined;
+}
+
+function detectMethodology(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\b(?:applied )?methodology\s*[:\-]\s*(.+)$/i,
+      /\bmethodological approach\s*[:\-]\s*(.+)$/i,
+    ], 'high');
+    if (labeled) return labeled;
+    const line = page.text.split(/\n+/).find((entry) => /\b(?:VM|VMD|AMS|ACM|AR-ACM)\d{3,4}\b/i.test(entry));
+    const raw = line?.match(/\b(?:VM|VMD|AMS|ACM|AR-ACM)\d{3,4}\b/i)?.[0];
+    if (line && raw) return { value: normalizeWhitespace(raw), confidence: 'medium', page: page.pageNumber, excerpt: excerptAround(line, raw) };
+  }
+  return undefined;
+}
+
+function detectStandard(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 4)) {
+    const labeled = matchLabeledValue(page, [
+      /\bstandard\s*[:\-]\s*(.+)$/i,
+    ], 'high');
+    if (labeled) return labeled;
+    const line = page.text.split(/\n+/).find((entry) => /\b(?:VCS Standard|Gold Standard|CCB(?: Standard)?|Article 6)\b/i.test(entry));
+    const raw = line?.match(/\b(?:VCS Standard[^,\n]*|Gold Standard[^,\n]*|CCB(?: Standard)?[^,\n]*|Article 6[^,\n]*)/i)?.[0];
+    if (line && raw) return { value: normalizeWhitespace(raw), confidence: 'medium', page: page.pageNumber, excerpt: excerptAround(line, raw) };
+  }
+  return undefined;
+}
+
+function detectProponent(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\b(?:project )?proponent\s*[:\-]\s*(.+)$/i,
+      /\bproject developer\s*[:\-]\s*(.+)$/i,
+    ], 'high');
+    if (labeled) return labeled;
+  }
+  return undefined;
+}
+
+function detectDocumentType(pages: ExtractedPage[], fileName: string): MatchCandidate | undefined {
+  const firstPage = pages[0];
+  const haystack = `${fileName}\n${firstPage?.text ?? ''}`;
+  const types = [
+    'Project Design Document',
+    'Monitoring Report',
+    'Verification Report',
+    'Validation Report',
+    'Quick Check Evidence',
+  ];
+  for (const type of types) {
+    if (new RegExp(type.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i').test(haystack)) {
+      return {
+        value: type,
+        confidence: /quick check/i.test(type) ? 'low' : 'high',
+        page: firstPage?.pageNumber ?? 1,
+        excerpt: excerptAround(firstPage?.text ?? fileName, type),
+      };
+    }
+  }
+  if (/\.pdf$/i.test(fileName)) {
+    return { value: 'PDF evidence document', confidence: 'low', page: 1, excerpt: fileName };
+  }
+  return undefined;
+}
+
+function detectVersion(pages: ExtractedPage[]): MatchCandidate | undefined {
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\bversion\s*[:\-]\s*([A-Z0-9._ -]{1,40})$/i,
+      /\brev(?:ision)?\s*[:\-]\s*([A-Z0-9._ -]{1,40})$/i,
+    ], 'high');
+    if (labeled) return labeled;
+  }
+  return undefined;
+}
+
+function detectDocumentDate(pages: ExtractedPage[]): MatchCandidate | undefined {
+  const datePattern = /\b(\d{4}-\d{2}-\d{2}|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}|\d{1,2}\s+[A-Z][a-z]+\s+\d{4})\b/;
+  for (const page of pages.slice(0, 5)) {
+    const labeled = matchLabeledValue(page, [
+      /\b(?:document )?date\s*[:\-]\s*(.+)$/i,
+      /\bissue date\s*[:\-]\s*(.+)$/i,
+      /\bprepared on\s*[:\-]\s*(.+)$/i,
+    ], 'high');
+    if (labeled) return labeled;
+    const line = page.text.split(/\n+/).find((entry) => /\b(?:date|issued|prepared)\b/i.test(entry) && datePattern.test(entry));
+    const raw = line?.match(datePattern)?.[1];
+    if (line && raw) return { value: normalizeWhitespace(raw), confidence: 'medium', page: page.pageNumber, excerpt: excerptAround(line, raw) };
+  }
+  return undefined;
+}
+
+function tokenize(value: string): Set<string> {
+  return new Set(normalizeForMatch(value).split(' ').filter((token) => token.length > 2));
+}
+
+function computeExistingProjectMatches(projects: Project[], title?: string, projectCode?: string): ExistingProjectMatch[] {
+  const titleTokens = tokenize(title ?? '');
+  const normalizedCode = normalizeForMatch(projectCode ?? '');
+  return projects
+    .map((project) => {
+      let score = 0;
+      const reasons: string[] = [];
+      if (normalizedCode && normalizeForMatch(project.projectCode ?? '') === normalizedCode) {
+        score = Math.max(score, 0.99);
+        reasons.push(`Project code matches ${project.projectCode}`);
+      }
+      const projectTokens = tokenize(project.name);
+      const overlap = Array.from(titleTokens).filter((token) => projectTokens.has(token)).length;
+      const union = new Set([...titleTokens, ...projectTokens]).size || 1;
+      const nameScore = overlap / union;
+      if (nameScore >= 0.55) {
+        score = Math.max(score, 0.55 + nameScore * 0.4);
+        reasons.push(`Project name overlaps on ${overlap} key terms`);
+      }
+      return {
+        projectId: project.id,
+        projectName: project.name,
+        projectCode: project.projectCode,
+        score,
+        confidence: confidenceFromScore(score),
+        matchReasons: reasons,
+      } satisfies ExistingProjectMatch;
+    })
+    .filter((match) => match.score >= 0.72)
+    .sort((a, b) => b.score - a.score || a.projectName.localeCompare(b.projectName))
+    .slice(0, 3);
+}
+
+async function extractPdfPages(input: { bytes: ArrayBuffer; fileName: string }): Promise<ExtractedPage[]> {
+  const response = await fetch('/api/quick-check/pdf-extract', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/pdf',
+      'x-article6-filename': encodeURIComponent(input.fileName),
+    },
+    body: input.bytes,
+  });
+  if (!response.ok) throw new Error(`PDF extraction failed with ${response.status}`);
+  const payload = (await response.json()) as { pages?: Array<{ pageNumber?: number; text?: string }>; text?: string };
+  if (Array.isArray(payload.pages) && payload.pages.length > 0) {
+    return payload.pages
+      .map((page, index) => ({
+        pageNumber: typeof page.pageNumber === 'number' ? page.pageNumber : index + 1,
+        text: String(page.text ?? '').trim(),
+      }))
+      .filter((page) => page.text);
+  }
+  return [{ pageNumber: 1, text: String(payload.text ?? '').trim() }].filter((page) => page.text);
+}
+
+export async function buildProjectDocumentMetadataDraft(input: {
+  origin: ProjectDocumentMetadataDraft['source']['origin'];
+  evidenceId: string;
+  attachmentId: string;
+  fileName: string;
+  mimeType: string;
+  contentSha256?: string;
+}): Promise<ProjectDocumentMetadataDraft> {
+  const bytes = await getAttachmentBytes(input.attachmentId);
+  if (!bytes) throw new Error('Source attachment bytes are unavailable.');
+  const pages = await extractPdfPages({ bytes, fileName: input.fileName });
+  const source: ProjectDocumentMetadataDraft['source'] = {
+    ...input,
+    extractedAt: nowIso(),
+  };
+  const title = detectProjectTitle(pages);
+  const projectId = detectProjectId(pages);
+  return {
+    source,
+    fields: {
+      projectTitle: buildField('projectTitle', source, title),
+      country: buildField('country', source, detectCountry(pages)),
+      projectId: buildField('projectId', source, projectId),
+      methodology: buildField('methodology', source, detectMethodology(pages)),
+      standard: buildField('standard', source, detectStandard(pages)),
+      proponent: buildField('proponent', source, detectProponent(pages)),
+      documentType: buildField('documentType', source, detectDocumentType(pages, input.fileName)),
+      version: buildField('version', source, detectVersion(pages)),
+      documentDate: buildField('documentDate', source, detectDocumentDate(pages)),
+    },
+    suggestedExistingProjects: computeExistingProjectMatches(listProjects(), title?.value, projectId?.value),
+  };
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  return window.sessionStorage ?? null;
+}
+
+export function stagePendingProjectDocumentDraft(draft: ProjectDocumentMetadataDraft): void {
+  getStorage()?.setItem(PENDING_DOCUMENT_DRAFT_KEY, JSON.stringify(draft));
+}
+
+export function readPendingProjectDocumentDraft(): ProjectDocumentMetadataDraft | null {
+  const raw = getStorage()?.getItem(PENDING_DOCUMENT_DRAFT_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ProjectDocumentMetadataDraft;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingProjectDocumentDraft(): void {
+  getStorage()?.removeItem(PENDING_DOCUMENT_DRAFT_KEY);
+}
+
+export async function stageProjectDocumentDraftFromAttachment(input: {
+  origin: ProjectDocumentMetadataDraft['source']['origin'];
+  evidenceId: string;
+  attachmentId: string;
+  fileName: string;
+  mimeType: string;
+  contentSha256?: string;
+}): Promise<ProjectDocumentMetadataDraft> {
+  const draft = await buildProjectDocumentMetadataDraft(input);
+  stagePendingProjectDocumentDraft(draft);
+  return draft;
+}
+
+export async function attachPendingProjectDocumentToProject(projectId: string): Promise<void> {
+  const draft = readPendingProjectDocumentDraft();
+  if (!draft) throw new Error('No staged document draft is available.');
+
+  const bytes = await getAttachmentBytes(draft.source.attachmentId);
+  if (!bytes) throw new Error('The staged document attachment is unavailable.');
+
+  const project = listProjects().find((candidate) => candidate.id === projectId);
+  if (!project) throw new Error('The selected project no longer exists.');
+  if (project.status === 'locked') {
+    throw new Error('The selected project is locked and cannot accept new documents.');
+  }
+
+  const contentBase64 = arrayBufferToBase64(bytes);
+  const updatedProject = addProjectDocument(projectId, {
+    fileName: draft.source.fileName,
+    mimeType: draft.source.mimeType,
+    sizeBytes: bytes.byteLength,
+    contentSha256: draft.source.contentSha256,
+    contentBase64,
+    extractedText: Object.values(draft.fields)
+      .map((field) => field.provenance?.excerpt)
+      .filter(Boolean)
+      .join('\n'),
+  });
+
+  if (!updatedProject) {
+    throw new Error('Failed to attach the staged document to the selected project.');
+  }
+}

--- a/src/lib/projects/types.ts
+++ b/src/lib/projects/types.ts
@@ -5,6 +5,56 @@ export type ProjectReviewMode = 'methodology-linked' | 'manual';
 export type RuleReviewStatus = 'not-started' | 'in-progress' | 'verified' | 'gap' | 'not-applicable';
 
 export type ProjectRegistry = 'UNFCCC' | 'Verra' | 'Gold Standard' | 'Unknown';
+export type MetadataConfidence = 'high' | 'medium' | 'low' | 'missing';
+export type ProjectMetadataFieldKey =
+  | 'projectTitle'
+  | 'country'
+  | 'projectId'
+  | 'methodology'
+  | 'standard'
+  | 'proponent'
+  | 'documentType'
+  | 'version'
+  | 'documentDate';
+
+export type ProjectMetadataFieldProvenance = {
+  attachmentId?: string;
+  fileName: string;
+  page?: number;
+  pageRange?: string;
+  excerpt?: string;
+};
+
+export type ProjectMetadataField = {
+  key: ProjectMetadataFieldKey;
+  label: string;
+  value?: string;
+  confidence: MetadataConfidence;
+  provenance?: ProjectMetadataFieldProvenance | null;
+};
+
+export type ExistingProjectMatch = {
+  projectId: string;
+  projectName: string;
+  projectCode?: string;
+  confidence: MetadataConfidence;
+  score: number;
+  matchReasons: string[];
+};
+
+export type ProjectDocumentMetadataDraft = {
+  source: {
+    origin: 'quick-check' | 'pdd-upload';
+    evidenceId: string;
+    attachmentId: string;
+    fileName: string;
+    mimeType: string;
+    contentSha256?: string;
+    extractedAt: string;
+  };
+  fields: Record<ProjectMetadataFieldKey, ProjectMetadataField>;
+  suggestedExistingProjects: ExistingProjectMatch[];
+};
 
 export type ManualFindingType = 'CAR' | 'CL' | 'FAR' | 'VVB finding' | 'evidence gap';
 

--- a/tests/components/demoNav.test.tsx
+++ b/tests/components/demoNav.test.tsx
@@ -41,7 +41,7 @@ describe("DemoNav", () => {
     expect(links.map((link) => link.textContent)).toEqual(
       expect.arrayContaining(["Quick Check", "Methods", "Projects"]),
     );
-    expect(links.find((link) => link.textContent?.includes("Quick Check"))?.getAttribute("href")).toBe("/");
+    expect(links.find((link) => link.textContent?.includes("Quick Check"))?.getAttribute("href")).toBe("/start-review");
     expect(links.find((link) => link.textContent?.includes("Methods"))?.getAttribute("href")).toBe("/m");
     expect(links.find((link) => link.textContent?.includes("Projects"))?.getAttribute("href")).toBe("/projects");
   });
@@ -55,6 +55,6 @@ describe("DemoNav", () => {
     const quickCheckLink = Array.from(container.querySelectorAll("a")).find((link) =>
       link.textContent?.includes("Quick Check"),
     );
-    expect(quickCheckLink?.getAttribute("href")).toBe("/");
+    expect(quickCheckLink?.getAttribute("href")).toBe("/start-review");
   });
 });

--- a/tests/components/projects/NewProjectForm.document-handoff.test.tsx
+++ b/tests/components/projects/NewProjectForm.document-handoff.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment jsdom
+ */
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { createRoot } from "react-dom/client";
+import { putAttachmentBytes } from "@/lib/proofMap/attachments";
+
+const pushMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+  useSearchParams: () => new URLSearchParams("handoff=document-metadata"),
+}));
+
+const NewProjectForm = require("@/components/projects/NewProjectForm")
+  .default as typeof import("@/components/projects/NewProjectForm").default;
+
+describe("NewProjectForm document handoff", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const originalFetch = global.fetch;
+
+  function asArrayBuffer(value: Uint8Array): ArrayBuffer {
+    return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+  }
+
+  beforeEach(async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    pushMock.mockReset();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    window.sessionStorage.setItem(
+      "article6:pending-project-document-draft",
+      JSON.stringify({
+        source: {
+          origin: "quick-check",
+          evidenceId: "ev-1",
+          attachmentId: "att-1",
+          fileName: "plum-project-pdd.pdf",
+          mimeType: "application/pdf",
+          contentSha256: "sha-att-1",
+          extractedAt: "2026-05-27T00:00:00.000Z",
+        },
+        fields: {
+          projectTitle: {
+            key: "projectTitle",
+            label: "Project Title",
+            value: "PLUM Project",
+            confidence: "high",
+            provenance: { fileName: "plum-project-pdd.pdf", page: 1, excerpt: "PLUM Project" },
+          },
+          country: {
+            key: "country",
+            label: "Country",
+            value: "Malawi",
+            confidence: "medium",
+            provenance: { fileName: "plum-project-pdd.pdf", page: 1, excerpt: "Malawi" },
+          },
+          projectId: {
+            key: "projectId",
+            label: "Registry / Project ID",
+            value: "VCS-1530",
+            confidence: "high",
+            provenance: { fileName: "plum-project-pdd.pdf", page: 1, excerpt: "VCS-1530" },
+          },
+          methodology: {
+            key: "methodology",
+            label: "Methodology",
+            value: "AR-ACM0003",
+            confidence: "high",
+            provenance: { fileName: "plum-project-pdd.pdf", page: 2, excerpt: "AR-ACM0003" },
+          },
+          standard: {
+            key: "standard",
+            label: "Standard",
+            value: "VCS Standard",
+            confidence: "medium",
+            provenance: { fileName: "plum-project-pdd.pdf", page: 1, excerpt: "VCS Standard" },
+          },
+          proponent: {
+            key: "proponent",
+            label: "Proponent",
+            value: "Article6 Climate",
+            confidence: "medium",
+            provenance: { fileName: "plum-project-pdd.pdf", page: 1, excerpt: "Article6 Climate" },
+          },
+          documentType: {
+            key: "documentType",
+            label: "Document Type",
+            value: "Project Design Document",
+            confidence: "high",
+            provenance: { fileName: "plum-project-pdd.pdf", page: 1, excerpt: "Project Design Document" },
+          },
+          version: {
+            key: "version",
+            label: "Version",
+            value: "v1",
+            confidence: "low",
+            provenance: { fileName: "plum-project-pdd.pdf", page: 1, excerpt: "v1" },
+          },
+          documentDate: {
+            key: "documentDate",
+            label: "Document Date",
+            value: "2026-05-01",
+            confidence: "medium",
+            provenance: { fileName: "plum-project-pdd.pdf", page: 1, excerpt: "2026-05-01" },
+          },
+        },
+        suggestedExistingProjects: [],
+      }),
+    );
+    await putAttachmentBytes("att-1", asArrayBuffer(new TextEncoder().encode("PLUM Project source document bytes")));
+
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects/methods") {
+        return new Response(JSON.stringify({
+          methods: [
+            { code: "AR-ACM0003", program: "UNFCCC/Forestry", version: "v02-0", ruleCount: 2 },
+          ],
+        }), { status: 200 });
+      }
+      if (url === "/api/projects/method-rules?code=AR-ACM0003&version=v02-0") {
+        return new Response(JSON.stringify({
+          rules: [
+            { id: "R-1-0001", title: "Monitoring frequency", sectionId: "S-1" },
+            { id: "R-1-0002", title: "Boundary consistency", sectionId: "S-2" },
+          ],
+        }), { status: 200 });
+      }
+      throw new Error(`Unhandled fetch ${url}`);
+    }) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (global as { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  it("creates a readiness workspace from detected project details", async () => {
+    await act(async () => {
+      root.render(<NewProjectForm />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Confirm Project Details");
+    expect(container.textContent).toContain("PLUM Project");
+    expect(container.textContent).toContain("AR-ACM0003");
+
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+    expect(checkbox).not.toBeNull();
+    await act(async () => {
+      checkbox!.click();
+    });
+
+    const submitButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Create Readiness Workspace"),
+    ) as HTMLButtonElement | undefined;
+    expect(submitButton).toBeDefined();
+    expect(submitButton?.disabled).toBe(false);
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const href = pushMock.mock.calls[0]?.[0] ?? "";
+    expect(href).toContain("/m/AR-ACM0003/v/v02-0?");
+    expect(href).toContain("projectId=");
+    expect(href).toContain("workspaceId=");
+    expect(href).toContain("tab=verify");
+    expect(window.sessionStorage.getItem("article6:pending-project-document-draft")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

**Two internal Quick Check paths** — The Quick Check pipeline now detects whether the user is asking a broad review question ("Does this PDD justify/explain/disclose/support...") or trying to match a specific evidence claim to a methodology requirement, and routes accordingly:

- **`claim_to_requirement_match`** — Existing behavior: extract evidence, detect methodology, build candidates, resolve against rules, present requirement matches
- **`review_question_answering`** — New behavior: classify the review area, look up relevant PDD sections per methodology, present section routing without forcing a requirement pick

**Broad question detection** — Questions matching the patterns `Does this PDD justify / explain / disclose / support ...` are routed to the review-question-answering path.

**Review area classification** — The question text is analysed to classify one of: baseline, boundary, deviations, leakage, monitoring, right_of_use, or general.

**VM0007 section routing** — For VM0007 PDDs, review areas are mapped to canonical sections:

| Review Area | Sections |
|---|---|
| baseline | 2.4, 2.5, 1.10 |
| boundary | 2.3, 1.9 |
| deviations | 2.6 |
| leakage | 1.13, 3.3 |
| monitoring | 4 |
| right_of_use | 1.11, 1.12.1 |

**Stale result clearing** — `clearDecisionState()` now clears the review question result alongside match candidates and recovery state, so stale requirement-match results do not persist when the review question changes.

## Why

- The current UI returns the same requirement-matching behaviour regardless of the review question asked.
- A user asking about baseline, leakage, or deviations expects targeted evidence retrieval, not a generic requirement picker.
- This makes Quick Check feel shallow and blocks real verification-readiness review.
- The "Multiple requirements could fit this claim" message should only appear when the user is trying to match a specific evidence claim to a requirement.

## Files changed

| File | Change |
|---|---|
| `src/lib/chat/quickCheckReviewQuestion.ts` | **New** — `ReviewArea`, `QuickCheckPath` types, `detectReviewPath()`, `classifyReviewArea()`, `resolveReviewSections()`, VM0007 section routing map |
| `src/components/chat/QuickCheckPanel.tsx` | Add review question result state, short-circuit `runQuickCheck` for broad questions, render section routing UI, clear stale results on claim change |

Signed-off-by: Fred E.