### PR TITLE
feat: split Quick Check into claim-to-requirement-match and review-question-answering paths

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -50,6 +50,12 @@ import { createAndStoreEvidenceAttachment } from "@/lib/proofMap/attachments";
 import { isRuleLikeId } from "@/lib/proofMap/pins";
 import { loadPins, savePins } from "@/lib/proofMap/storage";
 import type { EvidencePin, PddFragment } from "@/lib/proofMap/types";
+import {
+  buildReviewQuestionResult,
+  detectReviewPath,
+  reviewAreaLabel,
+  type ReviewQuestionResult,
+} from "@/lib/chat/quickCheckReviewQuestion";
 
 type MethodInventoryRecord = {
   code: string;
@@ -548,6 +554,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [showMethodology, setShowMethodology] = useState(false);
   const [isDragActive, setIsDragActive] = useState(false);
   const [showExtractionDetails, setShowExtractionDetails] = useState(false);
+  const [reviewQuestionResult, setReviewQuestionResult] = useState<ReviewQuestionResult | null>(null);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
     loading: false,
@@ -944,6 +951,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setRecoveryState(null);
     setMatchCandidates([]);
     setValidatedResultKey(null);
+    setReviewQuestionResult(null);
   }
 
   function resetQuickCheckUi() {
@@ -1386,6 +1394,26 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         setRecoveryState(buildUnsupportedMethodRecoveryState(currentMethodologyResolution.unsupportedCanonicalKeys[0] ?? "unknown methodology"));
         return;
       }
+
+      const resolvedMethodologyId = draft.methodologyId.trim()
+        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "" : "");
+      const resolvedMethodologyVersion = draft.methodologyVersion.trim()
+        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyVersion ?? "" : "");
+
+      if (detectReviewPath(effectiveClaimText) === "review_question_answering") {
+        const questionResult = buildReviewQuestionResult({
+          claimText: effectiveClaimText,
+          methodologyId: resolvedMethodologyId,
+          methodologyVersion: resolvedMethodologyVersion,
+        });
+        setReviewQuestionResult(questionResult);
+        setRecoveryState(null);
+        setFieldErrors({});
+        setSubmitting(false);
+        return;
+      }
+
+      setReviewQuestionResult(null);
 
       const selectedMethodologyId = draft.methodologyId.trim()
         || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "" : "");
@@ -2090,6 +2118,57 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       </select>
                     </div>
                   )}
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {reviewQuestionResult ? (
+            <div className="rounded-[1.6rem] border border-sky-200 bg-sky-50/80 p-5">
+              <div className="flex items-start gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-800">Review question</div>
+                  <div className="mt-2 text-sm text-slate-600">{draft.claimText}</div>
+                  <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Review area</div>
+                      <div className="mt-1 text-sm font-medium text-slate-900">{reviewAreaLabel(reviewQuestionResult.reviewArea)}</div>
+                    </div>
+                    {reviewQuestionResult.methodologyId ? (
+                      <div>
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Methodology</div>
+                        <div className="mt-1 text-sm font-medium text-slate-900">{reviewQuestionResult.methodologyId} · {reviewQuestionResult.methodologyVersion || "—"}</div>
+                      </div>
+                    ) : null}
+                  </div>
+                  {reviewQuestionResult.relevantSections.length > 0 ? (
+                    <div className="mt-4">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Relevant PDD sections</div>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {reviewQuestionResult.relevantSections.map((section) => (
+                          <span key={section} className="rounded-full border border-sky-200 bg-white px-3 py-1.5 text-sm font-medium text-sky-900">
+                            Section {section}
+                          </span>
+                        ))}
+                      </div>
+                      <p className="mt-2 text-xs text-slate-500">
+                        Open the full review to inspect these sections in the uploaded document.
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
+                      No methodology-specific section routing is available yet. Check the methodology document directly.
+                    </div>
+                  )}
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setReviewQuestionResult(null)}
+                      className="rounded-full border border-sky-200 bg-white px-4 py-2 text-sm font-medium text-sky-800 transition hover:border-sky-300"
+                    >
+                      Return to requirement match
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,0 +1,97 @@
+export type ReviewArea =
+  | "baseline"
+  | "boundary"
+  | "deviations"
+  | "leakage"
+  | "monitoring"
+  | "right_of_use"
+  | "general";
+
+export type QuickCheckPath = "claim_to_requirement_match" | "review_question_answering";
+
+export type ReviewQuestionResult = {
+  path: QuickCheckPath;
+  reviewArea: ReviewArea;
+  methodologyId: string;
+  methodologyVersion: string;
+  relevantSections: string[];
+  sectionContent: Record<string, string>;
+};
+
+const BROAD_QUESTION_PATTERNS: RegExp[] = [
+  /^does\s+this\s+pdd\s+justify/i,
+  /^does\s+this\s+pdd\s+explain/i,
+  /^does\s+this\s+pdd\s+disclose/i,
+  /^does\s+this\s+pdd\s+support/i,
+];
+
+const VM0007_SECTION_ROUTES: Record<ReviewArea, string[]> = {
+  baseline: ["2.4", "2.5", "1.10"],
+  boundary: ["2.3", "1.9"],
+  deviations: ["2.6"],
+  leakage: ["1.13", "3.3"],
+  monitoring: ["4"],
+  right_of_use: ["1.11", "1.12.1"],
+  general: [],
+};
+
+const REVIEW_AREA_LABELS: Record<ReviewArea, string> = {
+  baseline: "Baseline scenario",
+  boundary: "Project boundary",
+  deviations: "Deviations from methodology",
+  leakage: "Leakage",
+  monitoring: "Monitoring approach",
+  right_of_use: "Right of use / land tenure",
+  general: "General review",
+};
+
+export function detectReviewPath(claimText: string): QuickCheckPath {
+  const normalized = claimText.trim();
+  if (!normalized) return "claim_to_requirement_match";
+  const isBroadQuestion = BROAD_QUESTION_PATTERNS.some((pattern) => pattern.test(normalized));
+  if (isBroadQuestion) return "review_question_answering";
+  return "claim_to_requirement_match";
+}
+
+export function classifyReviewArea(claimText: string): ReviewArea {
+  const normalized = claimText.trim().toLowerCase();
+  if (/justify|baseline|scenario/i.test(normalized)) return "baseline";
+  if (/boundary|area\s+of|spatial|geographic|polygon/i.test(normalized)) return "boundary";
+  if (/deviations|departure|variance|deviation/i.test(normalized)) return "deviations";
+  if (/leakage|displacement/i.test(normalized)) return "leakage";
+  if (/monitoring|sampling|plot|measur/i.test(normalized)) return "monitoring";
+  if (/right of use|land tenure|carbon right|entitlement/i.test(normalized)) return "right_of_use";
+  return "general";
+}
+
+export function resolveReviewSections(
+  methodologyId: string,
+  reviewArea: ReviewArea,
+): string[] {
+  const normalizedMethod = methodologyId.trim().toUpperCase();
+  if (normalizedMethod === "VM0007") {
+    return VM0007_SECTION_ROUTES[reviewArea] ?? [];
+  }
+  return [];
+}
+
+export function reviewAreaLabel(area: ReviewArea): string {
+  return REVIEW_AREA_LABELS[area];
+}
+
+export function buildReviewQuestionResult(input: {
+  claimText: string;
+  methodologyId: string;
+  methodologyVersion: string;
+}): ReviewQuestionResult {
+  const reviewArea = classifyReviewArea(input.claimText);
+  const relevantSections = resolveReviewSections(input.methodologyId, reviewArea);
+  return {
+    path: "review_question_answering",
+    reviewArea,
+    methodologyId: input.methodologyId,
+    methodologyVersion: input.methodologyVersion,
+    relevantSections,
+    sectionContent: {},
+  };
+}

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,4 +1,5 @@
 export type ReviewArea =
+  | "additionality"
   | "baseline"
   | "boundary"
   | "deviations"
@@ -23,9 +24,17 @@ const BROAD_QUESTION_PATTERNS: RegExp[] = [
   /^does\s+this\s+pdd\s+explain/i,
   /^does\s+this\s+pdd\s+disclose/i,
   /^does\s+this\s+pdd\s+support/i,
+  /^does\s+this\s+pdd\s+define/i,
+  /^does\s+this\s+pdd\s+describe/i,
+  /^does\s+this\s+pdd\s+identify/i,
+  /^is\s+the\s+baseline/i,
+  /^is\s+additionality/i,
+  /^check\s+the/i,
+  /^review\s+the/i,
 ];
 
 const VM0007_SECTION_ROUTES: Record<ReviewArea, string[]> = {
+  additionality: ["2.5", "2.4", "1.10"],
   baseline: ["2.4", "2.5", "1.10"],
   boundary: ["2.3", "1.9"],
   deviations: ["2.6"],
@@ -36,6 +45,7 @@ const VM0007_SECTION_ROUTES: Record<ReviewArea, string[]> = {
 };
 
 const REVIEW_AREA_LABELS: Record<ReviewArea, string> = {
+  additionality: "Additionality",
   baseline: "Baseline scenario",
   boundary: "Project boundary",
   deviations: "Deviations from methodology",
@@ -55,10 +65,18 @@ export function detectReviewPath(claimText: string): QuickCheckPath {
 
 export function classifyReviewArea(claimText: string): ReviewArea {
   const normalized = claimText.trim().toLowerCase();
+
+  const hasBoundaryPair =
+    /\bleakage\s+belt\b/i.test(normalized) &&
+    (/\bproject\s+area\b/i.test(normalized) || /\breference\s+region\b/i.test(normalized));
+  if (hasBoundaryPair) return "boundary";
+
+  if (/additionality|VT0001|barrier\s+analysis|investment\s+analysis|common\s+practice|first\s+of\s+its\s+kind/i.test(normalized)) return "additionality";
+
   if (/justify|baseline|scenario/i.test(normalized)) return "baseline";
-  if (/boundary|area\s+of|spatial|geographic|polygon/i.test(normalized)) return "boundary";
+  if (/leakage\s+belt\b|reference\s+region\b|RRD\b|boundary|geographic\s+boundary|project\s+area|area\s+of|spatial|geographic|polygon/i.test(normalized)) return "boundary";
   if (/deviations|departure|variance|deviation/i.test(normalized)) return "deviations";
-  if (/leakage|displacement/i.test(normalized)) return "leakage";
+  if (/leakage\s+risk|activity\s+shifting|LK-ASU|displacement/i.test(normalized)) return "leakage";
   if (/monitoring|sampling|plot|measur/i.test(normalized)) return "monitoring";
   if (/right of use|land tenure|carbon right|entitlement/i.test(normalized)) return "right_of_use";
   return "general";

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  classifyReviewArea,
+  detectReviewPath,
+  resolveReviewSections,
+  reviewAreaLabel,
+  type ReviewArea,
+} from "@/lib/chat/quickCheckReviewQuestion";
+
+describe("detectReviewPath", () => {
+  it("routes 'Does this PDD support additionality under VT0001?' to review_question_answering", () => {
+    expect(detectReviewPath("Does this PDD support additionality under VT0001?")).toBe("review_question_answering");
+  });
+
+  it("routes 'Does this PDD define the project area, leakage belt, and reference region?' to review_question_answering", () => {
+    expect(detectReviewPath("Does this PDD define the project area, leakage belt, and reference region?")).toBe("review_question_answering");
+  });
+
+  it("routes 'Does this PDD disclose methodology deviations...' to review_question_answering", () => {
+    expect(detectReviewPath("Does this PDD disclose methodology deviations?")).toBe("review_question_answering");
+  });
+
+  it("routes 'Is the baseline scenario appropriate?' to review_question_answering", () => {
+    expect(detectReviewPath("Is the baseline scenario appropriate?")).toBe("review_question_answering");
+  });
+
+  it("routes 'Is additionality demonstrated?' to review_question_answering", () => {
+    expect(detectReviewPath("Is additionality demonstrated?")).toBe("review_question_answering");
+  });
+
+  it("routes 'Check the monitoring plan' to review_question_answering", () => {
+    expect(detectReviewPath("Check the monitoring plan")).toBe("review_question_answering");
+  });
+
+  it("routes 'Review the leakage assessment' to review_question_answering", () => {
+    expect(detectReviewPath("Review the leakage assessment")).toBe("review_question_answering");
+  });
+
+  it("routes empty text to claim_to_requirement_match", () => {
+    expect(detectReviewPath("")).toBe("claim_to_requirement_match");
+  });
+
+  it("routes a specific evidence claim to claim_to_requirement_match", () => {
+    expect(detectReviewPath("The monitoring report covers the full reporting period.")).toBe("claim_to_requirement_match");
+  });
+});
+
+describe("classifyReviewArea — additionality", () => {
+  it("classifies 'additionality' keyword", () => {
+    expect(classifyReviewArea("Does this PDD demonstrate additionality?")).toBe("additionality");
+  });
+
+  it("classifies 'VT0001' keyword", () => {
+    expect(classifyReviewArea("Does this PDD follow VT0001?")).toBe("additionality");
+  });
+
+  it("classifies 'barrier analysis'", () => {
+    expect(classifyReviewArea("Does this PDD include a barrier analysis?")).toBe("additionality");
+  });
+
+  it("classifies 'investment analysis'", () => {
+    expect(classifyReviewArea("Does this PDD describe the investment analysis?")).toBe("additionality");
+  });
+
+  it("classifies 'common practice'", () => {
+    expect(classifyReviewArea("Does this PDD justify common practice?")).toBe("additionality");
+  });
+
+  it("classifies 'first of its kind'", () => {
+    expect(classifyReviewArea("Does this PDD identify first of its kind?")).toBe("additionality");
+  });
+});
+
+describe("classifyReviewArea — boundary", () => {
+  it("classifies 'project area'", () => {
+    expect(classifyReviewArea("Does this PDD define the project area?")).toBe("boundary");
+  });
+
+  it("classifies 'leakage belt' paired with 'project area' as boundary", () => {
+    expect(classifyReviewArea("Does this PDD define the project area, leakage belt, and reference region?")).toBe("boundary");
+  });
+
+  it("classifies 'reference region'", () => {
+    expect(classifyReviewArea("Does this PDD define the reference region?")).toBe("boundary");
+  });
+
+  it("classifies 'RRD'", () => {
+    expect(classifyReviewArea("Does this PDD describe the RRD?")).toBe("boundary");
+  });
+
+  it("classifies 'geographic boundary'", () => {
+    expect(classifyReviewArea("Does this PDD define the geographic boundary?")).toBe("boundary");
+  });
+});
+
+describe("classifyReviewArea — leakage", () => {
+  it("classifies 'leakage risk'", () => {
+    expect(classifyReviewArea("Does this PDD disclose leakage risk?")).toBe("leakage");
+  });
+
+  it("classifies 'activity shifting'", () => {
+    expect(classifyReviewArea("Does this PDD describe activity shifting?")).toBe("leakage");
+  });
+
+  it("classifies 'LK-ASU'", () => {
+    expect(classifyReviewArea("Does this PDD address LK-ASU?")).toBe("leakage");
+  });
+
+  it("classifies 'displacement'", () => {
+    expect(classifyReviewArea("Does this PDD disclose displacement?")).toBe("leakage");
+  });
+
+  it("classifies standalone 'leakage belt' as boundary when not paired with project area or reference region", () => {
+    expect(classifyReviewArea("Please review the leakage belt analysis.")).toBe("boundary");
+  });
+});
+
+describe("classifyReviewArea — deviations", () => {
+  it("classifies methodology deviations", () => {
+    expect(classifyReviewArea("Does this PDD disclose methodology deviations?")).toBe("deviations");
+  });
+});
+
+describe("resolveReviewSections — VM0007", () => {
+  it("maps additionality to sections 2.5, 2.4, 1.10", () => {
+    expect(resolveReviewSections("VM0007", "additionality")).toEqual(["2.5", "2.4", "1.10"]);
+  });
+
+  it("maps baseline to sections 2.4, 2.5, 1.10", () => {
+    expect(resolveReviewSections("VM0007", "baseline")).toEqual(["2.4", "2.5", "1.10"]);
+  });
+
+  it("maps boundary to sections 2.3, 1.9", () => {
+    expect(resolveReviewSections("VM0007", "boundary")).toEqual(["2.3", "1.9"]);
+  });
+
+  it("maps deviations to section 2.6", () => {
+    expect(resolveReviewSections("VM0007", "deviations")).toEqual(["2.6"]);
+  });
+
+  it("maps leakage to sections 1.13, 3.3", () => {
+    expect(resolveReviewSections("VM0007", "leakage")).toEqual(["1.13", "3.3"]);
+  });
+
+  it("maps monitoring to section 4", () => {
+    expect(resolveReviewSections("VM0007", "monitoring")).toEqual(["4"]);
+  });
+
+  it("maps right_of_use to sections 1.11, 1.12.1", () => {
+    expect(resolveReviewSections("VM0007", "right_of_use")).toEqual(["1.11", "1.12.1"]);
+  });
+
+  it("returns empty array for non-VM0007 methodology", () => {
+    expect(resolveReviewSections("AR-ACM0003", "baseline")).toEqual([]);
+  });
+});
+
+describe("reviewAreaLabel", () => {
+  const areas: ReviewArea[] = [
+    "additionality", "baseline", "boundary", "deviations",
+    "leakage", "monitoring", "right_of_use", "general",
+  ];
+  for (const area of areas) {
+    it(`returns a non-empty label for ${area}`, () => {
+      expect(reviewAreaLabel(area).length).toBeGreaterThan(0);
+    });
+  }
+});


### PR DESCRIPTION
## What

**Two internal Quick Check paths** — The pipeline detects whether the user is asking a broad review question ("Does this PDD justify/explain/disclose/support...") or trying to match a specific evidence claim to a methodology requirement, and routes accordingly:

- **`claim_to_requirement_match`** — Existing behavior: extract evidence, detect methodology, build candidates, resolve against rules, present requirement matches
- **`review_question_answering`** — New behavior: classify the review area, look up relevant PDD sections per methodology, present section routing without forcing a requirement pick

**Broad question detection** — Questions matching the patterns `Does this PDD justify / explain / disclose / support ...` are routed to the review-question-answering path.

**Review area classification** — The question text is analysed to classify one of: baseline, boundary, deviations, leakage, monitoring, right_of_use, or general.

**VM0007 section routing** — For VM0007 PDDs, review areas are mapped to canonical sections:

| Review Area | Sections |
|---|---|
| baseline | 2.4, 2.5, 1.10 |
| boundary | 2.3, 1.9 |
| deviations | 2.6 |
| leakage | 1.13, 3.3 |
| monitoring | 4 |
| right_of_use | 1.11, 1.12.1 |

**Stale result clearing** — `clearDecisionState()` now clears the review question result alongside match candidates and recovery state.

## Why

- The current UI returns the same requirement-matching behaviour regardless of the review question asked.
- A user asking about baseline, leakage, or deviations expects targeted evidence retrieval, not a generic requirement picker.
- The "Multiple requirements could fit this claim" message should only appear when the user is trying to match a specific evidence claim to a requirement.

## Files changed

| File | Change |
|---|---|
| `src/lib/chat/quickCheckReviewQuestion.ts` | **New** — ReviewArea, QuickCheckPath types, detectReviewPath(), classifyReviewArea(), resolveReviewSections(), VM0007 section routing map |
| `src/components/chat/QuickCheckPanel.tsx` | Add reviewQuestionResult state, short-circuit runQuickCheck for broad questions, render section routing UI, clear stale results on claim change |

Signed-off-by: Fred E.