### PR TITLE
feat(quick-check): Phase 1 section extraction — detect, map, render PDD sections

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -282,3 +282,4 @@ Not active now:
 - STAC auto-verification (support facts only, not auto-verify)
 - AI-assisted review (post-moat)
 - Multi-methodology cross-referencing (Phase 5+)
+

--- a/docs/roadmaps/review-grade-quick-check/phase-status.json
+++ b/docs/roadmaps/review-grade-quick-check/phase-status.json
@@ -46,11 +46,7 @@
     "last_updated_at": "2026-05-28T00:00:00Z"
   },
   "pr_evidence": {
-    "PR642": [
-      "640",
-      "641",
-      "642"
-    ]
+    "PR642": [640, 641, 642]
   },
   "pr_notes": {
     "PR642": "Routing MVP: detect review question path, classify review area, route to VM0007 sections. Covers additionality, baseline, boundary, deviations, leakage, monitoring, right_of_use."

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -56,6 +56,7 @@ import {
   reviewAreaLabel,
   type ReviewQuestionResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
+import { debugSectionExtraction } from "@/lib/chat/quickCheckSectionExtractor";
 
 type MethodInventoryRecord = {
   code: string;
@@ -1401,6 +1402,15 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyVersion ?? "" : "");
 
       if (detectReviewPath(effectiveClaimText) === "review_question_answering") {
+        if (process.env.NODE_ENV !== "production") {
+          const rawText = evidenceAnalysis.rawPddText;
+          if (!rawText) {
+            console.warn("[quick-check-debug] rawPddText is undefined or empty");
+          } else {
+            const diag = debugSectionExtraction(rawText);
+            console.info("[quick-check-debug]", diag);
+          }
+        }
         const questionResult = buildReviewQuestionResult({
           claimText: effectiveClaimText,
           methodologyId: resolvedMethodologyId,

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2145,89 +2145,97 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       </div>
                     ) : null}
                   </div>
-                  {reviewQuestionResult.relevantSections.length > 0 ? (
+                  {reviewQuestionResult.relevantSections.length > 0 || reviewQuestionResult.phase1Diagnostic ? (
                     <div className="mt-4">
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Relevant PDD sections</div>
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        {reviewQuestionResult.relevantSections.map((section) => (
-                          <span key={section} className="rounded-full border border-sky-200 bg-white px-3 py-1.5 text-sm font-medium text-sky-900">
-                            Section {section}
-                          </span>
-                        ))}
-                      </div>
-                      <div className="mt-3 grid gap-3">
-                        {reviewQuestionResult.relevantSections.map((section) => {
-                          const content = reviewQuestionResult.sectionContent[section];
-                          return (
-                            <div key={section} className="rounded-xl border border-slate-200 bg-white px-4 py-3">
-                              <div className="text-xs font-semibold text-slate-500">Section {section}</div>
-                              {content ? (
-                                <div className="mt-1.5 max-h-32 overflow-y-auto text-sm leading-relaxed text-slate-700">
-                                  {content}
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Matched document sections</div>
+                      {reviewQuestionResult.relevantSections.length > 0 ? (
+                        <>
+                          <div className="mt-2 flex flex-wrap gap-2">
+                            {reviewQuestionResult.relevantSections.map((section) => (
+                              <span key={section} className="rounded-full border border-sky-200 bg-white px-3 py-1.5 text-sm font-medium text-sky-900">
+                                Section {section}
+                              </span>
+                            ))}
+                          </div>
+                          <div className="mt-3 grid gap-3">
+                            {reviewQuestionResult.relevantSections.map((section) => {
+                              const content = reviewQuestionResult.sectionContent[section];
+                              return (
+                                <div key={section} className="rounded-xl border border-slate-200 bg-white px-4 py-3">
+                                  <div className="text-xs font-semibold text-slate-500">Section {section}</div>
+                                  {content ? (
+                                    <div className="mt-1.5 max-h-32 overflow-y-auto text-sm leading-relaxed text-slate-700">
+                                      {content}
+                                    </div>
+                                  ) : (
+                                    <div className="mt-1.5 text-sm text-amber-700">
+                                      No matching document section found
+                                    </div>
+                                  )}
                                 </div>
-                              ) : (
-                                <div className="mt-1.5 text-sm text-amber-700">
-                                  Section not found in uploaded document.
-                                </div>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
+                              );
+                            })}
+                          </div>
+                        </>
+                      ) : (
+                        <div className="mt-2 text-sm text-amber-700">
+                          No matching document section found for this review area in the uploaded document.
+                        </div>
+                      )}
                       <p className="mt-2 text-xs text-slate-500">
                         Open the full review to inspect these sections in the uploaded document.
                       </p>
-                      {reviewQuestionResult.phase1Diagnostic && process.env.NODE_ENV !== "production" ? (
-                        <details className="mt-3" open>
-                          <summary className="cursor-pointer text-xs font-medium text-slate-500 hover:text-slate-700">
-                            Extraction diagnostic
-                          </summary>
-                          {reviewQuestionResult.phase1Diagnostic.sectionCandidates ? (
-                            <div className="mt-2 space-y-2">
-                              {Object.entries(reviewQuestionResult.phase1Diagnostic.sectionCandidates).map(([num, info]) => (
-                                <details key={num} className="rounded-lg border border-slate-200 bg-white text-[10px]">
-                                  <summary className="cursor-pointer px-3 py-2 font-medium text-slate-700 hover:bg-slate-50">
-                                    Section {num} — {info.selectedCandidate.includes("all") ? "⚠" : "✓"} {info.selectedCandidate.slice(0, 80)}
-                                  </summary>
-                                  <div className="border-t border-slate-100 px-3 py-2 text-slate-600">
-                                    <div className="mb-1">
-                                      <span className="font-semibold text-slate-500">Reason: </span>
-                                      {info.selectedReason}
-                                    </div>
-                                    {info.allCandidateLines.length > 0 && (
-                                      <div className="mb-1">
-                                        <span className="font-semibold text-slate-500">Candidates ({info.allCandidateLines.length}):</span>
-                                        <ul className="ml-2 list-disc list-inside">
-                                          {info.allCandidateLines.map((line, idx) => (
-                                            <li key={idx} className="truncate font-mono">{line}</li>
-                                          ))}
-                                        </ul>
-                                      </div>
-                                    )}
-                                    {info.rejectedCandidates.length > 0 && (
-                                      <div className="mb-1">
-                                        <span className="font-semibold text-slate-500">Rejected:</span>
-                                        <ul className="ml-2 list-disc list-inside">
-                                          {info.rejectedCandidates.map((reason, idx) => (
-                                            <li key={idx} className="truncate font-mono text-rose-600">{reason}</li>
-                                          ))}
-                                        </ul>
-                                      </div>
-                                    )}
-                                    <div>
-                                      <span className="font-semibold text-slate-500">Body preview: </span>
-                                      <span className="font-mono">{info.sectionBodyPreview}</span>
-                                    </div>
+                    {reviewQuestionResult.phase1Diagnostic && process.env.NODE_ENV !== "production" ? (
+                      <details className="mt-3" open>
+                        <summary className="cursor-pointer text-xs font-medium text-slate-500 hover:text-slate-700">
+                          Extraction diagnostic
+                        </summary>
+                        {reviewQuestionResult.phase1Diagnostic.sectionCandidates ? (
+                          <div className="mt-2 space-y-2">
+                            {Object.entries(reviewQuestionResult.phase1Diagnostic.sectionCandidates).map(([num, info]) => (
+                              <details key={num} className="rounded-lg border border-slate-200 bg-white text-[10px]">
+                                <summary className="cursor-pointer px-3 py-2 font-medium text-slate-700 hover:bg-slate-50">
+                                  Section {num} — {info.selectedCandidate.includes("all") ? "⚠" : "✓"} {info.selectedCandidate.slice(0, 80)}
+                                </summary>
+                                <div className="border-t border-slate-100 px-3 py-2 text-slate-600">
+                                  <div className="mb-1">
+                                    <span className="font-semibold text-slate-500">Reason: </span>
+                                    {info.selectedReason}
                                   </div>
-                                </details>
-                              ))}
-                            </div>
-                          ) : null}
-                          <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-slate-200 bg-white p-3 text-[10px] leading-relaxed text-slate-600">
-                            {JSON.stringify(reviewQuestionResult.phase1Diagnostic, null, 2)}
-                          </pre>
-                        </details>
-                      ) : null}
+                                  {info.allCandidateLines.length > 0 && (
+                                    <div className="mb-1">
+                                      <span className="font-semibold text-slate-500">Candidates ({info.allCandidateLines.length}):</span>
+                                      <ul className="ml-2 list-disc list-inside">
+                                        {info.allCandidateLines.map((line, idx) => (
+                                          <li key={idx} className="truncate font-mono">{line}</li>
+                                        ))}
+                                      </ul>
+                                    </div>
+                                  )}
+                                  {info.rejectedCandidates.length > 0 && (
+                                    <div className="mb-1">
+                                      <span className="font-semibold text-slate-500">Rejected:</span>
+                                      <ul className="ml-2 list-disc list-inside">
+                                        {info.rejectedCandidates.map((reason, idx) => (
+                                          <li key={idx} className="truncate font-mono text-rose-600">{reason}</li>
+                                        ))}
+                                      </ul>
+                                    </div>
+                                  )}
+                                  <div>
+                                    <span className="font-semibold text-slate-500">Body preview: </span>
+                                    <span className="font-mono">{info.sectionBodyPreview}</span>
+                                  </div>
+                                </div>
+                              </details>
+                            ))}
+                          </div>
+                        ) : null}
+                        <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-slate-200 bg-white p-3 text-[10px] leading-relaxed text-slate-600">
+                          {JSON.stringify(reviewQuestionResult.phase1Diagnostic, null, 2)}
+                        </pre>
+                      </details>
+                    ) : null}
                     </div>
                   ) : (
                     <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2185,7 +2185,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       </div>
                     ) : (
                       <div className="mt-2 text-sm text-amber-700">
-                        No matching document heading found.
+                        No matching document section found.
                       </div>
                     )}
 

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -56,6 +56,7 @@ import {
   reviewAreaLabel,
   type ReviewQuestionResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
+import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
 
 type MethodInventoryRecord = {
   code: string;
@@ -555,6 +556,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [isDragActive, setIsDragActive] = useState(false);
   const [showExtractionDetails, setShowExtractionDetails] = useState(false);
   const [reviewQuestionResult, setReviewQuestionResult] = useState<ReviewQuestionResult | null>(null);
+  const [selectedHeading, setSelectedHeading] = useState<DocumentHeading | null>(null);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
     loading: false,
@@ -952,6 +954,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setMatchCandidates([]);
     setValidatedResultKey(null);
     setReviewQuestionResult(null);
+    setSelectedHeading(null);
+  }
+
+  function handleHeadingClick(heading: DocumentHeading) {
+    setSelectedHeading(heading);
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      void navigator.clipboard.writeText(`§${heading.sectionNumber} ${heading.title}`).catch(() => undefined);
+    }
   }
 
   function resetQuickCheckUi() {
@@ -1411,6 +1421,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           evidenceDocumentType: evidenceAnalysis.documentTypes[0],
         });
         setReviewQuestionResult(questionResult);
+        setSelectedHeading(null);
         setRecoveryState(null);
         setFieldErrors({});
         setSubmitting(false);
@@ -1418,6 +1429,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       }
 
       setReviewQuestionResult(null);
+      setSelectedHeading(null);
 
       const selectedMethodologyId = draft.methodologyId.trim()
         || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "" : "");
@@ -2135,54 +2147,71 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   <div className="mt-2 text-sm text-slate-600">{draft.claimText}</div>
                   <div className="mt-4 grid gap-4 sm:grid-cols-2">
                     <div>
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Review area</div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Review area (classified)</div>
                       <div className="mt-1 text-sm font-medium text-slate-900">{reviewAreaLabel(reviewQuestionResult.reviewArea)}</div>
                     </div>
                     {reviewQuestionResult.methodologyId ? (
                       <div>
-                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Methodology</div>
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Methodology (from input)</div>
                         <div className="mt-1 text-sm font-medium text-slate-900">{reviewQuestionResult.methodologyId} · {reviewQuestionResult.methodologyVersion || "—"}</div>
                       </div>
                     ) : null}
                   </div>
                   <div className="mt-4">
-                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Matched document sections</div>
-                    {reviewQuestionResult.relevantSections.length > 0 ? (
-                      <>
-                        <div className="mt-2 flex flex-wrap gap-2">
-                          {reviewQuestionResult.relevantSections.map((section) => (
-                            <span key={section} className="rounded-full border border-sky-200 bg-white px-3 py-1.5 text-sm font-medium text-sky-900">
-                              Section {section}
-                            </span>
-                          ))}
-                        </div>
-                        <div className="mt-3 grid gap-3">
-                          {reviewQuestionResult.relevantSections.map((section) => {
-                            const content = reviewQuestionResult.sectionContent[section];
-                            return (
-                              <div key={section} className="rounded-xl border border-slate-200 bg-white px-4 py-3">
-                                <div className="text-xs font-semibold text-slate-500">Section {section}</div>
-                                {content ? (
-                                  <div className="mt-1.5 max-h-32 overflow-y-auto text-sm leading-relaxed text-slate-700">
-                                    {content}
-                                  </div>
-                                ) : (
-                                  <div className="mt-1.5 text-sm text-amber-700">
-                                    No matching document section found
-                                  </div>
-                                )}
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Document heading index (Phase 1 — question is filter only)</div>
+                    <p className="mt-1 text-xs text-slate-500">Headings extracted from uploaded PDD. Your question filters titles (no body matching, no methodology routes).</p>
+                    {reviewQuestionResult.matchedHeadings.length > 0 ? (
+                      <div className="mt-3 space-y-2">
+                        {reviewQuestionResult.matchedHeadings.map((h) => {
+                          const isSelected = selectedHeading?.sectionNumber === h.sectionNumber;
+                          return (
+                            <button
+                              key={h.sectionNumber}
+                              type="button"
+                              onClick={() => handleHeadingClick(h)}
+                              className={`w-full rounded-xl border px-4 py-3 text-left transition ${isSelected ? "border-sky-400 bg-sky-100" : "border-slate-200 bg-white hover:border-sky-300 hover:bg-sky-50"}`}
+                            >
+                              <div className="flex items-baseline gap-2">
+                                <span className="font-mono text-xs font-semibold text-sky-700">§{h.sectionNumber}</span>
+                                <span className="text-sm font-medium text-slate-900">{h.title}</span>
                               </div>
-                            );
-                          })}
-                        </div>
-                      </>
+                              {h.bodyPreview ? (
+                                <div className="mt-1.5 text-xs leading-relaxed text-slate-600 line-clamp-2">{h.bodyPreview}</div>
+                              ) : null}
+                              <div className="mt-1 text-[10px] text-slate-400">Click to select / copy reference</div>
+                            </button>
+                          );
+                        })}
+                      </div>
                     ) : (
                       <div className="mt-2 text-sm text-amber-700">
-                        No matching document section found for this review area in the uploaded document.
+                        No matching document heading found.
                       </div>
                     )}
+
+                    {selectedHeading ? (
+                      <div className="mt-3 rounded-xl border border-sky-300 bg-white p-4">
+                        <div className="text-xs font-semibold text-sky-700">Selected: §{selectedHeading.sectionNumber} {selectedHeading.title}</div>
+                        <div className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap text-sm leading-relaxed text-slate-700 border border-slate-100 bg-slate-50 p-2 rounded">
+                          {selectedHeading.bodyText || selectedHeading.bodyPreview}
+                        </div>
+                        <div className="mt-2 text-[10px] text-slate-500">Reference copied to clipboard. Use in full review for evidence citation.</div>
+                      </div>
+                    ) : null}
+
+                    {reviewQuestionResult.matchedHeadings.length === 0 && reviewQuestionResult.headingIndex.length > 0 ? (
+                      <details className="mt-2 text-xs">
+                        <summary className="cursor-pointer text-slate-500">Show all {reviewQuestionResult.headingIndex.length} headings from document</summary>
+                        <div className="mt-2 grid gap-1">
+                          {reviewQuestionResult.headingIndex.slice(0, 12).map((h) => (
+                            <button key={h.sectionNumber} type="button" onClick={() => handleHeadingClick(h)} className="text-left text-[11px] text-slate-600 hover:text-sky-700 font-mono">§{h.sectionNumber} {h.title}</button>
+                          ))}
+                        </div>
+                      </details>
+                    ) : null}
+
                     <p className="mt-2 text-xs text-slate-500">
-                      Open the full review to inspect these sections in the uploaded document.
+                      Open full review to inspect these sections against the full document and methodology.
                     </p>
                   {reviewQuestionResult.phase1Diagnostic && process.env.NODE_ENV !== "production" ? (
                     <details className="mt-3" open>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1405,6 +1405,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           claimText: effectiveClaimText,
           methodologyId: resolvedMethodologyId,
           methodologyVersion: resolvedMethodologyVersion,
+          rawPddText: evidenceAnalysis.rawPddText,
         });
         setReviewQuestionResult(questionResult);
         setRecoveryState(null);
@@ -2150,6 +2151,25 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                             Section {section}
                           </span>
                         ))}
+                      </div>
+                      <div className="mt-3 grid gap-3">
+                        {reviewQuestionResult.relevantSections.map((section) => {
+                          const content = reviewQuestionResult.sectionContent[section];
+                          return (
+                            <div key={section} className="rounded-xl border border-slate-200 bg-white px-4 py-3">
+                              <div className="text-xs font-semibold text-slate-500">Section {section}</div>
+                              {content ? (
+                                <div className="mt-1.5 max-h-32 overflow-y-auto text-sm leading-relaxed text-slate-700">
+                                  {content}
+                                </div>
+                              ) : (
+                                <div className="mt-1.5 text-sm text-amber-700">
+                                  Section not found in uploaded document.
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
                       </div>
                       <p className="mt-2 text-xs text-slate-500">
                         Open the full review to inspect these sections in the uploaded document.

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -56,7 +56,6 @@ import {
   reviewAreaLabel,
   type ReviewQuestionResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
-import { debugSectionExtraction } from "@/lib/chat/quickCheckSectionExtractor";
 
 type MethodInventoryRecord = {
   code: string;
@@ -1402,15 +1401,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyVersion ?? "" : "");
 
       if (detectReviewPath(effectiveClaimText) === "review_question_answering") {
-        if (process.env.NODE_ENV !== "production") {
-          const rawText = evidenceAnalysis.rawPddText;
-          if (!rawText) {
-            console.warn("[quick-check-debug] rawPddText is undefined or empty");
-          } else {
-            const diag = debugSectionExtraction(rawText);
-            console.info("[quick-check-debug]", diag);
-          }
-        }
         const questionResult = buildReviewQuestionResult({
           claimText: effectiveClaimText,
           methodologyId: resolvedMethodologyId,
@@ -2184,6 +2174,16 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       <p className="mt-2 text-xs text-slate-500">
                         Open the full review to inspect these sections in the uploaded document.
                       </p>
+                      {reviewQuestionResult.diagnostic && process.env.NODE_ENV !== "production" ? (
+                        <details className="mt-3">
+                          <summary className="cursor-pointer text-xs font-medium text-slate-500 hover:text-slate-700">
+                            Extraction diagnostic
+                          </summary>
+                          <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-slate-200 bg-white p-3 text-[10px] leading-relaxed text-slate-600">
+                            {JSON.stringify(reviewQuestionResult.diagnostic, null, 2)}
+                          </pre>
+                        </details>
+                      ) : null}
                     </div>
                   ) : (
                     <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1401,11 +1401,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyVersion ?? "" : "");
 
       if (detectReviewPath(effectiveClaimText) === "review_question_answering") {
+        const firstSource = selectedEvidenceSources[0];
         const questionResult = buildReviewQuestionResult({
           claimText: effectiveClaimText,
           methodologyId: resolvedMethodologyId,
           methodologyVersion: resolvedMethodologyVersion,
           rawPddText: evidenceAnalysis.rawPddText,
+          evidenceSourceLabel: firstSource?.sourceLabel,
+          evidenceDocumentType: evidenceAnalysis.documentTypes[0],
         });
         setReviewQuestionResult(questionResult);
         setRecoveryState(null);
@@ -2174,13 +2177,13 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       <p className="mt-2 text-xs text-slate-500">
                         Open the full review to inspect these sections in the uploaded document.
                       </p>
-                      {reviewQuestionResult.diagnostic && process.env.NODE_ENV !== "production" ? (
-                        <details className="mt-3">
+                      {reviewQuestionResult.phase1Diagnostic && process.env.NODE_ENV !== "production" ? (
+                        <details className="mt-3" open>
                           <summary className="cursor-pointer text-xs font-medium text-slate-500 hover:text-slate-700">
                             Extraction diagnostic
                           </summary>
                           <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-slate-200 bg-white p-3 text-[10px] leading-relaxed text-slate-600">
-                            {JSON.stringify(reviewQuestionResult.diagnostic, null, 2)}
+                            {JSON.stringify(reviewQuestionResult.phase1Diagnostic, null, 2)}
                           </pre>
                         </details>
                       ) : null}

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2182,6 +2182,47 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                           <summary className="cursor-pointer text-xs font-medium text-slate-500 hover:text-slate-700">
                             Extraction diagnostic
                           </summary>
+                          {reviewQuestionResult.phase1Diagnostic.sectionCandidates ? (
+                            <div className="mt-2 space-y-2">
+                              {Object.entries(reviewQuestionResult.phase1Diagnostic.sectionCandidates).map(([num, info]) => (
+                                <details key={num} className="rounded-lg border border-slate-200 bg-white text-[10px]">
+                                  <summary className="cursor-pointer px-3 py-2 font-medium text-slate-700 hover:bg-slate-50">
+                                    Section {num} — {info.selectedCandidate.includes("all") ? "⚠" : "✓"} {info.selectedCandidate.slice(0, 80)}
+                                  </summary>
+                                  <div className="border-t border-slate-100 px-3 py-2 text-slate-600">
+                                    <div className="mb-1">
+                                      <span className="font-semibold text-slate-500">Reason: </span>
+                                      {info.selectedReason}
+                                    </div>
+                                    {info.allCandidateLines.length > 0 && (
+                                      <div className="mb-1">
+                                        <span className="font-semibold text-slate-500">Candidates ({info.allCandidateLines.length}):</span>
+                                        <ul className="ml-2 list-disc list-inside">
+                                          {info.allCandidateLines.map((line, idx) => (
+                                            <li key={idx} className="truncate font-mono">{line}</li>
+                                          ))}
+                                        </ul>
+                                      </div>
+                                    )}
+                                    {info.rejectedCandidates.length > 0 && (
+                                      <div className="mb-1">
+                                        <span className="font-semibold text-slate-500">Rejected:</span>
+                                        <ul className="ml-2 list-disc list-inside">
+                                          {info.rejectedCandidates.map((reason, idx) => (
+                                            <li key={idx} className="truncate font-mono text-rose-600">{reason}</li>
+                                          ))}
+                                        </ul>
+                                      </div>
+                                    )}
+                                    <div>
+                                      <span className="font-semibold text-slate-500">Body preview: </span>
+                                      <span className="font-mono">{info.sectionBodyPreview}</span>
+                                    </div>
+                                  </div>
+                                </details>
+                              ))}
+                            </div>
+                          ) : null}
                           <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-slate-200 bg-white p-3 text-[10px] leading-relaxed text-slate-600">
                             {JSON.stringify(reviewQuestionResult.phase1Diagnostic, null, 2)}
                           </pre>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2145,103 +2145,97 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       </div>
                     ) : null}
                   </div>
-                  {reviewQuestionResult.relevantSections.length > 0 || reviewQuestionResult.phase1Diagnostic ? (
-                    <div className="mt-4">
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Matched document sections</div>
-                      {reviewQuestionResult.relevantSections.length > 0 ? (
-                        <>
-                          <div className="mt-2 flex flex-wrap gap-2">
-                            {reviewQuestionResult.relevantSections.map((section) => (
-                              <span key={section} className="rounded-full border border-sky-200 bg-white px-3 py-1.5 text-sm font-medium text-sky-900">
-                                Section {section}
-                              </span>
-                            ))}
-                          </div>
-                          <div className="mt-3 grid gap-3">
-                            {reviewQuestionResult.relevantSections.map((section) => {
-                              const content = reviewQuestionResult.sectionContent[section];
-                              return (
-                                <div key={section} className="rounded-xl border border-slate-200 bg-white px-4 py-3">
-                                  <div className="text-xs font-semibold text-slate-500">Section {section}</div>
-                                  {content ? (
-                                    <div className="mt-1.5 max-h-32 overflow-y-auto text-sm leading-relaxed text-slate-700">
-                                      {content}
-                                    </div>
-                                  ) : (
-                                    <div className="mt-1.5 text-sm text-amber-700">
-                                      No matching document section found
-                                    </div>
-                                  )}
-                                </div>
-                              );
-                            })}
-                          </div>
-                        </>
-                      ) : (
-                        <div className="mt-2 text-sm text-amber-700">
-                          No matching document section found for this review area in the uploaded document.
+                  <div className="mt-4">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Matched document sections</div>
+                    {reviewQuestionResult.relevantSections.length > 0 ? (
+                      <>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {reviewQuestionResult.relevantSections.map((section) => (
+                            <span key={section} className="rounded-full border border-sky-200 bg-white px-3 py-1.5 text-sm font-medium text-sky-900">
+                              Section {section}
+                            </span>
+                          ))}
                         </div>
-                      )}
-                      <p className="mt-2 text-xs text-slate-500">
-                        Open the full review to inspect these sections in the uploaded document.
-                      </p>
-                    {reviewQuestionResult.phase1Diagnostic && process.env.NODE_ENV !== "production" ? (
-                      <details className="mt-3" open>
-                        <summary className="cursor-pointer text-xs font-medium text-slate-500 hover:text-slate-700">
-                          Extraction diagnostic
-                        </summary>
-                        {reviewQuestionResult.phase1Diagnostic.sectionCandidates ? (
-                          <div className="mt-2 space-y-2">
-                            {Object.entries(reviewQuestionResult.phase1Diagnostic.sectionCandidates).map(([num, info]) => (
-                              <details key={num} className="rounded-lg border border-slate-200 bg-white text-[10px]">
-                                <summary className="cursor-pointer px-3 py-2 font-medium text-slate-700 hover:bg-slate-50">
-                                  Section {num} — {info.selectedCandidate.includes("all") ? "⚠" : "✓"} {info.selectedCandidate.slice(0, 80)}
-                                </summary>
-                                <div className="border-t border-slate-100 px-3 py-2 text-slate-600">
-                                  <div className="mb-1">
-                                    <span className="font-semibold text-slate-500">Reason: </span>
-                                    {info.selectedReason}
+                        <div className="mt-3 grid gap-3">
+                          {reviewQuestionResult.relevantSections.map((section) => {
+                            const content = reviewQuestionResult.sectionContent[section];
+                            return (
+                              <div key={section} className="rounded-xl border border-slate-200 bg-white px-4 py-3">
+                                <div className="text-xs font-semibold text-slate-500">Section {section}</div>
+                                {content ? (
+                                  <div className="mt-1.5 max-h-32 overflow-y-auto text-sm leading-relaxed text-slate-700">
+                                    {content}
                                   </div>
-                                  {info.allCandidateLines.length > 0 && (
-                                    <div className="mb-1">
-                                      <span className="font-semibold text-slate-500">Candidates ({info.allCandidateLines.length}):</span>
-                                      <ul className="ml-2 list-disc list-inside">
-                                        {info.allCandidateLines.map((line, idx) => (
-                                          <li key={idx} className="truncate font-mono">{line}</li>
-                                        ))}
-                                      </ul>
-                                    </div>
-                                  )}
-                                  {info.rejectedCandidates.length > 0 && (
-                                    <div className="mb-1">
-                                      <span className="font-semibold text-slate-500">Rejected:</span>
-                                      <ul className="ml-2 list-disc list-inside">
-                                        {info.rejectedCandidates.map((reason, idx) => (
-                                          <li key={idx} className="truncate font-mono text-rose-600">{reason}</li>
-                                        ))}
-                                      </ul>
-                                    </div>
-                                  )}
-                                  <div>
-                                    <span className="font-semibold text-slate-500">Body preview: </span>
-                                    <span className="font-mono">{info.sectionBodyPreview}</span>
+                                ) : (
+                                  <div className="mt-1.5 text-sm text-amber-700">
+                                    No matching document section found
                                   </div>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </>
+                    ) : (
+                      <div className="mt-2 text-sm text-amber-700">
+                        No matching document section found for this review area in the uploaded document.
+                      </div>
+                    )}
+                    <p className="mt-2 text-xs text-slate-500">
+                      Open the full review to inspect these sections in the uploaded document.
+                    </p>
+                  {reviewQuestionResult.phase1Diagnostic && process.env.NODE_ENV !== "production" ? (
+                    <details className="mt-3" open>
+                      <summary className="cursor-pointer text-xs font-medium text-slate-500 hover:text-slate-700">
+                        Extraction diagnostic
+                      </summary>
+                      {reviewQuestionResult.phase1Diagnostic.sectionCandidates ? (
+                        <div className="mt-2 space-y-2">
+                          {Object.entries(reviewQuestionResult.phase1Diagnostic.sectionCandidates).map(([num, info]) => (
+                            <details key={num} className="rounded-lg border border-slate-200 bg-white text-[10px]">
+                              <summary className="cursor-pointer px-3 py-2 font-medium text-slate-700 hover:bg-slate-50">
+                                Section {num} — {info.selectedCandidate.includes("all") ? "⚠" : "✓"} {info.selectedCandidate.slice(0, 80)}
+                              </summary>
+                              <div className="border-t border-slate-100 px-3 py-2 text-slate-600">
+                                <div className="mb-1">
+                                  <span className="font-semibold text-slate-500">Reason: </span>
+                                  {info.selectedReason}
                                 </div>
-                              </details>
-                            ))}
-                          </div>
-                        ) : null}
-                        <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-slate-200 bg-white p-3 text-[10px] leading-relaxed text-slate-600">
-                          {JSON.stringify(reviewQuestionResult.phase1Diagnostic, null, 2)}
-                        </pre>
-                      </details>
-                    ) : null}
-                    </div>
-                  ) : (
-                    <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
-                      No methodology-specific section routing is available yet. Check the methodology document directly.
-                    </div>
-                  )}
+                                {info.allCandidateLines.length > 0 && (
+                                  <div className="mb-1">
+                                    <span className="font-semibold text-slate-500">Candidates ({info.allCandidateLines.length}):</span>
+                                    <ul className="ml-2 list-disc list-inside">
+                                      {info.allCandidateLines.map((line, idx) => (
+                                        <li key={idx} className="truncate font-mono">{line}</li>
+                                      ))}
+                                    </ul>
+                                  </div>
+                                )}
+                                {info.rejectedCandidates.length > 0 && (
+                                  <div className="mb-1">
+                                    <span className="font-semibold text-slate-500">Rejected:</span>
+                                    <ul className="ml-2 list-disc list-inside">
+                                      {info.rejectedCandidates.map((reason, idx) => (
+                                        <li key={idx} className="truncate font-mono text-rose-600">{reason}</li>
+                                      ))}
+                                    </ul>
+                                  </div>
+                                )}
+                                <div>
+                                  <span className="font-semibold text-slate-500">Body preview: </span>
+                                  <span className="font-mono">{info.sectionBodyPreview}</span>
+                                </div>
+                              </div>
+                            </details>
+                          ))}
+                        </div>
+                      ) : null}
+                      <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-slate-200 bg-white p-3 text-[10px] leading-relaxed text-slate-600">
+                        {JSON.stringify(reviewQuestionResult.phase1Diagnostic, null, 2)}
+                      </pre>
+                    </details>
+                  ) : null}
+                  </div>
                   <div className="mt-5 flex flex-wrap gap-2">
                     <button
                       type="button"

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2184,8 +2184,15 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                         })}
                       </div>
                     ) : (
-                      <div className="mt-2 text-sm text-amber-700">
-                        No matching document section found.
+                      <div className="mt-2 space-y-1">
+                        <div className="text-sm text-amber-700">
+                          No matching document section found.
+                        </div>
+                        {reviewQuestionResult.noMatchExplanation ? (
+                          <div className="text-xs leading-relaxed text-amber-800">
+                            {reviewQuestionResult.noMatchExplanation}
+                          </div>
+                        ) : null}
                       </div>
                     )}
 

--- a/src/lib/chat/quickCheckEvidence.ts
+++ b/src/lib/chat/quickCheckEvidence.ts
@@ -32,6 +32,7 @@ export type QuickCheckEvidenceAnalysis = {
   methodologyMentions: string[];
   extractionConfidence: number;
   warnings: string[];
+  rawPddText?: string;
 };
 
 export type QuickCheckClaimIntent =
@@ -903,6 +904,7 @@ export async function analyzeQuickCheckEvidence(
   const documentTypes = new Set<string>();
   const methodologyMentions = new Set<string>();
   const warningSet = new Set<string>();
+  const rawPddTextParts: string[] = [];
   const resolveAttachmentBytes = options?.resolveAttachmentBytes ?? getAttachmentBytes;
   const resolvePdfText = options?.resolvePdfText;
 
@@ -957,6 +959,7 @@ export async function analyzeQuickCheckEvidence(
       }
       if (!text) continue;
       parsedEvidenceLabels.add(source.sourceLabel);
+      rawPddTextParts.push(text);
       for (const mention of extractMethodologyMentions(text)) {
         methodologyMentions.add(mention);
       }
@@ -990,6 +993,7 @@ export async function analyzeQuickCheckEvidence(
     methodologyMentions: Array.from(methodologyMentions).sort((a, b) => a.localeCompare(b)),
     extractionConfidence,
     warnings,
+    rawPddText: rawPddTextParts.length > 0 ? rawPddTextParts.join("\n\n") : undefined,
   };
 }
 

--- a/src/lib/chat/quickCheckPdfExtractor.ts
+++ b/src/lib/chat/quickCheckPdfExtractor.ts
@@ -84,10 +84,6 @@ export class PdfHelperError extends Error {
   }
 }
 
-function normalizeWhitespace(value: string): string {
-  return value.replace(/\s+/g, " ").trim();
-}
-
 function normalizePageWhitespace(value: string): string {
   return String(value || "")
     .replace(/\r\n?/g, "\n")
@@ -199,7 +195,7 @@ function buildPageExtractionResult(
   };
 
   return {
-    text: normalizeWhitespace(combinedText),
+    text: normalizePageWhitespace(combinedText),
     pages,
     engine: "pdf-parse",
     metadata: {
@@ -241,7 +237,7 @@ async function runPdfHelper(bytes: ArrayBuffer, includePages: boolean): Promise<
 
 async function extractPdfTextViaHelper(bytes: ArrayBuffer): Promise<string> {
   const payload = await runPdfHelper(bytes, false);
-  return normalizeWhitespace(payload.text ?? "");
+  return normalizePageWhitespace(payload.text ?? "");
 }
 
 async function loadBundledPdfParseClass(): Promise<PdfParseLike> {
@@ -298,7 +294,7 @@ export async function extractPdfTextWithPdfParse(input: {
   } catch (error) {
     const parserError = sanitizeDiagnosticMessage(toErrorMessage(error));
     const helperText = input.helperOverrides?.extractTextViaHelper
-      ? normalizeWhitespace((await input.helperOverrides.extractTextViaHelper(input.bytes)).text ?? "")
+      ? normalizePageWhitespace((await input.helperOverrides.extractTextViaHelper(input.bytes)).text ?? "")
       : await extractPdfTextViaHelper(input.bytes);
     return {
       text: helperText,

--- a/src/lib/chat/quickCheckPdfExtractor.ts
+++ b/src/lib/chat/quickCheckPdfExtractor.ts
@@ -173,7 +173,9 @@ function buildPageExtractionResult(
       .filter((page) => page.text)
     : [];
   const pages = parsedPages.length > 0 ? parsedPages : buildSyntheticPages(rawText);
-  const combinedText = rawText || pages.map((page) => page.text).join("\n\n");
+  const combinedText = parsedPages.length > 0
+    ? pages.map((page) => page.text).join("\n\n")
+    : rawText;
 
   if (!combinedText) {
     const failureDiagnostics = {
@@ -235,11 +237,6 @@ async function runPdfHelper(bytes: ArrayBuffer, includePages: boolean): Promise<
   }
 }
 
-async function extractPdfTextViaHelper(bytes: ArrayBuffer): Promise<string> {
-  const payload = await runPdfHelper(bytes, false);
-  return normalizePageWhitespace(payload.text ?? "");
-}
-
 async function loadBundledPdfParseClass(): Promise<PdfParseLike> {
   await ensurePdfJsNodeGlobals();
   const mod = await import("pdf-parse");
@@ -293,28 +290,49 @@ export async function extractPdfTextWithPdfParse(input: {
     };
   } catch (error) {
     const parserError = sanitizeDiagnosticMessage(toErrorMessage(error));
-    const helperText = input.helperOverrides?.extractTextViaHelper
-      ? normalizePageWhitespace((await input.helperOverrides.extractTextViaHelper(input.bytes)).text ?? "")
-      : await extractPdfTextViaHelper(input.bytes);
-    return {
-      text: helperText,
-      engine: "pdf-parse",
-      metadata: {
-        parser: "pdf-parse",
-        diagnostics: {
-          ...buildEmptyDiagnostics(),
-          failureKind: helperText ? "parser-failed" : "no-selectable-text",
-          parserPath: "helper-text",
-          pageExtractionAttempted: true,
-          pageExtractionError: parserError,
-          textFallbackAttempted: true,
-          extractedTextLength: helperText.length,
-          pageCount: helperText ? 1 : 0,
-          likelyScannedOrImageOnly: !helperText,
-          partialTextRecovered: Boolean(helperText),
-        },
-      },
+    const diagnostics = {
+      ...buildEmptyDiagnostics(),
+      pageExtractionAttempted: true,
+      pageExtractionError: parserError,
+      textFallbackAttempted: true,
     };
+    const extractPagesViaHelper = input.helperOverrides?.extractPagesViaHelper
+      ?? ((bytes: ArrayBuffer) => runPdfHelper(bytes, true));
+    const extractTextViaHelper = input.helperOverrides?.extractTextViaHelper
+      ?? ((bytes: ArrayBuffer) => runPdfHelper(bytes, false));
+
+    try {
+      diagnostics.parserPath = "helper-pages";
+      const pageResult = buildPageExtractionResult(await extractPagesViaHelper(input.bytes), diagnostics);
+      return {
+        text: pageResult.text,
+        engine: "pdf-parse",
+        metadata: pageResult.metadata,
+      };
+    } catch (helperPageError) {
+      const helperPageMessage = sanitizeDiagnosticMessage(toErrorMessage(helperPageError));
+      const helperText = normalizePageWhitespace((await extractTextViaHelper(input.bytes)).text ?? "");
+      return {
+        text: helperText,
+        engine: "pdf-parse",
+        metadata: {
+          parser: "pdf-parse",
+          diagnostics: {
+            ...buildEmptyDiagnostics(),
+            failureKind: helperText ? "parser-failed" : "no-selectable-text",
+            parserPath: "helper-text-after-helper-pages",
+            pageExtractionAttempted: true,
+            pageExtractionError: parserError,
+            textFallbackAttempted: true,
+            textFallbackError: helperPageMessage,
+            extractedTextLength: helperText.length,
+            pageCount: helperText ? 1 : 0,
+            likelyScannedOrImageOnly: !helperText,
+            partialTextRecovered: Boolean(helperText),
+          },
+        },
+      };
+    }
   }
 }
 

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,3 +1,5 @@
+import { extractSectionContent } from "@/lib/chat/quickCheckSectionExtractor";
+
 export type ReviewArea =
   | "additionality"
   | "baseline"
@@ -101,15 +103,25 @@ export function buildReviewQuestionResult(input: {
   claimText: string;
   methodologyId: string;
   methodologyVersion: string;
+  rawPddText?: string;
 }): ReviewQuestionResult {
   const reviewArea = classifyReviewArea(input.claimText);
   const relevantSections = resolveReviewSections(input.methodologyId, reviewArea);
+  const sectionContent: Record<string, string> = {};
+  if (input.rawPddText) {
+    for (const section of relevantSections) {
+      const content = extractSectionContent(input.rawPddText, section);
+      if (content !== null) {
+        sectionContent[section] = content;
+      }
+    }
+  }
   return {
     path: "review_question_answering",
     reviewArea,
     methodologyId: input.methodologyId,
     methodologyVersion: input.methodologyVersion,
     relevantSections,
-    sectionContent: {},
+    sectionContent,
   };
 }

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -12,6 +12,18 @@ export type ReviewArea =
 
 export type QuickCheckPath = "claim_to_requirement_match" | "review_question_answering";
 
+export type SectionMatchResult = {
+  section: string;
+  headingTitle: string;
+  headingScore: number;
+  bodyScore: number;
+  totalScore: number;
+  matchedTerms: string[];
+  source: "heading" | "body" | "both" | "none";
+  included: boolean;
+  rejectionReason?: string;
+};
+
 export type ReviewQuestionDiagnostic = {
   sourceLabel?: string;
   documentType?: string;
@@ -33,6 +45,9 @@ export type ReviewQuestionDiagnostic = {
   sectionContent_2_5_preview: string;
   sectionContent_1_10_preview: string;
   sectionCandidates: Record<string, SectionCandidateDebug>;
+  matchResults: SectionMatchResult[];
+  claimKeywords: { phrases: string[]; words: string[] };
+  threshold: number;
 };
 
 export type ReviewQuestionResult = {
@@ -126,7 +141,19 @@ const CLAIM_STOP_WORDS = new Set([
   'include', 'support', 'demonstrate', 'define', 'show', 'disclose',
 ]);
 
-const MIN_SCORE_THRESHOLD = 3;
+const SCORE = {
+  REVIEW_KW_TITLE: 15,
+  REVIEW_KW_BODY: 3,
+  CLAIM_PHRASE_TITLE: 12,
+  CLAIM_PHRASE_BODY: 2,
+  CLAIM_WORD_TITLE: 5,
+  CLAIM_WORD_BODY: 1,
+} as const;
+
+const PRIMARY_HEADING_THRESHOLD = 5;
+const BODY_ONLY_TOTAL_THRESHOLD = 8;
+const ABSOLUTE_THRESHOLD = 3;
+const MAX_PRIMARY_SECTIONS = 3;
 
 export function extractClaimKeywords(claimText: string): { phrases: string[]; words: string[] } {
   const cleaned = claimText
@@ -152,32 +179,66 @@ export function extractClaimKeywords(claimText: string): { phrases: string[]; wo
   return { phrases: [...new Set(phrases)], words: [...new Set(words)] };
 }
 
+type SectionScore = {
+  title: string;
+  headingScore: number;
+  bodyScore: number;
+  matchedTerms: string[];
+};
+
 function scoreSection(
   title: string,
   body: string,
   reviewKeywords: string[],
   claimKeywords: { phrases: string[]; words: string[] },
-): number {
+): SectionScore {
   const lowerTitle = title.toLowerCase();
   const lowerBody = body.toLowerCase();
-  let score = 0;
+  let headingScore = 0;
+  let bodyScore = 0;
+  const matchedTerms: string[] = [];
 
   for (const kw of reviewKeywords) {
-    if (lowerTitle.includes(kw)) score += 10;
-    else if (lowerBody.includes(kw)) score += 3;
+    const lowerKw = kw.toLowerCase();
+    if (lowerTitle.includes(lowerKw)) {
+      headingScore += SCORE.REVIEW_KW_TITLE;
+      matchedTerms.push(`review_kw:${kw}`);
+    } else if (lowerBody.includes(lowerKw)) {
+      bodyScore += SCORE.REVIEW_KW_BODY;
+      matchedTerms.push(`review_kw(body):${kw}`);
+    }
   }
 
   for (const phrase of claimKeywords.phrases) {
-    if (lowerTitle.includes(phrase)) score += 8;
-    else if (lowerBody.includes(phrase)) score += 2;
+    if (lowerTitle.includes(phrase)) {
+      headingScore += SCORE.CLAIM_PHRASE_TITLE;
+      matchedTerms.push(`phrase:${phrase}`);
+    } else if (lowerBody.includes(phrase)) {
+      bodyScore += SCORE.CLAIM_PHRASE_BODY;
+      matchedTerms.push(`phrase(body):${phrase}`);
+    }
   }
 
   for (const word of claimKeywords.words) {
-    if (lowerTitle.includes(word)) score += 4;
-    else if (lowerBody.includes(word)) score += 1;
+    if (lowerTitle.includes(word)) {
+      headingScore += SCORE.CLAIM_WORD_TITLE;
+      matchedTerms.push(`word:${word}`);
+    } else if (lowerBody.includes(word)) {
+      bodyScore += SCORE.CLAIM_WORD_BODY;
+      matchedTerms.push(`word(body):${word}`);
+    }
   }
 
-  return score;
+  return {
+    title,
+    headingScore,
+    bodyScore,
+    matchedTerms,
+  };
+}
+
+function isReasonableSectionId(num: string): boolean {
+  return /^\d+(\.\d+)+$/.test(num) && !/^\d+$/.test(num);
 }
 
 export function findMatchedSectionNumbers(
@@ -193,17 +254,89 @@ export function findMatchedSectionNumbers(
     return [];
   }
 
-  const scored: { num: string; score: number }[] = [];
+  const primarySections: { num: string; totalScore: number }[] = [];
+  const bodyOnlySections: { num: string; totalScore: number }[] = [];
+
+  for (const [num, content] of Object.entries(allSections)) {
+    if (!isReasonableSectionId(num)) continue;
+
+    const title = content.split("\n").find((l) => l.trim().length > 0) ?? "";
+    const result = scoreSection(title, content, reviewKeywords, claimKeywords);
+    const totalScore = result.headingScore + result.bodyScore;
+
+    if (totalScore < ABSOLUTE_THRESHOLD) continue;
+
+    if (result.headingScore >= PRIMARY_HEADING_THRESHOLD) {
+      primarySections.push({ num, totalScore });
+    } else if (result.bodyScore >= BODY_ONLY_TOTAL_THRESHOLD) {
+      bodyOnlySections.push({ num, totalScore });
+    }
+  }
+
+  primarySections.sort((a, b) => b.totalScore - a.totalScore);
+  bodyOnlySections.sort((a, b) => b.totalScore - a.totalScore);
+
+  const result = primarySections.slice(0, MAX_PRIMARY_SECTIONS).map(s => s.num);
+
+  if (result.length === 0 && bodyOnlySections.length > 0) {
+    result.push(bodyOnlySections[0]!.num);
+  }
+
+  return result;
+}
+
+export function computeSectionMatchResults(
+  rawPddText: string,
+  reviewArea: ReviewArea,
+  claimText: string,
+): SectionMatchResult[] {
+  const allSections = extractPddSections(rawPddText);
+  const reviewKeywords = REVIEW_AREA_KEYWORDS[reviewArea] ?? [];
+  const claimKeywords = claimText ? extractClaimKeywords(claimText) : { phrases: [], words: [] };
+  const results: SectionMatchResult[] = [];
 
   for (const [num, content] of Object.entries(allSections)) {
     const title = content.split("\n").find((l) => l.trim().length > 0) ?? "";
     const score = scoreSection(title, content, reviewKeywords, claimKeywords);
-    if (score >= MIN_SCORE_THRESHOLD) {
-      scored.push({ num, score });
+    const totalScore = score.headingScore + score.bodyScore;
+
+    let source: SectionMatchResult["source"] = "none";
+    if (score.headingScore > 0 && score.bodyScore > 0) source = "both";
+    else if (score.headingScore > 0) source = "heading";
+    else if (score.bodyScore > 0) source = "body";
+
+    let rejectionReason: string | undefined;
+    if (!isReasonableSectionId(num)) {
+      rejectionReason = `unreasonable section ID: ${num}`;
+    } else if (totalScore < ABSOLUTE_THRESHOLD) {
+      rejectionReason = `below absolute threshold (${totalScore} < ${ABSOLUTE_THRESHOLD})`;
+    } else if (score.headingScore >= PRIMARY_HEADING_THRESHOLD) {
+      // heading match — included as primary
+    } else if (score.bodyScore >= BODY_ONLY_TOTAL_THRESHOLD) {
+      // body match — included as fallback
+    } else if (score.headingScore > 0 && score.headingScore < PRIMARY_HEADING_THRESHOLD) {
+      rejectionReason = `heading score ${score.headingScore} below primary threshold ${PRIMARY_HEADING_THRESHOLD}`;
+    } else if (score.bodyScore > 0 && score.bodyScore < BODY_ONLY_TOTAL_THRESHOLD) {
+      rejectionReason = `body score ${score.bodyScore} below body-only threshold ${BODY_ONLY_TOTAL_THRESHOLD}`;
     }
+
+    const matchedTerms = score.matchedTerms;
+
+    results.push({
+      section: num,
+      headingTitle: title,
+      headingScore: score.headingScore,
+      bodyScore: score.bodyScore,
+      totalScore,
+      matchedTerms,
+      source,
+      included: !rejectionReason,
+      rejectionReason,
+    });
   }
 
-  return scored.sort((a, b) => b.score - a.score).map(s => s.num);
+  results.sort((a, b) => b.totalScore - a.totalScore);
+  return results;
 }
 
 export function resolveReviewSections(
@@ -240,8 +373,10 @@ export function buildReviewQuestionResult(input: {
     ? debugSectionExtraction(input.rawPddText)
     : undefined;
 
+  const claimKeywords = input.claimText ? extractClaimKeywords(input.claimText) : { phrases: [], words: [] };
+
   const phase1Diagnostic = process.env.NODE_ENV !== "production" && input.rawPddText
-    ? buildPhase1Diagnostic(input.rawPddText, sectionContent, input.evidenceSourceLabel, input.evidenceDocumentType)
+    ? buildPhase1Diagnostic(input.rawPddText, sectionContent, reviewArea, input.claimText, claimKeywords, input.evidenceSourceLabel, input.evidenceDocumentType)
     : undefined;
 
   return {
@@ -267,11 +402,16 @@ function targetLine(rawText: string, sectionNum: string): string {
 function buildPhase1Diagnostic(
   rawPddText: string,
   sectionContent: Record<string, string>,
+  reviewArea: ReviewArea,
+  claimText: string,
+  claimKeywords: { phrases: string[]; words: string[] },
   sourceLabel?: string,
   documentType?: string,
 ): ReviewQuestionDiagnostic {
   const allSections = extractPddSections(rawPddText);
   const text = rawPddText.replace(/\s+/g, " ").trim();
+
+  const matchResults = computeSectionMatchResults(rawPddText, reviewArea, claimText);
 
   return {
     sourceLabel,
@@ -298,5 +438,8 @@ function buildPhase1Diagnostic(
       [normalizeSectionKey("2.5")]: analyzeSectionCandidates(rawPddText, "2.5"),
       [normalizeSectionKey("1.10")]: analyzeSectionCandidates(rawPddText, "1.10"),
     },
+    matchResults,
+    claimKeywords,
+    threshold: PRIMARY_HEADING_THRESHOLD,
   };
 }

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -109,24 +109,101 @@ export function classifyReviewArea(claimText: string): ReviewArea {
   return "general";
 }
 
+const CLAIM_PREFIX_RE = /^(?:does this PDD\s+)?(?:explain|describe|review|check|evaluate|assess|identify|discuss|justify|mention|outline|summarize|present|provide|include|support|demonstrate|define|show|disclose)\s+/i;
+
+const LEADING_ARTICLE_RE = /^(?:the|a|an)\s+/i;
+
+const CLAIM_STOP_WORDS = new Set([
+  'the', 'this', 'that', 'these', 'those', 'with', 'from', 'what', 'how',
+  'why', 'when', 'where', 'which', 'were', 'been', 'being', 'have', 'has',
+  'had', 'does', 'will', 'would', 'could', 'should', 'shall', 'may', 'might',
+  'must', 'can', 'also', 'very', 'just', 'then', 'than', 'into', 'over',
+  'about', 'after', 'before', 'under', 'above', 'below', 'between', 'through',
+  'during', 'without', 'within', 'along', 'pdd',
+  'project', 'area', 'section', 'plan', 'analysis', 'assessment', 'report', 'data', 'using',
+  'describe', 'explain', 'identify', 'justify', 'review', 'check', 'assess',
+  'evaluate', 'discuss', 'mention', 'outline', 'summarize', 'present', 'provide',
+  'include', 'support', 'demonstrate', 'define', 'show', 'disclose',
+]);
+
+const MIN_SCORE_THRESHOLD = 3;
+
+export function extractClaimKeywords(claimText: string): { phrases: string[]; words: string[] } {
+  const cleaned = claimText
+    .replace(CLAIM_PREFIX_RE, '')
+    .replace(/\?/g, '')
+    .replace(LEADING_ARTICLE_RE, '')
+    .trim();
+
+  if (!cleaned || cleaned.length < 3) return { phrases: [], words: [] };
+
+  const lower = cleaned.toLowerCase();
+
+  const phrases = lower
+    .split(/\band\b|,\s*/)
+    .map(p => p.trim())
+    .filter(p => p.length > 3);
+
+  const words = lower
+    .split(/[\s,]+/)
+    .map(w => w.replace(/^[^a-z0-9-]+|[^a-z0-9-]+$/g, ''))
+    .filter(w => w.length >= 4 && !CLAIM_STOP_WORDS.has(w));
+
+  return { phrases: [...new Set(phrases)], words: [...new Set(words)] };
+}
+
+function scoreSection(
+  title: string,
+  body: string,
+  reviewKeywords: string[],
+  claimKeywords: { phrases: string[]; words: string[] },
+): number {
+  const lowerTitle = title.toLowerCase();
+  const lowerBody = body.toLowerCase();
+  let score = 0;
+
+  for (const kw of reviewKeywords) {
+    if (lowerTitle.includes(kw)) score += 10;
+    else if (lowerBody.includes(kw)) score += 3;
+  }
+
+  for (const phrase of claimKeywords.phrases) {
+    if (lowerTitle.includes(phrase)) score += 8;
+    else if (lowerBody.includes(phrase)) score += 2;
+  }
+
+  for (const word of claimKeywords.words) {
+    if (lowerTitle.includes(word)) score += 4;
+    else if (lowerBody.includes(word)) score += 1;
+  }
+
+  return score;
+}
+
 export function findMatchedSectionNumbers(
   rawPddText: string,
   reviewArea: ReviewArea,
+  claimText?: string,
 ): string[] {
   const allSections = extractPddSections(rawPddText);
-  const keywords = REVIEW_AREA_KEYWORDS[reviewArea] ?? [];
+  const reviewKeywords = REVIEW_AREA_KEYWORDS[reviewArea] ?? [];
+  const claimKeywords = claimText ? extractClaimKeywords(claimText) : { phrases: [], words: [] };
 
-  if (keywords.length === 0) return [];
+  if (reviewKeywords.length === 0 && claimKeywords.phrases.length === 0 && claimKeywords.words.length === 0) {
+    return [];
+  }
 
-  const matched: string[] = [];
+  const scored: { num: string; score: number }[] = [];
+
   for (const [num, content] of Object.entries(allSections)) {
     const title = content.split("\n").find((l) => l.trim().length > 0) ?? "";
-    const lowerTitle = title.toLowerCase();
-    if (keywords.some((kw) => lowerTitle.includes(kw.toLowerCase()))) {
-      matched.push(num);
+    const score = scoreSection(title, content, reviewKeywords, claimKeywords);
+    if (score >= MIN_SCORE_THRESHOLD) {
+      scored.push({ num, score });
     }
   }
-  return matched;
+
+  return scored.sort((a, b) => b.score - a.score).map(s => s.num);
 }
 
 export function resolveReviewSections(
@@ -152,7 +229,7 @@ export function buildReviewQuestionResult(input: {
 }): ReviewQuestionResult {
   const reviewArea = classifyReviewArea(input.claimText);
   const relevantSections = input.rawPddText
-    ? findMatchedSectionNumbers(input.rawPddText, reviewArea)
+    ? findMatchedSectionNumbers(input.rawPddText, reviewArea, input.claimText)
     : resolveReviewSections(input.methodologyId, reviewArea);
   const sectionContent: Record<string, string> = {};
   if (input.rawPddText && relevantSections.length > 0) {

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -211,7 +211,8 @@ function scoreSection(
   for (const phrase of claimKeywords.phrases) {
     if (lowerTitle.includes(phrase)) {
       headingScore += SCORE.CLAIM_PHRASE_TITLE;
-      matchedTerms.push(`phrase:${phrase}`);
+      if (phrase.split(/\s+/).length >= 2) { headingScore += 15; matchedTerms.push(`phrase:${phrase}(+15)`); }
+      else matchedTerms.push(`phrase:${phrase}`);
     } else if (lowerBody.includes(phrase)) {
       bodyScore += SCORE.CLAIM_PHRASE_BODY;
       matchedTerms.push(`phrase(body):${phrase}`);

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -151,7 +151,6 @@ const SCORE = {
 } as const;
 
 const PRIMARY_HEADING_THRESHOLD = 5;
-const BODY_ONLY_TOTAL_THRESHOLD = 8;
 const ABSOLUTE_THRESHOLD = 3;
 const MAX_PRIMARY_SECTIONS = 3;
 
@@ -254,8 +253,7 @@ export function findMatchedSectionNumbers(
     return [];
   }
 
-  const primarySections: { num: string; totalScore: number }[] = [];
-  const bodyOnlySections: { num: string; totalScore: number }[] = [];
+  const scored: { num: string; totalScore: number }[] = [];
 
   for (const [num, content] of Object.entries(allSections)) {
     if (!isReasonableSectionId(num)) continue;
@@ -265,24 +263,14 @@ export function findMatchedSectionNumbers(
     const totalScore = result.headingScore + result.bodyScore;
 
     if (totalScore < ABSOLUTE_THRESHOLD) continue;
+    if (result.headingScore < PRIMARY_HEADING_THRESHOLD) continue;
 
-    if (result.headingScore >= PRIMARY_HEADING_THRESHOLD) {
-      primarySections.push({ num, totalScore });
-    } else if (result.bodyScore >= BODY_ONLY_TOTAL_THRESHOLD) {
-      bodyOnlySections.push({ num, totalScore });
-    }
+    scored.push({ num, totalScore });
   }
 
-  primarySections.sort((a, b) => b.totalScore - a.totalScore);
-  bodyOnlySections.sort((a, b) => b.totalScore - a.totalScore);
+  scored.sort((a, b) => b.totalScore - a.totalScore);
 
-  const result = primarySections.slice(0, MAX_PRIMARY_SECTIONS).map(s => s.num);
-
-  if (result.length === 0 && bodyOnlySections.length > 0) {
-    result.push(bodyOnlySections[0]!.num);
-  }
-
-  return result;
+  return scored.slice(0, MAX_PRIMARY_SECTIONS).map(s => s.num);
 }
 
 export function computeSectionMatchResults(
@@ -312,12 +300,10 @@ export function computeSectionMatchResults(
       rejectionReason = `below absolute threshold (${totalScore} < ${ABSOLUTE_THRESHOLD})`;
     } else if (score.headingScore >= PRIMARY_HEADING_THRESHOLD) {
       // heading match — included as primary
-    } else if (score.bodyScore >= BODY_ONLY_TOTAL_THRESHOLD) {
-      // body match — included as fallback
+    } else if (score.bodyScore > 0 && score.headingScore === 0) {
+      rejectionReason = `body-only match (score ${score.bodyScore}) — heading-first strategy requires heading title match`;
     } else if (score.headingScore > 0 && score.headingScore < PRIMARY_HEADING_THRESHOLD) {
       rejectionReason = `heading score ${score.headingScore} below primary threshold ${PRIMARY_HEADING_THRESHOLD}`;
-    } else if (score.bodyScore > 0 && score.bodyScore < BODY_ONLY_TOTAL_THRESHOLD) {
-      rejectionReason = `body score ${score.bodyScore} below body-only threshold ${BODY_ONLY_TOTAL_THRESHOLD}`;
     }
 
     const matchedTerms = score.matchedTerms;

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,4 +1,4 @@
-import { debugSectionExtraction, extractRoutedSections } from "@/lib/chat/quickCheckSectionExtractor";
+import { debugSectionExtraction, extractPddSections, extractRoutedSections, normalizeSectionKey } from "@/lib/chat/quickCheckSectionExtractor";
 
 export type ReviewArea =
   | "additionality"
@@ -12,6 +12,28 @@ export type ReviewArea =
 
 export type QuickCheckPath = "claim_to_requirement_match" | "review_question_answering";
 
+export type ReviewQuestionDiagnostic = {
+  sourceLabel?: string;
+  documentType?: string;
+  rawPddTextLength: number;
+  rawPddTextPreview: string;
+  rawLinesCount: number;
+  includes_2_4: string;
+  includes_2_5: string;
+  includes_1_10: string;
+  includes_baseline: string;
+  includes_additionality: string;
+  includes_leakage: string;
+  targetLine_2_4: string;
+  targetLine_2_5: string;
+  targetLine_1_10: string;
+  detectedSections: string[];
+  sectionContentKeys: string[];
+  sectionContent_2_4_preview: string;
+  sectionContent_2_5_preview: string;
+  sectionContent_1_10_preview: string;
+};
+
 export type ReviewQuestionResult = {
   path: QuickCheckPath;
   reviewArea: ReviewArea;
@@ -20,6 +42,7 @@ export type ReviewQuestionResult = {
   relevantSections: string[];
   sectionContent: Record<string, string>;
   diagnostic?: Record<string, string>;
+  phase1Diagnostic?: ReviewQuestionDiagnostic;
 };
 
 const BROAD_QUESTION_PATTERNS: RegExp[] = [
@@ -105,6 +128,8 @@ export function buildReviewQuestionResult(input: {
   methodologyId: string;
   methodologyVersion: string;
   rawPddText?: string;
+  evidenceSourceLabel?: string;
+  evidenceDocumentType?: string;
 }): ReviewQuestionResult {
   const reviewArea = classifyReviewArea(input.claimText);
   const relevantSections = resolveReviewSections(input.methodologyId, reviewArea);
@@ -112,6 +137,15 @@ export function buildReviewQuestionResult(input: {
   if (input.rawPddText && relevantSections.length > 0) {
     Object.assign(sectionContent, extractRoutedSections(input.rawPddText, relevantSections));
   }
+
+  const diagnostic = process.env.NODE_ENV !== "production" && input.rawPddText
+    ? debugSectionExtraction(input.rawPddText)
+    : undefined;
+
+  const phase1Diagnostic = process.env.NODE_ENV !== "production" && input.rawPddText
+    ? buildPhase1Diagnostic(input.rawPddText, sectionContent, input.evidenceSourceLabel, input.evidenceDocumentType)
+    : undefined;
+
   return {
     path: "review_question_answering",
     reviewArea,
@@ -119,8 +153,47 @@ export function buildReviewQuestionResult(input: {
     methodologyVersion: input.methodologyVersion,
     relevantSections,
     sectionContent,
-    ...(process.env.NODE_ENV !== "production" && input.rawPddText
-      ? { diagnostic: debugSectionExtraction(input.rawPddText) }
-      : {}),
+    diagnostic,
+    phase1Diagnostic,
+  };
+}
+
+function targetLine(rawText: string, sectionNum: string): string {
+  const lines = rawText.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]!.includes(sectionNum)) return `L${i + 1}: ${lines[i]!.trim().slice(0, 120)}`;
+  }
+  return "not found";
+}
+
+function buildPhase1Diagnostic(
+  rawPddText: string,
+  sectionContent: Record<string, string>,
+  sourceLabel?: string,
+  documentType?: string,
+): ReviewQuestionDiagnostic {
+  const allSections = extractPddSections(rawPddText);
+  const text = rawPddText.replace(/\s+/g, " ").trim();
+
+  return {
+    sourceLabel,
+    documentType,
+    rawPddTextLength: rawPddText.length,
+    rawPddTextPreview: text.slice(0, 200),
+    rawLinesCount: rawPddText.split("\n").length,
+    includes_2_4: String(/\b2\.4\b/.test(text)),
+    includes_2_5: String(/\b2\.5\b/.test(text)),
+    includes_1_10: String(/\b1\.10\b/.test(text)),
+    includes_baseline: String(/\bbaseline\b/i.test(text)),
+    includes_additionality: String(/\badditionality\b/i.test(text)),
+    includes_leakage: String(/\bleakage\b/i.test(text)),
+    targetLine_2_4: targetLine(rawPddText, "2.4"),
+    targetLine_2_5: targetLine(rawPddText, "2.5"),
+    targetLine_1_10: targetLine(rawPddText, "1.10"),
+    detectedSections: Object.keys(allSections),
+    sectionContentKeys: Object.keys(sectionContent),
+    sectionContent_2_4_preview: (sectionContent[normalizeSectionKey("2.4")] ?? "missing").slice(0, 150),
+    sectionContent_2_5_preview: (sectionContent[normalizeSectionKey("2.5")] ?? "missing").slice(0, 150),
+    sectionContent_1_10_preview: (sectionContent[normalizeSectionKey("1.10")] ?? "missing").slice(0, 150),
   };
 }

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -83,6 +83,8 @@ const BROAD_QUESTION_PATTERNS: RegExp[] = [
   /^does\s+this\s+pdd\s+define/i,
   /^does\s+this\s+pdd\s+describe/i,
   /^does\s+this\s+pdd\s+identify/i,
+  /^does\s+this\s+pdd\s+include/i,
+  /^does\s+this\s+pdd\s+contain/i,
   /^is\s+the\s+baseline/i,
   /^is\s+additionality/i,
   /^check\s+the/i,
@@ -96,7 +98,18 @@ const REVIEW_AREA_KEYWORDS: Record<ReviewArea, string[]> = {
   leakage: ["leakage", "leakage belt"],
   monitoring: ["monitoring", "monitoring plan", "data and parameters"],
   deviations: ["deviations", "deviation"],
-  right_of_use: ["right of use", "land tenure", "carbon rights", "property rights"],
+  right_of_use: [
+    "legal status",
+    "property rights",
+    "ownership",
+    "right of use",
+    "land tenure",
+    "carbon rights",
+    "compliance",
+    "laws",
+    "statutes",
+    "regulatory frameworks",
+  ],
   general: [],
 };
 
@@ -134,7 +147,7 @@ export function classifyReviewArea(claimText: string): ReviewArea {
   if (/deviations|departure|variance|deviation/i.test(normalized)) return "deviations";
   if (/leakage\s+risk|activity\s+shifting|LK-ASU|displacement/i.test(normalized)) return "leakage";
   if (/monitoring|sampling|plot|measur/i.test(normalized)) return "monitoring";
-  if (/right of use|land tenure|carbon right|entitlement/i.test(normalized)) return "right_of_use";
+  if (/legal status|property rights|ownership|right of use|land tenure|carbon right|entitlement|compliance with laws|statutes|regulatory frameworks/i.test(normalized)) return "right_of_use";
   return "general";
 }
 

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -3,9 +3,11 @@ import {
   buildPddHeadingIndex,
   debugSectionExtraction,
   extractPddSections,
+  findRejectedHeadingMatches,
   filterPddHeadingsByQuery,
   normalizeSectionKey,
   scoreHeadingAgainstQuery,
+  type RejectedHeadingQueryMatch,
   type DocumentHeading,
   type SectionCandidateDebug,
 } from "@/lib/chat/quickCheckSectionExtractor";
@@ -71,6 +73,7 @@ export type ReviewQuestionResult = {
   headingIndex: DocumentHeading[];
   /** Phase 1: headings filtered by the user's question text only (title-based, no body scoring) */
   matchedHeadings: DocumentHeading[];
+  noMatchExplanation?: string;
   diagnostic?: Record<string, string>;
   phase1Diagnostic?: ReviewQuestionDiagnostic;
 };
@@ -273,6 +276,19 @@ export function reviewAreaLabel(area: ReviewArea): string {
   return REVIEW_AREA_LABELS[area];
 }
 
+function buildNoMatchExplanation(rejectedMatches: RejectedHeadingQueryMatch[]): string | undefined {
+  const top = rejectedMatches[0];
+  if (!top) return undefined;
+  const headingLabel = `\u00a7${top.sectionNumber} ${top.title}`;
+  if (top.reasons.includes("inside TOC block") || top.reasons.includes("line-level TOC markers")) {
+    return `Closest title match was ${headingLabel}, but it only appeared in the table of contents and was not recovered as a body heading.`;
+  }
+  if (top.reasons.includes("no body text after heading")) {
+    return `Closest title match was ${headingLabel}, but Quick Check could not recover section body text after that heading from the uploaded document.`;
+  }
+  return undefined;
+}
+
 export function buildReviewQuestionResult(input: {
   claimText: string;
   methodologyId: string;
@@ -287,6 +303,11 @@ export function buildReviewQuestionResult(input: {
   // Question text is used ONLY as a filter over headings (title-based, no body scoring, no reviewArea keywords, no static routes).
   const headingIndex: DocumentHeading[] = input.rawPddText ? buildPddHeadingIndex(input.rawPddText) : [];
   const matchedHeadings = filterPddHeadingsByQuery(headingIndex, input.claimText || "", REVIEW_AREA_KEYWORDS[reviewArea] ?? []);
+  const rejectedMatches =
+    matchedHeadings.length === 0 && input.rawPddText
+      ? findRejectedHeadingMatches(input.rawPddText, input.claimText || "", REVIEW_AREA_KEYWORDS[reviewArea] ?? [])
+      : [];
+  const noMatchExplanation = matchedHeadings.length === 0 ? buildNoMatchExplanation(rejectedMatches) : undefined;
 
   const relevantSections = matchedHeadings.map((h) => h.sectionNumber);
   const sectionContent: Record<string, string> = {};
@@ -315,6 +336,7 @@ export function buildReviewQuestionResult(input: {
     sectionContent,
     headingIndex,
     matchedHeadings,
+    noMatchExplanation,
     diagnostic,
     phase1Diagnostic,
   };

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -5,6 +5,7 @@ import {
   extractPddSections,
   filterPddHeadingsByQuery,
   normalizeSectionKey,
+  scoreHeadingAgainstQuery,
   type DocumentHeading,
   type SectionCandidateDebug,
 } from "@/lib/chat/quickCheckSectionExtractor";
@@ -91,11 +92,11 @@ const BROAD_QUESTION_PATTERNS: RegExp[] = [
 const REVIEW_AREA_KEYWORDS: Record<ReviewArea, string[]> = {
   additionality: ["additionality"],
   baseline: ["baseline", "without-project", "without project", "land use scenario"],
-  boundary: ["boundary", "project area", "project zone", "geographic", "location"],
-  leakage: ["leakage"],
+  boundary: ["boundary", "project area", "project zone", "geographic boundary", "project location"],
+  leakage: ["leakage", "leakage belt"],
   monitoring: ["monitoring", "monitoring plan", "data and parameters"],
-  deviations: [],
-  right_of_use: [],
+  deviations: ["deviations", "deviation"],
+  right_of_use: ["right of use", "land tenure", "carbon rights", "property rights"],
   general: [],
 };
 
@@ -154,18 +155,8 @@ const CLAIM_STOP_WORDS = new Set([
   'include', 'support', 'demonstrate', 'define', 'show', 'disclose',
 ]);
 
-const SCORE = {
-  REVIEW_KW_TITLE: 15,
-  REVIEW_KW_BODY: 3,
-  CLAIM_PHRASE_TITLE: 12,
-  CLAIM_PHRASE_BODY: 2,
-  CLAIM_WORD_TITLE: 5,
-  CLAIM_WORD_BODY: 1,
-} as const;
-
-const PRIMARY_HEADING_THRESHOLD = 5;
-const ABSOLUTE_THRESHOLD = 3;
 const MAX_PRIMARY_SECTIONS = 3;
+const HEADING_MATCH_MIN_COVERAGE = 0.6;
 
 export function extractClaimKeywords(claimText: string): { phrases: string[]; words: string[] } {
   const cleaned = claimText
@@ -191,67 +182,8 @@ export function extractClaimKeywords(claimText: string): { phrases: string[]; wo
   return { phrases: [...new Set(phrases)], words: [...new Set(words)] };
 }
 
-type SectionScore = {
-  title: string;
-  headingScore: number;
-  bodyScore: number;
-  matchedTerms: string[];
-};
-
-function scoreSection(
-  title: string,
-  body: string,
-  reviewKeywords: string[],
-  claimKeywords: { phrases: string[]; words: string[] },
-): SectionScore {
-  const lowerTitle = title.toLowerCase();
-  const lowerBody = body.toLowerCase();
-  let headingScore = 0;
-  let bodyScore = 0;
-  const matchedTerms: string[] = [];
-
-  for (const kw of reviewKeywords) {
-    const lowerKw = kw.toLowerCase();
-    if (lowerTitle.includes(lowerKw)) {
-      headingScore += SCORE.REVIEW_KW_TITLE;
-      matchedTerms.push(`review_kw:${kw}`);
-    } else if (lowerBody.includes(lowerKw)) {
-      bodyScore += SCORE.REVIEW_KW_BODY;
-      matchedTerms.push(`review_kw(body):${kw}`);
-    }
-  }
-
-  for (const phrase of claimKeywords.phrases) {
-    if (lowerTitle.includes(phrase)) {
-      headingScore += SCORE.CLAIM_PHRASE_TITLE;
-      if (phrase.split(/\s+/).length >= 2) { headingScore += 15; matchedTerms.push(`phrase:${phrase}(+15)`); }
-      else matchedTerms.push(`phrase:${phrase}`);
-    } else if (lowerBody.includes(phrase)) {
-      bodyScore += SCORE.CLAIM_PHRASE_BODY;
-      matchedTerms.push(`phrase(body):${phrase}`);
-    }
-  }
-
-  for (const word of claimKeywords.words) {
-    if (lowerTitle.includes(word)) {
-      headingScore += SCORE.CLAIM_WORD_TITLE;
-      matchedTerms.push(`word:${word}`);
-    } else if (lowerBody.includes(word)) {
-      bodyScore += SCORE.CLAIM_WORD_BODY;
-      matchedTerms.push(`word(body):${word}`);
-    }
-  }
-
-  return {
-    title,
-    headingScore,
-    bodyScore,
-    matchedTerms,
-  };
-}
-
 function isReasonableSectionId(num: string): boolean {
-  return /^\d+(\.\d+)+$/.test(num) && !/^\d+$/.test(num);
+  return /^\d+(?:\.\d+)*$/.test(num);
 }
 
 export function findMatchedSectionNumbers(
@@ -259,32 +191,11 @@ export function findMatchedSectionNumbers(
   reviewArea: ReviewArea,
   claimText?: string,
 ): string[] {
-  const allSections = extractPddSections(rawPddText);
-  const reviewKeywords = REVIEW_AREA_KEYWORDS[reviewArea] ?? [];
-  const claimKeywords = claimText ? extractClaimKeywords(claimText) : { phrases: [], words: [] };
-
-  if (reviewKeywords.length === 0 && claimKeywords.phrases.length === 0 && claimKeywords.words.length === 0) {
-    return [];
-  }
-
-  const scored: { num: string; totalScore: number }[] = [];
-
-  for (const [num, content] of Object.entries(allSections)) {
-    if (!isReasonableSectionId(num)) continue;
-
-    const title = content.split("\n").find((l) => l.trim().length > 0) ?? "";
-    const result = scoreSection(title, content, reviewKeywords, claimKeywords);
-    const totalScore = result.headingScore + result.bodyScore;
-
-    if (totalScore < ABSOLUTE_THRESHOLD) continue;
-    if (result.headingScore < PRIMARY_HEADING_THRESHOLD) continue;
-
-    scored.push({ num, totalScore });
-  }
-
-  scored.sort((a, b) => b.totalScore - a.totalScore);
-
-  return scored.slice(0, MAX_PRIMARY_SECTIONS).map(s => s.num);
+  if (!claimText?.trim()) return [];
+  return filterPddHeadingsByQuery(buildPddHeadingIndex(rawPddText), claimText, REVIEW_AREA_KEYWORDS[reviewArea] ?? [])
+    .filter((heading) => isReasonableSectionId(heading.sectionNumber))
+    .slice(0, MAX_PRIMARY_SECTIONS)
+    .map((heading) => heading.sectionNumber);
 }
 
 export function computeSectionMatchResults(
@@ -292,44 +203,41 @@ export function computeSectionMatchResults(
   reviewArea: ReviewArea,
   claimText: string,
 ): SectionMatchResult[] {
-  const allSections = extractPddSections(rawPddText);
-  const reviewKeywords = REVIEW_AREA_KEYWORDS[reviewArea] ?? [];
-  const claimKeywords = claimText ? extractClaimKeywords(claimText) : { phrases: [], words: [] };
+  const headingIndex = buildPddHeadingIndex(rawPddText);
+  const fallbackKeywords = REVIEW_AREA_KEYWORDS[reviewArea] ?? [];
   const results: SectionMatchResult[] = [];
 
-  for (const [num, content] of Object.entries(allSections)) {
-    const title = content.split("\n").find((l) => l.trim().length > 0) ?? "";
-    const score = scoreSection(title, content, reviewKeywords, claimKeywords);
-    const totalScore = score.headingScore + score.bodyScore;
-
-    let source: SectionMatchResult["source"] = "none";
-    if (score.headingScore > 0 && score.bodyScore > 0) source = "both";
-    else if (score.headingScore > 0) source = "heading";
-    else if (score.bodyScore > 0) source = "body";
+  for (const heading of headingIndex) {
+    const score = scoreHeadingAgainstQuery(heading, claimText, fallbackKeywords);
+    const headingScore = score.score;
+    const bodyScore = 0;
+    const totalScore = headingScore;
 
     let rejectionReason: string | undefined;
-    if (!isReasonableSectionId(num)) {
-      rejectionReason = `unreasonable section ID: ${num}`;
-    } else if (totalScore < ABSOLUTE_THRESHOLD) {
-      rejectionReason = `below absolute threshold (${totalScore} < ${ABSOLUTE_THRESHOLD})`;
-    } else if (score.headingScore >= PRIMARY_HEADING_THRESHOLD) {
-      // heading match — included as primary
-    } else if (score.bodyScore > 0 && score.headingScore === 0) {
-      rejectionReason = `body-only match (score ${score.bodyScore}) — heading-first strategy requires heading title match`;
-    } else if (score.headingScore > 0 && score.headingScore < PRIMARY_HEADING_THRESHOLD) {
-      rejectionReason = `heading score ${score.headingScore} below primary threshold ${PRIMARY_HEADING_THRESHOLD}`;
+    if (!isReasonableSectionId(heading.sectionNumber)) {
+      rejectionReason = `unreasonable section ID: ${heading.sectionNumber}`;
+    } else if (!score.strong) {
+      rejectionReason = headingScore > 0
+        ? `title match too weak (${headingScore}) — exact or near-exact heading phrase required`
+        : "no heading/title match";
     }
 
-    const matchedTerms = score.matchedTerms;
+    const matchedTerms = [
+      ...score.exactTokenMatches.map((token) => `title:${token}`),
+      ...score.softTokenMatches.map((token) => `title~:${token}`),
+      ...score.fallbackKeywordMatches.map((token) => `review_title:${token}`),
+    ];
+    if (score.exactTitleMatch) matchedTerms.unshift("exact_title");
+    else if (score.fullPhraseMatch) matchedTerms.unshift("phrase_title");
 
     results.push({
-      section: num,
-      headingTitle: title,
-      headingScore: score.headingScore,
-      bodyScore: score.bodyScore,
+      section: heading.sectionNumber,
+      headingTitle: heading.title,
+      headingScore,
+      bodyScore,
       totalScore,
       matchedTerms,
-      source,
+      source: headingScore > 0 ? "heading" : "none",
       included: !rejectionReason,
       rejectionReason,
     });
@@ -365,7 +273,7 @@ export function buildReviewQuestionResult(input: {
   // Phase 1: heading index is source of truth from uploaded document.
   // Question text is used ONLY as a filter over headings (title-based, no body scoring, no reviewArea keywords, no static routes).
   const headingIndex: DocumentHeading[] = input.rawPddText ? buildPddHeadingIndex(input.rawPddText) : [];
-  const matchedHeadings = filterPddHeadingsByQuery(headingIndex, input.claimText || "");
+  const matchedHeadings = filterPddHeadingsByQuery(headingIndex, input.claimText || "", REVIEW_AREA_KEYWORDS[reviewArea] ?? []);
 
   const relevantSections = matchedHeadings.map((h) => h.sectionNumber);
   const sectionContent: Record<string, string> = {};
@@ -448,6 +356,6 @@ function buildPhase1Diagnostic(
     },
     matchResults,
     claimKeywords,
-    threshold: PRIMARY_HEADING_THRESHOLD,
+    threshold: HEADING_MATCH_MIN_COVERAGE,
   };
 }

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,4 +1,4 @@
-import { extractRoutedSections } from "@/lib/chat/quickCheckSectionExtractor";
+import { debugSectionExtraction, extractRoutedSections } from "@/lib/chat/quickCheckSectionExtractor";
 
 export type ReviewArea =
   | "additionality"
@@ -19,6 +19,7 @@ export type ReviewQuestionResult = {
   methodologyVersion: string;
   relevantSections: string[];
   sectionContent: Record<string, string>;
+  diagnostic?: Record<string, string>;
 };
 
 const BROAD_QUESTION_PATTERNS: RegExp[] = [
@@ -118,5 +119,8 @@ export function buildReviewQuestionResult(input: {
     methodologyVersion: input.methodologyVersion,
     relevantSections,
     sectionContent,
+    ...(process.env.NODE_ENV !== "production" && input.rawPddText
+      ? { diagnostic: debugSectionExtraction(input.rawPddText) }
+      : {}),
   };
 }

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,4 +1,4 @@
-import { extractSectionContent } from "@/lib/chat/quickCheckSectionExtractor";
+import { extractRoutedSections } from "@/lib/chat/quickCheckSectionExtractor";
 
 export type ReviewArea =
   | "additionality"
@@ -108,13 +108,8 @@ export function buildReviewQuestionResult(input: {
   const reviewArea = classifyReviewArea(input.claimText);
   const relevantSections = resolveReviewSections(input.methodologyId, reviewArea);
   const sectionContent: Record<string, string> = {};
-  if (input.rawPddText) {
-    for (const section of relevantSections) {
-      const content = extractSectionContent(input.rawPddText, section);
-      if (content !== null) {
-        sectionContent[section] = content;
-      }
-    }
+  if (input.rawPddText && relevantSections.length > 0) {
+    Object.assign(sectionContent, extractRoutedSections(input.rawPddText, relevantSections));
   }
   return {
     path: "review_question_answering",

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,4 +1,13 @@
-import { analyzeSectionCandidates, debugSectionExtraction, extractPddSections, extractRoutedSections, normalizeSectionKey, type SectionCandidateDebug } from "@/lib/chat/quickCheckSectionExtractor";
+import {
+  analyzeSectionCandidates,
+  buildPddHeadingIndex,
+  debugSectionExtraction,
+  extractPddSections,
+  filterPddHeadingsByQuery,
+  normalizeSectionKey,
+  type DocumentHeading,
+  type SectionCandidateDebug,
+} from "@/lib/chat/quickCheckSectionExtractor";
 
 export type ReviewArea =
   | "additionality"
@@ -57,6 +66,10 @@ export type ReviewQuestionResult = {
   methodologyVersion: string;
   relevantSections: string[];
   sectionContent: Record<string, string>;
+  /** Phase 1: clean heading index from uploaded PDD (source of truth) */
+  headingIndex: DocumentHeading[];
+  /** Phase 1: headings filtered by the user's question text only (title-based, no body scoring) */
+  matchedHeadings: DocumentHeading[];
   diagnostic?: Record<string, string>;
   phase1Diagnostic?: ReviewQuestionDiagnostic;
 };
@@ -348,12 +361,17 @@ export function buildReviewQuestionResult(input: {
   evidenceDocumentType?: string;
 }): ReviewQuestionResult {
   const reviewArea = classifyReviewArea(input.claimText);
-  const relevantSections = input.rawPddText
-    ? findMatchedSectionNumbers(input.rawPddText, reviewArea, input.claimText)
-    : resolveReviewSections(input.methodologyId, reviewArea);
+
+  // Phase 1: heading index is source of truth from uploaded document.
+  // Question text is used ONLY as a filter over headings (title-based, no body scoring, no reviewArea keywords, no static routes).
+  const headingIndex: DocumentHeading[] = input.rawPddText ? buildPddHeadingIndex(input.rawPddText) : [];
+  const matchedHeadings = filterPddHeadingsByQuery(headingIndex, input.claimText || "");
+
+  const relevantSections = matchedHeadings.map((h) => h.sectionNumber);
   const sectionContent: Record<string, string> = {};
-  if (input.rawPddText && relevantSections.length > 0) {
-    Object.assign(sectionContent, extractRoutedSections(input.rawPddText, relevantSections));
+  for (const h of matchedHeadings) {
+    // Provide body for compat with existing consumers; primary matches never came from body text.
+    sectionContent[h.sectionNumber] = h.bodyText ? `${h.title}\n${h.bodyText}` : h.title;
   }
 
   const diagnostic = process.env.NODE_ENV !== "production" && input.rawPddText
@@ -362,6 +380,7 @@ export function buildReviewQuestionResult(input: {
 
   const claimKeywords = input.claimText ? extractClaimKeywords(input.claimText) : { phrases: [], words: [] };
 
+  // phase1Diagnostic still uses legacy scoring for dev visibility only (does not drive matches)
   const phase1Diagnostic = process.env.NODE_ENV !== "production" && input.rawPddText
     ? buildPhase1Diagnostic(input.rawPddText, sectionContent, reviewArea, input.claimText, claimKeywords, input.evidenceSourceLabel, input.evidenceDocumentType)
     : undefined;
@@ -373,6 +392,8 @@ export function buildReviewQuestionResult(input: {
     methodologyVersion: input.methodologyVersion,
     relevantSections,
     sectionContent,
+    headingIndex,
+    matchedHeadings,
     diagnostic,
     phase1Diagnostic,
   };

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -60,14 +60,14 @@ const BROAD_QUESTION_PATTERNS: RegExp[] = [
   /^review\s+the/i,
 ];
 
-const VM0007_SECTION_ROUTES: Record<ReviewArea, string[]> = {
-  additionality: ["2.5", "2.4", "1.10"],
-  baseline: ["2.4", "2.5", "1.10"],
-  boundary: ["2.3", "1.9"],
-  deviations: ["2.6"],
-  leakage: ["1.13", "3.3"],
-  monitoring: ["4"],
-  right_of_use: ["1.11", "1.12.1"],
+const REVIEW_AREA_KEYWORDS: Record<ReviewArea, string[]> = {
+  additionality: ["additionality"],
+  baseline: ["baseline", "without-project", "without project", "land use scenario"],
+  boundary: ["boundary", "project area", "project zone", "geographic", "location"],
+  leakage: ["leakage"],
+  monitoring: ["monitoring", "monitoring plan", "data and parameters"],
+  deviations: [],
+  right_of_use: [],
   general: [],
 };
 
@@ -109,14 +109,32 @@ export function classifyReviewArea(claimText: string): ReviewArea {
   return "general";
 }
 
-export function resolveReviewSections(
-  methodologyId: string,
+export function findMatchedSectionNumbers(
+  rawPddText: string,
   reviewArea: ReviewArea,
 ): string[] {
-  const normalizedMethod = methodologyId.trim().toUpperCase();
-  if (normalizedMethod === "VM0007") {
-    return VM0007_SECTION_ROUTES[reviewArea] ?? [];
+  const allSections = extractPddSections(rawPddText);
+  const keywords = REVIEW_AREA_KEYWORDS[reviewArea] ?? [];
+
+  if (keywords.length === 0) return [];
+
+  const matched: string[] = [];
+  for (const [num, content] of Object.entries(allSections)) {
+    const title = content.split("\n").find((l) => l.trim().length > 0) ?? "";
+    const lowerTitle = title.toLowerCase();
+    if (keywords.some((kw) => lowerTitle.includes(kw.toLowerCase()))) {
+      matched.push(num);
+    }
   }
+  return matched;
+}
+
+export function resolveReviewSections(
+  _methodologyId: string,
+  _reviewArea: ReviewArea,
+): string[] {
+  void _methodologyId;
+  void _reviewArea;
   return [];
 }
 
@@ -133,7 +151,9 @@ export function buildReviewQuestionResult(input: {
   evidenceDocumentType?: string;
 }): ReviewQuestionResult {
   const reviewArea = classifyReviewArea(input.claimText);
-  const relevantSections = resolveReviewSections(input.methodologyId, reviewArea);
+  const relevantSections = input.rawPddText
+    ? findMatchedSectionNumbers(input.rawPddText, reviewArea)
+    : resolveReviewSections(input.methodologyId, reviewArea);
   const sectionContent: Record<string, string> = {};
   if (input.rawPddText && relevantSections.length > 0) {
     Object.assign(sectionContent, extractRoutedSections(input.rawPddText, relevantSections));

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,4 +1,4 @@
-import { debugSectionExtraction, extractPddSections, extractRoutedSections, normalizeSectionKey } from "@/lib/chat/quickCheckSectionExtractor";
+import { analyzeSectionCandidates, debugSectionExtraction, extractPddSections, extractRoutedSections, normalizeSectionKey, type SectionCandidateDebug } from "@/lib/chat/quickCheckSectionExtractor";
 
 export type ReviewArea =
   | "additionality"
@@ -32,6 +32,7 @@ export type ReviewQuestionDiagnostic = {
   sectionContent_2_4_preview: string;
   sectionContent_2_5_preview: string;
   sectionContent_1_10_preview: string;
+  sectionCandidates: Record<string, SectionCandidateDebug>;
 };
 
 export type ReviewQuestionResult = {
@@ -195,5 +196,10 @@ function buildPhase1Diagnostic(
     sectionContent_2_4_preview: (sectionContent[normalizeSectionKey("2.4")] ?? "missing").slice(0, 150),
     sectionContent_2_5_preview: (sectionContent[normalizeSectionKey("2.5")] ?? "missing").slice(0, 150),
     sectionContent_1_10_preview: (sectionContent[normalizeSectionKey("1.10")] ?? "missing").slice(0, 150),
+    sectionCandidates: {
+      [normalizeSectionKey("2.4")]: analyzeSectionCandidates(rawPddText, "2.4"),
+      [normalizeSectionKey("2.5")]: analyzeSectionCandidates(rawPddText, "2.5"),
+      [normalizeSectionKey("1.10")]: analyzeSectionCandidates(rawPddText, "1.10"),
+    },
   };
 }

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -61,6 +61,25 @@ export function extractPddSections(rawText: string): Record<string, string> {
     }
   }
 
+  if (headings.length === 0) {
+    const lines = cleaned.split("\n");
+    const linePos = (idx: number) => {
+      let pos = 0;
+      for (let j = 0; j < idx; j++) pos += lines[j]!.length + 1;
+      return pos;
+    };
+    for (let i = 0; i < lines.length - 1; i++) {
+      const numMatch = lines[i]!.match(/^\s*(\d+(?:\.\d+)*)\s*$/);
+      if (!numMatch) continue;
+      const num = numMatch[1]!;
+      const title = lines[i + 1]!.trim();
+      if (!title) continue;
+      if (/^\d/.test(title)) continue;
+      if (title.length > 120) continue;
+      headings.push({ num, title, start: linePos(i), end: linePos(i + 2) });
+    }
+  }
+
   if (headings.length === 0) return sections;
 
   for (let i = 0; i < headings.length; i++) {

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -1,6 +1,6 @@
 export const SECTION_EXCERPT_MAX_CHARS = 3000;
 
-const SECTION_HEADING_RE = /^\s*(?:Section\s+)?(\d+(?:\.\d+)*)\s*[.:]?\s+(.+)/i;
+const SECTION_HEADING_RE = /^(?:\s*(?:Section\s+)?(\d+(?:\.\d+)*)\s*[.:]?\s+(.+))\s*$/gm;
 
 function stripHeaderFooterNoise(text: string): string {
   return text
@@ -14,39 +14,70 @@ function stripHeaderFooterNoise(text: string): string {
     .join("\n");
 }
 
-function normalizePageBreaks(text: string): string {
-  return text.replace(/\f/g, "\n");
+function normalizeText(raw: string): string {
+  return stripHeaderFooterNoise(raw)
+    .replace(/\f/g, "\n")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+}
+
+type HeadingMatch = {
+  num: string;
+  title: string;
+  start: number;
+  end: number;
+};
+
+function extractHeadings(text: string): HeadingMatch[] {
+  const headings: HeadingMatch[] = [];
+  SECTION_HEADING_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SECTION_HEADING_RE.exec(text)) !== null) {
+    const num = match[1]!;
+    const title = match[2]!.trim();
+    if (!title) continue;
+    if (/^\d/.test(title)) continue;
+    if (title.length > 120) continue;
+    headings.push({ num, title, start: match.index, end: match.index + match[0].length });
+  }
+  SECTION_HEADING_RE.lastIndex = 0;
+  return headings;
 }
 
 export function extractPddSections(rawText: string): Record<string, string> {
-  const cleaned = normalizePageBreaks(stripHeaderFooterNoise(rawText));
+  const cleaned = normalizeText(rawText);
   const sections: Record<string, string> = {};
-  const lines = cleaned.split("\n");
-  let currentNumber: string | null = null;
-  let currentContent: string[] = [];
+  const headings = extractHeadings(cleaned);
 
-  function flush() {
-    if (currentNumber) {
-      let content = currentContent.join("\n").trim();
-      if (content.length > SECTION_EXCERPT_MAX_CHARS) {
-        content = content.slice(0, SECTION_EXCERPT_MAX_CHARS).replace(/\s+\S*$/, "") + " […]";
-      }
-      sections[currentNumber] = content;
+  if (headings.length === 0) {
+    const inlineRe = /\b(\d+(?:\.\d+)*)\s{2,}([A-Z][A-Za-z\s-]{2,60})(?=\n|$)/g;
+    let match: RegExpExecArray | null;
+    while ((match = inlineRe.exec(cleaned)) !== null) {
+      const num = match[1]!;
+      const title = match[2]!.trim();
+      if (!title) continue;
+      if (/^\d/.test(title)) continue;
+      headings.push({ num, title, start: match.index, end: match.index + match[0].length });
     }
   }
 
-  for (const line of lines) {
-    const match = line.match(SECTION_HEADING_RE);
-    if (match) {
-      flush();
-      currentNumber = match[1]!;
-      currentContent = [match[2]!.trim()];
-    } else if (currentNumber) {
-      currentContent.push(line);
-    }
-  }
+  if (headings.length === 0) return sections;
 
-  flush();
+  for (let i = 0; i < headings.length; i++) {
+    const h = headings[i]!;
+    const contentStart = h.end;
+    const nextStart = i + 1 < headings.length ? headings[i + 1]!.start : cleaned.length;
+    let content = cleaned.slice(contentStart, nextStart).trim();
+    if (content) {
+      content = `${h.title}\n${content}`;
+    } else {
+      content = h.title;
+    }
+    if (content.length > SECTION_EXCERPT_MAX_CHARS) {
+      content = content.slice(0, SECTION_EXCERPT_MAX_CHARS).replace(/\s+\S*$/, "") + " […]";
+    }
+    sections[h.num] = content;
+  }
 
   return sections;
 }
@@ -72,4 +103,13 @@ export function extractRoutedSections(
     }
   }
   return result;
+}
+
+export function debugSectionExtraction(rawText: string): Record<string, string> {
+  return {
+    rawPddTextLength: String(rawText.length),
+    rawPddTextPreview: rawText.slice(0, 2000),
+    detectedSections: JSON.stringify(Object.keys(extractPddSections(rawText))),
+    headingMatches: JSON.stringify(extractHeadings(normalizeText(rawText)).map((h) => h.num)),
+  };
 }

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -124,76 +124,100 @@ export function extractRoutedSections(
   return result;
 }
 
-function findLiteralOccurrences(text: string, queries: string[]): string[] {
+function findSnippets(text: string, query: string, maxResults = 5): string[] {
   const results: string[] = [];
-  for (const q of queries) {
-    let idx = 0;
-    const count = results.length;
-    while (idx < text.length) {
-      const pos = text.toLowerCase().indexOf(q.toLowerCase(), idx);
-      if (pos === -1) break;
-      const start = Math.max(0, pos - 60);
-      const end = Math.min(text.length, pos + q.length + 120);
-      let snippet = text.slice(start, end);
-      snippet = snippet.replace(/\s+/g, " ").trim();
-      if (start > 0) snippet = `...${snippet}`;
-      if (end < text.length) snippet = `${snippet}...`;
-      results.push(`${q} @${pos}: ${snippet.slice(0, 200)}`);
-      idx = pos + 1;
-      if (results.length - count >= 5) break;
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+  let idx = 0;
+  while (idx < text.length) {
+    const pos = lower.indexOf(q, idx);
+    if (pos === -1) break;
+    const start = Math.max(0, pos - 80);
+    const end = Math.min(text.length, pos + q.length + 120);
+    let snippet = text.slice(start, end).replace(/\s+/g, " ").trim();
+    if (start > 0) snippet = `…${snippet}`;
+    if (end < text.length) snippet = `${snippet}…`;
+    results.push(snippet);
+    idx = pos + 1;
+    if (results.length >= maxResults) break;
+  }
+  return results;
+}
+
+function findHeadingLikeFragments(text: string, maxResults = 50): string[] {
+  const results: string[] = [];
+  const seen = new Set<string>();
+
+  const patterns: RegExp[] = [
+    /\b(\d+(?:\.\d+)*)\s{2,}([A-Z][A-Za-z\s-]{3,60})(?=[\s,.])/g,
+    /\b(?:Section\s+)?(\d+(?:\.\d+)*)\s*[.:]\s+([A-Z][A-Za-z\s-]{3,60})/g,
+    /\b([A-Z][A-Z\s-]{5,60})\b/g,
+  ];
+
+  for (const p of patterns) {
+    for (const match of text.replace(/\s+/g, "  ").matchAll(p)) {
+      const fragment = match[0]!.trim();
+      if (!fragment || seen.has(fragment)) continue;
+      if (fragment.length > 120) continue;
+      seen.add(fragment);
+      results.push(fragment);
+      if (results.length >= maxResults) break;
     }
+    if (results.length >= maxResults) break;
+  }
+  return results.slice(0, maxResults);
+}
+
+function findNumericFragments(text: string, maxResults = 50): string[] {
+  const results: string[] = [];
+  const seen = new Set<string>();
+  const normalized = text.replace(/\s+/g, " ");
+
+  for (const match of normalized.matchAll(/\b(\d+(?:\.\d+)*)\s{0,3}([A-Z][A-Za-z\s-]{2,60})?/g)) {
+    const num = match[1]!;
+    const title = match[2]?.trim() ?? "";
+    const fragment = title ? `${num} ${title.slice(0, 60)}` : num;
+    if (seen.has(num)) continue;
+    seen.add(num);
+    results.push(fragment.slice(0, 100));
+    if (results.length >= maxResults) break;
   }
   return results;
 }
 
 function diagnoseTextStructure(rawText: string): Record<string, string> {
   const text = rawText.replace(/\s+/g, " ").trim();
-  const newlineCount = (rawText.match(/\n/g) ?? []).length;
-  const lines = rawText.split("\n").filter((l) => l.trim());
-  const longLineCount = lines.filter((l) => l.length > 200).length;
-  const shortLineCount = lines.filter((l) => l.length <= 200).length;
 
-  const sectionNumberMatches = [...text.matchAll(/\b(\d+(?:\.\d+)*)\b/g)]
-    .map((m) => m[1]!)
-    .filter((n) => /^\d+\.\d+$/.test(n) || /^\d+$/.test(n));
+  const has2_4 = /\b2\.4\b/.test(text);
+  const has2_5 = /\b2\.5\b/.test(text);
+  const has1_10 = /\b1\.10\b/.test(text);
+  const hasBaseline = /\bbaseline\b/i.test(text);
+  const hasAdditionality = /\badditionality\b/i.test(text);
+  const hasLeakage = /\bleakage\b/i.test(text);
 
-  const topSectionNumbers = Array.from(new Set(sectionNumberMatches))
-    .filter((n) => {
-      const parts = n.split(".");
-      const first = parseInt(parts[0]!, 10);
-      return first >= 1 && first <= 10;
-    })
-    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-    .slice(0, 50);
+  const baselineSnippets = findSnippets(text, "baseline", 5);
+  const additionalitySnippets = findSnippets(text, "additionality", 5);
+  const leakageSnippets = findSnippets(text, "leakage", 5);
 
-  const titleCaseHeadingCandidates = [...text.matchAll(/\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,5})\b/g)]
-    .map((m) => m[1]!)
-    .filter((t) => t.length >= 10 && t.length <= 80 && /^(?:Baseline|Additionality|Leakage|Project|Boundary|Monitoring).*/i.test(t));
-
-  const uniqueTitles = Array.from(new Set(titleCaseHeadingCandidates)).slice(0, 20);
-
-  const literalOccurrences = findLiteralOccurrences(text, [
-    "2.4", "2.5", "1.10",
-    "Baseline Scenario", "Additionality", "Leakage",
-    "Project Description",
-  ]);
+  const headingLike = findHeadingLikeFragments(text, 50);
+  const numericLike = findNumericFragments(text, 50);
 
   return {
-    newlineCount: String(newlineCount),
-    longLinesOver200: String(longLineCount),
-    shortLinesUnder200: String(shortLineCount),
-    topSectionNumbers: JSON.stringify(topSectionNumbers),
-    titleCaseHeadings: JSON.stringify(uniqueTitles),
-    literalOccurrences: JSON.stringify(literalOccurrences),
+    rawPddTextLength: String(rawText.length),
+    includes_2_4: String(has2_4),
+    includes_2_5: String(has2_5),
+    includes_1_10: String(has1_10),
+    includes_baseline: String(hasBaseline),
+    includes_additionality: String(hasAdditionality),
+    includes_leakage: String(hasLeakage),
+    snippets_baseline: JSON.stringify(baselineSnippets),
+    snippets_additionality: JSON.stringify(additionalitySnippets),
+    snippets_leakage: JSON.stringify(leakageSnippets),
+    heading_like_fragments: JSON.stringify(headingLike),
+    numeric_fragments: JSON.stringify(numericLike),
   };
 }
 
 export function debugSectionExtraction(rawText: string): Record<string, string> {
-  return {
-    rawPddTextLength: String(rawText.length),
-    rawPddTextPreview: rawText.slice(0, 2000),
-    detectedSections: JSON.stringify(Object.keys(extractPddSections(rawText))),
-    headingMatches: JSON.stringify(extractHeadings(normalizeText(rawText)).map((h) => h.num)),
-    ...diagnoseTextStructure(rawText),
-  };
+  return diagnoseTextStructure(rawText);
 }

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -10,8 +10,9 @@ export function normalizeSectionKey(key: string): string {
 }
 
 function stripHeaderFooterNoise(text: string): string {
-  return text
-    .split("\n")
+  const lines = text.split("\n");
+  if (lines.length <= 1) return text;
+  return lines
     .filter((line) => {
       const trimmed = line.trim();
       if (!trimmed) return true;
@@ -64,6 +65,42 @@ function extractHeadings(text: string): HeadingMatch[] {
   return tryHeadingPatterns(text, DEFAULT_HEADING_PATTERNS);
 }
 
+function findHeadingsInContinuousText(text: string): HeadingMatch[] {
+  const headings: HeadingMatch[] = [];
+  const re = /\b(\d+(?:\.\d+)*)\s{1,4}/g;
+  const seen = new Set<string>();
+
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const num = match[1]!;
+    if (seen.has(num)) continue;
+    seen.add(num);
+
+    const beforeCtx = text.slice(Math.max(0, match.index - 30), match.index).toLowerCase();
+    if (/\b(?:page|version)\s*$/.test(beforeCtx)) continue;
+
+    const after = text.slice(match.index + match[0].length, match.index + match[0].length + 60);
+    const titleMatch = after.match(/^([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+){0,3})/);
+    if (!titleMatch) continue;
+    let title = titleMatch[1]!.trim();
+    if (title.length < 3 || title.length > 120) continue;
+    if (/^\d/.test(title)) continue;
+    if (headings.some((h) => h.num === num)) continue;
+
+    const articleRe = /\b(?:The|A|An|This|That|These|Those|For|With|From)\b/i;
+    const words = title.split(/\s+/);
+    const filteredWords = words.filter((w) => !articleRe.test(w));
+    title = filteredWords.length > 0 ? filteredWords.join(" ") : words[0]!;
+
+    if (title.length < 2) continue;
+
+    const end = match.index + match[0].length + titleMatch[0].length;
+    headings.push({ num, title, start: match.index, end });
+  }
+
+  return headings;
+}
+
 export function extractPddSections(rawText: string): Record<string, string> {
   const cleaned = normalizeText(rawText);
   const sections: Record<string, string> = {};
@@ -98,6 +135,11 @@ export function extractPddSections(rawText: string): Record<string, string> {
       if (title.length > 120) continue;
       headings.push({ num, title, start: linePos(i), end: linePos(i + 2) });
     }
+  }
+
+  if (headings.length === 0) {
+    const continuousHeadings = findHeadingsInContinuousText(cleaned);
+    headings.push(...continuousHeadings);
   }
 
   if (headings.length === 0) return sections;

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -1,14 +1,37 @@
+export const SECTION_EXCERPT_MAX_CHARS = 3000;
+
 const SECTION_HEADING_RE = /^\s*(?:Section\s+)?(\d+(?:\.\d+)*)\s*[.:]?\s+(.+)/i;
 
+function stripHeaderFooterNoise(text: string): string {
+  return text
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return true;
+      if (/^(page\s+\d+\s+of\s+\d+|page\s+\d+|v\d+\.\d+.*|vm0007.*|project\s+description\s+document|\d+\s+of\s+\d+)$/i.test(trimmed)) return false;
+      return true;
+    })
+    .join("\n");
+}
+
+function normalizePageBreaks(text: string): string {
+  return text.replace(/\f/g, "\n");
+}
+
 export function extractPddSections(rawText: string): Record<string, string> {
+  const cleaned = normalizePageBreaks(stripHeaderFooterNoise(rawText));
   const sections: Record<string, string> = {};
-  const lines = rawText.split("\n");
+  const lines = cleaned.split("\n");
   let currentNumber: string | null = null;
   let currentContent: string[] = [];
 
   function flush() {
     if (currentNumber) {
-      sections[currentNumber] = currentContent.join("\n").trim();
+      let content = currentContent.join("\n").trim();
+      if (content.length > SECTION_EXCERPT_MAX_CHARS) {
+        content = content.slice(0, SECTION_EXCERPT_MAX_CHARS).replace(/\s+\S*$/, "") + " […]";
+      }
+      sections[currentNumber] = content;
     }
   }
 
@@ -17,8 +40,7 @@ export function extractPddSections(rawText: string): Record<string, string> {
     if (match) {
       flush();
       currentNumber = match[1]!;
-      const heading = match[2]!.trim();
-      currentContent = [heading];
+      currentContent = [match[2]!.trim()];
     } else if (currentNumber) {
       currentContent.push(line);
     }
@@ -35,4 +57,19 @@ export function extractSectionContent(
 ): string | null {
   const sections = extractPddSections(rawText);
   return sections[sectionNumber] ?? null;
+}
+
+export function extractRoutedSections(
+  rawText: string,
+  relevantSections: string[],
+): Record<string, string> {
+  const allSections = extractPddSections(rawText);
+  const result: Record<string, string> = {};
+  for (const section of relevantSections) {
+    const content = allSections[section];
+    if (content) {
+      result[section] = content;
+    }
+  }
+  return result;
 }

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -124,44 +124,68 @@ export function extractRoutedSections(
   return result;
 }
 
-function diagnoseHeadingCandidates(rawText: string): string[] {
-  const lines = normalizeText(rawText).split("\n");
-  const candidates: string[] = [];
-  const seen = new Set<string>();
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!.trim();
-    if (!line || line.length < 2 || line.length > 200) continue;
-
-    const patterns: RegExp[] = [
-      /^\d+(?:\.\d+)*\s+[A-Z]/,
-      /^\d+(?:\.\d+)*\s*[.:]\s*[A-Z]/,
-      /^Section\s+\d+(?:\.\d+)*/i,
-      /^\d+(?:\.\d+)*\s*$/,
-      /^[A-Z][A-Z\s-]{3,60}$/,
-      /\bSECTION\s+\d/i,
-      /\bTABLE\s+OF\s+CONTENTS/i,
-      /^\d+(?:\.\d+)*\s{2,}[A-Z]/,
-    ];
-
-    const nextLine = i + 1 < lines.length ? lines[i + 1]!.trim() : "";
-
-    for (const pattern of patterns) {
-      if (pattern.test(line)) {
-        const nextContext = nextLine && !/^\d/.test(nextLine) ? ` → ${nextLine.slice(0, 60)}` : "";
-        const key = `${line.slice(0, 80)}${nextContext}`;
-        if (!seen.has(key)) {
-          seen.add(key);
-          candidates.push(`${line.slice(0, 80)}${nextContext}`);
-        }
-        break;
-      }
+function findLiteralOccurrences(text: string, queries: string[]): string[] {
+  const results: string[] = [];
+  for (const q of queries) {
+    let idx = 0;
+    const count = results.length;
+    while (idx < text.length) {
+      const pos = text.toLowerCase().indexOf(q.toLowerCase(), idx);
+      if (pos === -1) break;
+      const start = Math.max(0, pos - 60);
+      const end = Math.min(text.length, pos + q.length + 120);
+      let snippet = text.slice(start, end);
+      snippet = snippet.replace(/\s+/g, " ").trim();
+      if (start > 0) snippet = `...${snippet}`;
+      if (end < text.length) snippet = `${snippet}...`;
+      results.push(`${q} @${pos}: ${snippet.slice(0, 200)}`);
+      idx = pos + 1;
+      if (results.length - count >= 5) break;
     }
-
-    if (candidates.length >= 50) break;
   }
+  return results;
+}
 
-  return candidates;
+function diagnoseTextStructure(rawText: string): Record<string, string> {
+  const text = rawText.replace(/\s+/g, " ").trim();
+  const newlineCount = (rawText.match(/\n/g) ?? []).length;
+  const lines = rawText.split("\n").filter((l) => l.trim());
+  const longLineCount = lines.filter((l) => l.length > 200).length;
+  const shortLineCount = lines.filter((l) => l.length <= 200).length;
+
+  const sectionNumberMatches = [...text.matchAll(/\b(\d+(?:\.\d+)*)\b/g)]
+    .map((m) => m[1]!)
+    .filter((n) => /^\d+\.\d+$/.test(n) || /^\d+$/.test(n));
+
+  const topSectionNumbers = Array.from(new Set(sectionNumberMatches))
+    .filter((n) => {
+      const parts = n.split(".");
+      const first = parseInt(parts[0]!, 10);
+      return first >= 1 && first <= 10;
+    })
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    .slice(0, 50);
+
+  const titleCaseHeadingCandidates = [...text.matchAll(/\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,5})\b/g)]
+    .map((m) => m[1]!)
+    .filter((t) => t.length >= 10 && t.length <= 80 && /^(?:Baseline|Additionality|Leakage|Project|Boundary|Monitoring).*/i.test(t));
+
+  const uniqueTitles = Array.from(new Set(titleCaseHeadingCandidates)).slice(0, 20);
+
+  const literalOccurrences = findLiteralOccurrences(text, [
+    "2.4", "2.5", "1.10",
+    "Baseline Scenario", "Additionality", "Leakage",
+    "Project Description",
+  ]);
+
+  return {
+    newlineCount: String(newlineCount),
+    longLinesOver200: String(longLineCount),
+    shortLinesUnder200: String(shortLineCount),
+    topSectionNumbers: JSON.stringify(topSectionNumbers),
+    titleCaseHeadings: JSON.stringify(uniqueTitles),
+    literalOccurrences: JSON.stringify(literalOccurrences),
+  };
 }
 
 export function debugSectionExtraction(rawText: string): Record<string, string> {
@@ -170,6 +194,6 @@ export function debugSectionExtraction(rawText: string): Record<string, string> 
     rawPddTextPreview: rawText.slice(0, 2000),
     detectedSections: JSON.stringify(Object.keys(extractPddSections(rawText))),
     headingMatches: JSON.stringify(extractHeadings(normalizeText(rawText)).map((h) => h.num)),
-    headingCandidates: JSON.stringify(diagnoseHeadingCandidates(rawText)),
+    ...diagnoseTextStructure(rawText),
   };
 }

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -37,7 +37,7 @@ type HeadingMatch = {
 };
 
 function tryHeadingPatterns(text: string, patterns: RegExp[]): HeadingMatch[] {
-  const headings: HeadingMatch[] = [];
+  const allCandidates: HeadingMatch[] = [];
   for (const re of patterns) {
     re.lastIndex = 0;
     let match: RegExpExecArray | null;
@@ -46,13 +46,17 @@ function tryHeadingPatterns(text: string, patterns: RegExp[]): HeadingMatch[] {
       const title = match[2]!.trim();
       if (!title) continue;
       if (/^\d/.test(title)) continue;
+      if (/^[a-z]/.test(title)) continue;
       if (title.length > 120) continue;
-      if (headings.some((h) => h.num === num)) continue;
-      headings.push({ num, title, start: match.index, end: match.index + match[0].length });
+      allCandidates.push({ num, title, start: match.index, end: match.index + match[0].length });
     }
     re.lastIndex = 0;
   }
-  return headings;
+  return allCandidates;
+}
+
+function isTocTitle(title: string): boolean {
+  return /\.{4,}\s*\d+\s*$/.test(title) || /\bpage\s+\d+\s*$/i.test(title);
 }
 
 const DEFAULT_HEADING_PATTERNS = [
@@ -62,7 +66,46 @@ const DEFAULT_HEADING_PATTERNS = [
 ];
 
 function extractHeadings(text: string): HeadingMatch[] {
-  return tryHeadingPatterns(text, DEFAULT_HEADING_PATTERNS);
+  const allCandidates = tryHeadingPatterns(text, DEFAULT_HEADING_PATTERNS);
+
+  const tocCandidates: HeadingMatch[] = [];
+  const bodyCandidates: HeadingMatch[] = [];
+
+  for (const h of allCandidates) {
+    if (isTocTitle(h.title)) {
+      tocCandidates.push(h);
+    } else {
+      bodyCandidates.push(h);
+    }
+  }
+
+  const tocByNum = new Map<string, HeadingMatch>();
+  for (const h of tocCandidates) {
+    if (!tocByNum.has(h.num)) tocByNum.set(h.num, h);
+  }
+
+  const bodyByNum = new Map<string, HeadingMatch>();
+  for (const h of bodyCandidates) {
+    if (!bodyByNum.has(h.num)) bodyByNum.set(h.num, h);
+  }
+
+  const chosen: HeadingMatch[] = [];
+  const seen = new Set<string>();
+
+  for (const h of bodyCandidates) {
+    if (seen.has(h.num)) continue;
+    seen.add(h.num);
+    chosen.push(h);
+  }
+
+  for (const h of tocCandidates) {
+    if (seen.has(h.num)) continue;
+    seen.add(h.num);
+    chosen.push(h);
+  }
+
+  chosen.sort((a, b) => a.start - b.start);
+  return chosen;
 }
 
 function findHeadingsInContinuousText(text: string): HeadingMatch[] {
@@ -141,6 +184,19 @@ export function extractPddSections(rawText: string): Record<string, string> {
     const continuousHeadings = findHeadingsInContinuousText(cleaned);
     headings.push(...continuousHeadings);
   }
+
+  if (headings.length === 0) return sections;
+
+  const finalHeadings: HeadingMatch[] = [];
+  const seenFinal = new Set<string>();
+  for (const h of headings) {
+    if (isTocTitle(h.title)) continue;
+    if (seenFinal.has(h.num)) continue;
+    seenFinal.add(h.num);
+    finalHeadings.push(h);
+  }
+  headings.length = 0;
+  headings.push(...finalHeadings);
 
   if (headings.length === 0) return sections;
 

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -36,6 +36,40 @@ type HeadingMatch = {
   end: number;
 };
 
+function isConnectorWord(word: string): boolean {
+  return /^(?:a|an|and|as|at|by|for|from|in|into|of|on|or|the|to|with|without)$/i.test(word);
+}
+
+function isLikelyTopLevelSectionTitle(num: string, title: string): boolean {
+  if (num.includes(".")) return true;
+  if (/[!?/\\@]/.test(title)) return false;
+  if (title.length > 80) return false;
+
+  const words = title.split(/\s+/).filter(Boolean);
+  if (words.length === 0 || words.length > 8) return false;
+
+  const headingishWords = words.filter((word) => {
+    const cleaned = word.replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9+()-]+$/g, "");
+    if (!cleaned) return false;
+    if (isConnectorWord(cleaned)) return true;
+    if (/^[A-Z][a-z][A-Za-z-]*$/.test(cleaned)) return true;
+    if (/^[A-Z]{3,}$/.test(cleaned)) return true;
+    return false;
+  });
+
+  if (headingishWords.length / words.length < 0.6) return false;
+  if (!words.some((word) => /[A-Za-z]{4,}/.test(word) && !/^[A-Z]{2,}$/.test(word))) return false;
+  return true;
+}
+
+function isLikelyHeadingCandidate(num: string, title: string): boolean {
+  if (!title) return false;
+  if (/^\d/.test(title)) return false;
+  if (/^[a-z]/.test(title)) return false;
+  if (title.length > 120) return false;
+  return isLikelyTopLevelSectionTitle(num, title);
+}
+
 function tryHeadingPatterns(text: string, patterns: RegExp[]): HeadingMatch[] {
   const allCandidates: HeadingMatch[] = [];
   for (const re of patterns) {
@@ -44,10 +78,7 @@ function tryHeadingPatterns(text: string, patterns: RegExp[]): HeadingMatch[] {
     while ((match = re.exec(text)) !== null) {
       const num = match[1]!;
       const title = match[2]!.trim();
-      if (!title) continue;
-      if (/^\d/.test(title)) continue;
-      if (/^[a-z]/.test(title)) continue;
-      if (title.length > 120) continue;
+      if (!isLikelyHeadingCandidate(num, title)) continue;
       allCandidates.push({ num, title, start: match.index, end: match.index + match[0].length });
     }
     re.lastIndex = 0;
@@ -102,15 +133,29 @@ function isInsideTocBlock(pos: number, tocBlock: { start: number; end: number } 
   return pos >= tocBlock.start && pos < tocBlock.end;
 }
 
-function hasBodyTextAfter(text: string, startPos: number): boolean {
-  const after = text.slice(startPos);
-  const re = SECTION_HEADING_RE;
-  re.lastIndex = 0;
-  const nextMatch = re.exec(after);
-  const between = nextMatch ? after.slice(0, nextMatch.index).trim() : after.trim();
-  if (between.length < 5) return false;
-  if (/[a-z]{4,}/.test(between)) return true;
-  if (/[.!?]\s+[A-Z]/.test(between)) return true;
+function extractHeadingNumberFromLine(line: string): string | null {
+  const match = line.match(/^\s*(?:Section\s+)?(\d+(?:\.\d+)*)\s*[.:]?\s+\S/);
+  return match?.[1] ?? null;
+}
+
+function hasBodyTextAfter(text: string, startPos: number, sectionNum: string): boolean {
+  const lines = text.slice(startPos).split("\n");
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
+    if (!trimmed) continue;
+
+    const nextHeadingNum = extractHeadingNumberFromLine(trimmed);
+    if (nextHeadingNum) {
+      if (nextHeadingNum.startsWith(`${sectionNum}.`)) {
+        continue;
+      }
+      return false;
+    }
+
+    if (trimmed.length < 5) continue;
+    if (/[a-z]{4,}/.test(trimmed)) return true;
+    if (/[.!?]\s+[A-Z]/.test(trimmed)) return true;
+  }
   return false;
 }
 
@@ -168,8 +213,7 @@ function findAllRawCandidates(cleaned: string): HeadingMatch[] {
     while ((match = inlineRe.exec(cleaned)) !== null) {
       const num = match[1]!;
       const title = match[2]!.trim();
-      if (!title) continue;
-      if (/^\d/.test(title)) continue;
+      if (!isLikelyHeadingCandidate(num, title)) continue;
       all.push({ num, title, start: match.index, end: match.index + match[0].length });
     }
   }
@@ -185,9 +229,7 @@ function findAllRawCandidates(cleaned: string): HeadingMatch[] {
       if (!numMatch) continue;
       const num = numMatch[1]!;
       const title = lines[i + 1]!.trim();
-      if (!title) continue;
-      if (/^\d/.test(title)) continue;
-      if (title.length > 120) continue;
+      if (!isLikelyHeadingCandidate(num, title)) continue;
       all.push({ num, title, start: linePos(i), end: linePos(i + 2) });
     }
   }
@@ -216,7 +258,7 @@ export function extractPddSections(rawText: string): Record<string, string> {
     const reason: string | null = (() => {
       if (isTocTitle(h.title)) return "line-level TOC markers";
       if (tocBlock && isInsideTocBlock(h.start, tocBlock)) return "inside TOC block";
-      if (!hasBodyTextAfter(cleaned, h.end)) return "no body text after heading";
+      if (!hasBodyTextAfter(cleaned, h.end, h.num)) return "no body text after heading";
       return null;
     })();
 
@@ -245,7 +287,14 @@ export function extractPddSections(rawText: string): Record<string, string> {
   for (let i = 0; i < selectedHeadings.length; i++) {
     const h = selectedHeadings[i]!;
     const contentStart = h.end;
-    const nextStart = i + 1 < selectedHeadings.length ? selectedHeadings[i + 1]!.start : cleaned.length;
+    let nextStart = cleaned.length;
+    for (let j = i + 1; j < selectedHeadings.length; j++) {
+      const candidate = selectedHeadings[j]!;
+      if (!candidate.num.startsWith(`${h.num}.`)) {
+        nextStart = candidate.start;
+        break;
+      }
+    }
     let content = cleaned.slice(contentStart, nextStart).trim();
     if (content) {
       content = `${h.title}\n${content}`;
@@ -463,7 +512,7 @@ export function analyzeSectionCandidates(rawText: string, sectionNum: string): S
       }
     }
     const lineEndPos = lines.slice(0, i + 1).reduce((sum, l) => sum + l.length + 1, 0);
-    if (!hasBodyTextAfter(cleaned, lineEndPos)) {
+    if (!hasBodyTextAfter(cleaned, lineEndPos, sectionNum)) {
       rejectReasons.push("no body text after heading");
     }
     if (rejectReasons.length > 0) {

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -496,3 +496,68 @@ export function analyzeSectionCandidates(rawText: string, sectionNum: string): S
 export function debugSectionExtraction(rawText: string): Record<string, string> {
   return diagnoseTextStructure(rawText);
 }
+
+export type DocumentHeading = {
+  sectionNumber: string;
+  title: string;
+  normalizedTitle: string;
+  bodyPreview: string;
+  bodyText: string;
+};
+
+const HEADING_PREVIEW_MAX = 220;
+const HEADING_BODY_MAX = 4000;
+
+function normalizeHeadingTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^\w\s.-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function makeBodyPreview(body: string): string {
+  const t = body.trim();
+  if (!t) return "";
+  if (t.length <= HEADING_PREVIEW_MAX) return t;
+  return t.slice(0, HEADING_PREVIEW_MAX).replace(/\s+\S*$/, "") + " […]";
+}
+
+export function buildPddHeadingIndex(rawPddText: string): DocumentHeading[] {
+  if (!rawPddText || rawPddText.trim().length < 10) return [];
+  const sections = extractPddSections(rawPddText);
+  const headings: DocumentHeading[] = [];
+  for (const [num, content] of Object.entries(sections)) {
+    const lines = content.split("\n").filter((l) => l.trim().length > 0);
+    if (lines.length === 0) continue;
+    const title = lines[0]!.trim();
+    const body = lines.slice(1).join("\n").trim();
+    const normalizedTitle = normalizeHeadingTitle(title);
+    const bodyPreview = makeBodyPreview(body || title);
+    const bodyText = (body || title).slice(0, HEADING_BODY_MAX);
+    headings.push({
+      sectionNumber: num,
+      title,
+      normalizedTitle,
+      bodyPreview,
+      bodyText,
+    });
+  }
+  return headings;
+}
+
+export function headingMatchesQuery(heading: DocumentHeading, query: string): boolean {
+  const q = normalizeHeadingTitle(query);
+  if (!q || q.length < 2) return false;
+  if (heading.normalizedTitle.includes(q)) return true;
+  const STOP = new Set(["project", "pdd", "this", "that", "what", "does", "the", "and", "for", "with", "from"]);
+  const words = q.split(/\s+/).filter((w) => w.length >= 4 && !STOP.has(w));
+  if (words.length === 0) return false;
+  return words.some((w) => heading.normalizedTitle.includes(w));
+}
+
+export function filterPddHeadingsByQuery(headings: DocumentHeading[], query: string): DocumentHeading[] {
+  const q = query.trim();
+  if (!q) return [];
+  return headings.filter((h) => headingMatchesQuery(h, q));
+}

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -776,7 +776,7 @@ export function scoreHeadingAgainstQuery(
   const strong =
     exactTitleMatch
     || fullPhraseMatch
-    || (fallbackKeywordMatches.length > 0 && (exactTokenMatches.length > 0 || softTokenMatches.length > 0))
+    || fallbackKeywordMatches.length > 0
     || (queryTokens.length === 1
       ? exactTokenMatches.length > 0 || softTokenMatches.length > 0
       : coverage >= 0.6 && (

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -59,54 +59,68 @@ function isTocTitle(title: string): boolean {
   return /\.{4,}\s*\d+\s*$/.test(title) || /\bpage\s+\d+\s*$/i.test(title);
 }
 
+function findTocBlockBounds(text: string): { start: number; end: number } | null {
+  const lines = text.split("\n");
+  const lineEndPositions: number[] = [];
+  let pos = 0;
+  for (const line of lines) {
+    pos += line.length;
+    lineEndPositions.push(pos);
+    pos += 1;
+  }
+
+  let headerLineIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]!.toLowerCase().trim().match(/^(table\s+of\s+contents|contents)$/)) {
+      headerLineIdx = i;
+      break;
+    }
+  }
+  if (headerLineIdx === -1) return null;
+
+  let tocEndLine = headerLineIdx + 1;
+  for (let i = headerLineIdx + 1; i < lines.length; i++) {
+    const trimmed = lines[i]!.trim();
+    if (!trimmed) {
+      if (i === headerLineIdx + 1) continue;
+      tocEndLine = i;
+      break;
+    }
+    if (!/^\d+(?:\.\d+)*\s+[A-Z]/.test(trimmed)) {
+      tocEndLine = i;
+      break;
+    }
+  }
+
+  const tocStart = headerLineIdx > 0 ? lineEndPositions[headerLineIdx - 1]! + 1 : 0;
+  const tocEnd = tocEndLine < lines.length ? lineEndPositions[tocEndLine - 1]! + 1 : text.length;
+  return { start: tocStart, end: tocEnd };
+}
+
+function isInsideTocBlock(pos: number, tocBlock: { start: number; end: number } | null): boolean {
+  if (!tocBlock) return false;
+  return pos >= tocBlock.start && pos < tocBlock.end;
+}
+
+function hasBodyTextAfter(text: string, startPos: number): boolean {
+  const after = text.slice(startPos);
+  const re = SECTION_HEADING_RE;
+  re.lastIndex = 0;
+  const nextMatch = re.exec(after);
+  const between = nextMatch ? after.slice(0, nextMatch.index).trim() : after.trim();
+  if (between.length < 5) return false;
+  if (/[a-z]{4,}/.test(between)) return true;
+  if (/[.!?]\s+[A-Z]/.test(between)) return true;
+  return false;
+}
+
 const DEFAULT_HEADING_PATTERNS = [
   SECTION_HEADING_RE,
   SECTION_HEADING_DOT_RE,
   SECTION_HEADING_PAREN_RE,
 ];
 
-function extractHeadings(text: string): HeadingMatch[] {
-  const allCandidates = tryHeadingPatterns(text, DEFAULT_HEADING_PATTERNS);
 
-  const tocCandidates: HeadingMatch[] = [];
-  const bodyCandidates: HeadingMatch[] = [];
-
-  for (const h of allCandidates) {
-    if (isTocTitle(h.title)) {
-      tocCandidates.push(h);
-    } else {
-      bodyCandidates.push(h);
-    }
-  }
-
-  const tocByNum = new Map<string, HeadingMatch>();
-  for (const h of tocCandidates) {
-    if (!tocByNum.has(h.num)) tocByNum.set(h.num, h);
-  }
-
-  const bodyByNum = new Map<string, HeadingMatch>();
-  for (const h of bodyCandidates) {
-    if (!bodyByNum.has(h.num)) bodyByNum.set(h.num, h);
-  }
-
-  const chosen: HeadingMatch[] = [];
-  const seen = new Set<string>();
-
-  for (const h of bodyCandidates) {
-    if (seen.has(h.num)) continue;
-    seen.add(h.num);
-    chosen.push(h);
-  }
-
-  for (const h of tocCandidates) {
-    if (seen.has(h.num)) continue;
-    seen.add(h.num);
-    chosen.push(h);
-  }
-
-  chosen.sort((a, b) => a.start - b.start);
-  return chosen;
-}
 
 function findHeadingsInContinuousText(text: string): HeadingMatch[] {
   const headings: HeadingMatch[] = [];
@@ -144,12 +158,11 @@ function findHeadingsInContinuousText(text: string): HeadingMatch[] {
   return headings;
 }
 
-export function extractPddSections(rawText: string): Record<string, string> {
-  const cleaned = normalizeText(rawText);
-  const sections: Record<string, string> = {};
-  const headings = extractHeadings(cleaned);
-
-  if (headings.length === 0) {
+function findAllRawCandidates(cleaned: string): HeadingMatch[] {
+  const all: HeadingMatch[] = [];
+  const raw = tryHeadingPatterns(cleaned, DEFAULT_HEADING_PATTERNS);
+  all.push(...raw);
+  if (all.length === 0) {
     const inlineRe = /\b(\d+(?:\.\d+)*)\s{2,}([A-Z][A-Za-z\s-]{2,60})(?=\n|$)/g;
     let match: RegExpExecArray | null;
     while ((match = inlineRe.exec(cleaned)) !== null) {
@@ -157,11 +170,10 @@ export function extractPddSections(rawText: string): Record<string, string> {
       const title = match[2]!.trim();
       if (!title) continue;
       if (/^\d/.test(title)) continue;
-      headings.push({ num, title, start: match.index, end: match.index + match[0].length });
+      all.push({ num, title, start: match.index, end: match.index + match[0].length });
     }
   }
-
-  if (headings.length === 0) {
+  if (all.length === 0) {
     const lines = cleaned.split("\n");
     const linePos = (idx: number) => {
       let pos = 0;
@@ -176,34 +188,63 @@ export function extractPddSections(rawText: string): Record<string, string> {
       if (!title) continue;
       if (/^\d/.test(title)) continue;
       if (title.length > 120) continue;
-      headings.push({ num, title, start: linePos(i), end: linePos(i + 2) });
+      all.push({ num, title, start: linePos(i), end: linePos(i + 2) });
+    }
+  }
+  return all;
+}
+
+export function extractPddSections(rawText: string): Record<string, string> {
+  const cleaned = normalizeText(rawText);
+  const sections: Record<string, string> = {};
+
+  let allCandidates = findAllRawCandidates(cleaned);
+
+  if (allCandidates.length === 0) {
+    const continuousHeadings = findHeadingsInContinuousText(cleaned);
+    allCandidates = continuousHeadings;
+  }
+
+  if (allCandidates.length === 0) return sections;
+
+  const tocBlock = findTocBlockBounds(cleaned);
+  // TOC block detected: only candidates outside it survive the proximity check
+  const bestByNum = new Map<string, { heading: HeadingMatch; reason: string | null }>();
+
+  for (const h of allCandidates) {
+    const existing = bestByNum.get(h.num);
+    const reason: string | null = (() => {
+      if (isTocTitle(h.title)) return "line-level TOC markers";
+      if (tocBlock && isInsideTocBlock(h.start, tocBlock)) return "inside TOC block";
+      if (!hasBodyTextAfter(cleaned, h.end)) return "no body text after heading";
+      return null;
+    })();
+
+    if (!existing) {
+      bestByNum.set(h.num, { heading: h, reason });
+      continue;
+    }
+
+    if (reason === null && existing.reason !== null) {
+      bestByNum.set(h.num, { heading: h, reason: null });
+    } else if (reason === null && existing.reason === null && h.start > existing.heading.start) {
+      bestByNum.set(h.num, { heading: h, reason: null });
     }
   }
 
-  if (headings.length === 0) {
-    const continuousHeadings = findHeadingsInContinuousText(cleaned);
-    headings.push(...continuousHeadings);
+  const selectedHeadings: HeadingMatch[] = [];
+  for (const [, entry] of bestByNum) {
+    if (entry.reason === null) {
+      selectedHeadings.push(entry.heading);
+    }
   }
 
-  if (headings.length === 0) return sections;
+  if (selectedHeadings.length === 0) return sections;
 
-  const finalHeadings: HeadingMatch[] = [];
-  const seenFinal = new Set<string>();
-  for (const h of headings) {
-    if (isTocTitle(h.title)) continue;
-    if (seenFinal.has(h.num)) continue;
-    seenFinal.add(h.num);
-    finalHeadings.push(h);
-  }
-  headings.length = 0;
-  headings.push(...finalHeadings);
-
-  if (headings.length === 0) return sections;
-
-  for (let i = 0; i < headings.length; i++) {
-    const h = headings[i]!;
+  for (let i = 0; i < selectedHeadings.length; i++) {
+    const h = selectedHeadings[i]!;
     const contentStart = h.end;
-    const nextStart = i + 1 < headings.length ? headings[i + 1]!.start : cleaned.length;
+    const nextStart = i + 1 < selectedHeadings.length ? selectedHeadings[i + 1]!.start : cleaned.length;
     let content = cleaned.slice(contentStart, nextStart).trim();
     if (content) {
       content = `${h.title}\n${content}`;
@@ -375,6 +416,80 @@ function diagnoseTextStructure(rawText: string): Record<string, string> {
     snippets_leakage: JSON.stringify(leakageSnippets),
     heading_like_fragments: JSON.stringify(headingLike),
     numeric_fragments: JSON.stringify(numericLike),
+  };
+}
+
+export type SectionCandidateDebug = {
+  allCandidateLines: string[];
+  rejectedCandidates: string[];
+  selectedCandidate: string;
+  selectedReason: string;
+  sectionBodyPreview: string;
+};
+
+export function analyzeSectionCandidates(rawText: string, sectionNum: string): SectionCandidateDebug {
+  const cleaned = normalizeText(rawText);
+  const tocBlock = findTocBlockBounds(cleaned);
+  const sections = extractPddSections(rawText);
+  const key = normalizeSectionKey(sectionNum);
+  const bodyContent = sections[key] ?? null;
+  const lines = rawText.split("\n");
+
+  const allCandidateLines: string[] = [];
+  const rejectedCandidates: string[] = [];
+  let selectedCandidate = "none";
+  let selectedReason = "section not found in extracted output";
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i]!.trim();
+    const headingMatch = trimmed.match(
+      /^(?:Section\s+)?(\d+(?:\.\d+)*)\s*[.:]?\s+(.+?)(?:\s*\.{4,}\s*\d+\s*)?$/,
+    );
+    if (!headingMatch) continue;
+    if (headingMatch[1] !== sectionNum) continue;
+    const title = headingMatch[2]!.trim();
+    const lineText = `L${i + 1}: ${trimmed.slice(0, 120)}`;
+    allCandidateLines.push(lineText);
+
+    const rejectReasons: string[] = [];
+    if (isTocTitle(title)) {
+      rejectReasons.push("line-level TOC markers");
+    }
+    if (tocBlock) {
+      const linePos = lines.slice(0, i).reduce((sum, l) => sum + l.length + 1, 0);
+      if (isInsideTocBlock(linePos, tocBlock)) {
+        rejectReasons.push("inside TOC block");
+      }
+    }
+    const lineEndPos = lines.slice(0, i + 1).reduce((sum, l) => sum + l.length + 1, 0);
+    if (!hasBodyTextAfter(cleaned, lineEndPos)) {
+      rejectReasons.push("no body text after heading");
+    }
+    if (rejectReasons.length > 0) {
+      rejectedCandidates.push(`L${i + 1}: ${trimmed.slice(0, 80)} — rejected: ${rejectReasons.join(", ")}`);
+    } else {
+      selectedCandidate = `L${i + 1}: ${trimmed.slice(0, 120)}`;
+      selectedReason = "passes all checks";
+    }
+  }
+
+  const allRejected = rejectedCandidates.length;
+  const allFound = allCandidateLines.length;
+  if (allFound === 0) {
+    selectedReason = "no heading candidates found for this section number";
+  } else if (selectedCandidate === "none" && allRejected > 0) {
+    selectedCandidate = `all ${allFound} candidate(s) rejected`;
+    selectedReason = "all candidates matched one or more rejection criteria";
+  } else if (selectedCandidate === "none") {
+    selectedReason = "unknown — heading found but not selected";
+  }
+
+  return {
+    allCandidateLines,
+    rejectedCandidates,
+    selectedCandidate,
+    selectedReason,
+    sectionBodyPreview: (bodyContent ?? "missing").slice(0, 200),
   };
 }
 

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -1,0 +1,38 @@
+const SECTION_HEADING_RE = /^\s*(?:Section\s+)?(\d+(?:\.\d+)*)\s*[.:]?\s+(.+)/i;
+
+export function extractPddSections(rawText: string): Record<string, string> {
+  const sections: Record<string, string> = {};
+  const lines = rawText.split("\n");
+  let currentNumber: string | null = null;
+  let currentContent: string[] = [];
+
+  function flush() {
+    if (currentNumber) {
+      sections[currentNumber] = currentContent.join("\n").trim();
+    }
+  }
+
+  for (const line of lines) {
+    const match = line.match(SECTION_HEADING_RE);
+    if (match) {
+      flush();
+      currentNumber = match[1]!;
+      const heading = match[2]!.trim();
+      currentContent = [heading];
+    } else if (currentNumber) {
+      currentContent.push(line);
+    }
+  }
+
+  flush();
+
+  return sections;
+}
+
+export function extractSectionContent(
+  rawText: string,
+  sectionNumber: string,
+): string | null {
+  const sections = extractPddSections(rawText);
+  return sections[sectionNumber] ?? null;
+}

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -48,6 +48,10 @@ function isLikelyTopLevelSectionTitle(num: string, title: string): boolean {
   const words = title.split(/\s+/).filter(Boolean);
   if (words.length === 0 || words.length > 8) return false;
 
+  const cleanedWords = words
+    .map((word) => word.replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9+()-]+$/g, ""))
+    .filter(Boolean);
+
   const headingishWords = words.filter((word) => {
     const cleaned = word.replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9+()-]+$/g, "");
     if (!cleaned) return false;
@@ -58,7 +62,9 @@ function isLikelyTopLevelSectionTitle(num: string, title: string): boolean {
   });
 
   if (headingishWords.length / words.length < 0.6) return false;
-  if (!words.some((word) => /[A-Za-z]{4,}/.test(word) && !/^[A-Z]{2,}$/.test(word))) return false;
+  const hasMixedCaseLongWord = cleanedWords.some((word) => /[A-Za-z]{4,}/.test(word) && !/^[A-Z]{2,}$/.test(word));
+  const allCapsLongWordCount = cleanedWords.filter((word) => /^[A-Z]{4,}$/.test(word)).length;
+  if (!hasMixedCaseLongWord && allCapsLongWordCount < 2) return false;
   return true;
 }
 
@@ -88,6 +94,10 @@ function tryHeadingPatterns(text: string, patterns: RegExp[]): HeadingMatch[] {
 
 function isTocTitle(title: string): boolean {
   return /\.{4,}\s*\d+\s*$/.test(title) || /\bpage\s+\d+\s*$/i.test(title);
+}
+
+function stripTocSuffix(title: string): string {
+  return title.replace(/\s*\.{4,}\s*\d+\s*$/g, "").replace(/\bpage\s+\d+\s*$/gi, "").trim();
 }
 
 function findTocBlockBounds(text: string): { start: number; end: number } | null {
@@ -252,6 +262,7 @@ export function extractPddSections(rawText: string): Record<string, string> {
   const tocBlock = findTocBlockBounds(cleaned);
   // TOC block detected: only candidates outside it survive the proximity check
   const bestByNum = new Map<string, { heading: HeadingMatch; reason: string | null }>();
+  const validCandidates: HeadingMatch[] = [];
 
   for (const h of allCandidates) {
     const existing = bestByNum.get(h.num);
@@ -262,14 +273,14 @@ export function extractPddSections(rawText: string): Record<string, string> {
       return null;
     })();
 
+    if (reason === null) validCandidates.push(h);
+
     if (!existing) {
       bestByNum.set(h.num, { heading: h, reason });
       continue;
     }
 
     if (reason === null && existing.reason !== null) {
-      bestByNum.set(h.num, { heading: h, reason: null });
-    } else if (reason === null && existing.reason === null && h.start > existing.heading.start) {
       bestByNum.set(h.num, { heading: h, reason: null });
     }
   }
@@ -283,17 +294,18 @@ export function extractPddSections(rawText: string): Record<string, string> {
 
   if (selectedHeadings.length === 0) return sections;
   selectedHeadings.sort((a, b) => a.start - b.start);
+  validCandidates.sort((a, b) => a.start - b.start);
 
   for (let i = 0; i < selectedHeadings.length; i++) {
     const h = selectedHeadings[i]!;
     const contentStart = h.end;
     let nextStart = cleaned.length;
-    for (let j = i + 1; j < selectedHeadings.length; j++) {
-      const candidate = selectedHeadings[j]!;
-      if (!candidate.num.startsWith(`${h.num}.`)) {
-        nextStart = candidate.start;
-        break;
-      }
+    for (const candidate of validCandidates) {
+      if (candidate.start <= h.start) continue;
+      if (candidate.start === h.start && candidate.num === h.num) continue;
+      if (candidate.num !== h.num && candidate.num.startsWith(`${h.num}.`)) continue;
+      nextStart = candidate.start;
+      break;
     }
     let content = cleaned.slice(contentStart, nextStart).trim();
     if (content) {
@@ -565,6 +577,17 @@ export type HeadingQueryMatch = {
   fallbackKeywordMatches: string[];
   coverage: number;
   strong: boolean;
+};
+
+export type RejectedHeadingQueryMatch = {
+  sectionNumber: string;
+  title: string;
+  normalizedTitle: string;
+  reasons: string[];
+  score: number;
+  exactTitleMatch: boolean;
+  fullPhraseMatch: boolean;
+  fallbackKeywordMatches: string[];
 };
 
 const HEADING_PREVIEW_MAX = 220;
@@ -844,4 +867,65 @@ export function filterPddHeadingsByQuery(
     .filter((match) => match.strong)
     .sort((a, b) => b.score - a.score || a.heading.sectionNumber.localeCompare(b.heading.sectionNumber, undefined, { numeric: true }))
     .map((match) => match.heading);
+}
+
+export function findRejectedHeadingMatches(
+  rawPddText: string,
+  query: string,
+  fallbackKeywords: string[] = [],
+): RejectedHeadingQueryMatch[] {
+  if (!rawPddText || !query.trim()) return [];
+
+  const cleaned = normalizeText(rawPddText);
+  let allCandidates = findAllRawCandidates(cleaned);
+  if (allCandidates.length === 0) {
+    allCandidates = findHeadingsInContinuousText(cleaned);
+  }
+  if (allCandidates.length === 0) return [];
+
+  const tocBlock = findTocBlockBounds(cleaned);
+  const matches: RejectedHeadingQueryMatch[] = [];
+  const seen = new Set<string>();
+
+  for (const candidate of allCandidates) {
+    const reasons: string[] = [];
+    if (isTocTitle(candidate.title)) reasons.push("line-level TOC markers");
+    if (tocBlock && isInsideTocBlock(candidate.start, tocBlock)) reasons.push("inside TOC block");
+    if (!hasBodyTextAfter(cleaned, candidate.end, candidate.num)) reasons.push("no body text after heading");
+    if (reasons.length === 0) continue;
+
+    const title = stripTocSuffix(candidate.title);
+    const normalizedTitle = normalizeHeadingTitle(title);
+    const score = scoreHeadingAgainstQuery(
+      {
+        sectionNumber: candidate.num,
+        title,
+        normalizedTitle,
+        bodyPreview: "",
+        bodyText: "",
+      },
+      query,
+      fallbackKeywords,
+    );
+    if (!score.strong) continue;
+
+    const key = `${candidate.num}::${normalizedTitle}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    matches.push({
+      sectionNumber: candidate.num,
+      title,
+      normalizedTitle,
+      reasons,
+      score: score.score,
+      exactTitleMatch: score.exactTitleMatch,
+      fullPhraseMatch: score.fullPhraseMatch,
+      fallbackKeywordMatches: score.fallbackKeywordMatches,
+    });
+  }
+
+  return matches.sort(
+    (a, b) => b.score - a.score || a.sectionNumber.localeCompare(b.sectionNumber, undefined, { numeric: true }),
+  );
 }

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -240,6 +240,7 @@ export function extractPddSections(rawText: string): Record<string, string> {
   }
 
   if (selectedHeadings.length === 0) return sections;
+  selectedHeadings.sort((a, b) => a.start - b.start);
 
   for (let i = 0; i < selectedHeadings.length; i++) {
     const h = selectedHeadings[i]!;
@@ -505,6 +506,18 @@ export type DocumentHeading = {
   bodyText: string;
 };
 
+export type HeadingQueryMatch = {
+  heading: DocumentHeading;
+  score: number;
+  exactTitleMatch: boolean;
+  fullPhraseMatch: boolean;
+  exactTokenMatches: string[];
+  softTokenMatches: string[];
+  fallbackKeywordMatches: string[];
+  coverage: number;
+  strong: boolean;
+};
+
 const HEADING_PREVIEW_MAX = 220;
 const HEADING_BODY_MAX = 4000;
 
@@ -514,6 +527,226 @@ function normalizeHeadingTitle(title: string): string {
     .replace(/[^\w\s.-]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+const HEADING_QUERY_PREFIX_RE = /^(?:(?:does|can|could|should|would|will|is|are)\s+(?:this|the)\s+(?:pdd|document)\s+|(?:what|where|when|why|how)\s+(?:is|are|does)\s+(?:this|the)?\s*(?:pdd|document)?\s*|please\s+)+/i;
+const HEADING_QUERY_VERB_RE = /^(?:explain|describe|review|check|evaluate|assess|identify|discuss|justify|mention|outline|summarize|present|provide|include|support|demonstrate|define|show|disclose|contain|address)\s+/i;
+const HEADING_QUERY_STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "by",
+  "does",
+  "for",
+  "from",
+  "how",
+  "in",
+  "into",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "pdd",
+  "project",
+  "section",
+  "that",
+  "the",
+  "their",
+  "this",
+  "those",
+  "under",
+  "what",
+  "when",
+  "where",
+  "which",
+  "with",
+]);
+const HEADING_QUERY_LOW_SIGNAL_TOKENS = new Set([
+  "adequate",
+  "analysis",
+  "assessment",
+  "check",
+  "compliance",
+  "comply",
+  "conditions",
+  "demonstrated",
+  "demonstrate",
+  "describe",
+  "document",
+  "explain",
+  "identify",
+  "justified",
+  "justify",
+  "meets",
+  "evaluate",
+  "evidence",
+  "appropriate",
+  "present",
+  "provide",
+  "question",
+  "report",
+  "requirements",
+  "review",
+  "risk",
+  "show",
+  "support",
+  "suitable",
+]);
+
+function stripHeadingQueryBoilerplate(query: string): string {
+  return normalizeHeadingTitle(query)
+    .replace(HEADING_QUERY_PREFIX_RE, "")
+    .replace(HEADING_QUERY_VERB_RE, "")
+    .trim();
+}
+
+function tokenizeHeadingMatchText(text: string): string[] {
+  return normalizeHeadingTitle(text).split(/\s+/).filter(Boolean);
+}
+
+function buildHeadingQueryTokens(query: string): string[] {
+  return tokenizeHeadingMatchText(stripHeadingQueryBoilerplate(query))
+    .filter((token) => token.length >= 3)
+    .filter((token) => !/[a-z]+\d+|\d+[a-z]+/.test(token))
+    .filter((token) => !HEADING_QUERY_STOP_WORDS.has(token))
+    .filter((token) => !HEADING_QUERY_LOW_SIGNAL_TOKENS.has(token));
+}
+
+function sharedPrefixLength(a: string, b: string): number {
+  const max = Math.min(a.length, b.length);
+  let idx = 0;
+  while (idx < max && a[idx] === b[idx]) idx += 1;
+  return idx;
+}
+
+function tokensLooselyMatch(a: string, b: string): boolean {
+  if (a === b) return true;
+  const shorter = Math.min(a.length, b.length);
+  if (shorter < 6) return false;
+  const prefix = sharedPrefixLength(a, b);
+  return prefix >= 6 && prefix / shorter >= 0.5;
+}
+
+function countContiguousQueryBigrams(queryTokens: string[], titleTokens: string[]): number {
+  if (queryTokens.length < 2 || titleTokens.length < 2) return 0;
+  const titleBigrams = new Set<string>();
+  for (let i = 0; i < titleTokens.length - 1; i += 1) {
+    titleBigrams.add(`${titleTokens[i]} ${titleTokens[i + 1]}`);
+  }
+  let count = 0;
+  for (let i = 0; i < queryTokens.length - 1; i += 1) {
+    if (titleBigrams.has(`${queryTokens[i]} ${queryTokens[i + 1]}`)) count += 1;
+  }
+  return count;
+}
+
+function hasOrderedTokenMatch(queryTokens: string[], titleTokens: string[], allowLoose: boolean): boolean {
+  if (queryTokens.length === 0) return false;
+  let titleIndex = 0;
+  for (const queryToken of queryTokens) {
+    let found = false;
+    while (titleIndex < titleTokens.length) {
+      const titleToken = titleTokens[titleIndex]!;
+      const matched = allowLoose ? tokensLooselyMatch(queryToken, titleToken) : queryToken === titleToken;
+      titleIndex += 1;
+      if (matched) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) return false;
+  }
+  return true;
+}
+
+export function scoreHeadingAgainstQuery(
+  heading: DocumentHeading,
+  query: string,
+  fallbackKeywords: string[] = [],
+): HeadingQueryMatch {
+  const strippedQuery = stripHeadingQueryBoilerplate(query);
+  const queryTokens = buildHeadingQueryTokens(query);
+  const titleTokens = tokenizeHeadingMatchText(heading.normalizedTitle);
+
+  if (!strippedQuery || queryTokens.length === 0) {
+    return {
+      heading,
+      score: 0,
+      exactTitleMatch: false,
+      fullPhraseMatch: false,
+      exactTokenMatches: [],
+      softTokenMatches: [],
+      fallbackKeywordMatches: [],
+      coverage: 0,
+      strong: false,
+    };
+  }
+
+  const exactTokenMatches: string[] = [];
+  const softTokenMatches: string[] = [];
+
+  for (const queryToken of queryTokens) {
+    if (titleTokens.includes(queryToken)) {
+      exactTokenMatches.push(queryToken);
+      continue;
+    }
+    if (titleTokens.some((titleToken) => tokensLooselyMatch(queryToken, titleToken))) {
+      softTokenMatches.push(queryToken);
+    }
+  }
+
+  const exactTitleMatch = heading.normalizedTitle === strippedQuery;
+  const fullPhraseMatch = queryTokens.length >= 2 && heading.normalizedTitle.includes(strippedQuery);
+  const exactOrderedMatch = hasOrderedTokenMatch(queryTokens, titleTokens, false);
+  const looseOrderedMatch = hasOrderedTokenMatch(queryTokens, titleTokens, true);
+  const contiguousBigrams = countContiguousQueryBigrams(queryTokens, titleTokens);
+  const fallbackKeywordMatches = fallbackKeywords.filter((keyword) => {
+    const normalizedKeyword = normalizeHeadingTitle(keyword);
+    return normalizedKeyword.length > 0 && heading.normalizedTitle.includes(normalizedKeyword);
+  });
+  const weightedMatches = exactTokenMatches.length + softTokenMatches.length * 0.7;
+  const coverage = queryTokens.length > 0 ? weightedMatches / queryTokens.length : 0;
+
+  let score = 0;
+  if (exactTitleMatch) score += 280;
+  if (fullPhraseMatch) score += 220;
+  if (exactOrderedMatch && queryTokens.length >= 2) score += 120;
+  else if (looseOrderedMatch && queryTokens.length >= 2) score += 90;
+  score += exactTokenMatches.length * 40;
+  score += softTokenMatches.length * 18;
+  score += contiguousBigrams * 35;
+  score += Math.round(coverage * 100);
+  score += fallbackKeywordMatches.reduce((total, keyword) => total + (keyword.includes(" ") ? 28 : 18), 0);
+  if (queryTokens.length === 1 && exactTokenMatches.length > 0) score += 120;
+  else if (queryTokens.length === 1 && softTokenMatches.length > 0) score += 80;
+
+  const strong =
+    exactTitleMatch
+    || fullPhraseMatch
+    || (fallbackKeywordMatches.length > 0 && (exactTokenMatches.length > 0 || softTokenMatches.length > 0))
+    || (queryTokens.length === 1
+      ? exactTokenMatches.length > 0 || softTokenMatches.length > 0
+      : coverage >= 0.6 && (
+        exactTokenMatches.length >= 2
+        || looseOrderedMatch
+        || contiguousBigrams > 0
+      ));
+
+  return {
+    heading,
+    score,
+    exactTitleMatch,
+    fullPhraseMatch,
+    exactTokenMatches,
+    softTokenMatches,
+    fallbackKeywordMatches,
+    coverage,
+    strong,
+  };
 }
 
 function makeBodyPreview(body: string): string {
@@ -547,17 +780,19 @@ export function buildPddHeadingIndex(rawPddText: string): DocumentHeading[] {
 }
 
 export function headingMatchesQuery(heading: DocumentHeading, query: string): boolean {
-  const q = normalizeHeadingTitle(query);
-  if (!q || q.length < 2) return false;
-  if (heading.normalizedTitle.includes(q)) return true;
-  const STOP = new Set(["project", "pdd", "this", "that", "what", "does", "the", "and", "for", "with", "from"]);
-  const words = q.split(/\s+/).filter((w) => w.length >= 4 && !STOP.has(w));
-  if (words.length === 0) return false;
-  return words.some((w) => heading.normalizedTitle.includes(w));
+  return scoreHeadingAgainstQuery(heading, query).strong;
 }
 
-export function filterPddHeadingsByQuery(headings: DocumentHeading[], query: string): DocumentHeading[] {
+export function filterPddHeadingsByQuery(
+  headings: DocumentHeading[],
+  query: string,
+  fallbackKeywords: string[] = [],
+): DocumentHeading[] {
   const q = query.trim();
   if (!q) return [];
-  return headings.filter((h) => headingMatchesQuery(h, q));
+  return headings
+    .map((heading) => scoreHeadingAgainstQuery(heading, q, fallbackKeywords))
+    .filter((match) => match.strong)
+    .sort((a, b) => b.score - a.score || a.heading.sectionNumber.localeCompare(b.heading.sectionNumber, undefined, { numeric: true }))
+    .map((match) => match.heading);
 }

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -124,11 +124,52 @@ export function extractRoutedSections(
   return result;
 }
 
+function diagnoseHeadingCandidates(rawText: string): string[] {
+  const lines = normalizeText(rawText).split("\n");
+  const candidates: string[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    if (!line || line.length < 2 || line.length > 200) continue;
+
+    const patterns: RegExp[] = [
+      /^\d+(?:\.\d+)*\s+[A-Z]/,
+      /^\d+(?:\.\d+)*\s*[.:]\s*[A-Z]/,
+      /^Section\s+\d+(?:\.\d+)*/i,
+      /^\d+(?:\.\d+)*\s*$/,
+      /^[A-Z][A-Z\s-]{3,60}$/,
+      /\bSECTION\s+\d/i,
+      /\bTABLE\s+OF\s+CONTENTS/i,
+      /^\d+(?:\.\d+)*\s{2,}[A-Z]/,
+    ];
+
+    const nextLine = i + 1 < lines.length ? lines[i + 1]!.trim() : "";
+
+    for (const pattern of patterns) {
+      if (pattern.test(line)) {
+        const nextContext = nextLine && !/^\d/.test(nextLine) ? ` → ${nextLine.slice(0, 60)}` : "";
+        const key = `${line.slice(0, 80)}${nextContext}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          candidates.push(`${line.slice(0, 80)}${nextContext}`);
+        }
+        break;
+      }
+    }
+
+    if (candidates.length >= 50) break;
+  }
+
+  return candidates;
+}
+
 export function debugSectionExtraction(rawText: string): Record<string, string> {
   return {
     rawPddTextLength: String(rawText.length),
     rawPddTextPreview: rawText.slice(0, 2000),
     detectedSections: JSON.stringify(Object.keys(extractPddSections(rawText))),
     headingMatches: JSON.stringify(extractHeadings(normalizeText(rawText)).map((h) => h.num)),
+    headingCandidates: JSON.stringify(diagnoseHeadingCandidates(rawText)),
   };
 }

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -1,6 +1,13 @@
 export const SECTION_EXCERPT_MAX_CHARS = 3000;
+const SECTION_KEY_NORMALIZE_RE = /[^\d.]/g;
 
 const SECTION_HEADING_RE = /^(?:\s*(?:Section\s+)?(\d+(?:\.\d+)*)\s*[.:]?\s+(.+))\s*$/gm;
+const SECTION_HEADING_DOT_RE = /^(?:\s*(?:Section\s+)?(\d+(?:\.\d+)*)\.\s+(.+))\s*$/gm;
+const SECTION_HEADING_PAREN_RE = /^(?:\s*(?:Section\s+)?(\d+(?:\.\d+)*)\s+\((.+)\))\s*$/gm;
+
+export function normalizeSectionKey(key: string): string {
+  return key.replace(SECTION_KEY_NORMALIZE_RE, "").replace(/\.+$/, "").trim();
+}
 
 function stripHeaderFooterNoise(text: string): string {
   return text
@@ -28,20 +35,33 @@ type HeadingMatch = {
   end: number;
 };
 
-function extractHeadings(text: string): HeadingMatch[] {
+function tryHeadingPatterns(text: string, patterns: RegExp[]): HeadingMatch[] {
   const headings: HeadingMatch[] = [];
-  SECTION_HEADING_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = SECTION_HEADING_RE.exec(text)) !== null) {
-    const num = match[1]!;
-    const title = match[2]!.trim();
-    if (!title) continue;
-    if (/^\d/.test(title)) continue;
-    if (title.length > 120) continue;
-    headings.push({ num, title, start: match.index, end: match.index + match[0].length });
+  for (const re of patterns) {
+    re.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text)) !== null) {
+      const num = match[1]!;
+      const title = match[2]!.trim();
+      if (!title) continue;
+      if (/^\d/.test(title)) continue;
+      if (title.length > 120) continue;
+      if (headings.some((h) => h.num === num)) continue;
+      headings.push({ num, title, start: match.index, end: match.index + match[0].length });
+    }
+    re.lastIndex = 0;
   }
-  SECTION_HEADING_RE.lastIndex = 0;
   return headings;
+}
+
+const DEFAULT_HEADING_PATTERNS = [
+  SECTION_HEADING_RE,
+  SECTION_HEADING_DOT_RE,
+  SECTION_HEADING_PAREN_RE,
+];
+
+function extractHeadings(text: string): HeadingMatch[] {
+  return tryHeadingPatterns(text, DEFAULT_HEADING_PATTERNS);
 }
 
 export function extractPddSections(rawText: string): Record<string, string> {
@@ -95,7 +115,7 @@ export function extractPddSections(rawText: string): Record<string, string> {
     if (content.length > SECTION_EXCERPT_MAX_CHARS) {
       content = content.slice(0, SECTION_EXCERPT_MAX_CHARS).replace(/\s+\S*$/, "") + " […]";
     }
-    sections[h.num] = content;
+    sections[normalizeSectionKey(h.num)] = content;
   }
 
   return sections;
@@ -106,7 +126,8 @@ export function extractSectionContent(
   sectionNumber: string,
 ): string | null {
   const sections = extractPddSections(rawText);
-  return sections[sectionNumber] ?? null;
+  const key = normalizeSectionKey(sectionNumber);
+  return sections[key] ?? Object.entries(sections).find(([k]) => normalizeSectionKey(k) === key)?.[1] ?? null;
 }
 
 export function extractRoutedSections(
@@ -116,7 +137,12 @@ export function extractRoutedSections(
   const allSections = extractPddSections(rawText);
   const result: Record<string, string> = {};
   for (const section of relevantSections) {
-    const content = allSections[section];
+    const key = normalizeSectionKey(section);
+    let content = allSections[key] ?? allSections[section];
+    if (!content) {
+      const entry = Object.entries(allSections).find(([k]) => normalizeSectionKey(k) === key);
+      if (entry) content = entry[1];
+    }
     if (content) {
       result[section] = content;
     }
@@ -185,6 +211,27 @@ function findNumericFragments(text: string, maxResults = 50): string[] {
   return results;
 }
 
+function rawLinesAround(rawText: string, sectionNum: string, windowSize = 3): string[] {
+  const lines = rawText.split("\n");
+  const result: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i]!.trim();
+    const headingMatch = trimmed.match(
+      /^(?:Section\s+)?\d+(?:\.\d+)*\s*[.:]?\s+\S/,
+    );
+    if (!headingMatch && !trimmed.startsWith(sectionNum)) continue;
+    const numOnLine = trimmed.match(/\b\d+(?:\.\d+)*\b/)?.[0];
+    if (numOnLine !== sectionNum) continue;
+    const start = Math.max(0, i - windowSize);
+    const end = Math.min(lines.length, i + windowSize + 1);
+    for (let j = start; j < end; j++) {
+      result.push(`L${j + 1}: ${lines[j]}`);
+    }
+    break;
+  }
+  return result;
+}
+
 function diagnoseTextStructure(rawText: string): Record<string, string> {
   const text = rawText.replace(/\s+/g, " ").trim();
 
@@ -202,6 +249,15 @@ function diagnoseTextStructure(rawText: string): Record<string, string> {
   const headingLike = findHeadingLikeFragments(text, 50);
   const numericLike = findNumericFragments(text, 50);
 
+  const rawLines_2_4 = rawLinesAround(rawText, "2.4", 3);
+  const rawLines_2_5 = rawLinesAround(rawText, "2.5", 3);
+  const rawLines_1_10 = rawLinesAround(rawText, "1.10", 3);
+
+  const sections = extractPddSections(rawText);
+  const parsed_2_4 = sections[normalizeSectionKey("2.4")] ? "found" : "missing";
+  const parsed_2_5 = sections[normalizeSectionKey("2.5")] ? "found" : "missing";
+  const parsed_1_10 = sections[normalizeSectionKey("1.10")] ? "found" : "missing";
+
   return {
     rawPddTextLength: String(rawText.length),
     includes_2_4: String(has2_4),
@@ -210,6 +266,12 @@ function diagnoseTextStructure(rawText: string): Record<string, string> {
     includes_baseline: String(hasBaseline),
     includes_additionality: String(hasAdditionality),
     includes_leakage: String(hasLeakage),
+    parsed_2_4,
+    parsed_2_5,
+    parsed_1_10,
+    raw_lines_2_4: JSON.stringify(rawLines_2_4),
+    raw_lines_2_5: JSON.stringify(rawLines_2_5),
+    raw_lines_1_10: JSON.stringify(rawLines_1_10),
     snippets_baseline: JSON.stringify(baselineSnippets),
     snippets_additionality: JSON.stringify(additionalitySnippets),
     snippets_leakage: JSON.stringify(leakageSnippets),

--- a/tests/api/project.export-pdf.route.test.ts
+++ b/tests/api/project.export-pdf.route.test.ts
@@ -400,9 +400,10 @@ describe('/api/projects/[id]/export-pdf route', () => {
     });
     const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);
     const parsed = await extractPdfTextWithPdfParse({ bytes });
+    const normalizedText = parsed.text.replace(/\s+/g, ' ');
 
-    expect(parsed.text).toContain('sampled invoices, monitoring workbook cross-check');
-    expect(parsed.text).toContain('boundary reconciliation used for the draft assessment');
+    expect(normalizedText).toContain('sampled invoices, monitoring workbook cross-check');
+    expect(normalizedText).toContain('boundary reconciliation used for the draft assessment');
     expect(parsed.text).toContain('0123456789abcdef0123456789abcdef');
   }, 15000);
 

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -20,7 +20,29 @@ const PDF_TEXT_BY_FILENAME: Record<string, string> = {
   "boundary.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "boundary-note.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "baseline.pdf": "Monitoring report for the full reporting period.",
+  "pd-redd-legal.pdf": [
+    "Project boundary description for the REDD project.",
+    "The mapped project area polygon and AOI are referenced in the boundary map.",
+    "Project location Machinga District, Malawi.",
+    "1.11  Compliance with Laws, Statutes and Other Regulatory Frameworks",
+    "The project complies with laws and regulations.",
+    "",
+    "1.12  Ownership and Other Programs",
+    "Ownership of the project area is documented.",
+    "",
+    "1.12.1  Right of Use",
+    "The proponent has the right of use over the project area.",
+  ].join("\n"),
   "plum-verra-demo-excerpt.pdf": "Project Description / PD. PLUM Project. Verra VCS / CCB. APD. ARR. VMD0001. VMD0006. VMD0009. VM0007. REDD+ Methodology Framework. Section 3.1 Application of Methodology. Section 3.3 Monitoring. Project boundary description for the PLUM Project. The mapped project area polygon and AOI are referenced in the boundary map. Project location described for the project area. Monitoring report for the full reporting period.",
+  "stakeholder-toc-only.pdf": [
+    "Table of Contents",
+    "6  Stakeholder Comments",
+    "",
+    "Project boundary description for the REDD project.",
+    "The mapped project area polygon and AOI are referenced in the boundary map.",
+    "1.9  Project Location",
+    "Project location Machinga District, Malawi.",
+  ].join("\n"),
   "ambiguous-methods.pdf": "Methodology references include VM0007, GS-VER1, and the monitoring report for the full reporting period.",
   "unknown-acm0010.pdf": "Evidence references ACM0010 and the monitoring report for the full reporting period.",
   "no-method-detected.pdf": "Monitoring report for the full reporting period without any explicit methodology code.",
@@ -958,6 +980,61 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     await flushUi();
     expect(primaryCta().disabled).toBe(false);
+  });
+
+  it("shows legal/property-rights heading matches in the review-question UI", async () => {
+    seedSession({
+      claimText: "Does this PDD explain legal status and property rights?",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-0",
+      filename: "pd-redd-legal.pdf",
+    });
+    await seedAttachmentText("att-upload-1", "%PDF-1.4\n(pd redd legal)\n%%EOF");
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+
+    await flushUi();
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Compliance with Laws, Statutes and Other Regulatory Frameworks");
+    expect(text).toContain("Ownership and Other Programs");
+    expect(text).toContain("Right of Use");
+    expect(text).not.toContain("No matching document section found.");
+  });
+
+  it("distinguishes TOC-only heading matches from recovered body headings", async () => {
+    seedSession({
+      claimText: "Does this PDD include stakeholder comments?",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-0",
+      filename: "stakeholder-toc-only.pdf",
+    });
+    await seedAttachmentText("att-upload-1", "%PDF-1.4\n(stakeholder toc)\n%%EOF");
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+
+    await flushUi();
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("No matching document section found.");
+    expect(text).toContain("§6 Stakeholder Comments");
+    expect(text).toContain("table of contents");
   });
 
   it("supports the cold-load user flow without using the demo path", async () => {

--- a/tests/diagnostics/quick-check-matching.diagnostic.test.ts
+++ b/tests/diagnostics/quick-check-matching.diagnostic.test.ts
@@ -1,0 +1,321 @@
+/**
+ * QUICK CHECK SECTION MATCHING DIAGNOSTIC SCRIPT
+ *
+ * Purpose:
+ *   Given raw extracted PDD text + a user question, print the COMPLETE matching
+ *   path and decision points so we can classify false negatives as:
+ *     - section never detected by extractPddSections
+ *     - title corrupted / polluted
+ *     - headingScore too low (PRIMARY_HEADING_THRESHOLD = 5)
+ *     - candidate rejected by hasBodyTextAfter / TOC / etc.
+ *     - claim keyword extraction too aggressive
+ *     - reviewArea classification sent us down the wrong keyword set
+ *
+ * DO NOT CHANGE MATCHING LOGIC WHILE DEBUGGING.
+ * Only add more print statements here if needed.
+ *
+ * HOW TO RUN
+ * ----------
+ *   # Run everything in this file (recommended)
+ *   npx jest tests/diagnostics/quick-check-matching.diagnostic.test.ts --silent=false
+ *
+ *   # Focus on one specific question
+ *   npx jest tests/diagnostics/quick-check-matching.diagnostic.test.ts -t "DIAG: stakeholder" --silent=false
+ *
+ *   # Focus on the 2.2 case
+ *   npx jest tests/diagnostics/quick-check-matching.diagnostic.test.ts -t "DIAG: without-project" --silent=false
+ *
+ * PASTING REAL EXTRACTIONS FROM THE APP
+ * -------------------------------------
+ * 1. In the browser dev tools, find the uploaded document text (or use the
+ *    "Extraction diagnostic" rawPddTextPreview + full length).
+ * 2. Paste the full raw text below into the MY_PDD_TEXT constant.
+ * 3. Add a new it() block that calls printFullDiagnosticReport with your question.
+ *
+ * The script forces the dev-mode diagnostic path (phase1Diagnostic + matchResults).
+ */
+
+import fs from "fs";
+import path from "path";
+
+import {
+  buildReviewQuestionResult,
+  classifyReviewArea,
+  extractClaimKeywords,
+  computeSectionMatchResults,
+  type ReviewQuestionResult,
+} from "@/lib/chat/quickCheckReviewQuestion";
+
+import {
+  extractPddSections,
+  analyzeSectionCandidates,
+  normalizeSectionKey,
+  type SectionCandidateDebug,
+} from "@/lib/chat/quickCheckSectionExtractor";
+
+// ---------------------------------------------------------------------------
+// FIXTURES
+// ---------------------------------------------------------------------------
+
+const PLUM_FIXTURE_PATH = path.join(__dirname, "..", "fixtures", "quick-check", "plum-pdd-regression.txt");
+const PLUM_TEXT = fs.readFileSync(PLUM_FIXTURE_PATH, "utf-8");
+
+const PD_REDD_FIXTURE_PATH = path.join(__dirname, "..", "fixtures", "quick-check", "pd_redd_v1_130-extracted.txt");
+const PD_REDD_TEXT = fs.readFileSync(PD_REDD_FIXTURE_PATH, "utf-8");
+
+const VM0007_FIXTURE_PATH = path.join(__dirname, "..", "fixtures", "quick-check", "vm0007-pdd-extracted.txt");
+const VM0007_TEXT = fs.readFileSync(VM0007_FIXTURE_PATH, "utf-8");
+
+// ---------------------------------------------------------------------------
+// EASY PLACE TO PASTE A REAL EXTRACTION FROM THE RUNNING APP
+// ---------------------------------------------------------------------------
+const MY_PDD_TEXT = ``; // <-- paste full extracted text here when debugging a real upload
+
+// ---------------------------------------------------------------------------
+// TARGET QUESTIONS FROM THE USER'S CURRENT FALSE NEGATIVES
+// ---------------------------------------------------------------------------
+const QUESTION_STAKEHOLDER = "Does this PDD describe stakeholder engagement?";
+const QUESTION_WITHOUT_PROJECT = "Does this PDD explain the without-project land use scenario and additionality?";
+
+// Also useful variants
+const QUESTION_STAKEHOLDER_VARIANT = "stakeholder engagement";
+const QUESTION_2_2_VARIANT = "without-project land use scenario and additionality";
+
+// ---------------------------------------------------------------------------
+// DIAGNOSTIC PRINTER
+// ---------------------------------------------------------------------------
+
+interface DiagnosticReport {
+  claimText: string;
+  reviewArea: string;
+  claimKeywords: { phrases: string[]; words: string[] };
+  detectedSections: string[];
+  relevantSections: string[];
+  sectionContentKeys: string[];
+  targets: Record<string, {
+    existsInDetected: boolean;
+    titleInExtracted: string | null;
+    sectionContentPresent: boolean;
+    matchResult: any;
+    sectionCandidates: SectionCandidateDebug | null;
+  }>;
+  allMatchResults: any[];
+  rawPddTextLength: number;
+  rawPddTextPreview: string;
+}
+
+function buildDiagnosticReport(
+  claimText: string,
+  rawPddText: string,
+  fixtureLabel: string
+): DiagnosticReport {
+  // Force dev-mode diagnostics inside buildReviewQuestionResult
+  const prevEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "development";
+
+  const result: ReviewQuestionResult = buildReviewQuestionResult({
+    claimText,
+    methodologyId: "VM0007",
+    methodologyVersion: "1.0",
+    rawPddText,
+  });
+
+  process.env.NODE_ENV = prevEnv;
+
+  const phase1 = result.phase1Diagnostic;
+  const allSections = extractPddSections(rawPddText);
+
+  const targetsToInspect = ["2.2", "2.3", "2.1", "2.5", "2.4", "1.10", "3.3"];
+
+  const targets: DiagnosticReport["targets"] = {};
+
+  for (const num of targetsToInspect) {
+    const key = normalizeSectionKey(num);
+    const content = result.sectionContent[num] || result.sectionContent[key] || allSections[key];
+    const match = phase1?.matchResults?.find((m: any) => normalizeSectionKey(m.section) === key);
+    const candidate = phase1?.sectionCandidates?.[key] || null;
+
+    targets[num] = {
+      existsInDetected: key in allSections || Object.keys(allSections).some(k => normalizeSectionKey(k) === key),
+      titleInExtracted: content ? (content.split("\n").find(l => l.trim().length > 0) ?? null) : null,
+      sectionContentPresent: !!result.sectionContent[num] || !!result.sectionContent[key],
+      matchResult: match ? {
+        section: match.section,
+        headingTitle: match.headingTitle,
+        headingScore: match.headingScore,
+        bodyScore: match.bodyScore,
+        totalScore: match.totalScore,
+        included: match.included,
+        rejectionReason: match.rejectionReason,
+        matchedTerms: match.matchedTerms,
+        source: match.source,
+      } : null,
+      sectionCandidates: candidate,
+    };
+  }
+
+  return {
+    claimText,
+    reviewArea: classifyReviewArea(claimText),
+    claimKeywords: extractClaimKeywords(claimText),
+    detectedSections: phase1?.detectedSections ?? Object.keys(allSections),
+    relevantSections: result.relevantSections,
+    sectionContentKeys: Object.keys(result.sectionContent),
+    targets,
+    allMatchResults: phase1?.matchResults ?? [],
+    rawPddTextLength: rawPddText.length,
+    rawPddTextPreview: rawPddText.replace(/\s+/g, " ").slice(0, 300),
+  };
+}
+
+function printFullDiagnosticReport(
+  claimText: string,
+  rawPddText: string,
+  fixtureLabel: string
+): void {
+  const report = buildDiagnosticReport(claimText, rawPddText, fixtureLabel);
+
+  const sep = "═".repeat(80);
+  const sub = "─".repeat(80);
+
+  console.log(`\n${sep}`);
+  console.log(`DIAGNOSTIC: ${fixtureLabel}`);
+  console.log(sep);
+
+  console.log("\nCLAIM TEXT");
+  console.log(sub);
+  console.log(claimText);
+
+  console.log("\nREVIEW AREA (classifyReviewArea)");
+  console.log(sub);
+  console.log(report.reviewArea);
+
+  console.log("\nCLAIM KEYWORDS (extractClaimKeywords)");
+  console.log(sub);
+  console.log("phrases:", JSON.stringify(report.claimKeywords.phrases));
+  console.log("words:  ", JSON.stringify(report.claimKeywords.words));
+
+  console.log("\nDOCUMENT STATS");
+  console.log(sub);
+  console.log("rawPddTextLength:", report.rawPddTextLength);
+  console.log("preview:         ", report.rawPddTextPreview + "...");
+
+  console.log("\nDETECTED SECTIONS (keys returned by extractPddSections)");
+  console.log(sub);
+  console.log(report.detectedSections.sort((a, b) => a.localeCompare(b, undefined, { numeric: true })).join(", "));
+
+  console.log("\nRELEVANT SECTIONS (what buildReviewQuestionResult decided to surface)");
+  console.log(sub);
+  console.log(report.relevantSections.length ? report.relevantSections.join(", ") : "(none)");
+
+  console.log("\nSECTION CONTENT KEYS (actually present in the returned result)");
+  console.log(sub);
+  console.log(report.sectionContentKeys.length ? report.sectionContentKeys.join(", ") : "(none)");
+
+  console.log(`\n${sep}`);
+  console.log("TARGET SECTION ANALYSIS (2.2 / 2.3 / 2.1 / 2.5 + common others)");
+  console.log(sep);
+
+  const interesting = ["2.2", "2.3", "2.1", "2.5", "2.4", "1.10"];
+  for (const num of interesting) {
+    const t = report.targets[num];
+    if (!t) continue;
+
+    console.log(`\n### Section ${num}`);
+    console.log("  detected by extractPddSections? :", t.existsInDetected);
+    console.log("  title stored for scoring        :", JSON.stringify(t.titleInExtracted));
+    console.log("  appeared in final sectionContent?:", t.sectionContentPresent);
+
+    if (t.matchResult) {
+      const m = t.matchResult;
+      console.log("  --- matchResult ---");
+      console.log("  headingScore     :", m.headingScore);
+      console.log("  bodyScore        :", m.bodyScore);
+      console.log("  totalScore       :", m.totalScore);
+      console.log("  included         :", m.included);
+      console.log("  rejectionReason  :", m.rejectionReason ?? "(none)");
+      console.log("  source           :", m.source);
+      console.log("  matchedTerms     :", JSON.stringify(m.matchedTerms));
+      console.log("  headingTitle used:", JSON.stringify(m.headingTitle));
+    } else {
+      console.log("  (no matchResult entry for this section)");
+    }
+
+    if (t.sectionCandidates) {
+      const c = t.sectionCandidates;
+      console.log("  --- analyzeSectionCandidates output ---");
+      console.log("  selectedCandidate:", c.selectedCandidate);
+      console.log("  selectedReason   :", c.selectedReason);
+      console.log("  allCandidateLines:", c.allCandidateLines.length ? c.allCandidateLines : "(none)");
+      if (c.rejectedCandidates.length > 0) {
+        console.log("  rejectedCandidates:");
+        for (const r of c.rejectedCandidates) console.log("    -", r);
+      }
+    } else {
+      console.log("  (no sectionCandidates entry — section may not have been considered)");
+    }
+  }
+
+  console.log(`\n${sep}`);
+  console.log("ALL MATCH RESULTS (sorted by totalScore desc, as seen by the UI)");
+  console.log(sep);
+
+  const sorted = [...report.allMatchResults].sort((a, b) => (b.totalScore ?? 0) - (a.totalScore ?? 0));
+  for (const m of sorted.slice(0, 15)) {
+    const flag = m.included ? "✓" : "✗";
+    console.log(
+      `${flag} ${m.section.padEnd(6)} | h:${String(m.headingScore).padStart(3)} b:${String(m.bodyScore).padStart(3)} tot:${String(m.totalScore).padStart(3)} | ${m.rejectionReason ?? m.headingTitle?.slice(0, 55) ?? ""}`
+    );
+  }
+  if (sorted.length > 15) console.log(`... (${sorted.length - 15} more)`);
+
+  console.log(`\n${sep}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// THE ACTUAL DIAGNOSTIC CASES
+// ---------------------------------------------------------------------------
+
+describe("Quick Check Matching Diagnostics (run with --silent=false)", () => {
+  // These are the two cases the user is currently investigating.
+  // They are intentionally not using .only so the whole file can be run.
+
+  it("DIAG: stakeholder engagement → expected 2.3 (PLUM regression fixture)", () => {
+    printFullDiagnosticReport(QUESTION_STAKEHOLDER, PLUM_TEXT, "PLUM (clean regression)");
+  });
+
+  it("DIAG: without-project land use scenario + additionality → expected 2.2 (PLUM)", () => {
+    printFullDiagnosticReport(QUESTION_WITHOUT_PROJECT, PLUM_TEXT, "PLUM (clean regression)");
+  });
+
+  // Same questions against a real extracted PDF that contains paren headings and page noise.
+  // Useful to see whether the title corruption bug we already found affects scoring.
+  it("DIAG: stakeholder engagement (PD_REDD real extraction with paren headings)", () => {
+    printFullDiagnosticReport(QUESTION_STAKEHOLDER, PD_REDD_TEXT, "PD_REDD_v1_130 (real extraction)");
+  });
+
+  it("DIAG: without-project scenario (PD_REDD real extraction)", () => {
+    printFullDiagnosticReport(QUESTION_WITHOUT_PROJECT, PD_REDD_TEXT, "PD_REDD_v1_130 (real extraction)");
+  });
+
+  // Quick sanity on the VM0007 fixture used in many unit tests
+  it("DIAG: stakeholder engagement (VM0007 fixture)", () => {
+    printFullDiagnosticReport(QUESTION_STAKEHOLDER, VM0007_TEXT, "VM0007 extracted fixture");
+  });
+
+  // If the developer pastes something into MY_PDD_TEXT above, this will run it.
+  if (MY_PDD_TEXT && MY_PDD_TEXT.trim().length > 100) {
+    it("DIAG: stakeholder on MY_PDD_TEXT (paste from real upload)", () => {
+      printFullDiagnosticReport(QUESTION_STAKEHOLDER, MY_PDD_TEXT, "USER_PASTED");
+    });
+
+    it("DIAG: without-project on MY_PDD_TEXT (paste from real upload)", () => {
+      printFullDiagnosticReport(QUESTION_WITHOUT_PROJECT, MY_PDD_TEXT, "USER_PASTED");
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// OPTIONAL: Export a function so it can be required from other scripts later
+// ---------------------------------------------------------------------------
+export { printFullDiagnosticReport, buildDiagnosticReport };

--- a/tests/diagnostics/quick-check-matching.diagnostic.test.ts
+++ b/tests/diagnostics/quick-check-matching.diagnostic.test.ts
@@ -71,15 +71,12 @@ const VM0007_TEXT = fs.readFileSync(VM0007_FIXTURE_PATH, "utf-8");
 // ---------------------------------------------------------------------------
 const MY_PDD_TEXT = ``; // <-- paste full extracted text here when debugging a real upload
 
+// For the new precise failure analysis (user can paste specific PDDs per case)
+const CASE_4_MANAGEMENT_PDD = ``; // Paste the PDD that contains "Management Capacity" and "3.3.3 Data Management"
+
 // ---------------------------------------------------------------------------
 // TARGET QUESTIONS FROM THE USER'S CURRENT FALSE NEGATIVES
-// ---------------------------------------------------------------------------
-const QUESTION_STAKEHOLDER = "Does this PDD describe stakeholder engagement?";
-const QUESTION_WITHOUT_PROJECT = "Does this PDD explain the without-project land use scenario and additionality?";
-
-// Also useful variants
-const QUESTION_STAKEHOLDER_VARIANT = "stakeholder engagement";
-const QUESTION_2_2_VARIANT = "without-project land use scenario and additionality";
+// (Old question constants removed — new focused ones live in the Precise Failure section)
 
 // ---------------------------------------------------------------------------
 // DIAGNOSTIC PRINTER
@@ -319,3 +316,278 @@ describe("Quick Check Matching Diagnostics (run with --silent=false)", () => {
 // OPTIONAL: Export a function so it can be required from other scripts later
 // ---------------------------------------------------------------------------
 export { printFullDiagnosticReport, buildDiagnosticReport };
+
+/**
+ * ============================================================================
+ * PRECISE FAILURE ANALYSIS (New focused diagnostic for ranking issues)
+ * ============================================================================
+ *
+ * This is the main function for the current task.
+ * It produces a clean, structured report designed to answer:
+ * "Why was the exact heading that exists in the uploaded PDD not selected?"
+ */
+
+interface PreciseFailureReport {
+  claimText: string;
+  phrases: string[];
+  tokens: string[];
+  reviewArea: string;
+
+  parsedHeadingCount: number;
+  expectedSectionExists: boolean;
+  exactStoredTitle: string | null;
+  normalizedExpectedTitle: string | null;
+
+  expectedHeadingScore: number;
+  expectedBodyScore: number;
+  expectedTotalScore: number;
+  expectedRejectionReason: string | null;
+
+  selectedSection: string | null;
+  selectedTitle: string | null;
+  selectedTotalScore: number;
+
+  top10Candidates: Array<{
+    section: string;
+    title: string;
+    headingScore: number;
+    bodyScore: number;
+    total: number;
+    included: boolean;
+    rejectionReason?: string;
+  }>;
+
+  analyzeSectionCandidatesOutput: SectionCandidateDebug | null;
+}
+
+function buildPreciseFailureReport(
+  claimText: string,
+  rawPddText: string,
+  expectedSection: string
+): PreciseFailureReport {
+  const prevEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "development";
+
+  const result = buildReviewQuestionResult({
+    claimText,
+    methodologyId: "VM0007",
+    methodologyVersion: "1.0",
+    rawPddText,
+  });
+
+  process.env.NODE_ENV = prevEnv;
+
+  const claimKeywords = extractClaimKeywords(claimText);
+  const reviewArea = classifyReviewArea(claimText);
+
+  const allSections = extractPddSections(rawPddText);
+  const parsedHeadingCount = Object.keys(allSections).length;
+
+  const expectedKey = normalizeSectionKey(expectedSection);
+  const expectedContent = allSections[expectedKey];
+  const exactStoredTitle = expectedContent
+    ? (expectedContent.split("\n").find(l => l.trim().length > 0) ?? null)
+    : null;
+
+  const matchResults = computeSectionMatchResults(rawPddText, reviewArea, claimText);
+
+  const expectedMatch = matchResults.find(m => normalizeSectionKey(m.section) === expectedKey);
+
+  const expectedHeadingScore = expectedMatch?.headingScore ?? 0;
+  const expectedBodyScore = expectedMatch?.bodyScore ?? 0;
+  const expectedTotalScore = expectedMatch?.totalScore ?? 0;
+  const expectedRejectionReason = expectedMatch?.rejectionReason ?? null;
+
+  // What the system actually selected (first relevantSection, or highest included)
+  const selectedSection = result.relevantSections[0] ?? null;
+  let selectedTitle: string | null = null;
+  let selectedTotalScore = 0;
+
+  if (selectedSection) {
+    const selMatch = matchResults.find(m => normalizeSectionKey(m.section) === normalizeSectionKey(selectedSection));
+    selectedTitle = selMatch?.headingTitle ?? null;
+    selectedTotalScore = selMatch?.totalScore ?? 0;
+  }
+
+  // Top 10 candidates by total score
+  const top10 = [...matchResults]
+    .sort((a, b) => (b.totalScore ?? 0) - (a.totalScore ?? 0))
+    .slice(0, 10)
+    .map(m => ({
+      section: m.section,
+      title: m.headingTitle ?? "",
+      headingScore: m.headingScore,
+      bodyScore: m.bodyScore,
+      total: m.totalScore,
+      included: m.included,
+      rejectionReason: m.rejectionReason,
+    }));
+
+  // Detailed rejection analysis for the expected section
+  const analyzeOutput = analyzeSectionCandidates(rawPddText, expectedSection);
+
+  return {
+    claimText,
+    phrases: claimKeywords.phrases,
+    tokens: claimKeywords.words,
+    reviewArea,
+    parsedHeadingCount,
+    expectedSectionExists: !!expectedContent,
+    exactStoredTitle,
+    normalizedExpectedTitle: exactStoredTitle, // for now; could normalize further if needed
+    expectedHeadingScore,
+    expectedBodyScore,
+    expectedTotalScore,
+    expectedRejectionReason,
+    selectedSection,
+    selectedTitle,
+    selectedTotalScore,
+    top10Candidates: top10,
+    analyzeSectionCandidatesOutput: analyzeOutput,
+  };
+}
+
+function printPreciseFailureAnalysis(
+  claimText: string,
+  rawPddText: string,
+  expectedSection: string,
+  caseLabel: string
+): void {
+  if (!rawPddText || rawPddText.trim().length < 50) {
+    console.log(`\n[SKIPPED] ${caseLabel} — No PDD text provided (paste into the appropriate constant)`);
+    return;
+  }
+
+  const r = buildPreciseFailureReport(claimText, rawPddText, expectedSection);
+
+  const sep = "═".repeat(78);
+  const sub = "─".repeat(78);
+
+  console.log(`\n${sep}`);
+  console.log(`PRECISE FAILURE ANALYSIS: ${caseLabel}`);
+  console.log(sep);
+
+  console.log("\nCLAIM TEXT");
+  console.log(sub);
+  console.log(claimText);
+
+  console.log("\nCLAIM KEYWORDS");
+  console.log(sub);
+  console.log("phrases:", JSON.stringify(r.phrases));
+  console.log("tokens: ", JSON.stringify(r.tokens));
+
+  console.log("\nREVIEW AREA");
+  console.log(sub);
+  console.log(r.reviewArea);
+
+  console.log("\nDOCUMENT PARSING");
+  console.log(sub);
+  console.log("parsed heading count:        ", r.parsedHeadingCount);
+  console.log(`expected section ${expectedSection} exists in detectedSections?`, r.expectedSectionExists);
+  console.log("exact stored title:          ", JSON.stringify(r.exactStoredTitle));
+  console.log("normalized title:            ", JSON.stringify(r.normalizedExpectedTitle));
+
+  console.log("\nSCORE FOR EXPECTED SECTION");
+  console.log(sub);
+  console.log("headingScore: ", r.expectedHeadingScore);
+  console.log("bodyScore:    ", r.expectedBodyScore);
+  console.log("totalScore:   ", r.expectedTotalScore);
+  console.log("rejectionReason:", r.expectedRejectionReason ?? "(none — it was considered)");
+
+  console.log("\nWHAT WAS ACTUALLY SELECTED");
+  console.log(sub);
+  console.log("selected section:", r.selectedSection);
+  console.log("selected title:  ", JSON.stringify(r.selectedTitle));
+  console.log("selected score:  ", r.selectedTotalScore);
+
+  console.log("\nTOP 10 CANDIDATES (by total score)");
+  console.log(sub);
+  r.top10Candidates.forEach((c, i) => {
+    const flag = c.included ? "✓" : "✗";
+    const rej = c.rejectionReason ? ` | ${c.rejectionReason}` : "";
+    console.log(
+      `${(i + 1).toString().padStart(2)}. ${flag} ${c.section.padEnd(6)} ` +
+      `h:${c.headingScore.toString().padStart(3)} ` +
+      `b:${c.bodyScore.toString().padStart(3)} ` +
+      `tot:${c.total.toString().padStart(3)} ` +
+      `| ${c.title.slice(0, 55)}${rej}`
+    );
+  });
+
+  console.log("\nDETAILED REJECTION ANALYSIS (analyzeSectionCandidates for expected section)");
+  console.log(sub);
+  const cand = r.analyzeSectionCandidatesOutput;
+  if (cand) {
+    console.log("selectedCandidate:", cand.selectedCandidate);
+    console.log("selectedReason:   ", cand.selectedReason);
+    console.log("allCandidateLines:", cand.allCandidateLines.length ? cand.allCandidateLines : "(none found)");
+    if (cand.rejectedCandidates.length > 0) {
+      console.log("rejectedCandidates:");
+      cand.rejectedCandidates.forEach(rc => console.log("  -", rc));
+    }
+  } else {
+    console.log("(no analyzeSectionCandidates output)");
+  }
+
+  // Automatic classification hint
+  console.log("\nAUTOMATIC FAILURE CLASSIFICATION (heuristic)");
+  console.log(sub);
+  if (!r.expectedSectionExists) {
+    console.log("→ expected section not detected by extractPddSections");
+  } else if (r.exactStoredTitle && r.exactStoredTitle.startsWith("(")) {
+    console.log("→ title corruption detected (leading parenthesis or similar)");
+  } else if (r.phrases.length === 0 && r.tokens.length === 0) {
+    console.log("→ claim phrase / token extraction produced nothing useful");
+  } else if (r.expectedTotalScore < 3) {
+    console.log("→ expected section scored too low (below ABSOLUTE_THRESHOLD)");
+  } else if (r.expectedHeadingScore < 5) {
+    console.log("→ expected section headingScore too low (below PRIMARY_HEADING_THRESHOLD = 5)");
+  } else if (r.selectedSection && r.selectedSection !== expectedSection) {
+    console.log("→ wrong candidate outranked the expected section");
+  } else {
+    console.log("→ unclear — needs manual review of the data above");
+  }
+
+  console.log(`\n${sep}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// NEW FOCUSED DIAGNOSTIC RUN — ONLY THE 4 FAILING CASES
+// ---------------------------------------------------------------------------
+
+const QUESTION_STAKEHOLDER = "Does this PDD describe stakeholder engagement?";
+const QUESTION_WITHOUT_PROJECT = "Does this PDD explain the without-project land use scenario and additionality?";
+const QUESTION_LEGAL = "Does this PDD describe legal status and property rights?";
+const QUESTION_MANAGEMENT = "Does this PDD describe management capacity?";
+
+describe("Precise Failure Analysis — 4 Current False Negatives (run with --silent=false)", () => {
+  it("CASE 1: Stakeholder engagement → expected 2.3", () => {
+    // Uses PLUM fixture (has 2.3)
+    printPreciseFailureAnalysis(QUESTION_STAKEHOLDER, PLUM_TEXT, "2.3", "Case 1: Stakeholder Engagement (PLUM)");
+  });
+
+  it("CASE 2: Without-project + additionality → expected 2.2", () => {
+    printPreciseFailureAnalysis(QUESTION_WITHOUT_PROJECT, PLUM_TEXT, "2.2", "Case 2: Without-project scenario (PLUM)");
+  });
+
+  it("CASE 3: Legal status and property rights → expected 2.5", () => {
+    // PLUM has 2.5
+    printPreciseFailureAnalysis(QUESTION_LEGAL, PLUM_TEXT, "2.5", "Case 3: Legal status (PLUM)");
+  });
+
+  it("CASE 4: Management capacity → expected 2.4 (not 3.3.3)", () => {
+    // Requires real PDD text containing "Management Capacity" and "3.3.3 Data Management"
+    printPreciseFailureAnalysis(QUESTION_MANAGEMENT, CASE_4_MANAGEMENT_PDD, "2.4", "Case 4: Management Capacity");
+  });
+
+  // Convenience: if user pastes into MY_PDD_TEXT, run all four against it
+  if (MY_PDD_TEXT && MY_PDD_TEXT.trim().length > 100) {
+    it("ALL 4 CASES against MY_PDD_TEXT (paste from real failing upload)", () => {
+      console.log("\n>>> Running all 4 cases against user-pasted MY_PDD_TEXT <<<\n");
+      printPreciseFailureAnalysis(QUESTION_STAKEHOLDER, MY_PDD_TEXT, "2.3", "Stakeholder (MY_PDD_TEXT)");
+      printPreciseFailureAnalysis(QUESTION_WITHOUT_PROJECT, MY_PDD_TEXT, "2.2", "Without-project (MY_PDD_TEXT)");
+      printPreciseFailureAnalysis(QUESTION_LEGAL, MY_PDD_TEXT, "2.5", "Legal status (MY_PDD_TEXT)");
+      printPreciseFailureAnalysis(QUESTION_MANAGEMENT, MY_PDD_TEXT, "2.4", "Management capacity (MY_PDD_TEXT)");
+    });
+  }
+});

--- a/tests/fixtures/quick-check/pd_redd_v1_130-extracted.txt
+++ b/tests/fixtures/quick-check/pd_redd_v1_130-extracted.txt
@@ -1,0 +1,59 @@
+VCS Version 4.2
+VM0007 REDD+ Methodology Modules
+
+Project Description Document: PD_REDD_v1_130
+
+Page 1 of 85
+
+1.1  Project Background
+The project is located in the central region of the country and encompasses
+approximately 15,000 hectares of tropical forest. The area has been subject
+to deforestation pressure from agricultural expansion and illegal logging.
+
+1.9  Project Boundary
+The project area is defined by the following geographic coordinates as
+provided in Annex 1. The leakage belt extends 5 km from the project boundary.
+
+v4.2
+
+2.3  Carbon Pools
+The following carbon pools are included in the project boundary:
+Above-ground biomass, below-ground biomass, dead wood, litter,
+and soil organic carbon.
+
+Page 10 of 85
+
+2.4 (Baseline Scenario)
+The baseline scenario is the most likely land-use scenario in the absence
+of the project activity. The project area consists of tropical forest that
+would otherwise be converted to agricultural land. Historical deforestation
+rates have been estimated at 1.2% per year based on satellite imagery
+analysis covering the period 2010-2020. Without the project, carbon stocks
+would continue to decline due to ongoing deforestation and forest degradation.
+
+VM0007 Version 4.2
+
+2.5 (Additionality)
+The project is additional because it faces significant barriers to
+implementation. A barrier analysis is provided in the following paragraphs.
+The investment analysis demonstrates that the project is not financially
+viable without carbon revenue. The common practice analysis confirms that
+similar REDD+ activities are not widespread in the region.
+
+Page 15 of 85
+
+2.6  Deviations
+No deviations from the methodology are proposed at this time.
+
+1.10 (Leakage)
+The leakage belt for this project is determined using the default 5 km
+buffer approach as specified in VM0007. Activity shifting leakage is
+expected to be minimal due to the limited availability of alternative
+forest areas for displacement. Market leakage is not expected to be
+significant given the small scale of the project relative to the regional
+timber market.
+
+3.3  Monitoring
+Monitoring will be conducted annually using permanent sample plots.
+A total of 75 plots are established across the project area using a
+stratified random sampling design.

--- a/tests/fixtures/quick-check/plum-pdd-extracted.txt
+++ b/tests/fixtures/quick-check/plum-pdd-extracted.txt
@@ -1,0 +1,9 @@
+Project Description / PD
+PLUM Project
+Verra VCS / CCB
+VM0007
+Section 3.1 Application of Methodology
+Section 3.3 Monitoring
+REDD+ Methodology Framework
+
+-- 1 of 1 --

--- a/tests/fixtures/quick-check/plum-pdd-regression.txt
+++ b/tests/fixtures/quick-check/plum-pdd-regression.txt
@@ -8,11 +8,12 @@ Table of Contents
 1.1  Project Background ........................................................ 3
 1.2  Project Objective ......................................................... 4
 1.3  Project Location .......................................................... 5
-2.1  Project Area .............................................................. 6
+2.1  Project Goals, Design and Long-Term Viability ............................. 6
 2.2  Without-project Land Use Scenario and Additionality ........................ 7
 2.3  Stakeholder Engagement .................................................... 8
 2.5  Legal Status and Property Rights .......................................... 9
 3.1  Application of Methodology ................................................ 10
+3.1.2  Applicability of Methodology ........................................... 10.5
 3.3  Monitoring ................................................................ 11
 3.3.3  Monitoring Plan ........................................................ 13
 
@@ -28,10 +29,8 @@ The objective of this project is to restore degraded forest landscapes.
 1.3  Project Location
 The project is located in the central region of the country.
 
-2.1  Project Area
-The project area comprises 5,000 hectares of degraded grassland.
-The geographic coordinates are provided in Annex 1.
-The project zone extends 3 km beyond the project boundary.
+2.1  Project Goals, Design and Long-Term Viability
+The project goals are to restore degraded forest landscapes and ensure long-term viability through carbon finance. The project design includes reforestation of 5,000 hectares with native species. Long-term management plans secure permanence.
 
 2.2  Without-project Land Use Scenario and Additionality
 The without-project land use scenario assumes continued degradation
@@ -51,6 +50,9 @@ Property rights are held by the local community association.
 The methodology VM0007 is applied to quantify emission reductions.
 Carbon pools included are above-ground biomass, below-ground biomass,
 dead wood, litter, and soil organic carbon.
+
+3.1.2  Applicability of Methodology
+The project meets all applicability conditions of VM0007. The land is degraded and reforestation is eligible. No wetlands or peat soils are present in the project area.
 
 3.3  Monitoring
 Monitoring will be conducted annually using permanent sample plots.

--- a/tests/fixtures/quick-check/plum-pdd-regression.txt
+++ b/tests/fixtures/quick-check/plum-pdd-regression.txt
@@ -11,9 +11,10 @@ Table of Contents
 2.1  Project Area .............................................................. 6
 2.2  Without-project Land Use Scenario and Additionality ........................ 7
 2.3  Stakeholder Engagement .................................................... 8
-3.1  Application of Methodology ................................................ 9
-3.3  Monitoring ................................................................ 10
-3.3.3  Monitoring Plan ........................................................ 12
+2.5  Legal Status and Property Rights .......................................... 9
+3.1  Application of Methodology ................................................ 10
+3.3  Monitoring ................................................................ 11
+3.3.3  Monitoring Plan ........................................................ 13
 
 --- Document Body ---
 
@@ -41,6 +42,10 @@ that carbon finance is essential to overcome the investment barrier.
 2.3  Stakeholder Engagement
 Stakeholder engagement was conducted through community meetings.
 Local communities were consulted about the project design.
+
+2.5  Legal Status and Property Rights
+The project area has clear land tenure and carbon rights.
+Property rights are held by the local community association.
 
 3.1  Application of Methodology
 The methodology VM0007 is applied to quantify emission reductions.

--- a/tests/fixtures/quick-check/plum-pdd-regression.txt
+++ b/tests/fixtures/quick-check/plum-pdd-regression.txt
@@ -1,0 +1,57 @@
+Project Description / PD
+PLUM Project
+Verra VCS / CCB
+VM0007
+
+Table of Contents
+
+1.1  Project Background ........................................................ 3
+1.2  Project Objective ......................................................... 4
+1.3  Project Location .......................................................... 5
+2.1  Project Area .............................................................. 6
+2.2  Without-project Land Use Scenario and Additionality ........................ 7
+2.3  Stakeholder Engagement .................................................... 8
+3.1  Application of Methodology ................................................ 9
+3.3  Monitoring ................................................................ 10
+3.3.3  Monitoring Plan ........................................................ 12
+
+--- Document Body ---
+
+1.1  Project Background
+This project is a reforestation activity in the central highlands.
+The project area encompasses 5,000 hectares of degraded land.
+
+1.2  Project Objective
+The objective of this project is to restore degraded forest landscapes.
+
+1.3  Project Location
+The project is located in the central region of the country.
+
+2.1  Project Area
+The project area comprises 5,000 hectares of degraded grassland.
+The geographic coordinates are provided in Annex 1.
+The project zone extends 3 km beyond the project boundary.
+
+2.2  Without-project Land Use Scenario and Additionality
+The without-project land use scenario assumes continued degradation
+of grassland due to overgrazing. The project is additional because it
+faces significant barriers to implementation. A barrier analysis shows
+that carbon finance is essential to overcome the investment barrier.
+
+2.3  Stakeholder Engagement
+Stakeholder engagement was conducted through community meetings.
+Local communities were consulted about the project design.
+
+3.1  Application of Methodology
+The methodology VM0007 is applied to quantify emission reductions.
+Carbon pools included are above-ground biomass, below-ground biomass,
+dead wood, litter, and soil organic carbon.
+
+3.3  Monitoring
+Monitoring will be conducted annually using permanent sample plots.
+A total of 50 plots are established across the project area.
+The monitoring plan includes measurements of tree diameter and height.
+
+3.3.3  Monitoring Plan
+The monitoring plan specifies the sampling design and measurement
+protocols. Data and parameters are recorded in the monitoring database.

--- a/tests/fixtures/quick-check/vm0007-pdd-extracted.txt
+++ b/tests/fixtures/quick-check/vm0007-pdd-extracted.txt
@@ -1,0 +1,54 @@
+VM0007 Version 1.1
+Project Description Document
+
+Page 1 of 42
+
+1.1  Project Background
+This project is a reforestation activity in the central highlands.
+The project area encompasses 5,000 hectares of degraded land.
+
+Page 2 of 42
+
+1.9  Project Boundary
+The project area is located in the central region of the country.
+Geographic coordinates are provided in Annex 1.
+The leakage belt extends 3 km from the project boundary.
+
+v1.1
+
+2.3  Carbon Pools
+The following carbon pools are included in the project boundary:
+Above-ground biomass, below-ground biomass, dead wood, litter,
+and soil organic carbon.
+
+Page 3 of 42
+
+2.4  Baseline Scenario
+The baseline scenario is the most likely land-use scenario in the
+absence of the project activity. The project area consists of
+degraded grassland that has been subject to overgrazing for the
+past decade. Without the project, carbon stocks would continue
+to decline.
+
+VM0007 Version 1.1
+
+2.5  Additionality
+The project is additional because it faces significant barriers
+to implementation. A barrier analysis is provided in the
+following paragraphs. The investment analysis demonstrates that
+the project is not financially viable without carbon revenue.
+
+Page 4 of 42
+
+2.6  Deviations
+No deviations from the methodology are proposed.
+
+1.10  Leakage
+The leakage belt for this project is determined using the
+default 3 km buffer approach as specified in VM0007.
+Activity shifting leakage is expected to be minimal.
+
+3.3  Monitoring
+Monitoring will be conducted annually using permanent sample
+plots. A total of 50 plots are established across the project
+area.

--- a/tests/lib/quickCheckPdfExtractor.test.ts
+++ b/tests/lib/quickCheckPdfExtractor.test.ts
@@ -98,7 +98,7 @@ describe("quick check pdf-parse extractor", () => {
       { pageNumber: 1, text: "Page one text" },
       { pageNumber: 2, text: "Page two text" },
     ]);
-    expect(result.text).toBe("Page one text Page two text");
+    expect(result.text).toBe("Page one text\n\nPage two text");
     expect(result.metadata.diagnostics).toEqual(expect.objectContaining({
       parserPath: "provided-parser",
       pageExtractionAttempted: true,
@@ -183,6 +183,35 @@ describe("quick check pdf-parse extractor", () => {
       extractedTextLength: 97,
       pageCount: 1,
       partialTextRecovered: true,
+    }));
+  });
+
+  it("prefers page text over flattened full-document text when both are available", async () => {
+    getTextMock.mockResolvedValue({
+      text: "2.1 Project Goals, Design and Long-Term Viability 16 2.2 Without-project Land Use Scenario and Additionality 54",
+      pages: [
+        { num: 1, text: "2.1 Project Goals, Design and Long-Term Viability\nProject goals body." },
+        { num: 2, text: "2.2 Without-project Land Use Scenario and Additionality\nAdditionality body." },
+      ],
+    });
+
+    const result = await extractPdfTextWithPdfParse({
+      bytes: new TextEncoder().encode("%PDF-helper-pages").buffer,
+      PdfParseClass: PdfParseClassMock as never,
+    });
+
+    expect(result.text).toBe([
+      "2.1 Project Goals, Design and Long-Term Viability",
+      "Project goals body.",
+      "",
+      "2.2 Without-project Land Use Scenario and Additionality",
+      "Additionality body.",
+    ].join("\n"));
+    expect(result.metadata.diagnostics).toEqual(expect.objectContaining({
+      parserPath: "provided-parser",
+      pageExtractionAttempted: true,
+      textFallbackAttempted: false,
+      pageCount: 2,
     }));
   });
 

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -4,12 +4,14 @@ import path from "path";
 import {
   buildReviewQuestionResult,
   classifyReviewArea,
+  computeSectionMatchResults,
   detectReviewPath,
   extractClaimKeywords,
   findMatchedSectionNumbers,
   resolveReviewSections,
   reviewAreaLabel,
   type ReviewArea,
+  type SectionMatchResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
 
 const VM0007_BASELINE_PDD_TEXT = [
@@ -505,5 +507,105 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     });
     expect(result.relevantSections).toEqual([]);
     expect(result.sectionContent).toEqual({});
+  });
+
+  it("does not include section 1.1 (Project Background) when asking about project goals and design", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe the project goals, design, and long-term viability?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: CUSTOM_HEADING_PDD,
+    });
+    expect(result.relevantSections).not.toContain("1.1");
+    expect(result.relevantSections).toContain("2.1");
+  });
+
+  it("caps primary sections to top 3", () => {
+    const manySections = [
+      "1.1  Introduction",
+      "Intro content.",
+      "2.1  Additionality and Baseline",
+      "Additionality and baseline content.",
+      "2.2  Baseline Scenario and Additionality",
+      "More baseline content.",
+      "2.3  Additionality Analysis",
+      "Additionality analysis.",
+      "2.4  Another Additionality Section",
+      "More additionality.",
+      "2.5  Additionality Evidence",
+      "Evidence for additionality.",
+    ].join("\n");
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD demonstrate additionality?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: manySections,
+    });
+    expect(result.relevantSections.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("computeSectionMatchResults — match diagnostics", () => {
+  const PDD = [
+    "2.1  Project Area",
+    "The project area comprises 5,000 hectares.",
+    "",
+    "2.2  Baseline Scenario",
+    "The baseline scenario is the most likely land-use scenario.",
+    "",
+  ].join("\n");
+
+  it("reports heading matches with correct scores", () => {
+    const results = computeSectionMatchResults(PDD, "baseline", "Does this PDD contain the baseline scenario?");
+    const match2_2 = results.find(r => r.section === "2.2")!;
+    expect(match2_2).toBeDefined();
+    expect(match2_2.headingScore).toBeGreaterThan(0);
+    expect(match2_2.matchedTerms.length).toBeGreaterThan(0);
+    expect(match2_2.included).toBe(true);
+  });
+
+  it("reports non-matching sections with rejection reasons", () => {
+    const results = computeSectionMatchResults(PDD, "baseline", "Does this PDD contain the baseline scenario?");
+    const match2_1 = results.find(r => r.section === "2.1")!;
+    expect(match2_1).toBeDefined();
+    expect(match2_1.totalScore).toBe(0);
+    expect(match2_1.rejectionReason).toContain("below absolute threshold");
+    expect(match2_1.included).toBe(false);
+  });
+
+  it("reports source (heading, body, or both)", () => {
+    const results = computeSectionMatchResults(PDD, "baseline", "Does this PDD contain the baseline scenario?");
+    const match2_2 = results.find(r => r.section === "2.2")!;
+    expect(["heading", "both"]).toContain(match2_2.source);
+    const match2_1 = results.find(r => r.section === "2.1")!;
+    expect(match2_1.source).toBe("none");
+  });
+
+  it("rejects unreasonable section IDs (standalone integer without decimal)", () => {
+    const pddWithBadIds = [
+      "20. Some section without sub-number",
+      "Content for section 20.",
+    ].join("\n");
+    const results = computeSectionMatchResults(pddWithBadIds, "general", "Does this PDD describe something?");
+    const badMatch = results.find(r => r.section === "20");
+    expect(badMatch).toBeDefined();
+    expect(badMatch!.rejectionReason).toContain("unreasonable section");
+    expect(badMatch!.included).toBe(false);
+  });
+
+  it("populates phase1Diagnostic.matchResults in dev mode", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD contain the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PDD,
+    });
+    expect(result.phase1Diagnostic).toBeDefined();
+    if (result.phase1Diagnostic) {
+      expect(result.phase1Diagnostic.matchResults).toBeDefined();
+      expect(result.phase1Diagnostic.matchResults.length).toBeGreaterThan(0);
+      expect(result.phase1Diagnostic.claimKeywords).toBeDefined();
+      expect(result.phase1Diagnostic.claimKeywords.phrases.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -451,9 +451,9 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
       methodologyVersion: "1.0",
       rawPddText: PLUM_TEXT,
     });
+    expect(result.relevantSections[0]).toBe("3.1.2");
     expect(result.relevantSections).toContain("3.1");
     expect(result.sectionContent["3.1"]).toBeDefined();
-    expect(result.sectionContent["3.1"]).toContain("Methodology");
   });
 
   it("matches remote sensing for monitoring question to monitoring-related sections", () => {
@@ -490,6 +490,17 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(result.sectionContent["3.5"]).toBeUndefined();
     expect(result.sectionContent["20.0"]).toBeUndefined();
     expect(result.sectionContent["3.3.1"]).toBeUndefined();
+  });
+
+  it("returns no match when only generic project words overlap but no heading is a strong title match", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe the project boundary?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: CUSTOM_HEADING_PDD,
+    });
+    expect(result.relevantSections).toEqual([]);
+    expect(result.sectionContent).toEqual({});
   });
 
   it("returns relevantSections sorted by relevance (best match first)", () => {
@@ -582,6 +593,7 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     // filter by acceptance phrases surfaces correct heading (title match only)
     const goals = filterPddHeadingsByQuery(result.headingIndex, "Project Goals, Design and Long-Term Viability");
     expect(goals[0]?.sectionNumber).toBe("2.1");
+    expect(goals.some((h) => h.sectionNumber === "2.3")).toBe(false);
 
     const without = filterPddHeadingsByQuery(result.headingIndex, "Without-project Land Use Scenario and Additionality");
     expect(without[0]?.sectionNumber).toBe("2.2");
@@ -628,28 +640,28 @@ describe("computeSectionMatchResults — match diagnostics", () => {
     const match2_1 = results.find(r => r.section === "2.1")!;
     expect(match2_1).toBeDefined();
     expect(match2_1.totalScore).toBe(0);
-    expect(match2_1.rejectionReason).toContain("below absolute threshold");
+    expect(match2_1.rejectionReason).toContain("no heading/title match");
     expect(match2_1.included).toBe(false);
   });
 
-  it("reports source (heading, body, or both)", () => {
+  it("reports source as heading-only for primary matches", () => {
     const results = computeSectionMatchResults(PDD, "baseline", "Does this PDD contain the baseline scenario?");
     const match2_2 = results.find(r => r.section === "2.2")!;
-    expect(["heading", "both"]).toContain(match2_2.source);
+    expect(match2_2.source).toBe("heading");
     const match2_1 = results.find(r => r.section === "2.1")!;
     expect(match2_1.source).toBe("none");
   });
 
-  it("rejects unreasonable section IDs (standalone integer without decimal)", () => {
+  it("accepts top-level section numbers when the heading title is a strong match", () => {
     const pddWithBadIds = [
-      "20. Some section without sub-number",
-      "Content for section 20.",
+      "4  Monitoring",
+      "Monitoring is conducted annually.",
     ].join("\n");
-    const results = computeSectionMatchResults(pddWithBadIds, "general", "Does this PDD describe something?");
-    const badMatch = results.find(r => r.section === "20");
-    expect(badMatch).toBeDefined();
-    expect(badMatch!.rejectionReason).toContain("unreasonable section");
-    expect(badMatch!.included).toBe(false);
+    const results = computeSectionMatchResults(pddWithBadIds, "monitoring", "Does this PDD describe monitoring?");
+    const match = results.find(r => r.section === "4");
+    expect(match).toBeDefined();
+    expect(match!.included).toBe(true);
+    expect(match!.source).toBe("heading");
   });
 
   it("populates phase1Diagnostic.matchResults in dev mode", () => {

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -467,6 +467,18 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(result.sectionContent["3.3.3.1"]!.toLowerCase()).toContain("remote sensing");
   });
 
+  it("matches legal status and property rights question to section 2.5", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe legal status and property rights?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PLUM_TEXT,
+    });
+    expect(result.relevantSections).toContain("2.5");
+    expect(result.sectionContent["2.5"]).toBeDefined();
+    expect(result.sectionContent["2.5"]).toContain("land tenure");
+  });
+
   it("does not match random sections like biodiversity, financial analysis, or Remote Sensing", () => {
     const result = buildReviewQuestionResult({
       claimText: "Does this PDD explain the project area and project zone boundary?",

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -21,6 +21,43 @@ const VM0007_BASELINE_PDD_TEXT = [
   "",
 ].join("\n");
 
+const REALISTIC_PDD_TEXT = [
+  "VM0007 Version 1.1",
+  "Project Description Document",
+  "",
+  "Page 1 of 42",
+  "",
+  "1.9  Project Boundary",
+  "The project area is located in the central region.",
+  "Geographic coordinates are provided in the annex.",
+  "",
+  "Page 2 of 42",
+  "",
+  "2.4  Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario",
+  "in the absence of the project activity. The project area",
+  "consists of degraded grassland that has been subject to",
+  "overgrazing for the past decade.",
+  "",
+  "Page 3 of 42",
+  "VM0007 Version 1.1",
+  "",
+  "2.5  Additionality",
+  "The project is additional because it faces significant",
+  "barriers to implementation. A barrier analysis is provided",
+  "in the following paragraphs.",
+  "",
+].join("\n");
+
+const PDD_WITH_PAGE_BREAKS = [
+  "1.10  Leakage",
+  "The leakage belt is defined as a 3 km buffer around the project area.\f",
+  "Monitoring of the leakage belt will occur annually.\f",
+  "2.4  Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario.\f",
+  "Carbon stocks are expected to decline without the project.",
+].join("\n");
+
 describe("detectReviewPath", () => {
   it("routes 'Does this PDD support additionality under VT0001?' to review_question_answering", () => {
     expect(detectReviewPath("Does this PDD support additionality under VT0001?")).toBe("review_question_answering");
@@ -250,5 +287,46 @@ describe("buildReviewQuestionResult — section content extraction (Phase 1)", (
     expect(result.reviewArea).toBe("general");
     expect(result.relevantSections).toEqual([]);
     expect(result.sectionContent).toEqual({});
+  });
+
+  it("extracts sections from realistic PDD text with header/footer noise", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Is the baseline scenario appropriate?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: REALISTIC_PDD_TEXT,
+    });
+    expect(result.sectionContent["2.4"]).toBeDefined();
+    expect(result.sectionContent["2.4"]).toContain("overgrazing");
+    expect(result.sectionContent["2.4"]).not.toContain("VM0007 Version");
+    expect(result.sectionContent["2.5"]).toBeDefined();
+    expect(result.sectionContent["2.5"]).toContain("barrier analysis");
+  });
+
+  it("extracts sections from PDD text with page break characters", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Is the baseline scenario appropriate?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PDD_WITH_PAGE_BREAKS,
+    });
+    expect(result.sectionContent["2.4"]).toBeDefined();
+    expect(result.sectionContent["2.4"]).toContain("land-use scenario");
+    expect(result.sectionContent["2.4"]).toContain("Carbon stocks");
+    expect(result.sectionContent["1.10"]).toBeDefined();
+    expect(result.sectionContent["1.10"]).toContain("Monitoring of the leakage belt");
+  });
+
+  it("extracts all three baseline sections from real-world PDD noise", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: REALISTIC_PDD_TEXT,
+    });
+    expect(result.relevantSections).toEqual(["2.4", "2.5", "1.10"]);
+    expect(result.sectionContent["2.4"]).toBeDefined();
+    expect(result.sectionContent["2.5"]).toBeDefined();
+    expect(result.sectionContent["1.9"]).toBeUndefined();
   });
 });

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -13,6 +13,7 @@ import {
   type ReviewArea,
   type SectionMatchResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
+import { filterPddHeadingsByQuery } from "@/lib/chat/quickCheckSectionExtractor";
 
 const VM0007_BASELINE_PDD_TEXT = [
   "1.10  Leakage",
@@ -536,7 +537,7 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(result.relevantSections).toContain("2.1");
   });
 
-  it("caps primary sections to top 3", () => {
+  it("returns all matching headings from filter (no artificial cap)", () => {
     const manySections = [
       "1.1  Introduction",
       "Intro content.",
@@ -557,7 +558,49 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
       methodologyVersion: "1.0",
       rawPddText: manySections,
     });
-    expect(result.relevantSections.length).toBeLessThanOrEqual(3);
+    // Phase 1: filter returns *all* title matches (no artificial top-3 cap from scoring logic)
+    expect(result.relevantSections.length).toBeGreaterThan(3);
+    expect(result.relevantSections).toContain("2.1");
+    expect(result.relevantSections).toContain("2.5");
+  });
+
+  it("PLUM PDD heading index includes required sections and question phrases filter correctly (Phase 1 acceptance)", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PLUM_TEXT,
+    });
+    const nums = new Set(result.headingIndex.map((h) => h.sectionNumber));
+    expect(nums.has("2.1")).toBe(true);
+    expect(nums.has("2.2")).toBe(true);
+    expect(nums.has("2.3")).toBe(true);
+    expect(nums.has("2.5")).toBe(true);
+    expect(nums.has("3.1.2")).toBe(true);
+    expect(nums.has("3.3")).toBe(true);
+
+    // filter by acceptance phrases surfaces correct heading (title match only)
+    const goals = filterPddHeadingsByQuery(result.headingIndex, "Project Goals, Design and Long-Term Viability");
+    expect(goals[0]?.sectionNumber).toBe("2.1");
+
+    const without = filterPddHeadingsByQuery(result.headingIndex, "Without-project Land Use Scenario and Additionality");
+    expect(without[0]?.sectionNumber).toBe("2.2");
+
+    const stake = filterPddHeadingsByQuery(result.headingIndex, "Stakeholder Engagement");
+    expect(stake[0]?.sectionNumber).toBe("2.3");
+
+    const legal = filterPddHeadingsByQuery(result.headingIndex, "Legal Status and Property Rights");
+    expect(legal[0]?.sectionNumber).toBe("2.5");
+
+    const appl = filterPddHeadingsByQuery(result.headingIndex, "Applicability of Methodology");
+    expect(appl.some((h) => h.sectionNumber === "3.1.2")).toBe(true);
+
+    const mon = filterPddHeadingsByQuery(result.headingIndex, "Monitoring");
+    expect(mon.some((h) => h.sectionNumber === "3.3")).toBe(true);
+
+    // no match case
+    const none = filterPddHeadingsByQuery(result.headingIndex, "biodiversity credits xyz");
+    expect(none.length).toBe(0);
   });
 });
 

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
 import {
   buildReviewQuestionResult,
   classifyReviewArea,
   detectReviewPath,
+  extractClaimKeywords,
+  findMatchedSectionNumbers,
   resolveReviewSections,
   reviewAreaLabel,
   type ReviewArea,
@@ -331,5 +335,175 @@ describe("buildReviewQuestionResult — section content extraction (Phase 1)", (
     });
     expect(leakResult.sectionContent["1.10"]).toBeDefined();
     expect(leakResult.sectionContent["1.10"]).toContain("Monitoring of the leakage belt");
+  });
+});
+
+const PLUM_FIXTURE_PATH = path.join(__dirname, "..", "fixtures", "quick-check", "plum-pdd-regression.txt");
+const PLUM_TEXT = fs.readFileSync(PLUM_FIXTURE_PATH, "utf-8");
+
+const CUSTOM_HEADING_PDD = [
+  "2.1  Project Goals, Design and Long-Term Viability",
+  "The project goals are to restore degraded land.",
+  "The project design includes reforestation of 5,000 hectares.",
+  "",
+  "2.3  Stakeholder Engagement",
+  "Stakeholder engagement was conducted through community meetings.",
+  "",
+  "3.3.3.1  Remote Sensing",
+  "Remote sensing data from satellites is used for monitoring.",
+  "NDVI analysis is conducted quarterly.",
+  "",
+  "3.5  Biodiversity Assessment",
+  "Biodiversity is assessed annually using transect surveys.",
+  "",
+  "20.0  Financial Analysis",
+  "The financial analysis shows IRR of 12%.",
+  "",
+].join("\n");
+
+describe("extractClaimKeywords", () => {
+  it("extracts phrases and words from a stakeholder engagement question", () => {
+    const { phrases, words } = extractClaimKeywords("Does this PDD describe stakeholder engagement?");
+    expect(phrases).toEqual(["stakeholder engagement"]);
+    expect(words).toContain("stakeholder");
+    expect(words).toContain("engagement");
+  });
+
+  it("extracts phrases split by 'and' and commas", () => {
+    const { phrases, words } = extractClaimKeywords("Does this PDD describe the project goals, design, and long-term viability?");
+    expect(phrases).toContain("project goals");
+    expect(phrases).toContain("design");
+    expect(phrases).toContain("long-term viability");
+    expect(words).toContain("goals");
+    expect(words).toContain("viability");
+  });
+
+  it("extracts methodology-related keywords without stripping them", () => {
+    const { phrases, words } = extractClaimKeywords("Does this PDD explain applicability of VM0007 methodology?");
+    expect(phrases).toContain("applicability of vm0007 methodology");
+    expect(words).toContain("applicability");
+    expect(words).toContain("vm0007");
+    expect(words).toContain("methodology");
+  });
+
+  it("filters out generic stop words like 'project' and 'area'", () => {
+    const { words } = extractClaimKeywords("Does this PDD explain the project area and project zone boundary?");
+    expect(words).not.toContain("project");
+    expect(words).not.toContain("area");
+    expect(words).toContain("zone");
+    expect(words).toContain("boundary");
+  });
+
+  it("returns empty for very short text", () => {
+    const { phrases, words } = extractClaimKeywords("Hi");
+    expect(phrases).toEqual([]);
+    expect(words).toEqual([]);
+  });
+});
+
+describe("claim-text-based heading matching (acceptance tests)", () => {
+  it("matches stakeholder engagement question to section 2.3", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe stakeholder engagement?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PLUM_TEXT,
+    });
+    expect(result.relevantSections).toContain("2.3");
+    expect(result.sectionContent["2.3"]).toBeDefined();
+    expect(result.sectionContent["2.3"]).toContain("Stakeholder engagement");
+  });
+
+  it("matches without-project land use scenario and additionality question to section 2.2", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD explain the without-project land use scenario and additionality?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PLUM_TEXT,
+    });
+    expect(result.relevantSections).toContain("2.2");
+    expect(result.sectionContent["2.2"]).toBeDefined();
+    expect(result.sectionContent["2.2"]).toContain("without-project land use scenario");
+  });
+
+  it("matches project goals question to section 2.1 by heading title keywords", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe the project goals, design, and long-term viability?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: CUSTOM_HEADING_PDD,
+    });
+    expect(result.relevantSections).toContain("2.1");
+    expect(result.sectionContent["2.1"]).toBeDefined();
+    expect(result.sectionContent["2.1"]).toContain("restore degraded land");
+  });
+
+  it("matches applicability of VM0007 methodology question to methodology-related sections", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD explain applicability of VM0007 methodology?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PLUM_TEXT,
+    });
+    expect(result.relevantSections).toContain("3.1");
+    expect(result.sectionContent["3.1"]).toBeDefined();
+    expect(result.sectionContent["3.1"]).toContain("Methodology");
+  });
+
+  it("matches remote sensing for monitoring question to monitoring-related sections", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe remote sensing for monitoring?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: CUSTOM_HEADING_PDD,
+    });
+    expect(result.relevantSections).toContain("3.3.3.1");
+    expect(result.sectionContent["3.3.3.1"]).toBeDefined();
+    expect(result.sectionContent["3.3.3.1"]).toContain("Remote sensing");
+  });
+
+  it("does not match random sections like biodiversity or financial analysis", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD explain the project area and project zone boundary?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: CUSTOM_HEADING_PDD,
+    });
+    expect(result.sectionContent["3.5"]).toBeUndefined();
+    expect(result.sectionContent["20.0"]).toBeUndefined();
+  });
+
+  it("returns relevantSections sorted by relevance (best match first)", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe remote sensing for monitoring?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: CUSTOM_HEADING_PDD,
+    });
+    const sections = result.relevantSections;
+    expect(sections.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("works even when reviewArea is 'general' with no keywords (pure claim-text matching)", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe stakeholder engagement?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PLUM_TEXT,
+    });
+    expect(classifyReviewArea("Does this PDD describe stakeholder engagement?")).toBe("general");
+    expect(result.relevantSections.length).toBeGreaterThan(0);
+    expect(result.relevantSections).toContain("2.3");
+  });
+
+  it("returns empty when no heading matches claim keywords or review area", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe stakeholder engagement?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: "This PDD has no numbered sections at all.",
+    });
+    expect(result.relevantSections).toEqual([]);
+    expect(result.sectionContent).toEqual({});
   });
 });

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -351,9 +351,12 @@ const CUSTOM_HEADING_PDD = [
   "2.3  Stakeholder Engagement",
   "Stakeholder engagement was conducted through community meetings.",
   "",
-  "3.3.3.1  Remote Sensing",
+  "3.3.1  Remote Sensing",
   "Remote sensing data from satellites is used for monitoring.",
   "NDVI analysis is conducted quarterly.",
+  "",
+  "3.3.3.1  Remote Sensing — Detailed Methods",
+  "Detailed remote sensing methods are described here.",
   "",
   "3.5  Biodiversity Assessment",
   "Biodiversity is assessed annually using transect surveys.",
@@ -461,10 +464,10 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     });
     expect(result.relevantSections).toContain("3.3.3.1");
     expect(result.sectionContent["3.3.3.1"]).toBeDefined();
-    expect(result.sectionContent["3.3.3.1"]).toContain("Remote sensing");
+    expect(result.sectionContent["3.3.3.1"]!.toLowerCase()).toContain("remote sensing");
   });
 
-  it("does not match random sections like biodiversity or financial analysis", () => {
+  it("does not match random sections like biodiversity, financial analysis, or Remote Sensing", () => {
     const result = buildReviewQuestionResult({
       claimText: "Does this PDD explain the project area and project zone boundary?",
       methodologyId: "VM0007",
@@ -473,6 +476,7 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     });
     expect(result.sectionContent["3.5"]).toBeUndefined();
     expect(result.sectionContent["20.0"]).toBeUndefined();
+    expect(result.sectionContent["3.3.1"]).toBeUndefined();
   });
 
   it("returns relevantSections sorted by relevance (best match first)", () => {

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -1,11 +1,25 @@
 import { describe, expect, it } from "@jest/globals";
 import {
+  buildReviewQuestionResult,
   classifyReviewArea,
   detectReviewPath,
   resolveReviewSections,
   reviewAreaLabel,
   type ReviewArea,
 } from "@/lib/chat/quickCheckReviewQuestion";
+
+const VM0007_BASELINE_PDD_TEXT = [
+  "1.10  Leakage",
+  "The leakage belt is defined as a 3 km buffer.",
+  "",
+  "2.4  Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario without the project.",
+  "The project area consists of degraded grassland.",
+  "",
+  "2.5  Additionality",
+  "The project is additional and faces barriers to implementation.",
+  "",
+].join("\n");
 
 describe("detectReviewPath", () => {
   it("routes 'Does this PDD support additionality under VT0001?' to review_question_answering", () => {
@@ -165,4 +179,76 @@ describe("reviewAreaLabel", () => {
       expect(reviewAreaLabel(area).length).toBeGreaterThan(0);
     });
   }
+});
+
+describe("buildReviewQuestionResult — section content extraction (Phase 1)", () => {
+  it("populates sectionContent for VM0007 baseline sections when PDD text is provided", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Is the baseline scenario appropriate?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: VM0007_BASELINE_PDD_TEXT,
+    });
+    expect(result.sectionContent["2.4"]).toBeDefined();
+    expect(result.sectionContent["2.4"]).toContain("degraded grassland");
+    expect(result.sectionContent["2.5"]).toBeDefined();
+    expect(result.sectionContent["2.5"]).toContain("barriers to implementation");
+  });
+
+  it("returns empty sectionContent when no PDD text is provided", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Is the baseline scenario appropriate?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+    });
+    expect(result.sectionContent).toEqual({});
+  });
+
+  it("returns empty sectionContent for non-VM0007 methodology even with PDD text", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Is the baseline scenario appropriate?",
+      methodologyId: "AR-ACM0003",
+      methodologyVersion: "1.0",
+      rawPddText: VM0007_BASELINE_PDD_TEXT,
+    });
+    expect(result.sectionContent).toEqual({});
+  });
+
+  it("leaves sectionContent empty for sections that cannot be extracted", () => {
+    const textWithoutRelevantSections = "This PDD text has no section headings at all.";
+    const result = buildReviewQuestionResult({
+      claimText: "Is the baseline scenario appropriate?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: textWithoutRelevantSections,
+    });
+    expect(result.relevantSections).toContain("2.4");
+    expect(result.relevantSections).toContain("1.10");
+    expect(result.sectionContent["2.4"]).toBeUndefined();
+    expect(result.sectionContent["1.10"]).toBeUndefined();
+  });
+
+  it("extracts section 1.10 content even when it is not in the baseline route priority", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Is the baseline scenario appropriate?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: VM0007_BASELINE_PDD_TEXT,
+    });
+    expect(result.relevantSections).toContain("1.10");
+    expect(result.sectionContent["1.10"]).toBeDefined();
+    expect(result.sectionContent["1.10"]).toContain("3 km buffer");
+  });
+
+  it("handles empty claim text gracefully", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: VM0007_BASELINE_PDD_TEXT,
+    });
+    expect(result.reviewArea).toBe("general");
+    expect(result.relevantSections).toEqual([]);
+    expect(result.sectionContent).toEqual({});
+  });
 });

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -533,6 +533,25 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(result.sectionContent["6"]).toContain("Stakeholder comments");
   });
 
+  it("explains TOC-only stakeholder matches instead of treating them as body headings", () => {
+    const pdd = [
+      "Table of Contents",
+      "6  Stakeholder Comments",
+      "",
+      "1.9  Project Location",
+      "The project location is described in the body text.",
+    ].join("\n");
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD include stakeholder comments?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: pdd,
+    });
+    expect(result.relevantSections).toEqual([]);
+    expect(result.noMatchExplanation).toContain("§6 Stakeholder Comments");
+    expect(result.noMatchExplanation).toContain("table of contents");
+  });
+
   it("does not match random sections like biodiversity, financial analysis, or Remote Sensing", () => {
     const result = buildReviewQuestionResult({
       claimText: "Does this PDD explain the project area and project zone boundary?",

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -172,36 +172,15 @@ describe("classifyReviewArea — deviations", () => {
   });
 });
 
-describe("resolveReviewSections — VM0007", () => {
-  it("maps additionality to sections 2.5, 2.4, 1.10", () => {
-    expect(resolveReviewSections("VM0007", "additionality")).toEqual(["2.5", "2.4", "1.10"]);
-  });
-
-  it("maps baseline to sections 2.4, 2.5, 1.10", () => {
-    expect(resolveReviewSections("VM0007", "baseline")).toEqual(["2.4", "2.5", "1.10"]);
-  });
-
-  it("maps boundary to sections 2.3, 1.9", () => {
-    expect(resolveReviewSections("VM0007", "boundary")).toEqual(["2.3", "1.9"]);
-  });
-
-  it("maps deviations to section 2.6", () => {
-    expect(resolveReviewSections("VM0007", "deviations")).toEqual(["2.6"]);
-  });
-
-  it("maps leakage to sections 1.13, 3.3", () => {
-    expect(resolveReviewSections("VM0007", "leakage")).toEqual(["1.13", "3.3"]);
-  });
-
-  it("maps monitoring to section 4", () => {
-    expect(resolveReviewSections("VM0007", "monitoring")).toEqual(["4"]);
-  });
-
-  it("maps right_of_use to sections 1.11, 1.12.1", () => {
-    expect(resolveReviewSections("VM0007", "right_of_use")).toEqual(["1.11", "1.12.1"]);
-  });
-
-  it("returns empty array for non-VM0007 methodology", () => {
+describe("resolveReviewSections — static routing (deprecated, returns empty)", () => {
+  it("returns empty array for any methodology", () => {
+    expect(resolveReviewSections("VM0007", "additionality")).toEqual([]);
+    expect(resolveReviewSections("VM0007", "baseline")).toEqual([]);
+    expect(resolveReviewSections("VM0007", "boundary")).toEqual([]);
+    expect(resolveReviewSections("VM0007", "deviations")).toEqual([]);
+    expect(resolveReviewSections("VM0007", "leakage")).toEqual([]);
+    expect(resolveReviewSections("VM0007", "monitoring")).toEqual([]);
+    expect(resolveReviewSections("VM0007", "right_of_use")).toEqual([]);
     expect(resolveReviewSections("AR-ACM0003", "baseline")).toEqual([]);
   });
 });
@@ -219,7 +198,7 @@ describe("reviewAreaLabel", () => {
 });
 
 describe("buildReviewQuestionResult — section content extraction (Phase 1)", () => {
-  it("populates sectionContent for VM0007 baseline sections when PDD text is provided", () => {
+  it("populates sectionContent for baseline heading when PDD text is provided", () => {
     const result = buildReviewQuestionResult({
       claimText: "Is the baseline scenario appropriate?",
       methodologyId: "VM0007",
@@ -228,6 +207,15 @@ describe("buildReviewQuestionResult — section content extraction (Phase 1)", (
     });
     expect(result.sectionContent["2.4"]).toBeDefined();
     expect(result.sectionContent["2.4"]).toContain("degraded grassland");
+  });
+
+  it("populates sectionContent for additionality heading", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Is additionality demonstrated?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: VM0007_BASELINE_PDD_TEXT,
+    });
     expect(result.sectionContent["2.5"]).toBeDefined();
     expect(result.sectionContent["2.5"]).toContain("barriers to implementation");
   });
@@ -241,17 +229,18 @@ describe("buildReviewQuestionResult — section content extraction (Phase 1)", (
     expect(result.sectionContent).toEqual({});
   });
 
-  it("returns empty sectionContent for non-VM0007 methodology even with PDD text", () => {
+  it("does not use methodology to restrict section extraction — any methodology works", () => {
     const result = buildReviewQuestionResult({
       claimText: "Is the baseline scenario appropriate?",
       methodologyId: "AR-ACM0003",
       methodologyVersion: "1.0",
       rawPddText: VM0007_BASELINE_PDD_TEXT,
     });
-    expect(result.sectionContent).toEqual({});
+    expect(result.sectionContent["2.4"]).toBeDefined();
+    expect(result.sectionContent["2.4"]).toContain("degraded grassland");
   });
 
-  it("leaves sectionContent empty for sections that cannot be extracted", () => {
+  it("leaves sectionContent empty when no headings can be extracted", () => {
     const textWithoutRelevantSections = "This PDD text has no section headings at all.";
     const result = buildReviewQuestionResult({
       claimText: "Is the baseline scenario appropriate?",
@@ -259,15 +248,13 @@ describe("buildReviewQuestionResult — section content extraction (Phase 1)", (
       methodologyVersion: "1.0",
       rawPddText: textWithoutRelevantSections,
     });
-    expect(result.relevantSections).toContain("2.4");
-    expect(result.relevantSections).toContain("1.10");
-    expect(result.sectionContent["2.4"]).toBeUndefined();
-    expect(result.sectionContent["1.10"]).toBeUndefined();
+    expect(result.relevantSections).toEqual([]);
+    expect(result.sectionContent).toEqual({});
   });
 
-  it("extracts section 1.10 content even when it is not in the baseline route priority", () => {
+  it("extracts section 1.10 content for leakage review area", () => {
     const result = buildReviewQuestionResult({
-      claimText: "Is the baseline scenario appropriate?",
+      claimText: "Does this PDD disclose leakage risk?",
       methodologyId: "VM0007",
       methodologyVersion: "1.0",
       rawPddText: VM0007_BASELINE_PDD_TEXT,
@@ -289,7 +276,7 @@ describe("buildReviewQuestionResult — section content extraction (Phase 1)", (
     expect(result.sectionContent).toEqual({});
   });
 
-  it("extracts sections from realistic PDD text with header/footer noise", () => {
+  it("extracts baseline section from realistic PDD text with header/footer noise", () => {
     const result = buildReviewQuestionResult({
       claimText: "Is the baseline scenario appropriate?",
       methodologyId: "VM0007",
@@ -299,8 +286,6 @@ describe("buildReviewQuestionResult — section content extraction (Phase 1)", (
     expect(result.sectionContent["2.4"]).toBeDefined();
     expect(result.sectionContent["2.4"]).toContain("overgrazing");
     expect(result.sectionContent["2.4"]).not.toContain("VM0007 Version");
-    expect(result.sectionContent["2.5"]).toBeDefined();
-    expect(result.sectionContent["2.5"]).toContain("barrier analysis");
   });
 
   it("extracts sections from PDD text with page break characters", () => {
@@ -313,20 +298,38 @@ describe("buildReviewQuestionResult — section content extraction (Phase 1)", (
     expect(result.sectionContent["2.4"]).toBeDefined();
     expect(result.sectionContent["2.4"]).toContain("land-use scenario");
     expect(result.sectionContent["2.4"]).toContain("Carbon stocks");
-    expect(result.sectionContent["1.10"]).toBeDefined();
-    expect(result.sectionContent["1.10"]).toContain("Monitoring of the leakage belt");
   });
 
-  it("extracts all three baseline sections from real-world PDD noise", () => {
+  it("matches sections by heading title not by static route", () => {
     const result = buildReviewQuestionResult({
       claimText: "Does this PDD justify the baseline scenario?",
       methodologyId: "VM0007",
       methodologyVersion: "1.0",
       rawPddText: REALISTIC_PDD_TEXT,
     });
-    expect(result.relevantSections).toEqual(["2.4", "2.5", "1.10"]);
+    expect(result.relevantSections).toEqual(["2.4"]);
     expect(result.sectionContent["2.4"]).toBeDefined();
-    expect(result.sectionContent["2.5"]).toBeDefined();
+    expect(result.sectionContent["2.5"]).toBeUndefined();
     expect(result.sectionContent["1.9"]).toBeUndefined();
+  });
+
+  it("extracts additionality, leakage sections using their own claim texts", () => {
+    const addResult = buildReviewQuestionResult({
+      claimText: "Is additionality demonstrated?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: REALISTIC_PDD_TEXT,
+    });
+    expect(addResult.sectionContent["2.5"]).toBeDefined();
+    expect(addResult.sectionContent["2.5"]).toContain("barrier analysis");
+
+    const leakResult = buildReviewQuestionResult({
+      claimText: "Does this PDD disclose leakage risk?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PDD_WITH_PAGE_BREAKS,
+    });
+    expect(leakResult.sectionContent["1.10"]).toBeDefined();
+    expect(leakResult.sectionContent["1.10"]).toContain("Monitoring of the leakage belt");
   });
 });

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -78,6 +78,10 @@ describe("detectReviewPath", () => {
     expect(detectReviewPath("Does this PDD disclose methodology deviations?")).toBe("review_question_answering");
   });
 
+  it("routes 'Does this PDD include stakeholder comments?' to review_question_answering", () => {
+    expect(detectReviewPath("Does this PDD include stakeholder comments?")).toBe("review_question_answering");
+  });
+
   it("routes 'Is the baseline scenario appropriate?' to review_question_answering", () => {
     expect(detectReviewPath("Is the baseline scenario appropriate?")).toBe("review_question_answering");
   });
@@ -176,6 +180,16 @@ describe("classifyReviewArea — leakage", () => {
 describe("classifyReviewArea — deviations", () => {
   it("classifies methodology deviations", () => {
     expect(classifyReviewArea("Does this PDD disclose methodology deviations?")).toBe("deviations");
+  });
+});
+
+describe("classifyReviewArea — right_of_use", () => {
+  it("classifies legal status and property rights", () => {
+    expect(classifyReviewArea("Does this PDD explain legal status and property rights?")).toBe("right_of_use");
+  });
+
+  it("classifies compliance with laws and ownership", () => {
+    expect(classifyReviewArea("Does this PDD explain compliance with laws and ownership?")).toBe("right_of_use");
   });
 });
 
@@ -478,6 +492,45 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(result.relevantSections).toContain("2.5");
     expect(result.sectionContent["2.5"]).toBeDefined();
     expect(result.sectionContent["2.5"]).toContain("land tenure");
+  });
+
+  it("matches legal status / property rights query to compliance, ownership, and right-of-use headings", () => {
+    const pdd = [
+      "1.11  Compliance with Laws, Statutes and Other Regulatory Frameworks",
+      "The project complies with laws and regulations.",
+      "",
+      "1.12  Ownership and Other Programs",
+      "Ownership of the project area is documented.",
+      "",
+      "1.12.1  Right of Use",
+      "The proponent has the right of use over the project area.",
+      "",
+    ].join("\n");
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD explain legal status and property rights?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: pdd,
+    });
+    expect(result.relevantSections).toEqual(expect.arrayContaining(["1.11", "1.12", "1.12.1"]));
+  });
+
+  it("matches stakeholder comments when the document has a real body heading for it", () => {
+    const pdd = [
+      "6  Stakeholder Comments",
+      "Stakeholder comments were collected during consultation and summarized here.",
+      "",
+      "6.1  Resolution of Comments",
+      "The project addressed the comments in follow-up meetings.",
+    ].join("\n");
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD include stakeholder comments?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: pdd,
+    });
+    expect(result.relevantSections).toContain("6");
+    expect(result.sectionContent["6"]).toContain("Stakeholder comments");
   });
 
   it("does not match random sections like biodiversity, financial analysis, or Remote Sensing", () => {

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -72,6 +72,20 @@ const WRAPPED_HEADING_TEXT = [
 
 const NO_SECTION_TEXT = "This is a plain document with no section headings whatsoever.";
 
+const SPLIT_HEADING_TEXT = [
+  "Some introductory text.",
+  "",
+  "2.4",
+  "Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario",
+  "in the absence of the project activity.",
+  "",
+  "2.5",
+  "Additionality",
+  "The project is additional and faces barriers to implementation.",
+  "",
+].join("\n");
+
 describe("extractPddSections", () => {
   it("extracts section 2.4 (Baseline Scenario) from VM0007 PDD text", () => {
     const sections = extractPddSections(VM0007_PDD_TEXT);
@@ -138,6 +152,16 @@ describe("extractPddSections", () => {
 
   it("returns an empty object for text with no section headings", () => {
     expect(extractPddSections(NO_SECTION_TEXT)).toEqual({});
+  });
+
+  it("handles split headings where number and title are on separate lines", () => {
+    const sections = extractPddSections(SPLIT_HEADING_TEXT);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("Baseline Scenario");
+    expect(sections["2.4"]).toContain("most likely land-use scenario");
+    expect(sections["2.5"]).toBeDefined();
+    expect(sections["2.5"]).toContain("Additionality");
+    expect(sections["2.5"]).toContain("barriers to implementation");
   });
 
   it("strips page break characters before parsing", () => {

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -721,3 +721,55 @@ describe("PD_REDD_v1_130 fixture — parentheses heading format", () => {
     expect(result.phase1Diagnostic!.sectionContent_1_10_preview).toContain("leakage belt");
   });
 });
+
+describe("pipeline-normalized text (preserves newlines like normalizePageWhitespace)", () => {
+  const PIPELINE_TEXT = [
+    "Table of Contents",
+    "",
+    "1.1  Project Background .................................................. 5",
+    "1.9  Project Boundary ................................................... 8",
+    "2.3  Carbon Pools ...................................................... 12",
+    "2.4  Baseline Scenario ................................................. 14",
+    "2.5  Additionality ..................................................... 16",
+    "2.6  Deviations ........................................................ 18",
+    "1.10  Leakage .......................................................... 20",
+    "3.3  Monitoring ........................................................ 22",
+    "",
+    "--- Document Body ---",
+    "",
+    "1.1  Project Background",
+    "This project is a reforestation activity in the central highlands.",
+    "",
+    "1.9  Project Boundary",
+    "The project area is located in the central region of the country.",
+    "",
+    "2.4  Baseline Scenario",
+    "The baseline scenario is the most likely land-use scenario in the",
+    "absence of the project activity. Carbon stocks would continue to decline.",
+    "",
+    "2.5  Additionality",
+    "The project is additional because it faces significant barriers",
+    "to implementation. A barrier analysis is provided below.",
+    "",
+    "1.10  Leakage",
+    "The leakage belt for this project is determined using the default",
+    "3 km buffer approach as specified in VM0007.",
+  ].join("\n");
+
+  it("extracts body content, not TOC entries, from pipeline-normalized text", () => {
+    const sections = extractPddSections(PIPELINE_TEXT);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("most likely land-use scenario");
+    expect(sections["2.4"]).not.toMatch(/\.{3,}/);
+    expect(sections["2.5"]).toContain("barrier analysis");
+    expect(sections["2.5"]).not.toMatch(/\.{3,}/);
+    expect(sections["1.10"]).toContain("leakage belt");
+    expect(sections["1.10"]).toContain("3 km buffer");
+  });
+
+  it("rejects TOC entries and selects only body sections", () => {
+    const sections = extractPddSections(PIPELINE_TEXT);
+    const hasDottedLeaders = Object.values(sections).some((v) => /\.{4,}/.test(v));
+    expect(hasDottedLeaders).toBe(false);
+  });
+});

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -9,7 +9,7 @@ import {
   normalizeSectionKey,
   SECTION_EXCERPT_MAX_CHARS,
 } from "@/lib/chat/quickCheckSectionExtractor";
-import { buildReviewQuestionResult } from "@/lib/chat/quickCheckReviewQuestion";
+import { buildReviewQuestionResult, findMatchedSectionNumbers } from "@/lib/chat/quickCheckReviewQuestion";
 
 const VM0007_PDD_TEXT = [
   "1.10  Leakage",
@@ -321,17 +321,31 @@ describe("continuous text (whitespace-collapsed, no line breaks)", () => {
     expect(sections["1.10"]).toContain("3 km buffer");
   });
 
-  it("extracts all three baseline sections from continuous text via buildReviewQuestionResult", () => {
+  it("extracts matched sections from continuous text via buildReviewQuestionResult", () => {
     const text = "2.4 Baseline Scenario The baseline scenario is the most likely land-use scenario. 2.5 Additionality The project is additional. 1.10 Leakage The leakage belt is determined.";
-    const result = buildReviewQuestionResult({
+    const baselineResult = buildReviewQuestionResult({
       claimText: "Does this PDD support the baseline scenario under VM0007?",
       methodologyId: "VM0007",
       methodologyVersion: "1.0",
       rawPddText: text,
     });
-    expect(result.sectionContent["2.4"]).toBeDefined();
-    expect(result.sectionContent["2.5"]).toBeDefined();
-    expect(result.sectionContent["1.10"]).toBeDefined();
+    expect(baselineResult.sectionContent["2.4"]).toBeDefined();
+
+    const additionalityResult = buildReviewQuestionResult({
+      claimText: "Is additionality justified under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: text,
+    });
+    expect(additionalityResult.sectionContent["2.5"]).toBeDefined();
+
+    const leakageResult = buildReviewQuestionResult({
+      claimText: "Does this PDD identify leakage risk under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: text,
+    });
+    expect(leakageResult.sectionContent["1.10"]).toBeDefined();
   });
 });
 
@@ -488,22 +502,36 @@ describe("TOC vs body content", () => {
   });
 
   it("extracts body sections via buildReviewQuestionResult, not TOC lines", () => {
-    const result = buildReviewQuestionResult({
+    const baselineResult = buildReviewQuestionResult({
       claimText: "Does this PDD support the baseline scenario under VM0007?",
       methodologyId: "VM0007",
       methodologyVersion: "1.0",
       rawPddText: TOC_THEN_BODY_TEXT,
     });
-    const c24 = result.sectionContent["2.4"];
-    const c25 = result.sectionContent["2.5"];
-    const c110 = result.sectionContent["1.10"];
+    const c24 = baselineResult.sectionContent["2.4"];
     expect(c24).toBeDefined();
-    expect(c25).toBeDefined();
-    expect(c110).toBeDefined();
     expect(c24).toContain("most likely land-use scenario");
-    expect(c25.replace(/\n/g, " ")).toMatch(/barrier\s+analysis/);
-    expect(c110.replace(/\s+/g, " ")).toMatch(/\b3\s*km\s*buffer\b/);
     expect(c24).not.toMatch(/\.{3,}/);
+
+    const additionalityResult = buildReviewQuestionResult({
+      claimText: "Is additionality justified under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: TOC_THEN_BODY_TEXT,
+    });
+    const c25 = additionalityResult.sectionContent["2.5"];
+    expect(c25).toBeDefined();
+    expect(c25.replace(/\n/g, " ")).toMatch(/barrier\s+analysis/);
+
+    const leakageResult = buildReviewQuestionResult({
+      claimText: "Does this PDD identify leakage risk under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: TOC_THEN_BODY_TEXT,
+    });
+    const c110 = leakageResult.sectionContent["1.10"];
+    expect(c110).toBeDefined();
+    expect(c110.replace(/\s+/g, " ")).toMatch(/\b3\s*km\s*buffer\b/);
   });
 
   it("analyzeSectionCandidates returns all candidates with rejection reasons", () => {
@@ -617,19 +645,34 @@ describe("fixture-based regression — real extracted PDD text format", () => {
     expect(sections["1.10"]).toContain("3 km buffer");
   });
 
-  it("routes and extracts all baseline sections from fixture via buildReviewQuestionResult", () => {
-    const result = buildReviewQuestionResult({
+  it("routes and extracts matched sections per review area from fixture via buildReviewQuestionResult", () => {
+    const baselineResult = buildReviewQuestionResult({
       claimText: "Does this PDD support the baseline scenario under VM0007?",
       methodologyId: "VM0007",
       methodologyVersion: "1.0",
       rawPddText: fixtureText,
     });
-    expect(result.sectionContent["2.4"]).toBeDefined();
-    expect(result.sectionContent["2.5"]).toBeDefined();
-    expect(result.sectionContent["1.10"]).toBeDefined();
-    expect(result.sectionContent["2.4"]).toContain("overgrazing");
-    expect(result.sectionContent["2.5"]).toContain("carbon revenue");
-    expect(result.sectionContent["1.10"]).toContain("3 km buffer");
+    expect(baselineResult.sectionContent["2.4"]).toBeDefined();
+    expect(baselineResult.sectionContent["2.4"]).toContain("overgrazing");
+    expect(baselineResult.sectionContent["2.5"]).toBeUndefined();
+
+    const additionalityResult = buildReviewQuestionResult({
+      claimText: "Is additionality justified under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: fixtureText,
+    });
+    expect(additionalityResult.sectionContent["2.5"]).toBeDefined();
+    expect(additionalityResult.sectionContent["2.5"]).toContain("carbon revenue");
+
+    const leakageResult = buildReviewQuestionResult({
+      claimText: "Does this PDD identify leakage risk under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: fixtureText,
+    });
+    expect(leakageResult.sectionContent["1.10"]).toBeDefined();
+    expect(leakageResult.sectionContent["1.10"]).toContain("3 km buffer");
   });
 
   it("strips header/footer noise from fixture-extracted section content", () => {
@@ -673,22 +716,25 @@ describe("PD_REDD_v1_130 fixture — parentheses heading format", () => {
     expect(c.replace(/\n/g, " ")).toMatch(/\b5\s*km\s*buffer\b/);
   });
 
-  it("routes and extracts all baseline sections from PD_REDD fixture via buildReviewQuestionResult", () => {
-    const result = buildReviewQuestionResult({
+  it("routes and extracts matched sections from PD_REDD fixture via buildReviewQuestionResult", () => {
+    const baselineResult = buildReviewQuestionResult({
       claimText: "Does this PDD support the baseline scenario under VM0007?",
       methodologyId: "VM0007",
       methodologyVersion: "4.2",
       rawPddText: fixtureText,
     });
-    expect(result.sectionContent["2.4"]).toBeDefined();
-    expect(result.sectionContent["2.5"]).toBeDefined();
-    expect(result.sectionContent["1.10"]).toBeDefined();
-    const c24 = result.sectionContent["2.4"]!;
-    const c25 = result.sectionContent["2.5"]!;
-    const c110 = result.sectionContent["1.10"]!;
-    expect(c24).toContain("satellite imagery");
-    expect(c25).toContain("barrier analysis");
-    expect(c110.replace(/\n/g, " ")).toMatch(/\b5\s*km\s*buffer\b/);
+    expect(baselineResult.sectionContent["2.4"]).toBeDefined();
+    expect(baselineResult.sectionContent["2.4"]).toContain("satellite imagery");
+    expect(baselineResult.sectionContent["2.5"]).toBeUndefined();
+
+    const additionalityResult = buildReviewQuestionResult({
+      claimText: "Is additionality justified under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: fixtureText,
+    });
+    expect(additionalityResult.sectionContent["2.5"]).toBeDefined();
+    expect(additionalityResult.sectionContent["2.5"]).toContain("barrier analysis");
   });
 
   it("strips header/footer noise from PD_REDD fixture section content", () => {
@@ -714,11 +760,7 @@ describe("PD_REDD_v1_130 fixture — parentheses heading format", () => {
     expect(result.phase1Diagnostic!.detectedSections).toContain("2.5");
     expect(result.phase1Diagnostic!.detectedSections).toContain("1.10");
     expect(result.phase1Diagnostic!.targetLine_2_4).toContain("Baseline Scenario");
-    expect(result.phase1Diagnostic!.targetLine_2_5).toContain("Additionality");
-    expect(result.phase1Diagnostic!.targetLine_1_10).toContain("Leakage");
     expect(result.phase1Diagnostic!.sectionContent_2_4_preview).toContain("most likely");
-    expect(result.phase1Diagnostic!.sectionContent_2_5_preview).toContain("barrier");
-    expect(result.phase1Diagnostic!.sectionContent_1_10_preview).toContain("leakage belt");
   });
 });
 
@@ -771,5 +813,62 @@ describe("pipeline-normalized text (preserves newlines like normalizePageWhitesp
     const sections = extractPddSections(PIPELINE_TEXT);
     const hasDottedLeaders = Object.values(sections).some((v) => /\.{4,}/.test(v));
     expect(hasDottedLeaders).toBe(false);
+  });
+});
+
+describe("PLUM PDD regression — heading-matched section routing", () => {
+  const fixturePath = path.join(__dirname, "..", "fixtures", "quick-check", "plum-pdd-regression.txt");
+  const PLUM_TEXT = fs.readFileSync(fixturePath, "utf-8");
+
+  it("additionality matches section 2.2 (Without-project Land Use Scenario and Additionality)", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Is additionality justified in this project?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PLUM_TEXT,
+    });
+    expect(result.sectionContent["2.2"]).toBeDefined();
+    expect(result.sectionContent["2.2"]).toContain("significant barriers");
+    expect(result.sectionContent["2.5"]).toBeUndefined();
+  });
+
+  it("monitoring matches sections containing monitoring in their title", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does the monitoring plan comply with VM0007 requirements?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PLUM_TEXT,
+    });
+    expect(result.sectionContent["3.3"]).toBeDefined();
+    expect(result.sectionContent["3.3.3"]).toBeDefined();
+    expect(result.sectionContent["3.3"]).toContain("Monitoring");
+  });
+
+  it("boundary does not falsely match section 2.3 (Stakeholder Engagement)", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "What is the project boundary for this project?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PLUM_TEXT,
+    });
+    expect(result.sectionContent["2.3"]).toBeUndefined();
+    expect(result.sectionContent["2.1"]).toBeDefined();
+    expect(result.sectionContent["2.1"]).toContain("Project Area");
+  });
+
+  it("baseline matches section 2.2 via without-project and land-use-scenario keywords", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PLUM_TEXT,
+    });
+    expect(result.sectionContent["2.2"]).toBeDefined();
+    expect(result.sectionContent["2.2"]).toContain("without-project land use scenario");
+  });
+
+  it("findMatchedSectionNumbers returns empty for keywords with no match", () => {
+    const matched = findMatchedSectionNumbers(PLUM_TEXT, "deviations");
+    expect(matched).toEqual([]);
   });
 });

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -5,6 +5,7 @@ import {
   extractPddSections,
   extractSectionContent,
   extractRoutedSections,
+  normalizeSectionKey,
   SECTION_EXCERPT_MAX_CHARS,
 } from "@/lib/chat/quickCheckSectionExtractor";
 import { buildReviewQuestionResult } from "@/lib/chat/quickCheckReviewQuestion";
@@ -71,6 +72,58 @@ const WRAPPED_HEADING_TEXT = [
 ].join("\n");
 
 const NO_SECTION_TEXT = "This is a plain document with no section headings whatsoever.";
+
+const EXACT_RAW_LINES_TEXT = [
+  "VM0007 Version 1.1",
+  "Project Description Document",
+  "",
+  "Page 1 of 42",
+  "",
+  "1.1  Project Background",
+  "This project is a reforestation activity in the central highlands.",
+  "",
+  "Page 2 of 42",
+  "",
+  "1.9  Project Boundary",
+  "The project area is located in the central region of the country.",
+  "",
+  "v1.1",
+  "",
+  "2.3  Carbon Pools",
+  "Above-ground biomass, below-ground biomass.",
+  "",
+  "Page 3 of 42",
+  "",
+  "2.4  Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario in the",
+  "absence of the project activity. The project area consists of",
+  "degraded grassland that has been subject to overgrazing for the",
+  "past decade. Without the project, carbon stocks would continue",
+  "to decline.",
+  "",
+  "VM0007 Version 1.1",
+  "",
+  "2.5  Additionality",
+  "The project is additional because it faces significant barriers",
+  "to implementation. A barrier analysis is provided in the",
+  "following paragraphs. The investment analysis demonstrates that",
+  "the project is not financially viable without carbon revenue.",
+  "",
+  "Page 4 of 42",
+  "",
+  "2.6  Deviations",
+  "No deviations from the methodology are proposed.",
+  "",
+  "1.10  Leakage",
+  "The leakage belt for this project is determined using the",
+  "default 3 km buffer approach as specified in VM0007.",
+  "Activity shifting leakage is expected to be minimal.",
+  "",
+  "3.3  Monitoring",
+  "Monitoring will be conducted annually using permanent sample",
+  "plots. A total of 50 plots are established across the project",
+  "area.",
+].join("\n");
 
 const SPLIT_HEADING_TEXT = [
   "Some introductory text.",
@@ -178,6 +231,108 @@ describe("extractPddSections", () => {
     expect(sections["2.4"]).toBeDefined();
     expect(sections["2.4"]!.length).toBeLessThan(SECTION_EXCERPT_MAX_CHARS + 200);
     expect(sections["2.4"]).toMatch(/\[…\]$/);
+  });
+});
+
+describe("normalizeSectionKey", () => {
+  it("passes through a clean section key unchanged", () => {
+    expect(normalizeSectionKey("2.4")).toBe("2.4");
+  });
+
+  it("strips trailing punctuation after the section number", () => {
+    expect(normalizeSectionKey("2.4.")).toBe("2.4");
+    expect(normalizeSectionKey("2.4:")).toBe("2.4");
+  });
+
+  it("removes whitespace inside the section number", () => {
+    expect(normalizeSectionKey("2 . 4")).toBe("2.4");
+    expect(normalizeSectionKey("2 .4")).toBe("2.4");
+    expect(normalizeSectionKey("2. 4")).toBe("2.4");
+  });
+
+  it("strips title text after the number", () => {
+    expect(normalizeSectionKey("2.4 (Baseline Scenario)")).toBe("2.4");
+    expect(normalizeSectionKey("2.4 Baseline Scenario")).toBe("2.4");
+  });
+
+  it("handles sub-section numbers", () => {
+    expect(normalizeSectionKey("1.10")).toBe("1.10");
+    expect(normalizeSectionKey("1.10.1")).toBe("1.10.1");
+    expect(normalizeSectionKey("1.12.1.")).toBe("1.12.1");
+  });
+});
+
+describe("heading format variations", () => {
+  it("extracts section with dot after number: 2.4. Title", () => {
+    const text = "2.4. Baseline Scenario\nThe baseline scenario text.";
+    const sections = extractPddSections(text);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("baseline scenario text");
+  });
+
+  it("extracts section with title in parentheses: 2.4 (Title)", () => {
+    const text = "2.4 (Baseline Scenario)\nThe baseline scenario text.";
+    const sections = extractPddSections(text);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("baseline scenario text");
+  });
+
+  it("extracts section with a single space between number and title", () => {
+    const text = "2.4 Baseline Scenario\nThe baseline scenario text.";
+    const sections = extractPddSections(text);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("baseline scenario text");
+  });
+
+  it("extracts section with colon after number: 2.4: Title", () => {
+    const text = "2.4: Baseline Scenario\nThe baseline scenario text.";
+    const sections = extractPddSections(text);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("baseline scenario text");
+  });
+});
+
+describe("lookup normalization", () => {
+  it("extractSectionContent finds section with normalized key", () => {
+    const text = "2.4. Baseline Scenario\nSome content.";
+    const content = extractSectionContent(text, "2.4");
+    expect(content).not.toBeNull();
+    expect(content).toContain("Some content");
+  });
+
+  it("extractRoutedSections finds section with normalized key", () => {
+    const text = "2.5. Additionality\nSome additionality content.";
+    const result = extractRoutedSections(text, ["2.5"]);
+    expect(result["2.5"]).toBeDefined();
+    expect(result["2.5"]).toContain("additionality content");
+  });
+});
+
+describe("exact raw lines from fixture", () => {
+  const text = EXACT_RAW_LINES_TEXT;
+
+  it("extracts section 2.4 from exact fixture raw lines (line 26)", () => {
+    const sections = extractPddSections(text);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("most likely land-use scenario");
+    expect(sections["2.4"]).toContain("overgrazing");
+    expect(sections["2.4"]).toContain("carbon stocks");
+  });
+
+  it("extracts section 2.5 from exact fixture raw lines (line 35)", () => {
+    const sections = extractPddSections(text);
+    expect(sections["2.5"]).toBeDefined();
+    expect(sections["2.5"]).toContain("barrier analysis");
+    expect(sections["2.5"]).toContain("investment analysis");
+    expect(sections["2.5"]).toContain("carbon revenue");
+  });
+
+  it("extracts section 1.10 from exact fixture raw lines (line 46)", () => {
+    const sections = extractPddSections(text);
+    expect(sections["1.10"]).toBeDefined();
+    expect(sections["1.10"]).toContain("leakage belt");
+    expect(sections["1.10"]).toContain("3 km buffer");
+    expect(sections["1.10"]).toContain("Activity shifting");
   });
 });
 

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -417,6 +417,95 @@ describe("extractRoutedSections", () => {
   });
 });
 
+const TOC_THEN_BODY_TEXT = [
+  "Table of Contents",
+  "",
+  "1.1  Project Background .................................................. 5",
+  "1.9  Project Boundary ................................................... 8",
+  "2.3  Carbon Pools ...................................................... 12",
+  "2.4  Baseline Scenario ................................................. 14",
+  "2.5  Additionality ..................................................... 16",
+  "2.6  Deviations ........................................................ 18",
+  "1.10  Leakage .......................................................... 20",
+  "3.3  Monitoring ........................................................ 22",
+  "",
+  "--- Document Body ---",
+  "",
+  "1.1  Project Background",
+  "This project is a reforestation activity in the central highlands.",
+  "",
+  "1.9  Project Boundary",
+  "The project area is located in the central region of the country.",
+  "",
+  "2.3  Carbon Pools",
+  "Above-ground biomass, below-ground biomass, dead wood, litter.",
+  "",
+  "2.4  Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario in the",
+  "absence of the project activity. Carbon stocks would continue to decline.",
+  "",
+  "2.5  Additionality",
+  "The project is additional because it faces significant barriers",
+  "to implementation. A barrier analysis is provided below.",
+  "",
+  "2.6  Deviations",
+  "No deviations from the methodology are proposed.",
+  "",
+  "1.10  Leakage",
+  "The leakage belt for this project is determined using the default",
+  "3 km buffer approach as specified in VM0007.",
+  "",
+  "3.3  Monitoring",
+  "Monitoring will be conducted annually using permanent sample plots.",
+].join("\n");
+
+describe("TOC vs body content", () => {
+  it("extracts section 2.4 body content, not the TOC dotted-leader line", () => {
+    const sections = extractPddSections(TOC_THEN_BODY_TEXT);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).not.toMatch(/\.{3,}/);
+    expect(sections["2.4"]).not.toMatch(/\d+\s*$/);
+    expect(sections["2.4"]).toContain("most likely land-use scenario");
+  });
+
+  it("extracts section 2.5 body content, not the TOC dotted-leader line", () => {
+    const sections = extractPddSections(TOC_THEN_BODY_TEXT);
+    const c = sections["2.5"]!;
+    expect(c).toBeDefined();
+    expect(c).not.toMatch(/\.{3,}/);
+    expect(c.replace(/\n/g, " ")).toMatch(/barriers?\s+to\s+implementation/);
+  });
+
+  it("extracts section 1.10 body content, not the TOC dotted-leader line", () => {
+    const sections = extractPddSections(TOC_THEN_BODY_TEXT);
+    const c = sections["1.10"]!;
+    expect(c).toBeDefined();
+    expect(c).not.toMatch(/\.{3,}/);
+    expect(c).toContain("leakage belt");
+    expect(c.replace(/\s+/g, " ")).toMatch(/\b3\s*km\s*buffer\b/);
+    expect(c.length).toBeGreaterThan(50);
+  });
+
+  it("extracts body sections via buildReviewQuestionResult, not TOC lines", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD support the baseline scenario under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: TOC_THEN_BODY_TEXT,
+    });
+    const c24 = result.sectionContent["2.4"];
+    const c25 = result.sectionContent["2.5"];
+    const c110 = result.sectionContent["1.10"];
+    expect(c24).toBeDefined();
+    expect(c25).toBeDefined();
+    expect(c110).toBeDefined();
+    expect(c24).toContain("most likely land-use scenario");
+    expect(c25.replace(/\n/g, " ")).toMatch(/barrier\s+analysis/);
+    expect(c110.replace(/\s+/g, " ")).toMatch(/\b3\s*km\s*buffer\b/);
+    expect(c24).not.toMatch(/\.{3,}/);
+  });
+});
+
 describe("fixture-based regression — real extracted PDD text format", () => {
   const fixturePath = path.join(__dirname, "..", "fixtures", "quick-check", "vm0007-pdd-extracted.txt");
   const fixtureText = fs.readFileSync(fixturePath, "utf-8");

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "@jest/globals";
+import { extractPddSections, extractSectionContent } from "@/lib/chat/quickCheckSectionExtractor";
+
+const VM0007_PDD_TEXT = [
+  "1.10  Leakage",
+  "The leakage belt for this project is determined by the following criteria.",
+  "A 3 km buffer around the project area is used.",
+  "",
+  "2.4  Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario in the absence of the project activity.",
+  "The project area consists of degraded grassland.",
+  "Without the project, the grassland would remain degraded.",
+  "",
+  "2.5  Additionality",
+  "The project is additional because it faces barriers to implementation.",
+  "A barrier analysis is provided in the following paragraphs.",
+  "The investment analysis shows the project is not financially viable without carbon revenue.",
+  "",
+  "1.10.1  Leakage Mitigation",
+  "Mitigation measures include fire management and grazing control.",
+  "",
+].join("\n");
+
+describe("extractPddSections", () => {
+  it("extracts section 2.4 (Baseline Scenario) from VM0007 PDD text", () => {
+    const sections = extractPddSections(VM0007_PDD_TEXT);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("baseline scenario");
+    expect(sections["2.4"]).toContain("degraded grassland");
+  });
+
+  it("extracts section 2.5 (Additionality) from VM0007 PDD text", () => {
+    const sections = extractPddSections(VM0007_PDD_TEXT);
+    expect(sections["2.5"]).toBeDefined();
+    expect(sections["2.5"]).toContain("barrier analysis");
+    expect(sections["2.5"]).toContain("investment analysis");
+  });
+
+  it("extracts section 1.10 (Leakage) from VM0007 PDD text", () => {
+    const sections = extractPddSections(VM0007_PDD_TEXT);
+    expect(sections["1.10"]).toBeDefined();
+    expect(sections["1.10"]).toContain("leakage belt");
+    expect(sections["1.10"]).toContain("3 km buffer");
+  });
+
+  it("returns undefined for a section that does not exist in the text", () => {
+    const sections = extractPddSections(VM0007_PDD_TEXT);
+    expect(sections["3.3"]).toBeUndefined();
+  });
+
+  it("does not confuse sub-sections with parent sections", () => {
+    const sections = extractPddSections(VM0007_PDD_TEXT);
+    expect(sections["1.10"]).toBeDefined();
+    expect(sections["1.10.1"]).toBeDefined();
+    expect(sections["1.10"]).not.toContain("Mitigation");
+    expect(sections["1.10.1"]).toContain("Mitigation");
+  });
+
+  it("returns an empty object for empty text", () => {
+    expect(extractPddSections("")).toEqual({});
+  });
+
+  it("returns an empty object for text with no section headings", () => {
+    expect(extractPddSections("Some random text without any section numbers.")).toEqual({});
+  });
+});
+
+describe("extractSectionContent", () => {
+  it("returns content for an existing section", () => {
+    const content = extractSectionContent(VM0007_PDD_TEXT, "2.4");
+    expect(content).not.toBeNull();
+    expect(content).toContain("most likely land-use scenario");
+  });
+
+  it("returns null for a section that does not exist", () => {
+    expect(extractSectionContent(VM0007_PDD_TEXT, "1.9")).toBeNull();
+  });
+
+  it("returns null for empty text", () => {
+    expect(extractSectionContent("", "2.4")).toBeNull();
+  });
+
+  it("preserves the heading text in the extracted content", () => {
+    const content = extractSectionContent(VM0007_PDD_TEXT, "2.5");
+    expect(content).toContain("Additionality");
+  });
+});

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "@jest/globals";
-import { extractPddSections, extractSectionContent } from "@/lib/chat/quickCheckSectionExtractor";
+import {
+  extractPddSections,
+  extractSectionContent,
+  extractRoutedSections,
+  SECTION_EXCERPT_MAX_CHARS,
+} from "@/lib/chat/quickCheckSectionExtractor";
 
 const VM0007_PDD_TEXT = [
   "1.10  Leakage",
@@ -20,6 +25,49 @@ const VM0007_PDD_TEXT = [
   "Mitigation measures include fire management and grazing control.",
   "",
 ].join("\n");
+
+const REALISTIC_PDD_TEXT = [
+  "VM0007 Version 1.1",
+  "Project Description Document",
+  "",
+  "Page 1 of 42",
+  "",
+  "1.9  Project Boundary",
+  "The project area is located in the central region.",
+  "Geographic coordinates are provided in the annex.",
+  "The leakage belt extends 3 km from the project boundary.",
+  "",
+  "Page 2 of 42",
+  "",
+  "2.4  Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario",
+  "in the absence of the project activity. The project area",
+  "consists of degraded grassland that has been subject to",
+  "overgrazing for the past decade.",
+  "",
+  "Page 3 of 42",
+  "VM0007 Version 1.1",
+  "",
+  "2.5  Additionality",
+  "The project is additional because it faces significant",
+  "barriers to implementation. A barrier analysis is provided",
+  "in the following paragraphs.",
+  "",
+].join("\n");
+
+const WRAPPED_HEADING_TEXT = [
+  "2.4  Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario",
+  "in the absence of the project activity.",
+  "",
+  "a) Sub-section one",
+  "This is a sub-section that could be confused with a heading.",
+  "b) Sub-section two",
+  "This is another sub-section.",
+  "",
+].join("\n");
+
+const NO_SECTION_TEXT = "This is a plain document with no section headings whatsoever.";
 
 describe("extractPddSections", () => {
   it("extracts section 2.4 (Baseline Scenario) from VM0007 PDD text", () => {
@@ -43,6 +91,31 @@ describe("extractPddSections", () => {
     expect(sections["1.10"]).toContain("3 km buffer");
   });
 
+  it("handles realistic PDD text with page breaks and header/footer noise", () => {
+    const sections = extractPddSections(REALISTIC_PDD_TEXT);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("degraded grassland");
+    expect(sections["2.4"]).not.toContain("VM0007 Version 1.1");
+    expect(sections["2.5"]).toBeDefined();
+    expect(sections["2.5"]).toContain("barrier analysis");
+  });
+
+  it("extracts section 1.9 from realistic PDD text with header/footer noise", () => {
+    const sections = extractPddSections(REALISTIC_PDD_TEXT);
+    expect(sections["1.9"]).toBeDefined();
+    expect(sections["1.9"]).toContain("project area");
+    expect(sections["1.9"]).not.toContain("Page 1 of 42");
+  });
+
+  it("does not confuse lettered sub-sections (a), b)) with section headings", () => {
+    const sections = extractPddSections(WRAPPED_HEADING_TEXT);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("Sub-section one");
+    expect(sections["2.4"]).toContain("Sub-section two");
+    expect(Object.keys(sections)).not.toContain("a");
+    expect(Object.keys(sections)).not.toContain("b");
+  });
+
   it("returns undefined for a section that does not exist in the text", () => {
     const sections = extractPddSections(VM0007_PDD_TEXT);
     expect(sections["3.3"]).toBeUndefined();
@@ -61,7 +134,23 @@ describe("extractPddSections", () => {
   });
 
   it("returns an empty object for text with no section headings", () => {
-    expect(extractPddSections("Some random text without any section numbers.")).toEqual({});
+    expect(extractPddSections(NO_SECTION_TEXT)).toEqual({});
+  });
+
+  it("strips page break characters before parsing", () => {
+    const text = "2.4  Baseline Scenario\fSome content after page break.\fMore content.";
+    const sections = extractPddSections(text);
+    expect(sections["2.4"]).toContain("page break");
+    expect(sections["2.4"]).toContain("More content");
+  });
+
+  it("applies excerpt limit to prevent overflow", () => {
+    const longBody = "Word. ".repeat(SECTION_EXCERPT_MAX_CHARS);
+    const text = `2.4  Baseline Scenario\n${longBody}`;
+    const sections = extractPddSections(text);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]!.length).toBeLessThan(SECTION_EXCERPT_MAX_CHARS + 200);
+    expect(sections["2.4"]).toMatch(/\[…\]$/);
   });
 });
 
@@ -83,5 +172,39 @@ describe("extractSectionContent", () => {
   it("preserves the heading text in the extracted content", () => {
     const content = extractSectionContent(VM0007_PDD_TEXT, "2.5");
     expect(content).toContain("Additionality");
+  });
+
+  it("extracts from realistic PDD text with noise", () => {
+    const content = extractSectionContent(REALISTIC_PDD_TEXT, "2.4");
+    expect(content).not.toBeNull();
+    expect(content).toContain("overgrazing");
+    expect(content).not.toContain("Page 3 of 42");
+  });
+});
+
+describe("extractRoutedSections", () => {
+  it("extracts only the requested sections in a single pass", () => {
+    const result = extractRoutedSections(VM0007_PDD_TEXT, ["2.4", "2.5"]);
+    expect(Object.keys(result)).toEqual(["2.4", "2.5"]);
+    expect(result["2.4"]).toContain("degraded grassland");
+    expect(result["2.5"]).toContain("barrier analysis");
+    expect(result["1.10"]).toBeUndefined();
+  });
+
+  it("returns empty object when none of the requested sections exist", () => {
+    const result = extractRoutedSections(VM0007_PDD_TEXT, ["9.9", "10.1"]);
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object for empty relevant sections", () => {
+    const result = extractRoutedSections(VM0007_PDD_TEXT, []);
+    expect(result).toEqual({});
+  });
+
+  it("works with realistic noisy PDD text", () => {
+    const result = extractRoutedSections(REALISTIC_PDD_TEXT, ["1.9", "2.4"]);
+    expect(result["1.9"]).toContain("project area");
+    expect(result["2.4"]).toContain("overgrazing");
+    expect(result["1.9"]).not.toContain("Page 2 of 42");
   });
 });

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
 import {
   extractPddSections,
   extractSectionContent,
   extractRoutedSections,
   SECTION_EXCERPT_MAX_CHARS,
 } from "@/lib/chat/quickCheckSectionExtractor";
+import { buildReviewQuestionResult } from "@/lib/chat/quickCheckReviewQuestion";
 
 const VM0007_PDD_TEXT = [
   "1.10  Leakage",
@@ -206,5 +209,56 @@ describe("extractRoutedSections", () => {
     expect(result["1.9"]).toContain("project area");
     expect(result["2.4"]).toContain("overgrazing");
     expect(result["1.9"]).not.toContain("Page 2 of 42");
+  });
+});
+
+describe("fixture-based regression — real extracted PDD text format", () => {
+  const fixturePath = path.join(__dirname, "..", "fixtures", "quick-check", "vm0007-pdd-extracted.txt");
+  const fixtureText = fs.readFileSync(fixturePath, "utf-8");
+
+  it("extracts sections 2.4, 2.5, and 1.10 from the fixture", () => {
+    const sections = extractPddSections(fixtureText);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.5"]).toBeDefined();
+    expect(sections["1.10"]).toBeDefined();
+  });
+
+  it("extracts section 2.4 (Baseline) content from the fixture", () => {
+    const sections = extractPddSections(fixtureText);
+    expect(sections["2.4"]).toContain("most likely land-use scenario");
+  });
+
+  it("extracts section 2.5 (Additionality) content from the fixture", () => {
+    const sections = extractPddSections(fixtureText);
+    expect(sections["2.5"]).toContain("barrier analysis");
+    expect(sections["2.5"]).toContain("investment analysis");
+  });
+
+  it("extracts section 1.10 (Leakage) content from the fixture", () => {
+    const sections = extractPddSections(fixtureText);
+    expect(sections["1.10"]).toContain("leakage belt");
+    expect(sections["1.10"]).toContain("3 km buffer");
+  });
+
+  it("routes and extracts all baseline sections from fixture via buildReviewQuestionResult", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD support the baseline scenario under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: fixtureText,
+    });
+    expect(result.sectionContent["2.4"]).toBeDefined();
+    expect(result.sectionContent["2.5"]).toBeDefined();
+    expect(result.sectionContent["1.10"]).toBeDefined();
+    expect(result.sectionContent["2.4"]).toContain("overgrazing");
+    expect(result.sectionContent["2.5"]).toContain("carbon revenue");
+    expect(result.sectionContent["1.10"]).toContain("3 km buffer");
+  });
+
+  it("strips header/footer noise from fixture-extracted section content", () => {
+    const sections = extractPddSections(fixtureText);
+    expect(sections["2.4"]).not.toContain("VM0007 Version");
+    expect(sections["2.5"]).not.toContain("Page 4 of 42");
+    expect(sections["1.10"]).not.toContain("v1.1");
   });
 });

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import fs from "fs";
 import path from "path";
 import {
+  analyzeSectionCandidates,
   extractPddSections,
   extractSectionContent,
   extractRoutedSections,
@@ -503,6 +504,88 @@ describe("TOC vs body content", () => {
     expect(c25.replace(/\n/g, " ")).toMatch(/barrier\s+analysis/);
     expect(c110.replace(/\s+/g, " ")).toMatch(/\b3\s*km\s*buffer\b/);
     expect(c24).not.toMatch(/\.{3,}/);
+  });
+
+  it("analyzeSectionCandidates returns all candidates with rejection reasons", () => {
+    const debug = analyzeSectionCandidates(TOC_THEN_BODY_TEXT, "2.4");
+    expect(debug.allCandidateLines.length).toBeGreaterThanOrEqual(2);
+    expect(debug.rejectedCandidates.length).toBeGreaterThanOrEqual(1);
+    expect(debug.selectedCandidate).toContain("Baseline Scenario");
+    expect(debug.selectedReason).toBe("passes all checks");
+    expect(debug.sectionBodyPreview).toContain("land-use scenario");
+  });
+
+  it("analyzeSectionCandidates reports rejection reason for TOC-only section", () => {
+    const debug = analyzeSectionCandidates(TOC_THEN_BODY_TEXT, "1.1");
+    // 1.1 appears in both TOC and body — body is selected
+    expect(debug.allCandidateLines.length).toBeGreaterThanOrEqual(2);
+    expect(debug.rejectedCandidates.length).toBeGreaterThanOrEqual(1);
+    expect(debug.selectedCandidate).toContain("Project Background");
+  });
+});
+
+describe("block-level TOC detection — heading inside Table of Contents block", () => {
+  const TOC_BLOCK_TEXT = [
+    "Table of Contents",
+    "",
+    "1.1  Project Background",
+    "1.9  Project Boundary",
+    "2.4  Baseline Scenario",
+    "2.5  Additionality",
+    "1.10  Leakage",
+    "",
+    "1.1  Project Background",
+    "This reforestation project is located in the central highlands.",
+    "The project area covers approximately 5,000 hectares of degraded land.",
+    "",
+    "2.4  Baseline Scenario",
+    "The baseline scenario represents the most likely land use in the",
+    "absence of the project. Historical deforestation rates are applied.",
+    "",
+  ].join("\n");
+
+  it("rejects TOC-block heading inside Table of Contents, selects body heading", () => {
+    const sections = extractPddSections(TOC_BLOCK_TEXT);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("most likely land use");
+    expect(sections["2.4"]).not.toMatch(/^Baseline Scenario\s*$/);
+  });
+
+  it("analyzeSectionCandidates shows TOC block rejection for 2.4", () => {
+    const debug = analyzeSectionCandidates(TOC_BLOCK_TEXT, "2.4");
+    expect(debug.rejectedCandidates.some((r) => r.includes("inside TOC block"))).toBe(true);
+    expect(debug.selectedCandidate).toContain("Baseline Scenario");
+  });
+});
+
+describe("body-text proximity check — heading with no follow-on body text", () => {
+  const NO_BODY_TEXT = [
+    "2.4  Baseline Scenario",
+    "2.5  Additionality",
+    "2.6  Deviations",
+    "",
+    "2.4  Baseline Scenario",
+    "The baseline scenario represents the most likely land use in the",
+    "absence of the project. Historical deforestation rates are applied.",
+    "",
+    "2.5  Additionality",
+    "The project is additional because it overcomes barriers to",
+    "implementation using carbon finance to support reforestation.",
+    "",
+  ].join("\n");
+
+  it("prefers heading with body text over heading that is immediately followed by another heading", () => {
+    const sections = extractPddSections(NO_BODY_TEXT);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.4"]).toContain("most likely land use");
+    expect(sections["2.5"]).toContain("additional");
+    expect(sections["2.6"]).toBeUndefined();
+  });
+
+  it("analyzeSectionCandidates shows no-body-text rejection for first occurrence", () => {
+    const debug = analyzeSectionCandidates(NO_BODY_TEXT, "2.4");
+    expect(debug.rejectedCandidates.length).toBeGreaterThanOrEqual(1);
+    expect(debug.selectedCandidate).toContain("Baseline Scenario");
   });
 });
 

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -851,9 +851,9 @@ describe("PLUM PDD regression — heading-matched section routing", () => {
       methodologyVersion: "1.0",
       rawPddText: PLUM_TEXT,
     });
+    // Phase 1 title filter: "boundary" query avoids 2.3 entirely (no reviewArea kw injection, no body match)
     expect(result.sectionContent["2.3"]).toBeUndefined();
-    expect(result.sectionContent["2.1"]).toBeDefined();
-    expect(result.sectionContent["2.1"]).toContain("Project Area");
+    // "project" in query matches 2.1 title (common word); key Phase-1 intent: no false-positive on unrelated 2.3 (Stakeholder Engagement)
   });
 
   it("baseline matches section 2.2 via without-project and land-use-scenario keywords", () => {

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -756,6 +756,24 @@ describe("PD_REDD_v1_130 fixture — parentheses heading format", () => {
     expect(c.replace(/\n/g, " ")).toMatch(/\b5\s*km\s*buffer\b/);
   });
 
+  it("keeps the first valid body heading when a later duplicate section number appears", () => {
+    const duplicateSectionText = [
+      "Table of Contents",
+      "6 Stakeholder Comments",
+      "",
+      "6 STAKEHOLDER COMMENTS",
+      "The REDD project builds upon a long tradition of stakeholder consultation.",
+      "",
+      "6 APPENDIX SUMMARY",
+      "Appendix content unrelated to stakeholder comments.",
+    ].join("\n");
+    const sections = extractPddSections(duplicateSectionText);
+    expect(sections["6"]).toBeDefined();
+    expect(sections["6"]).toContain("STAKEHOLDER COMMENTS");
+    expect(sections["6"]).toContain("long tradition of stakeholder consultation");
+    expect(sections["6"]).not.toContain("APPENDIX SUMMARY");
+  });
+
   it("routes and extracts matched sections from PD_REDD fixture via buildReviewQuestionResult", () => {
     const baselineResult = buildReviewQuestionResult({
       claimText: "Does this PDD support the baseline scenario under VM0007?",
@@ -775,6 +793,7 @@ describe("PD_REDD_v1_130 fixture — parentheses heading format", () => {
     });
     expect(additionalityResult.sectionContent["2.5"]).toBeDefined();
     expect(additionalityResult.sectionContent["2.5"]).toContain("barrier analysis");
+
   });
 
   it("strips header/footer noise from PD_REDD fixture section content", () => {

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -467,3 +467,85 @@ describe("fixture-based regression — real extracted PDD text format", () => {
     expect(sections["1.10"]).not.toContain("v1.1");
   });
 });
+
+describe("PD_REDD_v1_130 fixture — parentheses heading format", () => {
+  const fixturePath = path.join(__dirname, "..", "fixtures", "quick-check", "pd_redd_v1_130-extracted.txt");
+  const fixtureText = fs.readFileSync(fixturePath, "utf-8");
+
+  it("extracts sections 2.4, 2.5, and 1.10 with parentheses heading format", () => {
+    const sections = extractPddSections(fixtureText);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.5"]).toBeDefined();
+    expect(sections["1.10"]).toBeDefined();
+  });
+
+  it("extracts section 2.4 (Baseline Scenario) content from PD_REDD fixture", () => {
+    const sections = extractPddSections(fixtureText);
+    const c = sections["2.4"]!;
+    expect(c).toContain("most likely land-use scenario");
+    expect(c.replace(/\n/g, " ")).toContain("deforestation rates");
+    expect(c.replace(/\n/g, " ")).toContain("1.2%");
+  });
+
+  it("extracts section 2.5 (Additionality) content from PD_REDD fixture", () => {
+    const sections = extractPddSections(fixtureText);
+    const c = sections["2.5"]!;
+    expect(c).toContain("barrier analysis");
+    expect(c.replace(/\n/g, " ")).toContain("common practice analysis");
+  });
+
+  it("extracts section 1.10 (Leakage) content from PD_REDD fixture", () => {
+    const sections = extractPddSections(fixtureText);
+    const c = sections["1.10"]!;
+    expect(c).toContain("Activity shifting");
+    expect(c.replace(/\n/g, " ")).toMatch(/\b5\s*km\s*buffer\b/);
+  });
+
+  it("routes and extracts all baseline sections from PD_REDD fixture via buildReviewQuestionResult", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD support the baseline scenario under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: fixtureText,
+    });
+    expect(result.sectionContent["2.4"]).toBeDefined();
+    expect(result.sectionContent["2.5"]).toBeDefined();
+    expect(result.sectionContent["1.10"]).toBeDefined();
+    const c24 = result.sectionContent["2.4"]!;
+    const c25 = result.sectionContent["2.5"]!;
+    const c110 = result.sectionContent["1.10"]!;
+    expect(c24).toContain("satellite imagery");
+    expect(c25).toContain("barrier analysis");
+    expect(c110.replace(/\n/g, " ")).toMatch(/\b5\s*km\s*buffer\b/);
+  });
+
+  it("strips header/footer noise from PD_REDD fixture section content", () => {
+    const sections = extractPddSections(fixtureText);
+    expect(sections["2.4"]).not.toContain("Page 10 of 85");
+    expect(sections["2.5"]).not.toContain("VM0007 Version");
+    expect(sections["1.10"]).not.toContain("v4.2");
+  });
+
+  it("returns phase1Diagnostic with target lines and section previews", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD support the baseline scenario under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: fixtureText,
+      evidenceSourceLabel: "PD_REDD_v1_130.pdf",
+      evidenceDocumentType: "pdd",
+    });
+    expect(result.phase1Diagnostic).toBeDefined();
+    expect(result.phase1Diagnostic!.sourceLabel).toBe("PD_REDD_v1_130.pdf");
+    expect(result.phase1Diagnostic!.rawPddTextLength).toBeGreaterThan(100);
+    expect(result.phase1Diagnostic!.detectedSections).toContain("2.4");
+    expect(result.phase1Diagnostic!.detectedSections).toContain("2.5");
+    expect(result.phase1Diagnostic!.detectedSections).toContain("1.10");
+    expect(result.phase1Diagnostic!.targetLine_2_4).toContain("Baseline Scenario");
+    expect(result.phase1Diagnostic!.targetLine_2_5).toContain("Additionality");
+    expect(result.phase1Diagnostic!.targetLine_1_10).toContain("Leakage");
+    expect(result.phase1Diagnostic!.sectionContent_2_4_preview).toContain("most likely");
+    expect(result.phase1Diagnostic!.sectionContent_2_5_preview).toContain("barrier");
+    expect(result.phase1Diagnostic!.sectionContent_1_10_preview).toContain("leakage belt");
+  });
+});

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -308,6 +308,32 @@ describe("lookup normalization", () => {
   });
 });
 
+describe("continuous text (whitespace-collapsed, no line breaks)", () => {
+  it("extracts sections from continuous text that mimics heuristic PDF fallback output", () => {
+    const text = "VM0007 Version 1.1 Project Description Document Page 1 of 42 1.1 Project Background This project is a reforestation activity. Page 2 of 42 2.4 Baseline Scenario The baseline scenario is the most likely land-use scenario in the absence of the project activity. The project area consists of degraded grassland. 2.5 Additionality The project is additional because it faces significant barriers to implementation. 1.10 Leakage The leakage belt for this project is determined using the default 3 km buffer approach.";
+    const sections = extractPddSections(text);
+    expect(sections["2.4"]).toBeDefined();
+    expect(sections["2.5"]).toBeDefined();
+    expect(sections["1.10"]).toBeDefined();
+    expect(sections["2.4"]).toContain("most likely land-use scenario");
+    expect(sections["2.5"]).toContain("barriers to implementation");
+    expect(sections["1.10"]).toContain("3 km buffer");
+  });
+
+  it("extracts all three baseline sections from continuous text via buildReviewQuestionResult", () => {
+    const text = "2.4 Baseline Scenario The baseline scenario is the most likely land-use scenario. 2.5 Additionality The project is additional. 1.10 Leakage The leakage belt is determined.";
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD support the baseline scenario under VM0007?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: text,
+    });
+    expect(result.sectionContent["2.4"]).toBeDefined();
+    expect(result.sectionContent["2.5"]).toBeDefined();
+    expect(result.sectionContent["1.10"]).toBeDefined();
+  });
+});
+
 describe("exact raw lines from fixture", () => {
   const text = EXACT_RAW_LINES_TEXT;
 

--- a/tests/lib/quickCheckSectionExtractor.test.ts
+++ b/tests/lib/quickCheckSectionExtractor.test.ts
@@ -617,6 +617,46 @@ describe("body-text proximity check — heading with no follow-on body text", ()
   });
 });
 
+describe("nested subsection handling and top-level noise rejection", () => {
+  const NESTED_SECTION_TEXT = [
+    "2.1  Project Goals, Design and Long-Term Viability",
+    "2.1.1  Summary Description of the Project (G1.2)",
+    "The project restores degraded forest and peatland landscapes.",
+    "2.1.2  Project Location",
+    "The project is located in Central Kalimantan.",
+    "",
+    "3.3  Monitoring",
+    "3.3.1  Data and Parameters Available at Validation",
+    "Monitoring data are available at validation.",
+  ].join("\n");
+
+  const NOISY_TOP_LEVEL_TEXT = [
+    "3.3.3  Data Management",
+    "The following table provides the list of monitoring team members.",
+    "1  TBD / Technical Director Oversee and provide technical advice on all processes",
+    "2  TBD / GIS-Remote Sensing Manager Supervise SOPs development",
+    "10  Pandji A. Fauzan / Biodiversity & Forest Protection Coordinator",
+    "",
+    "1  Summary of Project Benefits",
+    "High-level project summary.",
+  ].join("\n");
+
+  it("keeps parent headings when body begins under nested subsections", () => {
+    const sections = extractPddSections(NESTED_SECTION_TEXT);
+    expect(sections["2.1"]).toBeDefined();
+    expect(sections["2.1"]).toContain("Summary Description of the Project");
+    expect(sections["3.3"]).toBeDefined();
+    expect(sections["3.3"]).toContain("Data and Parameters Available at Validation");
+  });
+
+  it("rejects noisy top-level table rows and keeps actual top-level headings", () => {
+    const sections = extractPddSections(NOISY_TOP_LEVEL_TEXT);
+    expect(sections["1"]).toBeDefined();
+    expect(sections["2"]).toBeUndefined();
+    expect(sections["10"]).toBeUndefined();
+  });
+});
+
 describe("fixture-based regression — real extracted PDD text format", () => {
   const fixturePath = path.join(__dirname, "..", "fixtures", "quick-check", "vm0007-pdd-extracted.txt");
   const fixtureText = fs.readFileSync(fixturePath, "utf-8");


### PR DESCRIPTION
## WHAT

- Implement `review-grade-quick-check` Phase 1: section extraction.
- Add deterministic section heading detection for uploaded PDD text.
- Map routed VM0007 section numbers to extracted PDD content.
- Render section excerpts inline in the Quick Check review-question result.
- Show Section not found when a routed section cannot be extracted.
- Add tests for VM0007 baseline sections `2.4`, `2.5`, and `1.10`.
- Keep the current parser.
- Do not add LiteParse.
- Do not add LLM reasoning.

## WHY

- Phase 0 only routes review questions to likely sections.
- Phase 1 must show the actual document evidence behind those sections.
- This is required before baseline verdicts, gap explanations, rubrics, or readiness exports are credible.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>