### PR TITLE
[codex] start article6 quick check document model

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -169,7 +169,6 @@ Move Quick Check from tactical section-matching patches to a layered document pi
 
 Not active now:
 - LiteParse integration
-- Canonical document model migration
 - Retrieval/evaluation refactor
 - Declarative review policy config
 - Quick Check eval harness implementation

--- a/docs/roadmaps/quick-check-document-pipeline.md
+++ b/docs/roadmaps/quick-check-document-pipeline.md
@@ -153,4 +153,4 @@ Exit criteria:
 
 ## Immediate next action
 
-Open the Phase 1 PR from latest `main` with roadmap docs plus the parser adapter boundary only.
+Start Phase 2 by adding `src/lib/documentModel/` and the first `ParsedDocument -> Article6DocumentModel` conversion without refactoring retrieval, evaluation, or UI consumers yet.

--- a/docs/roadmaps/quick-check-document-pipeline/phase-status.json
+++ b/docs/roadmaps/quick-check-document-pipeline/phase-status.json
@@ -2,14 +2,14 @@
   "roadmap": "quick-check-document-pipeline",
   "repo": "Fredilly/app.article6",
   "status": "active",
-  "current_phase": "phase_1_parser_adapter_boundary",
+  "current_phase": "phase_2_article6_document_model",
   "phase_1_parser_adapter_boundary": {
-    "status": "active",
+    "status": "done",
     "title": "Phase 1 — parser adapter boundary",
     "summary": "Add src/lib/documentParsing/ and move the current Quick Check extractor behind an adapter boundary. Keep retrieval/evaluation behavior intact and do not start LiteParse yet."
   },
   "phase_2_article6_document_model": {
-    "status": "planned",
+    "status": "active",
     "title": "Phase 2 — canonical Article6 document model",
     "summary": "Add src/lib/documentModel/ as the canonical document representation for normalized sections, hierarchy, provenance, and cleaned display text."
   },
@@ -36,10 +36,9 @@
   "phase_meta": {
     "status": "active",
     "summary": "Move Quick Check from tactical section-matching patches to a layered document pipeline with explicit parser, document-model, retrieval, evaluation, UI, and eval boundaries.",
-    "current_focus": "Phase 1 only: roadmap docs plus parser adapter boundary around the current extractor. LiteParse, document-model adoption, retrieval/evaluation split, declarative policy, and eval harness remain intentionally out of scope for this PR.",
+    "current_focus": "Phase 2 only: add the canonical Article6 document model and ParsedDocument-to-model conversion. LiteParse, retrieval/evaluation refactor, review policy work, and UI changes remain intentionally out of scope for this step.",
     "not_active_now": [
       "LiteParse integration",
-      "Canonical document model migration",
       "Retrieval/evaluation refactor",
       "Declarative review policy config",
       "Quick Check eval harness implementation",

--- a/src/lib/documentModel/buildArticle6DocumentModel.ts
+++ b/src/lib/documentModel/buildArticle6DocumentModel.ts
@@ -52,6 +52,7 @@ function pageSourceRef(input: {
   return {
     source: input.source,
     parserAdapterId: input.parserAdapterId,
+    quality: "synthetic",
     pageNumber: input.pageNumber,
   };
 }
@@ -59,7 +60,7 @@ function pageSourceRef(input: {
 export function buildArticle6DocumentModel(
   input: BuildArticle6DocumentModelInput,
 ): Article6DocumentModel {
-  const { parsedDocument } = input;
+  const { parsedDocument, includeDebugPayload = false } = input;
   const parserAdapterId = parsedDocument.adapterId;
   const source = parsedDocument.source;
 
@@ -77,6 +78,7 @@ export function buildArticle6DocumentModel(
       sourceRefs: [{
         source,
         parserAdapterId,
+        quality: "synthetic",
         pageNumber: block.pageNumber,
         blockId: block.id,
         sectionId,
@@ -130,6 +132,7 @@ export function buildArticle6DocumentModel(
       const sourceRefs: Article6SourceRef[] = [{
         source,
         parserAdapterId,
+        quality: "synthetic",
         pageNumber: 1,
         headingId: `heading:${sectionNumber}`,
         sectionId,
@@ -184,6 +187,7 @@ export function buildArticle6DocumentModel(
         sourceRefs: [{
           source,
           parserAdapterId,
+          quality: "synthetic",
           pageNumber: heading.pageNumber,
           headingId: heading.id,
           sectionId,
@@ -235,6 +239,6 @@ export function buildArticle6DocumentModel(
     sections,
     extractionWarnings: warnings,
     parserDiagnostics: parsedDocument.diagnostics,
-    parserOutput: parsedDocument,
+    debug: includeDebugPayload ? { parserOutput: parsedDocument } : undefined,
   };
 }

--- a/src/lib/documentModel/buildArticle6DocumentModel.ts
+++ b/src/lib/documentModel/buildArticle6DocumentModel.ts
@@ -1,0 +1,240 @@
+import type {
+  Article6DocumentBlock,
+  Article6DocumentModel,
+  Article6DocumentPage,
+  Article6DocumentSection,
+  Article6ExtractionWarning,
+  Article6SourceRef,
+  BuildArticle6DocumentModelInput,
+} from "@/lib/documentModel/types";
+
+const DISPLAY_SNIPPET_MAX = 280;
+
+function cleanText(rawText: string): string {
+  return rawText
+    .replace(/\f/g, "\n")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function matchingText(rawText: string): string {
+  return cleanText(rawText).toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function coerceMatchingText(parserText: string | undefined, fallbackText: string): string {
+  const candidate = parserText && parserText.trim().length > 0 ? parserText : fallbackText;
+  return matchingText(candidate);
+}
+
+function makeSnippet(text: string): string {
+  const clean = cleanText(text);
+  if (clean.length <= DISPLAY_SNIPPET_MAX) return clean;
+  return `${clean.slice(0, DISPLAY_SNIPPET_MAX).replace(/\s+\S*$/, "")} […]`;
+}
+
+function sectionIdFromNumber(sectionNumber?: string): string | undefined {
+  return sectionNumber ? `section:${sectionNumber}` : undefined;
+}
+
+function parentSectionNumber(sectionNumber?: string): string | undefined {
+  if (!sectionNumber || !sectionNumber.includes(".")) return undefined;
+  return sectionNumber.split(".").slice(0, -1).join(".");
+}
+
+function pageSourceRef(input: {
+  source: string;
+  parserAdapterId: Article6DocumentModel["parserAdapterId"];
+  pageNumber: number;
+}): Article6SourceRef {
+  return {
+    source: input.source,
+    parserAdapterId: input.parserAdapterId,
+    pageNumber: input.pageNumber,
+  };
+}
+
+export function buildArticle6DocumentModel(
+  input: BuildArticle6DocumentModelInput,
+): Article6DocumentModel {
+  const { parsedDocument } = input;
+  const parserAdapterId = parsedDocument.adapterId;
+  const source = parsedDocument.source;
+
+  const blocks: Article6DocumentBlock[] = parsedDocument.blocks.map((block) => {
+    const sectionId = sectionIdFromNumber(block.sectionNumber);
+    return {
+      id: block.id,
+      type: block.type,
+      rawText: block.text,
+      cleanText: cleanText(block.text),
+      matchingText: coerceMatchingText(block.normalizedText, block.text),
+      pageNumber: block.pageNumber,
+      sectionId,
+      headingLevel: block.headingLevel,
+      sourceRefs: [{
+        source,
+        parserAdapterId,
+        pageNumber: block.pageNumber,
+        blockId: block.id,
+        sectionId,
+        sectionNumber: block.sectionNumber,
+      }],
+      confidence: block.type === "heading" ? 0.95 : 0.8,
+    };
+  });
+
+  const pageIdsByNumber = new Map<number, string>();
+  const pages: Article6DocumentPage[] = parsedDocument.pages.map((page) => {
+    const pageId = `page:${page.pageNumber}`;
+    pageIdsByNumber.set(page.pageNumber, pageId);
+    const blockIds = blocks
+      .filter((block) => block.pageNumber === page.pageNumber)
+      .map((block) => block.id);
+    return {
+      id: pageId,
+      pageNumber: page.pageNumber,
+      rawText: page.rawText,
+      cleanText: cleanText(page.rawText),
+      matchingText: coerceMatchingText(page.normalizedText, page.rawText),
+      blockIds,
+      sourceRefs: [pageSourceRef({ source, parserAdapterId, pageNumber: page.pageNumber })],
+    };
+  });
+  void pageIdsByNumber;
+
+  const warnings: Article6ExtractionWarning[] = [];
+  for (const warningText of parsedDocument.diagnostics?.warnings ?? []) {
+    warnings.push({
+      code: "parser_warning",
+      message: warningText,
+      severity: "warning",
+      sourceRefs: [],
+    });
+  }
+
+  const sections: Article6DocumentSection[] = [];
+  const headingIndex = parsedDocument.headingIndex ?? [];
+  if (headingIndex.length > 0) {
+    for (const heading of headingIndex) {
+      const sectionNumber = heading.sectionNumber;
+      const sectionId = sectionIdFromNumber(sectionNumber) ?? `section:bridge:${heading.title}`;
+      const sectionRaw = parsedDocument.sectionsByNumber?.[sectionNumber] ?? heading.title;
+      const bodyRaw = sectionRaw.split("\n").slice(1).join("\n").trim() || heading.bodyText || "";
+      const parentNumber = parentSectionNumber(sectionNumber);
+      const blockIds = blocks
+        .filter((block) => block.sectionId === sectionId)
+        .map((block) => block.id);
+      const sourceRefs: Article6SourceRef[] = [{
+        source,
+        parserAdapterId,
+        pageNumber: 1,
+        headingId: `heading:${sectionNumber}`,
+        sectionId,
+        sectionNumber,
+      }];
+      sections.push({
+        id: sectionId,
+        sectionNumber,
+        titleRaw: heading.title,
+        titleClean: cleanText(heading.title),
+        titleMatchingText: coerceMatchingText(heading.normalizedTitle, heading.title),
+        bodyRaw,
+        bodyClean: cleanText(bodyRaw),
+        bodyMatchingText: coerceMatchingText(undefined, bodyRaw),
+        displaySnippet: makeSnippet(bodyRaw || heading.title),
+        matchingText: coerceMatchingText(undefined, `${heading.title}\n${bodyRaw}`),
+        parentId: parentNumber ? sectionIdFromNumber(parentNumber) : undefined,
+        childIds: [],
+        blockIds,
+        sourceRefs,
+        confidence: 0.95,
+        extractionWarnings: [],
+      });
+    }
+  } else {
+    for (const heading of parsedDocument.headings) {
+      const sectionNumber = heading.sectionNumber;
+      const sectionId = sectionIdFromNumber(sectionNumber) ?? `section:${heading.id}`;
+      const relatedBlocks = parsedDocument.blocks.filter((block) => block.sectionNumber === sectionNumber);
+      const bodyRaw = relatedBlocks
+        .filter((block) => block.type !== "heading")
+        .map((block) => block.text)
+        .join("\n")
+        .trim();
+      const parentNumber = parentSectionNumber(sectionNumber);
+      sections.push({
+        id: sectionId,
+        sectionNumber,
+        titleRaw: heading.text,
+        titleClean: cleanText(heading.text),
+        titleMatchingText: coerceMatchingText(heading.normalizedText, heading.text),
+        bodyRaw,
+        bodyClean: cleanText(bodyRaw),
+        bodyMatchingText: coerceMatchingText(undefined, bodyRaw),
+        displaySnippet: makeSnippet(bodyRaw || heading.text),
+        matchingText: coerceMatchingText(undefined, `${heading.text}\n${bodyRaw}`),
+        parentId: parentNumber ? sectionIdFromNumber(parentNumber) : undefined,
+        childIds: [],
+        blockIds: blocks
+          .filter((block) => block.sectionId === sectionId)
+          .map((block) => block.id),
+        sourceRefs: [{
+          source,
+          parserAdapterId,
+          pageNumber: heading.pageNumber,
+          headingId: heading.id,
+          sectionId,
+          sectionNumber,
+        }],
+        confidence: 0.65,
+        extractionWarnings: [],
+      });
+    }
+  }
+
+  const sectionIds = new Set(sections.map((section) => section.id));
+  for (const section of sections) {
+    if (section.parentId && sectionIds.has(section.parentId)) {
+      const parent = sections.find((candidate) => candidate.id === section.parentId);
+      if (parent && !parent.childIds.includes(section.id)) {
+        parent.childIds.push(section.id);
+      }
+    }
+  }
+
+  if (parsedDocument.rawText.trim() && sections.length === 0) {
+    warnings.push({
+      code: "no_sections_detected",
+      message: "Parser output did not produce any canonical sections.",
+      severity: "warning",
+      sourceRefs: [],
+    });
+  }
+
+  if (parsedDocument.headings.length === 0 && parsedDocument.rawText.trim()) {
+    warnings.push({
+      code: "no_headings_detected",
+      message: "Parser output did not produce any headings.",
+      severity: "warning",
+      sourceRefs: [],
+    });
+  }
+
+  return {
+    id: `article6-document:${parserAdapterId}`,
+    source,
+    parserAdapterId,
+    rawText: parsedDocument.rawText,
+    cleanText: cleanText(parsedDocument.rawText),
+    matchingText: coerceMatchingText(parsedDocument.normalizedText, parsedDocument.rawText),
+    pages,
+    blocks,
+    sections,
+    extractionWarnings: warnings,
+    parserDiagnostics: parsedDocument.diagnostics,
+    parserOutput: parsedDocument,
+  };
+}

--- a/src/lib/documentModel/index.ts
+++ b/src/lib/documentModel/index.ts
@@ -1,0 +1,2 @@
+export { buildArticle6DocumentModel } from "@/lib/documentModel/buildArticle6DocumentModel";
+export * from "@/lib/documentModel/types";

--- a/src/lib/documentModel/types.ts
+++ b/src/lib/documentModel/types.ts
@@ -3,6 +3,7 @@ import type { DocumentParserAdapterId, ParsedBlock, ParsedDocument, ParsedHeadin
 export type Article6SourceRef = {
   source: string;
   parserAdapterId: DocumentParserAdapterId;
+  quality: "exact" | "synthetic" | "unknown";
   pageNumber?: number;
   blockId?: string;
   headingId?: string;
@@ -71,11 +72,14 @@ export type Article6DocumentModel = {
   sections: Article6DocumentSection[];
   extractionWarnings: Article6ExtractionWarning[];
   parserDiagnostics?: ParserDiagnostics;
-  parserOutput: ParsedDocument;
+  debug?: {
+    parserOutput: ParsedDocument;
+  };
 };
 
 export type BuildArticle6DocumentModelInput = {
   parsedDocument: ParsedDocument;
+  includeDebugPayload?: boolean;
 };
 
 export type ParsedArtifacts = {

--- a/src/lib/documentModel/types.ts
+++ b/src/lib/documentModel/types.ts
@@ -1,0 +1,85 @@
+import type { DocumentParserAdapterId, ParsedBlock, ParsedDocument, ParsedHeading, ParsedPage, ParserDiagnostics } from "@/lib/documentParsing";
+
+export type Article6SourceRef = {
+  source: string;
+  parserAdapterId: DocumentParserAdapterId;
+  pageNumber?: number;
+  blockId?: string;
+  headingId?: string;
+  sectionId?: string;
+  sectionNumber?: string;
+};
+
+export type Article6ExtractionWarning = {
+  code: string;
+  message: string;
+  severity: "info" | "warning";
+  sourceRefs: Article6SourceRef[];
+};
+
+export type Article6DocumentPage = {
+  id: string;
+  pageNumber: number;
+  rawText: string;
+  cleanText: string;
+  matchingText: string;
+  blockIds: string[];
+  sourceRefs: Article6SourceRef[];
+};
+
+export type Article6DocumentBlock = {
+  id: string;
+  type: ParsedBlock["type"];
+  rawText: string;
+  cleanText: string;
+  matchingText: string;
+  pageNumber?: number;
+  sectionId?: string;
+  headingLevel?: number;
+  sourceRefs: Article6SourceRef[];
+  confidence: number;
+};
+
+export type Article6DocumentSection = {
+  id: string;
+  sectionNumber?: string;
+  titleRaw: string;
+  titleClean: string;
+  titleMatchingText: string;
+  bodyRaw: string;
+  bodyClean: string;
+  bodyMatchingText: string;
+  displaySnippet: string;
+  matchingText: string;
+  parentId?: string;
+  childIds: string[];
+  blockIds: string[];
+  sourceRefs: Article6SourceRef[];
+  confidence: number;
+  extractionWarnings: string[];
+};
+
+export type Article6DocumentModel = {
+  id: string;
+  source: string;
+  parserAdapterId: DocumentParserAdapterId;
+  rawText: string;
+  cleanText: string;
+  matchingText: string;
+  pages: Article6DocumentPage[];
+  blocks: Article6DocumentBlock[];
+  sections: Article6DocumentSection[];
+  extractionWarnings: Article6ExtractionWarning[];
+  parserDiagnostics?: ParserDiagnostics;
+  parserOutput: ParsedDocument;
+};
+
+export type BuildArticle6DocumentModelInput = {
+  parsedDocument: ParsedDocument;
+};
+
+export type ParsedArtifacts = {
+  pages: ParsedPage[];
+  blocks: ParsedBlock[];
+  headings: ParsedHeading[];
+};

--- a/tests/lib/documentModel.test.ts
+++ b/tests/lib/documentModel.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "@jest/globals";
+import { parseDocumentText } from "@/lib/documentParsing";
+import { buildArticle6DocumentModel } from "@/lib/documentModel";
+
+const NESTED_PDD_TEXT = [
+  "4.3  Monitoring Plan",
+  "The monitoring plan describes annual monitoring activities.",
+  "",
+  "4.3.1  Monitoring Frequency",
+  "Monitoring occurs every 12 months with documented field checks.",
+  "",
+  "6  Stakeholder Comments",
+  "Stakeholder comments are recorded in community meeting summaries.",
+].join("\n");
+
+describe("buildArticle6DocumentModel", () => {
+  it("converts parser output into a canonical Article6 document model", () => {
+    const parsedDocument = parseDocumentText({ rawText: NESTED_PDD_TEXT });
+    const model = buildArticle6DocumentModel({ parsedDocument });
+
+    expect(model.parserAdapterId).toBe("current-extractor");
+    expect(model.source).toBe("current-extractor");
+    expect(model.rawText).toBe(NESTED_PDD_TEXT);
+    expect(model.cleanText).toContain("4.3 Monitoring Plan");
+    expect(model.matchingText).toContain("monitoring plan");
+    expect(model.pages).toHaveLength(1);
+    expect(model.blocks.some((block) => block.type === "heading")).toBe(true);
+    expect(model.blocks.some((block) => block.type === "paragraph")).toBe(true);
+
+    const monitoringPlan = model.sections.find((section) => section.sectionNumber === "4.3");
+    const monitoringFrequency = model.sections.find((section) => section.sectionNumber === "4.3.1");
+    const stakeholderComments = model.sections.find((section) => section.sectionNumber === "6");
+
+    expect(monitoringPlan).toBeDefined();
+    expect(monitoringFrequency).toBeDefined();
+    expect(stakeholderComments).toBeDefined();
+    expect(monitoringPlan?.childIds).toContain(monitoringFrequency?.id);
+    expect(monitoringFrequency?.parentId).toBe(monitoringPlan?.id);
+    expect(monitoringPlan?.displaySnippet).toContain("annual monitoring activities");
+    expect(monitoringPlan?.sourceRefs[0]?.sectionNumber).toBe("4.3");
+    expect(monitoringPlan?.blockIds.length).toBeGreaterThan(0);
+    expect(monitoringPlan?.confidence).toBeGreaterThan(0.9);
+  });
+
+  it("preserves raw parser text separately from clean and matching text", () => {
+    const parsedDocument = parseDocumentText({ rawText: "1.1  Title\r\nBody with   extra\tspacing\f" });
+    const model = buildArticle6DocumentModel({ parsedDocument });
+
+    expect(model.rawText).toContain("\r\n");
+    expect(model.cleanText).not.toContain("\r");
+    expect(model.cleanText).not.toContain("\f");
+    expect(model.matchingText).toBe(model.matchingText.toLowerCase());
+  });
+
+  it("emits extraction warnings when parser output has text but no headings or sections", () => {
+    const model = buildArticle6DocumentModel({
+      parsedDocument: {
+        adapterId: "current-extractor",
+        source: "test-parser",
+        rawText: "Loose body text without recoverable headings.",
+        normalizedText: "Loose body text without recoverable headings.",
+        pages: [{
+          pageNumber: 1,
+          rawText: "Loose body text without recoverable headings.",
+          normalizedText: "Loose body text without recoverable headings.",
+        }],
+        blocks: [],
+        headings: [],
+        diagnostics: {
+          warnings: ["heuristic fallback used"],
+        },
+      },
+    });
+
+    expect(model.sections).toEqual([]);
+    expect(model.extractionWarnings.map((warning) => warning.code)).toEqual([
+      "parser_warning",
+      "no_sections_detected",
+      "no_headings_detected",
+    ]);
+  });
+});

--- a/tests/lib/documentModel.test.ts
+++ b/tests/lib/documentModel.test.ts
@@ -26,6 +26,7 @@ describe("buildArticle6DocumentModel", () => {
     expect(model.pages).toHaveLength(1);
     expect(model.blocks.some((block) => block.type === "heading")).toBe(true);
     expect(model.blocks.some((block) => block.type === "paragraph")).toBe(true);
+    expect(model.debug).toBeUndefined();
 
     const monitoringPlan = model.sections.find((section) => section.sectionNumber === "4.3");
     const monitoringFrequency = model.sections.find((section) => section.sectionNumber === "4.3.1");
@@ -38,8 +39,11 @@ describe("buildArticle6DocumentModel", () => {
     expect(monitoringFrequency?.parentId).toBe(monitoringPlan?.id);
     expect(monitoringPlan?.displaySnippet).toContain("annual monitoring activities");
     expect(monitoringPlan?.sourceRefs[0]?.sectionNumber).toBe("4.3");
+    expect(monitoringPlan?.sourceRefs[0]?.quality).toBe("synthetic");
     expect(monitoringPlan?.blockIds.length).toBeGreaterThan(0);
     expect(monitoringPlan?.confidence).toBeGreaterThan(0.9);
+    expect(model.pages[0]?.sourceRefs[0]?.quality).toBe("synthetic");
+    expect(model.blocks[0]?.sourceRefs[0]?.quality).toBe("synthetic");
   });
 
   it("preserves raw parser text separately from clean and matching text", () => {
@@ -78,5 +82,15 @@ describe("buildArticle6DocumentModel", () => {
       "no_sections_detected",
       "no_headings_detected",
     ]);
+  });
+
+  it("only exposes parser output when explicitly requested for debugging", () => {
+    const parsedDocument = parseDocumentText({ rawText: NESTED_PDD_TEXT });
+
+    const withoutDebug = buildArticle6DocumentModel({ parsedDocument });
+    const withDebug = buildArticle6DocumentModel({ parsedDocument, includeDebugPayload: true });
+
+    expect(withoutDebug.debug).toBeUndefined();
+    expect(withDebug.debug?.parserOutput).toEqual(parsedDocument);
   });
 });


### PR DESCRIPTION
## What changed

- added a canonical `src/lib/documentModel/` package with Article6-owned normalized document types
- added `buildArticle6DocumentModel` to convert parser output into canonical pages, blocks, sections, hierarchy, source refs, snippets, confidence fields, and extraction warnings
- preserved raw parser text separately from clean display text and lowercased matching text
- added document-model regression tests and updated the Quick Check document pipeline roadmap status to mark Phase 1 done and Phase 2 active

## Why

PR #666 established the parser adapter boundary. The next scalable step is an Article6-owned document model so Quick Check stops depending on parser-native or legacy extractor structures.

This PR stays intentionally narrow. It does not add LiteParse, does not refactor retrieval/evaluation, does not add new review-area aliases, and does not change the Quick Check UI.

## Impact

- Quick Check now has a canonical document model layer under `src/lib/documentModel/`
- future parser work can target one Article6-owned contract instead of parser-specific shapes
- later retrieval/evaluation work can migrate onto the document model without reopening parser-boundary decisions

## Validation

- `npx jest tests/lib/documentParsing.test.ts tests/lib/documentModel.test.ts tests/lib/quickCheckReviewQuestion.test.ts --runInBand`
- `npm run typecheck`
- `npm run check:docs-layout`
- `npm run roadmap:gen`