### PR TITLE
[codex] improve Quick Check leakage eval routing

### DIFF
--- a/src/lib/quickCheck/retrieval/retrieveSections.ts
+++ b/src/lib/quickCheck/retrieval/retrieveSections.ts
@@ -99,7 +99,7 @@ export function classifyReviewArea(claimText: string): ReviewArea {
   if (/legal authority|legal right of use|property rights|ownership|use rights|right of use|land tenure|land and resource use rights|resource use rights|carbon right|entitlement|compliance with laws|statutes|regulatory frameworks|legal status/i.test(normalized)) return "right_of_use";
   if (/leakage\s+belt\b|reference\s+region\b|RRD\b|boundary|geographic\s+boundary|project\s+area|area\s+of|spatial|geographic|polygon/i.test(normalized)) return "boundary";
   if (/deviations|departure|variance|deviation/i.test(normalized)) return "deviations";
-  if (/leakage\s+risk|activity\s+shifting|LK-ASU|displacement/i.test(normalized)) return "leakage";
+  if (/\bleakage\b|activity\s+shifting|LK-ASU|displacement/i.test(normalized)) return "leakage";
   if (/monitoring|sampling|plot|measur/i.test(normalized)) return "monitoring";
   if (/stakeholder|consultation|participation|local communities|community engagement|community consultation|fpic|free prior and informed consent|grievance procedure|community meetings|project awareness/i.test(normalized)) return "stakeholder";
   return "general";

--- a/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
+++ b/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
@@ -46,7 +46,7 @@
       }
     },
     {
-      "id": "leakage_management_semantic_fallback",
+      "id": "leakage_management_alias_heading",
       "fixture": "leakage-semantic.txt",
       "input": {
         "claimText": "Does this PDD address leakage management?",
@@ -54,8 +54,8 @@
         "methodologyVersion": "1.0"
       },
       "expected": {
-        "reviewArea": "general",
-        "matchStage": "semantic_fallback",
+        "reviewArea": "leakage",
+        "matchStage": "alias_heading",
         "relevantSections": ["3.3"],
         "matchedHeadingTitle": "Leakage"
       }
@@ -177,7 +177,7 @@
       }
     },
     {
-      "id": "leakage_semantic_partial_status",
+      "id": "leakage_alias_heading_weak_status",
       "fixture": "leakage-semantic.txt",
       "input": {
         "claimText": "Does this PDD address leakage management?",
@@ -185,7 +185,7 @@
         "methodologyVersion": "1.0"
       },
       "expected": {
-        "status": "partial_evidence_found"
+        "status": "section_found_evidence_weak"
       }
     },
     {

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -180,6 +180,10 @@ describe("classifyReviewArea — boundary", () => {
 });
 
 describe("classifyReviewArea — leakage", () => {
+  it("classifies 'leakage management'", () => {
+    expect(classifyReviewArea("Does this PDD address leakage management?")).toBe("leakage");
+  });
+
   it("classifies 'leakage risk'", () => {
     expect(classifyReviewArea("Does this PDD disclose leakage risk?")).toBe("leakage");
   });
@@ -689,8 +693,9 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
 
     expect(result.relevantSections[0]).toBe("3.3");
     expect(result.sectionContent["3.3"]).toContain("Leakage Management procedures");
-    expect(result.status).toBe("partial_evidence_found");
-    expect(result.matchStage).toBe("semantic_fallback");
+    expect(result.reviewArea).toBe("leakage");
+    expect(result.status).toBe("section_found_evidence_weak");
+    expect(result.matchStage).toBe("alias_heading");
   });
 
   it("prefers 4.3 Monitoring Plan over generic monitoring equipment blocks in the Envira fixture", () => {
@@ -1024,7 +1029,7 @@ describe("Quick Check extraction edge-case coverage", () => {
     expect(result.status).toBe("extractor_uncertain");
   });
 
-  it("keeps semantic fallback matches document-grounded instead of escalating to strong evidence automatically", () => {
+  it("keeps alias-heading leakage matches document-grounded instead of escalating to strong evidence automatically", () => {
     const retrieval = buildReviewQuestionSectionRetrieval({
       claimText: "Does this PDD address leakage management?",
       methodologyId: "VM0007",
@@ -1033,9 +1038,10 @@ describe("Quick Check extraction edge-case coverage", () => {
     });
     const evaluation = evaluateRetrievedReviewQuestion(retrieval);
 
-    expect(retrieval.matchStage).toBe("semantic_fallback");
+    expect(retrieval.reviewArea).toBe("leakage");
+    expect(retrieval.matchStage).toBe("alias_heading");
     expect(retrieval.relevantSections[0]).toBe("3.3");
-    expect(evaluation.status).toBe("partial_evidence_found");
+    expect(evaluation.status).toBe("section_found_evidence_weak");
   });
 });
 


### PR DESCRIPTION
## WHAT

- run `npm run quickcheck:eval` and use the leakage-management case as the next weakest eval target
- classify explicit leakage-management questions under the `leakage` review area instead of falling back to `general`
- keep parser strategy unchanged and avoid LiteParse or tactical alias patches
- update the eval manifest and focused unit expectations to reflect the genuinely better retrieval/verdict behavior

## WHY

- Phase 5 is active and this keeps Quick Check changes measured through the eval harness before any parser work
- the previous eval encoded a retrieval weakness: `Does this PDD address leakage management?` was treated as `general` and only recovered via a generic semantic fallback
- routing that question into the leakage policy is a better general retrieval behavior and produces a more honest `section_found_evidence_weak` verdict for the current fixture

## IMPACT

- explicit leakage questions now follow the leakage retrieval policy earlier
- the leakage eval now asserts a stronger contract: `reviewArea: leakage`, `matchStage: alias_heading`, `status: section_found_evidence_weak`
- focused unit coverage now checks the leakage-management classification and the updated Envira expectations

## VALIDATION

- `npm run quickcheck:eval`
- `npx jest tests/lib/quickCheckReviewQuestion.test.ts --runInBand`
