### PR TITLE
fix(quick-check): finish phase_2_baseline_evidence_backed_review for Quick Check

### DIFF
--- a/docs/roadmaps/review-grade-quick-check/phase-status.json
+++ b/docs/roadmaps/review-grade-quick-check/phase-status.json
@@ -46,13 +46,13 @@
     "646": {
       "title": "Phase 1 — Uploaded PDD section extraction and heading matching"
     },
-    "655": {
+    "656": {
       "title": "Phase 2 — Baseline evidence-backed review (rubric hardening, fixture regression, UI clarity)"
     }
   },
   "pr_notes": {
     "PR642": "Routing MVP: detect review question path, classify review area, route to VM0007 sections. Covers additionality, baseline, boundary, deviations, leakage, monitoring, right_of_use.",
     "646": "completed Phase 1 MVP with uploaded PDD heading extraction, section body rendering, TOC skipping, all-caps heading recovery, duplicate heading handling, question-to-heading filtering, cross-document anti-hardcoding tests, and safe no-match behavior.",
-    "655": "Phase 2 complete: hardened baseline rubric (verdicts limited to supported/partial/missing, quant false-positive guards), full baselineReview shape (review_area, verdict, evidence_summary, cited_sections, gaps, recommended_follow_up_documents), strong/weak/missing + boundary/additionality + extracted VM0007 fixture tests (not just synthetic), clearer UI badges+labels for baseline review output. PR #654 protected regression path; this closes Phase 2 criteria."
+    "656": "Phase 2 complete: hardened baseline rubric (verdicts limited to supported/partial/missing, quant false-positive guards), full baselineReview shape (review_area, verdict, evidence_summary, cited_sections, gaps, recommended_follow_up_documents), strong/weak/missing + boundary/additionality + extracted VM0007 fixture tests (not just synthetic), clearer UI badges+labels for baseline review output. PR #654 protected regression path; this closes Phase 2 criteria."
   }
 }

--- a/docs/roadmaps/review-grade-quick-check/phase-status.json
+++ b/docs/roadmaps/review-grade-quick-check/phase-status.json
@@ -11,7 +11,7 @@
     "summary": "Extract section content from uploaded PDD pages. Map section numbers to extracted text. Render section excerpts inline in the review-question result."
   },
   "phase_2_baseline_evidence_backed_review": {
-    "status": "active",
+    "status": "done",
     "title": "Baseline evidence-backed review — verdicts and gaps",
     "summary": "For baseline review questions, produce evidence-backed verdicts (supported / partial / missing) with gap explanations. Reference extracted PDD section content. Surface next-step follow-up documents."
   },
@@ -33,22 +33,26 @@
   "phase_meta": {
     "status": "active",
     "summary": "Turn Quick Check from a requirement matcher / section router into an evidence-backed verification-readiness review engine. Phased path from routing to readiness note export.",
-    "current_focus": "Phase 2: baseline evidence-backed review — verdicts and gaps",
+    "current_focus": "Phase 2 complete (baseline evidence-backed review with fixture-backed tests and UI). Phase 3 (review-area rubrics) not started per instructions.",
     "not_active_now": [
       "Review area rubrics (phase 3+)",
       "Regression evaluation suite (phase 4+)",
       "Readiness note export (phase 5+)"
     ],
-    "last_updated_at": "2026-05-28T00:00:00Z"
+    "last_updated_at": "2026-05-31T00:00:00Z"
   },
   "pr_evidence": {
     "PR642": [640, 641, 642],
     "646": {
       "title": "Phase 1 — Uploaded PDD section extraction and heading matching"
+    },
+    "655": {
+      "title": "Phase 2 — Baseline evidence-backed review (rubric hardening, fixture regression, UI clarity)"
     }
   },
   "pr_notes": {
     "PR642": "Routing MVP: detect review question path, classify review area, route to VM0007 sections. Covers additionality, baseline, boundary, deviations, leakage, monitoring, right_of_use.",
-    "646": "completed Phase 1 MVP with uploaded PDD heading extraction, section body rendering, TOC skipping, all-caps heading recovery, duplicate heading handling, question-to-heading filtering, cross-document anti-hardcoding tests, and safe no-match behavior."
+    "646": "completed Phase 1 MVP with uploaded PDD heading extraction, section body rendering, TOC skipping, all-caps heading recovery, duplicate heading handling, question-to-heading filtering, cross-document anti-hardcoding tests, and safe no-match behavior.",
+    "655": "Phase 2 complete: hardened baseline rubric (verdicts limited to supported/partial/missing, quant false-positive guards), full baselineReview shape (review_area, verdict, evidence_summary, cited_sections, gaps, recommended_follow_up_documents), strong/weak/missing + boundary/additionality + extracted VM0007 fixture tests (not just synthetic), clearer UI badges+labels for baseline review output. PR #654 protected regression path; this closes Phase 2 criteria."
   }
 }

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2159,31 +2159,49 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   </div>
                   {reviewQuestionResult.baselineReview ? (
                     <div className="mt-4 rounded-xl border border-emerald-200 bg-white/80 p-4">
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700">Baseline review</div>
-                      <div className="mt-2 text-sm font-medium text-slate-900">
-                        Verdict: {reviewQuestionResult.baselineReview.verdict}
+                      <div className="flex items-center gap-2">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700">Baseline review</div>
+                        {(() => {
+                          const v = reviewQuestionResult.baselineReview.verdict;
+                          const badge =
+                            v === "supported"
+                              ? "bg-emerald-100 text-emerald-800 border-emerald-200"
+                              : v === "partial"
+                                ? "bg-amber-100 text-amber-800 border-amber-200"
+                                : "bg-rose-100 text-rose-800 border-rose-200";
+                          return (
+                            <span className={`inline-block rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] border ${badge}`}>
+                              {v}
+                            </span>
+                          );
+                        })()}
                       </div>
-                      <div className="mt-2 text-sm leading-relaxed text-slate-700">
-                        {reviewQuestionResult.baselineReview.evidence_summary}
+                      <div className="mt-3">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Evidence summary</div>
+                        <div className="mt-1 text-sm leading-relaxed text-slate-700">
+                          {reviewQuestionResult.baselineReview.evidence_summary}
+                        </div>
                       </div>
                       <div className="mt-3">
                         <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Cited sections</div>
-                        <div className="mt-1 text-sm text-slate-700">
+                        <div className="mt-1 text-sm text-slate-700 font-mono">
                           {reviewQuestionResult.baselineReview.cited_sections.length > 0
                             ? reviewQuestionResult.baselineReview.cited_sections.map((section) => `§${section}`).join(", ")
                             : "None"}
                         </div>
                       </div>
-                      {reviewQuestionResult.baselineReview.gaps.length > 0 ? (
-                        <div className="mt-3">
-                          <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Gaps</div>
+                      <div className="mt-3">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Gaps</div>
+                        {reviewQuestionResult.baselineReview.gaps.length > 0 ? (
                           <ul className="mt-1 list-disc pl-5 text-sm leading-relaxed text-slate-700">
                             {reviewQuestionResult.baselineReview.gaps.map((gap) => (
                               <li key={gap}>{gap}</li>
                             ))}
                           </ul>
-                        </div>
-                      ) : null}
+                        ) : (
+                          <div className="mt-1 text-sm text-emerald-700">None identified — baseline scenario appears supported by extracted PDD content.</div>
+                        )}
+                      </div>
                       <div className="mt-3">
                         <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Recommended follow-up documents</div>
                         <ul className="mt-1 list-disc pl-5 text-sm leading-relaxed text-slate-700">

--- a/src/lib/chat/quickCheckBaselineRubric.ts
+++ b/src/lib/chat/quickCheckBaselineRubric.ts
@@ -55,7 +55,6 @@ const BASELINE_QUANT_CONTEXT_PATTERNS = [
 
   // Historical / observed quantification
   /\b(historical|observed)\s+(?:deforestation|degradation|land.use|trend|rate|loss)\s+(?:of\s+)?\d+/i,
-  /\bfrom\s+\d{4}\s+to\s+\d{4}/i, // e.g. "from 2000 to 2020" in a trend context
 
   // Common PDD baseline units
   /\b\d+(?:\.\d+)?\s*(?:ha|hectare|hectares|tCO2|tCO₂|tons?|tonnes?)\s*(?:per|\/)?\s*(?:year|annum)/i,

--- a/src/lib/chat/quickCheckBaselineRubric.ts
+++ b/src/lib/chat/quickCheckBaselineRubric.ts
@@ -41,7 +41,25 @@ const BASELINE_EVIDENCE_SIGNALS = [
   "observed",
 ];
 
-const BASELINE_QUANT_SIGNAL = /\b\d+(?:\.\d+)?%?\b/;
+/**
+ * Stronger, contextual patterns for baseline-related quantitative claims.
+ * These require the number to appear together with baseline-specific reasoning language.
+ */
+const BASELINE_QUANT_CONTEXT_PATTERNS = [
+  // Rates over time explicitly tied to baseline
+  /\b\d+(?:\.\d+)?%?\s*(?:per|\/)\s*(?:year|annum|annual)/i,
+  /\bannual\s+(?:loss|deforestation|degradation|change|rate|trend)\s+(?:of\s+)?\d+/i,
+  /\bdeforestation\s+rate\s+(?:of\s+)?\d+/i,
+  /\bdegradation\s+rate\s+(?:of\s+)?\d+/i,
+  /\b\d+(?:\.\d+)?%?\s*(?:annual|per year|per annum)/i,
+
+  // Historical / observed quantification
+  /\b(historical|observed)\s+(?:deforestation|degradation|land.use|trend|rate|loss)\s+(?:of\s+)?\d+/i,
+  /\bfrom\s+\d{4}\s+to\s+\d{4}/i, // e.g. "from 2000 to 2020" in a trend context
+
+  // Common PDD baseline units
+  /\b\d+(?:\.\d+)?\s*(?:ha|hectare|hectares|tCO2|tCO₂|tons?|tonnes?)\s*(?:per|\/)?\s*(?:year|annum)/i,
+];
 
 const BASELINE_FOLLOW_UP_DEFAULT = [
   "Historical land-use change analysis or baseline modelling note",
@@ -92,7 +110,10 @@ export function evaluateBaselineReview(input: EvaluateBaselineReviewInput): Base
   const normalized = normalizeForSignal(combinedText);
   const scenarioSignals = collectMatchedSignalLabels(normalized, BASELINE_SCENARIO_SIGNALS);
   const evidenceSignals = collectMatchedSignalLabels(normalized, BASELINE_EVIDENCE_SIGNALS);
-  const hasQuantitativeIndicator = BASELINE_QUANT_SIGNAL.test(combinedText);
+
+  const hasContextualQuantitative = BASELINE_QUANT_CONTEXT_PATTERNS.some((pattern) =>
+    pattern.test(combinedText)
+  );
 
   const gaps: string[] = [];
   if (scenarioSignals.length === 0) {
@@ -101,12 +122,14 @@ export function evaluateBaselineReview(input: EvaluateBaselineReviewInput): Base
   if (evidenceSignals.length === 0) {
     gaps.push("No clear baseline justification basis was found, such as historical trends, drivers, or reference data.");
   }
-  if (!hasQuantitativeIndicator) {
-    gaps.push("No quantitative baseline assumption, rate, or measurement was found in the matched section text.");
+  if (!hasContextualQuantitative) {
+    gaps.push(
+      "No quantitative baseline assumption, rate, or measurement clearly tied to baseline reasoning was found (dates, page numbers, or unrelated figures do not count)."
+    );
   }
 
   const verdict: BaselineReviewVerdict =
-    scenarioSignals.length > 0 && evidenceSignals.length > 0 && hasQuantitativeIndicator
+    scenarioSignals.length > 0 && evidenceSignals.length > 0 && hasContextualQuantitative
       ? "supported"
       : scenarioSignals.length > 0
         ? "partial"

--- a/src/lib/chat/quickCheckBaselineRubric.ts
+++ b/src/lib/chat/quickCheckBaselineRubric.ts
@@ -1,6 +1,6 @@
 import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
 
-export type BaselineReviewVerdict = "supported" | "partial" | "missing" | "needs_review";
+export type BaselineReviewVerdict = "supported" | "partial" | "missing";
 
 export type BaselineReviewResult = {
   review_area: "baseline";
@@ -132,7 +132,7 @@ export function evaluateBaselineReview(input: EvaluateBaselineReviewInput): Base
       ? "supported"
       : scenarioSignals.length > 0
         ? "partial"
-        : "needs_review";
+        : "missing";
 
   const followUps = gaps.length > 0
     ? BASELINE_FOLLOW_UP_DEFAULT

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -56,11 +56,6 @@ const PDF_TEXT_BY_FILENAME: Record<string, string> = {
   "no-method-detected.pdf": "Monitoring report for the full reporting period without any explicit methodology code.",
 };
 
-// Load real extracted VM0007 PDD fixture text (Phase 2 requirement: prove extracted-PDD fixture, not only synthetic inline strings)
-const REDD_EXTRACTED_FIXTURE_PATH = path.join(process.cwd(), "tests/fixtures/quick-check/pd_redd_v1_130-extracted.txt");
-const REDD_EXTRACTED_FIXTURE_TEXT = fs.readFileSync(REDD_EXTRACTED_FIXTURE_PATH, "utf-8");
-PDF_TEXT_BY_FILENAME["pd_redd_v1_130-extracted.pdf"] = REDD_EXTRACTED_FIXTURE_TEXT;
-
 jest.mock("@/lib/proofMap/attachments", () => ({
   ...jest.requireActual("@/lib/proofMap/attachments"),
   createAndStoreEvidenceAttachment: (...args: unknown[]) => createAndStoreEvidenceAttachmentMock(...args),

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -56,6 +56,11 @@ const PDF_TEXT_BY_FILENAME: Record<string, string> = {
   "no-method-detected.pdf": "Monitoring report for the full reporting period without any explicit methodology code.",
 };
 
+// Load real extracted VM0007 PDD fixture text (Phase 2 requirement: prove extracted-PDD fixture, not only synthetic inline strings)
+const REDD_EXTRACTED_FIXTURE_PATH = path.join(process.cwd(), "tests/fixtures/quick-check/pd_redd_v1_130-extracted.txt");
+const REDD_EXTRACTED_FIXTURE_TEXT = fs.readFileSync(REDD_EXTRACTED_FIXTURE_PATH, "utf-8");
+PDF_TEXT_BY_FILENAME["pd_redd_v1_130-extracted.pdf"] = REDD_EXTRACTED_FIXTURE_TEXT;
+
 jest.mock("@/lib/proofMap/attachments", () => ({
   ...jest.requireActual("@/lib/proofMap/attachments"),
   createAndStoreEvidenceAttachment: (...args: unknown[]) => createAndStoreEvidenceAttachmentMock(...args),
@@ -1019,6 +1024,7 @@ describe("QuickCheckPanel claim-first flow", () => {
   });
 
   it("renders the baseline evidence-backed verdict for a baseline review question", async () => {
+    // Uses inline synthetic strong baseline (see lib tests for extracted-PDD fixture proving complete baselineReview from real VM0007 text)
     seedSession({
       claimText: "Does this PDD justify the baseline scenario?",
       methodologyId: "VM0007",
@@ -1041,8 +1047,11 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     const text = container.textContent ?? "";
     expect(text).toContain("Baseline review");
-    expect(text).toContain("Verdict: supported");
+    expect(text).toContain("supported");
     expect(text).toContain("§2.4");
+    expect(text).toContain("Evidence summary");
+    expect(text).toContain("Gaps");
+    expect(text).toContain("Recommended follow-up documents");
     expect(text).toContain("Conservative Quick Check signal only");
   });
 

--- a/tests/lib/quickCheckBaselineRubric.test.ts
+++ b/tests/lib/quickCheckBaselineRubric.test.ts
@@ -173,6 +173,87 @@ describe("baseline evidence-backed review", () => {
 });
 
 // ============================================================================
+// Real extracted PDD regression tests (Phase 2 follow-up)
+// These use actual extracted fixture text from a VM0007-style PDD to protect
+// the end-to-end routing + baselineReview production path (not just synthetic
+// inline strings).
+// ============================================================================
+
+import * as fs from "fs";
+import * as path from "path";
+
+const REDD_EXTRACTED_FIXTURE = path.join(
+  __dirname,
+  "../fixtures/quick-check/pd_redd_v1_130-extracted.txt"
+);
+const REDD_EXTRACTED_TEXT = fs.readFileSync(REDD_EXTRACTED_FIXTURE, "utf-8");
+
+describe("real extracted PDD regression — VM0007 baseline routing + baselineReview", () => {
+  it("baseline question on real extracted VM0007 PDD returns reviewArea: baseline and produces baselineReview", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: REDD_EXTRACTED_TEXT,
+    });
+
+    expect(result.reviewArea).toBe("baseline");
+    expect(result.baselineReview).toBeDefined();
+    expect(result.baselineReview?.review_area).toBe("baseline");
+  });
+
+  it("baseline result from real extracted PDD includes cited extracted sections", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: REDD_EXTRACTED_TEXT,
+    });
+
+    expect(result.baselineReview).toBeDefined();
+    expect(Array.isArray(result.baselineReview?.cited_sections)).toBe(true);
+    expect(result.baselineReview!.cited_sections.length).toBeGreaterThan(0);
+  });
+
+  it("baseline result from real extracted PDD includes follow-up document recommendations", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: REDD_EXTRACTED_TEXT,
+    });
+
+    expect(result.baselineReview).toBeDefined();
+    expect(Array.isArray(result.baselineReview?.recommended_follow_up_documents)).toBe(true);
+    expect(result.baselineReview!.recommended_follow_up_documents.length).toBeGreaterThan(0);
+  });
+
+  it("boundary question on real extracted VM0007 PDD returns reviewArea: boundary and does not produce baselineReview", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe the project boundary?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: REDD_EXTRACTED_TEXT,
+    });
+
+    expect(result.reviewArea).toBe("boundary");
+    expect(result.baselineReview).toBeUndefined();
+  });
+
+  it("additionality question on real extracted VM0007 PDD returns reviewArea: additionality and does not produce baselineReview", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Is additionality demonstrated in this PDD?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: REDD_EXTRACTED_TEXT,
+    });
+
+    expect(result.reviewArea).toBe("additionality");
+    expect(result.baselineReview).toBeUndefined();
+  });
+});
+
+// ============================================================================
 // Real-document-style baseline regression evals (Phase 2)
 // These use longer, messier PDD-style text with dates, page numbers, project
 // sizes, mixed sections, and realistic (imperfect) baseline wording.

--- a/tests/lib/quickCheckBaselineRubric.test.ts
+++ b/tests/lib/quickCheckBaselineRubric.test.ts
@@ -149,4 +149,25 @@ describe("baseline evidence-backed review", () => {
     // Should still detect some evidence signals but lack a properly tied quantitative claim
     expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
   });
+
+  // Regression for bare date ranges (previously allowed by the removed from-YYYY-to-YYYY pattern)
+  const BASELINE_WITH_BARE_DATE_RANGE = [
+    "2.4  Baseline Scenario",
+    "The baseline scenario is the most likely land-use scenario in the absence of the project.",
+    "Historical land use data from 2000 to 2020 was reviewed.",
+    "Satellite data was used to observe changes in the reference region.",
+  ].join("\n");
+
+  it("does not return 'supported' for bare date ranges without a tied rate or measurement (regression)", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BASELINE_WITH_BARE_DATE_RANGE,
+    });
+
+    expect(result.baselineReview?.verdict).not.toBe("supported");
+    expect(["partial", "needs_review"]).toContain(result.baselineReview?.verdict);
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
+  });
 });

--- a/tests/lib/quickCheckBaselineRubric.test.ts
+++ b/tests/lib/quickCheckBaselineRubric.test.ts
@@ -193,7 +193,7 @@ describe("real extracted PDD regression — VM0007 baseline routing + baselineRe
     const result = buildReviewQuestionResult({
       claimText: "Does this PDD justify the baseline scenario?",
       methodologyId: "VM0007",
-      methodologyVersion: "1.0",
+      methodologyVersion: "4.2", // matches "VM0007 Version 4.2" in the pd_redd_v1_130-extracted.txt fixture
       rawPddText: REDD_EXTRACTED_TEXT,
     });
 
@@ -206,7 +206,7 @@ describe("real extracted PDD regression — VM0007 baseline routing + baselineRe
     const result = buildReviewQuestionResult({
       claimText: "Does this PDD justify the baseline scenario?",
       methodologyId: "VM0007",
-      methodologyVersion: "1.0",
+      methodologyVersion: "4.2", // matches "VM0007 Version 4.2" in the pd_redd_v1_130-extracted.txt fixture
       rawPddText: REDD_EXTRACTED_TEXT,
     });
 
@@ -219,7 +219,7 @@ describe("real extracted PDD regression — VM0007 baseline routing + baselineRe
     const result = buildReviewQuestionResult({
       claimText: "Does this PDD justify the baseline scenario?",
       methodologyId: "VM0007",
-      methodologyVersion: "1.0",
+      methodologyVersion: "4.2", // matches "VM0007 Version 4.2" in the pd_redd_v1_130-extracted.txt fixture
       rawPddText: REDD_EXTRACTED_TEXT,
     });
 
@@ -232,7 +232,7 @@ describe("real extracted PDD regression — VM0007 baseline routing + baselineRe
     const result = buildReviewQuestionResult({
       claimText: "Does this PDD describe the project boundary?",
       methodologyId: "VM0007",
-      methodologyVersion: "1.0",
+      methodologyVersion: "4.2", // matches "VM0007 Version 4.2" in the pd_redd_v1_130-extracted.txt fixture
       rawPddText: REDD_EXTRACTED_TEXT,
     });
 
@@ -244,7 +244,7 @@ describe("real extracted PDD regression — VM0007 baseline routing + baselineRe
     const result = buildReviewQuestionResult({
       claimText: "Is additionality demonstrated in this PDD?",
       methodologyId: "VM0007",
-      methodologyVersion: "1.0",
+      methodologyVersion: "4.2", // matches "VM0007 Version 4.2" in the pd_redd_v1_130-extracted.txt fixture
       rawPddText: REDD_EXTRACTED_TEXT,
     });
 

--- a/tests/lib/quickCheckBaselineRubric.test.ts
+++ b/tests/lib/quickCheckBaselineRubric.test.ts
@@ -171,3 +171,135 @@ describe("baseline evidence-backed review", () => {
     expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
   });
 });
+
+// ============================================================================
+// Real-document-style baseline regression evals (Phase 2)
+// These use longer, messier PDD-style text with dates, page numbers, project
+// sizes, mixed sections, and realistic (imperfect) baseline wording.
+// ============================================================================
+
+describe("real-document-style baseline regression evals (VM0007 only)", () => {
+  const STRONG_REALISTIC_BASELINE_PDD = [
+    "2.3  Project Location and Boundaries",
+    "The project is located in the province of Zambezia, Mozambique. The project area covers 48,750 hectares as delineated in the attached maps (see Figure 2.1 on page 14). The project boundary was defined using Landsat imagery acquired on 15 March 2010 and updated with Sentinel-2 data from 2022.",
+    "",
+    "2.4  Baseline Scenario",
+    "The baseline scenario is the continuation of the most likely land-use scenario in the absence of the project activity. Without the project, smallholder agriculture and charcoal production would continue to drive deforestation in the reference region.",
+    "Historical analysis of satellite imagery covering the period 2000-2020 (see Annex 3, pages 87-112) indicates an average annual deforestation rate of 1.85% within the reference region. This rate is derived from supervised classification of Landsat 5, 7 and 8 scenes acquired between 15 January and 30 April of each year. The analysis shows a total loss of 14,320 hectares of forest cover between 2005 and 2018.",
+    "Key drivers of deforestation identified through participatory rural appraisal and analysis of national land-use statistics include: expansion of subsistence agriculture (42%), charcoal production for urban markets (31%), and small-scale commercial logging (18%). These trends are expected to persist or accelerate in the without-project scenario due to population growth of 2.7% per annum and limited enforcement of existing forest regulations.",
+    "Page 23 of 156",
+  ].join("\n");
+
+  const WEAK_REALISTIC_BASELINE_PDD = [
+    "1.1  Introduction",
+    "This Project Design Document describes a REDD+ initiative in the Central Region of Ghana. The total project area is approximately 32,400 ha.",
+    "",
+    "2.4  Baseline Scenario",
+    "In the absence of the proposed project activities, the current land use practices are expected to continue. The area has historically been used for a combination of small-scale farming and fuelwood collection.",
+    "Some forest loss has occurred in the past, as can be seen from older maps dated 1998 and 2007 (Appendix B). The project area is bordered by community lands to the north and a protected area to the south.",
+    "Data collection for this analysis was completed in June 2019. Additional field visits were conducted in February 2021 (see field notes on page 67).",
+    "The without-project scenario assumes that  the rate of land conversion will remain similar to what has been observed in neighbouring districts over the last decade.",
+  ].join("\n");
+
+  const FALSE_POSITIVE_NUMBERS_BASELINE_PDD = [
+    "2.1  General Project Information",
+    "Project ID: REDD-GH-042. Version 2.3 of this PDD was submitted on 12 September 2022.",
+    "",
+    "2.4  Baseline Scenario",
+    "The baseline scenario represents the most likely land use in the absence of the project. The project area comprises 27,850 ha of which approximately 65% is currently under some form of forest cover according to the 2015 national forest inventory.",
+    "Land use data was compiled from various sources including the 2008 and 2016 district development plans. A total of 1,245 households were surveyed between March and July 2019 (survey instrument reproduced in Annex 4, pages 44-51).",
+    "Without the project, it is assumed that the current mosaic of agriculture, fallow and degraded woodland will persist. The reference region experienced a population increase from 186,000 in 2010 to 214,000 in 2020.",
+    "See also Section 3.2 (page 31) for additional information on land tenure and Section 4.7 (page 58) for climate data covering the period 1995-2021.",
+  ].join("\n");
+
+  const NO_BASELINE_SECTION_PDD = [
+    "1.2  Project Boundary",
+    "The project boundary encompasses 19,600 ha of miombo woodland in the Eastern Province of Zambia. The boundary was delineated using a combination of GPS tracks collected during the 14-22 April 2018 field campaign and high-resolution imagery acquired on 03 May 2018 (see Map 1.1 on page 9).",
+    "",
+    "2.5  Additionality",
+    "The project faces significant implementation barriers including limited access to carbon finance, weak enforcement of land-use regulations, and high transaction costs associated with community engagement across 14 villages.",
+    "Without carbon revenues the project would not be financially viable. The internal rate of return without carbon credit sales is estimated at 2.1%, below the 8% benchmark used by the project developer.",
+    "Page 17 of 94",
+  ].join("\n");
+
+  it("returns supported for strong, realistic baseline evidence with rates and historical data", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: STRONG_REALISTIC_BASELINE_PDD,
+    });
+
+    expect(result.reviewArea).toBe("baseline");
+    expect(result.relevantSections).toContain("2.4");
+    expect(result.baselineReview?.verdict).toBe("supported");
+    expect(result.baselineReview?.cited_sections).toContain("2.4");
+    // Should not have the "no quantitative" gap
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(false);
+  });
+
+  it("returns partial for baseline section that mentions scenario but lacks tied quantitative evidence", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: WEAK_REALISTIC_BASELINE_PDD,
+    });
+
+    expect(result.reviewArea).toBe("baseline");
+    expect(result.relevantSections).toContain("2.4");
+    expect(result.baselineReview?.verdict).toBe("partial");
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
+  });
+
+  it("does not return supported when baseline section contains only dates, project sizes and page numbers without rate context", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: FALSE_POSITIVE_NUMBERS_BASELINE_PDD,
+    });
+
+    expect(result.reviewArea).toBe("baseline");
+    expect(result.baselineReview?.verdict).not.toBe("supported");
+    expect(["partial", "needs_review"]).toContain(result.baselineReview?.verdict);
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
+  });
+
+  it("returns missing when the uploaded PDD has no baseline section matching the question", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: NO_BASELINE_SECTION_PDD,
+    });
+
+    expect(result.reviewArea).toBe("baseline");
+    expect(result.relevantSections).toEqual([]);
+    expect(result.baselineReview?.verdict).toBe("missing");
+    expect(result.baselineReview?.cited_sections).toEqual([]);
+  });
+
+  it("does not produce baselineReview when the question is about boundary or additionality", () => {
+    // Strong baseline text but non-baseline question
+    const resultBoundary = buildReviewQuestionResult({
+      claimText: "Does this PDD describe the project boundary?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: STRONG_REALISTIC_BASELINE_PDD,
+    });
+
+    expect(resultBoundary.reviewArea).toBe("boundary");
+    expect(resultBoundary.baselineReview).toBeUndefined();
+
+    const resultAdditionality = buildReviewQuestionResult({
+      claimText: "Is additionality demonstrated for this project?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: STRONG_REALISTIC_BASELINE_PDD,
+    });
+
+    expect(resultAdditionality.reviewArea).toBe("additionality");
+    expect(resultAdditionality.baselineReview).toBeUndefined();
+  });
+});

--- a/tests/lib/quickCheckBaselineRubric.test.ts
+++ b/tests/lib/quickCheckBaselineRubric.test.ts
@@ -67,7 +67,7 @@ describe("baseline evidence-backed review", () => {
       "No clear baseline justification basis was found, such as historical trends, drivers, or reference data.",
     );
     expect(result.baselineReview?.gaps).toContain(
-      "No quantitative baseline assumption, rate, or measurement was found in the matched section text.",
+      "No quantitative baseline assumption, rate, or measurement clearly tied to baseline reasoning was found (dates, page numbers, or unrelated figures do not count).",
     );
   });
 
@@ -87,5 +87,66 @@ describe("baseline evidence-backed review", () => {
     }));
     expect(result.baselineReview?.evidence_summary).toContain("No baseline-matched document section was recovered");
     expect(result.baselineReview?.gaps[0]).toContain("No uploaded PDD section heading matched");
+  });
+
+  // --- False positive hardening tests (numbers that should NOT trigger "supported") ---
+
+  const BASELINE_WITH_DATE_ONLY = [
+    "2.4  Baseline Scenario",
+    "The baseline scenario is the most likely land-use scenario in the absence of the project.",
+    "Historical land use data from the reference region was collected in 2018.",
+    "The project is expected to start operations in 2025.",
+  ].join("\n");
+
+  const BASELINE_WITH_UNRELATED_PERCENT = [
+    "2.4  Baseline Scenario",
+    "The baseline scenario assumes continuation of current land use practices.",
+    "Satellite imagery from the reference region shows that 65% of the area remains forested.",
+    "The project boundary covers approximately 12,500 ha.",
+  ].join("\n");
+
+  const BASELINE_WITH_SECTION_AND_PAGE_NUMBERS = [
+    "2.4  Baseline Scenario",
+    "The baseline scenario is described in detail on page 47 of this PDD (see also section 3.2).",
+    "Without the project, land-use patterns observed in 2005-2010 would continue.",
+    "Version 1.2 of the methodology was used for this analysis.",
+  ].join("\n");
+
+  it("does not return 'supported' when the only numbers are dates (false positive guard)", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BASELINE_WITH_DATE_ONLY,
+    });
+
+    expect(result.baselineReview?.verdict).not.toBe("supported");
+    expect(["partial", "needs_review"]).toContain(result.baselineReview?.verdict);
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
+  });
+
+  it("does not return 'supported' for unrelated percentages or area sizes without baseline rate context", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BASELINE_WITH_UNRELATED_PERCENT,
+    });
+
+    expect(result.baselineReview?.verdict).not.toBe("supported");
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
+  });
+
+  it("does not return 'supported' when numbers are page numbers, section references, versions, or years without rate context", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD justify the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BASELINE_WITH_SECTION_AND_PAGE_NUMBERS,
+    });
+
+    expect(result.baselineReview?.verdict).not.toBe("supported");
+    // Should still detect some evidence signals but lack a properly tied quantitative claim
+    expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
   });
 });

--- a/tests/lib/quickCheckBaselineRubric.test.ts
+++ b/tests/lib/quickCheckBaselineRubric.test.ts
@@ -121,7 +121,7 @@ describe("baseline evidence-backed review", () => {
     });
 
     expect(result.baselineReview?.verdict).not.toBe("supported");
-    expect(["partial", "needs_review"]).toContain(result.baselineReview?.verdict);
+    expect(result.baselineReview?.verdict).toBe("partial");
     expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
   });
 
@@ -167,7 +167,7 @@ describe("baseline evidence-backed review", () => {
     });
 
     expect(result.baselineReview?.verdict).not.toBe("supported");
-    expect(["partial", "needs_review"]).toContain(result.baselineReview?.verdict);
+    expect(result.baselineReview?.verdict).toBe("partial");
     expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
   });
 });
@@ -200,6 +200,13 @@ describe("real extracted PDD regression — VM0007 baseline routing + baselineRe
     expect(result.reviewArea).toBe("baseline");
     expect(result.baselineReview).toBeDefined();
     expect(result.baselineReview?.review_area).toBe("baseline");
+    // Phase 2 complete: extracted fixture (not synthetic) produces full evidence-backed baselineReview
+    expect(result.baselineReview?.verdict).toBe("supported");
+    expect(result.baselineReview?.cited_sections).toEqual(["2.4"]);
+    expect(result.baselineReview?.gaps).toEqual([]);
+    expect(Array.isArray(result.baselineReview?.recommended_follow_up_documents)).toBe(true);
+    expect(result.baselineReview!.recommended_follow_up_documents.length).toBeGreaterThan(0);
+    expect(result.baselineReview?.evidence_summary).toContain("§2.4 (Baseline Scenario)");
   });
 
   it("baseline result from real extracted PDD includes cited extracted sections", () => {
@@ -211,8 +218,8 @@ describe("real extracted PDD regression — VM0007 baseline routing + baselineRe
     });
 
     expect(result.baselineReview).toBeDefined();
-    expect(Array.isArray(result.baselineReview?.cited_sections)).toBe(true);
-    expect(result.baselineReview!.cited_sections.length).toBeGreaterThan(0);
+    expect(result.baselineReview?.cited_sections).toEqual(["2.4"]);
+    expect(result.baselineReview?.verdict).toBe("supported");
   });
 
   it("baseline result from real extracted PDD includes follow-up document recommendations", () => {
@@ -224,8 +231,8 @@ describe("real extracted PDD regression — VM0007 baseline routing + baselineRe
     });
 
     expect(result.baselineReview).toBeDefined();
-    expect(Array.isArray(result.baselineReview?.recommended_follow_up_documents)).toBe(true);
-    expect(result.baselineReview!.recommended_follow_up_documents.length).toBeGreaterThan(0);
+    expect(result.baselineReview?.recommended_follow_up_documents.length).toBeGreaterThan(0);
+    expect(result.baselineReview?.gaps).toEqual([]);
   });
 
   it("boundary question on real extracted VM0007 PDD returns reviewArea: boundary and does not produce baselineReview", () => {
@@ -343,7 +350,7 @@ describe("real-document-style baseline regression evals (VM0007 only)", () => {
 
     expect(result.reviewArea).toBe("baseline");
     expect(result.baselineReview?.verdict).not.toBe("supported");
-    expect(["partial", "needs_review"]).toContain(result.baselineReview?.verdict);
+    expect(result.baselineReview?.verdict).toBe("partial");
     expect(result.baselineReview?.gaps.some(g => g.includes("quantitative baseline assumption"))).toBe(true);
   });
 


### PR DESCRIPTION
### WHAT

- Finish `phase_2_baseline_evidence_backed_review` for Quick Check.
- Confirm uploaded/extracted VM0007 PDD text can produce a complete `baselineReview`.
- Ensure `baselineReview` includes:
  - `review_area`
  - `verdict`
  - `evidence_summary`
  - `cited_sections`
  - `gaps`
  - `recommended_follow_up_documents`
- Add or update tests proving:
  - strong baseline evidence returns `supported`
  - weak baseline evidence returns `partial`
  - missing baseline evidence returns `missing`
  - boundary questions do not produce `baselineReview`
  - additionality questions do not produce `baselineReview`
  - extracted-PDD fixture text works, not only short inline synthetic strings
- Confirm the Quick Check UI renders the baseline review output clearly (color-coded verdict badges, labeled sections, always-visible gaps/follow-ups with positive state).
- Updated `docs/roadmaps/review-grade-quick-check/phase-status.json` (Phase 2 now done). Did **not** update `review-grade-evidence-intelligence/phase-status.json` (its Phase 2 / RC phases already complete; criteria scope is Quick Check). Did not start Phase 3 review-area rubrics.

### WHY

- Phase 2 is still the active roadmap focus.
- PR #654 protects the extracted-PDD regression path, but it does not by itself prove Phase 2 is complete.
- Phase 2 is done only when baseline questions produce evidence-backed verdicts, gaps, cited sections, and follow-up documents from extracted PDD content.

### Roadmap-Update
- slug: review-grade-quick-check
- items:
  - phase_2_baseline_evidence_backed_review: done
  - PR656: done

Signed-off-by: Fred Egbuedike <fredilly@article6.org>