### PR TITLE
[codex] Expand Quick Check eval harness with real-world fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "node --require ./scripts/node-version-shim.js ./node_modules/next/dist/bin/next lint --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "quickcheck:eval": "jest tests/evals/quickCheckEval.test.ts --runInBand",
-    "ci": "npm run guard:methodology-boundary && npm run lint && npm run typecheck && npm run check:docs-layout && npm run roadmap:validate-evidence && npm test && npm run build && npm run check:quick-check-pdf-trace && npm run roadmap:check",
+    "ci": "npm run guard:methodology-boundary && npm run lint && npm run typecheck && npm run check:docs-layout && npm run roadmap:validate-evidence && npm run quickcheck:eval && npm test && npm run build && npm run check:quick-check-pdf-trace && npm run roadmap:check",
     "test": "jest --passWithNoTests",
     "test:e2e": "playwright test",
     "test:audit-pack:smoke": "node scripts/test-audit-pack-smoke.mjs",

--- a/tests/fixtures/quick-check/eval/pd-redd-baseline-page-split.txt
+++ b/tests/fixtures/quick-check/eval/pd-redd-baseline-page-split.txt
@@ -1,0 +1,16 @@
+VCS Version 4.2
+Project Description Document: PD_REDD_v1_130
+
+Page 10 of 85
+
+2.4 (Baseline Scenario)
+The baseline scenario is the most likely land-use scenario in the absence
+of the project activity. The project area consists of tropical forest that
+would otherwise be converted to agricultural land.
+
+Page 11 of 85
+VM0007 Version 4.2
+
+Historical deforestation rates have been estimated at 1.2% per year based
+on satellite imagery analysis covering the period 2010-2020. Without the
+project, carbon stocks would continue to decline due to ongoing deforestation.

--- a/tests/fixtures/quick-check/eval/pd-redd-wrapped-baseline.txt
+++ b/tests/fixtures/quick-check/eval/pd-redd-wrapped-baseline.txt
@@ -1,0 +1,8 @@
+VCS Version 4.2
+VM0007 REDD+ Methodology Modules
+
+2.4
+(Baseline Scenario)
+The baseline scenario is the most likely land-use scenario in the absence
+of the project activity. Historical deforestation rates were estimated
+from satellite imagery analysis covering the period 2010-2020.

--- a/tests/fixtures/quick-check/eval/plum-repeated-stakeholder-title.txt
+++ b/tests/fixtures/quick-check/eval/plum-repeated-stakeholder-title.txt
@@ -1,0 +1,12 @@
+Table of Contents
+
+6  Stakeholder Comments .................................................... 8
+
+--- Document Body ---
+
+6  Stakeholder Comments
+Stakeholder consultation was conducted through community meetings and follow-up sessions.
+Stakeholder comments were documented and resolved in this section.
+
+6.1  Resolution of Comments
+The project team addressed concerns raised during consultation.

--- a/tests/fixtures/quick-check/eval/plum-toc-only-stakeholder.txt
+++ b/tests/fixtures/quick-check/eval/plum-toc-only-stakeholder.txt
@@ -1,0 +1,9 @@
+Table of Contents
+
+2.3  Stakeholder Engagement .................................................... 8
+3.3.3  Monitoring Plan ........................................................ 13
+
+--- Document Body ---
+
+1.1  Project Background
+This project is a reforestation activity in the central highlands.

--- a/tests/fixtures/quick-check/eval/plum-wide-horizontal-monitoring.txt
+++ b/tests/fixtures/quick-check/eval/plum-wide-horizontal-monitoring.txt
@@ -1,0 +1,11 @@
+Project Description / PD
+PLUM Project
+Verra VCS / CCB
+VM0007
+Section 3.1 Application of Methodology
+Section 3.3 Monitoring
+REDD+ Methodology Framework
+
+3.3.3  Monitoring Plan
+The monitoring plan specifies the sampling design and measurement
+protocols. Data and parameters are recorded in the monitoring database.

--- a/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
+++ b/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
@@ -73,6 +73,80 @@
         "matchStage": "none",
         "relevantSections": []
       }
+    },
+    {
+      "id": "wide_horizontal_text_monitoring_plan",
+      "fixture": "plum-wide-horizontal-monitoring.txt",
+      "input": {
+        "claimText": "Check the monitoring plan",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "reviewArea": "monitoring",
+        "matchStage": "exact_heading",
+        "relevantSections": ["3.3", "3.3.3"],
+        "matchedHeadingTitle": "Monitoring"
+      }
+    },
+    {
+      "id": "wrapped_heading_baseline_section",
+      "fixture": "pd-redd-wrapped-baseline.txt",
+      "input": {
+        "claimText": "Does this PDD justify the baseline scenario?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "4.2"
+      },
+      "expected": {
+        "reviewArea": "baseline",
+        "matchStage": "exact_heading",
+        "relevantSections": ["2.4"],
+        "matchedHeadingTitle": "(Baseline Scenario)"
+      }
+    },
+    {
+      "id": "real_world_toc_false_positive_rejected",
+      "fixture": "plum-toc-only-stakeholder.txt",
+      "input": {
+        "claimText": "Does this PDD include stakeholder comments?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "reviewArea": "stakeholder",
+        "matchStage": "none",
+        "relevantSections": []
+      }
+    },
+    {
+      "id": "repeated_stakeholder_title_prefers_body_heading",
+      "fixture": "plum-repeated-stakeholder-title.txt",
+      "input": {
+        "claimText": "Does this PDD include stakeholder comments?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "reviewArea": "stakeholder",
+        "matchStage": "exact_heading",
+        "relevantSections": ["6"],
+        "matchedHeadingTitle": "Stakeholder Comments"
+      }
+    },
+    {
+      "id": "section_body_split_across_pages_baseline",
+      "fixture": "pd-redd-baseline-page-split.txt",
+      "input": {
+        "claimText": "Does this PDD justify the baseline scenario?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "4.2"
+      },
+      "expected": {
+        "reviewArea": "baseline",
+        "matchStage": "exact_heading",
+        "relevantSections": ["2.4"],
+        "matchedHeadingTitle": "(Baseline Scenario)"
+      }
     }
   ],
   "verdictCases": [
@@ -124,6 +198,44 @@
       },
       "expected": {
         "status": "extractor_uncertain"
+      }
+    },
+    {
+      "id": "wrapped_heading_baseline_supported_verdict",
+      "fixture": "pd-redd-wrapped-baseline.txt",
+      "input": {
+        "claimText": "Does this PDD justify the baseline scenario?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "4.2"
+      },
+      "expected": {
+        "status": "partial_evidence_found",
+        "baselineVerdict": "partial"
+      }
+    },
+    {
+      "id": "real_world_toc_false_positive_extractor_uncertain",
+      "fixture": "plum-toc-only-stakeholder.txt",
+      "input": {
+        "claimText": "Does this PDD include stakeholder comments?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "extractor_uncertain"
+      }
+    },
+    {
+      "id": "page_split_baseline_supported_verdict",
+      "fixture": "pd-redd-baseline-page-split.txt",
+      "input": {
+        "claimText": "Does this PDD justify the baseline scenario?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "4.2"
+      },
+      "expected": {
+        "status": "strong_evidence_found",
+        "baselineVerdict": "supported"
       }
     }
   ]


### PR DESCRIPTION
## WHAT

- create a fresh Phase 5 follow-up from latest `main` after `#679`
- expand the Quick Check eval harness with real-world extracted-text fixtures
- add representative cases for:
  - wide horizontal text
  - wrapped headings
  - table-of-contents false positives
  - repeated section titles
  - section body split across pages
- add those cases to the existing Quick Check eval manifest
- explicitly wire `npm run quickcheck:eval` into `npm run ci`, which is what `pr-gate` runs
- keep parser strategy unchanged
- do not add LiteParse
- do not add tactical alias patches

## WHY

- `#679` created the measurement harness, but it still needed real-world failure coverage
- these fixtures make the harness useful against representative user failure patterns instead of only synthetic samples
- explicit CI wiring ensures the eval runs deterministically in the existing gate path

## VALIDATION

- `npm run typecheck`
- `npm run quickcheck:eval`
- `npx jest tests/lib/quickCheckReviewQuestion.test.ts tests/lib/quickCheckBaselineRubric.test.ts tests/lib/quickCheckReviewRubric.test.ts tests/lib/quickCheckReviewPolicy.test.ts --runInBand`
- `npm run check:docs-layout`
- verified `npm run ci` now includes `npm run quickcheck:eval`

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>