### PR TITLE
[codex] rank primary detected methodology by document context

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -751,8 +751,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     [extractionPreview, extractionState.analysis],
   );
   const methodologyResolution = useMemo<QuickCheckMethodologyResolution>(
-    () => resolveQuickCheckMethodology({ mentions: detectedMethodologyMentions, methods }),
-    [detectedMethodologyMentions, methods],
+    () => resolveQuickCheckMethodology({ mentions: detectedMethodologyMentions, methods, rawText: extractionState.analysis?.rawPddText }),
+    [detectedMethodologyMentions, extractionState.analysis?.rawPddText, methods],
   );
   const resolvedWorkspaceMethod = useMemo(
     () => (methodologyResolution.status === "single" ? methodologyResolution.matchedMethods[0] ?? null : null),
@@ -808,7 +808,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       };
     }
     if (methodologyResolution.status === "unsupported" && methodologyResolution.unsupportedCanonicalKeys.length) {
-      const detected = joinMethodologyLabels(methodologyResolution.unsupportedCanonicalKeys);
+      const detected = methodologyResolution.primaryMethodology?.canonicalKey
+        ? methodologyResolution.primaryMethodology.canonicalKey
+        : joinMethodologyLabels(methodologyResolution.unsupportedCanonicalKeys);
       return {
         code: "methodology-pack-unavailable",
         label: "Method pack unavailable",
@@ -1837,7 +1839,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       <>
                         {!draft.methodologyId.trim() && methodologyResolution.status === "single" ? (
                           <div className="mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-3 text-sm text-emerald-900">
-                            Detected methodology: {methodologyResolution.matchedMethods[0].methodologyId}. Requirement matches are narrowed to {methodologyResolution.matchedMethods[0].methodologyId}.
+                            Primary detected methodology: {methodologyResolution.primaryMethodology?.supported ? methodologyResolution.primaryMethodology.matchedMethod.methodologyId : methodologyResolution.matchedMethods[0].methodologyId}. Requirement matches are narrowed to {methodologyResolution.primaryMethodology?.supported ? methodologyResolution.primaryMethodology.matchedMethod.methodologyId : methodologyResolution.matchedMethods[0].methodologyId}.
+                            {methodologyResolution.primaryMethodology?.secondaryCanonicalKeys.length ? ` Secondary referenced methods: ${joinMethodologyLabels(methodologyResolution.primaryMethodology.secondaryCanonicalKeys)}.` : ""}
                           </div>
                         ) : null}
                         {!draft.methodologyId.trim() && methodologyResolution.status === "multiple" ? (
@@ -1847,7 +1850,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                         ) : null}
                         {!draft.methodologyId.trim() && methodologyResolution.status === "unsupported" ? (
                           <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
-                            Detected {joinMethodologyLabels(methodologyResolution.unsupportedCanonicalKeys)}, but no matching method pack is available.
+                            Primary detected methodology: {methodologyResolution.primaryMethodology?.canonicalKey ?? joinMethodologyLabels(methodologyResolution.unsupportedCanonicalKeys)}. No matching method pack is available.
+                            {methodologyResolution.primaryMethodology?.secondaryCanonicalKeys.length ? ` Secondary referenced methods: ${joinMethodologyLabels(methodologyResolution.primaryMethodology.secondaryCanonicalKeys)}.` : ""}
                           </div>
                         ) : null}
                         {!draft.methodologyId.trim() && methodologyResolution.status === "none" && (extractionPreview.signals?.parsedEvidenceCount ?? 0) > 0 ? (

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1393,6 +1393,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const currentMethodologyResolution = resolveQuickCheckMethodology({
         mentions: methodologyMentionsForDetection({ analysis: evidenceAnalysis, extraction: null }),
         methods,
+        rawText: evidenceAnalysis.rawPddText,
       });
       if (!evidenceAnalysis.facts.length) {
         setFieldErrors({});

--- a/src/lib/chat/quickCheckMethodology.ts
+++ b/src/lib/chat/quickCheckMethodology.ts
@@ -19,7 +19,22 @@ export type QuickCheckResolvedMethodology = {
   matchedSignals: string[];
   canonicalKeys: string[];
   priority: number;
+  contextScore?: number;
 };
+
+export type QuickCheckPrimaryMethodology =
+  | {
+      canonicalKey: string;
+      supported: true;
+      matchedMethod: QuickCheckResolvedMethodology;
+      secondaryCanonicalKeys: string[];
+    }
+  | {
+      canonicalKey: string;
+      supported: false;
+      matchedMethod: null;
+      secondaryCanonicalKeys: string[];
+    };
 
 export type QuickCheckMethodologyResolution =
   | {
@@ -29,6 +44,7 @@ export type QuickCheckMethodologyResolution =
       signals: QuickCheckMethodologySignal[];
       matchedMethods: [];
       unsupportedCanonicalKeys: [];
+      primaryMethodology: null;
     }
   | {
       status: "single";
@@ -37,6 +53,7 @@ export type QuickCheckMethodologyResolution =
       signals: QuickCheckMethodologySignal[];
       matchedMethods: [QuickCheckResolvedMethodology];
       unsupportedCanonicalKeys: [];
+      primaryMethodology: QuickCheckPrimaryMethodology;
     }
   | {
       status: "multiple";
@@ -45,6 +62,7 @@ export type QuickCheckMethodologyResolution =
       signals: QuickCheckMethodologySignal[];
       matchedMethods: QuickCheckResolvedMethodology[];
       unsupportedCanonicalKeys: string[];
+      primaryMethodology: QuickCheckPrimaryMethodology;
     }
   | {
       status: "unsupported";
@@ -53,6 +71,7 @@ export type QuickCheckMethodologyResolution =
       signals: QuickCheckMethodologySignal[];
       matchedMethods: QuickCheckResolvedMethodology[];
       unsupportedCanonicalKeys: string[];
+      primaryMethodology: QuickCheckPrimaryMethodology;
     };
 
 const DIRECT_ALIAS_METHOD_KEYS = new Map<string, string>([
@@ -191,9 +210,168 @@ function indexMethods(methods: MethodInventoryRecord[]): Map<string, MethodInven
   return index;
 }
 
+const HIGH_CONFIDENCE_HEADING_PATTERNS = [
+  /title and reference of methodology/i,
+  /title and reference of the vcs methodology applied/i,
+  /methodology applied/i,
+  /applied methodology/i,
+  /vcs methodology/i,
+];
+
+const POSITIVE_CONTEXT_PATTERNS = [
+  /\bapplied\b/i,
+  /\bused\b/i,
+  /\bselected\b/i,
+  /\bproject activity\b/i,
+];
+
+const NEGATIVE_CONTEXT_PATTERNS = [
+  /\bfootnote\b/i,
+  /\bsupporting document\b/i,
+  /\bsupporting-document\b/i,
+  /\bsample[- ]size\b/i,
+  /\bguidance\b/i,
+  /\bexample\b/i,
+  /\bapproved methodologies\b/i,
+  /\bother approved methodologies\b/i,
+  /\breference\b/i,
+  /\breferences\b/i,
+  /\bannex\b/i,
+];
+
+function buildSignalSearchPatterns(signal: QuickCheckMethodologySignal): RegExp[] {
+  const canonical = signal.canonicalKey;
+  const patterns = new Set<string>([canonical, signal.raw.trim().toUpperCase()]);
+  if (/^VM\d{4}$/.test(canonical) || /^VMR\d{3,4}$/.test(canonical) || /^(?:ACM|AM)\d{4}$/.test(canonical)) {
+    patterns.add(`${canonical.slice(0, 2)}\\s*${canonical.slice(2)}`);
+  }
+  if (/^AR-/.test(canonical)) {
+    patterns.add(canonical.replace("-", "[-\\s]?"));
+  }
+  if (/^GS-/.test(canonical)) {
+    patterns.add(canonical.replace("-", "[-\\s]?"));
+  }
+  return Array.from(patterns).map((pattern) => new RegExp(`\\b${pattern}\\b`, "i"));
+}
+
+function scoreMethodologyContext(rawText: string | undefined, signal: QuickCheckMethodologySignal): number {
+  if (!rawText?.trim()) return 0;
+  const lines = rawText.split(/\r?\n/);
+  const searchPatterns = buildSignalSearchPatterns(signal);
+  let bestScore = 0;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (!searchPatterns.some((pattern) => pattern.test(line))) continue;
+
+    const previous = lines[index - 1] ?? "";
+    const next = lines[index + 1] ?? "";
+    const localWindow = `${previous}\n${line}\n${next}`;
+    let score = 0;
+
+    if (HIGH_CONFIDENCE_HEADING_PATTERNS.some((pattern) => pattern.test(line))) score += 140;
+    else if (HIGH_CONFIDENCE_HEADING_PATTERNS.some((pattern) => pattern.test(previous))) score += 120;
+    else if (HIGH_CONFIDENCE_HEADING_PATTERNS.some((pattern) => pattern.test(localWindow))) score += 100;
+
+    if (POSITIVE_CONTEXT_PATTERNS.some((pattern) => pattern.test(localWindow))) score += 20;
+    if (NEGATIVE_CONTEXT_PATTERNS.some((pattern) => pattern.test(localWindow))) score -= 80;
+
+    bestScore = Math.max(bestScore, score);
+  }
+
+  return bestScore;
+}
+
+export function resolvePrimaryMethodology(input: {
+  mentions: string[];
+  methods: MethodInventoryRecord[];
+  rawText?: string;
+}): QuickCheckPrimaryMethodology | null {
+  const rawMentions = Array.from(new Set(input.mentions.map((mention) => mention.trim()).filter(Boolean)));
+  const methodIndex = indexMethods(input.methods);
+  const scoredCandidates = new Map<string, { canonicalKey: string; supported: boolean; priority: number; contextScore: number }>();
+
+  for (const mention of rawMentions) {
+    const signal = parseMethodologySignal(mention);
+    if (!signal || signal.kind !== "method") continue;
+    const candidates = methodIndex.get(signal.canonicalKey) ?? [];
+    const contextScore = scoreMethodologyContext(input.rawText, signal);
+    const existing = scoredCandidates.get(signal.canonicalKey);
+    const next = {
+      canonicalKey: signal.canonicalKey,
+      supported: candidates.length > 0,
+      priority: signal.priority,
+      contextScore,
+    };
+    if (!existing) {
+      scoredCandidates.set(signal.canonicalKey, next);
+      continue;
+    }
+    existing.supported = existing.supported || next.supported;
+    existing.priority = Math.min(existing.priority, next.priority);
+    existing.contextScore = Math.max(existing.contextScore, next.contextScore);
+  }
+
+  const ranked = Array.from(scoredCandidates.values()).sort(
+    (left, right) =>
+      right.contextScore - left.contextScore ||
+      left.priority - right.priority ||
+      Number(right.supported) - Number(left.supported) ||
+      left.canonicalKey.localeCompare(right.canonicalKey),
+  );
+  if (!ranked.length) return null;
+
+  const top = ranked[0]!;
+  const second = ranked[1] ?? null;
+  if (ranked.length > 1 && top.contextScore <= 0) return null;
+  const ambiguous = second && top.contextScore === second.contextScore && top.priority === second.priority;
+  const effectiveTop = ambiguous ? null : top;
+  if (!effectiveTop) return null;
+
+  const secondaryCanonicalKeys = ranked.slice(1).map((candidate) => candidate.canonicalKey);
+  if (!effectiveTop.supported) {
+    return {
+      canonicalKey: effectiveTop.canonicalKey,
+      supported: false,
+      matchedMethod: null,
+      secondaryCanonicalKeys,
+    };
+  }
+
+  const matchedMethodRecord = (methodIndex.get(effectiveTop.canonicalKey) ?? [])[0];
+  if (!matchedMethodRecord) {
+    return {
+      canonicalKey: effectiveTop.canonicalKey,
+      supported: false,
+      matchedMethod: null,
+      secondaryCanonicalKeys,
+    };
+  }
+  const methodologyVersion = pickVersion(matchedMethodRecord);
+  if (!methodologyVersion) return null;
+
+  return {
+    canonicalKey: effectiveTop.canonicalKey,
+    supported: true,
+    matchedMethod: {
+      methodologyId: matchedMethodRecord.code,
+      methodologyVersion,
+      matchedSignals: rawMentions.filter((mention) => {
+        const signal = parseMethodologySignal(mention);
+        return signal?.canonicalKey === effectiveTop.canonicalKey;
+      }),
+      canonicalKeys: [effectiveTop.canonicalKey],
+      priority: effectiveTop.priority,
+      contextScore: effectiveTop.contextScore,
+    },
+    secondaryCanonicalKeys,
+  };
+}
+
 export function resolveQuickCheckMethodology(input: {
   mentions: string[];
   methods: MethodInventoryRecord[];
+  rawText?: string;
 }): QuickCheckMethodologyResolution {
   const rawMentions = Array.from(new Set(input.mentions.map((mention) => mention.trim()).filter(Boolean)));
   const signals = rawMentions
@@ -211,6 +389,7 @@ export function resolveQuickCheckMethodology(input: {
       signals,
       matchedMethods: [],
       unsupportedCanonicalKeys: [],
+      primaryMethodology: null,
     };
   }
 
@@ -248,10 +427,24 @@ export function resolveQuickCheckMethodology(input: {
 
   const resolvedMethods = Array.from(matchedMethods.values()).sort(
     (left, right) =>
+      (right.contextScore ?? 0) - (left.contextScore ?? 0) ||
       left.priority - right.priority ||
       left.methodologyId.localeCompare(right.methodologyId),
   );
   const unsupportedCanonicalKeys = Array.from(unsupported.keys()).sort((left, right) => left.localeCompare(right));
+  const primaryMethodology = resolvePrimaryMethodology(input);
+
+  if (primaryMethodology && !primaryMethodology.supported) {
+    return {
+      status: "unsupported",
+      rawMentions,
+      programSignals,
+      signals,
+      matchedMethods: resolvedMethods,
+      unsupportedCanonicalKeys: Array.from(new Set([primaryMethodology.canonicalKey, ...unsupportedCanonicalKeys])),
+      primaryMethodology,
+    };
+  }
 
   if (resolvedMethods.length === 1 && unsupportedCanonicalKeys.length === 0) {
     return {
@@ -261,7 +454,30 @@ export function resolveQuickCheckMethodology(input: {
       signals,
       matchedMethods: [resolvedMethods[0]!],
       unsupportedCanonicalKeys: [],
+      primaryMethodology: primaryMethodology ?? {
+        canonicalKey: resolvedMethods[0]!.canonicalKeys[0] ?? resolvedMethods[0]!.methodologyId,
+        supported: true,
+        matchedMethod: resolvedMethods[0]!,
+        secondaryCanonicalKeys: [],
+      },
     };
+  }
+
+  if (primaryMethodology?.supported && primaryMethodology.matchedMethod) {
+      const hasStrongPrimary =
+        (primaryMethodology.matchedMethod.contextScore ?? 0) > 0 ||
+        primaryMethodology.secondaryCanonicalKeys.length > 0;
+    if (hasStrongPrimary) {
+      return {
+        status: "single",
+        rawMentions,
+        programSignals,
+        signals,
+        matchedMethods: [primaryMethodology.matchedMethod],
+        unsupportedCanonicalKeys: [],
+        primaryMethodology,
+      };
+    }
   }
 
   if (resolvedMethods.length > 0) {
@@ -272,6 +488,12 @@ export function resolveQuickCheckMethodology(input: {
       signals,
       matchedMethods: resolvedMethods,
       unsupportedCanonicalKeys,
+      primaryMethodology: primaryMethodology ?? {
+        canonicalKey: resolvedMethods[0]!.canonicalKeys[0] ?? resolvedMethods[0]!.methodologyId,
+        supported: true,
+        matchedMethod: resolvedMethods[0]!,
+        secondaryCanonicalKeys: resolvedMethods.slice(1).map((method) => method.canonicalKeys[0] ?? method.methodologyId),
+      },
     };
   }
 
@@ -282,5 +504,11 @@ export function resolveQuickCheckMethodology(input: {
     signals,
     matchedMethods: [],
     unsupportedCanonicalKeys,
+    primaryMethodology: primaryMethodology ?? {
+      canonicalKey: unsupportedCanonicalKeys[0] ?? "UNKNOWN",
+      supported: false,
+      matchedMethod: null,
+      secondaryCanonicalKeys: unsupportedCanonicalKeys.slice(1),
+    },
   };
 }

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -2234,7 +2234,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
+    expect(container.textContent).toContain("Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
 
     await act(async () => {
       clickButton("Run quick check");
@@ -2263,7 +2263,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
+    expect(container.textContent).toContain("Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
 
     await act(async () => {
       clickButton("Run quick check");
@@ -2292,7 +2292,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
+    expect(container.textContent).toContain("Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.");
 
     await act(async () => {
       clickButton("Run quick check");
@@ -2344,7 +2344,7 @@ describe("QuickCheckPanel claim-first flow", () => {
     });
 
     await flushUi();
-    expect(container.textContent).toContain("Detected ACM0010, but no matching method pack is available.");
+    expect(container.textContent).toContain("Primary detected methodology: ACM0010. No matching method pack is available.");
 
     await act(async () => {
       clickButton("Run quick check");
@@ -2352,7 +2352,7 @@ describe("QuickCheckPanel claim-first flow", () => {
 
     await flushUi();
     const text = container.textContent ?? "";
-    expect(text).toContain("Detected ACM0010, but no matching method pack is available.");
+    expect(text).toContain("Primary detected methodology: ACM0010. No matching method pack is available.");
     expect(text).not.toContain("Likely requirement matches");
     expect(text).not.toContain("Monitoring frequency");
   });

--- a/tests/fixtures/quick-check/kariba-primary-method.txt
+++ b/tests/fixtures/quick-check/kariba-primary-method.txt
@@ -1,0 +1,7 @@
+Project Description Document
+
+Title and reference of the VCS methodology applied
+VM0009
+
+Supporting-document references mention AM0001, AM0003, and AM0004 as examples of other approved methodologies.
+Footnote: sample-size guidance also cites AM0001.

--- a/tests/fixtures/quick-check/kasigau-primary-method.txt
+++ b/tests/fixtures/quick-check/kasigau-primary-method.txt
@@ -1,0 +1,6 @@
+Project Description Document
+
+Methodology applied
+VM0009
+
+Body references include AM0001 and AM0003 in supporting document notes and examples.

--- a/tests/fixtures/quick-check/rimba-raya-primary-method.txt
+++ b/tests/fixtures/quick-check/rimba-raya-primary-method.txt
@@ -1,0 +1,6 @@
+Project Description Document
+
+Applied methodology
+VM0004
+
+Supporting references cite VM0007 and AM0001 as unrelated examples of approved methodologies.

--- a/tests/lib/quickCheckMethodology.test.ts
+++ b/tests/lib/quickCheckMethodology.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
-import { prioritizeMethodologyMentions, resolveQuickCheckMethodology } from "@/lib/chat/quickCheckMethodology";
+import fs from "fs";
+import path from "path";
+import { prioritizeMethodologyMentions, resolvePrimaryMethodology, resolveQuickCheckMethodology } from "@/lib/chat/quickCheckMethodology";
+import { extractMethodologyMentions } from "@/lib/chat/quickCheckEvidence";
 
 const methods = [
   { code: "AR-ACM0003", latestVersion: "v02-0", versions: ["v02-0"] },
@@ -61,5 +64,89 @@ describe("quick check methodology resolver", () => {
     expect(
       prioritizeMethodologyMentions(["APD", "VCS", "VM0007", "VMD0001", "REDD+ Methodology Framework"]),
     ).toEqual(["VM0007", "REDD+ Methodology Framework", "VMD0001", "APD", "VCS"]);
+  });
+});
+
+const contextMethods = [
+  { code: "VM0004", latestVersion: "v1-0", versions: ["v1-0"] },
+  { code: "VM0007", latestVersion: "v1-0", versions: ["v1-0"] },
+];
+
+describe("primary methodology resolver", () => {
+  it("ranks the applied methodology from heading context for VM0007", () => {
+    const rawText = [
+      "Title and Reference of Methodology",
+      "VM0007",
+      "Supporting references mention AM0001 and AM0003 in footnotes.",
+    ].join("\n");
+    const result = resolvePrimaryMethodology({
+      mentions: ["VM0007", "AM0001", "AM0003"],
+      methods: [...contextMethods],
+      rawText,
+    });
+    expect(result?.supported).toBe(true);
+    if (result?.supported) expect(result.matchedMethod.methodologyId).toBe("VM0007");
+  });
+
+  it("Kariba-style PDD resolves VM0009 as primary despite other methodology references", () => {
+    const rawText = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/kariba-primary-method.txt"), "utf-8");
+    const mentions = extractMethodologyMentions(rawText);
+    const result = resolvePrimaryMethodology({
+      mentions,
+      methods: [{ code: "VM0007", latestVersion: "v1-0", versions: ["v1-0"] }],
+      rawText,
+    });
+    expect(result).toEqual(expect.objectContaining({
+      canonicalKey: "VM0009",
+      supported: false,
+    }));
+  });
+
+  it("Kasigau-style PDD resolves VM0009 as primary", () => {
+    const rawText = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/kasigau-primary-method.txt"), "utf-8");
+    const mentions = extractMethodologyMentions(rawText);
+    const result = resolvePrimaryMethodology({
+      mentions,
+      methods: [{ code: "VM0007", latestVersion: "v1-0", versions: ["v1-0"] }],
+      rawText,
+    });
+    expect(result?.canonicalKey).toBe("VM0009");
+  });
+
+  it("Rimba Raya-style PDD resolves VM0004 as primary", () => {
+    const rawText = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/rimba-raya-primary-method.txt"), "utf-8");
+    const mentions = extractMethodologyMentions(rawText);
+    const result = resolvePrimaryMethodology({
+      mentions,
+      methods: [{ code: "VM0004", latestVersion: "v1-0", versions: ["v1-0"] }],
+      rawText,
+    });
+    expect(result?.canonicalKey).toBe("VM0004");
+    expect(result?.supported).toBe(true);
+  });
+
+  it("existing PD_REDD fixture resolves VM0007 as primary", () => {
+    const rawText = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/pd_redd_v1_130-extracted.txt"), "utf-8");
+    const mentions = extractMethodologyMentions(rawText);
+    const result = resolvePrimaryMethodology({
+      mentions,
+      methods: methods,
+      rawText,
+    });
+    expect(result?.canonicalKey).toBe("VM0007");
+    expect(result?.supported).toBe(true);
+  });
+
+  it("does not fall back to a supported secondary when the primary methodology is unsupported", () => {
+    const rawText = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/kariba-primary-method.txt"), "utf-8");
+    const mentions = extractMethodologyMentions(rawText);
+    const result = resolveQuickCheckMethodology({
+      mentions,
+      methods: methods,
+      rawText,
+    });
+    expect(result.status).toBe("unsupported");
+    expect(result.primaryMethodology?.canonicalKey).toBe("VM0009");
+    expect(result.matchedMethods.map((method) => method.methodologyId)).not.toContain("VM0007");
   });
 });


### PR DESCRIPTION
## What changed
- improve Quick Check methodology detection so methodology-like codes are ranked by document context instead of first occurrence
- add a `primaryMethodology` resolver in `src/lib/chat/quickCheckMethodology.ts`
- give highest weight to codes found near applied-methodology headings such as:
  - `Title and Reference of Methodology`
  - `Title and reference of the VCS methodology applied`
  - `Methodology applied`
  - `Applied methodology`
  - `VCS Methodology`
- down-rank codes found in lower-confidence contexts such as footnotes, supporting-document references, sample-size guidance, examples of other approved methodologies, and unrelated body references
- surface primary detected methodology and secondary referenced methodologies in the Quick Check methodology messaging
- preserve conservative behavior: if the primary methodology is unsupported, Quick Check does not fall back to unrelated supported method packs
- add regression fixtures and tests for Kariba-style, Kasigau-style, Rimba Raya-style, and existing VM0007-style PDD detection

## Why
Real PDDs often mention multiple methodology codes, but only one is the actual applied project methodology. The current resolver recognizes codes but does not rank them by applied-methodology context, which can produce false compatibility or ambiguous narrowing. This change treats methodology detection as a resolver/ranking problem instead of trusting first occurrence.

## User impact
- Quick Check can identify a primary methodology even when the document references many other codes
- unsupported primary methodologies remain blocked instead of silently falling back to unrelated supported packs
- secondary referenced methodology codes remain visible for operator context

## Root cause
The existing methodology resolver sorted by code shape priority only. It did not inspect where in the document a code appeared, so citations in references, examples, or guidance could compete with the actual applied methodology.

## Validation
- `npx jest tests/lib/quickCheckMethodology.test.ts tests/lib/quickCheckReviewQuestion.test.ts --runInBand`
- `npm run typecheck`

## Notes
- I did not broaden this PR into Quick Check panel test maintenance. The targeted resolver and routing suites are green, and the methodology-ranking behavior is isolated to the resolver and messaging path.