### PR TITLE
[codex] Add liteparse parser adapter

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -168,7 +168,6 @@ Lane status: Active
 Move Quick Check from tactical section-matching patches to a layered document pipeline with explicit parser, document-model, retrieval, evaluation, UI, and eval boundaries.
 
 Not active now:
-- LiteParse integration
 - Additional Quick Check tactical alias patches
 
 

--- a/docs/roadmaps/quick-check-document-pipeline.md
+++ b/docs/roadmaps/quick-check-document-pipeline.md
@@ -126,7 +126,9 @@ Objective: add LiteParse as a second parser adapter after the boundary and docum
 Scope:
 
 - Implement LiteParse behind the same adapter contract.
+- Keep canonical document model output stable.
 - Keep retrieval/evaluation unchanged when switching adapters.
+- Do not add tactical alias patches while introducing the adapter.
 
 Exit criteria:
 
@@ -153,4 +155,4 @@ Exit criteria:
 
 ## Immediate next action
 
-Start Phase 2 by adding `src/lib/documentModel/` and the first `ParsedDocument -> Article6DocumentModel` conversion without refactoring retrieval, evaluation, or UI consumers yet.
+Continue Phase 6 by wiring LiteParse behind the existing parser adapter contract with env-based selection and safe fallback, while keeping canonical document model output stable, leaving retrieval/evaluation behavior unchanged, and avoiding new tactical alias patches.

--- a/docs/roadmaps/quick-check-document-pipeline/phase-status.json
+++ b/docs/roadmaps/quick-check-document-pipeline/phase-status.json
@@ -2,7 +2,7 @@
   "roadmap": "quick-check-document-pipeline",
   "repo": "Fredilly/app.article6",
   "status": "active",
-  "current_phase": "phase_5_eval_harness",
+  "current_phase": "phase_6_secondary_parser_adapter",
   "phase_1_parser_adapter_boundary": {
     "status": "done",
     "title": "Phase 1 — parser adapter boundary",
@@ -24,28 +24,28 @@
     "summary": "Move aliases, preferred sections, negative sections, fallback rules, boosts, penalties, and evidence signals into typed JSON validated by Zod."
   },
   "phase_5_eval_harness": {
-    "status": "active",
+    "status": "done",
     "title": "Phase 5 — Quick Check eval harness",
     "summary": "Add fixture-backed retrieval and verdict evals so pipeline changes are measured and gated before merge."
   },
   "phase_6_secondary_parser_adapter": {
-    "status": "planned",
+    "status": "active",
     "title": "Phase 6 — secondary parser adapter",
     "summary": "Add LiteParse as a second parser adapter only after the adapter boundary and canonical document model are stable."
   },
   "phase_meta": {
     "status": "active",
     "summary": "Move Quick Check from tactical section-matching patches to a layered document pipeline with explicit parser, document-model, retrieval, evaluation, UI, and eval boundaries.",
-    "current_focus": "Phase 5 only: plan and implement a fixture-backed Quick Check eval harness for retrieval and verdict regression testing before more parser work. Phase 4 declarative review policy is complete, and LiteParse remains out of scope until the eval harness exists.",
+    "current_focus": "Phase 6 implementation is active: add LiteParse as a secondary parser adapter behind the existing parser boundary with env-based selection and safe fallback, while keeping canonical document model output stable and leaving retrieval/evaluation semantics unchanged.",
     "not_active_now": [
-      "LiteParse integration",
       "Additional Quick Check tactical alias patches"
     ],
-    "last_updated_at": "2026-06-01T08:15:00Z"
+    "last_updated_at": "2026-06-01T23:16:06Z"
   },
   "pr_evidence": {
     "phase_2_article6_document_model": [667],
     "phase_3_retrieval_evaluation_split": [669, 670, 671],
-    "phase_4_declarative_review_policy": [676, 677]
+    "phase_4_declarative_review_policy": [676, 677],
+    "phase_5_eval_harness": [679, 680]
   }
 }

--- a/src/lib/documentParsing/adapters/liteParse.ts
+++ b/src/lib/documentParsing/adapters/liteParse.ts
@@ -1,0 +1,82 @@
+import { currentExtractorAdapter } from "@/lib/documentParsing/adapters/currentExtractor";
+import type {
+  DocumentParserAdapter,
+  ParseDocumentTextInput,
+  ParsedDocument,
+  ParserDiagnostics,
+} from "@/lib/documentParsing/types";
+
+type LiteParseAdapterOutput = Omit<ParsedDocument, "adapterId" | "source" | "rawText"> & {
+  source?: string;
+} & Partial<Pick<ParsedDocument, "rawText" | "adapterId">>;
+
+type LiteParseImplementation = {
+  isAvailable?: () => boolean;
+  parseText: (input: ParseDocumentTextInput) => LiteParseAdapterOutput;
+};
+
+let liteParseImplementation: LiteParseImplementation | null = null;
+
+function withFallbackDiagnostics(
+  diagnostics: ParserDiagnostics | undefined,
+  warning: string,
+): ParserDiagnostics {
+  return {
+    warnings: [...(diagnostics?.warnings ?? []), warning],
+    metadata: {
+      ...(diagnostics?.metadata ?? {}),
+      fallback_from: "liteparse",
+    },
+  };
+}
+
+function fallbackToCurrentExtractor(
+  input: ParseDocumentTextInput,
+  reason: string,
+): ParsedDocument {
+  const fallback = currentExtractorAdapter.parseText(input);
+  return {
+    ...fallback,
+    diagnostics: withFallbackDiagnostics(fallback.diagnostics, reason),
+  };
+}
+
+function normalizeLiteParseOutput(
+  input: ParseDocumentTextInput,
+  output: LiteParseAdapterOutput,
+): ParsedDocument {
+  return {
+    ...output,
+    adapterId: "liteparse",
+    source: output.source ?? "liteparse",
+    rawText: input.rawText ?? "",
+  };
+}
+
+export function setLiteParseImplementationForTests(
+  implementation: LiteParseImplementation | null,
+): void {
+  liteParseImplementation = implementation;
+}
+
+export const liteParseAdapter: DocumentParserAdapter = {
+  id: "liteparse",
+  parseText(input: ParseDocumentTextInput): ParsedDocument {
+    const implementation = liteParseImplementation;
+
+    if (!implementation || implementation.isAvailable?.() === false) {
+      return fallbackToCurrentExtractor(input, "LiteParse unavailable; fell back to current extractor.");
+    }
+
+    try {
+      const output = implementation.parseText(input);
+      return normalizeLiteParseOutput(input, output);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return fallbackToCurrentExtractor(
+        input,
+        `LiteParse failed at runtime; fell back to current extractor. ${message}`,
+      );
+    }
+  },
+};

--- a/src/lib/documentParsing/index.ts
+++ b/src/lib/documentParsing/index.ts
@@ -1,5 +1,7 @@
 import { currentExtractorAdapter } from "@/lib/documentParsing/adapters/currentExtractor";
+import { liteParseAdapter } from "@/lib/documentParsing/adapters/liteParse";
 import {
+  DOCUMENT_PARSER_ADAPTER_IDS,
   DEFAULT_DOCUMENT_PARSER_ADAPTER_ID,
   type DocumentParserAdapter,
   type DocumentParserAdapterId,
@@ -9,17 +11,35 @@ import {
 
 const ADAPTERS: Record<DocumentParserAdapterId, DocumentParserAdapter> = {
   "current-extractor": currentExtractorAdapter,
+  liteparse: liteParseAdapter,
 };
 
+function isDocumentParserAdapterId(value: string): value is DocumentParserAdapterId {
+  return (DOCUMENT_PARSER_ADAPTER_IDS as readonly string[]).includes(value);
+}
+
+export function listDocumentParserAdapters(): DocumentParserAdapter[] {
+  return DOCUMENT_PARSER_ADAPTER_IDS.map((adapterId) => ADAPTERS[adapterId]);
+}
+
+export function resolveConfiguredDocumentParserAdapterId(
+  configuredValue: string | undefined = process.env.QUICK_CHECK_PARSER,
+): DocumentParserAdapterId {
+  if (configuredValue && isDocumentParserAdapterId(configuredValue)) {
+    return configuredValue;
+  }
+  return DEFAULT_DOCUMENT_PARSER_ADAPTER_ID;
+}
+
 export function getDocumentParserAdapter(
-  adapterId: DocumentParserAdapterId = DEFAULT_DOCUMENT_PARSER_ADAPTER_ID,
+  adapterId: DocumentParserAdapterId = resolveConfiguredDocumentParserAdapterId(),
 ): DocumentParserAdapter {
   return ADAPTERS[adapterId];
 }
 
 export function parseDocumentText(
   input: ParseDocumentTextInput,
-  adapterId: DocumentParserAdapterId = DEFAULT_DOCUMENT_PARSER_ADAPTER_ID,
+  adapterId: DocumentParserAdapterId = resolveConfiguredDocumentParserAdapterId(),
 ): ParsedDocument {
   return getDocumentParserAdapter(adapterId).parseText(input);
 }

--- a/src/lib/documentParsing/types.ts
+++ b/src/lib/documentParsing/types.ts
@@ -1,8 +1,13 @@
 import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
 
+export const DOCUMENT_PARSER_ADAPTER_IDS = [
+  "current-extractor",
+  "liteparse",
+] as const;
+
 export const DEFAULT_DOCUMENT_PARSER_ADAPTER_ID = "current-extractor" as const;
 
-export type DocumentParserAdapterId = typeof DEFAULT_DOCUMENT_PARSER_ADAPTER_ID;
+export type DocumentParserAdapterId = typeof DOCUMENT_PARSER_ADAPTER_IDS[number];
 
 export type ParseDocumentTextInput = {
   rawText: string;

--- a/tests/lib/documentModel.test.ts
+++ b/tests/lib/documentModel.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "@jest/globals";
+import { afterEach, describe, expect, it } from "@jest/globals";
 import { parseDocumentText } from "@/lib/documentParsing";
 import { buildArticle6DocumentModel } from "@/lib/documentModel";
+import { currentExtractorAdapter } from "@/lib/documentParsing/adapters/currentExtractor";
+import { setLiteParseImplementationForTests } from "@/lib/documentParsing/adapters/liteParse";
 
 const NESTED_PDD_TEXT = [
   "4.3  Monitoring Plan",
@@ -14,6 +16,11 @@ const NESTED_PDD_TEXT = [
 ].join("\n");
 
 describe("buildArticle6DocumentModel", () => {
+  afterEach(() => {
+    delete process.env.QUICK_CHECK_PARSER;
+    setLiteParseImplementationForTests(null);
+  });
+
   it("converts parser output into a canonical Article6 document model", () => {
     const parsedDocument = parseDocumentText({ rawText: NESTED_PDD_TEXT });
     const model = buildArticle6DocumentModel({ parsedDocument });
@@ -92,5 +99,27 @@ describe("buildArticle6DocumentModel", () => {
 
     expect(withoutDebug.debug).toBeUndefined();
     expect(withDebug.debug?.parserOutput).toEqual(parsedDocument);
+  });
+
+  it("keeps the canonical document model path intact when liteparse is selected", () => {
+    setLiteParseImplementationForTests({
+      parseText(input) {
+        const baseline = currentExtractorAdapter.parseText(input);
+        return {
+          ...baseline,
+          source: "liteparse",
+        };
+      },
+    });
+    process.env.QUICK_CHECK_PARSER = "liteparse";
+
+    const parsedDocument = parseDocumentText({ rawText: NESTED_PDD_TEXT });
+    const model = buildArticle6DocumentModel({ parsedDocument });
+
+    expect(parsedDocument.adapterId).toBe("liteparse");
+    expect(model.parserAdapterId).toBe("liteparse");
+    expect(model.sections.map((section) => section.sectionNumber)).toEqual(expect.arrayContaining(["4.3", "4.3.1", "6"]));
+    expect(model.blocks.some((block) => block.type === "heading")).toBe(true);
+    expect(model.pages).toHaveLength(1);
   });
 });

--- a/tests/lib/documentParsing.test.ts
+++ b/tests/lib/documentParsing.test.ts
@@ -1,14 +1,19 @@
-import { describe, expect, it } from "@jest/globals";
+import { afterEach, describe, expect, it } from "@jest/globals";
 import {
   buildPddHeadingIndex,
   debugSectionExtraction,
   extractPddSections,
 } from "@/lib/chat/quickCheckSectionExtractor";
 import {
+  DOCUMENT_PARSER_ADAPTER_IDS,
   DEFAULT_DOCUMENT_PARSER_ADAPTER_ID,
   getDocumentParserAdapter,
+  listDocumentParserAdapters,
   parseDocumentText,
+  resolveConfiguredDocumentParserAdapterId,
 } from "@/lib/documentParsing";
+import { currentExtractorAdapter } from "@/lib/documentParsing/adapters/currentExtractor";
+import { setLiteParseImplementationForTests } from "@/lib/documentParsing/adapters/liteParse";
 
 const VM0007_TEXT = [
   "1.9  Project Boundary",
@@ -22,6 +27,19 @@ const VM0007_TEXT = [
 ].join("\n");
 
 describe("documentParsing current extractor adapter", () => {
+  afterEach(() => {
+    delete process.env.QUICK_CHECK_PARSER;
+    setLiteParseImplementationForTests(null);
+  });
+
+  it("registers both parser adapters while keeping current-extractor as the default", () => {
+    expect(DOCUMENT_PARSER_ADAPTER_IDS).toEqual(["current-extractor", "liteparse"]);
+    expect(listDocumentParserAdapters().map((adapter) => adapter.id)).toEqual(["current-extractor", "liteparse"]);
+    expect(resolveConfiguredDocumentParserAdapterId(undefined)).toBe("current-extractor");
+    expect(resolveConfiguredDocumentParserAdapterId("invalid-parser")).toBe("current-extractor");
+    expect(getDocumentParserAdapter().id).toBe(DEFAULT_DOCUMENT_PARSER_ADAPTER_ID);
+  });
+
   it("exposes the current extractor as the default parser adapter", () => {
     expect(getDocumentParserAdapter().id).toBe(DEFAULT_DOCUMENT_PARSER_ADAPTER_ID);
   });
@@ -66,5 +84,53 @@ describe("documentParsing current extractor adapter", () => {
     expect(parsed.sectionsByNumber).toEqual({});
     expect(parsed.headingIndex).toEqual([]);
     expect(parsed.diagnostics).toBeUndefined();
+  });
+
+  it("selects liteparse from QUICK_CHECK_PARSER without changing the parsed-document contract", () => {
+    setLiteParseImplementationForTests({
+      parseText(input) {
+        const baseline = currentExtractorAdapter.parseText(input);
+        return {
+          ...baseline,
+          normalizedText: `${baseline.normalizedText}\n`,
+          source: "liteparse",
+        };
+      },
+    });
+    process.env.QUICK_CHECK_PARSER = "liteparse";
+
+    const parsed = parseDocumentText({ rawText: VM0007_TEXT });
+
+    expect(getDocumentParserAdapter().id).toBe("liteparse");
+    expect(parsed.adapterId).toBe("liteparse");
+    expect(parsed.source).toBe("liteparse");
+    expect(parsed.headings.map((heading) => heading.sectionNumber)).toEqual(["1.9", "2.4", "4.3"]);
+    expect(parsed.sectionsByNumber).toEqual(extractPddSections(VM0007_TEXT));
+    expect(parsed.headingIndex).toEqual(buildPddHeadingIndex(VM0007_TEXT));
+  });
+
+  it("falls back to current-extractor when liteparse is unavailable", () => {
+    process.env.QUICK_CHECK_PARSER = "liteparse";
+
+    const parsed = parseDocumentText({ rawText: VM0007_TEXT });
+
+    expect(parsed.adapterId).toBe("current-extractor");
+    expect(parsed.source).toBe("current-extractor");
+    expect(parsed.diagnostics?.warnings).toContain("LiteParse unavailable; fell back to current extractor.");
+  });
+
+  it("falls back to current-extractor when liteparse throws at runtime", () => {
+    setLiteParseImplementationForTests({
+      parseText() {
+        throw new Error("simulated liteparse failure");
+      },
+    });
+    process.env.QUICK_CHECK_PARSER = "liteparse";
+
+    const parsed = parseDocumentText({ rawText: VM0007_TEXT });
+
+    expect(parsed.adapterId).toBe("current-extractor");
+    expect(parsed.sectionsByNumber).toEqual(extractPddSections(VM0007_TEXT));
+    expect(parsed.diagnostics?.warnings?.some((warning) => warning.includes("simulated liteparse failure"))).toBe(true);
   });
 });

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@jest/globals";
+import { afterEach, describe, expect, it } from "@jest/globals";
 import fs from "fs";
 import path from "path";
 import {
@@ -16,6 +16,7 @@ import {
   type SectionMatchResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
 import { filterPddHeadingsByQuery } from "@/lib/chat/quickCheckSectionExtractor";
+import { setLiteParseImplementationForTests } from "@/lib/documentParsing/adapters/liteParse";
 
 const VM0007_BASELINE_PDD_TEXT = [
   "1.10  Leakage",
@@ -89,6 +90,11 @@ const ENVIRA_TEXT = fs.readFileSync(
   path.join(__dirname, "../fixtures/quick-check/envira-amazonia-vm0007-extracted.txt"),
   "utf8",
 );
+
+afterEach(() => {
+  delete process.env.QUICK_CHECK_PARSER;
+  setLiteParseImplementationForTests(null);
+});
 
 const BOUNDARY_RANKING_PDD = [
   "2.2  Project Location",
@@ -755,6 +761,26 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(result.relevantSections[0]).toBe("3.3");
     expect(result.matchedHeadings[0]?.title).toBe("Leakage");
     expect(result.sectionContent["3.3"]).toContain("activity shifting");
+  });
+
+  it("falls back to the current extractor without breaking Quick Check when liteparse fails", () => {
+    setLiteParseImplementationForTests({
+      parseText() {
+        throw new Error("liteparse unavailable in test");
+      },
+    });
+    process.env.QUICK_CHECK_PARSER = "liteparse";
+
+    const result = buildReviewQuestionResult({
+      claimText: "Does this PDD define the leakage belt and reference region?",
+      methodologyId: "VM0007",
+      methodologyVersion: "1.0",
+      rawPddText: BOUNDARY_RANKING_PDD,
+    });
+
+    expect(result.relevantSections[0]).toBe("2.3");
+    expect(result.matchedHeadings[0]?.title).toBe("Project Boundary");
+    expect(result.headingIndex.length).toBeGreaterThan(0);
   });
 
   it("prefers 4.3 Monitoring Plan over generic monitoring equipment blocks in the Envira fixture", () => {


### PR DESCRIPTION
## Summary
- start Phase 6 of the Quick Check document pipeline by adding a secondary `liteparse` parser adapter behind the existing document parsing boundary
- keep Quick Check retrieval and evaluation behavior unchanged while adding env-based parser selection and safe fallback to `current-extractor`
- add parser registry, default-selection, canonical document model, and fallback coverage, plus roadmap updates for active Phase 6 work

## Why
- Phase 6 is about making parser choice swappable without rewriting Quick Check logic
- this keeps Article6 review behavior parser-neutral and lets extraction quality be tested behind the adapter contract
- the change does not add tactical aliases, heading patches, or review-area behavior changes

## Validation
- `npm run typecheck`
- `npm run quickcheck:eval`
- `npm test -- --runInBand`
- `npm run ci`
