### PR TITLE
[codex] Enforce exact Quick Check policy keys

### DIFF
--- a/src/lib/quickCheck/policy/types.ts
+++ b/src/lib/quickCheck/policy/types.ts
@@ -1,6 +1,18 @@
 import { z } from "zod";
 import type { ReviewArea, ReviewQuestionMatchStage } from "@/lib/quickCheck/retrieval/types";
 
+export const REVIEW_AREA_KEYS = [
+  "additionality",
+  "baseline",
+  "boundary",
+  "deviations",
+  "leakage",
+  "monitoring",
+  "right_of_use",
+  "stakeholder",
+  "general",
+] as const satisfies readonly ReviewArea[];
+
 export const reviewQuestionMatchStageSchema = z.enum([
   "exact_heading",
   "normalized_heading",
@@ -33,9 +45,25 @@ export const reviewAreaPolicySchema = z.object({
   enableAncestorExpansion: z.boolean().default(false),
 });
 
+export const reviewAreaSchema = z.enum(REVIEW_AREA_KEYS);
+
+const reviewAreasShape = {
+  additionality: reviewAreaPolicySchema,
+  baseline: reviewAreaPolicySchema,
+  boundary: reviewAreaPolicySchema,
+  deviations: reviewAreaPolicySchema,
+  leakage: reviewAreaPolicySchema,
+  monitoring: reviewAreaPolicySchema,
+  right_of_use: reviewAreaPolicySchema,
+  stakeholder: reviewAreaPolicySchema,
+  general: reviewAreaPolicySchema,
+} satisfies Record<ReviewArea, typeof reviewAreaPolicySchema>;
+
+export const reviewAreasSchema = z.object(reviewAreasShape).strict();
+
 export const reviewPolicyConfigSchema = z.object({
   fallbackStages: z.array(reviewQuestionMatchStageSchema).min(4),
-  reviewAreas: z.record(reviewAreaPolicySchema),
+  reviewAreas: reviewAreasSchema,
 });
 
 export type PreferredSectionBoost = z.infer<typeof preferredSectionBoostSchema>;

--- a/tests/lib/quickCheckReviewPolicy.test.ts
+++ b/tests/lib/quickCheckReviewPolicy.test.ts
@@ -10,25 +10,13 @@ import {
   shouldExpandAncestors,
   REVIEW_POLICY_CONFIG,
 } from "@/lib/quickCheck/policy/reviewPolicy";
-import type { ReviewArea } from "@/lib/quickCheck/retrieval/types";
-
-const REVIEW_AREAS: ReviewArea[] = [
-  "additionality",
-  "baseline",
-  "boundary",
-  "deviations",
-  "leakage",
-  "monitoring",
-  "right_of_use",
-  "stakeholder",
-  "general",
-];
+import { REVIEW_AREA_KEYS, reviewPolicyConfigSchema } from "@/lib/quickCheck/policy/types";
 
 describe("quickCheck review policy", () => {
   it("defines a policy entry for every review area", () => {
-    expect(Object.keys(REVIEW_POLICY_CONFIG.reviewAreas).sort()).toEqual([...REVIEW_AREAS].sort());
+    expect(Object.keys(REVIEW_POLICY_CONFIG.reviewAreas).sort()).toEqual([...REVIEW_AREA_KEYS].sort());
 
-    for (const reviewArea of REVIEW_AREAS) {
+    for (const reviewArea of REVIEW_AREA_KEYS) {
       expect(getReviewAreaPolicy(reviewArea)).toBeDefined();
     }
   });
@@ -96,5 +84,27 @@ describe("quickCheck review policy", () => {
       "community meetings",
       "project awareness",
     ]);
+  });
+
+  it("rejects configs with missing review-area keys", () => {
+    const invalidConfig = structuredClone(REVIEW_POLICY_CONFIG);
+    delete invalidConfig.reviewAreas.general;
+
+    const result = reviewPolicyConfigSchema.safeParse(invalidConfig);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects configs with unexpected extra review-area keys", () => {
+    const invalidConfig = structuredClone(REVIEW_POLICY_CONFIG) as typeof REVIEW_POLICY_CONFIG & {
+      reviewAreas: typeof REVIEW_POLICY_CONFIG.reviewAreas & {
+        unexpected_area?: typeof REVIEW_POLICY_CONFIG.reviewAreas.general;
+      };
+    };
+    invalidConfig.reviewAreas.unexpected_area = invalidConfig.reviewAreas.general;
+
+    const result = reviewPolicyConfigSchema.safeParse(invalidConfig);
+
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## WHAT

- start the next Phase 4 follow-up from fresh `main`
- strengthen Quick Check review policy validation so policy coverage cannot silently regress
- enforce exact review-area keys at the schema and config-validation level
- add direct tests proving the config rejects missing review-area keys
- add direct tests proving the config rejects unexpected extra review-area keys
- keep the existing policy coverage, fallback-order, VM0007, monitoring, and stakeholder policy tests in place
- keep parser, document model, retrieval, and evaluation behavior unchanged
- do not move to Phase 5
- do not add LiteParse
- do not build the eval harness

## WHY

- PR #676 moved Quick Check review policy out of retrieval internals, but the remaining Phase 4 risk was weak key enforcement
- exact review-area validation prevents silent gaps when review areas are added, renamed, or accidentally removed
- this hardens the declarative policy boundary without reopening retrieval or evaluation refactors

## VALIDATION

- `npm run typecheck`
- `npx jest tests/lib/quickCheckReviewPolicy.test.ts tests/lib/quickCheckReviewQuestion.test.ts tests/lib/quickCheckBaselineRubric.test.ts tests/lib/quickCheckReviewRubric.test.ts --runInBand`
- `npm run check:docs-layout`

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>