### PR TITLE
[codex] Add semantic evidence retrieval for Quick Check

### DIFF
--- a/src/app/api/quick-check/semantic-evidence/route.ts
+++ b/src/app/api/quick-check/semantic-evidence/route.ts
@@ -1,0 +1,51 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { withMetrics } from "@/lib/metrics";
+import { suggestSemanticEvidenceCandidates } from "@/lib/quickCheck/semanticEvidence/huggingFace";
+
+async function handlePost(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body.", code: "invalid-json" }, { status: 400 });
+  }
+
+  const claimText = typeof body === "object" && body && "claimText" in body && typeof body.claimText === "string"
+    ? body.claimText
+    : "";
+  const rawPddText = typeof body === "object" && body && "rawPddText" in body && typeof body.rawPddText === "string"
+    ? body.rawPddText
+    : "";
+  const methodologyId = typeof body === "object" && body && "methodologyId" in body && typeof body.methodologyId === "string"
+    ? body.methodologyId
+    : "";
+  const methodologyVersion = typeof body === "object" && body && "methodologyVersion" in body && typeof body.methodologyVersion === "string"
+    ? body.methodologyVersion
+    : "";
+
+  if (!claimText.trim() || !rawPddText.trim()) {
+    return NextResponse.json({ error: "claimText and rawPddText are required.", code: "missing-input" }, { status: 400 });
+  }
+
+  const result = await suggestSemanticEvidenceCandidates({
+    claimText,
+    rawPddText,
+    methodologyId,
+    methodologyVersion,
+  });
+
+  return NextResponse.json(result);
+}
+
+async function handleGet() {
+  return NextResponse.json({
+    ok: true,
+    configured: Boolean(process.env.HF_API_KEY),
+    model: "openbmb/MiniCPM5-1B",
+  });
+}
+
+export const POST = withMetrics("api/quick-check/semantic-evidence:POST", handlePost);
+export const GET = withMetrics("api/quick-check/semantic-evidence:GET", handleGet);

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -57,6 +57,7 @@ import {
   type ReviewQuestionResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
 import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
+import { fetchSemanticEvidenceCandidates } from "@/lib/quickCheck/semanticEvidence/client";
 
 type MethodInventoryRecord = {
   code: string;
@@ -546,6 +547,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const claimRef = useRef<HTMLTextAreaElement | null>(null);
   const resultRef = useRef<HTMLDivElement | null>(null);
   const rulesCache = useRef(new Map<string, RuleSummary[]>());
+  const reviewQuestionRunRef = useRef(0);
 
   const [methods, setMethods] = useState<MethodInventoryRecord[]>([]);
   const [loadingMethods, setLoadingMethods] = useState(false);
@@ -1439,7 +1441,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
       if (detectReviewPath(effectiveClaimText) === "review_question_answering") {
         const firstSource = selectedEvidenceSources[0];
-        const questionResult = buildReviewQuestionResult({
+        const baseQuestionResult = buildReviewQuestionResult({
           claimText: effectiveClaimText,
           methodologyId: resolvedMethodologyId,
           methodologyVersion: resolvedMethodologyVersion,
@@ -1447,11 +1449,50 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           evidenceSourceLabel: firstSource?.sourceLabel,
           evidenceDocumentType: evidenceAnalysis.documentTypes[0],
         });
-        setReviewQuestionResult(questionResult);
+        const runId = reviewQuestionRunRef.current + 1;
+        reviewQuestionRunRef.current = runId;
+        setReviewQuestionResult({
+          ...baseQuestionResult,
+          semanticEvidenceStatus: evidenceAnalysis.rawPddText?.trim() ? "disabled" : "no_input",
+          semanticEvidenceWarning: evidenceAnalysis.rawPddText?.trim()
+            ? "Loading semantic evidence suggestions."
+            : "No parsed PDD text available for semantic evidence suggestions.",
+        });
         setSelectedHeading(null);
         setRecoveryState(null);
         setFieldErrors({});
         setSubmitting(false);
+        if (evidenceAnalysis.rawPddText?.trim()) {
+          void fetchSemanticEvidenceCandidates({
+            claimText: effectiveClaimText,
+            rawPddText: evidenceAnalysis.rawPddText,
+            methodologyId: resolvedMethodologyId,
+            methodologyVersion: resolvedMethodologyVersion,
+          })
+            .then((semanticEvidence) => {
+              if (reviewQuestionRunRef.current !== runId) return;
+              setReviewQuestionResult((current) => {
+                if (!current) return current;
+                return {
+                  ...current,
+                  semanticEvidenceCandidates: semanticEvidence.candidates,
+                  semanticEvidenceStatus: semanticEvidence.status,
+                  semanticEvidenceWarning: semanticEvidence.warning,
+                };
+              });
+            })
+            .catch((error) => {
+              if (reviewQuestionRunRef.current !== runId) return;
+              setReviewQuestionResult((current) => {
+                if (!current) return current;
+                return {
+                  ...current,
+                  semanticEvidenceStatus: "request_failed",
+                  semanticEvidenceWarning: error instanceof Error ? error.message : String(error),
+                };
+              });
+            });
+        }
         return;
       }
 
@@ -2250,6 +2291,44 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                       </p>
                     </div>
                   ) : null}
+                  <div className="mt-4 rounded-xl border border-violet-200 bg-white/80 p-4">
+                    <div className="flex items-center gap-2">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-violet-700">
+                        Semantic evidence suggestions
+                      </div>
+                      {reviewQuestionResult.semanticEvidenceStatus ? (
+                        <span className="inline-block rounded border border-violet-200 bg-violet-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-violet-700">
+                          {reviewQuestionResult.semanticEvidenceStatus}
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="mt-1 text-xs text-slate-500">
+                      LLM suggestions are advisory only. Deterministic Quick Check scoring still controls the result.
+                    </p>
+                    {reviewQuestionResult.semanticEvidenceWarning ? (
+                      <div className="mt-2 text-xs leading-relaxed text-slate-600">
+                        {reviewQuestionResult.semanticEvidenceWarning}
+                      </div>
+                    ) : null}
+                    {reviewQuestionResult.semanticEvidenceCandidates && reviewQuestionResult.semanticEvidenceCandidates.length > 0 ? (
+                      <div className="mt-3 space-y-2">
+                        {reviewQuestionResult.semanticEvidenceCandidates.map((candidate) => (
+                          <div key={`${candidate.blockId}:${candidate.quote}`} className="rounded-lg border border-violet-100 bg-violet-50/40 p-3">
+                            <div className="flex flex-wrap items-center gap-2 text-[11px] text-violet-800">
+                              <span className="font-mono">{candidate.blockId}</span>
+                              <span>p. {candidate.page ?? "—"}</span>
+                              {candidate.heading ? <span>{candidate.heading}</span> : null}
+                              <span>{Math.round(candidate.confidence * 100)}% confidence</span>
+                            </div>
+                            <div className="mt-2 rounded border border-violet-100 bg-white px-3 py-2 text-sm leading-relaxed text-slate-700">
+                              “{candidate.quote}”
+                            </div>
+                            <div className="mt-2 text-xs leading-relaxed text-slate-600">{candidate.reason}</div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
                   <div className="mt-4">
                     <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Document heading index (Phase 1 — title matching)</div>
                     <p className="mt-1 text-xs text-slate-500">Headings extracted from uploaded PDD. Quick Check matches section titles using your question, with limited methodology-aware fallback for certain review areas.</p>

--- a/src/lib/quickCheck/retrieval/types.ts
+++ b/src/lib/quickCheck/retrieval/types.ts
@@ -88,6 +88,22 @@ export type ReviewRoutingDiagnostic = {
   noMatchReason?: string;
 };
 
+export type SemanticEvidenceCandidate = {
+  blockId: string;
+  page: number | null;
+  heading: string | null;
+  quote: string;
+  reason: string;
+  confidence: number;
+};
+
+export type SemanticEvidenceStatus =
+  | "disabled"
+  | "no_input"
+  | "available"
+  | "invalid_response"
+  | "request_failed";
+
 export type ReviewQuestionResult = {
   path: QuickCheckPath;
   reviewArea: ReviewArea;
@@ -105,6 +121,9 @@ export type ReviewQuestionResult = {
   diagnostic?: Record<string, string>;
   phase1Diagnostic?: ReviewQuestionDiagnostic;
   routingDiagnostic?: ReviewRoutingDiagnostic;
+  semanticEvidenceCandidates?: SemanticEvidenceCandidate[];
+  semanticEvidenceStatus?: SemanticEvidenceStatus;
+  semanticEvidenceWarning?: string;
 };
 
 export type ReviewQuestionRetrievalResult = Omit<ReviewQuestionResult, "baselineReview" | "reviewAreaReview"> & {

--- a/src/lib/quickCheck/semanticEvidence/client.ts
+++ b/src/lib/quickCheck/semanticEvidence/client.ts
@@ -1,0 +1,30 @@
+import type { SemanticEvidenceCandidate, SemanticEvidenceStatus } from "@/lib/quickCheck/retrieval/types";
+
+export type SemanticEvidenceApiResult = {
+  status: SemanticEvidenceStatus;
+  candidates: SemanticEvidenceCandidate[];
+  warning?: string;
+  requestBlockCount: number;
+  parserAdapterId?: string;
+};
+
+export async function fetchSemanticEvidenceCandidates(input: {
+  claimText: string;
+  rawPddText: string;
+  methodologyId: string;
+  methodologyVersion: string;
+}): Promise<SemanticEvidenceApiResult> {
+  const response = await fetch("/api/quick-check/semantic-evidence", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Semantic evidence request failed with ${response.status}`);
+  }
+
+  return response.json() as Promise<SemanticEvidenceApiResult>;
+}

--- a/src/lib/quickCheck/semanticEvidence/huggingFace.ts
+++ b/src/lib/quickCheck/semanticEvidence/huggingFace.ts
@@ -1,0 +1,305 @@
+import { z } from "zod";
+import { buildArticle6DocumentModel } from "@/lib/documentModel";
+import { parseDocumentText } from "@/lib/documentParsing";
+import type { Article6DocumentBlock, Article6DocumentModel } from "@/lib/documentModel/types";
+import type { SemanticEvidenceCandidate, SemanticEvidenceStatus } from "@/lib/quickCheck/retrieval/types";
+
+const HUGGING_FACE_URL = "https://api-inference.huggingface.co/models/openbmb/MiniCPM5-1B";
+const MAX_BLOCKS = 40;
+const MAX_BLOCK_CHARS = 1400;
+const MAX_RETURNED_CANDIDATES = 8;
+
+const llmCandidateSchema = z.object({
+  block_id: z.string().min(1),
+  page: z.number().int().nonnegative().nullable().optional(),
+  exact_quote: z.string().min(1),
+  reason: z.string().min(1),
+  confidence: z.number().min(0).max(1),
+});
+
+const llmResponseSchema = z.array(llmCandidateSchema);
+
+export type SemanticEvidenceBlock = {
+  blockId: string;
+  page: number | null;
+  heading: string | null;
+  text: string;
+  score: number;
+};
+
+export type SemanticEvidenceSuggestionResult = {
+  status: SemanticEvidenceStatus;
+  candidates: SemanticEvidenceCandidate[];
+  warning?: string;
+  requestBlockCount: number;
+  parserAdapterId?: string;
+};
+
+type SemanticEvidenceInput = {
+  claimText: string;
+  rawPddText?: string;
+  methodologyId?: string;
+  methodologyVersion?: string;
+};
+
+type FetchLike = typeof fetch;
+
+function normalizeText(value: string): string {
+  return value.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function trimBlockText(value: string, maxChars = MAX_BLOCK_CHARS): string {
+  const clean = value.replace(/\s+/g, " ").trim();
+  if (clean.length <= maxChars) return clean;
+  return `${clean.slice(0, maxChars).replace(/\s+\S*$/, "")} […]`;
+}
+
+function extractKeywords(claimText: string): string[] {
+  const normalized = normalizeText(claimText);
+  return [...new Set(
+    normalized
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter((token) => token.length >= 4)
+      .filter((token) => !new Set([
+        "does", "this", "that", "with", "from", "what", "when", "where", "which",
+        "have", "been", "being", "will", "would", "could", "should", "shall",
+        "document", "project", "section", "describe", "explain", "assess", "review",
+        "question", "evidence", "check", "include", "support", "provide",
+      ]).has(token)),
+  )];
+}
+
+function buildBlockHeadingMap(model: Article6DocumentModel): Map<string, string> {
+  const byId = new Map(model.sections.map((section) => [section.id, section.titleClean]));
+  return byId;
+}
+
+function scoreBlock(block: Article6DocumentBlock, claimKeywords: string[], heading: string | null): number {
+  const haystack = normalizeText(`${heading ?? ""} ${block.cleanText}`);
+  let score = 0;
+  for (const keyword of claimKeywords) {
+    if (haystack.includes(keyword)) score += heading && normalizeText(heading).includes(keyword) ? 3 : 1;
+  }
+  if (block.type === "paragraph") score += 0.5;
+  if (heading) score += 0.25;
+  return score;
+}
+
+export function selectSemanticEvidenceBlocks(
+  model: Article6DocumentModel,
+  claimText: string,
+  maxBlocks = MAX_BLOCKS,
+): SemanticEvidenceBlock[] {
+  const claimKeywords = extractKeywords(claimText);
+  const headingsBySectionId = buildBlockHeadingMap(model);
+
+  return model.blocks
+    .filter((block) => block.cleanText.trim().length > 0)
+    .map((block) => {
+      const heading = block.sectionId ? (headingsBySectionId.get(block.sectionId) ?? null) : null;
+      return {
+        blockId: block.id,
+        page: block.pageNumber ?? null,
+        heading,
+        text: trimBlockText(block.cleanText),
+        score: scoreBlock(block, claimKeywords, heading),
+      };
+    })
+    .sort((left, right) =>
+      right.score - left.score
+      || (right.text.length - left.text.length)
+      || left.blockId.localeCompare(right.blockId),
+    )
+    .slice(0, maxBlocks);
+}
+
+function buildPrompt(input: {
+  claimText: string;
+  methodologyId?: string;
+  methodologyVersion?: string;
+  blocks: SemanticEvidenceBlock[];
+}): string {
+  const blockPayload = input.blocks.map((block) => ({
+    block_id: block.blockId,
+    page: block.page,
+    heading: block.heading,
+    text: block.text,
+  }));
+
+  return [
+    "You are selecting evidence blocks for a PDF review question.",
+    "Return JSON only. Do not use markdown fences. Do not add commentary.",
+    "Return an array of objects with keys: block_id, page, exact_quote, reason, confidence.",
+    "Rules:",
+    "- exact_quote must be copied exactly from the provided block text.",
+    "- block_id and page must match the chosen block.",
+    "- confidence must be between 0 and 1.",
+    "- Prefer the smallest number of strong candidates.",
+    "- Return [] if no block clearly supports the question.",
+    "",
+    `Question: ${input.claimText}`,
+    `Methodology: ${input.methodologyId || "unknown"} ${input.methodologyVersion || ""}`.trim(),
+    "Candidate blocks:",
+    JSON.stringify(blockPayload),
+  ].join("\n");
+}
+
+function extractGeneratedText(payload: unknown): string {
+  if (typeof payload === "string") return payload;
+  if (Array.isArray(payload)) {
+    for (const item of payload) {
+      if (item && typeof item === "object" && "generated_text" in item && typeof item.generated_text === "string") {
+        return item.generated_text;
+      }
+    }
+  }
+  if (payload && typeof payload === "object") {
+    if ("generated_text" in payload && typeof payload.generated_text === "string") return payload.generated_text;
+    if ("error" in payload && typeof payload.error === "string") throw new Error(payload.error);
+  }
+  throw new Error("Hugging Face response did not include generated text.");
+}
+
+function extractJsonArray(text: string): string | null {
+  const start = text.indexOf("[");
+  const end = text.lastIndexOf("]");
+  if (start === -1 || end === -1 || end <= start) return null;
+  return text.slice(start, end + 1);
+}
+
+function validateCandidates(
+  rawCandidates: z.infer<typeof llmResponseSchema>,
+  blocks: SemanticEvidenceBlock[],
+): SemanticEvidenceCandidate[] {
+  const blockMap = new Map(blocks.map((block) => [block.blockId, block]));
+  return rawCandidates
+    .map((candidate) => {
+      const block = blockMap.get(candidate.block_id);
+      if (!block) return null;
+      const page = candidate.page ?? null;
+      if (block.page !== page) return null;
+      if (!block.text.includes(candidate.exact_quote)) return null;
+      return {
+        blockId: block.blockId,
+        page,
+        heading: block.heading,
+        quote: candidate.exact_quote,
+        reason: candidate.reason.trim(),
+        confidence: candidate.confidence,
+      } satisfies SemanticEvidenceCandidate;
+    })
+    .filter((candidate): candidate is SemanticEvidenceCandidate => candidate !== null)
+    .sort((left, right) => right.confidence - left.confidence)
+    .slice(0, MAX_RETURNED_CANDIDATES);
+}
+
+export async function suggestSemanticEvidenceCandidates(
+  input: SemanticEvidenceInput,
+  options?: {
+    fetchImpl?: FetchLike;
+    apiKey?: string | undefined;
+  },
+): Promise<SemanticEvidenceSuggestionResult> {
+  if (!input.claimText.trim() || !input.rawPddText?.trim()) {
+    return { status: "no_input", candidates: [], requestBlockCount: 0 };
+  }
+
+  const apiKey = options?.apiKey ?? process.env.HF_API_KEY;
+  if (!apiKey) {
+    return {
+      status: "disabled",
+      candidates: [],
+      warning: "HF_API_KEY is not configured; semantic evidence suggestions are disabled.",
+      requestBlockCount: 0,
+    };
+  }
+
+  const parsedDocument = parseDocumentText({ rawText: input.rawPddText });
+  const model = buildArticle6DocumentModel({ parsedDocument });
+  const blocks = selectSemanticEvidenceBlocks(model, input.claimText);
+
+  if (blocks.length === 0) {
+    return {
+      status: "no_input",
+      candidates: [],
+      warning: "No canonical document blocks were available for semantic evidence retrieval.",
+      requestBlockCount: 0,
+      parserAdapterId: model.parserAdapterId,
+    };
+  }
+
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const prompt = buildPrompt({
+    claimText: input.claimText,
+    methodologyId: input.methodologyId,
+    methodologyVersion: input.methodologyVersion,
+    blocks,
+  });
+
+  try {
+    const response = await fetchImpl(HUGGING_FACE_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        inputs: prompt,
+        parameters: {
+          max_new_tokens: 700,
+          return_full_text: false,
+          temperature: 0.1,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Hugging Face request failed with ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const generatedText = extractGeneratedText(payload);
+    const jsonArrayText = extractJsonArray(generatedText);
+    if (!jsonArrayText) {
+      return {
+        status: "invalid_response",
+        candidates: [],
+        warning: "Semantic evidence model did not return a JSON array.",
+        requestBlockCount: blocks.length,
+        parserAdapterId: model.parserAdapterId,
+      };
+    }
+
+    const parsedCandidates = llmResponseSchema.safeParse(JSON.parse(jsonArrayText));
+    if (!parsedCandidates.success) {
+      return {
+        status: "invalid_response",
+        candidates: [],
+        warning: "Semantic evidence model returned JSON, but it did not match the expected shape.",
+        requestBlockCount: blocks.length,
+        parserAdapterId: model.parserAdapterId,
+      };
+    }
+
+    const candidates = validateCandidates(parsedCandidates.data, blocks);
+    return {
+      status: "available",
+      candidates,
+      warning: candidates.length === 0
+        ? "Semantic evidence model responded, but no candidates passed deterministic quote/block validation."
+        : undefined,
+      requestBlockCount: blocks.length,
+      parserAdapterId: model.parserAdapterId,
+    };
+  } catch (error) {
+    return {
+      status: "request_failed",
+      candidates: [],
+      warning: error instanceof Error ? error.message : String(error),
+      requestBlockCount: blocks.length,
+      parserAdapterId: model.parserAdapterId,
+    };
+  }
+}
+

--- a/tests/api/quick-check.semantic-evidence.route.test.ts
+++ b/tests/api/quick-check.semantic-evidence.route.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/quickCheck/semanticEvidence/huggingFace", () => ({
+  suggestSemanticEvidenceCandidates: jest.fn(),
+}));
+
+import { GET, POST } from "@/app/api/quick-check/semantic-evidence/route";
+
+describe("POST /api/quick-check/semantic-evidence", () => {
+  it("returns 400 when claimText or rawPddText is missing", async () => {
+    const response = await POST(new NextRequest("http://localhost/api/quick-check/semantic-evidence", {
+      method: "POST",
+      body: JSON.stringify({ claimText: "", rawPddText: "" }),
+      headers: { "content-type": "application/json" },
+    }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: "missing-input" });
+  });
+
+});
+
+describe("GET /api/quick-check/semantic-evidence", () => {
+  it("reports route health and model metadata", async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      model: "openbmb/MiniCPM5-1B",
+    });
+  });
+});

--- a/tests/lib/semanticEvidence.huggingFace.test.ts
+++ b/tests/lib/semanticEvidence.huggingFace.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  selectSemanticEvidenceBlocks,
+  suggestSemanticEvidenceCandidates,
+} from "@/lib/quickCheck/semanticEvidence/huggingFace";
+import { buildArticle6DocumentModel } from "@/lib/documentModel";
+import { parseDocumentText } from "@/lib/documentParsing";
+
+const RAW_PDD_TEXT = [
+  "4.3  Monitoring Plan",
+  "The monitoring plan describes annual monitoring activities and plot remeasurement.",
+  "",
+  "4.3.1  Monitoring Frequency",
+  "Monitoring occurs every 12 months with documented field checks.",
+  "",
+  "6  Stakeholder Comments",
+  "Stakeholder comments are recorded in community meeting summaries.",
+].join("\n");
+
+describe("suggestSemanticEvidenceCandidates", () => {
+  it("selects canonical blocks, calls Hugging Face, and returns only validated candidates", async () => {
+    const model = buildArticle6DocumentModel({ parsedDocument: parseDocumentText({ rawText: RAW_PDD_TEXT }) });
+    const blocks = selectSemanticEvidenceBlocks(model, "Does this PDD describe the monitoring plan?");
+    const monitoringBlock = blocks.find((block) => block.text.includes("annual monitoring activities"));
+    expect(monitoringBlock).toBeDefined();
+
+    const fetchMock = jest.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(_input)).toBe("https://api-inference.huggingface.co/models/openbmb/MiniCPM5-1B");
+      expect(init?.method).toBe("POST");
+      expect((init?.headers as Record<string, string>)?.authorization).toBe("Bearer test-key");
+      const body = JSON.parse(String(init?.body));
+      expect(body.inputs).toContain(`\"block_id\":\"${monitoringBlock?.blockId}\"`);
+      return {
+        ok: true,
+        json: async () => ([{
+          generated_text: JSON.stringify([{
+            block_id: monitoringBlock?.blockId,
+            page: monitoringBlock?.page,
+            exact_quote: "The monitoring plan describes annual monitoring activities and plot remeasurement.",
+            reason: "This block explicitly describes the monitoring plan content.",
+            confidence: 0.92,
+          }]),
+        }]),
+      } as Response;
+    });
+
+    const result = await suggestSemanticEvidenceCandidates(
+      {
+        claimText: "Does this PDD describe the monitoring plan?",
+        rawPddText: RAW_PDD_TEXT,
+        methodologyId: "VM0007",
+        methodologyVersion: "1.0",
+      },
+      {
+        apiKey: "test-key",
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      },
+    );
+
+    expect(result.status).toBe("available");
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        blockId: monitoringBlock?.blockId,
+        page: monitoringBlock?.page,
+        heading: "Monitoring Plan",
+        quote: "The monitoring plan describes annual monitoring activities and plot remeasurement.",
+        confidence: 0.92,
+      }),
+    ]);
+  });
+
+  it("drops candidates whose quote does not exist in the selected block", async () => {
+    const fetchMock = jest.fn(async () => ({
+      ok: true,
+      json: async () => ([{
+        generated_text: JSON.stringify([{
+          block_id: "block:body:4.3",
+          page: 1,
+          exact_quote: "This quote does not exist.",
+          reason: "Invalid candidate.",
+          confidence: 0.8,
+        }]),
+      }]),
+    })) as unknown as typeof fetch;
+
+    const result = await suggestSemanticEvidenceCandidates(
+      {
+        claimText: "Does this PDD describe the monitoring plan?",
+        rawPddText: RAW_PDD_TEXT,
+      },
+      {
+        apiKey: "test-key",
+        fetchImpl: fetchMock,
+      },
+    );
+
+    expect(result.status).toBe("available");
+    expect(result.candidates).toEqual([]);
+    expect(result.warning).toMatch(/no candidates passed deterministic quote\/block validation/i);
+  });
+
+  it("disables semantic evidence retrieval when HF_API_KEY is missing", async () => {
+    const result = await suggestSemanticEvidenceCandidates({
+      claimText: "Does this PDD describe the monitoring plan?",
+      rawPddText: RAW_PDD_TEXT,
+    });
+
+    expect(result.status).toBe("disabled");
+    expect(result.candidates).toEqual([]);
+    expect(result.warning).toMatch(/HF_API_KEY/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add a server-side Hugging Face semantic evidence retrieval path for Quick Check using `openbmb/MiniCPM5-1B`
- send canonical document blocks to the model, then strictly validate returned quotes against the selected block and page before surfacing any suggestion
- keep existing deterministic Quick Check scoring unchanged and show LLM evidence suggestions as advisory UI output only

## Validation
- `npm run typecheck`
- `npm test -- --runInBand tests/lib/semanticEvidence.huggingFace.test.ts tests/api/quick-check.semantic-evidence.route.test.ts tests/lib/quickCheckReviewQuestion.test.ts`
- `npm run quickcheck:eval`

## Notes
- requires server-side `HF_API_KEY` to enable the Hugging Face call
- falls back cleanly when the key is missing or the model response fails validation