### PR TITLE
[codex] Extract Quick Check evaluation module

### DIFF
--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,27 +1,25 @@
-import { evaluateBaselineReview } from "@/lib/chat/quickCheckBaselineRubric";
-import { evaluateReviewRubric } from "@/lib/chat/quickCheckReviewRubric";
 import {
   buildReviewQuestionSectionRetrieval,
-  deriveReviewQuestionStatus,
 } from "@/lib/quickCheck/retrieval/retrieveSections";
 import type {
-  ReviewQuestionEvaluationResult,
   ReviewQuestionResult,
-  ReviewQuestionRetrievalResult,
 } from "@/lib/quickCheck/retrieval/types";
+import {
+  evaluateRetrievedReviewQuestion,
+} from "@/lib/quickCheck/evaluation/evaluateEvidence";
 
 export type {
   BuildReviewQuestionSectionRetrievalInput,
   QuickCheckPath,
   ReviewArea,
   ReviewQuestionDiagnostic,
-  ReviewQuestionEvaluationResult,
   ReviewQuestionMatchStage,
   ReviewQuestionResult,
   ReviewQuestionRetrievalResult,
   ReviewQuestionStatus,
   SectionMatchResult,
 } from "@/lib/quickCheck/retrieval/types";
+export type { ReviewQuestionEvaluationResult } from "@/lib/quickCheck/evaluation/types";
 
 export {
   buildReviewQuestionSectionRetrieval,
@@ -33,6 +31,7 @@ export {
   resolveReviewSections,
   reviewAreaLabel,
 } from "@/lib/quickCheck/retrieval/retrieveSections";
+export { evaluateRetrievedReviewQuestion } from "@/lib/quickCheck/evaluation/evaluateEvidence";
 
 export function buildReviewQuestionResult(input: {
   claimText: string;
@@ -48,30 +47,5 @@ export function buildReviewQuestionResult(input: {
   return {
     ...retrieval,
     ...evaluation,
-  };
-}
-
-export function evaluateRetrievedReviewQuestion(
-  retrieval: Pick<ReviewQuestionRetrievalResult, "reviewArea" | "matchedHeadings" | "headingIndex" | "rejectedMatches" | "matchStage">,
-): ReviewQuestionEvaluationResult {
-  const baselineReview = retrieval.reviewArea === "baseline"
-    ? evaluateBaselineReview({ matchedHeadings: retrieval.matchedHeadings })
-    : undefined;
-  const reviewAreaReview =
-    retrieval.reviewArea === "baseline" || retrieval.reviewArea === "right_of_use" || retrieval.reviewArea === "stakeholder"
-      ? evaluateReviewRubric({ reviewArea: retrieval.reviewArea, matchedHeadings: retrieval.matchedHeadings })
-      : undefined;
-  const status = deriveReviewQuestionStatus({
-    matchedHeadings: retrieval.matchedHeadings,
-    headingIndex: retrieval.headingIndex,
-    rejectedMatches: retrieval.rejectedMatches,
-    matchStage: retrieval.matchStage,
-    reviewAreaReview,
-  });
-
-  return {
-    baselineReview,
-    reviewAreaReview,
-    status,
   };
 }

--- a/src/lib/quickCheck/evaluation/evaluateEvidence.ts
+++ b/src/lib/quickCheck/evaluation/evaluateEvidence.ts
@@ -1,0 +1,32 @@
+import { evaluateBaselineReview } from "@/lib/chat/quickCheckBaselineRubric";
+import { evaluateReviewRubric } from "@/lib/chat/quickCheckReviewRubric";
+import { deriveReviewQuestionStatus } from "@/lib/quickCheck/retrieval/retrieveSections";
+import type {
+  EvaluateRetrievedReviewQuestionInput,
+  ReviewQuestionEvaluationResult,
+} from "@/lib/quickCheck/evaluation/types";
+
+export function evaluateRetrievedReviewQuestion(
+  retrieval: EvaluateRetrievedReviewQuestionInput,
+): ReviewQuestionEvaluationResult {
+  const baselineReview = retrieval.reviewArea === "baseline"
+    ? evaluateBaselineReview({ matchedHeadings: retrieval.matchedHeadings })
+    : undefined;
+  const reviewAreaReview =
+    retrieval.reviewArea === "baseline" || retrieval.reviewArea === "right_of_use" || retrieval.reviewArea === "stakeholder"
+      ? evaluateReviewRubric({ reviewArea: retrieval.reviewArea, matchedHeadings: retrieval.matchedHeadings })
+      : undefined;
+  const status = deriveReviewQuestionStatus({
+    matchedHeadings: retrieval.matchedHeadings,
+    headingIndex: retrieval.headingIndex,
+    rejectedMatches: retrieval.rejectedMatches,
+    matchStage: retrieval.matchStage,
+    reviewAreaReview,
+  });
+
+  return {
+    baselineReview,
+    reviewAreaReview,
+    status,
+  };
+}

--- a/src/lib/quickCheck/evaluation/evaluateEvidence.ts
+++ b/src/lib/quickCheck/evaluation/evaluateEvidence.ts
@@ -1,6 +1,6 @@
 import { evaluateBaselineReview } from "@/lib/chat/quickCheckBaselineRubric";
 import { evaluateReviewRubric } from "@/lib/chat/quickCheckReviewRubric";
-import { deriveReviewQuestionStatus } from "@/lib/quickCheck/retrieval/retrieveSections";
+import { deriveReviewQuestionStatus } from "@/lib/quickCheck/evaluation/status";
 import type {
   EvaluateRetrievedReviewQuestionInput,
   ReviewQuestionEvaluationResult,

--- a/src/lib/quickCheck/evaluation/status.ts
+++ b/src/lib/quickCheck/evaluation/status.ts
@@ -1,0 +1,20 @@
+import type { DocumentHeading, RejectedHeadingQueryMatch } from "@/lib/chat/quickCheckSectionExtractor";
+import type { ReviewRubricResult } from "@/lib/chat/quickCheckReviewRubric";
+import type { ReviewQuestionMatchStage, ReviewQuestionStatus } from "@/lib/quickCheck/retrieval/types";
+
+export function deriveReviewQuestionStatus(input: {
+  matchedHeadings: DocumentHeading[];
+  headingIndex: DocumentHeading[];
+  rejectedMatches: RejectedHeadingQueryMatch[];
+  matchStage: ReviewQuestionMatchStage;
+  reviewAreaReview?: ReviewRubricResult;
+}): ReviewQuestionStatus {
+  if (input.reviewAreaReview?.verdict === "supported") return "strong_evidence_found";
+  if (input.reviewAreaReview?.verdict === "partial") return "partial_evidence_found";
+  if (input.reviewAreaReview?.verdict === "missing" && input.matchedHeadings.length > 0) return "section_found_evidence_weak";
+  if (input.matchedHeadings.length > 0) {
+    return input.matchStage === "semantic_fallback" ? "partial_evidence_found" : "section_found_evidence_weak";
+  }
+  if (input.rejectedMatches.length > 0 || input.headingIndex.length === 0) return "extractor_uncertain";
+  return "no_document_grounded_evidence";
+}

--- a/src/lib/quickCheck/evaluation/types.ts
+++ b/src/lib/quickCheck/evaluation/types.ts
@@ -1,0 +1,11 @@
+import type { ReviewQuestionRetrievalResult, ReviewQuestionResult } from "@/lib/quickCheck/retrieval/types";
+
+export type EvaluateRetrievedReviewQuestionInput = Pick<
+  ReviewQuestionRetrievalResult,
+  "reviewArea" | "matchedHeadings" | "headingIndex" | "rejectedMatches" | "matchStage"
+>;
+
+export type ReviewQuestionEvaluationResult = Pick<
+  ReviewQuestionResult,
+  "baselineReview" | "reviewAreaReview" | "status"
+>;

--- a/src/lib/quickCheck/retrieval/retrieveSections.ts
+++ b/src/lib/quickCheck/retrieval/retrieveSections.ts
@@ -8,8 +8,8 @@ import {
   type RejectedHeadingQueryMatch,
   type DocumentHeading,
 } from "@/lib/chat/quickCheckSectionExtractor";
-import type { ReviewRubricResult } from "@/lib/chat/quickCheckReviewRubric";
 import { parseDocumentText } from "@/lib/documentParsing";
+import { deriveReviewQuestionStatus } from "@/lib/quickCheck/evaluation/status";
 import type {
   BuildReviewQuestionSectionRetrievalInput,
   QuickCheckPath,
@@ -17,7 +17,6 @@ import type {
   ReviewQuestionDiagnostic,
   ReviewQuestionMatchStage,
   ReviewQuestionRetrievalResult,
-  ReviewQuestionStatus,
   SectionMatchResult,
 } from "@/lib/quickCheck/retrieval/types";
 
@@ -392,23 +391,6 @@ function resolveReviewQuestionSections(input: {
     ? findRejectedHeadingMatches(input.rawPddText, input.claimText || "", [...reviewAreaKeywords, ...aliases])
     : [];
   return { matchedHeadings: [], rejectedMatches, matchStage: "none" };
-}
-
-export function deriveReviewQuestionStatus(input: {
-  matchedHeadings: DocumentHeading[];
-  headingIndex: DocumentHeading[];
-  rejectedMatches: RejectedHeadingQueryMatch[];
-  matchStage: ReviewQuestionMatchStage;
-  reviewAreaReview?: ReviewRubricResult;
-}): ReviewQuestionStatus {
-  if (input.reviewAreaReview?.verdict === "supported") return "strong_evidence_found";
-  if (input.reviewAreaReview?.verdict === "partial") return "partial_evidence_found";
-  if (input.reviewAreaReview?.verdict === "missing" && input.matchedHeadings.length > 0) return "section_found_evidence_weak";
-  if (input.matchedHeadings.length > 0) {
-    return input.matchStage === "semantic_fallback" ? "partial_evidence_found" : "section_found_evidence_weak";
-  }
-  if (input.rejectedMatches.length > 0 || input.headingIndex.length === 0) return "extractor_uncertain";
-  return "no_document_grounded_evidence";
 }
 
 export function findMatchedSectionNumbers(

--- a/src/lib/quickCheck/retrieval/types.ts
+++ b/src/lib/quickCheck/retrieval/types.ts
@@ -84,8 +84,6 @@ export type ReviewQuestionRetrievalResult = Omit<ReviewQuestionResult, "baseline
   rejectedMatches: RejectedHeadingQueryMatch[];
 };
 
-export type ReviewQuestionEvaluationResult = Pick<ReviewQuestionResult, "baselineReview" | "reviewAreaReview" | "status">;
-
 export type BuildReviewQuestionSectionRetrievalInput = {
   claimText: string;
   methodologyId: string;


### PR DESCRIPTION
## WHAT

- Complete Phase 3B of the Quick Check document pipeline.
- Move evidence evaluation out of the chat compatibility wrapper.
- Keep retrieval and evaluation as separate modules.
- Preserve existing Quick Check behavior.

## WHY

- PR #669 created the retrieval boundary.
- Evaluation still lives in the wrapper file.
- Finishing the module split prevents retrieval and evidence judgment from drifting back together.

## Validation

- `npm run typecheck`
- `npx jest tests/lib/quickCheckReviewQuestion.test.ts tests/lib/quickCheckBaselineRubric.test.ts tests/lib/quickCheckReviewRubric.test.ts --runInBand`
- `npm run check:docs-layout`

Signed-off-by: Fred Egbuedike <fredilly@article6.org>