### PR TITLE
[codex] harden quick check section matching and result display

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -537,6 +537,36 @@ function joinMethodologyLabels(values: string[]): string {
   return values.join(", ");
 }
 
+function reviewQuestionStatusLabel(status: ReviewQuestionResult["status"]): string {
+  switch (status) {
+    case "strong_evidence_found":
+      return "Strong evidence found";
+    case "partial_evidence_found":
+      return "Partial evidence found";
+    case "section_found_evidence_weak":
+      return "Section found, evidence weak";
+    case "extractor_uncertain":
+      return "Extractor uncertain";
+    case "no_document_grounded_evidence":
+      return "No document-grounded evidence";
+  }
+}
+
+function reviewQuestionStatusClass(status: ReviewQuestionResult["status"]): string {
+  switch (status) {
+    case "strong_evidence_found":
+      return "border-emerald-200 bg-emerald-100 text-emerald-800";
+    case "partial_evidence_found":
+      return "border-amber-200 bg-amber-100 text-amber-800";
+    case "section_found_evidence_weak":
+      return "border-sky-200 bg-sky-100 text-sky-800";
+    case "extractor_uncertain":
+      return "border-amber-200 bg-amber-50 text-amber-900";
+    case "no_document_grounded_evidence":
+      return "border-rose-200 bg-rose-100 text-rose-800";
+  }
+}
+
 export default function QuickCheckPanel({ initialMethod, initialVersion, onContinueToWorkspace }: QuickCheckPanelProps) {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const claimRef = useRef<HTMLTextAreaElement | null>(null);
@@ -2145,11 +2175,16 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           ) : null}
 
           {reviewQuestionResult ? (
-            <div className="rounded-[1.6rem] border border-sky-200 bg-sky-50/80 p-5">
-              <div className="flex items-start gap-3">
-                <div className="min-w-0 flex-1">
+            <div
+              data-testid="quick-check-review-result"
+              className="min-w-0 max-w-full overflow-hidden rounded-[1.6rem] border border-sky-200 bg-sky-50/80 p-5"
+            >
+              <div className="flex min-w-0 max-w-full items-start gap-3 overflow-hidden">
+                <div className="min-w-0 max-w-full flex-1 overflow-hidden">
                   <div className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-800">Review question</div>
-                  <div className="mt-2 text-sm text-slate-600">{draft.claimText}</div>
+                  <div className="mt-2 min-w-0 max-w-full overflow-hidden whitespace-normal break-words text-sm text-slate-600 [overflow-wrap:anywhere]">
+                    {draft.claimText}
+                  </div>
                   <div className="mt-4 grid gap-4 sm:grid-cols-2">
                     <div>
                       <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Review area (classified)</div>
@@ -2162,10 +2197,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       </div>
                     ) : null}
                   </div>
+                  <div className="mt-4 flex min-w-0 max-w-full flex-wrap items-center gap-2 overflow-hidden">
+                    <span className={`inline-flex max-w-full rounded-full border px-2.5 py-1 text-[11px] font-semibold ${reviewQuestionStatusClass(reviewQuestionResult.status)}`}>
+                      {reviewQuestionStatusLabel(reviewQuestionResult.status)}
+                    </span>
+                    <span className="inline-flex max-w-full rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700">
+                      Match stage: {reviewQuestionResult.matchStage.replace(/_/g, " ")}
+                    </span>
+                  </div>
                   {reviewQuestionResult.reviewAreaReview ? (
-                    <div className="mt-4 rounded-xl border border-emerald-200 bg-white/80 p-4">
-                      <div className="flex items-center gap-2">
-                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700">
+                    <div className="mt-4 min-w-0 max-w-full overflow-hidden rounded-xl border border-emerald-200 bg-white/80 p-4">
+                      <div className="flex min-w-0 max-w-full flex-wrap items-center gap-2 overflow-hidden">
+                        <div className="min-w-0 max-w-full overflow-hidden whitespace-normal break-words text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700 [overflow-wrap:anywhere]">
                           {reviewQuestionResult.reviewArea === "baseline"
                             ? "Baseline review"
                             : `${reviewAreaLabel(reviewQuestionResult.reviewArea)} review`}
@@ -2187,13 +2230,13 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       </div>
                       <div className="mt-3">
                         <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Evidence summary</div>
-                        <div className="mt-1 text-sm leading-relaxed text-slate-700">
+                        <div className="mt-1 min-w-0 max-w-full overflow-hidden whitespace-normal break-words text-sm leading-relaxed text-slate-700 [overflow-wrap:anywhere]">
                           {reviewQuestionResult.reviewAreaReview.evidence_summary}
                         </div>
                       </div>
                       <div className="mt-3">
                         <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Cited sections</div>
-                        <div className="mt-1 text-sm text-slate-700 font-mono">
+                        <div className="mt-1 min-w-0 max-w-full overflow-hidden whitespace-normal break-words font-mono text-sm text-slate-700 [overflow-wrap:anywhere]">
                           {reviewQuestionResult.reviewAreaReview.cited_sections.length > 0
                             ? reviewQuestionResult.reviewAreaReview.cited_sections.map((section) => `§${section}`).join(", ")
                             : "None"}
@@ -2204,11 +2247,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                         {reviewQuestionResult.reviewAreaReview.gaps.length > 0 ? (
                           <ul className="mt-1 list-disc pl-5 text-sm leading-relaxed text-slate-700">
                             {reviewQuestionResult.reviewAreaReview.gaps.map((gap) => (
-                              <li key={gap}>{gap}</li>
+                              <li key={gap} className="whitespace-normal break-words [overflow-wrap:anywhere]">{gap}</li>
                             ))}
                           </ul>
                         ) : (
-                          <div className="mt-1 text-sm text-emerald-700">
+                          <div className="mt-1 min-w-0 max-w-full overflow-hidden whitespace-normal break-words text-sm text-emerald-700 [overflow-wrap:anywhere]">
                             None identified — the extracted PDD content meets the current Quick Check rubric for this review area.
                           </div>
                         )}
@@ -2217,7 +2260,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                         <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Recommended follow-up documents</div>
                         <ul className="mt-1 list-disc pl-5 text-sm leading-relaxed text-slate-700">
                           {reviewQuestionResult.reviewAreaReview.recommended_follow_up_documents.map((item) => (
-                            <li key={item}>{item}</li>
+                            <li key={item} className="whitespace-normal break-words [overflow-wrap:anywhere]">{item}</li>
                           ))}
                         </ul>
                       </div>
@@ -2226,9 +2269,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       </p>
                     </div>
                   ) : null}
-                  <div className="mt-4">
+                  <div className="mt-4 min-w-0 max-w-full overflow-hidden">
                     <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Document heading index (Phase 1 — title matching)</div>
-                    <p className="mt-1 text-xs text-slate-500">Headings extracted from uploaded PDD. Quick Check matches section titles using your question, with limited methodology-aware fallback for certain review areas.</p>
+                    <p className="mt-1 min-w-0 max-w-full overflow-hidden whitespace-normal break-words text-xs text-slate-500 [overflow-wrap:anywhere]">
+                      Headings extracted from the uploaded PDD. Quick Check now checks exact titles, normalized titles, review-area aliases, and a conservative semantic fallback before returning no document-grounded evidence.
+                    </p>
                     {reviewQuestionResult.matchedHeadings.length > 0 ? (
                       <div className="mt-3 space-y-2">
                         {reviewQuestionResult.matchedHeadings.map((h) => {
@@ -2238,14 +2283,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                               key={h.sectionNumber}
                               type="button"
                               onClick={() => handleHeadingClick(h)}
-                              className={`w-full rounded-xl border px-4 py-3 text-left transition ${isSelected ? "border-sky-400 bg-sky-100" : "border-slate-200 bg-white hover:border-sky-300 hover:bg-sky-50"}`}
+                              className={`min-w-0 max-w-full overflow-hidden w-full rounded-xl border px-4 py-3 text-left transition ${isSelected ? "border-sky-400 bg-sky-100" : "border-slate-200 bg-white hover:border-sky-300 hover:bg-sky-50"}`}
                             >
-                              <div className="flex items-baseline gap-2">
+                              <div className="flex min-w-0 max-w-full items-baseline gap-2 overflow-hidden">
                                 <span className="font-mono text-xs font-semibold text-sky-700">§{h.sectionNumber}</span>
-                                <span className="text-sm font-medium text-slate-900">{h.title}</span>
+                                <span className="min-w-0 max-w-full overflow-hidden whitespace-normal break-words text-sm font-medium text-slate-900 [overflow-wrap:anywhere]">{h.title}</span>
                               </div>
                               {h.bodyPreview ? (
-                                <div className="mt-1.5 text-xs leading-relaxed text-slate-600 line-clamp-2">{h.bodyPreview}</div>
+                                <div className="mt-1.5 min-w-0 max-w-full overflow-hidden whitespace-normal break-words text-xs leading-relaxed text-slate-600 line-clamp-2 [overflow-wrap:anywhere]">{h.bodyPreview}</div>
                               ) : null}
                               <div className="mt-1 text-[10px] text-slate-400">Click to select / copy reference</div>
                             </button>
@@ -2258,7 +2303,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                           No matching document section found.
                         </div>
                         {reviewQuestionResult.noMatchExplanation ? (
-                          <div className="text-xs leading-relaxed text-amber-800">
+                          <div className="min-w-0 max-w-full overflow-hidden whitespace-normal break-words text-xs leading-relaxed text-amber-800 [overflow-wrap:anywhere]">
                             {reviewQuestionResult.noMatchExplanation}
                           </div>
                         ) : null}
@@ -2266,9 +2311,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     )}
 
                     {selectedHeading ? (
-                      <div className="mt-3 rounded-xl border border-sky-300 bg-white p-4">
-                        <div className="text-xs font-semibold text-sky-700">Selected: §{selectedHeading.sectionNumber} {selectedHeading.title}</div>
-                        <div className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap text-sm leading-relaxed text-slate-700 border border-slate-100 bg-slate-50 p-2 rounded">
+                      <div className="mt-3 min-w-0 max-w-full overflow-hidden rounded-xl border border-sky-300 bg-white p-4">
+                        <div className="min-w-0 max-w-full overflow-hidden whitespace-normal break-words text-xs font-semibold text-sky-700 [overflow-wrap:anywhere]">Selected: §{selectedHeading.sectionNumber} {selectedHeading.title}</div>
+                        <div className="mt-2 max-h-40 min-w-0 max-w-full overflow-auto whitespace-pre-wrap break-words border border-slate-100 bg-slate-50 p-2 text-sm leading-relaxed text-slate-700 rounded [overflow-wrap:anywhere]">
                           {selectedHeading.bodyText || selectedHeading.bodyPreview}
                         </div>
                         <div className="mt-2 text-[10px] text-slate-500">Reference copied to clipboard. Use in full review for evidence citation.</div>
@@ -2280,7 +2325,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                         <summary className="cursor-pointer text-slate-500">Show all {reviewQuestionResult.headingIndex.length} headings from document</summary>
                         <div className="mt-2 grid gap-1">
                           {reviewQuestionResult.headingIndex.slice(0, 12).map((h) => (
-                            <button key={h.sectionNumber} type="button" onClick={() => handleHeadingClick(h)} className="text-left text-[11px] text-slate-600 hover:text-sky-700 font-mono">§{h.sectionNumber} {h.title}</button>
+                            <button key={h.sectionNumber} type="button" onClick={() => handleHeadingClick(h)} className="min-w-0 max-w-full overflow-hidden whitespace-normal break-words text-left text-[11px] text-slate-600 hover:text-sky-700 font-mono [overflow-wrap:anywhere]">§{h.sectionNumber} {h.title}</button>
                           ))}
                         </div>
                       </details>

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -27,6 +27,15 @@ export type ReviewArea =
 
 export type QuickCheckPath = "claim_to_requirement_match" | "review_question_answering";
 
+export type ReviewQuestionStatus =
+  | "strong_evidence_found"
+  | "partial_evidence_found"
+  | "section_found_evidence_weak"
+  | "no_document_grounded_evidence"
+  | "extractor_uncertain";
+
+export type ReviewQuestionMatchStage = "exact_heading" | "normalized_heading" | "alias_heading" | "semantic_fallback" | "none";
+
 export type SectionMatchResult = {
   section: string;
   headingTitle: string;
@@ -68,6 +77,8 @@ export type ReviewQuestionDiagnostic = {
 export type ReviewQuestionResult = {
   path: QuickCheckPath;
   reviewArea: ReviewArea;
+  status: ReviewQuestionStatus;
+  matchStage: ReviewQuestionMatchStage;
   methodologyId: string;
   methodologyVersion: string;
   relevantSections: string[];
@@ -141,6 +152,40 @@ const REVIEW_AREA_LABELS: Record<ReviewArea, string> = {
   general: "General review",
 };
 
+const REVIEW_AREA_ALIASES: Record<ReviewArea, string[]> = {
+  additionality: [],
+  baseline: [],
+  boundary: [],
+  deviations: [
+    "methodology deviations",
+    "2.6 methodology deviations",
+    "deviation from methodology",
+  ],
+  leakage: [
+    "leakage",
+    "leakage management",
+    "3.3 leakage",
+    "activity shifting leakage",
+  ],
+  monitoring: [
+    "monitoring plan",
+    "4.3 monitoring plan",
+    "monitoring procedures",
+    "monitoring approach",
+  ],
+  right_of_use: [],
+  stakeholder: [
+    "stakeholder comments",
+    "stakeholder consultation",
+    "project awareness",
+    "fpic",
+    "free prior and informed consent",
+    "grievance procedure",
+    "community meetings",
+  ],
+  general: [],
+};
+
 const VM0007_STYLE_IDS = new Set(["VM0007", "PD_REDD_V1_130"]);
 
 function isVm0007StylePdd(methodologyId: string, rawPddText?: string): boolean {
@@ -205,7 +250,7 @@ export function classifyReviewArea(claimText: string): ReviewArea {
   if (/deviations|departure|variance|deviation/i.test(normalized)) return "deviations";
   if (/leakage\s+risk|activity\s+shifting|LK-ASU|displacement/i.test(normalized)) return "leakage";
   if (/monitoring|sampling|plot|measur/i.test(normalized)) return "monitoring";
-  if (/stakeholder|consultation|participation|local communities|community engagement|community consultation/i.test(normalized)) return "stakeholder";
+  if (/stakeholder|consultation|participation|local communities|community engagement|community consultation|fpic|free prior and informed consent|grievance procedure|community meetings|project awareness/i.test(normalized)) return "stakeholder";
   return "general";
 }
 
@@ -228,6 +273,12 @@ const CLAIM_STOP_WORDS = new Set([
 
 const MAX_PRIMARY_SECTIONS = 3;
 const HEADING_MATCH_MIN_COVERAGE = 0.6;
+
+type ReviewQuestionSectionResolution = {
+  matchedHeadings: DocumentHeading[];
+  rejectedMatches: RejectedHeadingQueryMatch[];
+  matchStage: ReviewQuestionMatchStage;
+};
 
 export function extractClaimKeywords(claimText: string): { phrases: string[]; words: string[] } {
   const cleaned = claimText
@@ -257,6 +308,170 @@ function isReasonableSectionId(num: string): boolean {
   return /^\d+(?:\.\d+)*$/.test(num);
 }
 
+function normalizeReviewText(text: string): string {
+  return text.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function reviewAreaAliasKeywords(area: ReviewArea): string[] {
+  return REVIEW_AREA_ALIASES[area] ?? [];
+}
+
+function uniqueHeadings(headings: DocumentHeading[]): DocumentHeading[] {
+  const seen = new Set<string>();
+  return headings.filter((heading) => {
+    const key = `${heading.sectionNumber}::${heading.title}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function exactHeadingMatches(headings: DocumentHeading[], claimText: string): DocumentHeading[] {
+  const normalizedClaim = normalizeReviewText(
+    claimText
+      .replace(CLAIM_PREFIX_RE, "")
+      .replace(/\?/g, "")
+      .replace(LEADING_ARTICLE_RE, "")
+      .trim(),
+  );
+  if (!normalizedClaim) return [];
+  return headings.filter((heading) => heading.normalizedTitle === normalizedClaim);
+}
+
+function aliasHeadingMatches(headings: DocumentHeading[], aliases: string[]): DocumentHeading[] {
+  const normalizedAliases = aliases.map(normalizeReviewText).filter(Boolean);
+  if (normalizedAliases.length === 0) return [];
+  return headings.filter((heading) =>
+    normalizedAliases.some((alias) => heading.normalizedTitle === alias || heading.normalizedTitle.includes(alias)),
+  );
+}
+
+function scoreSemanticHeading(
+  heading: DocumentHeading,
+  reviewArea: ReviewArea,
+  searchTerms: string[],
+  claimKeywords: { phrases: string[]; words: string[] },
+): number {
+  const titleText = heading.normalizedTitle;
+  const bodyText = heading.normalizedBodyText;
+  let score = 0;
+
+  for (const term of searchTerms) {
+    const normalizedTerm = normalizeReviewText(term);
+    if (!normalizedTerm) continue;
+    if (titleText.includes(normalizedTerm)) {
+      score += normalizedTerm.includes(" ") ? 8 : 4;
+      continue;
+    }
+    if (bodyText.includes(normalizedTerm)) {
+      score += normalizedTerm.includes(" ") ? 4 : 2;
+    }
+  }
+
+  for (const phrase of claimKeywords.phrases) {
+    const normalizedPhrase = normalizeReviewText(phrase);
+    if (!normalizedPhrase) continue;
+    if (titleText.includes(normalizedPhrase)) score += 5;
+    else if (bodyText.includes(normalizedPhrase)) score += 2;
+  }
+
+  for (const word of claimKeywords.words) {
+    const normalizedWord = normalizeReviewText(word);
+    if (!normalizedWord) continue;
+    if (titleText.includes(normalizedWord)) score += 2;
+    else if (bodyText.includes(normalizedWord)) score += 1;
+  }
+
+  if (reviewArea === "monitoring") {
+    if (heading.sectionNumber === "4.3" && titleText.includes("monitoring plan")) score += 16;
+    if (titleText.includes("monitoring equipment") && !titleText.includes("monitoring plan")) score -= 10;
+  }
+
+  if (reviewArea === "stakeholder" && /(fpic|free prior and informed consent|grievance procedure|community meetings|project awareness)/.test(`${titleText} ${bodyText}`)) {
+    score += 6;
+  }
+
+  return score;
+}
+
+function semanticFallbackMatches(
+  headings: DocumentHeading[],
+  reviewArea: ReviewArea,
+  searchTerms: string[],
+  claimKeywords: { phrases: string[]; words: string[] },
+): DocumentHeading[] {
+  return headings
+    .map((heading) => ({
+      heading,
+      score: scoreSemanticHeading(heading, reviewArea, searchTerms, claimKeywords),
+    }))
+    .filter((entry) => entry.score >= 6)
+    .sort((left, right) => right.score - left.score || left.heading.sectionNumber.localeCompare(right.heading.sectionNumber, undefined, { numeric: true }))
+    .map((entry) => entry.heading);
+}
+
+function resolveReviewQuestionSections(input: {
+  headingIndex: DocumentHeading[];
+  claimText: string;
+  reviewArea: ReviewArea;
+  methodologyId: string;
+  rawPddText?: string;
+}): ReviewQuestionSectionResolution {
+  const aliases = reviewAreaAliasKeywords(input.reviewArea);
+  const reviewAreaKeywords = reviewAreaKeywordsForInput({
+    reviewArea: input.reviewArea,
+    methodologyId: input.methodologyId,
+    rawPddText: input.rawPddText,
+  });
+  const claimKeywords = extractClaimKeywords(input.claimText);
+  const searchTerms = [...new Set([...reviewAreaKeywords, ...aliases, ...claimKeywords.phrases, ...claimKeywords.words])];
+
+  const exactMatches = uniqueHeadings(exactHeadingMatches(input.headingIndex, input.claimText));
+  if (exactMatches.length > 0) {
+    return { matchedHeadings: exactMatches, rejectedMatches: [], matchStage: "exact_heading" };
+  }
+
+  const normalizedMatches = uniqueHeadings(filterPddHeadingsByQuery(input.headingIndex, input.claimText, []));
+  if (normalizedMatches.length > 0) {
+    return { matchedHeadings: normalizedMatches, rejectedMatches: [], matchStage: "normalized_heading" };
+  }
+
+  const aliasMatches = uniqueHeadings([
+    ...aliasHeadingMatches(input.headingIndex, aliases),
+    ...filterPddHeadingsByQuery(input.headingIndex, input.claimText, [...reviewAreaKeywords, ...aliases]),
+  ]);
+  if (aliasMatches.length > 0) {
+    return { matchedHeadings: aliasMatches, rejectedMatches: [], matchStage: "alias_heading" };
+  }
+
+  const semanticMatches = uniqueHeadings(semanticFallbackMatches(input.headingIndex, input.reviewArea, searchTerms, claimKeywords));
+  if (semanticMatches.length > 0) {
+    return { matchedHeadings: semanticMatches, rejectedMatches: [], matchStage: "semantic_fallback" };
+  }
+
+  const rejectedMatches = input.rawPddText
+    ? findRejectedHeadingMatches(input.rawPddText, input.claimText || "", [...reviewAreaKeywords, ...aliases])
+    : [];
+  return { matchedHeadings: [], rejectedMatches, matchStage: "none" };
+}
+
+function deriveReviewQuestionStatus(input: {
+  matchedHeadings: DocumentHeading[];
+  headingIndex: DocumentHeading[];
+  rejectedMatches: RejectedHeadingQueryMatch[];
+  matchStage: ReviewQuestionMatchStage;
+  reviewAreaReview?: ReviewRubricResult;
+}): ReviewQuestionStatus {
+  if (input.reviewAreaReview?.verdict === "supported") return "strong_evidence_found";
+  if (input.reviewAreaReview?.verdict === "partial") return "partial_evidence_found";
+  if (input.reviewAreaReview?.verdict === "missing" && input.matchedHeadings.length > 0) return "section_found_evidence_weak";
+  if (input.matchedHeadings.length > 0) {
+    return input.matchStage === "semantic_fallback" ? "partial_evidence_found" : "section_found_evidence_weak";
+  }
+  if (input.rejectedMatches.length > 0 || input.headingIndex.length === 0) return "extractor_uncertain";
+  return "no_document_grounded_evidence";
+}
+
 export function findMatchedSectionNumbers(
   rawPddText: string,
   reviewArea: ReviewArea,
@@ -264,11 +479,13 @@ export function findMatchedSectionNumbers(
   methodologyId = "",
 ): string[] {
   if (!claimText?.trim()) return [];
-  return filterPddHeadingsByQuery(
-    buildPddHeadingIndex(rawPddText),
+  return resolveReviewQuestionSections({
+    headingIndex: buildPddHeadingIndex(rawPddText),
     claimText,
-    reviewAreaKeywordsForInput({ reviewArea, methodologyId, rawPddText }),
-  )
+    reviewArea,
+    methodologyId,
+    rawPddText,
+  }).matchedHeadings
     .filter((heading) => isReasonableSectionId(heading.sectionNumber))
     .slice(0, MAX_PRIMARY_SECTIONS)
     .map((heading) => heading.sectionNumber);
@@ -359,20 +576,20 @@ export function buildReviewQuestionResult(input: {
   evidenceDocumentType?: string;
 }): ReviewQuestionResult {
   const reviewArea = classifyReviewArea(input.claimText);
-  const reviewAreaKeywords = reviewAreaKeywordsForInput({
+
+  // Heading extraction remains the source of truth from the uploaded document.
+  // Matching runs through exact, normalized, alias, and semantic fallback stages against
+  // a cleaned heading layer while preserving the original extracted text for diagnostics.
+  const headingIndex: DocumentHeading[] = input.rawPddText ? buildPddHeadingIndex(input.rawPddText) : [];
+  const sectionResolution = resolveReviewQuestionSections({
+    headingIndex,
+    claimText: input.claimText || "",
     reviewArea,
     methodologyId: input.methodologyId,
     rawPddText: input.rawPddText,
   });
-
-  // Heading extraction remains the source of truth from the uploaded document.
-  // Question text primarily matches section titles, with limited review-area and methodology-aware fallback keywords for supported areas.
-  const headingIndex: DocumentHeading[] = input.rawPddText ? buildPddHeadingIndex(input.rawPddText) : [];
-  const matchedHeadings = filterPddHeadingsByQuery(headingIndex, input.claimText || "", reviewAreaKeywords);
-  const rejectedMatches =
-    matchedHeadings.length === 0 && input.rawPddText
-      ? findRejectedHeadingMatches(input.rawPddText, input.claimText || "", reviewAreaKeywords)
-      : [];
+  const matchedHeadings = sectionResolution.matchedHeadings;
+  const rejectedMatches = sectionResolution.rejectedMatches;
   const noMatchExplanation = matchedHeadings.length === 0 ? buildNoMatchExplanation(rejectedMatches) : undefined;
 
   const relevantSections = matchedHeadings.map((h) => h.sectionNumber);
@@ -388,6 +605,13 @@ export function buildReviewQuestionResult(input: {
     reviewArea === "baseline" || reviewArea === "right_of_use" || reviewArea === "stakeholder"
       ? evaluateReviewRubric({ reviewArea, matchedHeadings })
       : undefined;
+  const status = deriveReviewQuestionStatus({
+    matchedHeadings,
+    headingIndex,
+    rejectedMatches,
+    matchStage: sectionResolution.matchStage,
+    reviewAreaReview,
+  });
 
   const diagnostic = process.env.NODE_ENV !== "production" && input.rawPddText
     ? debugSectionExtraction(input.rawPddText)
@@ -403,6 +627,8 @@ export function buildReviewQuestionResult(input: {
   return {
     path: "review_question_answering",
     reviewArea,
+    status,
+    matchStage: sectionResolution.matchStage,
     methodologyId: input.methodologyId,
     methodologyVersion: input.methodologyVersion,
     relevantSections,

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -326,6 +326,25 @@ function uniqueHeadings(headings: DocumentHeading[]): DocumentHeading[] {
   });
 }
 
+function withMonitoringAncestors(headings: DocumentHeading[], reviewArea: ReviewArea, headingIndex: DocumentHeading[]): DocumentHeading[] {
+  if (reviewArea !== "monitoring" || headings.length === 0) return headings;
+  const expanded = [...headings];
+  for (const heading of headings) {
+    const parts = heading.sectionNumber.split(".");
+    if (parts.length < 2) continue;
+    for (let depth = parts.length - 1; depth >= 1; depth -= 1) {
+      const parentSection = parts.slice(0, depth).join(".");
+      const parent = headingIndex.find((candidate) =>
+        candidate.sectionNumber === parentSection && candidate.normalizedTitle.includes("monitoring"),
+      );
+      if (parent) expanded.push(parent);
+    }
+  }
+  return uniqueHeadings(expanded).sort(
+    (left, right) => left.sectionNumber.localeCompare(right.sectionNumber, undefined, { numeric: true }),
+  );
+}
+
 function exactHeadingMatches(headings: DocumentHeading[], claimText: string): DocumentHeading[] {
   const normalizedClaim = normalizeReviewText(
     claimText
@@ -428,12 +447,12 @@ function resolveReviewQuestionSections(input: {
 
   const exactMatches = uniqueHeadings(exactHeadingMatches(input.headingIndex, input.claimText));
   if (exactMatches.length > 0) {
-    return { matchedHeadings: exactMatches, rejectedMatches: [], matchStage: "exact_heading" };
+    return { matchedHeadings: withMonitoringAncestors(exactMatches, input.reviewArea, input.headingIndex), rejectedMatches: [], matchStage: "exact_heading" };
   }
 
   const normalizedMatches = uniqueHeadings(filterPddHeadingsByQuery(input.headingIndex, input.claimText, []));
   if (normalizedMatches.length > 0) {
-    return { matchedHeadings: normalizedMatches, rejectedMatches: [], matchStage: "normalized_heading" };
+    return { matchedHeadings: withMonitoringAncestors(normalizedMatches, input.reviewArea, input.headingIndex), rejectedMatches: [], matchStage: "normalized_heading" };
   }
 
   const aliasMatches = uniqueHeadings([
@@ -441,12 +460,12 @@ function resolveReviewQuestionSections(input: {
     ...filterPddHeadingsByQuery(input.headingIndex, input.claimText, [...reviewAreaKeywords, ...aliases]),
   ]);
   if (aliasMatches.length > 0) {
-    return { matchedHeadings: aliasMatches, rejectedMatches: [], matchStage: "alias_heading" };
+    return { matchedHeadings: withMonitoringAncestors(aliasMatches, input.reviewArea, input.headingIndex), rejectedMatches: [], matchStage: "alias_heading" };
   }
 
   const semanticMatches = uniqueHeadings(semanticFallbackMatches(input.headingIndex, input.reviewArea, searchTerms, claimKeywords));
   if (semanticMatches.length > 0) {
-    return { matchedHeadings: semanticMatches, rejectedMatches: [], matchStage: "semantic_fallback" };
+    return { matchedHeadings: withMonitoringAncestors(semanticMatches, input.reviewArea, input.headingIndex), rejectedMatches: [], matchStage: "semantic_fallback" };
   }
 
   const rejectedMatches = input.rawPddText

--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -562,9 +562,12 @@ export function debugSectionExtraction(rawText: string): Record<string, string> 
 export type DocumentHeading = {
   sectionNumber: string;
   title: string;
+  originalTitle: string;
   normalizedTitle: string;
   bodyPreview: string;
   bodyText: string;
+  originalBodyText: string;
+  normalizedBodyText: string;
 };
 
 export type HeadingQueryMatch = {
@@ -593,8 +596,21 @@ export type RejectedHeadingQueryMatch = {
 const HEADING_PREVIEW_MAX = 220;
 const HEADING_BODY_MAX = 4000;
 
+function repairPdfExtractionJoins(text: string): string {
+  return text
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]{2,})([A-Z][a-z])/g, "$1 $2")
+    .replace(/([a-zA-Z])([/|])([A-Za-z])/g, "$1 $2 $3");
+}
+
+function cleanExtractedDisplayText(text: string): string {
+  return repairPdfExtractionJoins(text)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function normalizeHeadingTitle(title: string): string {
-  return title
+  return cleanExtractedDisplayText(title)
     .toLowerCase()
     .replace(/[^\w\s.-]/g, " ")
     .replace(/\s+/g, " ")
@@ -835,17 +851,22 @@ export function buildPddHeadingIndex(rawPddText: string): DocumentHeading[] {
   for (const [num, content] of Object.entries(sections)) {
     const lines = content.split("\n").filter((l) => l.trim().length > 0);
     if (lines.length === 0) continue;
-    const title = lines[0]!.trim();
-    const body = lines.slice(1).join("\n").trim();
+    const originalTitle = lines[0]!.trim();
+    const originalBodyText = lines.slice(1).join("\n").trim();
+    const title = cleanExtractedDisplayText(originalTitle);
+    const body = cleanExtractedDisplayText(originalBodyText);
     const normalizedTitle = normalizeHeadingTitle(title);
     const bodyPreview = makeBodyPreview(body || title);
     const bodyText = (body || title).slice(0, HEADING_BODY_MAX);
     headings.push({
       sectionNumber: num,
       title,
+      originalTitle,
       normalizedTitle,
       bodyPreview,
       bodyText,
+      originalBodyText,
+      normalizedBodyText: normalizeHeadingTitle(bodyText),
     });
   }
   return headings;
@@ -900,9 +921,12 @@ export function findRejectedHeadingMatches(
       {
         sectionNumber: candidate.num,
         title,
+        originalTitle: title,
         normalizedTitle,
         bodyPreview: "",
         bodyText: "",
+        originalBodyText: "",
+        normalizedBodyText: "",
       },
       query,
       fallbackKeywords,

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -9,6 +9,7 @@ import { putAttachmentBytes } from "@/lib/proofMap/attachments";
 
 const pushMock = jest.fn();
 const createAndStoreEvidenceAttachmentMock = jest.fn();
+const ENVIRA_VM0007_TEXT = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/envira-amazonia-vm0007-extracted.txt"), "utf-8");
 const PDF_TEXT_BY_FILENAME: Record<string, string> = {
   "fresh-monitoring-report.pdf": "Monitoring report for the full reporting period. Gold Standard TPDD TEC Version 4.0. AR-ACM0003 methodology reference.",
   "monitoring-report.pdf": "Monitoring report for the full reporting period.",
@@ -50,6 +51,11 @@ const PDF_TEXT_BY_FILENAME: Record<string, string> = {
     "The mapped project area polygon and AOI are referenced in the boundary map.",
     "1.9  Project Location",
     "Project location Machinga District, Malawi.",
+  ].join("\n"),
+  "envira-amazonia-vm0007.pdf": ENVIRA_VM0007_TEXT,
+  "long-overflow-monitoring.pdf": [
+    "4.3  MonitoringPlan",
+    "The monitoring plan includes SUPERLONGUNBROKENTOKENFORQUICKCHECKOVERFLOWASSERTION1234567890SUPERLONGUNBROKENTOKENFORQUICKCHECKOVERFLOWASSERTION1234567890SUPERLONGUNBROKENTOKENFORQUICKCHECKOVERFLOWASSERTION1234567890.",
   ].join("\n"),
   "ambiguous-methods.pdf": "Methodology references include VM0007, GS-VER1, and the monitoring report for the full reporting period.",
   "unknown-acm0010.pdf": "Evidence references ACM0010 and the monitoring report for the full reporting period.",
@@ -1075,6 +1081,46 @@ describe("QuickCheckPanel claim-first flow", () => {
     expect(text).toContain("No matching document section found.");
     expect(text).toContain("§6 Stakeholder Comments");
     expect(text).toContain("table of contents");
+  });
+
+  it("keeps long extracted review-question strings from expanding the Quick Check card horizontally", async () => {
+    seedSession({
+      claimText: "Check the monitoring plan",
+      methodologyId: "VM0007",
+      methodologyVersion: "v4-2",
+      filename: "long-overflow-monitoring.pdf",
+    });
+    await seedAttachmentText("att-upload-1", "%PDF-1.4\n(long overflow monitoring)\n%%EOF");
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+
+    await flushUi();
+
+    const reviewCard = container.querySelector('[data-testid="quick-check-review-result"]');
+    expect(reviewCard).toBeTruthy();
+    expect(reviewCard?.className).toContain("min-w-0");
+    expect(reviewCard?.className).toContain("max-w-full");
+    expect(reviewCard?.className).toContain("overflow-hidden");
+
+    const monitoringHeading = Array.from(container.querySelectorAll("button")).find((node) =>
+      node.textContent?.includes("Monitoring Plan"),
+    );
+    expect(monitoringHeading).toBeTruthy();
+    expect(monitoringHeading?.className).toContain("min-w-0");
+    expect(monitoringHeading?.className).toContain("max-w-full");
+    expect(monitoringHeading?.className).toContain("overflow-hidden");
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Section found, evidence weak");
+    expect(text).toContain("Monitoring Plan");
   });
 
   it("supports the cold-load user flow without using the demo path", async () => {

--- a/tests/fixtures/quick-check/envira-amazonia-vm0007-extracted.txt
+++ b/tests/fixtures/quick-check/envira-amazonia-vm0007-extracted.txt
@@ -1,0 +1,23 @@
+VM0007 Version 4.2
+Project Description Document
+Envira Amazonia REDD+ Project
+
+2.6  Methodology Deviations
+No methodology deviations from VM0007 were applied in the project scenario.
+Any temporary departures from default data collection were documented in annexes.
+
+3.3  Leakage
+Activity shifting leakage is addressed through community agreements and surveillance.
+Leakage Management procedures are described for nearby forest users and buffer communities.
+
+4.2  Data and Parameters
+Monitoring equipment includes GPS devices, diameter tapes, and handheld tablets for field teams.
+
+4.3  MonitoringPlan
+The monitoring plan defines the sampling design, plot remeasurement schedule, QA/QC checks, and reporting workflow.
+Monitoring procedures describe how plot data, leakage observations, and safeguards evidence are reviewed annually.
+
+6  Stakeholder Comments
+Project awareness activities were conducted through community meetings and workshops.
+FPIC and Free Prior and Informed Consent steps were completed with indigenous representatives.
+The grievance procedure, stakeholder comments, and follow-up responses were summarized in this section.

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -395,6 +395,8 @@ describe("buildReviewQuestionResult — section content extraction (Phase 1)", (
 
 const PLUM_FIXTURE_PATH = path.join(__dirname, "..", "fixtures", "quick-check", "plum-pdd-regression.txt");
 const PLUM_TEXT = fs.readFileSync(PLUM_FIXTURE_PATH, "utf-8");
+const ENVIRA_FIXTURE_PATH = path.join(__dirname, "..", "fixtures", "quick-check", "envira-amazonia-vm0007-extracted.txt");
+const ENVIRA_TEXT = fs.readFileSync(ENVIRA_FIXTURE_PATH, "utf-8");
 
 const CUSTOM_HEADING_PDD = [
   "2.1  Project Goals, Design and Long-Term Viability",
@@ -588,6 +590,73 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(result.relevantSections).toEqual([]);
     expect(result.noMatchExplanation).toContain("§6 Stakeholder Comments");
     expect(result.noMatchExplanation).toContain("table of contents");
+  });
+
+  it("finds methodology deviations from the Envira Amazonia VM0007 fixture", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD disclose methodology deviations?",
+      methodologyId: "VM0007",
+      methodologyVersion: "v4-2",
+      rawPddText: ENVIRA_TEXT,
+    });
+
+    expect(result.relevantSections[0]).toBe("2.6");
+    expect(result.sectionContent["2.6"]).toContain("No methodology deviations");
+    expect(result.status).toBe("section_found_evidence_weak");
+    expect(result.matchStage).not.toBe("none");
+  });
+
+  it("finds stakeholder consultation evidence from stakeholder-comments and FPIC text in the Envira fixture", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe stakeholder consultation and FPIC?",
+      methodologyId: "VM0007",
+      methodologyVersion: "v4-2",
+      rawPddText: ENVIRA_TEXT,
+    });
+
+    expect(result.relevantSections).toContain("6");
+    expect(result.reviewAreaReview?.verdict).toBe("partial");
+    expect(result.status).toBe("partial_evidence_found");
+    expect(result.sectionContent["6"]).toContain("Free Prior and Informed Consent");
+  });
+
+  it("finds leakage from 3.3 Leakage / Leakage Management in the Envira fixture", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD address leakage management?",
+      methodologyId: "VM0007",
+      methodologyVersion: "v4-2",
+      rawPddText: ENVIRA_TEXT,
+    });
+
+    expect(result.relevantSections[0]).toBe("3.3");
+    expect(result.sectionContent["3.3"]).toContain("Leakage Management procedures");
+    expect(result.status).toBe("partial_evidence_found");
+  });
+
+  it("prefers 4.3 Monitoring Plan over generic monitoring equipment blocks in the Envira fixture", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Check the monitoring plan",
+      methodologyId: "VM0007",
+      methodologyVersion: "v4-2",
+      rawPddText: ENVIRA_TEXT,
+    });
+
+    expect(result.relevantSections[0]).toBe("4.3");
+    expect(result.sectionContent["4.3"]).toContain("sampling design");
+    expect(result.sectionContent["4.2"]).toBeUndefined();
+    expect(result.matchedHeadings[0]?.title).toBe("Monitoring Plan");
+  });
+
+  it("cleans common PDF extraction joins before exposing heading titles", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Check the monitoring plan",
+      methodologyId: "VM0007",
+      methodologyVersion: "v4-2",
+      rawPddText: ENVIRA_TEXT,
+    });
+
+    expect(result.matchedHeadings[0]?.title).toBe("Monitoring Plan");
+    expect(result.matchedHeadings[0]?.originalTitle).toBe("MonitoringPlan");
   });
 
   it("does not match random sections like biodiversity, financial analysis, or Remote Sensing", () => {


### PR DESCRIPTION
## What changed
- add a cleaned Quick Check document-section layer that preserves original extracted heading/body text for diagnostics while normalizing display and match text
- normalize extracted heading text before review-question matching by lowercasing, trimming, collapsing repeated whitespace, and repairing common PDF join issues such as `MonitoringPlan`
- replace the review-question section resolver with staged matching: exact heading, normalized heading, review-area alias match, then conservative semantic fallback
- add alias coverage for the current false-negative areas:
  - `deviations`: `Methodology Deviations`, `2.6 Methodology Deviations`
  - `stakeholder`: `Stakeholder Comments`, `Stakeholder Consultation`, `Project Awareness`, `FPIC`, `Free Prior and Informed Consent`, `grievance procedure`, `community meetings`
  - `leakage`: `Leakage`, `Leakage Management`, `3.3 Leakage`
  - `monitoring`: strong preference for `4.3 Monitoring Plan` while down-ranking generic `Monitoring equipment` parameter blocks
- add review-question result status values for stronger UI/state reporting:
  - `strong_evidence_found`
  - `partial_evidence_found`
  - `section_found_evidence_weak`
  - `no_document_grounded_evidence`
  - `extractor_uncertain`
- harden the Quick Check result card and section list against horizontal overflow with defensive width, wrapping, and overflow classes
- ensure cleaned section titles/snippets are rendered in the result UI instead of raw extracted PDF text
- add an Envira Amazonia VM0007 regression fixture plus matching tests for deviations, stakeholder consultation, leakage, and monitoring-plan preference
- add a UI regression proving long unbroken extracted strings do not expand the review-question card horizontally

## Why
PR #664 fixed primary methodology detection, but Quick Check review-question matching still relied too heavily on brittle raw heading extraction and the result card could still be stretched by hostile extracted strings.

## User impact
- real PDDs are less likely to return false negatives for methodology deviations, leakage, stakeholder consultation, and monitoring-plan questions
- Quick Check now reports clearer result status when it finds a section but the evidence is weak versus when the extractor itself is uncertain
- extracted PDF text is cleaned before it is shown in result titles/snippets, reducing ugly joins and overflow regressions

## Root cause
The previous review-question path treated the raw heading index as both the extraction layer and the display layer, with narrow title-only matching and no explicit staged fallback. That made the behavior fragile to whitespace noise, PDF extraction joins, alias headings, and long unbroken strings.

## Validation
- `npx jest tests/lib/quickCheckReviewQuestion.test.ts --runInBand`
- `npx jest tests/components/quickCheckPanel.test.tsx -t "shows legal/property-rights heading matches in the review-question UI|renders the baseline evidence-backed verdict for a baseline review question|distinguishes TOC-only heading matches from recovered body headings|keeps long extracted review-question strings from expanding the Quick Check card horizontally" --runInBand`
- `npm run typecheck`

## Notes
- this PR is intentionally scoped to section matching and result display hardening
- it does not revert or rewrite the primary methodology resolver introduced in PR #664