### PR TITLE
test(quick-check): align VM0007 extracted-PDD regression metadata with fixture version

### DIFF
--- a/tests/lib/quickCheckBaselineRubric.test.ts
+++ b/tests/lib/quickCheckBaselineRubric.test.ts
@@ -303,3 +303,83 @@ describe("real-document-style baseline regression evals (VM0007 only)", () => {
     expect(resultAdditionality.baselineReview).toBeUndefined();
   });
 });
+
+// ============================================================================
+// Real extracted PDD regression — VM0007 (Phase 2 follow-up)
+// Uses actual extracted fixture text (pd_redd_v1_130-extracted.txt) to protect
+// the real extracted-PDD code path for baseline routing + baselineReview.
+// ============================================================================
+
+import * as fs from "fs";
+import * as path from "path";
+
+const REDD_EXTRACTED_FIXTURE = path.join(
+  __dirname,
+  "../fixtures/quick-check/pd_redd_v1_130-extracted.txt"
+);
+const REDD_EXTRACTED_TEXT = fs.readFileSync(REDD_EXTRACTED_FIXTURE, "utf-8");
+
+describe("real extracted PDD regression — VM0007 baseline routing + baselineReview", () => {
+  it("baseline question on real extracted VM0007 PDD returns reviewArea: baseline and produces baselineReview", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2", // matches "VM0007 Version 4.2" in pd_redd_v1_130-extracted.txt
+      rawPddText: REDD_EXTRACTED_TEXT,
+    });
+
+    expect(result.reviewArea).toBe("baseline");
+    expect(result.baselineReview).toBeDefined();
+    expect(result.baselineReview?.review_area).toBe("baseline");
+  });
+
+  it("baseline result from real extracted PDD includes cited extracted sections", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2", // matches "VM0007 Version 4.2" in pd_redd_v1_130-extracted.txt
+      rawPddText: REDD_EXTRACTED_TEXT,
+    });
+
+    expect(result.baselineReview).toBeDefined();
+    expect(Array.isArray(result.baselineReview?.cited_sections)).toBe(true);
+    expect(result.baselineReview!.cited_sections.length).toBeGreaterThan(0);
+  });
+
+  it("baseline result from real extracted PDD includes follow-up document recommendations", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2", // matches "VM0007 Version 4.2" in pd_redd_v1_130-extracted.txt
+      rawPddText: REDD_EXTRACTED_TEXT,
+    });
+
+    expect(result.baselineReview).toBeDefined();
+    expect(Array.isArray(result.baselineReview?.recommended_follow_up_documents)).toBe(true);
+    expect(result.baselineReview!.recommended_follow_up_documents.length).toBeGreaterThan(0);
+  });
+
+  it("boundary question on real extracted VM0007 PDD returns reviewArea: boundary and does not produce baselineReview", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe the project boundary?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2", // matches "VM0007 Version 4.2" in pd_redd_v1_130-extracted.txt
+      rawPddText: REDD_EXTRACTED_TEXT,
+    });
+
+    expect(result.reviewArea).toBe("boundary");
+    expect(result.baselineReview).toBeUndefined();
+  });
+
+  it("additionality question on real extracted VM0007 PDD returns reviewArea: additionality and does not produce baselineReview", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Is additionality demonstrated in this PDD?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2", // matches "VM0007 Version 4.2" in pd_redd_v1_130-extracted.txt
+      rawPddText: REDD_EXTRACTED_TEXT,
+    });
+
+    expect(result.reviewArea).toBe("additionality");
+    expect(result.baselineReview).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## WHAT

- Optionally align the new VM0007 extracted-PDD regression test metadata with the fixture text.
- In `tests/lib/quickCheckBaselineRubric.test.ts`, update the new real extracted PDD regression cases so `methodologyVersion` matches the fixture’s VM0007 version, or add a short test comment explaining that version is irrelevant to review-area routing.
- Keep the PR test-only.
- Do not mark Phase 2 done.

## WHY

- PR #654 correctly adds the missing extracted-PDD regression coverage.
- The only cleanup is semantic consistency between the VM0007 fixture and the test metadata.
- This avoids future confusion when debugging methodology-version-specific behavior.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>