### PR TITLE
[codex] start quick check parser adapter boundary

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
+Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, quick-check-document-pipeline, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
 Frozen lanes: agentic-verification.
 
 
@@ -159,6 +159,22 @@ Not active now:
 3) RC3 — Verification pack PDF: Planned — Review-ready PDF with branded cover, coverage matrix, evidence inventory, gap summary, and draft verification opinion.
 4) RC4 — Verra methodology support: Planned — Wire app to use Verra VM0007 rules once encoded upstream. Depends on article6-methodologies VF1-VF3.
 5) RC5 — End-to-end demo case: Planned — One complete VM0007 forestry verification with synthetic data, full rule coverage, and review-ready PDF export.
+
+## quick-check-document-pipeline
+
+Status SSOT: `docs/roadmaps/quick-check-document-pipeline/phase-status.json`
+
+Lane status: Active
+Move Quick Check from tactical section-matching patches to a layered document pipeline with explicit parser, document-model, retrieval, evaluation, UI, and eval boundaries.
+
+Not active now:
+- LiteParse integration
+- Canonical document model migration
+- Retrieval/evaluation refactor
+- Declarative review policy config
+- Quick Check eval harness implementation
+- Additional Quick Check tactical alias patches
+
 
 ## requirement-coverage
 

--- a/docs/roadmaps/quick-check-document-pipeline.md
+++ b/docs/roadmaps/quick-check-document-pipeline.md
@@ -1,0 +1,156 @@
+# Quick Check Document Pipeline
+
+Status is sourced from `docs/roadmaps/quick-check-document-pipeline/phase-status.json`; docs must not drift.
+
+Goal: move Quick Check from tactical heading/alias patching to a layered document pipeline with explicit parser, document-model, retrieval, evaluation, and eval boundaries.
+
+## Why this lane exists
+
+PR `#665` is the last tactical stabilization PR for Quick Check section matching and result display hardening.
+
+After that point, Quick Check should stop absorbing one-off alias and edge-case patches into retrieval logic. The system needs a stable document pipeline so parser behavior, review-area routing, evidence sufficiency, and UI output no longer drift together.
+
+The Article6 moat is not raw PDF extraction. The moat is methodology-aware evidence judgment on top of a parser-neutral document representation.
+
+## Target pipeline
+
+```text
+uploaded document
+-> parser adapter
+-> Article6 canonical document model
+-> section retrieval
+-> evidence evaluation
+-> UI output
+-> eval harness
+```
+
+## Principles
+
+- Do not build parser/vendor lock-in into Quick Check logic.
+- Do not let retrieval and evidence sufficiency share one heuristic layer.
+- Do not render raw extracted text directly in the UI.
+- Do not add new Quick Check alias or edge-case patches after PR `#665` unless they are required for migration safety.
+- Keep parser integration commodity; keep Article6 review judgment proprietary.
+
+## Phase plan
+
+### Phase 1 — Parser adapter boundary
+
+Objective: add `src/lib/documentParsing/` and move the current extractor behind an adapter boundary without changing retrieval/evaluation behavior.
+
+Scope:
+
+- Add parser adapter types and registry.
+- Keep the current extractor as adapter `current-extractor`.
+- Route Phase 1 Quick Check parsing reads through the adapter boundary where safe.
+- Do not start LiteParse in this phase.
+- Do not refactor retrieval/evaluation in this phase.
+- Do not add new section aliases or edge-case matcher patches in this phase.
+
+Exit criteria:
+
+- `src/lib/documentParsing/` exists with a parser-neutral contract.
+- The current extractor is accessible only as an adapter implementation.
+- Quick Check review-question code can consume parsed headings/sections through the adapter boundary without changing verdict logic.
+
+### Phase 2 — Canonical Article6 document model
+
+Objective: add `src/lib/documentModel/` as the single canonical document representation consumed by Quick Check.
+
+Scope:
+
+- Define canonical section, hierarchy, provenance, normalized title, cleaned body, display snippet, extraction flags, and confidence surfaces.
+- Preserve raw extracted text separately for citations/debug.
+- Keep parser adapters responsible only for parsing; they must not emit Article6 verdicts.
+
+Exit criteria:
+
+- Quick Check retrieval/evaluation no longer depends on parser-native section structures.
+- Canonical document model is the only downstream input contract.
+
+### Phase 3 — Retrieval / evaluation split
+
+Objective: separate section retrieval from evidence sufficiency evaluation.
+
+Scope:
+
+- Retrieval returns ranked candidate sections plus reasons and confidence.
+- Evaluation returns sufficiency status, missing signals, follow-up docs, and citations.
+- Retrieval does not emit verdicts.
+- Evaluation does not rediscover section relevance from scratch.
+
+Exit criteria:
+
+- Review-question routing and rubric judgment are independently testable.
+- A retrieval change cannot silently change evidence sufficiency semantics.
+
+### Phase 4 — Declarative review policy
+
+Objective: move review-area behavior into typed JSON config validated by Zod.
+
+Scope:
+
+- Review-area aliases
+- Preferred sections
+- Negative sections
+- Fallback rules
+- Ranking boosts and penalties
+- Required evidence signals
+- Weak evidence signals
+
+Exit criteria:
+
+- Adding or changing review policy is primarily config work, not matcher patching.
+- Config validation fails fast in CI when policy shape drifts.
+
+### Phase 5 — Quick Check eval harness
+
+Objective: gate changes with real fixture-backed retrieval and verdict expectations.
+
+Scope:
+
+- Real fixture corpus across methodology/document styles
+- Expected retrieval outputs
+- Expected verdict/status outputs
+- Regression CLI and CI gate
+
+Exit criteria:
+
+- Quick Check pipeline changes are evaluated before merge.
+- Known failures stop reappearing as tactical regressions.
+
+### Phase 6 — Secondary parser adapter
+
+Objective: add LiteParse as a second parser adapter after the boundary and document model are stable.
+
+Scope:
+
+- Implement LiteParse behind the same adapter contract.
+- Keep retrieval/evaluation unchanged when switching adapters.
+
+Exit criteria:
+
+- Parser choice is swappable.
+- Quick Check logic remains Article6-owned and parser-neutral.
+
+## Out of scope for this lane
+
+- OPA
+- Drools
+- Redis
+- Event-driven infrastructure
+- LLM-first scoring
+- New Quick Check tactical alias patches after PR `#665`
+
+## Execution order
+
+1. Phase 1 — parser adapter boundary
+2. Phase 2 — canonical document model
+3. Phase 3 — retrieval / evaluation split
+4. Phase 4 — declarative review policy
+5. Phase 5 — eval harness
+6. Phase 6 — secondary parser adapter
+
+## Immediate next action
+
+Open the Phase 1 PR from latest `main` with roadmap docs plus the parser adapter boundary only.

--- a/docs/roadmaps/quick-check-document-pipeline/phase-status.json
+++ b/docs/roadmaps/quick-check-document-pipeline/phase-status.json
@@ -1,4 +1,8 @@
 {
+  "roadmap": "quick-check-document-pipeline",
+  "repo": "Fredilly/app.article6",
+  "status": "active",
+  "current_phase": "phase_1_parser_adapter_boundary",
   "phase_1_parser_adapter_boundary": {
     "status": "active",
     "title": "Phase 1 — parser adapter boundary",

--- a/docs/roadmaps/quick-check-document-pipeline/phase-status.json
+++ b/docs/roadmaps/quick-check-document-pipeline/phase-status.json
@@ -1,0 +1,47 @@
+{
+  "phase_1_parser_adapter_boundary": {
+    "status": "active",
+    "title": "Phase 1 — parser adapter boundary",
+    "summary": "Add src/lib/documentParsing/ and move the current Quick Check extractor behind an adapter boundary. Keep retrieval/evaluation behavior intact and do not start LiteParse yet."
+  },
+  "phase_2_article6_document_model": {
+    "status": "planned",
+    "title": "Phase 2 — canonical Article6 document model",
+    "summary": "Add src/lib/documentModel/ as the canonical document representation for normalized sections, hierarchy, provenance, and cleaned display text."
+  },
+  "phase_3_retrieval_evaluation_split": {
+    "status": "planned",
+    "title": "Phase 3 — section retrieval and evidence evaluation split",
+    "summary": "Separate candidate section retrieval from evidence sufficiency judgment so routing and verdict semantics can evolve independently."
+  },
+  "phase_4_declarative_review_policy": {
+    "status": "planned",
+    "title": "Phase 4 — declarative typed review policy",
+    "summary": "Move aliases, preferred sections, negative sections, fallback rules, boosts, penalties, and evidence signals into typed JSON validated by Zod."
+  },
+  "phase_5_eval_harness": {
+    "status": "planned",
+    "title": "Phase 5 — Quick Check eval harness",
+    "summary": "Add fixture-backed retrieval and verdict evals so pipeline changes are measured and gated before merge."
+  },
+  "phase_6_secondary_parser_adapter": {
+    "status": "planned",
+    "title": "Phase 6 — secondary parser adapter",
+    "summary": "Add LiteParse as a second parser adapter only after the adapter boundary and canonical document model are stable."
+  },
+  "phase_meta": {
+    "status": "active",
+    "summary": "Move Quick Check from tactical section-matching patches to a layered document pipeline with explicit parser, document-model, retrieval, evaluation, UI, and eval boundaries.",
+    "current_focus": "Phase 1 only: roadmap docs plus parser adapter boundary around the current extractor. LiteParse, document-model adoption, retrieval/evaluation split, declarative policy, and eval harness remain intentionally out of scope for this PR.",
+    "not_active_now": [
+      "LiteParse integration",
+      "Canonical document model migration",
+      "Retrieval/evaluation refactor",
+      "Declarative review policy config",
+      "Quick Check eval harness implementation",
+      "Additional Quick Check tactical alias patches"
+    ],
+    "last_updated_at": "2026-06-01T00:00:00Z"
+  },
+  "pr_evidence": {}
+}

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -499,7 +499,7 @@ export function findMatchedSectionNumbers(
   if (!claimText?.trim()) return [];
   const parsedDocument = parseDocumentText({ rawText: rawPddText });
   return resolveReviewQuestionSections({
-    headingIndex: parsedDocument.headingIndex,
+    headingIndex: parsedDocument.headingIndex ?? [],
     claimText,
     reviewArea,
     methodologyId,
@@ -516,7 +516,7 @@ export function computeSectionMatchResults(
   claimText: string,
   methodologyId = "",
 ): SectionMatchResult[] {
-  const headingIndex = parseDocumentText({ rawText: rawPddText }).headingIndex;
+  const headingIndex = parseDocumentText({ rawText: rawPddText }).headingIndex ?? [];
   const fallbackKeywords = reviewAreaKeywordsForInput({ reviewArea, methodologyId, rawPddText });
   const results: SectionMatchResult[] = [];
 
@@ -634,7 +634,7 @@ export function buildReviewQuestionResult(input: {
   });
 
   const diagnostic = process.env.NODE_ENV !== "production" && input.rawPddText
-    ? parsedDocument?.diagnostics ?? debugSectionExtraction(input.rawPddText)
+    ? parsedDocument?.diagnostics?.metadata ?? debugSectionExtraction(input.rawPddText)
     : undefined;
 
   const claimKeywords = input.claimText ? extractClaimKeywords(input.claimText) : { phrases: [], words: [] };
@@ -680,7 +680,7 @@ function buildPhase1Diagnostic(
   sourceLabel?: string,
   documentType?: string,
 ): ReviewQuestionDiagnostic {
-  const allSections = parseDocumentText({ rawText: rawPddText }).sectionsByNumber;
+  const allSections = parseDocumentText({ rawText: rawPddText }).sectionsByNumber ?? {};
   const text = rawPddText.replace(/\s+/g, " ").trim();
 
   const matchResults = computeSectionMatchResults(rawPddText, reviewArea, claimText);

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,8 +1,6 @@
 import {
   analyzeSectionCandidates,
-  buildPddHeadingIndex,
   debugSectionExtraction,
-  extractPddSections,
   findRejectedHeadingMatches,
   filterPddHeadingsByQuery,
   normalizeSectionKey,
@@ -13,6 +11,7 @@ import {
 } from "@/lib/chat/quickCheckSectionExtractor";
 import { evaluateBaselineReview, type BaselineReviewResult } from "@/lib/chat/quickCheckBaselineRubric";
 import { evaluateReviewRubric, type ReviewRubricResult } from "@/lib/chat/quickCheckReviewRubric";
+import { parseDocumentText } from "@/lib/documentParsing";
 
 export type ReviewArea =
   | "additionality"
@@ -498,8 +497,9 @@ export function findMatchedSectionNumbers(
   methodologyId = "",
 ): string[] {
   if (!claimText?.trim()) return [];
+  const parsedDocument = parseDocumentText({ rawText: rawPddText });
   return resolveReviewQuestionSections({
-    headingIndex: buildPddHeadingIndex(rawPddText),
+    headingIndex: parsedDocument.headingIndex,
     claimText,
     reviewArea,
     methodologyId,
@@ -516,7 +516,7 @@ export function computeSectionMatchResults(
   claimText: string,
   methodologyId = "",
 ): SectionMatchResult[] {
-  const headingIndex = buildPddHeadingIndex(rawPddText);
+  const headingIndex = parseDocumentText({ rawText: rawPddText }).headingIndex;
   const fallbackKeywords = reviewAreaKeywordsForInput({ reviewArea, methodologyId, rawPddText });
   const results: SectionMatchResult[] = [];
 
@@ -595,11 +595,12 @@ export function buildReviewQuestionResult(input: {
   evidenceDocumentType?: string;
 }): ReviewQuestionResult {
   const reviewArea = classifyReviewArea(input.claimText);
+  const parsedDocument = input.rawPddText ? parseDocumentText({ rawText: input.rawPddText }) : undefined;
 
   // Heading extraction remains the source of truth from the uploaded document.
   // Matching runs through exact, normalized, alias, and semantic fallback stages against
   // a cleaned heading layer while preserving the original extracted text for diagnostics.
-  const headingIndex: DocumentHeading[] = input.rawPddText ? buildPddHeadingIndex(input.rawPddText) : [];
+  const headingIndex: DocumentHeading[] = parsedDocument?.headingIndex ?? [];
   const sectionResolution = resolveReviewQuestionSections({
     headingIndex,
     claimText: input.claimText || "",
@@ -633,7 +634,7 @@ export function buildReviewQuestionResult(input: {
   });
 
   const diagnostic = process.env.NODE_ENV !== "production" && input.rawPddText
-    ? debugSectionExtraction(input.rawPddText)
+    ? parsedDocument?.diagnostics ?? debugSectionExtraction(input.rawPddText)
     : undefined;
 
   const claimKeywords = input.claimText ? extractClaimKeywords(input.claimText) : { phrases: [], words: [] };
@@ -679,7 +680,7 @@ function buildPhase1Diagnostic(
   sourceLabel?: string,
   documentType?: string,
 ): ReviewQuestionDiagnostic {
-  const allSections = extractPddSections(rawPddText);
+  const allSections = parseDocumentText({ rawText: rawPddText }).sectionsByNumber;
   const text = rawPddText.replace(/\s+/g, " ").trim();
 
   const matchResults = computeSectionMatchResults(rawPddText, reviewArea, claimText);

--- a/src/lib/documentParsing/adapters/currentExtractor.ts
+++ b/src/lib/documentParsing/adapters/currentExtractor.ts
@@ -5,16 +5,71 @@ import {
 } from "@/lib/chat/quickCheckSectionExtractor";
 import type { DocumentParserAdapter, ParseDocumentTextInput, ParsedDocument } from "@/lib/documentParsing/types";
 
+function normalizeParserText(rawText: string): string {
+  return rawText
+    .replace(/\f/g, "\n")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+}
+
+function headingLevel(sectionNumber?: string): number | undefined {
+  if (!sectionNumber) return undefined;
+  return sectionNumber.split(".").length;
+}
+
 export const currentExtractorAdapter: DocumentParserAdapter = {
   id: "current-extractor",
   parseText(input: ParseDocumentTextInput): ParsedDocument {
     const rawText = input.rawText ?? "";
+    const normalizedText = normalizeParserText(rawText);
+    const sectionsByNumber = extractPddSections(rawText);
+    const headingIndex = buildPddHeadingIndex(rawText);
+    const headings = headingIndex.map((heading) => ({
+      id: `heading:${heading.sectionNumber}`,
+      text: heading.title,
+      normalizedText: heading.normalizedTitle,
+      level: headingLevel(heading.sectionNumber),
+      sectionNumber: heading.sectionNumber,
+    }));
+    const blocks = headingIndex.flatMap((heading) => {
+      const headingBlock = {
+        id: `block:heading:${heading.sectionNumber}`,
+        type: "heading" as const,
+        text: heading.title,
+        normalizedText: heading.normalizedTitle,
+        headingLevel: headingLevel(heading.sectionNumber),
+        sectionNumber: heading.sectionNumber,
+      };
+      const bodyBlocks = heading.bodyText
+        ? [{
+            id: `block:body:${heading.sectionNumber}`,
+            type: "paragraph" as const,
+            text: heading.bodyText,
+            normalizedText: normalizeParserText(heading.bodyText).replace(/\s+/g, " ").trim(),
+            sectionNumber: heading.sectionNumber,
+          }]
+        : [];
+      return [headingBlock, ...bodyBlocks];
+    });
     return {
       adapterId: "current-extractor",
+      source: "current-extractor",
       rawText,
-      sectionsByNumber: extractPddSections(rawText),
-      headingIndex: buildPddHeadingIndex(rawText),
-      diagnostics: rawText.trim() ? debugSectionExtraction(rawText) : undefined,
+      normalizedText,
+      pages: [{
+        pageNumber: 1,
+        rawText,
+        normalizedText,
+      }],
+      blocks,
+      headings,
+      diagnostics: rawText.trim()
+        ? {
+            metadata: debugSectionExtraction(rawText),
+          }
+        : undefined,
+      sectionsByNumber,
+      headingIndex,
     };
   },
 };

--- a/src/lib/documentParsing/adapters/currentExtractor.ts
+++ b/src/lib/documentParsing/adapters/currentExtractor.ts
@@ -1,0 +1,20 @@
+import {
+  buildPddHeadingIndex,
+  debugSectionExtraction,
+  extractPddSections,
+} from "@/lib/chat/quickCheckSectionExtractor";
+import type { DocumentParserAdapter, ParseDocumentTextInput, ParsedDocument } from "@/lib/documentParsing/types";
+
+export const currentExtractorAdapter: DocumentParserAdapter = {
+  id: "current-extractor",
+  parseText(input: ParseDocumentTextInput): ParsedDocument {
+    const rawText = input.rawText ?? "";
+    return {
+      adapterId: "current-extractor",
+      rawText,
+      sectionsByNumber: extractPddSections(rawText),
+      headingIndex: buildPddHeadingIndex(rawText),
+      diagnostics: rawText.trim() ? debugSectionExtraction(rawText) : undefined,
+    };
+  },
+};

--- a/src/lib/documentParsing/index.ts
+++ b/src/lib/documentParsing/index.ts
@@ -1,0 +1,27 @@
+import { currentExtractorAdapter } from "@/lib/documentParsing/adapters/currentExtractor";
+import {
+  DEFAULT_DOCUMENT_PARSER_ADAPTER_ID,
+  type DocumentParserAdapter,
+  type DocumentParserAdapterId,
+  type ParseDocumentTextInput,
+  type ParsedDocument,
+} from "@/lib/documentParsing/types";
+
+const ADAPTERS: Record<DocumentParserAdapterId, DocumentParserAdapter> = {
+  "current-extractor": currentExtractorAdapter,
+};
+
+export function getDocumentParserAdapter(
+  adapterId: DocumentParserAdapterId = DEFAULT_DOCUMENT_PARSER_ADAPTER_ID,
+): DocumentParserAdapter {
+  return ADAPTERS[adapterId];
+}
+
+export function parseDocumentText(
+  input: ParseDocumentTextInput,
+  adapterId: DocumentParserAdapterId = DEFAULT_DOCUMENT_PARSER_ADAPTER_ID,
+): ParsedDocument {
+  return getDocumentParserAdapter(adapterId).parseText(input);
+}
+
+export * from "@/lib/documentParsing/types";

--- a/src/lib/documentParsing/types.ts
+++ b/src/lib/documentParsing/types.ts
@@ -1,0 +1,22 @@
+import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
+
+export const DEFAULT_DOCUMENT_PARSER_ADAPTER_ID = "current-extractor" as const;
+
+export type DocumentParserAdapterId = typeof DEFAULT_DOCUMENT_PARSER_ADAPTER_ID;
+
+export type ParseDocumentTextInput = {
+  rawText: string;
+};
+
+export type ParsedDocument = {
+  adapterId: DocumentParserAdapterId;
+  rawText: string;
+  sectionsByNumber: Record<string, string>;
+  headingIndex: DocumentHeading[];
+  diagnostics?: Record<string, string>;
+};
+
+export interface DocumentParserAdapter {
+  readonly id: DocumentParserAdapterId;
+  parseText(input: ParseDocumentTextInput): ParsedDocument;
+}

--- a/src/lib/documentParsing/types.ts
+++ b/src/lib/documentParsing/types.ts
@@ -8,12 +8,48 @@ export type ParseDocumentTextInput = {
   rawText: string;
 };
 
+export type ParsedPage = {
+  pageNumber: number;
+  rawText: string;
+  normalizedText: string;
+};
+
+export type ParsedBlock = {
+  id: string;
+  type: "heading" | "paragraph" | "unknown";
+  text: string;
+  normalizedText: string;
+  pageNumber?: number;
+  headingLevel?: number;
+  sectionNumber?: string;
+};
+
+export type ParsedHeading = {
+  id: string;
+  text: string;
+  normalizedText: string;
+  pageNumber?: number;
+  level?: number;
+  sectionNumber?: string;
+};
+
+export type ParserDiagnostics = {
+  warnings?: string[];
+  metadata?: Record<string, string>;
+};
+
 export type ParsedDocument = {
   adapterId: DocumentParserAdapterId;
+  source: string;
   rawText: string;
-  sectionsByNumber: Record<string, string>;
-  headingIndex: DocumentHeading[];
-  diagnostics?: Record<string, string>;
+  normalizedText: string;
+  pages: ParsedPage[];
+  blocks: ParsedBlock[];
+  headings: ParsedHeading[];
+  diagnostics?: ParserDiagnostics;
+  // Bridge fields for the current Quick Check migration only.
+  sectionsByNumber?: Record<string, string>;
+  headingIndex?: DocumentHeading[];
 };
 
 export interface DocumentParserAdapter {

--- a/tests/lib/documentParsing.test.ts
+++ b/tests/lib/documentParsing.test.ts
@@ -30,15 +30,39 @@ describe("documentParsing current extractor adapter", () => {
     const parsed = parseDocumentText({ rawText: VM0007_TEXT });
 
     expect(parsed.adapterId).toBe("current-extractor");
+    expect(parsed.source).toBe("current-extractor");
     expect(parsed.rawText).toBe(VM0007_TEXT);
+    expect(parsed.normalizedText).toBe(VM0007_TEXT);
+    expect(parsed.pages).toEqual([
+      {
+        pageNumber: 1,
+        rawText: VM0007_TEXT,
+        normalizedText: VM0007_TEXT,
+      },
+    ]);
+    expect(parsed.headings.map((heading) => heading.sectionNumber)).toEqual(["1.9", "2.4", "4.3"]);
+    expect(parsed.blocks.some((block) => block.type === "heading")).toBe(true);
+    expect(parsed.blocks.some((block) => block.type === "paragraph")).toBe(true);
     expect(parsed.sectionsByNumber).toEqual(extractPddSections(VM0007_TEXT));
     expect(parsed.headingIndex).toEqual(buildPddHeadingIndex(VM0007_TEXT));
-    expect(parsed.diagnostics).toEqual(debugSectionExtraction(VM0007_TEXT));
+    expect(parsed.diagnostics).toEqual({
+      metadata: debugSectionExtraction(VM0007_TEXT),
+    });
   });
 
   it("avoids noisy diagnostics for blank input while keeping a stable empty shape", () => {
     const parsed = parseDocumentText({ rawText: "   " });
 
+    expect(parsed.normalizedText).toBe("   ");
+    expect(parsed.pages).toEqual([
+      {
+        pageNumber: 1,
+        rawText: "   ",
+        normalizedText: "   ",
+      },
+    ]);
+    expect(parsed.blocks).toEqual([]);
+    expect(parsed.headings).toEqual([]);
     expect(parsed.sectionsByNumber).toEqual({});
     expect(parsed.headingIndex).toEqual([]);
     expect(parsed.diagnostics).toBeUndefined();

--- a/tests/lib/documentParsing.test.ts
+++ b/tests/lib/documentParsing.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  buildPddHeadingIndex,
+  debugSectionExtraction,
+  extractPddSections,
+} from "@/lib/chat/quickCheckSectionExtractor";
+import {
+  DEFAULT_DOCUMENT_PARSER_ADAPTER_ID,
+  getDocumentParserAdapter,
+  parseDocumentText,
+} from "@/lib/documentParsing";
+
+const VM0007_TEXT = [
+  "1.9  Project Boundary",
+  "The project area is defined in this section.",
+  "",
+  "2.4  Baseline Scenario",
+  "The baseline scenario is the most likely land-use scenario without the project.",
+  "",
+  "4.3  Monitoring Plan",
+  "The monitoring plan defines the monitoring frequency and responsibilities.",
+].join("\n");
+
+describe("documentParsing current extractor adapter", () => {
+  it("exposes the current extractor as the default parser adapter", () => {
+    expect(getDocumentParserAdapter().id).toBe(DEFAULT_DOCUMENT_PARSER_ADAPTER_ID);
+  });
+
+  it("returns the same section and heading extraction as the legacy quick check helpers", () => {
+    const parsed = parseDocumentText({ rawText: VM0007_TEXT });
+
+    expect(parsed.adapterId).toBe("current-extractor");
+    expect(parsed.rawText).toBe(VM0007_TEXT);
+    expect(parsed.sectionsByNumber).toEqual(extractPddSections(VM0007_TEXT));
+    expect(parsed.headingIndex).toEqual(buildPddHeadingIndex(VM0007_TEXT));
+    expect(parsed.diagnostics).toEqual(debugSectionExtraction(VM0007_TEXT));
+  });
+
+  it("avoids noisy diagnostics for blank input while keeping a stable empty shape", () => {
+    const parsed = parseDocumentText({ rawText: "   " });
+
+    expect(parsed.sectionsByNumber).toEqual({});
+    expect(parsed.headingIndex).toEqual([]);
+    expect(parsed.diagnostics).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed

- added a new `src/lib/documentParsing/` boundary with adapter types, a small registry, and the current Quick Check extractor as the first adapter
- routed review-question parsing reads through the new adapter boundary without changing retrieval or evidence-evaluation behavior
- added `tests/lib/documentParsing.test.ts` to lock adapter parity with the legacy extractor helpers
- added the Quick Check document pipeline roadmap and phase-status SSOT, then regenerated `docs/roadmaps/SUMMARY.md`

## Why

PR #665 was the last tactical Quick Check stabilization PR. The next step needs to be structural: a parser adapter boundary first, then the canonical document model, retrieval/evaluation split, declarative policy, eval harness, and only later a second parser adapter.

This PR stays intentionally narrow. It does not start LiteParse, does not refactor retrieval/evaluation, and does not add new Quick Check alias or edge-case patches.

## Impact

- Quick Check now has an explicit parser-adapter seam under `src/lib/documentParsing/`
- current review-question behavior stays intact while future parser work gains a stable landing zone
- the roadmap/phase-status files make the implementation order and out-of-scope guardrails explicit

## Validation

- `npx jest tests/lib/documentParsing.test.ts tests/lib/quickCheckReviewQuestion.test.ts --runInBand`
- `npm run typecheck`
- `npm run check:docs-layout`
- `npm run roadmap:gen`