### PR TITLE
feat(quick-check): baseline-only Phase 2 review path (deterministic rubric)

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2157,6 +2157,46 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       </div>
                     ) : null}
                   </div>
+                  {reviewQuestionResult.baselineReview ? (
+                    <div className="mt-4 rounded-xl border border-emerald-200 bg-white/80 p-4">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700">Baseline review</div>
+                      <div className="mt-2 text-sm font-medium text-slate-900">
+                        Verdict: {reviewQuestionResult.baselineReview.verdict}
+                      </div>
+                      <div className="mt-2 text-sm leading-relaxed text-slate-700">
+                        {reviewQuestionResult.baselineReview.evidence_summary}
+                      </div>
+                      <div className="mt-3">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Cited sections</div>
+                        <div className="mt-1 text-sm text-slate-700">
+                          {reviewQuestionResult.baselineReview.cited_sections.length > 0
+                            ? reviewQuestionResult.baselineReview.cited_sections.map((section) => `§${section}`).join(", ")
+                            : "None"}
+                        </div>
+                      </div>
+                      {reviewQuestionResult.baselineReview.gaps.length > 0 ? (
+                        <div className="mt-3">
+                          <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Gaps</div>
+                          <ul className="mt-1 list-disc pl-5 text-sm leading-relaxed text-slate-700">
+                            {reviewQuestionResult.baselineReview.gaps.map((gap) => (
+                              <li key={gap}>{gap}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      ) : null}
+                      <div className="mt-3">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Recommended follow-up documents</div>
+                        <ul className="mt-1 list-disc pl-5 text-sm leading-relaxed text-slate-700">
+                          {reviewQuestionResult.baselineReview.recommended_follow_up_documents.map((item) => (
+                            <li key={item}>{item}</li>
+                          ))}
+                        </ul>
+                      </div>
+                      <p className="mt-3 text-xs text-slate-500">
+                        Conservative Quick Check signal only. This is not a review-grade certainty finding.
+                      </p>
+                    </div>
+                  ) : null}
                   <div className="mt-4">
                     <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Document heading index (Phase 1 — question is filter only)</div>
                     <p className="mt-1 text-xs text-slate-500">Headings extracted from uploaded PDD. Your question filters titles (no body matching, no methodology routes).</p>

--- a/src/lib/chat/quickCheckBaselineRubric.ts
+++ b/src/lib/chat/quickCheckBaselineRubric.ts
@@ -1,0 +1,127 @@
+import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
+
+export type BaselineReviewVerdict = "supported" | "partial" | "missing" | "needs_review";
+
+export type BaselineReviewResult = {
+  review_area: "baseline";
+  verdict: BaselineReviewVerdict;
+  evidence_summary: string;
+  cited_sections: string[];
+  gaps: string[];
+  recommended_follow_up_documents: string[];
+};
+
+type EvaluateBaselineReviewInput = {
+  matchedHeadings: DocumentHeading[];
+};
+
+const BASELINE_SCENARIO_SIGNALS = [
+  "baseline scenario",
+  "without-project",
+  "without project",
+  "absence of the project",
+  "most likely land-use scenario",
+  "most likely land use scenario",
+  "business as usual",
+];
+
+const BASELINE_EVIDENCE_SIGNALS = [
+  "historical",
+  "satellite",
+  "remote sensing",
+  "deforestation",
+  "degradation",
+  "land-use change",
+  "land use change",
+  "reference region",
+  "drivers",
+  "trend",
+  "rates",
+  "inventory",
+  "observed",
+];
+
+const BASELINE_QUANT_SIGNAL = /\b\d+(?:\.\d+)?%?\b/;
+
+const BASELINE_FOLLOW_UP_DEFAULT = [
+  "Historical land-use change analysis or baseline modelling note",
+  "Remote sensing or inventory source used to justify baseline assumptions",
+];
+
+function normalizeForSignal(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function collectMatchedSignalLabels(text: string, phrases: string[]): string[] {
+  return phrases.filter((phrase) => text.includes(phrase));
+}
+
+function buildEvidenceSummary(headings: DocumentHeading[]): string {
+  const fragments = headings
+    .slice(0, 2)
+    .map((heading) => {
+      const preview = heading.bodyPreview || heading.bodyText || heading.title;
+      const singleLine = preview.replace(/\s+/g, " ").trim();
+      return `§${heading.sectionNumber} ${heading.title}: ${singleLine}`;
+    });
+  return fragments.join(" ");
+}
+
+export function evaluateBaselineReview(input: EvaluateBaselineReviewInput): BaselineReviewResult {
+  const headings = input.matchedHeadings.filter((heading) => heading.sectionNumber.trim().length > 0);
+  if (headings.length === 0) {
+    return {
+      review_area: "baseline",
+      verdict: "missing",
+      evidence_summary: "No baseline-matched document section was recovered from the uploaded PDD heading index.",
+      cited_sections: [],
+      gaps: [
+        "No uploaded PDD section heading matched the baseline review question.",
+        "Quick Check could not verify a baseline scenario discussion from document-grounded sections.",
+      ],
+      recommended_follow_up_documents: [
+        "PDD section or annex describing the baseline scenario / without-project case",
+        "Historical land-use change analysis or baseline modelling note",
+      ],
+    };
+  }
+
+  const combinedText = headings
+    .map((heading) => `${heading.title}\n${heading.bodyText}`)
+    .join("\n\n");
+  const normalized = normalizeForSignal(combinedText);
+  const scenarioSignals = collectMatchedSignalLabels(normalized, BASELINE_SCENARIO_SIGNALS);
+  const evidenceSignals = collectMatchedSignalLabels(normalized, BASELINE_EVIDENCE_SIGNALS);
+  const hasQuantitativeIndicator = BASELINE_QUANT_SIGNAL.test(combinedText);
+
+  const gaps: string[] = [];
+  if (scenarioSignals.length === 0) {
+    gaps.push("No clear baseline or without-project scenario statement was found in the matched section text.");
+  }
+  if (evidenceSignals.length === 0) {
+    gaps.push("No clear baseline justification basis was found, such as historical trends, drivers, or reference data.");
+  }
+  if (!hasQuantitativeIndicator) {
+    gaps.push("No quantitative baseline assumption, rate, or measurement was found in the matched section text.");
+  }
+
+  const verdict: BaselineReviewVerdict =
+    scenarioSignals.length > 0 && evidenceSignals.length > 0 && hasQuantitativeIndicator
+      ? "supported"
+      : scenarioSignals.length > 0
+        ? "partial"
+        : "needs_review";
+
+  const followUps = gaps.length > 0
+    ? BASELINE_FOLLOW_UP_DEFAULT
+    : ["Supporting source for baseline assumptions, such as remote sensing or inventory evidence"];
+
+  return {
+    review_area: "baseline",
+    verdict,
+    evidence_summary: buildEvidenceSummary(headings),
+    cited_sections: headings.map((heading) => heading.sectionNumber),
+    gaps,
+    recommended_follow_up_documents: followUps,
+  };
+}

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -11,6 +11,7 @@ import {
   type DocumentHeading,
   type SectionCandidateDebug,
 } from "@/lib/chat/quickCheckSectionExtractor";
+import { evaluateBaselineReview, type BaselineReviewResult } from "@/lib/chat/quickCheckBaselineRubric";
 
 export type ReviewArea =
   | "additionality"
@@ -73,6 +74,7 @@ export type ReviewQuestionResult = {
   headingIndex: DocumentHeading[];
   /** Phase 1: headings filtered by the user's question text only (title-based, no body scoring) */
   matchedHeadings: DocumentHeading[];
+  baselineReview?: BaselineReviewResult;
   noMatchExplanation?: string;
   diagnostic?: Record<string, string>;
   phase1Diagnostic?: ReviewQuestionDiagnostic;
@@ -315,6 +317,9 @@ export function buildReviewQuestionResult(input: {
     // Provide body for compat with existing consumers; primary matches never came from body text.
     sectionContent[h.sectionNumber] = h.bodyText ? `${h.title}\n${h.bodyText}` : h.title;
   }
+  const baselineReview = reviewArea === "baseline"
+    ? evaluateBaselineReview({ matchedHeadings })
+    : undefined;
 
   const diagnostic = process.env.NODE_ENV !== "production" && input.rawPddText
     ? debugSectionExtraction(input.rawPddText)
@@ -336,6 +341,7 @@ export function buildReviewQuestionResult(input: {
     sectionContent,
     headingIndex,
     matchedHeadings,
+    baselineReview,
     noMatchExplanation,
     diagnostic,
     phase1Diagnostic,

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -20,6 +20,14 @@ const PDF_TEXT_BY_FILENAME: Record<string, string> = {
   "boundary.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "boundary-note.pdf": "Project boundary description for the Malawi grouped activity. The mapped project area polygon and AOI are referenced in the boundary map. Project location Machinga District, Malawi.",
   "baseline.pdf": "Monitoring report for the full reporting period.",
+  "baseline-strong-review.pdf": [
+    "Project boundary description for the REDD project.",
+    "The mapped project area polygon and AOI are referenced in the boundary map.",
+    "Project location Machinga District, Malawi.",
+    "2.4  Baseline Scenario",
+    "The baseline scenario is the most likely land-use scenario in the absence of the project activity.",
+    "Historical deforestation rates from satellite imagery show a 1.2% annual loss in the reference region.",
+  ].join("\n"),
   "pd-redd-legal.pdf": [
     "Project boundary description for the REDD project.",
     "The mapped project area polygon and AOI are referenced in the boundary map.",
@@ -1008,6 +1016,34 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(text).toContain("Ownership and Other Programs");
     expect(text).toContain("Right of Use");
     expect(text).not.toContain("No matching document section found.");
+  });
+
+  it("renders the baseline evidence-backed verdict for a baseline review question", async () => {
+    seedSession({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-0",
+      filename: "baseline-strong-review.pdf",
+    });
+    await seedAttachmentText("att-upload-1", "%PDF-1.4\n(baseline strong review)\n%%EOF");
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+
+    await flushUi();
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Baseline review");
+    expect(text).toContain("Verdict: supported");
+    expect(text).toContain("§2.4");
+    expect(text).toContain("Conservative Quick Check signal only");
   });
 
   it("distinguishes TOC-only heading matches from recovered body headings", async () => {

--- a/tests/lib/quickCheckBaselineRubric.test.ts
+++ b/tests/lib/quickCheckBaselineRubric.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "@jest/globals";
+import { buildReviewQuestionResult } from "@/lib/chat/quickCheckReviewQuestion";
+
+const STRONG_BASELINE_PDD = [
+  "1.9  Project Location",
+  "Project location Machinga District, Malawi.",
+  "",
+  "2.4  Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario in the absence of the project activity.",
+  "Historical deforestation rates from satellite imagery show a 1.2% annual loss in the reference region.",
+  "",
+].join("\n");
+
+const WEAK_BASELINE_PDD = [
+  "1.9  Project Location",
+  "Project location Machinga District, Malawi.",
+  "",
+  "2.4  Baseline Scenario",
+  "The baseline scenario assumes the same land use without the project.",
+  "",
+].join("\n");
+
+const MISSING_BASELINE_PDD = [
+  "1.9  Project Location",
+  "Project location Machinga District, Malawi.",
+  "",
+  "2.5  Additionality",
+  "The project faces implementation barriers and depends on carbon revenue.",
+  "",
+].join("\n");
+
+describe("baseline evidence-backed review", () => {
+  it("returns supported when a strong baseline section is matched", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: STRONG_BASELINE_PDD,
+    });
+
+    expect(result.reviewArea).toBe("baseline");
+    expect(result.relevantSections).toEqual(["2.4"]);
+    expect(result.baselineReview).toEqual(expect.objectContaining({
+      review_area: "baseline",
+      verdict: "supported",
+      cited_sections: ["2.4"],
+    }));
+    expect(result.baselineReview?.evidence_summary).toContain("§2.4 Baseline Scenario");
+    expect(result.baselineReview?.gaps).toEqual([]);
+  });
+
+  it("returns partial with gaps when the baseline section is weak", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: WEAK_BASELINE_PDD,
+    });
+
+    expect(result.relevantSections).toEqual(["2.4"]);
+    expect(result.baselineReview).toEqual(expect.objectContaining({
+      review_area: "baseline",
+      verdict: "partial",
+      cited_sections: ["2.4"],
+    }));
+    expect(result.baselineReview?.gaps).toContain(
+      "No clear baseline justification basis was found, such as historical trends, drivers, or reference data.",
+    );
+    expect(result.baselineReview?.gaps).toContain(
+      "No quantitative baseline assumption, rate, or measurement was found in the matched section text.",
+    );
+  });
+
+  it("returns missing with a clear reason when no baseline section is matched", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: MISSING_BASELINE_PDD,
+    });
+
+    expect(result.relevantSections).toEqual([]);
+    expect(result.baselineReview).toEqual(expect.objectContaining({
+      review_area: "baseline",
+      verdict: "missing",
+      cited_sections: [],
+    }));
+    expect(result.baselineReview?.evidence_summary).toContain("No baseline-matched document section was recovered");
+    expect(result.baselineReview?.gaps[0]).toContain("No uploaded PDD section heading matched");
+  });
+});


### PR DESCRIPTION
## Summary

Implemented the baseline-only Phase 2 review path.

The main change is a new deterministic rubric in `src/lib/chat/quickCheckBaselineRubric.ts` that evaluates only Phase 1 matched baseline headings and returns:

- `review_area`
- `verdict`
- `evidence_summary`
- `cited_sections`
- `gaps`
- `recommended_follow_up_documents`

That result is now wired into `src/lib/chat/quickCheckReviewQuestion.ts` as `baselineReview`, but **only** when the classified review area is `baseline`. Other review areas are unchanged.

The UI in `src/components/chat/QuickCheckPanel.tsx` now renders a compact “Baseline review” block with the conservative verdict and citations, plus an explicit note that it is **not** a review-grade certainty finding.

### Tests added

- `tests/lib/quickCheckBaselineRubric.test.ts` — synthetic Phase 2 cases:
  - strong baseline evidence → `supported`
  - weak baseline section → `partial` with gaps
  - missing baseline section → `missing`

- Panel regression in `tests/components/quickCheckPanel.test.tsx` to confirm the verdict renders.

Existing heading extraction tests continue to pass.

### Verification

- `npm test` ✓
- `npm run typecheck` ✓

---

**Roadmap alignment**: This implements the active work for `review-grade-quick-check` Phase 2 (baseline evidence-backed review). See PR #650 for the corresponding roadmap status update.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>