### PR TITLE
docs(roadmap): update review-grade-quick-check lane for Phase 1 completion

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -128,12 +128,7 @@ Details: `docs/roadmaps/review-grade-quick-check/PLAN.md`
 Lane status: Active
 Turn Quick Check from a requirement matcher / section router into an evidence-backed verification-readiness review engine. Phased path from routing to readiness note export.
 
-Current focus:
-- Phase 0: routing MVP — detect review question path, classify review area, route to VM0007 sections (PR 642)
-
 Not active now:
-- Full multi-methodology section extraction (phase 1 starts after VM0007 routing is stable)
-- Evidence-backed verdicts and gap detection (phase 2+)
 - Review area rubrics (phase 3+)
 - Regression evaluation suite (phase 4+)
 - Readiness note export (phase 5+)

--- a/docs/roadmaps/review-grade-quick-check/phase-status.json
+++ b/docs/roadmaps/review-grade-quick-check/phase-status.json
@@ -1,17 +1,17 @@
 {
   "PR642": "done",
   "phase_0_routing_mvp": {
-    "status": "active",
+    "status": "done",
     "title": "Routing MVP — review question detection and section routing",
     "summary": "Detect broad review questions, classify review area, route to relevant VM0007 PDD sections. Narrow first implementation to VM0007 baseline review question only."
   },
   "phase_1_section_extraction": {
-    "status": "planned",
+    "status": "done",
     "title": "Section extraction — retrieve and render PDD section content",
     "summary": "Extract section content from uploaded PDD pages. Map section numbers to extracted text. Render section excerpts inline in the review-question result."
   },
   "phase_2_baseline_evidence_backed_review": {
-    "status": "planned",
+    "status": "active",
     "title": "Baseline evidence-backed review — verdicts and gaps",
     "summary": "For baseline review questions, produce evidence-backed verdicts (supported / partial / missing) with gap explanations. Reference extracted PDD section content. Surface next-step follow-up documents."
   },
@@ -33,12 +33,8 @@
   "phase_meta": {
     "status": "active",
     "summary": "Turn Quick Check from a requirement matcher / section router into an evidence-backed verification-readiness review engine. Phased path from routing to readiness note export.",
-    "current_focus": [
-      "Phase 0: routing MVP — detect review question path, classify review area, route to VM0007 sections (PR 642)"
-    ],
+    "current_focus": "Phase 2: baseline evidence-backed review — verdicts and gaps",
     "not_active_now": [
-      "Full multi-methodology section extraction (phase 1 starts after VM0007 routing is stable)",
-      "Evidence-backed verdicts and gap detection (phase 2+)",
       "Review area rubrics (phase 3+)",
       "Regression evaluation suite (phase 4+)",
       "Readiness note export (phase 5+)"
@@ -46,9 +42,13 @@
     "last_updated_at": "2026-05-28T00:00:00Z"
   },
   "pr_evidence": {
-    "PR642": [640, 641, 642]
+    "PR642": [640, 641, 642],
+    "646": {
+      "title": "Phase 1 — Uploaded PDD section extraction and heading matching"
+    }
   },
   "pr_notes": {
-    "PR642": "Routing MVP: detect review question path, classify review area, route to VM0007 sections. Covers additionality, baseline, boundary, deviations, leakage, monitoring, right_of_use."
+    "PR642": "Routing MVP: detect review question path, classify review area, route to VM0007 sections. Covers additionality, baseline, boundary, deviations, leakage, monitoring, right_of_use.",
+    "646": "completed Phase 1 MVP with uploaded PDD heading extraction, section body rendering, TOC skipping, all-caps heading recovery, duplicate heading handling, question-to-heading filtering, cross-document anti-hardcoding tests, and safe no-match behavior."
   }
 }


### PR DESCRIPTION
## WHAT

- Update **only** `docs/roadmaps/review-grade-quick-check/phase-status.json`.
- Do **not** touch `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`.
- Do not rewrite or replace any other roadmap.
- Set `phase_0_routing_mvp.status` to `done`.
- Set `phase_1_section_extraction.status` to `done`.
- Set `phase_2_baseline_evidence_backed_review.status` to `active`.
- Keep phases 3, 4, and 5 as `planned`.
- Update `phase_meta.current_focus` to `Phase 2: baseline evidence-backed review — verdicts and gaps`.
- Remove stale `not_active_now` entries saying Phase 1 starts later or evidence-backed verdicts are Phase 2+.
- Add PR646 to `pr_evidence` and `pr_notes` as the completed Phase 1 section extraction work.
- Regenerate `docs/roadmaps/SUMMARY.md` (only the minimal generator diff for this lane).

## WHY

- The Quick Check roadmap (`review-grade-quick-check`) is stale.
- PR642 completed Phase 0 routing.
- PR646 completed Phase 1 uploaded PDD section extraction and heading matching.
- The next active work should be Phase 2: evidence-backed review verdicts and gap analysis.
- Previous attempt targeted the wrong roadmap file.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>

---

**This PR changes exactly two files:**
- `docs/roadmaps/review-grade-quick-check/phase-status.json`
- `docs/roadmaps/SUMMARY.md` (generator output only)