### PR TITLE
Route review field input to document q&a

### DIFF
--- a/docs/roadmaps/OVERRIDES.md
+++ b/docs/roadmaps/OVERRIDES.md
@@ -5,3 +5,4 @@ Each line records a manual rollback approved via `roadmap-override`.
 Format:
 `YYYY-MM-DD | <slug> | PRxx | revert_of PR# | reason`
 2026-04-23 | phase-assurance-surface-mvp | PR12 | revert_of PR326 | Demo verification pack contract extends the PR12 lane with a truthful placeholder review scaffold after the earlier done state.
+2026-06-02 | phase-assurance-surface-mvp | PR12 | revert_of PR326 | Review question routing reopens the PR12 lane because Document Q&A now owns review-field intent instead of claim matching.

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -144,8 +144,8 @@ type MethodologyEvidenceSignals =
   | undefined;
 
 const CLAIM_SUGGESTIONS = [
-  "The monitoring report covers the full reporting period.",
-  "The boundary description matches the mapped project area.",
+  "Does the monitoring report cover the full reporting period?",
+  "Does the boundary description match the mapped project area?",
   "The baseline methodology is clearly justified by the evidence.",
 ];
 
@@ -1416,8 +1416,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setMatchCandidates([]);
     try {
       const evidenceAnalysis = await analyzeQuickCheckEvidence(selectedEvidenceSources, { resolvePdfText });
+      const reviewFieldText = draft.claimText.trim();
       const claimIntents = classifyQuickCheckClaimIntents(effectiveClaimText);
-      const isReviewQuestion = detectReviewPath(effectiveClaimText) === "review_question_answering";
+      const isReviewQuestion = detectReviewPath(reviewFieldText, { inputContext: "review_question_field" }) === "review_question_answering";
       const currentMethodologyResolution = resolveQuickCheckMethodology({
         mentions: methodologyMentionsForDetection({ analysis: evidenceAnalysis, extraction: null }),
         methods,
@@ -1436,7 +1437,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       if (isReviewQuestion) {
         const firstSource = selectedEvidenceSources[0];
         const questionResult = buildReviewQuestionResult({
-          claimText: effectiveClaimText,
+          claimText: reviewFieldText,
           methodologyId: resolvedMethodologyId,
           methodologyVersion: resolvedMethodologyVersion,
           rawPddText: evidenceAnalysis.rawPddText,
@@ -1454,7 +1455,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         });
         if (evidenceAnalysis.rawPddText?.trim()) {
           void fetchSemanticEvidenceCandidates({
-            claimText: effectiveClaimText,
+            claimText: reviewFieldText,
             rawPddText: evidenceAnalysis.rawPddText,
             methodologyId: resolvedMethodologyId,
             methodologyVersion: resolvedMethodologyVersion,

--- a/src/lib/quickCheck/retrieval/retrieveSections.ts
+++ b/src/lib/quickCheck/retrieval/retrieveSections.ts
@@ -22,6 +22,7 @@ import {
   shouldExpandAncestors,
 } from "@/lib/quickCheck/policy/reviewPolicy";
 import type {
+  QuickCheckInputContext,
   BuildReviewQuestionSectionRetrievalInput,
   QuickCheckPath,
   ReviewArea,
@@ -101,9 +102,26 @@ function hasReferenceRegionBoundaryIntent(normalizedClaimText: string): boolean 
   return /\bboundary\b|\bproject\s+boundary\b|\bleakage\s+belt\b|\bdefine\b|\bdescribe\b|\bexplain\b|\binclude\b/.test(normalizedClaimText);
 }
 
-export function detectReviewPath(claimText: string): QuickCheckPath {
+function explicitlyRequestsRequirementMatching(normalizedClaimText: string): boolean {
+  return (
+    /\bmatch(?:ing)?\b.*\bmethodolog(?:y|ies)\b.*\brequirements?\b/i.test(normalizedClaimText) ||
+    /\bmethodolog(?:y|ies)\b.*\brequirements?\b/i.test(normalizedClaimText) ||
+    /\brequirements?\b.*\bmatch(?:ing)?\b/i.test(normalizedClaimText) ||
+    /\bgeneral evidence check\b/i.test(normalizedClaimText)
+  );
+}
+
+export function detectReviewPath(
+  claimText: string,
+  options?: { inputContext?: QuickCheckInputContext },
+): QuickCheckPath {
   const normalized = claimText.trim();
   if (!normalized) return "claim_to_requirement_match";
+  if (options?.inputContext === "review_question_field") {
+    return explicitlyRequestsRequirementMatching(normalized)
+      ? "claim_to_requirement_match"
+      : "review_question_answering";
+  }
   if (hasReferenceRegionBoundaryIntent(normalized)) return "review_question_answering";
   return BROAD_QUESTION_PATTERNS.some((pattern) => pattern.test(normalized))
     ? "review_question_answering"

--- a/src/lib/quickCheck/retrieval/types.ts
+++ b/src/lib/quickCheck/retrieval/types.ts
@@ -14,6 +14,7 @@ export type ReviewArea =
   | "general";
 
 export type QuickCheckPath = "claim_to_requirement_match" | "review_question_answering";
+export type QuickCheckInputContext = "claim_field" | "review_question_field";
 
 export type ReviewQuestionStatus =
   | "strong_evidence_found"

--- a/tests/components/quickCheckPanel.review-question-fallback.test.tsx
+++ b/tests/components/quickCheckPanel.review-question-fallback.test.tsx
@@ -39,6 +39,8 @@ jest.mock("@/lib/chat/quickCheckPdfClient", () => {
 
 import QuickCheckPanel from "@/components/chat/QuickCheckPanel";
 
+const REVIEW_FIELD_CLAIM_STYLE_TEXT = "The boundary description matches the mapped project area.";
+
 describe("QuickCheckPanel review-question fallback", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
@@ -136,7 +138,12 @@ describe("QuickCheckPanel review-question fallback", () => {
     global.fetch = jest.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes("/api/methods/inventory")) {
-        return new Response(JSON.stringify({ methods: [{ code: "VM0007", latestVersion: "v1-0", versions: ["v1-0"] }] }), { status: 200 });
+        return new Response(JSON.stringify({
+          methods: [
+            { code: "VM0007", latestVersion: "v1-0", versions: ["v1-0"] },
+            { code: "ACM0010", latestVersion: "v01-0", versions: ["v01-0"] },
+          ],
+        }), { status: 200 });
       }
       if (url.includes("/api/quick-check/semantic-evidence")) {
         return new Response(JSON.stringify({
@@ -213,6 +220,35 @@ describe("QuickCheckPanel review-question fallback", () => {
     expect(text).toContain("recovery suppressed: yes");
     expect(text).not.toContain("No valid analysis path");
     expect(text).not.toContain("No valid analysis path in VM0007");
+  });
+
+  it("routes claim-style text entered in the Review question field to Document Q&A instead of methodology fallback", async () => {
+    seedSession({
+      claimText: REVIEW_FIELD_CLAIM_STYLE_TEXT,
+      filename: "document-qa-messy.pdf",
+      methodologyId: "ACM0010",
+      methodologyVersion: "v01-0",
+    });
+    await seedAttachmentText("att-upload-1", `%PDF-1.4\n(${PDF_TEXT_BY_FILENAME["document-qa-messy.pdf"]})\n%%EOF`);
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+
+    await flushUntilText("Document Q&A");
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Document Q&A");
+    expect(text).toContain("route: document_question");
+    expect(text).toContain("raw text: available");
+    expect(text).toContain("recovery suppressed: yes");
+    expect(text).not.toContain("No valid analysis path");
+    expect(text).not.toContain("No valid analysis path in ACM0010");
   });
 
   it("keeps Document Q&A primary for a negative document question when raw text exists but no relevant evidence matches", async () => {

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -982,7 +982,7 @@ describe.skip("QuickCheckPanel claim-first flow (phase-3 UI drift - see note abo
     });
 
     const chip = Array.from(container.querySelectorAll("button")).find((node) =>
-      node.textContent?.includes("The monitoring report covers the full reporting period."),
+      node.textContent?.includes("Does the monitoring report cover the full reporting period?"),
     );
     expect(chip).toBeTruthy();
 
@@ -990,7 +990,7 @@ describe.skip("QuickCheckPanel claim-first flow (phase-3 UI drift - see note abo
       chip?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(claimInput().value).toBe("The monitoring report covers the full reporting period.");
+    expect(claimInput().value).toBe("Does the monitoring report cover the full reporting period?");
   });
 
   it("keeps the CTA disabled until a document is present", async () => {
@@ -1199,7 +1199,7 @@ describe.skip("QuickCheckPanel claim-first flow (phase-3 UI drift - see note abo
     expect(primaryCta().disabled).toBe(true);
 
     await act(async () => {
-      clickButton("The monitoring report covers the full reporting period.");
+      clickButton("Does the monitoring report cover the full reporting period?");
     });
     expect(primaryCta().disabled).toBe(true);
 
@@ -1233,7 +1233,7 @@ describe.skip("QuickCheckPanel claim-first flow (phase-3 UI drift - see note abo
     const inventorySelect = savedEvidenceSelect();
 
     await act(async () => {
-      clickButton("The monitoring report covers the full reporting period.");
+      clickButton("Does the monitoring report cover the full reporting period?");
       inventorySelect.value = "ev-1";
       inventorySelect.dispatchEvent(new Event("change", { bubbles: true }));
     });
@@ -1245,7 +1245,7 @@ describe.skip("QuickCheckPanel claim-first flow (phase-3 UI drift - see note abo
       clickButton("Run quick check");
     });
 
-    expect(container.textContent).toContain("The monitoring report covers the full reporting period.");
+    expect(container.textContent).toContain("Does the monitoring report cover the full reporting period?");
     expect(container.textContent).toContain("Likely requirement matches");
     expect(container.textContent).toContain("AR-ACM0003 · v02-0");
     expect(container.textContent).toContain("R-1-0001");
@@ -1594,7 +1594,7 @@ describe.skip("QuickCheckPanel claim-first flow (phase-3 UI drift - see note abo
     });
 
     await act(async () => {
-      clickButton("The boundary description matches the mapped project area.");
+      clickButton("Does the boundary description match the mapped project area?");
       openOptions();
     });
 

--- a/tests/components/quickCheckPanel.upload-regression.test.tsx
+++ b/tests/components/quickCheckPanel.upload-regression.test.tsx
@@ -199,7 +199,8 @@ describe("QuickCheckPanel upload regression", () => {
 
     await flushUi();
 
-    expect(container.textContent).toContain("Weak extraction");
+    expect(container.textContent).toContain("Document Q&A");
+    expect(container.textContent).toContain("raw text: unavailable");
 
     await uploadEvidence(
       new File(
@@ -214,6 +215,7 @@ describe("QuickCheckPanel upload regression", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("fresh-monitoring-report.pdf");
     expect(text).toContain("Extraction preview");
-    expect(text).not.toContain("Weak extraction");
+    expect(text).not.toContain("Document Q&A");
+    expect(text).not.toContain("raw text: unavailable");
   });
 });

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -182,6 +182,22 @@ describe("detectReviewPath", () => {
   it("routes a specific evidence claim to claim_to_requirement_match", () => {
     expect(detectReviewPath("The monitoring report covers the full reporting period.")).toBe("claim_to_requirement_match");
   });
+
+  it("uses field context so claim-style text in the claim field still uses claim matching", () => {
+    expect(detectReviewPath("The monitoring report covers the full reporting period.", { inputContext: "claim_field" })).toBe("claim_to_requirement_match");
+  });
+
+  it("uses field context so the same claim-style text in the review question field routes to document q&a", () => {
+    expect(detectReviewPath("The monitoring report covers the full reporting period.", { inputContext: "review_question_field" })).toBe("review_question_answering");
+  });
+
+  it("routes question-style text in the review question field to document q&a", () => {
+    expect(detectReviewPath("Does the monitoring report cover the full reporting period?", { inputContext: "review_question_field" })).toBe("review_question_answering");
+  });
+
+  it("keeps explicit methodology requirement-matching requests on the claim-matching path even in the review question field", () => {
+    expect(detectReviewPath("General evidence check against the selected methodology requirements.", { inputContext: "review_question_field" })).toBe("claim_to_requirement_match");
+  });
 });
 
 describe("classifyReviewArea — additionality", () => {


### PR DESCRIPTION
## WHAT

- Change Quick Check routing so the Review question field is context-aware.
- If the user enters text in the Review question field, route it through Document Q&A by default.
- Do not rely only on phrase patterns like “Does the document…” or “Is the…”.
- Treat review-field input as `document_question` unless:
  - the field is empty, or
  - the user explicitly requests methodology requirement matching, or
  - the user is using the separate claim-check/general-check path.
- Update the example pills so they are phrased as questions:
  - “Does the monitoring report cover the full reporting period?”
  - “Does the boundary description match the mapped project area?”
- Add tests that prove the field context controls routing:
  - claim-style text in the claim field can still use claim matching
  - the same text in the Review question field routes to Document Q&A
  - question-style text in the Review question field routes to Document Q&A
  - ACM0010 methodology fallback does not become the primary result for Review question inputs with parsed text
- Keep PR 691’s Document Q&A invariant unchanged.

## WHY

- Adding more phrase patterns is whack-a-mole.
- The UI already labels the field “Review question,” so the field context should drive routing.
- Users should not need to know which sentence shapes trigger Document Q&A.
- Methodology matching and document review are separate user intents.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>

## Roadmap

### Roadmap-Update
- slug: phase-assurance-surface-mvp
- ack: human
- items:
  - PR12: in_progress

Allowed statuses: planned | next | in_progress | done | blocked

### Roadmap-Override
- slug: phase-assurance-surface-mvp
- pr: PR12
- from_status: done
- to_status: in_progress
- revert_of: PR326
- reason: Review question routing reopens the PR12 lane because Document Q&A now owns review-field intent instead of claim matching.

Visible UI changes to look for:
- Review question input routes non-empty field text to Document Q&A by default.
- Example pills are phrased as review questions, not declarative claims.
