### PR TITLE
Improve boundary heading ranking

### DIFF
--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -704,6 +704,25 @@ function buildHeadingQueryTokens(query: string): string[] {
     .filter((token) => !HEADING_QUERY_LOW_SIGNAL_TOKENS.has(token));
 }
 
+function scoreBoundaryHeadingSpecificity(query: string, heading: DocumentHeading): number {
+  const normalizedQuery = stripHeadingQueryBoilerplate(query);
+  if (!normalizedQuery) return 0;
+
+  const asksForDirectBoundaryTerms =
+    /\bproject boundary\b|\bboundary\b|\bleakage belt\b|\breference region\b/.test(normalizedQuery);
+  if (!asksForDirectBoundaryTerms) return 0;
+
+  const title = heading.normalizedTitle;
+  let score = 0;
+
+  if (/\bproject boundary\b|\bboundary\b/.test(title)) score += 55;
+  if (/\breference region\b/.test(title)) score += 40;
+  if (/\bleakage belt\b/.test(title)) score += 30;
+  if (/\blocation\b/.test(title) && !/\bboundary\b/.test(title)) score -= 35;
+
+  return score;
+}
+
 function sharedPrefixLength(a: string, b: string): number {
   const max = Math.min(a.length, b.length);
   let idx = 0;
@@ -809,6 +828,7 @@ export function scoreHeadingAgainstQuery(
   score += contiguousBigrams * 35;
   score += Math.round(coverage * 100);
   score += fallbackKeywordMatches.reduce((total, keyword) => total + (keyword.includes(" ") ? 28 : 18), 0);
+  score += scoreBoundaryHeadingSpecificity(query, heading);
   if (queryTokens.length === 1 && exactTokenMatches.length > 0) score += 120;
   else if (queryTokens.length === 1 && softTokenMatches.length > 0) score += 80;
 

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -90,6 +90,18 @@ const ENVIRA_TEXT = fs.readFileSync(
   "utf8",
 );
 
+const BOUNDARY_RANKING_PDD = [
+  "2.2  Project Location",
+  "The project location is described with regional context and coordinates.",
+  "",
+  "2.3  Project Boundary",
+  "The project boundary defines the project area, leakage belt, and reference region.",
+  "",
+  "3.3  Leakage",
+  "Leakage from activity shifting is assessed and mitigated in this section.",
+  "",
+].join("\n");
+
 describe("detectReviewPath", () => {
   it("routes 'Does this PDD support additionality under VT0001?' to review_question_answering", () => {
     expect(detectReviewPath("Does this PDD support additionality under VT0001?")).toBe("review_question_answering");
@@ -688,6 +700,32 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(result.reviewArea).toBe("leakage");
     expect(result.status).toBe("section_found_evidence_weak");
     expect(result.matchStage).toBe("alias_heading");
+  });
+
+  it("ranks Project Boundary above Project Location for leakage belt and reference region questions", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD define the leakage belt and reference region?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BOUNDARY_RANKING_PDD,
+    });
+
+    expect(result.relevantSections[0]).toBe("2.3");
+    expect(result.matchedHeadings[0]?.title).toBe("Project Boundary");
+    expect(result.sectionContent["2.3"]).toContain("reference region");
+  });
+
+  it("preserves leakage ranking for activity shifting questions", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD assess leakage from activity shifting?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BOUNDARY_RANKING_PDD,
+    });
+
+    expect(result.relevantSections[0]).toBe("3.3");
+    expect(result.matchedHeadings[0]?.title).toBe("Leakage");
+    expect(result.sectionContent["3.3"]).toContain("activity shifting");
   });
 
   it("prefers 4.3 Monitoring Plan over generic monitoring equipment blocks in the Envira fixture", () => {


### PR DESCRIPTION
## Summary
- improve Quick Check final heading ranking for boundary questions
- prefer direct boundary headings like `Project Boundary` over broader location headings when the question mentions `leakage belt`, `reference region`, or `project boundary`
- add regression coverage for the boundary ranking case and preserve leakage ranking for activity-shifting questions

## Validation
- `npm test -- --runTestsByPath tests/lib/quickCheckReviewQuestion.test.ts`
- pre-push `lint`
- pre-push `typecheck`
