### PR TITLE
[codex] Complete Quick Check Phase 3 on main

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -169,8 +169,6 @@ Move Quick Check from tactical section-matching patches to a layered document pi
 
 Not active now:
 - LiteParse integration
-- Retrieval/evaluation refactor
-- Declarative review policy config
 - Quick Check eval harness implementation
 - Additional Quick Check tactical alias patches
 

--- a/docs/roadmaps/quick-check-document-pipeline/phase-status.json
+++ b/docs/roadmaps/quick-check-document-pipeline/phase-status.json
@@ -2,19 +2,19 @@
   "roadmap": "quick-check-document-pipeline",
   "repo": "Fredilly/app.article6",
   "status": "active",
-  "current_phase": "phase_2_article6_document_model",
+  "current_phase": "phase_4_declarative_review_policy",
   "phase_1_parser_adapter_boundary": {
     "status": "done",
     "title": "Phase 1 — parser adapter boundary",
     "summary": "Add src/lib/documentParsing/ and move the current Quick Check extractor behind an adapter boundary. Keep retrieval/evaluation behavior intact and do not start LiteParse yet."
   },
   "phase_2_article6_document_model": {
-    "status": "active",
+    "status": "done",
     "title": "Phase 2 — canonical Article6 document model",
     "summary": "Add src/lib/documentModel/ as the canonical document representation for normalized sections, hierarchy, provenance, and cleaned display text."
   },
   "phase_3_retrieval_evaluation_split": {
-    "status": "planned",
+    "status": "done",
     "title": "Phase 3 — section retrieval and evidence evaluation split",
     "summary": "Separate candidate section retrieval from evidence sufficiency judgment so routing and verdict semantics can evolve independently."
   },
@@ -36,15 +36,16 @@
   "phase_meta": {
     "status": "active",
     "summary": "Move Quick Check from tactical section-matching patches to a layered document pipeline with explicit parser, document-model, retrieval, evaluation, UI, and eval boundaries.",
-    "current_focus": "Phase 2 only: add the canonical Article6 document model and ParsedDocument-to-model conversion. LiteParse, retrieval/evaluation refactor, review policy work, and UI changes remain intentionally out of scope for this step.",
+    "current_focus": "Phase 4 only: move Quick Check aliases, preferred sections, negative sections, fallback rules, boosts, penalties, and evidence signals into declarative typed policy config. Parser/document-model boundaries and retrieval/evaluation split are complete.",
     "not_active_now": [
       "LiteParse integration",
-      "Retrieval/evaluation refactor",
-      "Declarative review policy config",
       "Quick Check eval harness implementation",
       "Additional Quick Check tactical alias patches"
     ],
     "last_updated_at": "2026-06-01T00:00:00Z"
   },
-  "pr_evidence": {}
+  "pr_evidence": {
+    "phase_2_article6_document_model": [667],
+    "phase_3_retrieval_evaluation_split": [669, 670, 671]
+  }
 }

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,27 +1,25 @@
-import { evaluateBaselineReview } from "@/lib/chat/quickCheckBaselineRubric";
-import { evaluateReviewRubric } from "@/lib/chat/quickCheckReviewRubric";
 import {
   buildReviewQuestionSectionRetrieval,
-  deriveReviewQuestionStatus,
 } from "@/lib/quickCheck/retrieval/retrieveSections";
 import type {
-  ReviewQuestionEvaluationResult,
   ReviewQuestionResult,
-  ReviewQuestionRetrievalResult,
 } from "@/lib/quickCheck/retrieval/types";
+import {
+  evaluateRetrievedReviewQuestion,
+} from "@/lib/quickCheck/evaluation/evaluateEvidence";
 
 export type {
   BuildReviewQuestionSectionRetrievalInput,
   QuickCheckPath,
   ReviewArea,
   ReviewQuestionDiagnostic,
-  ReviewQuestionEvaluationResult,
   ReviewQuestionMatchStage,
   ReviewQuestionResult,
   ReviewQuestionRetrievalResult,
   ReviewQuestionStatus,
   SectionMatchResult,
 } from "@/lib/quickCheck/retrieval/types";
+export type { ReviewQuestionEvaluationResult } from "@/lib/quickCheck/evaluation/types";
 
 export {
   buildReviewQuestionSectionRetrieval,
@@ -33,6 +31,7 @@ export {
   resolveReviewSections,
   reviewAreaLabel,
 } from "@/lib/quickCheck/retrieval/retrieveSections";
+export { evaluateRetrievedReviewQuestion } from "@/lib/quickCheck/evaluation/evaluateEvidence";
 
 export function buildReviewQuestionResult(input: {
   claimText: string;
@@ -48,30 +47,5 @@ export function buildReviewQuestionResult(input: {
   return {
     ...retrieval,
     ...evaluation,
-  };
-}
-
-export function evaluateRetrievedReviewQuestion(
-  retrieval: Pick<ReviewQuestionRetrievalResult, "reviewArea" | "matchedHeadings" | "headingIndex" | "rejectedMatches" | "matchStage">,
-): ReviewQuestionEvaluationResult {
-  const baselineReview = retrieval.reviewArea === "baseline"
-    ? evaluateBaselineReview({ matchedHeadings: retrieval.matchedHeadings })
-    : undefined;
-  const reviewAreaReview =
-    retrieval.reviewArea === "baseline" || retrieval.reviewArea === "right_of_use" || retrieval.reviewArea === "stakeholder"
-      ? evaluateReviewRubric({ reviewArea: retrieval.reviewArea, matchedHeadings: retrieval.matchedHeadings })
-      : undefined;
-  const status = deriveReviewQuestionStatus({
-    matchedHeadings: retrieval.matchedHeadings,
-    headingIndex: retrieval.headingIndex,
-    rejectedMatches: retrieval.rejectedMatches,
-    matchStage: retrieval.matchStage,
-    reviewAreaReview,
-  });
-
-  return {
-    baselineReview,
-    reviewAreaReview,
-    status,
   };
 }

--- a/src/lib/quickCheck/evaluation/evaluateEvidence.ts
+++ b/src/lib/quickCheck/evaluation/evaluateEvidence.ts
@@ -1,0 +1,32 @@
+import { evaluateBaselineReview } from "@/lib/chat/quickCheckBaselineRubric";
+import { evaluateReviewRubric } from "@/lib/chat/quickCheckReviewRubric";
+import { deriveReviewQuestionStatus } from "@/lib/quickCheck/retrieval/retrieveSections";
+import type {
+  EvaluateRetrievedReviewQuestionInput,
+  ReviewQuestionEvaluationResult,
+} from "@/lib/quickCheck/evaluation/types";
+
+export function evaluateRetrievedReviewQuestion(
+  retrieval: EvaluateRetrievedReviewQuestionInput,
+): ReviewQuestionEvaluationResult {
+  const baselineReview = retrieval.reviewArea === "baseline"
+    ? evaluateBaselineReview({ matchedHeadings: retrieval.matchedHeadings })
+    : undefined;
+  const reviewAreaReview =
+    retrieval.reviewArea === "baseline" || retrieval.reviewArea === "right_of_use" || retrieval.reviewArea === "stakeholder"
+      ? evaluateReviewRubric({ reviewArea: retrieval.reviewArea, matchedHeadings: retrieval.matchedHeadings })
+      : undefined;
+  const status = deriveReviewQuestionStatus({
+    matchedHeadings: retrieval.matchedHeadings,
+    headingIndex: retrieval.headingIndex,
+    rejectedMatches: retrieval.rejectedMatches,
+    matchStage: retrieval.matchStage,
+    reviewAreaReview,
+  });
+
+  return {
+    baselineReview,
+    reviewAreaReview,
+    status,
+  };
+}

--- a/src/lib/quickCheck/evaluation/evaluateEvidence.ts
+++ b/src/lib/quickCheck/evaluation/evaluateEvidence.ts
@@ -1,6 +1,6 @@
 import { evaluateBaselineReview } from "@/lib/chat/quickCheckBaselineRubric";
 import { evaluateReviewRubric } from "@/lib/chat/quickCheckReviewRubric";
-import { deriveReviewQuestionStatus } from "@/lib/quickCheck/retrieval/retrieveSections";
+import { deriveReviewQuestionStatus } from "@/lib/quickCheck/evaluation/status";
 import type {
   EvaluateRetrievedReviewQuestionInput,
   ReviewQuestionEvaluationResult,

--- a/src/lib/quickCheck/evaluation/status.ts
+++ b/src/lib/quickCheck/evaluation/status.ts
@@ -1,0 +1,20 @@
+import type { DocumentHeading, RejectedHeadingQueryMatch } from "@/lib/chat/quickCheckSectionExtractor";
+import type { ReviewRubricResult } from "@/lib/chat/quickCheckReviewRubric";
+import type { ReviewQuestionMatchStage, ReviewQuestionStatus } from "@/lib/quickCheck/retrieval/types";
+
+export function deriveReviewQuestionStatus(input: {
+  matchedHeadings: DocumentHeading[];
+  headingIndex: DocumentHeading[];
+  rejectedMatches: RejectedHeadingQueryMatch[];
+  matchStage: ReviewQuestionMatchStage;
+  reviewAreaReview?: ReviewRubricResult;
+}): ReviewQuestionStatus {
+  if (input.reviewAreaReview?.verdict === "supported") return "strong_evidence_found";
+  if (input.reviewAreaReview?.verdict === "partial") return "partial_evidence_found";
+  if (input.reviewAreaReview?.verdict === "missing" && input.matchedHeadings.length > 0) return "section_found_evidence_weak";
+  if (input.matchedHeadings.length > 0) {
+    return input.matchStage === "semantic_fallback" ? "partial_evidence_found" : "section_found_evidence_weak";
+  }
+  if (input.rejectedMatches.length > 0 || input.headingIndex.length === 0) return "extractor_uncertain";
+  return "no_document_grounded_evidence";
+}

--- a/src/lib/quickCheck/evaluation/types.ts
+++ b/src/lib/quickCheck/evaluation/types.ts
@@ -1,0 +1,11 @@
+import type { ReviewQuestionRetrievalResult, ReviewQuestionResult } from "@/lib/quickCheck/retrieval/types";
+
+export type EvaluateRetrievedReviewQuestionInput = Pick<
+  ReviewQuestionRetrievalResult,
+  "reviewArea" | "matchedHeadings" | "headingIndex" | "rejectedMatches" | "matchStage"
+>;
+
+export type ReviewQuestionEvaluationResult = Pick<
+  ReviewQuestionResult,
+  "baselineReview" | "reviewAreaReview" | "status"
+>;

--- a/src/lib/quickCheck/retrieval/retrieveSections.ts
+++ b/src/lib/quickCheck/retrieval/retrieveSections.ts
@@ -8,8 +8,8 @@ import {
   type RejectedHeadingQueryMatch,
   type DocumentHeading,
 } from "@/lib/chat/quickCheckSectionExtractor";
-import type { ReviewRubricResult } from "@/lib/chat/quickCheckReviewRubric";
 import { parseDocumentText } from "@/lib/documentParsing";
+import { deriveReviewQuestionStatus } from "@/lib/quickCheck/evaluation/status";
 import type {
   BuildReviewQuestionSectionRetrievalInput,
   QuickCheckPath,
@@ -17,7 +17,6 @@ import type {
   ReviewQuestionDiagnostic,
   ReviewQuestionMatchStage,
   ReviewQuestionRetrievalResult,
-  ReviewQuestionStatus,
   SectionMatchResult,
 } from "@/lib/quickCheck/retrieval/types";
 
@@ -392,23 +391,6 @@ function resolveReviewQuestionSections(input: {
     ? findRejectedHeadingMatches(input.rawPddText, input.claimText || "", [...reviewAreaKeywords, ...aliases])
     : [];
   return { matchedHeadings: [], rejectedMatches, matchStage: "none" };
-}
-
-export function deriveReviewQuestionStatus(input: {
-  matchedHeadings: DocumentHeading[];
-  headingIndex: DocumentHeading[];
-  rejectedMatches: RejectedHeadingQueryMatch[];
-  matchStage: ReviewQuestionMatchStage;
-  reviewAreaReview?: ReviewRubricResult;
-}): ReviewQuestionStatus {
-  if (input.reviewAreaReview?.verdict === "supported") return "strong_evidence_found";
-  if (input.reviewAreaReview?.verdict === "partial") return "partial_evidence_found";
-  if (input.reviewAreaReview?.verdict === "missing" && input.matchedHeadings.length > 0) return "section_found_evidence_weak";
-  if (input.matchedHeadings.length > 0) {
-    return input.matchStage === "semantic_fallback" ? "partial_evidence_found" : "section_found_evidence_weak";
-  }
-  if (input.rejectedMatches.length > 0 || input.headingIndex.length === 0) return "extractor_uncertain";
-  return "no_document_grounded_evidence";
 }
 
 export function findMatchedSectionNumbers(

--- a/src/lib/quickCheck/retrieval/types.ts
+++ b/src/lib/quickCheck/retrieval/types.ts
@@ -84,8 +84,6 @@ export type ReviewQuestionRetrievalResult = Omit<ReviewQuestionResult, "baseline
   rejectedMatches: RejectedHeadingQueryMatch[];
 };
 
-export type ReviewQuestionEvaluationResult = Pick<ReviewQuestionResult, "baselineReview" | "reviewAreaReview" | "status">;
-
 export type BuildReviewQuestionSectionRetrievalInput = {
   claimText: string;
   methodologyId: string;

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -431,12 +431,31 @@ describe("review-question pipeline split — retrieval vs evaluation", () => {
       cited_sections: ["2.4"],
     }));
   });
+
+  it("buildReviewQuestionResult remains a compatibility wrapper that orchestrates retrieval plus evaluation", () => {
+    expect(QUICK_CHECK_WRAPPER_SOURCE).toContain("buildReviewQuestionSectionRetrieval");
+    expect(QUICK_CHECK_WRAPPER_SOURCE).toContain("evaluateRetrievedReviewQuestion");
+    expect(QUICK_CHECK_WRAPPER_SOURCE).toContain("const retrieval = buildReviewQuestionSectionRetrieval(input);");
+    expect(QUICK_CHECK_WRAPPER_SOURCE).toContain("const evaluation = evaluateRetrievedReviewQuestion(retrieval);");
+    expect(QUICK_CHECK_WRAPPER_SOURCE).toContain("...retrieval");
+    expect(QUICK_CHECK_WRAPPER_SOURCE).toContain("...evaluation");
+  });
+
+  it("buildReviewQuestionResult wrapper does not directly import rubric evaluators or contain evidence judgment logic", () => {
+    expect(QUICK_CHECK_WRAPPER_SOURCE).not.toContain("evaluateBaselineReview");
+    expect(QUICK_CHECK_WRAPPER_SOURCE).not.toContain("evaluateReviewRubric");
+    expect(QUICK_CHECK_WRAPPER_SOURCE).not.toContain("reviewArea === \"baseline\"");
+    expect(QUICK_CHECK_WRAPPER_SOURCE).not.toContain("reviewArea === \"right_of_use\"");
+    expect(QUICK_CHECK_WRAPPER_SOURCE).not.toContain("reviewArea === \"stakeholder\"");
+  });
 });
 
 const PLUM_FIXTURE_PATH = path.join(__dirname, "..", "fixtures", "quick-check", "plum-pdd-regression.txt");
 const PLUM_TEXT = fs.readFileSync(PLUM_FIXTURE_PATH, "utf-8");
 const ENVIRA_FIXTURE_PATH = path.join(__dirname, "..", "fixtures", "quick-check", "envira-amazonia-vm0007-extracted.txt");
 const ENVIRA_TEXT = fs.readFileSync(ENVIRA_FIXTURE_PATH, "utf-8");
+const QUICK_CHECK_WRAPPER_PATH = path.join(__dirname, "..", "..", "src", "lib", "chat", "quickCheckReviewQuestion.ts");
+const QUICK_CHECK_WRAPPER_SOURCE = fs.readFileSync(QUICK_CHECK_WRAPPER_PATH, "utf-8");
 
 const CUSTOM_HEADING_PDD = [
   "2.1  Project Goals, Design and Long-Term Viability",
@@ -671,6 +690,7 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(result.relevantSections[0]).toBe("3.3");
     expect(result.sectionContent["3.3"]).toContain("Leakage Management procedures");
     expect(result.status).toBe("partial_evidence_found");
+    expect(result.matchStage).toBe("semantic_fallback");
   });
 
   it("prefers 4.3 Monitoring Plan over generic monitoring equipment blocks in the Envira fixture", () => {
@@ -754,6 +774,7 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     });
     expect(result.relevantSections).toEqual([]);
     expect(result.sectionContent).toEqual({});
+    expect(result.status).toBe("extractor_uncertain");
   });
 
   it("does not include section 1.1 (Project Background) when asking about project goals and design", () => {
@@ -939,6 +960,82 @@ describe("computeSectionMatchResults — match diagnostics", () => {
       expect(result.phase1Diagnostic.claimKeywords).toBeDefined();
       expect(result.phase1Diagnostic.claimKeywords.phrases.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("Quick Check extraction edge-case coverage", () => {
+  it("broad review questions still orchestrate retrieval plus evaluation through the wrapper", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Check the monitoring plan",
+      methodologyId: "VM0007",
+      methodologyVersion: "v4-2",
+      rawPddText: ENVIRA_TEXT,
+    });
+
+    expect(result.path).toBe("review_question_answering");
+    expect(result.relevantSections[0]).toBe("4.3");
+    expect(result.sectionContent["4.3"]).toContain("sampling design");
+    expect(result.status).toBe("section_found_evidence_weak");
+  });
+
+  it("returns section_found_evidence_weak when a broad question finds a section but evidence evaluation remains weak", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD disclose methodology deviations?",
+      methodologyId: "VM0007",
+      methodologyVersion: "v4-2",
+      rawPddText: ENVIRA_TEXT,
+    });
+
+    expect(result.relevantSections[0]).toBe("2.6");
+    expect(result.status).toBe("section_found_evidence_weak");
+    expect(result.reviewAreaReview).toBeUndefined();
+  });
+
+  it("treats rejected heading matches as extractor uncertainty when only TOC headings are recovered", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD include stakeholder comments?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: [
+        "Table of Contents",
+        "6  Stakeholder Comments",
+        "",
+        "1.9  Project Location",
+        "The project location is described in the body text.",
+      ].join("\n"),
+    });
+
+    expect(result.relevantSections).toEqual([]);
+    expect(result.noMatchExplanation).toContain("table of contents");
+    expect(result.status).toBe("extractor_uncertain");
+  });
+
+  it("treats empty or poorly parsed heading indexes as extractor uncertainty", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD describe stakeholder engagement?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: "This scan has no recoverable numbered headings or usable section structure.",
+    });
+
+    expect(result.headingIndex).toEqual([]);
+    expect(result.relevantSections).toEqual([]);
+    expect(result.sectionContent).toEqual({});
+    expect(result.status).toBe("extractor_uncertain");
+  });
+
+  it("keeps semantic fallback matches document-grounded instead of escalating to strong evidence automatically", () => {
+    const retrieval = buildReviewQuestionSectionRetrieval({
+      claimText: "Does this PDD address leakage management?",
+      methodologyId: "VM0007",
+      methodologyVersion: "v4-2",
+      rawPddText: ENVIRA_TEXT,
+    });
+    const evaluation = evaluateRetrievedReviewQuestion(retrieval);
+
+    expect(retrieval.matchStage).toBe("semantic_fallback");
+    expect(retrieval.relevantSections[0]).toBe("3.3");
+    expect(evaluation.status).toBe("partial_evidence_found");
   });
 });
 


### PR DESCRIPTION
## WHAT

- Create a new PR against `main` for the remaining Phase 3 Quick Check document pipeline work.
- Bring in the Phase 3B evaluation-module split from PR #670 that was not present on `main`.
- Bring in the boundary guard and extraction edge-case tests from PR #671 that were not present on `main`.
- Verify `src/lib/chat/quickCheckReviewQuestion.ts` remains a compatibility wrapper only.
- Update `docs/roadmaps/quick-check-document-pipeline/phase-status.json` so:
  - Phase 2 is `done`
  - Phase 3 is `done`
  - current phase advances to Phase 4
- Regenerate `docs/roadmaps/SUMMARY.md` to keep roadmap outputs in sync.

## WHY

- Phase 2 was completed by PR #667, but the roadmap still showed it as active.
- Phase 3 started with PR #669, but the later Phase 3B and boundary-guard follow-up work did not actually land on `main`.
- The roadmap should reflect what is on `main`, not what only existed on stacked feature branches.

## Validation

- `npm run typecheck`
- `npx jest tests/lib/quickCheckReviewQuestion.test.ts tests/lib/quickCheckBaselineRubric.test.ts tests/lib/quickCheckReviewRubric.test.ts --runInBand`
- `npm run check:docs-layout`
- `npm run roadmap:gen`

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>