### PR TITLE
[codex] Mark Quick Check boundary guards complete

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -213,10 +213,10 @@ Define and implement an app-side project export standard covering uploads, evide
 
 Current focus:
 - Maintain the export-conventions contract across new export surfaces
-- Cover Quick Check extraction edge case tests
 - Responsive UI QA for reconciliation and decision badges
 
 Not active now:
+- Quick Check extraction edge case tests (done)
 - Refactoring extraction or export code — documentation and planning only in RC0-RC1
 - Changes to canonical methodology metadata or pack encoding
 - Unbounded AI classification, auto-verification, or final evidence sufficiency decisions

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -13,10 +13,10 @@
     "summary": "Define and implement an app-side project export standard covering uploads, evidence inventory, fragments, extracted facts, candidate links, coverage matrix, reviewer decisions, provenance, and premium PDF/ZIP exports. The export must be beautiful enough to sell, structured enough to defend, and conservative enough to trust.",
     "current_focus": [
       "Maintain the export-conventions contract across new export surfaces",
-      "Cover Quick Check extraction edge case tests",
       "Responsive UI QA for reconciliation and decision badges"
     ],
     "not_active_now": [
+      "Quick Check extraction edge case tests (done)",
       "Refactoring extraction or export code — documentation and planning only in RC0-RC1",
       "Changes to canonical methodology metadata or pack encoding",
       "Unbounded AI classification, auto-verification, or final evidence sufficiency decisions"


### PR DESCRIPTION
## WHAT

- Update `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json` to remove Quick Check extraction edge-case tests from active focus.
- Regenerate `docs/roadmaps/SUMMARY.md` so the roadmap summary reflects that this Quick Check follow-up is done.
- Keep Quick Check runtime behavior unchanged.

## WHY

- PR #671 completed the Quick Check boundary guard and extraction edge-case test coverage.
- The roadmap still listed that follow-up as active work.
- This cleanup keeps roadmap state aligned with what has already shipped and avoids confusion before the next task.

## Validation

- `npm run typecheck`
- `npm run check:docs-layout`
- `npx jest tests/lib/quickCheckReviewQuestion.test.ts tests/lib/quickCheckBaselineRubric.test.ts tests/lib/quickCheckReviewRubric.test.ts --runInBand`
- `npm run roadmap:gen`

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>