### PR TITLE
[codex] Add Quick Check eval harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "node --require ./scripts/node-version-shim.js ./node_modules/next/dist/bin/next lint --max-warnings=0",
     "typecheck": "tsc --noEmit",
+    "quickcheck:eval": "jest tests/evals/quickCheckEval.test.ts --runInBand",
     "ci": "npm run guard:methodology-boundary && npm run lint && npm run typecheck && npm run check:docs-layout && npm run roadmap:validate-evidence && npm test && npm run build && npm run check:quick-check-pdf-trace && npm run roadmap:check",
     "test": "jest --passWithNoTests",
     "test:e2e": "playwright test",

--- a/tests/evals/quickCheckEval.test.ts
+++ b/tests/evals/quickCheckEval.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import {
+  buildReviewQuestionResult,
+  buildReviewQuestionSectionRetrieval,
+} from "@/lib/chat/quickCheckReviewQuestion";
+import type {
+  BuildReviewQuestionSectionRetrievalInput,
+  ReviewArea,
+  ReviewQuestionMatchStage,
+  ReviewQuestionStatus,
+} from "@/lib/quickCheck/retrieval/types";
+
+type RetrievalEvalCase = {
+  id: string;
+  fixture: string;
+  input: BuildReviewQuestionSectionRetrievalInput;
+  expected: {
+    reviewArea: ReviewArea;
+    matchStage: ReviewQuestionMatchStage;
+    relevantSections: string[];
+    matchedHeadingTitle?: string;
+  };
+};
+
+type VerdictEvalCase = {
+  id: string;
+  fixture: string;
+  input: BuildReviewQuestionSectionRetrievalInput;
+  expected: {
+    status: ReviewQuestionStatus;
+    baselineVerdict?: string;
+    reviewAreaVerdict?: string;
+  };
+};
+
+type EvalFixtureManifest = {
+  retrievalCases: RetrievalEvalCase[];
+  verdictCases: VerdictEvalCase[];
+};
+
+const EVAL_FIXTURE_DIR = path.join(__dirname, "../fixtures/quick-check/eval");
+const EVAL_MANIFEST_PATH = path.join(EVAL_FIXTURE_DIR, "quickcheck-eval-cases.json");
+const EVAL_MANIFEST = JSON.parse(
+  fs.readFileSync(EVAL_MANIFEST_PATH, "utf-8"),
+) as EvalFixtureManifest;
+
+function readFixtureText(fixture: string): string {
+  return fs.readFileSync(path.join(EVAL_FIXTURE_DIR, fixture), "utf-8");
+}
+
+describe("Quick Check eval harness — retrieval", () => {
+  for (const testCase of EVAL_MANIFEST.retrievalCases) {
+    it(testCase.id, () => {
+      const retrieval = buildReviewQuestionSectionRetrieval({
+        ...testCase.input,
+        rawPddText: readFixtureText(testCase.fixture),
+      });
+
+      expect(retrieval.reviewArea).toBe(testCase.expected.reviewArea);
+      expect(retrieval.matchStage).toBe(testCase.expected.matchStage);
+      expect(retrieval.relevantSections).toEqual(testCase.expected.relevantSections);
+
+      if (testCase.expected.matchedHeadingTitle) {
+        expect(retrieval.matchedHeadings[0]?.title).toBe(testCase.expected.matchedHeadingTitle);
+      }
+    });
+  }
+});
+
+describe("Quick Check eval harness — verdicts", () => {
+  for (const testCase of EVAL_MANIFEST.verdictCases) {
+    it(testCase.id, () => {
+      const result = buildReviewQuestionResult({
+        ...testCase.input,
+        rawPddText: readFixtureText(testCase.fixture),
+      });
+
+      expect(result.status).toBe(testCase.expected.status);
+
+      if (testCase.expected.baselineVerdict) {
+        expect(result.baselineReview?.verdict).toBe(testCase.expected.baselineVerdict);
+      }
+
+      if (testCase.expected.reviewAreaVerdict) {
+        expect(result.reviewAreaReview?.verdict).toBe(testCase.expected.reviewAreaVerdict);
+      }
+    });
+  }
+});

--- a/tests/fixtures/quick-check/eval/baseline-supported.txt
+++ b/tests/fixtures/quick-check/eval/baseline-supported.txt
@@ -1,0 +1,6 @@
+1.9  Project Location
+Project location Machinga District, Malawi.
+
+2.4  Baseline Scenario
+The baseline scenario is the most likely land-use scenario in the absence of the project activity.
+Historical deforestation rates from satellite imagery show a 1.2% annual loss in the reference region.

--- a/tests/fixtures/quick-check/eval/leakage-semantic.txt
+++ b/tests/fixtures/quick-check/eval/leakage-semantic.txt
@@ -1,0 +1,3 @@
+3.3  Leakage
+Leakage Management procedures are applied through grazing controls and fuelwood alternatives in adjacent areas.
+The project monitors displacement risk in the leakage belt each year.

--- a/tests/fixtures/quick-check/eval/monitoring-plan.txt
+++ b/tests/fixtures/quick-check/eval/monitoring-plan.txt
@@ -1,0 +1,5 @@
+4.2  Monitoring Equipment
+Monitoring equipment is calibrated annually.
+
+4.3  Monitoring Plan
+The monitoring plan defines the sampling design, permanent plots, and annual data collection procedures.

--- a/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
+++ b/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
@@ -1,0 +1,130 @@
+{
+  "retrievalCases": [
+    {
+      "id": "baseline_supported_exact_heading",
+      "fixture": "baseline-supported.txt",
+      "input": {
+        "claimText": "Does this PDD describe baseline scenario?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "reviewArea": "baseline",
+        "matchStage": "exact_heading",
+        "relevantSections": ["2.4"],
+        "matchedHeadingTitle": "Baseline Scenario"
+      }
+    },
+    {
+      "id": "stakeholder_comments_exact_heading",
+      "fixture": "stakeholder-comments.txt",
+      "input": {
+        "claimText": "Does this PDD include stakeholder comments?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "reviewArea": "stakeholder",
+        "matchStage": "exact_heading",
+        "relevantSections": ["6"],
+        "matchedHeadingTitle": "Stakeholder Comments"
+      }
+    },
+    {
+      "id": "monitoring_plan_preferred_section",
+      "fixture": "monitoring-plan.txt",
+      "input": {
+        "claimText": "Check the monitoring plan",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "reviewArea": "monitoring",
+        "matchStage": "exact_heading",
+        "relevantSections": ["4.3"],
+        "matchedHeadingTitle": "Monitoring Plan"
+      }
+    },
+    {
+      "id": "leakage_management_semantic_fallback",
+      "fixture": "leakage-semantic.txt",
+      "input": {
+        "claimText": "Does this PDD address leakage management?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "reviewArea": "general",
+        "matchStage": "semantic_fallback",
+        "relevantSections": ["3.3"],
+        "matchedHeadingTitle": "Leakage"
+      }
+    },
+    {
+      "id": "stakeholder_toc_only_rejected",
+      "fixture": "toc-only-stakeholder.txt",
+      "input": {
+        "claimText": "Does this PDD include stakeholder comments?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "reviewArea": "stakeholder",
+        "matchStage": "none",
+        "relevantSections": []
+      }
+    }
+  ],
+  "verdictCases": [
+    {
+      "id": "baseline_supported_verdict",
+      "fixture": "baseline-supported.txt",
+      "input": {
+        "claimText": "Does this PDD describe baseline scenario?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "strong_evidence_found",
+        "baselineVerdict": "supported"
+      }
+    },
+    {
+      "id": "stakeholder_supported_verdict",
+      "fixture": "stakeholder-comments.txt",
+      "input": {
+        "claimText": "Does this PDD include stakeholder comments?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "strong_evidence_found",
+        "reviewAreaVerdict": "supported"
+      }
+    },
+    {
+      "id": "leakage_semantic_partial_status",
+      "fixture": "leakage-semantic.txt",
+      "input": {
+        "claimText": "Does this PDD address leakage management?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "partial_evidence_found"
+      }
+    },
+    {
+      "id": "stakeholder_toc_only_extractor_uncertain",
+      "fixture": "toc-only-stakeholder.txt",
+      "input": {
+        "claimText": "Does this PDD include stakeholder comments?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "extractor_uncertain"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/quick-check/eval/stakeholder-comments.txt
+++ b/tests/fixtures/quick-check/eval/stakeholder-comments.txt
@@ -1,0 +1,4 @@
+6  Stakeholder Comments
+Stakeholder consultation and participation were conducted through community meetings.
+Free Prior and Informed Consent was documented during consultation with local communities.
+Stakeholder comments were summarized and addressed in follow-up meetings.

--- a/tests/fixtures/quick-check/eval/toc-only-stakeholder.txt
+++ b/tests/fixtures/quick-check/eval/toc-only-stakeholder.txt
@@ -1,0 +1,5 @@
+Table of Contents
+6  Stakeholder Comments
+
+1.9  Project Location
+The project location is described in the body text.


### PR DESCRIPTION
## WHAT

- start Phase 5 by adding a fixture-backed Quick Check eval harness
- add small deterministic plain-text fixtures and a JSON manifest for representative Quick Check cases
- assert retrieval expectations for:
  - review area
  - matched section number
  - matched heading title where applicable
  - retrieval stage
- assert final verdict/status expectations where the current pipeline supports them
- add a dedicated script: `npm run quickcheck:eval`
- keep parser, document model, retrieval, and evaluation boundaries unchanged
- do not add LiteParse
- do not change parser strategy
- do not add tactical alias patches

## WHY

- Phase 5 is now the active roadmap item
- the current bottleneck is measuring whether Quick Check changes improve or regress retrieval and verdict behavior
- this harness makes future fixes measurable instead of whack-a-mole while keeping the current pipeline intact

## VALIDATION

- `npm run typecheck`
- `npm run quickcheck:eval`
- `npx jest tests/lib/quickCheckReviewQuestion.test.ts tests/lib/quickCheckBaselineRubric.test.ts tests/lib/quickCheckReviewRubric.test.ts tests/lib/quickCheckReviewPolicy.test.ts --runInBand`
- `npm run check:docs-layout`

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>