### PR TITLE
[codex] add Quick Check routing diagnostics

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -541,6 +541,7 @@ function joinMethodologyLabels(values: string[]): string {
 }
 
 export default function QuickCheckPanel({ initialMethod, initialVersion, onContinueToWorkspace }: QuickCheckPanelProps) {
+  const showReviewRoutingDiagnostic = process.env.NODE_ENV !== "production" || process.env.NEXT_PUBLIC_VERCEL_ENV === "preview";
   const fileRef = useRef<HTMLInputElement | null>(null);
   const claimRef = useRef<HTMLTextAreaElement | null>(null);
   const resultRef = useRef<HTMLDivElement | null>(null);
@@ -2312,6 +2313,48 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     <p className="mt-2 text-xs text-slate-500">
                       Open full review to inspect these sections against the full document and methodology.
                     </p>
+                  {reviewQuestionResult.routingDiagnostic && showReviewRoutingDiagnostic ? (
+                    <details className="mt-3 text-xs">
+                      <summary className="cursor-pointer font-medium text-slate-500 hover:text-slate-700">
+                        Review routing diagnostic
+                      </summary>
+                      <div className="mt-2 rounded-lg border border-slate-200 bg-white p-3 text-[11px] leading-relaxed text-slate-600">
+                        <div><span className="font-semibold text-slate-500">Question: </span>{reviewQuestionResult.routingDiagnostic.inputReviewQuestion}</div>
+                        <div><span className="font-semibold text-slate-500">Review area: </span>{reviewQuestionResult.routingDiagnostic.classifiedReviewArea}</div>
+                        <div>
+                          <span className="font-semibold text-slate-500">Selected methodology: </span>
+                          {reviewQuestionResult.routingDiagnostic.selectedMethodology.methodologyId || "none"}
+                          {reviewQuestionResult.routingDiagnostic.selectedMethodology.methodologyVersion
+                            ? ` ${reviewQuestionResult.routingDiagnostic.selectedMethodology.methodologyVersion}`
+                            : ""}
+                        </div>
+                        <div className="mt-2">
+                          <div className="font-semibold text-slate-500">Candidate methodology headings found</div>
+                          {reviewQuestionResult.routingDiagnostic.candidateMethodologyHeadingsFound.length > 0 ? (
+                            <ul className="mt-1 list-disc pl-5">
+                              {reviewQuestionResult.routingDiagnostic.candidateMethodologyHeadingsFound.map((heading) => (
+                                <li key={`${heading.sectionNumber}:${heading.title}`} className="font-mono">
+                                  §{heading.sectionNumber} {heading.title}
+                                </li>
+                              ))}
+                            </ul>
+                          ) : (
+                            <div className="mt-1">None</div>
+                          )}
+                        </div>
+                        <div className="mt-2">
+                          <div className="font-semibold text-slate-500">Final routing decision</div>
+                          {reviewQuestionResult.routingDiagnostic.finalMatch ? (
+                            <div className="mt-1 font-mono">
+                              {reviewQuestionResult.routingDiagnostic.finalMatch.matchStage}: §{reviewQuestionResult.routingDiagnostic.finalMatch.heading.sectionNumber} {reviewQuestionResult.routingDiagnostic.finalMatch.heading.title}
+                            </div>
+                          ) : (
+                            <div className="mt-1">{reviewQuestionResult.routingDiagnostic.noMatchReason ?? "No match selected."}</div>
+                          )}
+                        </div>
+                      </div>
+                    </details>
+                  ) : null}
                   {reviewQuestionResult.phase1Diagnostic && process.env.NODE_ENV !== "production" ? (
                     <details className="mt-3" open>
                       <summary className="cursor-pointer text-xs font-medium text-slate-500 hover:text-slate-700">

--- a/src/lib/quickCheck/retrieval/retrieveSections.ts
+++ b/src/lib/quickCheck/retrieval/retrieveSections.ts
@@ -26,6 +26,8 @@ import type {
   QuickCheckPath,
   ReviewArea,
   ReviewQuestionDiagnostic,
+  ReviewRoutingDiagnostic,
+  ReviewRoutingDiagnosticHeading,
   ReviewQuestionMatchStage,
   ReviewQuestionRetrievalResult,
   SectionMatchResult,
@@ -75,7 +77,18 @@ type ReviewQuestionSectionResolution = {
   matchedHeadings: DocumentHeading[];
   rejectedMatches: RejectedHeadingQueryMatch[];
   matchStage: ReviewQuestionMatchStage;
+  stageAttempts: Array<{
+    stage: ReviewQuestionMatchStage;
+    candidateHeadingsFound: ReviewRoutingDiagnosticHeading[];
+  }>;
 };
+
+function toDiagnosticHeading(heading: DocumentHeading): ReviewRoutingDiagnosticHeading {
+  return {
+    sectionNumber: heading.sectionNumber,
+    title: heading.title,
+  };
+}
 
 export function detectReviewPath(claimText: string): QuickCheckPath {
   const normalized = claimText.trim();
@@ -285,6 +298,7 @@ function resolveReviewQuestionSections(input: {
   const claimKeywords = extractClaimKeywords(input.claimText);
   const searchTerms = [...new Set([...reviewAreaKeywords, ...aliases, ...claimKeywords.phrases, ...claimKeywords.words])];
   const fallbackStages = getFallbackStages();
+  const stageAttempts: ReviewQuestionSectionResolution["stageAttempts"] = [];
 
   for (const stage of fallbackStages) {
     let matches: DocumentHeading[] = [];
@@ -301,11 +315,17 @@ function resolveReviewQuestionSections(input: {
       matches = uniqueHeadings(semanticFallbackMatches(input.headingIndex, input.reviewArea, searchTerms, claimKeywords));
     }
 
+    stageAttempts.push({
+      stage,
+      candidateHeadingsFound: matches.map(toDiagnosticHeading),
+    });
+
     if (matches.length > 0) {
       return {
         matchedHeadings: withMonitoringAncestors(matches, input.reviewArea, input.headingIndex),
         rejectedMatches: [],
         matchStage: stage,
+        stageAttempts,
       };
     }
   }
@@ -313,7 +333,41 @@ function resolveReviewQuestionSections(input: {
   const rejectedMatches = input.rawPddText
     ? findRejectedHeadingMatches(input.rawPddText, input.claimText || "", [...reviewAreaKeywords, ...aliases])
     : [];
-  return { matchedHeadings: [], rejectedMatches, matchStage: "none" };
+  return { matchedHeadings: [], rejectedMatches, matchStage: "none", stageAttempts };
+}
+
+function buildRoutingDiagnostic(input: BuildReviewQuestionSectionRetrievalInput & {
+  reviewArea: ReviewArea;
+  sectionResolution: ReviewQuestionSectionResolution;
+  noMatchExplanation?: string;
+}): ReviewRoutingDiagnostic {
+  const candidateMethodologyHeadingsFound = input.sectionResolution.stageAttempts
+    .flatMap((attempt) => attempt.candidateHeadingsFound)
+    .filter((heading, index, list) =>
+      list.findIndex((candidate) => candidate.sectionNumber === heading.sectionNumber && candidate.title === heading.title) === index,
+    );
+
+  const firstMatchedHeading = input.sectionResolution.matchedHeadings[0];
+
+  return {
+    inputReviewQuestion: input.claimText,
+    classifiedReviewArea: input.reviewArea,
+    selectedMethodology: {
+      methodologyId: input.methodologyId,
+      methodologyVersion: input.methodologyVersion,
+    },
+    candidateMethodologyHeadingsFound,
+    stageAttempts: input.sectionResolution.stageAttempts,
+    finalMatch: firstMatchedHeading
+      ? {
+          matchStage: input.sectionResolution.matchStage,
+          heading: toDiagnosticHeading(firstMatchedHeading),
+        }
+      : null,
+    noMatchReason: firstMatchedHeading
+      ? undefined
+      : input.noMatchExplanation ?? "No routing stage produced a usable methodology heading match.",
+  };
 }
 
 export function findMatchedSectionNumbers(
@@ -503,6 +557,15 @@ export function buildReviewQuestionSectionRetrieval(
   const phase1Diagnostic = process.env.NODE_ENV !== "production" && input.rawPddText
     ? buildPhase1Diagnostic(input.rawPddText, sectionContent, reviewArea, input.claimText, claimKeywords, input.evidenceSourceLabel, input.evidenceDocumentType)
     : undefined;
+  const routingDiagnostic =
+    (process.env.NODE_ENV !== "production" || process.env.NEXT_PUBLIC_VERCEL_ENV === "preview")
+      ? buildRoutingDiagnostic({
+          ...input,
+          reviewArea,
+          sectionResolution,
+          noMatchExplanation,
+        })
+      : undefined;
 
   return {
     path: "review_question_answering",
@@ -519,5 +582,6 @@ export function buildReviewQuestionSectionRetrieval(
     noMatchExplanation,
     diagnostic,
     phase1Diagnostic,
+    routingDiagnostic,
   };
 }

--- a/src/lib/quickCheck/retrieval/types.ts
+++ b/src/lib/quickCheck/retrieval/types.ts
@@ -62,6 +62,32 @@ export type ReviewQuestionDiagnostic = {
   threshold: number;
 };
 
+export type ReviewRoutingDiagnosticHeading = {
+  sectionNumber: string;
+  title: string;
+};
+
+export type ReviewRoutingDiagnosticStageAttempt = {
+  stage: ReviewQuestionMatchStage;
+  candidateHeadingsFound: ReviewRoutingDiagnosticHeading[];
+};
+
+export type ReviewRoutingDiagnostic = {
+  inputReviewQuestion: string;
+  classifiedReviewArea: ReviewArea;
+  selectedMethodology: {
+    methodologyId: string;
+    methodologyVersion: string;
+  };
+  candidateMethodologyHeadingsFound: ReviewRoutingDiagnosticHeading[];
+  stageAttempts: ReviewRoutingDiagnosticStageAttempt[];
+  finalMatch: {
+    matchStage: ReviewQuestionMatchStage;
+    heading: ReviewRoutingDiagnosticHeading;
+  } | null;
+  noMatchReason?: string;
+};
+
 export type ReviewQuestionResult = {
   path: QuickCheckPath;
   reviewArea: ReviewArea;
@@ -78,6 +104,7 @@ export type ReviewQuestionResult = {
   noMatchExplanation?: string;
   diagnostic?: Record<string, string>;
   phase1Diagnostic?: ReviewQuestionDiagnostic;
+  routingDiagnostic?: ReviewRoutingDiagnostic;
 };
 
 export type ReviewQuestionRetrievalResult = Omit<ReviewQuestionResult, "baselineReview" | "reviewAreaReview"> & {

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -956,6 +956,32 @@ describe("computeSectionMatchResults — match diagnostics", () => {
       expect(result.phase1Diagnostic.claimKeywords.phrases.length).toBeGreaterThan(0);
     }
   });
+
+  it("populates routingDiagnostic with question, methodology, candidates, and final match in dev mode", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD contain the baseline scenario?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: PDD,
+    });
+
+    expect(result.routingDiagnostic).toEqual(expect.objectContaining({
+      inputReviewQuestion: "Does this PDD contain the baseline scenario?",
+      classifiedReviewArea: "baseline",
+      selectedMethodology: {
+        methodologyId: "VM0007",
+        methodologyVersion: "1.0",
+      },
+      candidateMethodologyHeadingsFound: expect.arrayContaining([
+        expect.objectContaining({ title: "Baseline Scenario" }),
+      ]),
+      finalMatch: expect.objectContaining({
+        matchStage: expect.any(String),
+        heading: expect.objectContaining({ title: "Baseline Scenario" }),
+      }),
+      stageAttempts: expect.any(Array),
+    }));
+  });
 });
 
 describe("Quick Check extraction edge-case coverage", () => {


### PR DESCRIPTION
## WHAT

- add a dev/preview-only Quick Check routing diagnostic payload for review-question runs
- expose the internal routing decision path with:
  - input review question
  - classified review area
  - selected methodology
  - candidate methodology headings found
  - final matched heading or reason no match was selected
- surface the routing diagnostic in a collapsed dev-only panel section while keeping the normal user-facing UI clean
- add lib-level regression coverage for the diagnostic output shape
- do not change parser strategy, classifier behavior, or methodology retrieval

## WHY

- recent Quick Check failures have mixed signals: some look like classification problems, while others look like heading or retrieval matching problems
- without visibility into the routing pipeline, we risk applying classifier fixes to bugs that really live in heading selection or methodology-aware matching
- this gives us evidence before attempting a broader classifier refactor

## IMPACT

- development and preview environments can inspect review-routing decisions without exposing extra UI in normal production use
- the retrieval result now carries a structured `routingDiagnostic` object for review-question runs
- no parser or retrieval behavior changes were introduced in this PR

## VALIDATION

- `npx jest tests/lib/quickCheckReviewQuestion.test.ts --runInBand`
- `npm run quickcheck:eval`
- `npm run typecheck`
