### PR TITLE
chore: add review-grade-quick-check roadmap with phased implementation plan

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, project-readiness-verification-output, project-verification, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
+Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
 Frozen lanes: agentic-verification.
 
 
@@ -119,6 +119,26 @@ Not active now:
 
 1) PR542: Done (PR #542)
 2) PR555: Done (PR #555)
+
+## review-grade-quick-check
+
+Status SSOT: `docs/roadmaps/review-grade-quick-check/phase-status.json`
+Details: `docs/roadmaps/review-grade-quick-check/PLAN.md`
+
+Lane status: Active
+Turn Quick Check from a requirement matcher / section router into an evidence-backed verification-readiness review engine. Phased path from routing to readiness note export.
+
+Current focus:
+- Phase 0: routing MVP — detect review question path, classify review area, route to VM0007 sections (PR 642)
+
+Not active now:
+- Full multi-methodology section extraction (phase 1 starts after VM0007 routing is stable)
+- Evidence-backed verdicts and gap detection (phase 2+)
+- Review area rubrics (phase 3+)
+- Regression evaluation suite (phase 4+)
+- Readiness note export (phase 5+)
+
+1) PR642: Active
 
 ## project-verification
 

--- a/docs/roadmaps/review-grade-quick-check/PLAN.md
+++ b/docs/roadmaps/review-grade-quick-check/PLAN.md
@@ -1,0 +1,178 @@
+# Review-Grade Quick Check — Implementation Plan
+
+Status SSOT: `docs/roadmaps/review-grade-quick-check/phase-status.json`
+
+Repo boundary: this roadmap covers routing, section extraction, evidence-backed review, rubrics, eval, and export within `app.article6`. No upstream methodology encoding dependency — all work is client-side or app-side.
+
+## PR body standard
+
+Every PR in this roadmap must include the following directive block in its body:
+
+```
+### Roadmap-Update
+- slug: review-grade-quick-check
+- items:
+  - <phase_id>: <status>
+  - <PR_id>: <status>
+```
+
+Allowed statuses: planned | next | active | in_progress | done | blocked | deferred | frozen | parked
+
+---
+
+## Phase 0 — Routing MVP (active)
+
+**PR 642**
+
+Detect broad review questions, classify review area, route to VM0007 PDD sections. Narrow first implementation to VM0007 baseline review question only.
+
+### Files
+
+| File | Change |
+|---|---|
+| `src/lib/chat/quickCheckReviewQuestion.ts` | New module: ReviewArea, QuickCheckPath types, detectReviewPath(), classifyReviewArea(), resolveReviewSections(), VM0007 section routing map |
+| `src/components/chat/QuickCheckPanel.tsx` | Add reviewQuestionResult state, short-circuit runQuickCheck for broad questions, render section routing UI, clear stale results on claim change |
+| `tests/lib/quickCheckReviewQuestion.test.ts` | 42+ regression tests for detection, classification, section routing |
+
+### PR body
+
+```
+### Roadmap-Update
+- slug: review-grade-quick-check
+- items:
+  - phase_0_routing_mvp: active
+  - PR642: active
+```
+
+---
+
+## Phase 1 — Section extraction (planned)
+
+Extract and render actual PDD section content inline in the review-question result.
+
+### Required changes
+
+- Add section heading detection to split extracted PDF pages into section-granular content
+  - Detect patterns like `1.10`, `2.4`, `Section 2.4` at line starts
+  - Map section numbers to extracted text ranges
+- Extend `ReviewQuestionResult.sectionContent` to hold extracted text per section
+- Render section excerpts inline in the review-question result card
+- Handle sections that span multiple pages or are not found in the uploaded PDD
+
+### Files to create/modify
+
+| File | Change |
+|---|---|
+| `src/lib/chat/quickCheckReviewQuestion.ts` | Wire sectionContent population from extracted pages |
+| `src/lib/chat/quickCheckSectionExtractor.ts` | New — section heading detection and text mapping |
+| `src/components/chat/QuickCheckPanel.tsx` | Render section excerpts inline |
+| `tests/lib/quickCheckSectionExtractor.test.ts` | Section extraction tests |
+
+---
+
+## Phase 2 — Baseline evidence-backed review (planned)
+
+For baseline review questions, produce evidence-backed verdicts with gap explanations.
+
+### Required changes
+
+- Build baseline rubric: expected evidence signals for a justified baseline scenario
+  - Investment analysis present
+  - Barrier analysis present
+  - Common practice test applied
+  - Regulatory surplus considered
+- Wire evidence analysis pipeline to section content
+  - Currently `analyzeQuickCheckEvidence()` analyses uploaded evidence
+  - Add path to analyse extracted section content against rubric criteria
+- Verdict: Supported / Partial / Missing with confidence indicator
+- Gap list referencing specific missing elements
+- Follow-up document recommendation
+
+### Files to create/modify
+
+| File | Change |
+|---|---|
+| `src/lib/chat/quickCheckBaselineRubric.ts` | New — baseline rubric criteria and evaluation |
+| `src/lib/chat/quickCheckReviewQuestion.ts` | Wire rubric evaluation into buildReviewQuestionResult |
+| `src/components/chat/QuickCheckPanel.tsx` | Verdict + gap + follow-up UI rendering |
+| `tests/lib/quickCheckBaselineRubric.test.ts` | Rubric evaluation tests |
+
+---
+
+## Phase 3 — Review area rubrics (planned)
+
+Define rubric criteria for every review area so all areas get evidence-backed verdicts.
+
+### Required changes
+
+- Define rubric per review area: boundary, additionality, leakage, monitoring, deviations, right_of_use
+- Each rubric maps area keywords to expected evidence signals and minimum confidence thresholds
+- Make rubrics data-driven (JSON-configurable, not hardcoded)
+- Wire all rubrics into the review pipeline
+
+### Files to create/modify
+
+| File | Change |
+|---|---|
+| `src/lib/chat/rubrics/index.ts` | New — rubric registry and data loader |
+| `src/lib/chat/rubrics/baseline.json` | Baseline rubric data |
+| `src/lib/chat/rubrics/boundary.json` | Boundary rubric data |
+| `src/lib/chat/rubrics/additionality.json` | Additionality rubric data |
+| ... | One JSON per review area |
+| `src/lib/chat/quickCheckRubricEvaluator.ts` | New — generic rubric evaluator |
+| `tests/lib/rubrics/` | Per-rubric test cases |
+
+---
+
+## Phase 4 — Regression evaluation suite (planned)
+
+Automated eval harness that runs known review questions against known PDDs and detects regressions.
+
+### Required changes
+
+- Eval harness: CLI script that reads test cases (question + PDD), runs pipeline, records verdict
+- Labelled test cases: input → expected output (review area, sections, verdict)
+- CI integration: eval gate before merge
+- Regression diff: compare current output to baseline, alert on unexpected changes
+
+### Files to create/modify
+
+| File | Change |
+|---|---|
+| `scripts/eval/run-review-eval.mjs` | New — eval harness CLI |
+| `tests/eval/review-cases/` | Labelled test cases |
+| `.github/workflows/review-eval.yml` | CI eval gate |
+
+---
+
+## Phase 5 — Readiness note export (planned)
+
+Export the review-question result as a shareable readiness note (PDF or link).
+
+### Required changes
+
+- Readiness note data model: review area, methodology, sections, verdicts, gaps, follow-ups
+- Export button on review-question result
+- PDF generation with branded template
+- Immutable note storage (once exported, preserved)
+
+### Files to create/modify
+
+| File | Change |
+|---|---|
+| `src/lib/chat/quickCheckReadinessNote.ts` | New — note data model and builder |
+| `src/app/api/quick-check/export-readiness-note/route.ts` | New — PDF export API |
+| `src/components/chat/QuickCheckPanel.tsx` | Export button UI |
+| `tests/lib/quickCheckReadinessNote.test.ts` | Note builder tests |
+
+---
+
+## Exclusion list
+
+This roadmap explicitly excludes:
+
+- Full multi-methodology section extraction (scope-limited to VM0007 for MVP)
+- Auto-verification or automated rule review (human review remains the product)
+- Quantitative carbon calculations (track as separate workstream)
+- Team collaboration or approval workflows
+- Integration with external VVB tools or APIs

--- a/docs/roadmaps/review-grade-quick-check/ROADMAP.md
+++ b/docs/roadmaps/review-grade-quick-check/ROADMAP.md
@@ -1,0 +1,159 @@
+# Review-Grade Quick Check
+
+Status is sourced from `docs/roadmaps/review-grade-quick-check/phase-status.json`; docs must not drift.
+
+Goal: turn Quick Check from a requirement matcher / section router into an evidence-backed verification-readiness review engine.
+
+## Product narrative
+
+Quick Check today can route a review question to relevant PDD sections for VM0007. That is useful but shallow — it tells the user where to look, not what the document says or whether it passes.
+
+A VVB or project developer uploading a PDD wants to know: "Does this document satisfy the methodology requirements for this review area?" The answer is not a section number; it is a verdict backed by extracted evidence, identified gaps, and recommended next documents.
+
+The commercial value is evidence-backed readiness: a baseline review answers "Is the baseline justified?" with cited PDD excerpts, confidence signals, and a clear gap list — not "see section 2.4."
+
+## Current focus
+
+- Phase 0 (routing MVP) is active with PR 642: detect broad review questions, classify review area, route to VM0007 sections.
+- Narrow first implementation to VM0007 baseline review question only.
+
+## Not active now
+
+- Multi-methodology section routing (phase 1 starts after VM0007 routing is stable)
+- Evidence-backed verdicts and gap detection (phase 2+)
+- Review area rubrics (phase 3+)
+- Automated regression eval suite (phase 4+)
+- Readiness note export (phase 5+)
+
+## Phase 0 — Routing MVP
+
+Objective: detect the user's intent (requirement match vs. review question), classify the review area, and route to relevant VM0007 PDD sections.
+
+### Scope
+
+- Broad question detection: "Does this PDD justify/explain/disclose/support/define/describe/identify...", "Is the baseline...", "Is additionality...", "Check the...", "Review the..."
+- Review area classification: additionality, baseline, boundary, deviations, leakage, monitoring, right_of_use, general
+- VM0007 section routing per review area
+- Regression tests for detection, classification, and section routing
+- UI: show classified review area, methodology, and relevant sections as badge chips
+- Stale result clearing when review question changes
+
+### Methodology dependency
+
+None. Routing is purely client-side keyword and pattern matching.
+
+### Exit criteria
+
+- "Does this PDD support additionality under VT0001?" routes to additionality with sections 2.5, 2.4, 1.10
+- "Does this PDD define the project area, leakage belt, and reference region?" routes to boundary with sections 2.3, 1.9
+- "Does this PDD disclose methodology deviations..." routes to deviations with section 2.6
+- Boundary/review questions do not show the "Multiple requirements could fit this claim" warning
+- 42+ regression tests pass
+
+## Phase 1 — Section extraction
+
+Objective: extract and render the actual content of routed PDD sections so the user sees evidence, not just section numbers.
+
+### Key changes
+
+- Map section numbers (e.g. "2.4") to extracted PDF pages and text offsets
+- Render section excerpts inline in the review-question result card
+- Highlight detected methodology keywords within section content
+- Handle sections that span multiple pages or are not found
+
+### App responsibilities
+
+- PDF page extraction already returns per-page text from `/api/quick-check/pdf-extract`
+- Add section heading detection to split pages into section-granular content
+- Match section numbers from routing to extracted content
+
+### Exit criteria
+
+- A VM0007 baseline review question shows inline excerpts from sections 2.4, 2.5, and 1.10
+- Missing sections display "Section not found" rather than empty space
+- Section content updates when the user uploads a different PDD
+
+## Phase 2 — Baseline evidence-backed review
+
+Objective: produce evidence-backed verdicts for baseline review questions — supported, partial, or missing — with gap explanations.
+
+### Key changes
+
+- For baseline review questions, analyse extracted section content against baseline rubric criteria
+- Produce a verdict: Supported (clear baseline justification), Partial (some justification, gaps remain), or Missing (no baseline justification found)
+- Surface gap explanations referencing specific missing elements
+- Recommend follow-up documents (e.g. "Upload a feasibility study to support the investment analysis")
+
+### App responsibilities
+
+- Build baseline rubric: expected evidence signals for a justified baseline scenario
+- Wire evidence analysis pipeline to section content (currently analyses uploaded evidence, not sections)
+- Verdict display with confidence indicator and gap list
+
+### Exit criteria
+
+- "Does this PDD justify the baseline?" returns a verdict backed by extracted section text
+- Gap list references specific missing elements (e.g. "No investment analysis found in sections 2.4-2.5")
+- Follow-up document recommendation is non-empty when gaps exist
+
+## Phase 3 — Review area rubrics
+
+Objective: define rubric criteria for each review area so every area gets evidence-backed verdicts, not just baseline.
+
+### Key changes
+
+- Define rubric per review area: boundary, additionality, leakage, monitoring, deviations, right_of_use
+- Each rubric maps area keywords to expected evidence signals and minimum confidence thresholds
+- Rubrics are maintainable data (not hardcoded) — add new areas by adding a rubric entry
+
+### Exit criteria
+
+- All 7 review areas return evidence-backed verdicts (not just baseline)
+- Changing the review question to a different area produces a different verdict
+- Rubric data is readable and extendable without code changes
+
+## Phase 4 — Regression evaluation suite
+
+Objective: build an automated eval harness so routing and verdict changes are caught before they ship.
+
+### Key changes
+
+- Eval harness reads known review questions + known PDDs, runs the full pipeline, records verdicts
+- Labelled test cases: input (question + PDD) → expected output (review area, sections, verdict)
+- CI gate: eval suite must pass before review-grade-quick-check PRs merge
+- Regression detection: diff output between runs, alert on unexpected changes
+
+### Exit criteria
+
+- Eval harness runs from CLI with a single command
+- 20+ labelled test cases covering all review areas and common PDDs
+- CI blocks PRs that introduce routing or verdict regressions
+
+## Phase 5 — Readiness note export
+
+Objective: export the review result as a shareable readiness note.
+
+### Key changes
+
+- Readiness note includes: review area, methodology, sections reviewed, evidence-backed verdicts, gap list, recommended follow-up documents
+- Export format: PDF or shareable link
+- Note is timestamped and immutable once exported
+
+### Exit criteria
+
+- Export button appears on review-question result
+- Exported note renders correctly with all sections populated
+- Re-running the review produces a new note; old notes are preserved
+
+## Sequencing
+
+1. Phase 0 — Routing MVP (active, PR 642)
+2. Phase 1 — Section extraction
+3. Phase 2 — Baseline evidence-backed review
+4. Phase 3 — Review area rubrics
+5. Phase 4 — Regression evaluation suite
+6. Phase 5 — Readiness note export
+
+## Immediate next action
+
+Merge PR 642, then start Phase 1: extract and render section content from uploaded PDD pages.

--- a/docs/roadmaps/review-grade-quick-check/phase-status.json
+++ b/docs/roadmaps/review-grade-quick-check/phase-status.json
@@ -1,0 +1,54 @@
+{
+  "phase_meta": {
+    "status": "active",
+    "summary": "Turn Quick Check from a requirement matcher / section router into an evidence-backed verification-readiness review engine. Phased path from routing to readiness note export.",
+    "current_focus": [
+      "Phase 0: routing MVP — detect review question path, classify review area, route to VM0007 sections (PR 642)"
+    ],
+    "not_active_now": [
+      "Full multi-methodology section extraction (phase 1 starts after VM0007 routing is stable)",
+      "Evidence-backed verdicts and gap detection (phase 2+)",
+      "Review area rubrics (phase 3+)",
+      "Regression evaluation suite (phase 4+)",
+      "Readiness note export (phase 5+)"
+    ],
+    "last_updated_at": "2026-05-28T00:00:00Z"
+  },
+  "phase_0_routing_mvp": {
+    "status": "active",
+    "title": "Routing MVP — review question detection and section routing",
+    "summary": "Detect broad review questions, classify review area, route to relevant VM0007 PDD sections. Narrow first implementation to VM0007 baseline review question only."
+  },
+  "phase_1_section_extraction": {
+    "status": "planned",
+    "title": "Section extraction — retrieve and render PDD section content",
+    "summary": "Extract section content from uploaded PDD pages. Map section numbers to extracted text. Render section excerpts inline in the review-question result."
+  },
+  "phase_2_baseline_evidence_backed_review": {
+    "status": "planned",
+    "title": "Baseline evidence-backed review — verdicts and gaps",
+    "summary": "For baseline review questions, produce evidence-backed verdicts (supported / partial / missing) with gap explanations. Reference extracted PDD section content. Surface next-step follow-up documents."
+  },
+  "phase_3_review_area_rubrics": {
+    "status": "planned",
+    "title": "Review area rubrics — per-area evidence criteria",
+    "summary": "Define rubric criteria for each review area (baseline, boundary, additionality, leakage, monitoring, deviations, right of use). Each rubric maps area keywords to expected evidence signals and minimum confidence thresholds."
+  },
+  "phase_4_regression_evals": {
+    "status": "planned",
+    "title": "Regression evaluation suite — automated eval harness",
+    "summary": "Build an automated eval harness that runs known review questions against known PDDs, records verdicts, and detects regressions. Benchmark routing accuracy, section extraction fidelity, and verdict correctness against labelled test cases."
+  },
+  "phase_5_readiness_note_export": {
+    "status": "planned",
+    "title": "Readiness note export — shareable verification-readiness summary",
+    "summary": "Export the review-question result as a readiness note: review area, methodology, sections reviewed, evidence-backed verdicts, gaps, and recommended follow-up documents. PDF or shareable link format."
+  },
+  "PR642": "active",
+  "pr_evidence": {
+    "PR642": ["640", "641", "642"]
+  },
+  "pr_notes": {
+    "PR642": "Routing MVP: detect review question path, classify review area, route to VM0007 sections. Covers additionality, baseline, boundary, deviations, leakage, monitoring, right_of_use."
+  }
+}


### PR DESCRIPTION
## What

New roadmap for `review-grade-quick-check` — turning Quick Check from a requirement matcher / section router into an evidence-backed verification-readiness review engine.

**6 phases:**

| Phase | Status | Description |
|---|---|---|
| phase_0_routing_mvp | active (PR 642) | Detect review question path, classify review area, route to VM0007 sections |
| phase_1_section_extraction | planned | Extract and render PDD section content inline |
| phase_2_baseline_evidence_backed_review | planned | Evidence-backed verdicts with gap explanations for baseline questions |
| phase_3_review_area_rubrics | planned | Per-area rubric criteria, data-driven, all 7 review areas |
| phase_4_regression_evals | planned | Automated eval harness with CI gate |
| phase_5_readiness_note_export | planned | Shareable readiness note PDF/link export |

**First implementation milestone:** VM0007 baseline review question only.

## Files

| File | Purpose |
|---|---|
| `docs/roadmaps/review-grade-quick-check/ROADMAP.md` | Product narrative, phase objectives, exit criteria |
| `docs/roadmaps/review-grade-quick-check/PLAN.md` | Implementation plan with file breakdown per phase, PR body standard, exclusion list |
| `docs/roadmaps/review-grade-quick-check/phase-status.json` | SSOT — links PR 642 to phase_0_routing_mvp |
| `docs/roadmaps/SUMMARY.md` | Regenerated to include new review-grade-quick-check lane |

### Roadmap-Update
- slug: review-grade-quick-check
- items:
  - phase_0_routing_mvp: active
  - PR642: active

Signed-off-by: Fred E.