### PR TITLE
[codex] Mark Quick Check Phase 4 complete

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -169,7 +169,6 @@ Move Quick Check from tactical section-matching patches to a layered document pi
 
 Not active now:
 - LiteParse integration
-- Quick Check eval harness implementation
 - Additional Quick Check tactical alias patches
 
 

--- a/docs/roadmaps/quick-check-document-pipeline/phase-status.json
+++ b/docs/roadmaps/quick-check-document-pipeline/phase-status.json
@@ -2,7 +2,7 @@
   "roadmap": "quick-check-document-pipeline",
   "repo": "Fredilly/app.article6",
   "status": "active",
-  "current_phase": "phase_4_declarative_review_policy",
+  "current_phase": "phase_5_eval_harness",
   "phase_1_parser_adapter_boundary": {
     "status": "done",
     "title": "Phase 1 — parser adapter boundary",
@@ -19,12 +19,12 @@
     "summary": "Separate candidate section retrieval from evidence sufficiency judgment so routing and verdict semantics can evolve independently."
   },
   "phase_4_declarative_review_policy": {
-    "status": "active",
+    "status": "done",
     "title": "Phase 4 — declarative typed review policy",
     "summary": "Move aliases, preferred sections, negative sections, fallback rules, boosts, penalties, and evidence signals into typed JSON validated by Zod."
   },
   "phase_5_eval_harness": {
-    "status": "planned",
+    "status": "active",
     "title": "Phase 5 — Quick Check eval harness",
     "summary": "Add fixture-backed retrieval and verdict evals so pipeline changes are measured and gated before merge."
   },
@@ -36,16 +36,17 @@
   "phase_meta": {
     "status": "active",
     "summary": "Move Quick Check from tactical section-matching patches to a layered document pipeline with explicit parser, document-model, retrieval, evaluation, UI, and eval boundaries.",
-    "current_focus": "Phase 4 only: move Quick Check aliases, preferred sections, negative sections, fallback rules, boosts, penalties, and evidence signals into declarative typed policy config. Parser/document-model boundaries and retrieval/evaluation split are complete.",
+    "current_focus": "Phase 5 only: plan and implement a fixture-backed Quick Check eval harness for retrieval and verdict regression testing before more parser work. Phase 4 declarative review policy is complete, and LiteParse remains out of scope until the eval harness exists.",
     "not_active_now": [
       "LiteParse integration",
       "Quick Check eval harness implementation",
       "Additional Quick Check tactical alias patches"
     ],
-    "last_updated_at": "2026-06-01T08:00:00Z"
+    "last_updated_at": "2026-06-01T08:15:00Z"
   },
   "pr_evidence": {
     "phase_2_article6_document_model": [667],
-    "phase_3_retrieval_evaluation_split": [669, 670, 671]
+    "phase_3_retrieval_evaluation_split": [669, 670, 671],
+    "phase_4_declarative_review_policy": [676, 677]
   }
 }

--- a/docs/roadmaps/quick-check-document-pipeline/phase-status.json
+++ b/docs/roadmaps/quick-check-document-pipeline/phase-status.json
@@ -39,7 +39,6 @@
     "current_focus": "Phase 5 only: plan and implement a fixture-backed Quick Check eval harness for retrieval and verdict regression testing before more parser work. Phase 4 declarative review policy is complete, and LiteParse remains out of scope until the eval harness exists.",
     "not_active_now": [
       "LiteParse integration",
-      "Quick Check eval harness implementation",
       "Additional Quick Check tactical alias patches"
     ],
     "last_updated_at": "2026-06-01T08:15:00Z"


### PR DESCRIPTION
## WHAT

- update `docs/roadmaps/quick-check-document-pipeline/phase-status.json`
- mark `phase_4_declarative_review_policy` as `done`
- set `current_phase` to `phase_5_eval_harness`
- mark `phase_5_eval_harness` as the active phase
- add Phase 4 PR evidence for the completed declarative review policy work: `#676` and `#677`
- update `phase_meta.current_focus` so the active focus is Phase 5 eval harness planning and implementation
- keep LiteParse listed as not active

## WHY

- PR #677 completed the remaining Phase 4 policy-key hardening work
- the roadmap should reflect that Phase 4 is complete and that Phase 5 is the correct next step
- LiteParse should remain blocked until the eval harness exists

## VALIDATION

- `npm run roadmap:gen`

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>