### PR TITLE
[codex] start Phase 3 quick check routing for right-of-use and stakeholder

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -129,7 +129,6 @@ Lane status: Active
 Turn Quick Check from a requirement matcher / section router into an evidence-backed verification-readiness review engine. Phased path from routing to readiness note export.
 
 Not active now:
-- Review area rubrics (phase 3+)
 - Regression evaluation suite (phase 4+)
 - Readiness note export (phase 5+)
 

--- a/docs/roadmaps/review-grade-quick-check/phase-status.json
+++ b/docs/roadmaps/review-grade-quick-check/phase-status.json
@@ -16,7 +16,7 @@
     "summary": "For baseline review questions, produce evidence-backed verdicts (supported / partial / missing) with gap explanations. Reference extracted PDD section content. Surface next-step follow-up documents."
   },
   "phase_3_review_area_rubrics": {
-    "status": "planned",
+    "status": "active",
     "title": "Review area rubrics — per-area evidence criteria",
     "summary": "Define rubric criteria for each review area (baseline, boundary, additionality, leakage, monitoring, deviations, right of use). Each rubric maps area keywords to expected evidence signals and minimum confidence thresholds."
   },
@@ -33,9 +33,8 @@
   "phase_meta": {
     "status": "active",
     "summary": "Turn Quick Check from a requirement matcher / section router into an evidence-backed verification-readiness review engine. Phased path from routing to readiness note export.",
-    "current_focus": "Phase 2 complete (baseline evidence-backed review with fixture-backed tests and UI). Phase 3 (review-area rubrics) not started per instructions.",
+    "current_focus": "Phase 2 complete (baseline evidence-backed review with fixture-backed tests and UI). Phase 3 is active for narrow routing + section matching on right_of_use and stakeholder questions; non-baseline verdicts remain intentionally unimplemented.",
     "not_active_now": [
-      "Review area rubrics (phase 3+)",
       "Regression evaluation suite (phase 4+)",
       "Readiness note export (phase 5+)"
     ],

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2216,8 +2216,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     </div>
                   ) : null}
                   <div className="mt-4">
-                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Document heading index (Phase 1 — question is filter only)</div>
-                    <p className="mt-1 text-xs text-slate-500">Headings extracted from uploaded PDD. Your question filters titles (no body matching, no methodology routes).</p>
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Document heading index (Phase 1 — title matching)</div>
+                    <p className="mt-1 text-xs text-slate-500">Headings extracted from uploaded PDD. Quick Check matches section titles using your question, with limited methodology-aware fallback for certain review areas.</p>
                     {reviewQuestionResult.matchedHeadings.length > 0 ? (
                       <div className="mt-3 space-y-2">
                         {reviewQuestionResult.matchedHeadings.map((h) => {

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -21,6 +21,7 @@ export type ReviewArea =
   | "leakage"
   | "monitoring"
   | "right_of_use"
+  | "stakeholder"
   | "general";
 
 export type QuickCheckPath = "claim_to_requirement_match" | "review_question_answering";
@@ -114,6 +115,15 @@ const REVIEW_AREA_KEYWORDS: Record<ReviewArea, string[]> = {
     "statutes",
     "regulatory frameworks",
   ],
+  stakeholder: [
+    "stakeholder",
+    "stakeholder engagement",
+    "stakeholder consultation",
+    "stakeholder participation",
+    "stakeholder comments",
+    "local communities",
+    "community consultation",
+  ],
   general: [],
 };
 
@@ -125,8 +135,49 @@ const REVIEW_AREA_LABELS: Record<ReviewArea, string> = {
   leakage: "Leakage",
   monitoring: "Monitoring approach",
   right_of_use: "Right of use / land tenure",
+  stakeholder: "Stakeholder consultation",
   general: "General review",
 };
+
+const VM0007_STYLE_IDS = new Set(["VM0007", "PD_REDD_V1_130"]);
+
+function isVm0007StylePdd(methodologyId: string, rawPddText?: string): boolean {
+  if (VM0007_STYLE_IDS.has(methodologyId.trim().toUpperCase())) return true;
+  const text = rawPddText?.toUpperCase() ?? "";
+  return text.includes("PD_REDD_V1_130") || text.includes("VM0007");
+}
+
+function reviewAreaKeywordsForInput(input: {
+  reviewArea: ReviewArea;
+  methodologyId: string;
+  rawPddText?: string;
+}): string[] {
+  const baseKeywords = REVIEW_AREA_KEYWORDS[input.reviewArea] ?? [];
+  if (!isVm0007StylePdd(input.methodologyId, input.rawPddText)) return baseKeywords;
+
+  if (input.reviewArea === "right_of_use") {
+    return [
+      ...baseKeywords,
+      "compliance with laws",
+      "compliance with laws statutes and other regulatory frameworks",
+      "right of use",
+      "ownership",
+      "land and resource use rights",
+    ];
+  }
+
+  if (input.reviewArea === "stakeholder") {
+    return [
+      ...baseKeywords,
+      "stakeholder comments",
+      "consultation",
+      "participation",
+      "local communities",
+    ];
+  }
+
+  return baseKeywords;
+}
 
 export function detectReviewPath(claimText: string): QuickCheckPath {
   const normalized = claimText.trim();
@@ -147,11 +198,12 @@ export function classifyReviewArea(claimText: string): ReviewArea {
   if (/additionality|VT0001|barrier\s+analysis|investment\s+analysis|common\s+practice|first\s+of\s+its\s+kind/i.test(normalized)) return "additionality";
 
   if (/justify|baseline|scenario|without-project|without project/i.test(normalized)) return "baseline";
+  if (/legal authority|legal right of use|property rights|ownership|use rights|right of use|land tenure|land and resource use rights|resource use rights|carbon right|entitlement|compliance with laws|statutes|regulatory frameworks|legal status/i.test(normalized)) return "right_of_use";
   if (/leakage\s+belt\b|reference\s+region\b|RRD\b|boundary|geographic\s+boundary|project\s+area|area\s+of|spatial|geographic|polygon/i.test(normalized)) return "boundary";
   if (/deviations|departure|variance|deviation/i.test(normalized)) return "deviations";
   if (/leakage\s+risk|activity\s+shifting|LK-ASU|displacement/i.test(normalized)) return "leakage";
   if (/monitoring|sampling|plot|measur/i.test(normalized)) return "monitoring";
-  if (/legal status|property rights|ownership|right of use|land tenure|carbon right|entitlement|compliance with laws|statutes|regulatory frameworks/i.test(normalized)) return "right_of_use";
+  if (/stakeholder|consultation|participation|local communities|community engagement|community consultation/i.test(normalized)) return "stakeholder";
   return "general";
 }
 
@@ -207,9 +259,14 @@ export function findMatchedSectionNumbers(
   rawPddText: string,
   reviewArea: ReviewArea,
   claimText?: string,
+  methodologyId = "",
 ): string[] {
   if (!claimText?.trim()) return [];
-  return filterPddHeadingsByQuery(buildPddHeadingIndex(rawPddText), claimText, REVIEW_AREA_KEYWORDS[reviewArea] ?? [])
+  return filterPddHeadingsByQuery(
+    buildPddHeadingIndex(rawPddText),
+    claimText,
+    reviewAreaKeywordsForInput({ reviewArea, methodologyId, rawPddText }),
+  )
     .filter((heading) => isReasonableSectionId(heading.sectionNumber))
     .slice(0, MAX_PRIMARY_SECTIONS)
     .map((heading) => heading.sectionNumber);
@@ -219,9 +276,10 @@ export function computeSectionMatchResults(
   rawPddText: string,
   reviewArea: ReviewArea,
   claimText: string,
+  methodologyId = "",
 ): SectionMatchResult[] {
   const headingIndex = buildPddHeadingIndex(rawPddText);
-  const fallbackKeywords = REVIEW_AREA_KEYWORDS[reviewArea] ?? [];
+  const fallbackKeywords = reviewAreaKeywordsForInput({ reviewArea, methodologyId, rawPddText });
   const results: SectionMatchResult[] = [];
 
   for (const heading of headingIndex) {
@@ -299,14 +357,19 @@ export function buildReviewQuestionResult(input: {
   evidenceDocumentType?: string;
 }): ReviewQuestionResult {
   const reviewArea = classifyReviewArea(input.claimText);
+  const reviewAreaKeywords = reviewAreaKeywordsForInput({
+    reviewArea,
+    methodologyId: input.methodologyId,
+    rawPddText: input.rawPddText,
+  });
 
   // Phase 1: heading index is source of truth from uploaded document.
   // Question text is used ONLY as a filter over headings (title-based, no body scoring, no reviewArea keywords, no static routes).
   const headingIndex: DocumentHeading[] = input.rawPddText ? buildPddHeadingIndex(input.rawPddText) : [];
-  const matchedHeadings = filterPddHeadingsByQuery(headingIndex, input.claimText || "", REVIEW_AREA_KEYWORDS[reviewArea] ?? []);
+  const matchedHeadings = filterPddHeadingsByQuery(headingIndex, input.claimText || "", reviewAreaKeywords);
   const rejectedMatches =
     matchedHeadings.length === 0 && input.rawPddText
-      ? findRejectedHeadingMatches(input.rawPddText, input.claimText || "", REVIEW_AREA_KEYWORDS[reviewArea] ?? [])
+      ? findRejectedHeadingMatches(input.rawPddText, input.claimText || "", reviewAreaKeywords)
       : [];
   const noMatchExplanation = matchedHeadings.length === 0 ? buildNoMatchExplanation(rejectedMatches) : undefined;
 

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -56,6 +56,23 @@ const REALISTIC_PDD_TEXT = [
   "",
 ].join("\n");
 
+const VM0007_PHASE_3_PDD_TEXT = [
+  "VM0007 Version 4.2",
+  "Project Description Document: PD_REDD_v1_130",
+  "",
+  "1.11  Compliance with Laws, Statutes and Other Regulatory Frameworks",
+  "The project complies with applicable laws and regulatory frameworks for the project area.",
+  "",
+  "1.12.1  Right of Use",
+  "The project proponent has legal right of use and authority to manage the project area.",
+  "Land and resource use rights are held by the community association and documented in agreements.",
+  "",
+  "6  Stakeholder Comments",
+  "Stakeholder consultation and participation were conducted through community meetings.",
+  "Local communities were consulted and their comments were summarized in this section.",
+  "",
+].join("\n");
+
 const PDD_WITH_PAGE_BREAKS = [
   "1.10  Leakage",
   "The leakage belt is defined as a 3 km buffer around the project area.\f",
@@ -191,6 +208,21 @@ describe("classifyReviewArea — right_of_use", () => {
   it("classifies compliance with laws and ownership", () => {
     expect(classifyReviewArea("Does this PDD explain compliance with laws and ownership?")).toBe("right_of_use");
   });
+
+  it("classifies legal right of use / authority questions", () => {
+    expect(classifyReviewArea("Does this PDD demonstrate legal right of use for the project area?")).toBe("right_of_use");
+    expect(classifyReviewArea("Does the project have legal authority to manage the project area?")).toBe("right_of_use");
+    expect(classifyReviewArea("Does the PDD identify who has land and resource use rights?")).toBe("right_of_use");
+    expect(classifyReviewArea("Does the PDD explain ownership or use rights for the project area?")).toBe("right_of_use");
+  });
+});
+
+describe("classifyReviewArea — stakeholder", () => {
+  it("classifies stakeholder consultation and participation questions", () => {
+    expect(classifyReviewArea("Does this PDD describe stakeholder consultation and participation?")).toBe("stakeholder");
+    expect(classifyReviewArea("Does this PDD explain stakeholder engagement?")).toBe("stakeholder");
+    expect(classifyReviewArea("Were local communities consulted?")).toBe("stakeholder");
+  });
 });
 
 describe("resolveReviewSections — static routing (deprecated, returns empty)", () => {
@@ -202,6 +234,7 @@ describe("resolveReviewSections — static routing (deprecated, returns empty)",
     expect(resolveReviewSections("VM0007", "leakage")).toEqual([]);
     expect(resolveReviewSections("VM0007", "monitoring")).toEqual([]);
     expect(resolveReviewSections("VM0007", "right_of_use")).toEqual([]);
+    expect(resolveReviewSections("VM0007", "stakeholder")).toEqual([]);
     expect(resolveReviewSections("AR-ACM0003", "baseline")).toEqual([]);
   });
 });
@@ -209,7 +242,7 @@ describe("resolveReviewSections — static routing (deprecated, returns empty)",
 describe("reviewAreaLabel", () => {
   const areas: ReviewArea[] = [
     "additionality", "baseline", "boundary", "deviations",
-    "leakage", "monitoring", "right_of_use", "general",
+    "leakage", "monitoring", "right_of_use", "stakeholder", "general",
   ];
   for (const area of areas) {
     it(`returns a non-empty label for ${area}`, () => {
@@ -586,14 +619,14 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(sections.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("works even when reviewArea is 'general' with no keywords (pure claim-text matching)", () => {
+  it("routes stakeholder engagement to the stakeholder review area and still matches 2.3", () => {
     const result = buildReviewQuestionResult({
       claimText: "Does this PDD describe stakeholder engagement?",
       methodologyId: "VM0007",
       methodologyVersion: "1.0",
       rawPddText: PLUM_TEXT,
     });
-    expect(classifyReviewArea("Does this PDD describe stakeholder engagement?")).toBe("general");
+    expect(classifyReviewArea("Does this PDD describe stakeholder engagement?")).toBe("stakeholder");
     expect(result.relevantSections.length).toBeGreaterThan(0);
     expect(result.relevantSections).toContain("2.3");
   });
@@ -685,6 +718,45 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     // no match case
     const none = filterPddHeadingsByQuery(result.headingIndex, "biodiversity credits xyz");
     expect(none.length).toBe(0);
+  });
+
+  it.each([
+    "Does this PDD demonstrate legal right of use for the project area?",
+    "Does the project have legal authority to manage the project area?",
+    "Does the PDD identify who has land and resource use rights?",
+    "Does the PDD explain ownership or use rights for the project area?",
+  ])("routes exact right-of-use manual-preview question: %s", (claimText) => {
+    const result = buildReviewQuestionResult({
+      claimText,
+      methodologyId: "PD_REDD_v1_130",
+      methodologyVersion: "v4-2",
+      rawPddText: VM0007_PHASE_3_PDD_TEXT,
+    });
+
+    expect(result.reviewArea).toBe("right_of_use");
+    expect(result.relevantSections).toEqual(expect.arrayContaining(["1.11", "1.12.1"]));
+    expect(result.sectionContent["1.11"]).toContain("complies with applicable laws");
+    expect(result.sectionContent["1.12.1"]).toContain("legal right of use and authority to manage");
+    expect(result.baselineReview).toBeUndefined();
+  });
+
+  it.each([
+    "Does this PDD describe stakeholder consultation and participation?",
+    "Does this PDD explain stakeholder engagement?",
+    "Were local communities consulted?",
+  ])("routes exact stakeholder manual-preview question: %s", (claimText) => {
+    const result = buildReviewQuestionResult({
+      claimText,
+      methodologyId: "PD_REDD_v1_130",
+      methodologyVersion: "v4-2",
+      rawPddText: VM0007_PHASE_3_PDD_TEXT,
+    });
+
+    expect(result.reviewArea).toBe("stakeholder");
+    expect(result.relevantSections).toContain("6");
+    expect(result.sectionContent["6"]).toContain("Stakeholder consultation and participation");
+    expect(result.sectionContent["6"]).toContain("Local communities were consulted");
+    expect(result.baselineReview).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What changed
- add Phase 3 quick-check routing for `right_of_use` and `stakeholder`
- add natural-language detection for the failed manual-preview right-of-use and stakeholder questions
- add VM0007 / `PD_REDD_v1_130` style heading fallback so right-of-use questions route toward `1.11 Compliance with Laws, Statutes and Other Regulatory Frameworks` and `1.12.1 Right of Use`
- route stakeholder questions toward `6 Stakeholder Comments`
- keep non-baseline review areas limited to matched sections and extracted excerpts only
- update the Quick Check review-question UI copy to reflect limited methodology-aware fallback matching
- mark Phase 3 as active in the roadmap status file

## Why
Phase 2 completed baseline evidence-backed review, but Quick Check still missed real user questions about legal/right-of-use and stakeholder consultation even when the uploaded PDD contained the relevant sections. This change starts Phase 3 narrowly by improving routing and section matching without fabricating non-baseline verdicts.

## User impact
- users can ask natural-language right-of-use and stakeholder questions without knowing internal taxonomy labels
- VM0007-style and `PD_REDD_v1_130` style PDDs now surface the expected matched sections and excerpts for those review areas
- baseline, boundary, and additionality behavior remains preserved

## Root cause
The review-question classifier and title matcher did not explicitly model stakeholder review questions, and right-of-use phrasing that included `project area` could be misclassified as boundary before legal-rights terms were considered.

## Validation
- `npx jest tests/lib/quickCheckReviewQuestion.test.ts --runInBand`
- `npx jest tests/lib/quickCheckBaselineRubric.test.ts --runInBand`
- `npx jest tests/components/quickCheckPanel.test.tsx -t "distinguishes TOC-only heading matches from recovered body headings" --runInBand`
- `npm run typecheck`