### PR TITLE
[codex] guard Quick Check boundary precedence

### DIFF
--- a/src/lib/quickCheck/retrieval/retrieveSections.ts
+++ b/src/lib/quickCheck/retrieval/retrieveSections.ts
@@ -87,6 +87,7 @@ export function detectReviewPath(claimText: string): QuickCheckPath {
 
 export function classifyReviewArea(claimText: string): ReviewArea {
   const normalized = claimText.trim().toLowerCase();
+  const hasNonLeakageQualifier = /\bnon[-\s]+leakage\b/i.test(normalized);
 
   const hasBoundaryPair =
     /\bleakage\s+belt\b/i.test(normalized) &&
@@ -99,7 +100,7 @@ export function classifyReviewArea(claimText: string): ReviewArea {
   if (/legal authority|legal right of use|property rights|ownership|use rights|right of use|land tenure|land and resource use rights|resource use rights|carbon right|entitlement|compliance with laws|statutes|regulatory frameworks|legal status/i.test(normalized)) return "right_of_use";
   if (/leakage\s+belt\b|reference\s+region\b|RRD\b|boundary|geographic\s+boundary|project\s+area|area\s+of|spatial|geographic|polygon/i.test(normalized)) return "boundary";
   if (/deviations|departure|variance|deviation/i.test(normalized)) return "deviations";
-  if (/\bleakage\b|activity\s+shifting|LK-ASU|displacement/i.test(normalized)) return "leakage";
+  if (!hasNonLeakageQualifier && (/\bleakage\b|activity\s+shifting|LK-ASU|displacement/i.test(normalized))) return "leakage";
   if (/monitoring|sampling|plot|measur/i.test(normalized)) return "monitoring";
   if (/stakeholder|consultation|participation|local communities|community engagement|community consultation|fpic|free prior and informed consent|grievance procedure|community meetings|project awareness/i.test(normalized)) return "stakeholder";
   return "general";

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -171,6 +171,10 @@ describe("classifyReviewArea — boundary", () => {
     expect(classifyReviewArea("Does this PDD define the project area, leakage belt, and reference region?")).toBe("boundary");
   });
 
+  it("keeps boundary precedence when 'leakage belt' and 'reference region' appear together", () => {
+    expect(classifyReviewArea("Does this PDD define the leakage belt and reference region?")).toBe("boundary");
+  });
+
   it("classifies 'reference region'", () => {
     expect(classifyReviewArea("Does this PDD define the reference region?")).toBe("boundary");
   });
@@ -207,6 +211,10 @@ describe("classifyReviewArea — leakage", () => {
 
   it("classifies standalone 'leakage belt' as boundary when not paired with project area or reference region", () => {
     expect(classifyReviewArea("Please review the leakage belt analysis.")).toBe("boundary");
+  });
+
+  it("does not treat non-leakage accounting issues as leakage questions", () => {
+    expect(classifyReviewArea("Does this PDD describe a non-leakage accounting issue?")).toBe("general");
   });
 });
 


### PR DESCRIPTION
## WHAT

- add a regression test proving `leakage belt` plus `reference region` still routes to `boundary`
- add a small negative-case test for `non-leakage accounting issue`
- add a minimal classifier guard so `non-leakage` phrases do not get swept into the broader leakage match
- leave parser strategy unchanged

## WHY

- PR #684 correctly improved leakage-management routing, but the broader `leakage` classification depends on rule ordering
- this follow-up locks the intended precedence so future edits do not accidentally move boundary phrasing into leakage
- the negative case guards against future over-broad leakage matching from phrases that explicitly negate leakage

## IMPACT

- `leakage belt` with `reference region` remains firmly in the `boundary` review area
- `non-leakage accounting issue` stays out of the `leakage` review area
- no parser or extraction strategy changes

## VALIDATION

- `npx jest tests/lib/quickCheckReviewQuestion.test.ts --runInBand`
