### PR TITLE
[codex] Prefer specific monitoring headings in Quick Check evals

### DIFF
--- a/src/lib/quickCheck/retrieval/retrieveSections.ts
+++ b/src/lib/quickCheck/retrieval/retrieveSections.ts
@@ -161,9 +161,7 @@ function withMonitoringAncestors(headings: DocumentHeading[], reviewArea: Review
       if (parent) expanded.push(parent);
     }
   }
-  return uniqueHeadings(expanded).sort(
-    (left, right) => left.sectionNumber.localeCompare(right.sectionNumber, undefined, { numeric: true }),
-  );
+  return uniqueHeadings(expanded);
 }
 
 function exactHeadingMatches(headings: DocumentHeading[], claimText: string): DocumentHeading[] {

--- a/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
+++ b/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
@@ -85,8 +85,8 @@
       "expected": {
         "reviewArea": "monitoring",
         "matchStage": "exact_heading",
-        "relevantSections": ["3.3", "3.3.3"],
-        "matchedHeadingTitle": "Monitoring"
+        "relevantSections": ["3.3.3", "3.3"],
+        "matchedHeadingTitle": "Monitoring Plan"
       }
     },
     {


### PR DESCRIPTION
## WHAT

- create a fresh branch from `main` after `#680`
- run `npm run quickcheck:eval` and use the current harness output to pick one concrete weak case
- fix one specific retrieval weakness: wide-horizontal monitoring text where ancestor expansion promoted `Monitoring` ahead of `Monitoring Plan`
- keep the originally matched heading first and append monitoring ancestors afterward
- update the eval manifest regression for that case so the harness now expects `Monitoring Plan` first and section order `3.3.3`, then `3.3`
- keep parser strategy unchanged for all other cases
- do not add LiteParse
- do not add tactical alias patches
- keep CI coverage through `npm run quickcheck:eval`

## WHY

- `#680` expanded the eval harness with real-world fixtures
- the next step is to use that harness to improve one measurable weak case rather than broadening scope again
- this fix reduces whack-a-mole risk by making the improvement explicit and regression-tested in the eval manifest

## VALIDATION

- `npm run quickcheck:eval`
- `npm run typecheck`
- `npx jest tests/lib/quickCheckReviewQuestion.test.ts tests/lib/quickCheckBaselineRubric.test.ts tests/lib/quickCheckReviewRubric.test.ts tests/lib/quickCheckReviewPolicy.test.ts --runInBand`
- `npm run check:docs-layout`

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>