### PR TITLE
[codex] Start Quick Check Phase 4 review policy

### DIFF
--- a/docs/roadmaps/quick-check-document-pipeline/phase-status.json
+++ b/docs/roadmaps/quick-check-document-pipeline/phase-status.json
@@ -19,7 +19,7 @@
     "summary": "Separate candidate section retrieval from evidence sufficiency judgment so routing and verdict semantics can evolve independently."
   },
   "phase_4_declarative_review_policy": {
-    "status": "planned",
+    "status": "active",
     "title": "Phase 4 — declarative typed review policy",
     "summary": "Move aliases, preferred sections, negative sections, fallback rules, boosts, penalties, and evidence signals into typed JSON validated by Zod."
   },
@@ -42,7 +42,7 @@
       "Quick Check eval harness implementation",
       "Additional Quick Check tactical alias patches"
     ],
-    "last_updated_at": "2026-06-01T00:00:00Z"
+    "last_updated_at": "2026-06-01T08:00:00Z"
   },
   "pr_evidence": {
     "phase_2_article6_document_model": [667],

--- a/src/lib/quickCheck/policy/reviewPolicy.ts
+++ b/src/lib/quickCheck/policy/reviewPolicy.ts
@@ -1,0 +1,191 @@
+import { reviewPolicyConfigSchema, type ReviewAreaPolicy, type ReviewPolicyConfig } from "@/lib/quickCheck/policy/types";
+import type { ReviewArea, ReviewQuestionMatchStage } from "@/lib/quickCheck/retrieval/types";
+
+const REVIEW_POLICY_CONFIG_RAW = {
+  fallbackStages: [
+    "exact_heading",
+    "normalized_heading",
+    "alias_heading",
+    "semantic_fallback",
+  ],
+  reviewAreas: {
+    additionality: {
+      baseKeywords: ["additionality"],
+      aliases: [],
+      evidenceSignals: [],
+    },
+    baseline: {
+      baseKeywords: ["baseline", "without-project", "without project", "land use scenario"],
+      aliases: [],
+      evidenceSignals: [],
+    },
+    boundary: {
+      baseKeywords: ["boundary", "project area", "project zone", "geographic boundary", "project location"],
+      aliases: [],
+      evidenceSignals: [],
+    },
+    deviations: {
+      baseKeywords: ["deviations", "deviation"],
+      aliases: [
+        "methodology deviations",
+        "2.6 methodology deviations",
+        "deviation from methodology",
+      ],
+      evidenceSignals: [],
+    },
+    leakage: {
+      baseKeywords: ["leakage", "leakage belt"],
+      aliases: [
+        "leakage",
+        "leakage management",
+        "3.3 leakage",
+        "activity shifting leakage",
+      ],
+      evidenceSignals: [],
+    },
+    monitoring: {
+      baseKeywords: ["monitoring", "monitoring plan", "data and parameters"],
+      aliases: [
+        "monitoring plan",
+        "4.3 monitoring plan",
+        "monitoring procedures",
+        "monitoring approach",
+      ],
+      preferredSections: [
+        {
+          sectionNumber: "4.3",
+          titleIncludes: "monitoring plan",
+          score: 16,
+        },
+      ],
+      titlePenalties: [
+        {
+          titleIncludes: "monitoring equipment",
+          unlessTitleIncludes: "monitoring plan",
+          score: 10,
+        },
+      ],
+      evidenceSignals: [],
+      enableAncestorExpansion: true,
+    },
+    right_of_use: {
+      baseKeywords: [
+        "legal status",
+        "property rights",
+        "ownership",
+        "right of use",
+        "land tenure",
+        "carbon rights",
+        "compliance",
+        "laws",
+        "statutes",
+        "regulatory frameworks",
+      ],
+      vm0007ExtraKeywords: [
+        "compliance with laws",
+        "compliance with laws statutes and other regulatory frameworks",
+        "right of use",
+        "ownership",
+        "land and resource use rights",
+      ],
+      aliases: [],
+      evidenceSignals: [],
+    },
+    stakeholder: {
+      baseKeywords: [
+        "stakeholder",
+        "stakeholder engagement",
+        "stakeholder consultation",
+        "stakeholder participation",
+        "stakeholder comments",
+        "local communities",
+        "community consultation",
+      ],
+      vm0007ExtraKeywords: [
+        "stakeholder comments",
+        "consultation",
+        "participation",
+        "local communities",
+      ],
+      aliases: [
+        "stakeholder comments",
+        "stakeholder consultation",
+        "project awareness",
+        "fpic",
+        "free prior and informed consent",
+        "grievance procedure",
+        "community meetings",
+      ],
+      evidenceSignals: [
+        "fpic",
+        "free prior and informed consent",
+        "grievance procedure",
+        "community meetings",
+        "project awareness",
+      ],
+    },
+    general: {
+      baseKeywords: [],
+      aliases: [],
+      evidenceSignals: [],
+    },
+  },
+} satisfies ReviewPolicyConfig;
+
+export const REVIEW_POLICY_CONFIG = reviewPolicyConfigSchema.parse(REVIEW_POLICY_CONFIG_RAW);
+
+const VM0007_STYLE_IDS = new Set(["VM0007", "PD_REDD_V1_130"]);
+
+export function isVm0007StylePdd(methodologyId: string, rawPddText?: string): boolean {
+  if (VM0007_STYLE_IDS.has(methodologyId.trim().toUpperCase())) return true;
+  const text = rawPddText?.toUpperCase() ?? "";
+  return text.includes("PD_REDD_V1_130") || text.includes("VM0007");
+}
+
+export function getReviewAreaPolicy(reviewArea: ReviewArea): ReviewAreaPolicy {
+  return REVIEW_POLICY_CONFIG.reviewAreas[reviewArea];
+}
+
+export function getReviewAreaKeywords(input: {
+  reviewArea: ReviewArea;
+  methodologyId: string;
+  rawPddText?: string;
+}): string[] {
+  const policy = getReviewAreaPolicy(input.reviewArea);
+  if (!isVm0007StylePdd(input.methodologyId, input.rawPddText)) {
+    return policy.baseKeywords;
+  }
+  return [...policy.baseKeywords, ...policy.vm0007ExtraKeywords];
+}
+
+export function getReviewAreaAliases(reviewArea: ReviewArea): string[] {
+  return getReviewAreaPolicy(reviewArea).aliases;
+}
+
+export function getSemanticThreshold(reviewArea: ReviewArea): number {
+  return getReviewAreaPolicy(reviewArea).semanticThreshold;
+}
+
+export function getSemanticSignals(reviewArea: ReviewArea): string[] {
+  return getReviewAreaPolicy(reviewArea).evidenceSignals;
+}
+
+export function getPreferredSectionBoosts(reviewArea: ReviewArea) {
+  return getReviewAreaPolicy(reviewArea).preferredSections;
+}
+
+export function getTitlePenalties(reviewArea: ReviewArea) {
+  return getReviewAreaPolicy(reviewArea).titlePenalties;
+}
+
+export function getNegativeSectionTerms(reviewArea: ReviewArea): string[] {
+  return getReviewAreaPolicy(reviewArea).negativeSectionTerms;
+}
+
+export function shouldExpandAncestors(reviewArea: ReviewArea): boolean {
+  return getReviewAreaPolicy(reviewArea).enableAncestorExpansion;
+}
+
+export function getFallbackStages(): ReviewQuestionMatchStage[] {
+  return REVIEW_POLICY_CONFIG.fallbackStages;
+}

--- a/src/lib/quickCheck/policy/reviewPolicy.ts
+++ b/src/lib/quickCheck/policy/reviewPolicy.ts
@@ -1,4 +1,8 @@
-import { reviewPolicyConfigSchema, type ReviewAreaPolicy, type ReviewPolicyConfig } from "@/lib/quickCheck/policy/types";
+import {
+  reviewPolicyConfigSchema,
+  type ReviewAreaPolicy,
+  type ReviewPolicyConfigInput,
+} from "@/lib/quickCheck/policy/types";
 import type { ReviewArea, ReviewQuestionMatchStage } from "@/lib/quickCheck/retrieval/types";
 
 const REVIEW_POLICY_CONFIG_RAW = {
@@ -130,7 +134,7 @@ const REVIEW_POLICY_CONFIG_RAW = {
       evidenceSignals: [],
     },
   },
-} satisfies ReviewPolicyConfig;
+} satisfies ReviewPolicyConfigInput;
 
 export const REVIEW_POLICY_CONFIG = reviewPolicyConfigSchema.parse(REVIEW_POLICY_CONFIG_RAW);
 

--- a/src/lib/quickCheck/policy/types.ts
+++ b/src/lib/quickCheck/policy/types.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { ReviewArea, ReviewQuestionMatchStage } from "@/lib/quickCheck/retrieval/types";
+
+export const reviewQuestionMatchStageSchema = z.enum([
+  "exact_heading",
+  "normalized_heading",
+  "alias_heading",
+  "semantic_fallback",
+  "none",
+]);
+
+export const preferredSectionBoostSchema = z.object({
+  sectionNumber: z.string().min(1),
+  titleIncludes: z.string().min(1),
+  score: z.number().int(),
+});
+
+export const titlePenaltySchema = z.object({
+  titleIncludes: z.string().min(1),
+  unlessTitleIncludes: z.string().min(1).optional(),
+  score: z.number().int().nonnegative(),
+});
+
+export const reviewAreaPolicySchema = z.object({
+  baseKeywords: z.array(z.string()),
+  vm0007ExtraKeywords: z.array(z.string()).default([]),
+  aliases: z.array(z.string()),
+  preferredSections: z.array(preferredSectionBoostSchema).default([]),
+  negativeSectionTerms: z.array(z.string()).default([]),
+  titlePenalties: z.array(titlePenaltySchema).default([]),
+  evidenceSignals: z.array(z.string()).default([]),
+  semanticThreshold: z.number().int().nonnegative().default(6),
+  enableAncestorExpansion: z.boolean().default(false),
+});
+
+export const reviewPolicyConfigSchema = z.object({
+  fallbackStages: z.array(reviewQuestionMatchStageSchema).min(4),
+  reviewAreas: z.record(reviewAreaPolicySchema),
+});
+
+export type PreferredSectionBoost = z.infer<typeof preferredSectionBoostSchema>;
+export type TitlePenalty = z.infer<typeof titlePenaltySchema>;
+export type ReviewAreaPolicy = z.infer<typeof reviewAreaPolicySchema>;
+export type ReviewPolicyConfig = z.infer<typeof reviewPolicyConfigSchema>;
+
+export type ReviewPolicyAreaKey = ReviewArea;
+export type ReviewPolicyStage = ReviewQuestionMatchStage;

--- a/src/lib/quickCheck/policy/types.ts
+++ b/src/lib/quickCheck/policy/types.ts
@@ -40,7 +40,9 @@ export const reviewPolicyConfigSchema = z.object({
 
 export type PreferredSectionBoost = z.infer<typeof preferredSectionBoostSchema>;
 export type TitlePenalty = z.infer<typeof titlePenaltySchema>;
+export type ReviewAreaPolicyInput = z.input<typeof reviewAreaPolicySchema>;
 export type ReviewAreaPolicy = z.infer<typeof reviewAreaPolicySchema>;
+export type ReviewPolicyConfigInput = z.input<typeof reviewPolicyConfigSchema>;
 export type ReviewPolicyConfig = z.infer<typeof reviewPolicyConfigSchema>;
 
 export type ReviewPolicyAreaKey = ReviewArea;

--- a/src/lib/quickCheck/retrieval/retrieveSections.ts
+++ b/src/lib/quickCheck/retrieval/retrieveSections.ts
@@ -10,6 +10,16 @@ import {
 } from "@/lib/chat/quickCheckSectionExtractor";
 import { parseDocumentText } from "@/lib/documentParsing";
 import { deriveReviewQuestionStatus } from "@/lib/quickCheck/evaluation/status";
+import {
+  getFallbackStages,
+  getNegativeSectionTerms,
+  getPreferredSectionBoosts,
+  getReviewAreaAliases,
+  getReviewAreaKeywords,
+  getSemanticSignals,
+  getSemanticThreshold,
+  shouldExpandAncestors,
+} from "@/lib/quickCheck/policy/reviewPolicy";
 import type {
   BuildReviewQuestionSectionRetrievalInput,
   QuickCheckPath,
@@ -29,37 +39,6 @@ const BROAD_QUESTION_PATTERNS: RegExp[] = [
   /^review\s+the/i,
 ];
 
-const REVIEW_AREA_KEYWORDS: Record<ReviewArea, string[]> = {
-  additionality: ["additionality"],
-  baseline: ["baseline", "without-project", "without project", "land use scenario"],
-  boundary: ["boundary", "project area", "project zone", "geographic boundary", "project location"],
-  leakage: ["leakage", "leakage belt"],
-  monitoring: ["monitoring", "monitoring plan", "data and parameters"],
-  deviations: ["deviations", "deviation"],
-  right_of_use: [
-    "legal status",
-    "property rights",
-    "ownership",
-    "right of use",
-    "land tenure",
-    "carbon rights",
-    "compliance",
-    "laws",
-    "statutes",
-    "regulatory frameworks",
-  ],
-  stakeholder: [
-    "stakeholder",
-    "stakeholder engagement",
-    "stakeholder consultation",
-    "stakeholder participation",
-    "stakeholder comments",
-    "local communities",
-    "community consultation",
-  ],
-  general: [],
-};
-
 const REVIEW_AREA_LABELS: Record<ReviewArea, string> = {
   additionality: "Additionality",
   baseline: "Baseline scenario",
@@ -71,42 +50,6 @@ const REVIEW_AREA_LABELS: Record<ReviewArea, string> = {
   stakeholder: "Stakeholder consultation",
   general: "General review",
 };
-
-const REVIEW_AREA_ALIASES: Record<ReviewArea, string[]> = {
-  additionality: [],
-  baseline: [],
-  boundary: [],
-  deviations: [
-    "methodology deviations",
-    "2.6 methodology deviations",
-    "deviation from methodology",
-  ],
-  leakage: [
-    "leakage",
-    "leakage management",
-    "3.3 leakage",
-    "activity shifting leakage",
-  ],
-  monitoring: [
-    "monitoring plan",
-    "4.3 monitoring plan",
-    "monitoring procedures",
-    "monitoring approach",
-  ],
-  right_of_use: [],
-  stakeholder: [
-    "stakeholder comments",
-    "stakeholder consultation",
-    "project awareness",
-    "fpic",
-    "free prior and informed consent",
-    "grievance procedure",
-    "community meetings",
-  ],
-  general: [],
-};
-
-const VM0007_STYLE_IDS = new Set(["VM0007", "PD_REDD_V1_130"]);
 
 const CLAIM_PREFIX_RE = /^(?:does this PDD\s+)?(?:explain|describe|review|check|evaluate|assess|identify|discuss|justify|mention|outline|summarize|present|provide|include|support|demonstrate|define|show|disclose)\s+/i;
 const LEADING_ARTICLE_RE = /^(?:the|a|an)\s+/i;
@@ -132,44 +75,6 @@ type ReviewQuestionSectionResolution = {
   rejectedMatches: RejectedHeadingQueryMatch[];
   matchStage: ReviewQuestionMatchStage;
 };
-
-function isVm0007StylePdd(methodologyId: string, rawPddText?: string): boolean {
-  if (VM0007_STYLE_IDS.has(methodologyId.trim().toUpperCase())) return true;
-  const text = rawPddText?.toUpperCase() ?? "";
-  return text.includes("PD_REDD_V1_130") || text.includes("VM0007");
-}
-
-function reviewAreaKeywordsForInput(input: {
-  reviewArea: ReviewArea;
-  methodologyId: string;
-  rawPddText?: string;
-}): string[] {
-  const baseKeywords = REVIEW_AREA_KEYWORDS[input.reviewArea] ?? [];
-  if (!isVm0007StylePdd(input.methodologyId, input.rawPddText)) return baseKeywords;
-
-  if (input.reviewArea === "right_of_use") {
-    return [
-      ...baseKeywords,
-      "compliance with laws",
-      "compliance with laws statutes and other regulatory frameworks",
-      "right of use",
-      "ownership",
-      "land and resource use rights",
-    ];
-  }
-
-  if (input.reviewArea === "stakeholder") {
-    return [
-      ...baseKeywords,
-      "stakeholder comments",
-      "consultation",
-      "participation",
-      "local communities",
-    ];
-  }
-
-  return baseKeywords;
-}
 
 export function detectReviewPath(claimText: string): QuickCheckPath {
   const normalized = claimText.trim();
@@ -231,10 +136,6 @@ function normalizeReviewText(text: string): string {
   return text.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
 }
 
-function reviewAreaAliasKeywords(area: ReviewArea): string[] {
-  return REVIEW_AREA_ALIASES[area] ?? [];
-}
-
 function uniqueHeadings(headings: DocumentHeading[]): DocumentHeading[] {
   const seen = new Set<string>();
   return headings.filter((heading) => {
@@ -246,7 +147,7 @@ function uniqueHeadings(headings: DocumentHeading[]): DocumentHeading[] {
 }
 
 function withMonitoringAncestors(headings: DocumentHeading[], reviewArea: ReviewArea, headingIndex: DocumentHeading[]): DocumentHeading[] {
-  if (reviewArea !== "monitoring" || headings.length === 0) return headings;
+  if (!shouldExpandAncestors(reviewArea) || headings.length === 0) return headings;
   const expanded = [...headings];
   for (const heading of headings) {
     const parts = heading.sectionNumber.split(".");
@@ -293,6 +194,10 @@ function scoreSemanticHeading(
   const titleText = heading.normalizedTitle;
   const bodyText = heading.normalizedBodyText;
   let score = 0;
+  const preferredSectionBoosts = getPreferredSectionBoosts(reviewArea);
+  const titlePenalties = getTitlePenalties(reviewArea);
+  const semanticSignals = getSemanticSignals(reviewArea);
+  const negativeSectionTerms = getNegativeSectionTerms(reviewArea);
 
   for (const term of searchTerms) {
     const normalizedTerm = normalizeReviewText(term);
@@ -320,13 +225,28 @@ function scoreSemanticHeading(
     else if (bodyText.includes(normalizedWord)) score += 1;
   }
 
-  if (reviewArea === "monitoring") {
-    if (heading.sectionNumber === "4.3" && titleText.includes("monitoring plan")) score += 16;
-    if (titleText.includes("monitoring equipment") && !titleText.includes("monitoring plan")) score -= 10;
+  for (const boost of preferredSectionBoosts) {
+    if (heading.sectionNumber === boost.sectionNumber && titleText.includes(normalizeReviewText(boost.titleIncludes))) {
+      score += boost.score;
+    }
   }
 
-  if (reviewArea === "stakeholder" && /(fpic|free prior and informed consent|grievance procedure|community meetings|project awareness)/.test(`${titleText} ${bodyText}`)) {
+  for (const penalty of titlePenalties) {
+    const includesTitle = titleText.includes(normalizeReviewText(penalty.titleIncludes));
+    const unlessAllowed = penalty.unlessTitleIncludes
+      ? titleText.includes(normalizeReviewText(penalty.unlessTitleIncludes))
+      : false;
+    if (includesTitle && !unlessAllowed) {
+      score -= penalty.score;
+    }
+  }
+
+  if (semanticSignals.some((signal) => `${titleText} ${bodyText}`.includes(normalizeReviewText(signal)))) {
     score += 6;
+  }
+
+  if (negativeSectionTerms.some((term) => titleText.includes(normalizeReviewText(term)))) {
+    score -= 4;
   }
 
   return score;
@@ -338,12 +258,13 @@ function semanticFallbackMatches(
   searchTerms: string[],
   claimKeywords: { phrases: string[]; words: string[] },
 ): DocumentHeading[] {
+  const semanticThreshold = getSemanticThreshold(reviewArea);
   return headings
     .map((heading) => ({
       heading,
       score: scoreSemanticHeading(heading, reviewArea, searchTerms, claimKeywords),
     }))
-    .filter((entry) => entry.score >= 6)
+    .filter((entry) => entry.score >= semanticThreshold)
     .sort((left, right) => right.score - left.score || left.heading.sectionNumber.localeCompare(right.heading.sectionNumber, undefined, { numeric: true }))
     .map((entry) => entry.heading);
 }
@@ -355,36 +276,38 @@ function resolveReviewQuestionSections(input: {
   methodologyId: string;
   rawPddText?: string;
 }): ReviewQuestionSectionResolution {
-  const aliases = reviewAreaAliasKeywords(input.reviewArea);
-  const reviewAreaKeywords = reviewAreaKeywordsForInput({
+  const aliases = getReviewAreaAliases(input.reviewArea);
+  const reviewAreaKeywords = getReviewAreaKeywords({
     reviewArea: input.reviewArea,
     methodologyId: input.methodologyId,
     rawPddText: input.rawPddText,
   });
   const claimKeywords = extractClaimKeywords(input.claimText);
   const searchTerms = [...new Set([...reviewAreaKeywords, ...aliases, ...claimKeywords.phrases, ...claimKeywords.words])];
+  const fallbackStages = getFallbackStages();
 
-  const exactMatches = uniqueHeadings(exactHeadingMatches(input.headingIndex, input.claimText));
-  if (exactMatches.length > 0) {
-    return { matchedHeadings: withMonitoringAncestors(exactMatches, input.reviewArea, input.headingIndex), rejectedMatches: [], matchStage: "exact_heading" };
-  }
+  for (const stage of fallbackStages) {
+    let matches: DocumentHeading[] = [];
+    if (stage === "exact_heading") {
+      matches = uniqueHeadings(exactHeadingMatches(input.headingIndex, input.claimText));
+    } else if (stage === "normalized_heading") {
+      matches = uniqueHeadings(filterPddHeadingsByQuery(input.headingIndex, input.claimText, []));
+    } else if (stage === "alias_heading") {
+      matches = uniqueHeadings([
+        ...aliasHeadingMatches(input.headingIndex, aliases),
+        ...filterPddHeadingsByQuery(input.headingIndex, input.claimText, [...reviewAreaKeywords, ...aliases]),
+      ]);
+    } else if (stage === "semantic_fallback") {
+      matches = uniqueHeadings(semanticFallbackMatches(input.headingIndex, input.reviewArea, searchTerms, claimKeywords));
+    }
 
-  const normalizedMatches = uniqueHeadings(filterPddHeadingsByQuery(input.headingIndex, input.claimText, []));
-  if (normalizedMatches.length > 0) {
-    return { matchedHeadings: withMonitoringAncestors(normalizedMatches, input.reviewArea, input.headingIndex), rejectedMatches: [], matchStage: "normalized_heading" };
-  }
-
-  const aliasMatches = uniqueHeadings([
-    ...aliasHeadingMatches(input.headingIndex, aliases),
-    ...filterPddHeadingsByQuery(input.headingIndex, input.claimText, [...reviewAreaKeywords, ...aliases]),
-  ]);
-  if (aliasMatches.length > 0) {
-    return { matchedHeadings: withMonitoringAncestors(aliasMatches, input.reviewArea, input.headingIndex), rejectedMatches: [], matchStage: "alias_heading" };
-  }
-
-  const semanticMatches = uniqueHeadings(semanticFallbackMatches(input.headingIndex, input.reviewArea, searchTerms, claimKeywords));
-  if (semanticMatches.length > 0) {
-    return { matchedHeadings: withMonitoringAncestors(semanticMatches, input.reviewArea, input.headingIndex), rejectedMatches: [], matchStage: "semantic_fallback" };
+    if (matches.length > 0) {
+      return {
+        matchedHeadings: withMonitoringAncestors(matches, input.reviewArea, input.headingIndex),
+        rejectedMatches: [],
+        matchStage: stage,
+      };
+    }
   }
 
   const rejectedMatches = input.rawPddText
@@ -420,7 +343,7 @@ export function computeSectionMatchResults(
   methodologyId = "",
 ): SectionMatchResult[] {
   const headingIndex = parseDocumentText({ rawText: rawPddText }).headingIndex ?? [];
-  const fallbackKeywords = reviewAreaKeywordsForInput({ reviewArea, methodologyId, rawPddText });
+  const fallbackKeywords = getReviewAreaKeywords({ reviewArea, methodologyId, rawPddText });
   const results: SectionMatchResult[] = [];
 
   for (const heading of headingIndex) {

--- a/src/lib/quickCheck/retrieval/retrieveSections.ts
+++ b/src/lib/quickCheck/retrieval/retrieveSections.ts
@@ -18,6 +18,7 @@ import {
   getReviewAreaKeywords,
   getSemanticSignals,
   getSemanticThreshold,
+  getTitlePenalties,
   shouldExpandAncestors,
 } from "@/lib/quickCheck/policy/reviewPolicy";
 import type {

--- a/tests/lib/quickCheckReviewPolicy.test.ts
+++ b/tests/lib/quickCheckReviewPolicy.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getFallbackStages,
+  getPreferredSectionBoosts,
+  getReviewAreaKeywords,
+  getReviewAreaPolicy,
+  getSemanticSignals,
+  getTitlePenalties,
+  isVm0007StylePdd,
+  shouldExpandAncestors,
+  REVIEW_POLICY_CONFIG,
+} from "@/lib/quickCheck/policy/reviewPolicy";
+import type { ReviewArea } from "@/lib/quickCheck/retrieval/types";
+
+const REVIEW_AREAS: ReviewArea[] = [
+  "additionality",
+  "baseline",
+  "boundary",
+  "deviations",
+  "leakage",
+  "monitoring",
+  "right_of_use",
+  "stakeholder",
+  "general",
+];
+
+describe("quickCheck review policy", () => {
+  it("defines a policy entry for every review area", () => {
+    expect(Object.keys(REVIEW_POLICY_CONFIG.reviewAreas).sort()).toEqual([...REVIEW_AREAS].sort());
+
+    for (const reviewArea of REVIEW_AREAS) {
+      expect(getReviewAreaPolicy(reviewArea)).toBeDefined();
+    }
+  });
+
+  it("keeps the fallback stage order stable", () => {
+    expect(getFallbackStages()).toEqual([
+      "exact_heading",
+      "normalized_heading",
+      "alias_heading",
+      "semantic_fallback",
+    ]);
+  });
+
+  it("applies vm0007 extra keywords only for vm0007-style inputs", () => {
+    const nonVm0007Keywords = getReviewAreaKeywords({
+      reviewArea: "right_of_use",
+      methodologyId: "VCS-OTHER",
+    });
+    const vm0007MethodKeywords = getReviewAreaKeywords({
+      reviewArea: "right_of_use",
+      methodologyId: "VM0007",
+    });
+    const vm0007RawTextKeywords = getReviewAreaKeywords({
+      reviewArea: "right_of_use",
+      methodologyId: "VCS-OTHER",
+      rawPddText: "Project Description Document for PD_REDD_v1_130",
+    });
+
+    expect(nonVm0007Keywords).not.toContain("compliance with laws statutes and other regulatory frameworks");
+    expect(vm0007MethodKeywords).toContain("compliance with laws statutes and other regulatory frameworks");
+    expect(vm0007RawTextKeywords).toContain("compliance with laws statutes and other regulatory frameworks");
+  });
+
+  it("detects vm0007-style pdds from methodology id or raw text only", () => {
+    expect(isVm0007StylePdd("VM0007")).toBe(true);
+    expect(isVm0007StylePdd("pd_redd_v1_130")).toBe(true);
+    expect(isVm0007StylePdd("other-method", "This PDD follows PD_REDD_v1_130 guidance.")).toBe(true);
+    expect(isVm0007StylePdd("other-method", "Generic methodology document")).toBe(false);
+  });
+
+  it("exposes monitoring boosts, penalties, and ancestor expansion through helpers", () => {
+    expect(getPreferredSectionBoosts("monitoring")).toEqual([
+      {
+        sectionNumber: "4.3",
+        titleIncludes: "monitoring plan",
+        score: 16,
+      },
+    ]);
+    expect(getTitlePenalties("monitoring")).toEqual([
+      {
+        titleIncludes: "monitoring equipment",
+        unlessTitleIncludes: "monitoring plan",
+        score: 10,
+      },
+    ]);
+    expect(shouldExpandAncestors("monitoring")).toBe(true);
+    expect(shouldExpandAncestors("baseline")).toBe(false);
+  });
+
+  it("exposes stakeholder evidence signals through helpers", () => {
+    expect(getSemanticSignals("stakeholder")).toEqual([
+      "fpic",
+      "free prior and informed consent",
+      "grievance procedure",
+      "community meetings",
+      "project awareness",
+    ]);
+  });
+});


### PR DESCRIPTION
## WHAT

- keep this PR scoped as the Phase 4 kickoff for `docs/roadmaps/quick-check-document-pipeline`, not Phase 4 completion
- keep Phase 2 and Phase 3 explicitly marked `done` in the Quick Check phase status file
- keep Phase 4 as the active phase and keep the current phase set to `phase_4_declarative_review_policy`
- move Quick Check aliases, preferred sections, negative sections, fallback stages, boosts, penalties, and evidence signals behind declarative typed policy helpers
- validate the policy config with Zod
- add direct policy tests proving:
  - all review areas have policy coverage
  - fallback stage order remains stable
  - VM0007, monitoring, and stakeholder policy behavior remains unchanged
- keep parser, document model, retrieval, and evaluation boundaries unchanged
- do not start LiteParse
- do not start the eval harness
- after merge, follow with the next Phase 4 PR to either move the review policy config closer to true external typed JSON or enforce exact review-area keys at the schema level

## WHY

- this PR successfully moves Quick Check review policy out of retrieval internals and adds direct policy tests
- the remaining risk is policy enforcement strength, not the retrieval refactor itself
- Phase 4 should not be marked complete until the declarative policy boundary is harder to regress

## VALIDATION

- `npm run typecheck`
- `npx jest tests/lib/quickCheckReviewPolicy.test.ts tests/lib/quickCheckReviewQuestion.test.ts tests/lib/quickCheckBaselineRubric.test.ts tests/lib/quickCheckReviewRubric.test.ts --runInBand`
- `npm run check:docs-layout`
- `npm run roadmap:gen`

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>