### PR TITLE
fix(quick-check): harden baseline rubric against false-positive numbers (dates, pages, unrelated %)

### DIFF
--- a/src/lib/chat/quickCheckBaselineRubric.ts
+++ b/src/lib/chat/quickCheckBaselineRubric.ts
@@ -55,7 +55,6 @@ const BASELINE_QUANT_CONTEXT_PATTERNS = [
 
   // Historical / observed quantification
   /\b(historical|observed)\s+(?:deforestation|degradation|land.use|trend|rate|loss)\s+(?:of\s+)?\d+/i,
-  /\bfrom\s+\d{4}\s+to\s+\d{4}/i, // e.g. "from 2000 to 2020" in a trend context
 
   // Common PDD baseline units
   /\b\d+(?:\.\d+)?\s*(?:ha|hectare|hectares|tCO2|tCO₂|tons?|tonnes?)\s*(?:per|\/)?\s*(?:year|annum)/i,

--- a/src/lib/chat/quickCheckBaselineRubric.ts
+++ b/src/lib/chat/quickCheckBaselineRubric.ts
@@ -41,7 +41,25 @@ const BASELINE_EVIDENCE_SIGNALS = [
   "observed",
 ];
 
-const BASELINE_QUANT_SIGNAL = /\b\d+(?:\.\d+)?%?\b/;
+/**
+ * Stronger, contextual patterns for baseline-related quantitative claims.
+ * These require the number to appear together with baseline-specific reasoning language.
+ */
+const BASELINE_QUANT_CONTEXT_PATTERNS = [
+  // Rates over time explicitly tied to baseline
+  /\b\d+(?:\.\d+)?%?\s*(?:per|\/)\s*(?:year|annum|annual)/i,
+  /\bannual\s+(?:loss|deforestation|degradation|change|rate|trend)\s+(?:of\s+)?\d+/i,
+  /\bdeforestation\s+rate\s+(?:of\s+)?\d+/i,
+  /\bdegradation\s+rate\s+(?:of\s+)?\d+/i,
+  /\b\d+(?:\.\d+)?%?\s*(?:annual|per year|per annum)/i,
+
+  // Historical / observed quantification
+  /\b(historical|observed)\s+(?:deforestation|degradation|land.use|trend|rate|loss)\s+(?:of\s+)?\d+/i,
+  /\bfrom\s+\d{4}\s+to\s+\d{4}/i, // e.g. "from 2000 to 2020" in a trend context
+
+  // Common PDD baseline units
+  /\b\d+(?:\.\d+)?\s*(?:ha|hectare|hectares|tCO2|tCO₂|tons?|tonnes?)\s*(?:per|\/)?\s*(?:year|annum)/i,
+];
 
 const BASELINE_FOLLOW_UP_DEFAULT = [
   "Historical land-use change analysis or baseline modelling note",
@@ -92,7 +110,10 @@ export function evaluateBaselineReview(input: EvaluateBaselineReviewInput): Base
   const normalized = normalizeForSignal(combinedText);
   const scenarioSignals = collectMatchedSignalLabels(normalized, BASELINE_SCENARIO_SIGNALS);
   const evidenceSignals = collectMatchedSignalLabels(normalized, BASELINE_EVIDENCE_SIGNALS);
-  const hasQuantitativeIndicator = BASELINE_QUANT_SIGNAL.test(combinedText);
+
+  const hasContextualQuantitative = BASELINE_QUANT_CONTEXT_PATTERNS.some((pattern) =>
+    pattern.test(combinedText)
+  );
 
   const gaps: string[] = [];
   if (scenarioSignals.length === 0) {
@@ -101,12 +122,14 @@ export function evaluateBaselineReview(input: EvaluateBaselineReviewInput): Base
   if (evidenceSignals.length === 0) {
     gaps.push("No clear baseline justification basis was found, such as historical trends, drivers, or reference data.");
   }
-  if (!hasQuantitativeIndicator) {
-    gaps.push("No quantitative baseline assumption, rate, or measurement was found in the matched section text.");
+  if (!hasContextualQuantitative) {
+    gaps.push(
+      "No quantitative baseline assumption, rate, or measurement clearly tied to baseline reasoning was found (dates, page numbers, or unrelated figures do not count)."
+    );
   }
 
   const verdict: BaselineReviewVerdict =
-    scenarioSignals.length > 0 && evidenceSignals.length > 0 && hasQuantitativeIndicator
+    scenarioSignals.length > 0 && evidenceSignals.length > 0 && hasContextualQuantitative
       ? "supported"
       : scenarioSignals.length > 0
         ? "partial"

--- a/tests/lib/quickCheckBaselineRubric.test.ts
+++ b/tests/lib/quickCheckBaselineRubric.test.ts
@@ -149,4 +149,25 @@ describe("baseline evidence-backed review", () => {
     // Should still detect some evidence signals but lack a properly tied quantitative claim
     expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
   });
+
+  // Regression for bare date ranges (previously allowed by the removed from-YYYY-to-YYYY pattern)
+  const BASELINE_WITH_BARE_DATE_RANGE = [
+    "2.4  Baseline Scenario",
+    "The baseline scenario is the most likely land-use scenario in the absence of the project.",
+    "Historical land use data from 2000 to 2020 was reviewed.",
+    "Satellite data was used to observe changes in the reference region.",
+  ].join("\n");
+
+  it("does not return 'supported' for bare date ranges without a tied rate or measurement (regression)", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BASELINE_WITH_BARE_DATE_RANGE,
+    });
+
+    expect(result.baselineReview?.verdict).not.toBe("supported");
+    expect(["partial", "needs_review"]).toContain(result.baselineReview?.verdict);
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
+  });
 });

--- a/tests/lib/quickCheckBaselineRubric.test.ts
+++ b/tests/lib/quickCheckBaselineRubric.test.ts
@@ -67,7 +67,7 @@ describe("baseline evidence-backed review", () => {
       "No clear baseline justification basis was found, such as historical trends, drivers, or reference data.",
     );
     expect(result.baselineReview?.gaps).toContain(
-      "No quantitative baseline assumption, rate, or measurement was found in the matched section text.",
+      "No quantitative baseline assumption, rate, or measurement clearly tied to baseline reasoning was found (dates, page numbers, or unrelated figures do not count).",
     );
   });
 
@@ -87,5 +87,66 @@ describe("baseline evidence-backed review", () => {
     }));
     expect(result.baselineReview?.evidence_summary).toContain("No baseline-matched document section was recovered");
     expect(result.baselineReview?.gaps[0]).toContain("No uploaded PDD section heading matched");
+  });
+
+  // --- False positive hardening tests (numbers that should NOT trigger "supported") ---
+
+  const BASELINE_WITH_DATE_ONLY = [
+    "2.4  Baseline Scenario",
+    "The baseline scenario is the most likely land-use scenario in the absence of the project.",
+    "Historical land use data from the reference region was collected in 2018.",
+    "The project is expected to start operations in 2025.",
+  ].join("\n");
+
+  const BASELINE_WITH_UNRELATED_PERCENT = [
+    "2.4  Baseline Scenario",
+    "The baseline scenario assumes continuation of current land use practices.",
+    "Satellite imagery from the reference region shows that 65% of the area remains forested.",
+    "The project boundary covers approximately 12,500 ha.",
+  ].join("\n");
+
+  const BASELINE_WITH_SECTION_AND_PAGE_NUMBERS = [
+    "2.4  Baseline Scenario",
+    "The baseline scenario is described in detail on page 47 of this PDD (see also section 3.2).",
+    "Without the project, land-use patterns observed in 2005-2010 would continue.",
+    "Version 1.2 of the methodology was used for this analysis.",
+  ].join("\n");
+
+  it("does not return 'supported' when the only numbers are dates (false positive guard)", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BASELINE_WITH_DATE_ONLY,
+    });
+
+    expect(result.baselineReview?.verdict).not.toBe("supported");
+    expect(["partial", "needs_review"]).toContain(result.baselineReview?.verdict);
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
+  });
+
+  it("does not return 'supported' for unrelated percentages or area sizes without baseline rate context", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BASELINE_WITH_UNRELATED_PERCENT,
+    });
+
+    expect(result.baselineReview?.verdict).not.toBe("supported");
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
+  });
+
+  it("does not return 'supported' when numbers are page numbers, section references, versions, or years without rate context", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BASELINE_WITH_SECTION_AND_PAGE_NUMBERS,
+    });
+
+    expect(result.baselineReview?.verdict).not.toBe("supported");
+    // Should still detect some evidence signals but lack a properly tied quantitative claim
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
   });
 });


### PR DESCRIPTION
## WHAT

- Harden the baseline Quick Check rubric against false positives.
- Add tests where numbers are unrelated to baseline evidence, such as dates, page numbers, section numbers, or unrelated percentages.
- Keep `supported` only when the quantitative value is clearly tied to baseline reasoning.
- Do not expand to other review areas.
- Do not mark Phase 2 done yet.

## WHY

- PR #651 works as the baseline-only Phase 2 MVP.
- The remaining risk is false confidence from keyword and number matching.
- We need safer verdict behavior before expanding to more review areas.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>

---

This is a follow-up hardening PR on top of #651 (base branch: `feat/quick-check-baseline-phase2`). The diff is intentionally small and focused.