### PR TITLE
chore: add Fallow as development-only codebase analysis tool

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "entry": [
+    "scripts/**/*.{mjs,cjs,js,ts,tsx}",
+    "src/index.{ts,tsx,js,jsx}",
+    "src/main.{ts,tsx,js,jsx}"
+  ],
+  "ignorePatterns": [
+    "**/*.generated.*",
+    ".next/**",
+    "out/**",
+    "test-results/**",
+    "coverage/**",
+    "artifacts/**",
+    "public/methodologies/**",
+    "public/_provenance/**"
+  ],
+  "duplicates": {
+    "minOccurrences": 3,
+    "ignore": [
+      "scripts/audit-pack/**"
+    ]
+  },
+  "rules": {
+    "unused-files": "warn",
+    "unused-exports": "warn",
+    "unused-types": "warn",
+    "unused-dependencies": "warn",
+    "unlisted-dependencies": "warn"
+  },
+  "health": {
+    "maxCyclomatic": 25,
+    "maxCognitive": 20
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,9 @@
   <!-- - PR12: done -->
   <!-- - PR13: in_progress -->
 
-Allowed statuses: planned | next | in_progress | done | blocked
+For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactors with no SSOT impact), leave `slug: N/A`. The roadmap gates will skip.
+
+Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.
 
 <!--
 ### Roadmap-Override

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ yarn-error.log*
 # local build-time artifact sync
 .cache/
 public/methodologies/
+
+# Fallow codebase analysis (local reports, cache, snapshots)
+.fallow/
 public/_provenance/
 public/exports/audit-pack.zip
 

--- a/artifacts/fallow/dead-code.json
+++ b/artifacts/fallow/dead-code.json
@@ -1,0 +1,3745 @@
+{
+  "kind": "dead-code",
+  "schema_version": 7,
+  "version": "2.86.0",
+  "elapsed_ms": 754,
+  "total_issues": 157,
+  "entry_points": {
+    "total": 234,
+    "sources": {
+      "manual_entry": 50,
+      "package.json": 2,
+      "plugin": 182
+    }
+  },
+  "summary": {
+    "total_issues": 157,
+    "unused_files": 21,
+    "unused_exports": 70,
+    "unused_types": 51,
+    "private_type_leaks": 0,
+    "unused_dependencies": 2,
+    "unused_enum_members": 0,
+    "unused_class_members": 0,
+    "unresolved_imports": 0,
+    "unlisted_dependencies": 2,
+    "duplicate_exports": 9,
+    "type_only_dependencies": 0,
+    "test_only_dependencies": 2,
+    "circular_dependencies": 0,
+    "re_export_cycles": 0,
+    "boundary_violations": 0,
+    "stale_suppressions": 0,
+    "unused_catalog_entries": 0,
+    "empty_catalog_groups": 0,
+    "unresolved_catalog_references": 0,
+    "unused_dependency_overrides": 0,
+    "misconfigured_dependency_overrides": 0
+  },
+  "unused_files": [
+    {
+      "path": "src/app/manifest/_state/useManifestFilters.ts",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/FinderShell.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/ManifestHealthBadge.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/MethodologiesPackProvenance.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/RuleCard.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/actions/ShareLinkButton.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/assistant/AssistantPanel.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/chat/Composer.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/chat/MessageList.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/manifest/HashCopyButton.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/manifest/ManifestApp.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/manifest/MethodologyGroup.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/manifest/VersionDiffModal.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/snapshot/index.ts",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/verify/RunStatusCard.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/components/verify/VerifierMinutesPanel.tsx",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/exports/buildAuditPack.ts",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/extraction/index.ts",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/manifest/data.ts",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/types.ts",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/trace/evidenceLinks.ts",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    }
+  ],
+  "unused_exports": [
+    {
+      "path": "src/app/manifest/_state/useManifestFilters.ts",
+      "export_name": "default",
+      "is_type_only": false,
+      "line": 71,
+      "col": 0,
+      "span_start": 1908,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/components/RuleCard.tsx",
+      "export_name": "default",
+      "is_type_only": false,
+      "line": 107,
+      "col": 0,
+      "span_start": 3359,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/components/chat/SidePane.tsx",
+      "export_name": "default",
+      "is_type_only": false,
+      "line": 110,
+      "col": 0,
+      "span_start": 3696,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/components/manifest/HashCopyButton.tsx",
+      "export_name": "default",
+      "is_type_only": false,
+      "line": 11,
+      "col": 0,
+      "span_start": 202,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/components/manifest/MethodologyGroup.tsx",
+      "export_name": "default",
+      "is_type_only": false,
+      "line": 11,
+      "col": 0,
+      "span_start": 161,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/components/manifest/VersionDiffModal.tsx",
+      "export_name": "default",
+      "is_type_only": false,
+      "line": 106,
+      "col": 0,
+      "span_start": 2614,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/baseline/baselineStore.ts",
+      "export_name": "getBaseline",
+      "is_type_only": false,
+      "line": 49,
+      "col": 16,
+      "span_start": 1429,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/client.ts",
+      "export_name": "sendChat",
+      "is_type_only": false,
+      "line": 5,
+      "col": 22,
+      "span_start": 182,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheck.ts",
+      "export_name": "createQuickCheckDraft",
+      "is_type_only": false,
+      "line": 130,
+      "col": 16,
+      "span_start": 3358,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheck.ts",
+      "export_name": "buildQuickCheckWorkspaceUrl",
+      "is_type_only": false,
+      "line": 408,
+      "col": 16,
+      "span_start": 15728,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckPdfExtractor.ts",
+      "export_name": "PdfHelperError",
+      "is_type_only": false,
+      "line": 75,
+      "col": 13,
+      "span_start": 1952,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckSectionExtractor.ts",
+      "export_name": "headingMatchesQuery",
+      "is_type_only": false,
+      "line": 895,
+      "col": 16,
+      "span_start": 29339,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/schema.ts",
+      "export_name": "ChatMessageSchema",
+      "is_type_only": false,
+      "line": 3,
+      "col": 13,
+      "span_start": 39,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/composers/metadata.ts",
+      "export_name": "getComposerForMethod",
+      "is_type_only": false,
+      "line": 180,
+      "col": 16,
+      "span_start": 6032,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/decisions/engine.ts",
+      "export_name": "checkDecisionWarnings",
+      "is_type_only": false,
+      "line": 148,
+      "col": 22,
+      "span_start": 4590,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/export/verificationPackIntegration.ts",
+      "export_name": "buildEvidenceIntelligenceJson",
+      "is_type_only": false,
+      "line": 45,
+      "col": 16,
+      "span_start": 1382,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/inventory.ts",
+      "export_name": "enrichInventoryWithReconciliation",
+      "is_type_only": false,
+      "line": 505,
+      "col": 16,
+      "span_start": 20228,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/reviewGrade.ts",
+      "export_name": "loadMethodMeta",
+      "is_type_only": false,
+      "line": 131,
+      "col": 16,
+      "span_start": 3630,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/workbook.ts",
+      "export_name": "workbookGroupTypeLabel",
+      "is_type_only": false,
+      "line": 444,
+      "col": 16,
+      "span_start": 14579,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/export/conventions.ts",
+      "export_name": "EXPORT_TIMESTAMP_FALLBACK",
+      "is_type_only": false,
+      "line": 4,
+      "col": 13,
+      "span_start": 132,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/export/conventions.ts",
+      "export_name": "CANONICAL_EXPORT_TERMINOLOGY",
+      "is_type_only": false,
+      "line": 6,
+      "col": 13,
+      "span_start": 202,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/export/conventions.ts",
+      "export_name": "exportSchemaVersion",
+      "is_type_only": false,
+      "line": 129,
+      "col": 16,
+      "span_start": 3584,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/export/conventions.ts",
+      "export_name": "exportSectionOrder",
+      "is_type_only": false,
+      "line": 133,
+      "col": 16,
+      "span_start": 3710,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/intake/storage.ts",
+      "export_name": "saveIntakeRegistry",
+      "is_type_only": false,
+      "line": 40,
+      "col": 16,
+      "span_start": 1076,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/manifest/cards.ts",
+      "export_name": "manifestKey",
+      "is_type_only": false,
+      "line": 35,
+      "col": 16,
+      "span_start": 877,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/manifest/cards.ts",
+      "export_name": "extractRemoteKey",
+      "is_type_only": false,
+      "line": 63,
+      "col": 16,
+      "span_start": 1784,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/methodologyBoundary.ts",
+      "export_name": "CANON_SCHEMA_PATHS",
+      "is_type_only": false,
+      "line": 1,
+      "col": 13,
+      "span_start": 13,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/methodologyBoundary.ts",
+      "export_name": "VENDORED_METHODOLOGY_PATH_PREFIXES",
+      "is_type_only": false,
+      "line": 8,
+      "col": 13,
+      "span_start": 258,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/projects/exportPdf.ts",
+      "export_name": "getProjectCoverage",
+      "is_type_only": false,
+      "line": 52,
+      "col": 16,
+      "span_start": 2142,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/projects/learningCase.ts",
+      "export_name": "manualReviewLearningCaseDedupKey",
+      "is_type_only": false,
+      "line": 31,
+      "col": 16,
+      "span_start": 1200,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/projects/reportFindings.ts",
+      "export_name": "manualFindingCodeFromType",
+      "is_type_only": false,
+      "line": 65,
+      "col": 16,
+      "span_start": 2235,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/projects/reviewHandoff.ts",
+      "export_name": "clearPendingProjectReviewHandoff",
+      "is_type_only": false,
+      "line": 220,
+      "col": 16,
+      "span_start": 8196,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/projects/reviewHandoff.ts",
+      "export_name": "getImportedReviewForRule",
+      "is_type_only": false,
+      "line": 309,
+      "col": 16,
+      "span_start": 11216,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/projects/verificationReport.ts",
+      "export_name": "sectionTitle",
+      "is_type_only": false,
+      "line": 43,
+      "col": 16,
+      "span_start": 1240,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proof/bundle.ts",
+      "export_name": "buildEvidenceSnapshot",
+      "is_type_only": false,
+      "line": 74,
+      "col": 16,
+      "span_start": 2107,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/aoi.ts",
+      "export_name": "AOI_FEATURE_ROLE_OPTIONS",
+      "is_type_only": false,
+      "line": 7,
+      "col": 13,
+      "span_start": 182,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/aoi.ts",
+      "export_name": "setAoiPrimaryFeature",
+      "is_type_only": false,
+      "line": 445,
+      "col": 16,
+      "span_start": 15272,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/attachments.ts",
+      "export_name": "MAX_EVIDENCE_ATTACHMENT_BYTES",
+      "is_type_only": false,
+      "line": 9,
+      "col": 13,
+      "span_start": 320,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/attachments.ts",
+      "export_name": "ALLOWED_EVIDENCE_ATTACHMENT_MIME_TYPES",
+      "is_type_only": false,
+      "line": 10,
+      "col": 13,
+      "span_start": 383,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/evidenceSnapshot.ts",
+      "export_name": "ReviewSummarySchema",
+      "is_type_only": false,
+      "line": 8,
+      "col": 13,
+      "span_start": 375,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/pins.ts",
+      "export_name": "isSectionLikeId",
+      "is_type_only": false,
+      "line": 22,
+      "col": 16,
+      "span_start": 547,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/pins.ts",
+      "export_name": "evidencePinFingerprint",
+      "is_type_only": false,
+      "line": 62,
+      "col": 22,
+      "span_start": 1790,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "reviewQuestionMatchStageSchema",
+      "is_type_only": false,
+      "line": 16,
+      "col": 13,
+      "span_start": 352,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "preferredSectionBoostSchema",
+      "is_type_only": false,
+      "line": 24,
+      "col": 13,
+      "span_start": 507,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "titlePenaltySchema",
+      "is_type_only": false,
+      "line": 30,
+      "col": 13,
+      "span_start": 665,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "reviewAreaPolicySchema",
+      "is_type_only": false,
+      "line": 36,
+      "col": 13,
+      "span_start": 845,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "reviewAreaSchema",
+      "is_type_only": false,
+      "line": 48,
+      "col": 13,
+      "span_start": 1382,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "reviewAreasSchema",
+      "is_type_only": false,
+      "line": 62,
+      "col": 13,
+      "span_start": 1870,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/readiness/clientReadinessExport.tsx",
+      "export_name": "buildClientReadinessAppendixArtifact",
+      "is_type_only": false,
+      "line": 363,
+      "col": 16,
+      "span_start": 16131,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/readiness/reportHtmlTheme.ts",
+      "export_name": "renderKeyValueGrid",
+      "is_type_only": false,
+      "line": 28,
+      "col": 16,
+      "span_start": 988,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/reviewWorkspaces/storage.ts",
+      "export_name": "listReviewWorkspaces",
+      "is_type_only": false,
+      "line": 63,
+      "col": 16,
+      "span_start": 2158,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/reviewWorkspaces/storage.ts",
+      "export_name": "createReviewWorkspace",
+      "is_type_only": false,
+      "line": 90,
+      "col": 16,
+      "span_start": 2997,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/reviewWorkspaces/storage.ts",
+      "export_name": "updateReviewWorkspace",
+      "is_type_only": false,
+      "line": 153,
+      "col": 16,
+      "span_start": 4850,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/reviewWorkspaces/storage.ts",
+      "export_name": "buildReviewWorkspaceName",
+      "is_type_only": false,
+      "line": 172,
+      "col": 16,
+      "span_start": 5491,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/export.ts",
+      "export_name": "snapshotExportJson",
+      "is_type_only": false,
+      "line": 28,
+      "col": 16,
+      "span_start": 927,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "deleteAllSnapshots",
+      "is_type_only": false,
+      "line": 15,
+      "col": 67,
+      "span_start": 459,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "getSnapshot",
+      "is_type_only": false,
+      "line": 15,
+      "col": 24,
+      "span_start": 416,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "snapshotExportJson",
+      "is_type_only": false,
+      "line": 16,
+      "col": 30,
+      "span_start": 526,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "canonicalJsonStringify",
+      "is_type_only": false,
+      "line": 18,
+      "col": 9,
+      "span_start": 645,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "sha256Hex",
+      "is_type_only": false,
+      "line": 18,
+      "col": 33,
+      "span_start": 669,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/store.ts",
+      "export_name": "getSnapshot",
+      "is_type_only": false,
+      "line": 28,
+      "col": 16,
+      "span_start": 828,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/store.ts",
+      "export_name": "deleteAllSnapshots",
+      "is_type_only": false,
+      "line": 48,
+      "col": 16,
+      "span_start": 1488,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/auditTrail.ts",
+      "export_name": "getAuditTrail",
+      "is_type_only": false,
+      "line": 36,
+      "col": 16,
+      "span_start": 958,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/reviewStore.ts",
+      "export_name": "deleteReview",
+      "is_type_only": false,
+      "line": 170,
+      "col": 16,
+      "span_start": 5704,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/reviewValidation.ts",
+      "export_name": "isValid",
+      "is_type_only": false,
+      "line": 35,
+      "col": 16,
+      "span_start": 839,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/reviewValidation.ts",
+      "export_name": "requiresRationale",
+      "is_type_only": false,
+      "line": 39,
+      "col": 16,
+      "span_start": 952,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/reviewValidation.ts",
+      "export_name": "statusColor",
+      "is_type_only": false,
+      "line": 56,
+      "col": 16,
+      "span_start": 1343,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/runState.ts",
+      "export_name": "loadLinkedRuleIds",
+      "is_type_only": false,
+      "line": 487,
+      "col": 16,
+      "span_start": 16880,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/runState.ts",
+      "export_name": "setLinkedRuleIdsInStorage",
+      "is_type_only": false,
+      "line": 530,
+      "col": 16,
+      "span_start": 18293,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/runState.ts",
+      "export_name": "clearLinkedRuleIdsFromStorage",
+      "is_type_only": false,
+      "line": 737,
+      "col": 16,
+      "span_start": 26701,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    }
+  ],
+  "unused_types": [
+    {
+      "path": "src/app/m/_components/RequirementCoverageWorkspace.tsx",
+      "export_name": "RequirementCoverageFilter",
+      "is_type_only": true,
+      "line": 16,
+      "col": 12,
+      "span_start": 607,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/app/m/_lib/methodRules.ts",
+      "export_name": "RuleFull",
+      "is_type_only": true,
+      "line": 39,
+      "col": 12,
+      "span_start": 879,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/app/m/_lib/methodSections.ts",
+      "export_name": "SectionFull",
+      "is_type_only": true,
+      "line": 16,
+      "col": 12,
+      "span_start": 415,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/exports/verificationPackContract.ts",
+      "export_name": "TraceSectionLink",
+      "is_type_only": true,
+      "line": 1760,
+      "col": 90,
+      "span_start": 68563,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckReviewQuestion.ts",
+      "export_name": "BuildReviewQuestionSectionRetrievalInput",
+      "is_type_only": true,
+      "line": 14,
+      "col": 2,
+      "span_start": 472,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckReviewQuestion.ts",
+      "export_name": "QuickCheckPath",
+      "is_type_only": true,
+      "line": 15,
+      "col": 2,
+      "span_start": 516,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckReviewQuestion.ts",
+      "export_name": "ReviewQuestionDiagnostic",
+      "is_type_only": true,
+      "line": 17,
+      "col": 2,
+      "span_start": 548,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckReviewQuestion.ts",
+      "export_name": "ReviewQuestionMatchStage",
+      "is_type_only": true,
+      "line": 18,
+      "col": 2,
+      "span_start": 576,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckReviewQuestion.ts",
+      "export_name": "ReviewQuestionRetrievalResult",
+      "is_type_only": true,
+      "line": 20,
+      "col": 2,
+      "span_start": 628,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckReviewQuestion.ts",
+      "export_name": "ReviewQuestionStatus",
+      "is_type_only": true,
+      "line": 21,
+      "col": 2,
+      "span_start": 661,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckReviewQuestion.ts",
+      "export_name": "SectionMatchResult",
+      "is_type_only": true,
+      "line": 22,
+      "col": 2,
+      "span_start": 685,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckReviewQuestion.ts",
+      "export_name": "ReviewQuestionEvaluationResult",
+      "is_type_only": true,
+      "line": 24,
+      "col": 14,
+      "span_start": 762,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/documentModel/types.ts",
+      "export_name": "ParsedArtifacts",
+      "is_type_only": true,
+      "line": 85,
+      "col": 12,
+      "span_start": 2017,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/decisions/index.ts",
+      "export_name": "ReviewerDecision",
+      "is_type_only": true,
+      "line": 3,
+      "col": 2,
+      "span_start": 93,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/decisions/index.ts",
+      "export_name": "DecisionRun",
+      "is_type_only": true,
+      "line": 5,
+      "col": 2,
+      "span_start": 130,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/decisions/index.ts",
+      "export_name": "DecisionStatus",
+      "is_type_only": true,
+      "line": 6,
+      "col": 2,
+      "span_start": 145,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/decisions/index.ts",
+      "export_name": "DecisionWarning",
+      "is_type_only": true,
+      "line": 7,
+      "col": 2,
+      "span_start": 163,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/export/index.ts",
+      "export_name": "ManifestEntry",
+      "is_type_only": true,
+      "line": 5,
+      "col": 74,
+      "span_start": 366,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/export/index.ts",
+      "export_name": "PremiumExportMeta",
+      "is_type_only": true,
+      "line": 5,
+      "col": 55,
+      "span_start": 347,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/export/index.ts",
+      "export_name": "PremiumExportOutput",
+      "is_type_only": true,
+      "line": 5,
+      "col": 34,
+      "span_start": 326,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/export/pdfExporter.ts",
+      "export_name": "PdfPage",
+      "is_type_only": true,
+      "line": 118,
+      "col": 12,
+      "span_start": 3900,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/export/types.ts",
+      "export_name": "PremiumExportOutput",
+      "is_type_only": true,
+      "line": 31,
+      "col": 12,
+      "span_start": 990,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/export/types.ts",
+      "export_name": "PremiumExportMeta",
+      "is_type_only": true,
+      "line": 36,
+      "col": 12,
+      "span_start": 1060,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/extraction/types.ts",
+      "export_name": "ExtractionConfig",
+      "is_type_only": true,
+      "line": 91,
+      "col": 12,
+      "span_start": 1842,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/metrics/index.ts",
+      "export_name": "FragmentQuality",
+      "is_type_only": true,
+      "line": 3,
+      "col": 2,
+      "span_start": 60,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/metrics/index.ts",
+      "export_name": "SectionCoverage",
+      "is_type_only": true,
+      "line": 6,
+      "col": 2,
+      "span_start": 128,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/metrics/index.ts",
+      "export_name": "EvidenceQualityMetrics",
+      "is_type_only": true,
+      "line": 7,
+      "col": 2,
+      "span_start": 147,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/metrics/index.ts",
+      "export_name": "MetricsInput",
+      "is_type_only": true,
+      "line": 8,
+      "col": 2,
+      "span_start": 173,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/metrics/types.ts",
+      "export_name": "MetricsInput",
+      "is_type_only": true,
+      "line": 42,
+      "col": 12,
+      "span_start": 1119,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/reconciliation/index.ts",
+      "export_name": "ReconciliationRun",
+      "is_type_only": true,
+      "line": 4,
+      "col": 2,
+      "span_start": 89,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/reconciliation/index.ts",
+      "export_name": "ReconciliationItem",
+      "is_type_only": true,
+      "line": 5,
+      "col": 2,
+      "span_start": 110,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/reconciliation/index.ts",
+      "export_name": "ReconciliationItemStatus",
+      "is_type_only": true,
+      "line": 6,
+      "col": 2,
+      "span_start": 132,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/reconciliation/index.ts",
+      "export_name": "ReconciliationStatus",
+      "is_type_only": true,
+      "line": 7,
+      "col": 2,
+      "span_start": 160,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/reconciliation/index.ts",
+      "export_name": "CoverageGap",
+      "is_type_only": true,
+      "line": 8,
+      "col": 2,
+      "span_start": 184,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/mode.ts",
+      "export_name": "VerifyView",
+      "is_type_only": true,
+      "line": 12,
+      "col": 12,
+      "span_start": 393,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/projects/types.ts",
+      "export_name": "ReviewedLearningCase",
+      "is_type_only": true,
+      "line": 62,
+      "col": 12,
+      "span_start": 2092,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/types.ts",
+      "export_name": "VerificationSnapshot",
+      "is_type_only": true,
+      "line": 181,
+      "col": 12,
+      "span_start": 4245,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/types.ts",
+      "export_name": "ProofMapState",
+      "is_type_only": true,
+      "line": 185,
+      "col": 12,
+      "span_start": 4326,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "PreferredSectionBoost",
+      "is_type_only": true,
+      "line": 69,
+      "col": 12,
+      "span_start": 2096,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "TitlePenalty",
+      "is_type_only": true,
+      "line": 70,
+      "col": 12,
+      "span_start": 2177,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "ReviewAreaPolicyInput",
+      "is_type_only": true,
+      "line": 71,
+      "col": 12,
+      "span_start": 2240,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "ReviewPolicyConfig",
+      "is_type_only": true,
+      "line": 74,
+      "col": 12,
+      "span_start": 2467,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "ReviewPolicyAreaKey",
+      "is_type_only": true,
+      "line": 76,
+      "col": 12,
+      "span_start": 2543,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/policy/types.ts",
+      "export_name": "ReviewPolicyStage",
+      "is_type_only": true,
+      "line": 77,
+      "col": 12,
+      "span_start": 2589,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "EvidenceSnapshotState",
+      "is_type_only": true,
+      "line": 3,
+      "col": 2,
+      "span_start": 36,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "SnapshotComparableSectionMap",
+      "is_type_only": true,
+      "line": 5,
+      "col": 2,
+      "span_start": 85,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "SnapshotDiffKind",
+      "is_type_only": true,
+      "line": 7,
+      "col": 2,
+      "span_start": 137,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "SnapshotDiffSectionSummary",
+      "is_type_only": true,
+      "line": 9,
+      "col": 2,
+      "span_start": 183,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "SnapshotProjectMeta",
+      "is_type_only": true,
+      "line": 10,
+      "col": 2,
+      "span_start": 213,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/index.ts",
+      "export_name": "SnapshotExport",
+      "is_type_only": true,
+      "line": 17,
+      "col": 14,
+      "span_start": 602,
+      "is_re_export": true,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration",
+          "note": "This finding originates from a re-export; verify it is not part of your public API before removing"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/snapshot/types_v2.ts",
+      "export_name": "SnapshotComparableSectionMap",
+      "is_type_only": true,
+      "line": 120,
+      "col": 12,
+      "span_start": 2955,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    }
+  ],
+  "private_type_leaks": [],
+  "unused_dependencies": [],
+  "unused_dev_dependencies": [
+    {
+      "package_name": "eslint-config-next",
+      "location": "devDependencies",
+      "path": "package.json",
+      "line": 91,
+      "actions": [
+        {
+          "type": "remove-dependency",
+          "auto_fixable": true,
+          "description": "Remove from devDependencies in package.json"
+        },
+        {
+          "type": "add-to-config",
+          "auto_fixable": false,
+          "description": "Add \"eslint-config-next\" to ignoreDependencies in fallow config",
+          "config_key": "ignoreDependencies",
+          "value": "eslint-config-next",
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreDependencies/items"
+        }
+      ]
+    },
+    {
+      "package_name": "jest-environment-node",
+      "location": "devDependencies",
+      "path": "package.json",
+      "line": 97,
+      "actions": [
+        {
+          "type": "remove-dependency",
+          "auto_fixable": true,
+          "description": "Remove from devDependencies in package.json"
+        },
+        {
+          "type": "add-to-config",
+          "auto_fixable": false,
+          "description": "Add \"jest-environment-node\" to ignoreDependencies in fallow config",
+          "config_key": "ignoreDependencies",
+          "value": "jest-environment-node",
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreDependencies/items"
+        }
+      ]
+    }
+  ],
+  "unused_optional_dependencies": [],
+  "unused_enum_members": [],
+  "unused_class_members": [],
+  "unresolved_imports": [],
+  "unlisted_dependencies": [
+    {
+      "package_name": "@napi-rs/canvas",
+      "imported_from": [
+        {
+          "path": "src/lib/chat/quickCheckPdfExtractor.ts",
+          "line": 137,
+          "col": 31
+        }
+      ],
+      "actions": [
+        {
+          "type": "install-dependency",
+          "auto_fixable": false,
+          "description": "Add this package to dependencies in package.json",
+          "note": "Verify this package should be a direct dependency before adding"
+        },
+        {
+          "type": "add-to-config",
+          "auto_fixable": false,
+          "description": "Add \"@napi-rs/canvas\" to ignoreDependencies in fallow config",
+          "config_key": "ignoreDependencies",
+          "value": "@napi-rs/canvas",
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreDependencies/items"
+        }
+      ]
+    },
+    {
+      "package_name": "tsconfig-paths",
+      "imported_from": [
+        {
+          "path": "scripts/build-audit-pack.mjs",
+          "line": 18,
+          "col": 0
+        },
+        {
+          "path": "scripts/ci-verify-run-summary.mjs",
+          "line": 10,
+          "col": 0
+        },
+        {
+          "path": "scripts/test-evidence-map-smoke.cjs",
+          "line": 6,
+          "col": 0
+        },
+        {
+          "path": "scripts/verify-export-snapshot.mjs",
+          "line": 10,
+          "col": 0
+        }
+      ],
+      "actions": [
+        {
+          "type": "install-dependency",
+          "auto_fixable": false,
+          "description": "Add this package to dependencies in package.json",
+          "note": "Verify this package should be a direct dependency before adding"
+        },
+        {
+          "type": "add-to-config",
+          "auto_fixable": false,
+          "description": "Add \"tsconfig-paths\" to ignoreDependencies in fallow config",
+          "config_key": "ignoreDependencies",
+          "value": "tsconfig-paths",
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreDependencies/items"
+        }
+      ]
+    }
+  ],
+  "duplicate_exports": [
+    {
+      "export_name": "EvidenceAttachment",
+      "locations": [
+        {
+          "path": "src/lib/proofMap/types.ts",
+          "line": 122,
+          "col": 12
+        },
+        {
+          "path": "src/lib/verify/reviewStore.ts",
+          "line": 3,
+          "col": 12
+        }
+      ],
+      "actions": [
+        {
+          "type": "add-to-config",
+          "auto_fixable": true,
+          "description": "Add an ignoreExports rule so these files are excluded from duplicate-export grouping (use when this duplication is an intentional namespace-barrel API).",
+          "config_key": "ignoreExports",
+          "value": [
+            {
+              "file": "src/lib/proofMap/types.ts",
+              "exports": [
+                "*"
+              ]
+            },
+            {
+              "file": "src/lib/verify/reviewStore.ts",
+              "exports": [
+                "*"
+              ]
+            }
+          ],
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreExports"
+        },
+        {
+          "type": "remove-duplicate",
+          "auto_fixable": false,
+          "description": "Keep one canonical export location and remove the others",
+          "note": "If every location is the sole `index.*` of its directory, this is likely an intentional namespace-barrel API. Prefer adding these files to `ignoreExports` over removing exports."
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line duplicate-export",
+          "scope": "per-location"
+        }
+      ]
+    },
+    {
+      "export_name": "ReconciliationItemStatus",
+      "locations": [
+        {
+          "path": "src/lib/evidence/inventory.ts",
+          "line": 23,
+          "col": 12
+        },
+        {
+          "path": "src/lib/evidence/reconciliation/types.ts",
+          "line": 1,
+          "col": 12
+        }
+      ],
+      "actions": [
+        {
+          "type": "add-to-config",
+          "auto_fixable": true,
+          "description": "Add an ignoreExports rule so these files are excluded from duplicate-export grouping (use when this duplication is an intentional namespace-barrel API).",
+          "config_key": "ignoreExports",
+          "value": [
+            {
+              "file": "src/lib/evidence/inventory.ts",
+              "exports": [
+                "*"
+              ]
+            },
+            {
+              "file": "src/lib/evidence/reconciliation/types.ts",
+              "exports": [
+                "*"
+              ]
+            }
+          ],
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreExports"
+        },
+        {
+          "type": "remove-duplicate",
+          "auto_fixable": false,
+          "description": "Keep one canonical export location and remove the others",
+          "note": "If every location is the sole `index.*` of its directory, this is likely an intentional namespace-barrel API. Prefer adding these files to `ignoreExports` over removing exports."
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line duplicate-export",
+          "scope": "per-location"
+        }
+      ]
+    },
+    {
+      "export_name": "RuleReview",
+      "locations": [
+        {
+          "path": "src/lib/projects/types.ts",
+          "line": 69,
+          "col": 12
+        },
+        {
+          "path": "src/lib/verify/reviewStore.ts",
+          "line": 11,
+          "col": 12
+        }
+      ],
+      "actions": [
+        {
+          "type": "add-to-config",
+          "auto_fixable": true,
+          "description": "Add an ignoreExports rule so these files are excluded from duplicate-export grouping (use when this duplication is an intentional namespace-barrel API).",
+          "config_key": "ignoreExports",
+          "value": [
+            {
+              "file": "src/lib/projects/types.ts",
+              "exports": [
+                "*"
+              ]
+            },
+            {
+              "file": "src/lib/verify/reviewStore.ts",
+              "exports": [
+                "*"
+              ]
+            }
+          ],
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreExports"
+        },
+        {
+          "type": "remove-duplicate",
+          "auto_fixable": false,
+          "description": "Keep one canonical export location and remove the others",
+          "note": "If every location is the sole `index.*` of its directory, this is likely an intentional namespace-barrel API. Prefer adding these files to `ignoreExports` over removing exports."
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line duplicate-export",
+          "scope": "per-location"
+        }
+      ]
+    },
+    {
+      "export_name": "buildEvidenceSnapshot",
+      "locations": [
+        {
+          "path": "src/lib/proof/bundle.ts",
+          "line": 74,
+          "col": 16
+        },
+        {
+          "path": "src/lib/proofMap/evidenceSnapshot.ts",
+          "line": 350,
+          "col": 22
+        }
+      ],
+      "actions": [
+        {
+          "type": "add-to-config",
+          "auto_fixable": true,
+          "description": "Add an ignoreExports rule so these files are excluded from duplicate-export grouping (use when this duplication is an intentional namespace-barrel API).",
+          "config_key": "ignoreExports",
+          "value": [
+            {
+              "file": "src/lib/proof/bundle.ts",
+              "exports": [
+                "*"
+              ]
+            },
+            {
+              "file": "src/lib/proofMap/evidenceSnapshot.ts",
+              "exports": [
+                "*"
+              ]
+            }
+          ],
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreExports"
+        },
+        {
+          "type": "remove-duplicate",
+          "auto_fixable": false,
+          "description": "Keep one canonical export location and remove the others",
+          "note": "If every location is the sole `index.*` of its directory, this is likely an intentional namespace-barrel API. Prefer adding these files to `ignoreExports` over removing exports."
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line duplicate-export",
+          "scope": "per-location"
+        }
+      ]
+    },
+    {
+      "export_name": "canonicalJsonStringify",
+      "locations": [
+        {
+          "path": "src/lib/auditTrail/canonicalJson.ts",
+          "line": 14,
+          "col": 16
+        },
+        {
+          "path": "src/lib/export/canonicalJson.ts",
+          "line": 14,
+          "col": 16
+        }
+      ],
+      "actions": [
+        {
+          "type": "add-to-config",
+          "auto_fixable": true,
+          "description": "Add an ignoreExports rule so these files are excluded from duplicate-export grouping (use when this duplication is an intentional namespace-barrel API).",
+          "config_key": "ignoreExports",
+          "value": [
+            {
+              "file": "src/lib/auditTrail/canonicalJson.ts",
+              "exports": [
+                "*"
+              ]
+            },
+            {
+              "file": "src/lib/export/canonicalJson.ts",
+              "exports": [
+                "*"
+              ]
+            }
+          ],
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreExports"
+        },
+        {
+          "type": "remove-duplicate",
+          "auto_fixable": false,
+          "description": "Keep one canonical export location and remove the others",
+          "note": "If every location is the sole `index.*` of its directory, this is likely an intentional namespace-barrel API. Prefer adding these files to `ignoreExports` over removing exports."
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line duplicate-export",
+          "scope": "per-location"
+        }
+      ]
+    },
+    {
+      "export_name": "composeGoldStandardVerificationReport",
+      "locations": [
+        {
+          "path": "src/lib/composers/composeGoldStandardVerificationReport.ts",
+          "line": 86,
+          "col": 16
+        },
+        {
+          "path": "src/lib/projects/verificationReport.ts",
+          "line": 432,
+          "col": 16
+        }
+      ],
+      "actions": [
+        {
+          "type": "add-to-config",
+          "auto_fixable": true,
+          "description": "Add an ignoreExports rule so these files are excluded from duplicate-export grouping (use when this duplication is an intentional namespace-barrel API).",
+          "config_key": "ignoreExports",
+          "value": [
+            {
+              "file": "src/lib/composers/composeGoldStandardVerificationReport.ts",
+              "exports": [
+                "*"
+              ]
+            },
+            {
+              "file": "src/lib/projects/verificationReport.ts",
+              "exports": [
+                "*"
+              ]
+            }
+          ],
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreExports"
+        },
+        {
+          "type": "remove-duplicate",
+          "auto_fixable": false,
+          "description": "Keep one canonical export location and remove the others",
+          "note": "If every location is the sole `index.*` of its directory, this is likely an intentional namespace-barrel API. Prefer adding these files to `ignoreExports` over removing exports."
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line duplicate-export",
+          "scope": "per-location"
+        }
+      ]
+    },
+    {
+      "export_name": "composeVerraVerificationReport",
+      "locations": [
+        {
+          "path": "src/lib/composers/composeVerraVerificationReport.ts",
+          "line": 90,
+          "col": 16
+        },
+        {
+          "path": "src/lib/projects/verificationReport.ts",
+          "line": 428,
+          "col": 16
+        }
+      ],
+      "actions": [
+        {
+          "type": "add-to-config",
+          "auto_fixable": true,
+          "description": "Add an ignoreExports rule so these files are excluded from duplicate-export grouping (use when this duplication is an intentional namespace-barrel API).",
+          "config_key": "ignoreExports",
+          "value": [
+            {
+              "file": "src/lib/composers/composeVerraVerificationReport.ts",
+              "exports": [
+                "*"
+              ]
+            },
+            {
+              "file": "src/lib/projects/verificationReport.ts",
+              "exports": [
+                "*"
+              ]
+            }
+          ],
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreExports"
+        },
+        {
+          "type": "remove-duplicate",
+          "auto_fixable": false,
+          "description": "Keep one canonical export location and remove the others",
+          "note": "If every location is the sole `index.*` of its directory, this is likely an intentional namespace-barrel API. Prefer adding these files to `ignoreExports` over removing exports."
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line duplicate-export",
+          "scope": "per-location"
+        }
+      ]
+    },
+    {
+      "export_name": "getProjectCoverage",
+      "locations": [
+        {
+          "path": "src/lib/projects/exportPdf.ts",
+          "line": 52,
+          "col": 16
+        },
+        {
+          "path": "src/lib/projects/storage.ts",
+          "line": 181,
+          "col": 16
+        }
+      ],
+      "actions": [
+        {
+          "type": "add-to-config",
+          "auto_fixable": true,
+          "description": "Add an ignoreExports rule so these files are excluded from duplicate-export grouping (use when this duplication is an intentional namespace-barrel API).",
+          "config_key": "ignoreExports",
+          "value": [
+            {
+              "file": "src/lib/projects/exportPdf.ts",
+              "exports": [
+                "*"
+              ]
+            },
+            {
+              "file": "src/lib/projects/storage.ts",
+              "exports": [
+                "*"
+              ]
+            }
+          ],
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreExports"
+        },
+        {
+          "type": "remove-duplicate",
+          "auto_fixable": false,
+          "description": "Keep one canonical export location and remove the others",
+          "note": "If every location is the sole `index.*` of its directory, this is likely an intentional namespace-barrel API. Prefer adding these files to `ignoreExports` over removing exports."
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line duplicate-export",
+          "scope": "per-location"
+        }
+      ]
+    },
+    {
+      "export_name": "sha256Hex",
+      "locations": [
+        {
+          "path": "src/lib/auditTrail/hash.ts",
+          "line": 7,
+          "col": 22
+        },
+        {
+          "path": "src/lib/proof/bundle.ts",
+          "line": 152,
+          "col": 22
+        },
+        {
+          "path": "src/lib/proof/fingerprints.ts",
+          "line": 20,
+          "col": 22
+        }
+      ],
+      "actions": [
+        {
+          "type": "add-to-config",
+          "auto_fixable": true,
+          "description": "Add an ignoreExports rule so these files are excluded from duplicate-export grouping (use when this duplication is an intentional namespace-barrel API).",
+          "config_key": "ignoreExports",
+          "value": [
+            {
+              "file": "src/lib/auditTrail/hash.ts",
+              "exports": [
+                "*"
+              ]
+            },
+            {
+              "file": "src/lib/proof/bundle.ts",
+              "exports": [
+                "*"
+              ]
+            },
+            {
+              "file": "src/lib/proof/fingerprints.ts",
+              "exports": [
+                "*"
+              ]
+            }
+          ],
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreExports"
+        },
+        {
+          "type": "remove-duplicate",
+          "auto_fixable": false,
+          "description": "Keep one canonical export location and remove the others",
+          "note": "If every location is the sole `index.*` of its directory, this is likely an intentional namespace-barrel API. Prefer adding these files to `ignoreExports` over removing exports."
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line duplicate-export",
+          "scope": "per-location"
+        }
+      ]
+    }
+  ],
+  "type_only_dependencies": [],
+  "test_only_dependencies": [
+    {
+      "package_name": "fake-indexeddb",
+      "path": "package.json",
+      "line": 68,
+      "actions": [
+        {
+          "type": "move-to-dev",
+          "auto_fixable": false,
+          "description": "Move to devDependencies (only test files import this)",
+          "note": "Only test files import this package so it does not need to be a production dependency"
+        },
+        {
+          "type": "add-to-config",
+          "auto_fixable": false,
+          "description": "Add \"fake-indexeddb\" to ignoreDependencies in fallow config",
+          "config_key": "ignoreDependencies",
+          "value": "fake-indexeddb",
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreDependencies/items"
+        }
+      ]
+    },
+    {
+      "package_name": "react-dom",
+      "path": "package.json",
+      "line": 77,
+      "actions": [
+        {
+          "type": "move-to-dev",
+          "auto_fixable": false,
+          "description": "Move to devDependencies (only test files import this)",
+          "note": "Only test files import this package so it does not need to be a production dependency"
+        },
+        {
+          "type": "add-to-config",
+          "auto_fixable": false,
+          "description": "Add \"react-dom\" to ignoreDependencies in fallow config",
+          "config_key": "ignoreDependencies",
+          "value": "react-dom",
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreDependencies/items"
+        }
+      ]
+    }
+  ],
+  "circular_dependencies": [],
+  "re_export_cycles": [],
+  "boundary_violations": [],
+  "stale_suppressions": [],
+  "unused_catalog_entries": [],
+  "empty_catalog_groups": [],
+  "unresolved_catalog_references": [],
+  "unused_dependency_overrides": [],
+  "misconfigured_dependency_overrides": []
+}

--- a/artifacts/fallow/dupes.json
+++ b/artifacts/fallow/dupes.json
@@ -1,0 +1,4836 @@
+{
+  "kind": "dupes",
+  "schema_version": 7,
+  "version": "2.86.0",
+  "elapsed_ms": 1610,
+  "clone_groups": [
+    {
+      "instances": [
+        {
+          "file": "scripts/build-derived-artifacts.mjs",
+          "start_line": 5,
+          "end_line": 25,
+          "start_col": 42,
+          "end_col": 1,
+          "fragment": "\"./_stable-json.mjs\";\n\nasync function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction extractList(input, key) {\n  if (Array.isArray(input)) return input;\n  if (input && typeof input === \"object\" && Array.isArray(input[key])) return input[key];\n  return [];\n}"
+        },
+        {
+          "file": "scripts/build-derived-manifest.mjs",
+          "start_line": 5,
+          "end_line": 35,
+          "start_col": 56,
+          "end_col": 1,
+          "fragment": "\"./_stable-json.mjs\";\n\nasync function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values());\n}"
+        },
+        {
+          "file": "scripts/verify-derived-artifacts.mjs",
+          "start_line": 5,
+          "end_line": 35,
+          "start_col": 27,
+          "end_col": 1,
+          "fragment": "\"./_stable-json.mjs\";\n\nasync function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values());\n}"
+        }
+      ],
+      "token_count": 63,
+      "line_count": 31,
+      "fingerprint": "dup:933cfb21",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (31 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "scripts/build-derived-artifacts.mjs",
+          "start_line": 31,
+          "end_line": 44,
+          "start_col": 0,
+          "end_col": 33,
+          "fragment": "function collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values())"
+        },
+        {
+          "file": "scripts/build-derived-manifest.mjs",
+          "start_line": 21,
+          "end_line": 34,
+          "start_col": 0,
+          "end_col": 33,
+          "fragment": "function collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values())"
+        },
+        {
+          "file": "scripts/test-derived-determinism.mjs",
+          "start_line": 21,
+          "end_line": 34,
+          "start_col": 0,
+          "end_col": 33,
+          "fragment": "function collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values())"
+        },
+        {
+          "file": "scripts/verify-derived-artifacts.mjs",
+          "start_line": 21,
+          "end_line": 34,
+          "start_col": 0,
+          "end_col": 33,
+          "fragment": "function collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values())"
+        }
+      ],
+      "token_count": 142,
+      "line_count": 14,
+      "fingerprint": "dup:f2ffa934",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (14 lines, 4 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "scripts/build-derived-manifest.mjs",
+          "start_line": 7,
+          "end_line": 78,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "async function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values());\n}\n\nasync function main() {\n  const manifestPath = path.join(process.cwd(), \"public\", \"manifest\", \"index.json\");\n  if (!(await fileExists(manifestPath))) {\n    throw new Error(\"Derived manifest: manifest index missing.\");\n  }\n  const manifest = await readJson(manifestPath);\n  if (!Array.isArray(manifest)) {\n    throw new Error(\"Derived manifest: manifest index invalid.\");\n  }\n\n  const datasets = collectDatasets(manifest);\n\n  for (const dataset of datasets) {\n    const derivedDir = path.join(dataset.baseDir, \"derived\");\n    if (!(await fileExists(derivedDir))) {\n      throw new Error(`Derived manifest: missing derived directory at ${derivedDir}`);\n    }\n\n    const entries = await readdir(derivedDir, { withFileTypes: true });\n    const files = entries.filter((entry) => entry.isFile()).map((entry) => entry.name);\n    const derivedFiles = files.filter((name) => name !== \"manifest.json\");\n\n    const derivedRecords = [];\n    for (const name of derivedFiles) {\n      const fullPath = path.join(derivedDir, name);\n      const stats = await stat(fullPath);\n      const sha256 = await sha256File(fullPath);\n      derivedRecords.push({ path: `derived/${name}`, sha256, bytes: stats.size });\n    }\n\n    derivedRecords.sort(sortByPath);\n\n    const manifestOut = {\n      version: 1,\n      derived_files: derivedRecords,\n      note: \"sha256 over exact file bytes\",\n    };\n\n    const manifestOutPath = path.join(derivedDir, \"manifest.json\");\n    await writeFile(manifestOutPath, stableStringify(manifestOut), \"utf8\");\n  }\n}"
+        },
+        {
+          "file": "scripts/test-derived-determinism.mjs",
+          "start_line": 7,
+          "end_line": 57,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "async function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values());\n}\n\nasync function loadManifestTexts() {\n  const manifestPath = path.join(process.cwd(), \"public\", \"manifest\", \"index.json\");\n  if (!(await fileExists(manifestPath))) {\n    throw new Error(\"Determinism: manifest index missing.\");\n  }\n  const manifest = await readJson(manifestPath);\n  if (!Array.isArray(manifest)) {\n    throw new Error(\"Determinism: manifest index invalid.\");\n  }\n  const datasets = collectDatasets(manifest);\n  const output = new Map();\n  for (const dataset of datasets) {\n    const manifestFile = path.join(dataset.baseDir, \"derived\", \"manifest.json\");\n    if (!(await fileExists(manifestFile))) {\n      throw new Error(`Determinism: missing manifest at ${manifestFile}`);\n    }\n    const text = await readFile(manifestFile, \"utf8\");\n    output.set(manifestFile, text);\n  }\n  return output;\n}"
+        },
+        {
+          "file": "scripts/verify-derived-artifacts.mjs",
+          "start_line": 7,
+          "end_line": 96,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "async function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values());\n}\n\nasync function main() {\n  const manifestPath = path.join(process.cwd(), \"public\", \"manifest\", \"index.json\");\n  if (!(await fileExists(manifestPath))) {\n    throw new Error(\"Derived verifier: manifest index missing.\");\n  }\n  const manifest = await readJson(manifestPath);\n  if (!Array.isArray(manifest)) {\n    throw new Error(\"Derived verifier: manifest index invalid.\");\n  }\n\n  const datasets = collectDatasets(manifest);\n\n  for (const dataset of datasets) {\n    const derivedDir = path.join(dataset.baseDir, \"derived\");\n    const manifestFile = path.join(derivedDir, \"manifest.json\");\n    if (!(await fileExists(manifestFile))) {\n      throw new Error(`Derived verifier: missing manifest.json at ${manifestFile}`);\n    }\n\n    const manifestJson = await readJson(manifestFile);\n    const derivedFiles = Array.isArray(manifestJson?.derived_files) ? manifestJson.derived_files : null;\n    if (!derivedFiles) {\n      throw new Error(`Derived verifier: invalid manifest at ${manifestFile}`);\n    }\n\n    const listed = new Map();\n    for (const entry of derivedFiles) {\n      if (!entry || typeof entry !== \"object\") continue;\n      const relPath = typeof entry.path === \"string\" ? entry.path : null;\n      const sha256 = typeof entry.sha256 === \"string\" ? entry.sha256 : null;\n      if (!relPath || !sha256) {\n        throw new Error(`Derived verifier: invalid manifest entry in ${manifestFile}`);\n      }\n      listed.set(relPath, sha256);\n    }\n\n    const entries = await readdir(derivedDir, { withFileTypes: true });\n    const files = entries.filter((entry) => entry.isFile()).map((entry) => entry.name);\n    const derivedFileNames = files.filter((name) => name !== \"manifest.json\");\n\n    for (const name of derivedFileNames) {\n      const relPath = `derived/${name}`;\n      if (!listed.has(relPath)) {\n        throw new Error(`Derived verifier: extra file ${relPath} in ${derivedDir}`);\n      }\n    }\n\n    for (const [relPath, expectedSha] of listed.entries()) {\n      const name = relPath.replace(/^derived\\//, \"\");\n      const fullPath = path.join(derivedDir, name);\n      if (!(await fileExists(fullPath))) {\n        throw new Error(`Derived verifier: missing file ${relPath} in ${derivedDir}`);\n      }\n      const actualSha = await sha256File(fullPath);\n      if (actualSha !== expectedSha) {\n        throw new Error(`Derived verifier: sha mismatch for ${relPath}`);\n      }\n    }\n  }\n}"
+        }
+      ],
+      "token_count": 203,
+      "line_count": 90,
+      "fingerprint": "dup:86cd13c3",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (90 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/app/m/_lib/methodInventory.ts",
+          "start_line": 52,
+          "end_line": 60,
+          "start_col": 56,
+          "end_col": 18,
+          "fragment": ");\n}\n\nfunction pickString(entry: Record<string, unknown>, keys: string[]): string | undefined {\n  for (const key of keys) {\n    const value = entry[key];\n    if (typeof value === \"string\" && value.trim()) return value.trim();\n  }\n  return undefined"
+        },
+        {
+          "file": "src/app/m/_lib/methodRules.ts",
+          "start_line": 62,
+          "end_line": 70,
+          "start_col": 45,
+          "end_col": 18,
+          "fragment": ")}…`;\n}\n\nfunction pickString(entry: Record<string, unknown>, keys: string[]): string | undefined {\n  for (const key of keys) {\n    const value = entry[key];\n    if (typeof value === \"string\" && value.trim()) return value.trim();\n  }\n  return undefined"
+        },
+        {
+          "file": "src/app/m/_lib/methodSections.ts",
+          "start_line": 34,
+          "end_line": 42,
+          "start_col": 45,
+          "end_col": 18,
+          "fragment": ")}…`;\n}\n\nfunction pickString(entry: Record<string, unknown>, keys: string[]): string | undefined {\n  for (const key of keys) {\n    const value = entry[key];\n    if (typeof value === \"string\" && value.trim()) return value.trim();\n  }\n  return undefined"
+        }
+      ],
+      "token_count": 60,
+      "line_count": 9,
+      "fingerprint": "dup:22b46640",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/app/m/_lib/methodRich.ts",
+          "start_line": 33,
+          "end_line": 41,
+          "start_col": 0,
+          "end_col": 3,
+          "fragment": "async function readJsonFile(filePath: string): Promise<unknown> {\n  const raw = await readFile(filePath, \"utf8\");\n  try {\n    return JSON.parse(raw);\n  } catch (error) {\n    throw new Error(\n      `Failed to parse rich JSON at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,\n    );\n  }"
+        },
+        {
+          "file": "src/app/m/_lib/methodRules.ts",
+          "start_line": 176,
+          "end_line": 184,
+          "start_col": 0,
+          "end_col": 3,
+          "fragment": "async function readJsonFile(filePath: string): Promise<unknown> {\n  const raw = await readFile(filePath, \"utf8\");\n  try {\n    return JSON.parse(raw);\n  } catch (error) {\n    throw new Error(\n      `Failed to parse rules JSON at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,\n    );\n  }"
+        },
+        {
+          "file": "src/app/m/_lib/methodSections.ts",
+          "start_line": 65,
+          "end_line": 73,
+          "start_col": 0,
+          "end_col": 3,
+          "fragment": "async function readJsonFile(filePath: string): Promise<unknown> {\n  const raw = await readFile(filePath, \"utf8\");\n  try {\n    return JSON.parse(raw);\n  } catch (error) {\n    throw new Error(\n      `Failed to parse sections JSON at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,\n    );\n  }"
+        }
+      ],
+      "token_count": 62,
+      "line_count": 9,
+      "fingerprint": "dup:7d115d0d",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/app/m/_lib/methodRich.ts",
+          "start_line": 96,
+          "end_line": 113,
+          "start_col": 8,
+          "end_col": 3,
+          "fragment": "manifestPath =\n    entries\n      .map((entry) =>\n        typeof (entry as Record<string, unknown>).path === \"string\"\n          ? ((entry as Record<string, unknown>).path as string)\n          : null,\n      )\n      .find((value): value is string => Boolean(value)) ?? undefined;\n\n  if (!manifestPath) {\n    return {\n      ok: false,\n      sources: [],\n      attempted: [\"(manifest missing path field for this method/version)\"],\n      missing: [\"rich.json\", \"rules.rich.json\", \"sections.rich.json\"],\n      data: null,\n    };\n  }"
+        },
+        {
+          "file": "src/app/m/_lib/methodRules.ts",
+          "start_line": 317,
+          "end_line": 331,
+          "start_col": 6,
+          "end_col": 3,
+          "fragment": "manifestPath =\n    entries\n      .map((entry) =>\n        typeof (entry as Record<string, unknown>).path === \"string\"\n          ? ((entry as Record<string, unknown>).path as string)\n          : null,\n      )\n      .find((value): value is string => Boolean(value)) ?? undefined;\n\n  if (!manifestPath) {\n    const resolved = await resolveMethodVersionFiles(normalizedCode, normalizedVersion);\n    if (resolved) {\n      manifestPath = path.relative(process.cwd(), path.join(resolved.dir, \"rules.json\"));\n    }\n  }"
+        },
+        {
+          "file": "src/app/m/_lib/methodSections.ts",
+          "start_line": 206,
+          "end_line": 220,
+          "start_col": 6,
+          "end_col": 3,
+          "fragment": "manifestPath =\n    entries\n      .map((entry) =>\n        typeof (entry as Record<string, unknown>).path === \"string\"\n          ? ((entry as Record<string, unknown>).path as string)\n          : null,\n      )\n      .find((value): value is string => Boolean(value)) ?? undefined;\n\n  if (!manifestPath) {\n    const resolved = await resolveMethodVersionFiles(normalizedCode, normalizedVersion);\n    if (resolved) {\n      manifestPath = path.relative(process.cwd(), path.join(resolved.dir, \"rules.json\"));\n    }\n  }"
+        }
+      ],
+      "token_count": 67,
+      "line_count": 18,
+      "fingerprint": "dup:f6a19a1c",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (18 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/exports/verificationPackContract.ts",
+          "start_line": 811,
+          "end_line": 817,
+          "start_col": 0,
+          "end_col": 29,
+          "fragment": "function escapeHtml(value: string): string {\n  return value\n    .replaceAll(\"&\", \"&amp;\")\n    .replaceAll(\"<\", \"&lt;\")\n    .replaceAll(\">\", \"&gt;\")\n    .replaceAll('\"', \"&quot;\")\n    .replaceAll(\"'\", \"&#39;\")"
+        },
+        {
+          "file": "src/lib/evidence/export/verificationPackIntegration.ts",
+          "start_line": 21,
+          "end_line": 27,
+          "start_col": 0,
+          "end_col": 29,
+          "fragment": "function escapeHtml(value: string): string {\n  return value\n    .replaceAll('&', '&amp;')\n    .replaceAll('<', '&lt;')\n    .replaceAll('>', '&gt;')\n    .replaceAll('\"', '&quot;')\n    .replaceAll(\"'\", '&#39;')"
+        },
+        {
+          "file": "src/lib/readiness/reportHtmlTheme.ts",
+          "start_line": 1,
+          "end_line": 7,
+          "start_col": 7,
+          "end_col": 29,
+          "fragment": "function escapeHtml(value: string): string {\n  return value\n    .replaceAll(\"&\", \"&amp;\")\n    .replaceAll(\"<\", \"&lt;\")\n    .replaceAll(\">\", \"&gt;\")\n    .replaceAll('\"', \"&quot;\")\n    .replaceAll(\"'\", \"&#39;\")"
+        }
+      ],
+      "token_count": 54,
+      "line_count": 7,
+      "fingerprint": "dup:27431e87",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (7 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/lib/chat/quickCheckEvidence.ts",
+          "start_line": 629,
+          "end_line": 640,
+          "start_col": 25,
+          "end_col": 26,
+          "fragment": ");\n  }\n\n  // VM-prefixed methodology codes: VM0007, VM 0007\n  for (const match of text.matchAll(/\\b(VM\\d{4})\\b/g)) {\n    mentions.add(match[1]);\n  }\n  for (const match of text.matchAll(/\\b(VM)\\s+(\\d{4})\\b/g)) {\n    mentions.add(`${match[1]}${match[2]}`);\n  }\n  for (const match of text.matchAll(/\\b(AR-AMS\\d{4}|AR-ACM\\d{4})\\b/gi)) {\n    mentions.add((match[1]"
+        },
+        {
+          "file": "src/lib/chat/quickCheckEvidence.ts",
+          "start_line": 645,
+          "end_line": 654,
+          "start_col": 52,
+          "end_col": 25,
+          "fragment": ");\n  }\n  for (const match of text.matchAll(/\\b(VMD\\d{4})\\b/g)) {\n    mentions.add(match[1]);\n  }\n  for (const match of text.matchAll(/\\b(VMD)\\s+(\\d{4})\\b/g)) {\n    mentions.add(`${match[1]}${match[2]}`);\n  }\n  for (const match of text.matchAll(/\\b(APD|ARR|RWE|APWD)\\b/g)) {\n    mentions.add(match[1]"
+        },
+        {
+          "file": "src/lib/chat/quickCheckEvidence.ts",
+          "start_line": 663,
+          "end_line": 676,
+          "start_col": 44,
+          "end_col": 25,
+          "fragment": ");\n  }\n\n  // VMR-prefixed methodology codes: VMR001, VMR 001\n  for (const match of text.matchAll(/\\b(VMR\\d{3,4})\\b/g)) {\n    mentions.add(match[1]);\n  }\n  for (const match of text.matchAll(/\\b(VMR)\\s+(\\d{3,4})\\b/g)) {\n    mentions.add(`${match[1]}${match[2]}`);\n  }\n\n  // Gold Standard for the Global Goals (GS4GG) and related\n  for (const match of text.matchAll(/\\b(GS4GG|Gold Standard for the Global Goals)\\b/gi)) {\n    mentions.add(match[1]"
+        }
+      ],
+      "token_count": 86,
+      "line_count": 14,
+      "fingerprint": "dup:c6e4fe8a",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (14 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/lib/composers/composeGoldStandardVerificationReport.ts",
+          "start_line": 92,
+          "end_line": 100,
+          "start_col": 2,
+          "end_col": 11,
+          "fragment": "const reviewedCount = coverage.verified + coverage.gap;\n  const findings = buildFindings(project);\n  const findingCounts = countFindings(findings);\n  const status: VerificationReportStatus = reviewedCount === 0 ? 'insufficient_source_content' : 'ready';\n  const provenance = buildProvenance(project, coverage, registry, status, exportTime);\n\n  const meta = project.methodCode && project.methodVersion && project.methodCategory\n    ? loadMethodologyMetadata('Gold Standard', project.methodCategory, project.methodCode, project.methodVersion)\n    : null;"
+        },
+        {
+          "file": "src/lib/composers/composeVerraVerificationReport.ts",
+          "start_line": 96,
+          "end_line": 104,
+          "start_col": 2,
+          "end_col": 11,
+          "fragment": "const reviewedCount = coverage.verified + coverage.gap;\n  const findings = buildFindings(project);\n  const findingCounts = countFindings(findings);\n  const status: VerificationReportStatus = reviewedCount === 0 ? 'insufficient_source_content' : 'ready';\n  const provenance = buildProvenance(project, coverage, registry, status, exportTime);\n\n  const meta = project.methodCode && project.methodVersion && project.methodCategory\n    ? loadMethodologyMetadata('Verra', project.methodCategory, project.methodCode, project.methodVersion)\n    : null;"
+        },
+        {
+          "file": "src/lib/projects/verificationReport.ts",
+          "start_line": 346,
+          "end_line": 351,
+          "start_col": 2,
+          "end_col": 209,
+          "fragment": "const reviewedCount = coverage.verified + coverage.gap;\n  const findings = buildFindings(project);\n  const findingCounts = countFindings(findings);\n  const status: VerificationReportStatus = reviewedCount === 0 ? 'insufficient_source_content' : 'ready';\n  const provenance = buildProvenance(project, coverage, registry, status, exportTime);\n  const limitation = 'This draft readiness report summarizes reviewer-entered project review data. It is not a formal certification, validation, verification opinion, issuance approval, or registry decision.';"
+        }
+      ],
+      "token_count": 58,
+      "line_count": 9,
+      "fingerprint": "dup:104c2ea2",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/lib/evidence/export/pdfExporter.ts",
+          "start_line": 102,
+          "end_line": 110,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function safeDate(iso: string | undefined): string {\n  if (!iso) return 'n/a';\n  const d = iso.slice(0, 10);\n  return /^\\d{4}-\\d{2}-\\d{2}$/.test(d) ? d : iso.slice(0, 16);\n}\n\nfunction exportTimestamp(input: PremiumExportInput): string {\n  return resolveProjectExportTimestamp(input.project, input.exportTime);\n}"
+        },
+        {
+          "file": "src/lib/evidence/export/verificationPackIntegration.ts",
+          "start_line": 30,
+          "end_line": 38,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function safeDate(iso: string | undefined): string {\n  if (!iso) return 'n/a';\n  const d = iso.slice(0, 10);\n  return /^\\d{4}-\\d{2}-\\d{2}$/.test(d) ? d : iso.slice(0, 16);\n}\n\nfunction truncate(s: string, max: number): string {\n  return s.length > max ? s.slice(0, max - 3) + '...' : s;\n}"
+        },
+        {
+          "file": "src/lib/projects/exportPdf.ts",
+          "start_line": 64,
+          "end_line": 72,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function safeDate(iso: string | undefined): string {\n  if (!iso) return 'n/a';\n  const d = iso.slice(0, 10);\n  return /^\\d{4}-\\d{2}-\\d{2}$/.test(d) ? d : iso.slice(0, 16);\n}\n\nfunction truncate(s: string, max: number): string {\n  return s.length > max ? s.slice(0, max - 3) + '...' : s;\n}"
+        }
+      ],
+      "token_count": 54,
+      "line_count": 9,
+      "fingerprint": "dup:4106b9a3",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/lib/evidence/export/pdfExporter.ts",
+          "start_line": 134,
+          "end_line": 138,
+          "start_col": 8,
+          "end_col": 41,
+          "fragment": "lines = state.ln;\n\n  lines.push(...centerText(520, 'FB', 10, 'ARTICLE6', '0.5 0.5 0.5 rg'));\n  lines.push(RC(cx - 150, 498, 300, 1, 0.8));\n  lines.push(...centerText(470, 'FB', 24,"
+        },
+        {
+          "file": "src/lib/projects/exportPdf.ts",
+          "start_line": 134,
+          "end_line": 138,
+          "start_col": 8,
+          "end_col": 41,
+          "fragment": "reportLabel = report.title;\n\n  lines.push(...centerText(520, 'FB', 10, 'ARTICLE6', '0.5 0.5 0.5 rg'));\n  lines.push(RC(cx - 150, 498, 300, 1, 0.8));\n  lines.push(...centerText(470, 'FB', 24,"
+        },
+        {
+          "file": "src/lib/projects/exportPdf.ts",
+          "start_line": 160,
+          "end_line": 164,
+          "start_col": 8,
+          "end_col": 41,
+          "fragment": "metaR = cx + 40;\n\n  lines.push(...centerText(520, 'FB', 10, 'ARTICLE6', '0.5 0.5 0.5 rg'));\n  lines.push(RC(cx - 150, 498, 300, 1, 0.8));\n  lines.push(...centerText(470, 'FB', 24,"
+        }
+      ],
+      "token_count": 57,
+      "line_count": 5,
+      "fingerprint": "dup:4e83f70b",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (5 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/lib/evidence/export/projectExportData.ts",
+          "start_line": 13,
+          "end_line": 20,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function sortByString<T>(items: T[], select: (item: T) => string): T[] {\n  return [...items].sort((a, b) => select(a).localeCompare(select(b)));\n}\n\nfunction sanitizeId(value: string): string {\n  const normalized = value.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');\n  return normalized || 'item';\n}"
+        },
+        {
+          "file": "src/lib/evidence/export/verificationPackDerivation.ts",
+          "start_line": 17,
+          "end_line": 24,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function sortByString<T>(items: T[], select: (item: T) => string): T[] {\n  return [...items].sort((a, b) => select(a).localeCompare(select(b)));\n}\n\nfunction sanitizeId(value: string): string {\n  const normalized = value.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');\n  return normalized || 'item';\n}"
+        },
+        {
+          "file": "src/lib/snapshot/builder_v2.ts",
+          "start_line": 24,
+          "end_line": 33,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function sortByString<T>(items: T[], select: (item: T) => string): T[] {\n  return [...items].sort((a, b) => select(a).localeCompare(select(b)));\n}\n\nfunction latestTimestamp(values: Array<string | undefined | null>): string {\n  const ordered = values\n    .filter((value): value is string => Boolean(value))\n    .sort((a, b) => a.localeCompare(b));\n  return ordered.at(-1) ?? EPOCH;\n}"
+        }
+      ],
+      "token_count": 58,
+      "line_count": 10,
+      "fingerprint": "dup:972f20f1",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (10 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/lib/export/canonicalJson.ts",
+          "start_line": 1,
+          "end_line": 16,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function canonicalizeValue(value: unknown): unknown {\n  if (value === null) return null;\n  if (typeof value !== \"object\") return value;\n  if (Array.isArray(value)) return value.map(canonicalizeValue);\n\n  const record = value as Record<string, unknown>;\n  const out: Record<string, unknown> = {};\n  for (const key of Object.keys(record).sort()) {\n    out[key] = canonicalizeValue(record[key]);\n  }\n  return out;\n}\n\nexport function canonicalJsonStringify(value: unknown): string {\n  return JSON.stringify(canonicalizeValue(value), null, 2);\n}"
+        },
+        {
+          "file": "src/lib/proof/bundle.ts",
+          "start_line": 125,
+          "end_line": 150,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function canonicalizeValue(value: unknown): unknown {\n  if (value === null) return null;\n  if (typeof value !== \"object\") return value;\n  if (Array.isArray(value)) return value.map(canonicalizeValue);\n\n  const record = value as Record<string, unknown>;\n  const out: Record<string, unknown> = {};\n  for (const key of Object.keys(record).sort()) {\n    out[key] = canonicalizeValue(record[key]);\n  }\n  return out;\n}\n\nexport function canonicalizeProofBundleForHash(bundle: Omit<ProofBundleV1, \"integrity\"> & { integrity?: unknown }): string {\n  const withoutSha: Record<string, unknown> = { ...(bundle as Record<string, unknown>) };\n  const rawIntegrity = (withoutSha.integrity ?? {}) as Record<string, unknown>;\n  withoutSha.integrity = {\n    ...rawIntegrity,\n    bundle_sha256: \"\",\n    zip_sha256: \"\",\n    manifest_sha256: \"\",\n    sha256: \"\",\n    sha256_meaning: \"\",\n  };\n  return JSON.stringify(canonicalizeValue(withoutSha));\n}"
+        },
+        {
+          "file": "src/lib/proof/fingerprints.ts",
+          "start_line": 3,
+          "end_line": 18,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function canonicalizeValue(value: unknown): unknown {\n  if (value === null) return null;\n  if (typeof value !== \"object\") return value;\n  if (Array.isArray(value)) return value.map(canonicalizeValue);\n\n  const record = value as Record<string, unknown>;\n  const out: Record<string, unknown> = {};\n  for (const key of Object.keys(record).sort()) {\n    out[key] = canonicalizeValue(record[key]);\n  }\n  return out;\n}\n\nexport function canonicalJson(value: unknown): string {\n  return JSON.stringify(canonicalizeValue(value));\n}"
+        }
+      ],
+      "token_count": 100,
+      "line_count": 26,
+      "fingerprint": "dup:ff0810ed",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (26 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/lib/proofMap/aoi.test.ts",
+          "start_line": 11,
+          "end_line": 16,
+          "start_col": 47,
+          "end_col": 22,
+          "fragment": ");\n  expect(result.ok).toBe(true);\n  if (!result.ok) return;\n  const resolved = resolvePrimaryAreaFeature(result.aoi);\n  expect(resolved.ok).toBe(true);\n  expect(resolved.aoi."
+        },
+        {
+          "file": "src/lib/proofMap/aoi.test.ts",
+          "start_line": 90,
+          "end_line": 95,
+          "start_col": 47,
+          "end_col": 22,
+          "fragment": ");\n  expect(result.ok).toBe(true);\n  if (!result.ok) return;\n  const resolved = resolvePrimaryAreaFeature(result.aoi);\n  expect(resolved.ok).toBe(true);\n  expect(resolved.aoi."
+        },
+        {
+          "file": "src/lib/proofMap/aoi.test.ts",
+          "start_line": 144,
+          "end_line": 149,
+          "start_col": 52,
+          "end_col": 22,
+          "fragment": ");\n  expect(result.ok).toBe(true);\n  if (!result.ok) return;\n  const resolved = resolvePrimaryAreaFeature(result.aoi);\n  expect(resolved.ok).toBe(true);\n  expect(resolved.aoi."
+        }
+      ],
+      "token_count": 56,
+      "line_count": 6,
+      "fingerprint": "dup:9f338725",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (6 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "src/lib/verify/runState.ts",
+          "start_line": 307,
+          "end_line": 314,
+          "start_col": 34,
+          "end_col": 56,
+          "fragment": "methodCode: string, version: string, workspaceId?: string | null): string {\n  const normalizedMethod = normalizeMethodCode(methodCode);\n  const normalizedVersion = normalizeVersion(version);\n  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);\n  if (normalizedWorkspaceId) {\n    return `verify:workspace:${normalizedWorkspaceId}`;\n  }\n  return `verify:${normalizedMethod}:${normalizedVersion"
+        },
+        {
+          "file": "src/lib/verify/runState.ts",
+          "start_line": 317,
+          "end_line": 324,
+          "start_col": 28,
+          "end_col": 66,
+          "fragment": "methodCode: string, version: string, workspaceId?: string | null): string {\n  const normalizedMethod = normalizeMethodCode(methodCode);\n  const normalizedVersion = normalizeVersion(version);\n  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);\n  if (normalizedWorkspaceId) {\n    return `verifyRunHistory:workspace:${normalizedWorkspaceId}`;\n  }\n  return `verifyRunHistory:${normalizedMethod}:${normalizedVersion"
+        },
+        {
+          "file": "src/lib/verify/runState.ts",
+          "start_line": 339,
+          "end_line": 346,
+          "start_col": 36,
+          "end_col": 67,
+          "fragment": "methodCode: string, version: string, workspaceId?: string | null): string {\n  const normalizedMethod = normalizeMethodCode(methodCode);\n  const normalizedVersion = normalizeVersion(version);\n  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);\n  if (normalizedWorkspaceId) {\n    return `verifyLinkedRules:workspace:${normalizedWorkspaceId}`;\n  }\n  return `verifyLinkedRules:${normalizedMethod}:${normalizedVersion"
+        }
+      ],
+      "token_count": 52,
+      "line_count": 8,
+      "fingerprint": "dup:57ceb1cb",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (8 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/api/manifest.test.ts",
+          "start_line": 1,
+          "end_line": 10,
+          "start_col": 0,
+          "end_col": 12,
+          "fragment": "import { beforeEach, describe, expect, jest, test } from '@jest/globals';\nimport { NextRequest } from 'next/server';\n\nconst loadManifestAllMock = jest.fn();\n\njest.mock('@/lib/manifestSource', () => ({\n  loadManifestAll: (...args: unknown[]) => loadManifestAllMock(...args),\n}));\n\nimport { GET"
+        },
+        {
+          "file": "tests/api/route.health.test.ts",
+          "start_line": 1,
+          "end_line": 10,
+          "start_col": 0,
+          "end_col": 12,
+          "fragment": "import { beforeEach, describe, expect, jest, test } from '@jest/globals';\nimport { NextRequest } from 'next/server';\n\nconst loadManifestAllMock = jest.fn();\n\njest.mock('@/lib/manifestSource', () => ({\n  loadManifestAll: (...args: unknown[]) => loadManifestAllMock(...args),\n}));\n\nimport { GET"
+        },
+        {
+          "file": "tests/api/route.manifest.test.ts",
+          "start_line": 1,
+          "end_line": 10,
+          "start_col": 0,
+          "end_col": 12,
+          "fragment": "import { beforeEach, describe, expect, jest, test } from '@jest/globals';\nimport { NextRequest } from 'next/server';\n\nconst loadManifestAllMock = jest.fn();\n\njest.mock('@/lib/manifestSource', () => ({\n  loadManifestAll: (...args: unknown[]) => loadManifestAllMock(...args),\n}));\n\nimport { GET"
+        }
+      ],
+      "token_count": 60,
+      "line_count": 10,
+      "fingerprint": "dup:0f53ca58",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (10 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 42,
+          "end_line": 50,
+          "start_col": 41,
+          "end_col": 31,
+          "fragment": ", async () => {\n    const project = makeProject();\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n\n    const res = await POST(req)"
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 95,
+          "end_line": 102,
+          "start_col": 57,
+          "end_col": 31,
+          "fragment": ", async () => {\n    const project = makeProject();\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req)"
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 434,
+          "end_line": 441,
+          "start_col": 54,
+          "end_col": 31,
+          "fragment": ", async () => {\n    const project = makeProject();\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req)"
+        }
+      ],
+      "token_count": 53,
+      "line_count": 9,
+      "fingerprint": "dup:84468538",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 47,
+          "end_line": 53,
+          "start_col": 38,
+          "end_col": 68,
+          "fragment": "),\n    });\n\n    const res = await POST(req);\n\n    expect(res.status).toBe(200);\n    expect(res.headers.get('Content-Type')).toBe('application/pdf');"
+        },
+        {
+          "file": "tests/lib/evidence/export/premiumExport.test.ts",
+          "start_line": 454,
+          "end_line": 459,
+          "start_col": 54,
+          "end_col": 68,
+          "fragment": "),\n    });\n\n    const res = await POST(req);\n    expect(res.status).toBe(200);\n    expect(res.headers.get('Content-Type')).toBe('application/pdf');"
+        },
+        {
+          "file": "tests/lib/evidence/export/premiumExport.test.ts",
+          "start_line": 496,
+          "end_line": 501,
+          "start_col": 32,
+          "end_col": 68,
+          "fragment": "),\n    });\n\n    const res = await POST(req);\n    expect(res.status).toBe(200);\n    expect(res.headers.get('Content-Type')).toBe('application/pdf');"
+        }
+      ],
+      "token_count": 50,
+      "line_count": 7,
+      "fingerprint": "dup:551171ec",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (7 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 97,
+          "end_line": 106,
+          "start_col": 87,
+          "end_col": 11,
+          "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 118,
+          "end_line": 127,
+          "start_col": 87,
+          "end_col": 11,
+          "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 144,
+          "end_line": 153,
+          "start_col": 87,
+          "end_col": 11,
+          "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 169,
+          "end_line": 177,
+          "start_col": 89,
+          "end_col": 13,
+          "fragment": ", {\n        method: 'POST',\n        headers: { 'Content-Type': 'application/json' },\n        body: JSON.stringify({ project }),\n      });\n      const res = await POST(req);\n      const bytes = await res.arrayBuffer();\n      const parsed = await extractPdfTextWithPdfParse({ bytes });\n      expect("
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 222,
+          "end_line": 231,
+          "start_col": 87,
+          "end_col": 11,
+          "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 288,
+          "end_line": 297,
+          "start_col": 92,
+          "end_col": 11,
+          "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 370,
+          "end_line": 379,
+          "start_col": 87,
+          "end_col": 11,
+          "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 436,
+          "end_line": 445,
+          "start_col": 87,
+          "end_col": 11,
+          "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+        }
+      ],
+      "token_count": 59,
+      "line_count": 10,
+      "fingerprint": "dup:05d8d0eb",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (10 lines, 8 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 113,
+          "end_line": 127,
+          "start_col": 20,
+          "end_col": 24,
+          "fragment": "{\n      ...makeProject(),\n      methodCode: 'VM0007',\n      registry: 'Verra' as const,\n    };\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 137,
+          "end_line": 153,
+          "start_col": 20,
+          "end_col": 24,
+          "fragment": "{\n      ...makeProject(),\n      methodCode: 'GS-00XX',\n      methodVersion: 'v1-0',\n      methodCategory: 'AFOLU',\n      registry: 'Gold Standard' as const,\n    };\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 162,
+          "end_line": 177,
+          "start_col": 22,
+          "end_col": 26,
+          "fragment": "{\n        ...makeProject(),\n        registry,\n        methodCode: registry === 'UNFCCC' ? 'AR-AMS0007' : registry === 'Verra' ? 'VM0007' : 'GS-00XX',\n        methodVersion: registry === 'Gold Standard' ? 'v1-0' : makeProject().methodVersion,\n        methodCategory: registry === 'Gold Standard' ? 'AFOLU' : undefined,\n      };\n      const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n        method: 'POST',\n        headers: { 'Content-Type': 'application/json' },\n        body: JSON.stringify({ project }),\n      });\n      const res = await POST(req);\n      const bytes = await res.arrayBuffer();\n      const parsed = await extractPdfTextWithPdfParse({ bytes });\n      expect(parsed.text)."
+        },
+        {
+          "file": "tests/api/project.export-pdf.route.test.ts",
+          "start_line": 365,
+          "end_line": 379,
+          "start_col": 25,
+          "end_col": 24,
+          "fragment": "{\n      ...project.reviews[1],\n      status: 'gap',\n      note: 'Boundary worksheet not provided.',\n    };\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+        }
+      ],
+      "token_count": 74,
+      "line_count": 17,
+      "fingerprint": "dup:4b5be01f",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (17 lines, 4 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/app/api/exports/audit-pack.route.test.ts",
+          "start_line": 133,
+          "end_line": 141,
+          "start_col": 59,
+          "end_col": 44,
+          "fragment": ", {\n        method: \"POST\",\n        headers: { \"Content-Type\": \"application/json\" },\n        body: JSON.stringify({}),\n      }),\n    );\n\n    expect(response.status).toBe(400);\n    expect(await response.text()).toContain("
+        },
+        {
+          "file": "tests/app/api/exports/client-readiness-report.route.test.ts",
+          "start_line": 57,
+          "end_line": 65,
+          "start_col": 72,
+          "end_col": 44,
+          "fragment": ", {\n        method: \"POST\",\n        headers: { \"Content-Type\": \"application/json\" },\n        body: JSON.stringify({}),\n      }),\n    );\n\n    expect(response.status).toBe(400);\n    expect(await response.text()).toContain("
+        },
+        {
+          "file": "tests/app/api/exports/vvb-workpaper.route.test.ts",
+          "start_line": 61,
+          "end_line": 69,
+          "start_col": 62,
+          "end_col": 44,
+          "fragment": ", {\n        method: \"POST\",\n        headers: { \"Content-Type\": \"application/json\" },\n        body: JSON.stringify({}),\n      }),\n    );\n\n    expect(response.status).toBe(400);\n    expect(await response.text()).toContain("
+        }
+      ],
+      "token_count": 51,
+      "line_count": 9,
+      "fingerprint": "dup:f53f6b16",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/finalReviewSummaryPanel.test.tsx",
+          "start_line": 19,
+          "end_line": 60,
+          "start_col": 10,
+          "end_col": 26,
+          "fragment": "html = renderToStaticMarkup(\n      <FinalReviewSummaryPanel\n        summary={{\n          methodCode: \"AR-ACM0003\",\n          version: \"v02-0\",\n          ruleId: \"R-1\",\n          ruleSection: \"Monitoring period\",\n          ruleText: \"Evidence must fall inside the monitoring period.\",\n          selectedEvidenceId: \"stac-1\",\n          selectedEvidenceDatetime: \"2026-03-25T00:00:00Z\",\n          cloudCover: 4.5,\n          aoiLabel: \"Project AOI\",\n          reviewState: \"finalized\",\n          generatedAt: \"2026-03-25T00:10:00Z\",\n          outcomeNote: \"Stable result.\",\n          stacSearchResultCount: 3,\n          linkedRuleCount: 1,\n          selectedEvidenceLinkedRules: [\"R-1\"],\n          stacSupportFactsStatus: null,\n          linkedStacSupportFactCount: null,\n          unlinkedStacSupportFactCount: null,\n          checklistStatus: \"unused\",\n          reconciliationStatus: \"Supported\",\n          reconciliationReason: \"All expected evidence is linked.\",\n          narrative: \"Finalized verify review.\",\n        }}\n        artifact={null}\n        currentRunLabel=\"run-1234\"\n        finalizedAt=\"2026-03-25T00:10:00Z\"\n        reviewedRuleCount={1}\n        linkedEvidenceCount={2}\n        wizard={getVerifyWizardStepDetails({\n          selectedRuleId: \"R-1\",\n          aoiHash: \"aoi\",\n          stacItemIds: [\"item-1\"],\n          selectedStacItemId: \"item-1\",\n          linkedRuleIds: [\"R-1\"],\n          reviewerArtifactSavedAt: \"2026-03-25T00:05:00Z\",\n          finalizedAt: \"2026-03-25T00:10:00Z\",\n        })}\n        onDownloadJson={() => {}}\n        onDownloadPdf={() "
+        },
+        {
+          "file": "tests/components/finalReviewSummaryPanel.test.tsx",
+          "start_line": 87,
+          "end_line": 128,
+          "start_col": 10,
+          "end_col": 26,
+          "fragment": "withoutExport = renderToStaticMarkup(\n      <FinalReviewSummaryPanel\n        summary={{\n          methodCode: \"AR-ACM0003\",\n          version: \"v02-0\",\n          ruleId: \"R-1\",\n          ruleSection: \"Monitoring period\",\n          ruleText: \"Evidence must fall inside the monitoring period.\",\n          selectedEvidenceId: \"stac-1\",\n          selectedEvidenceDatetime: \"2026-03-25T00:00:00Z\",\n          cloudCover: 4.5,\n          aoiLabel: \"Project AOI\",\n          reviewState: \"finalized\",\n          generatedAt: \"2026-03-25T00:10:00Z\",\n          outcomeNote: \"Stable result.\",\n          stacSearchResultCount: 3,\n          linkedRuleCount: 1,\n          selectedEvidenceLinkedRules: [\"R-1\"],\n          stacSupportFactsStatus: null,\n          linkedStacSupportFactCount: null,\n          unlinkedStacSupportFactCount: null,\n          checklistStatus: \"unused\",\n          reconciliationStatus: \"Supported\",\n          reconciliationReason: \"All expected evidence is linked.\",\n          narrative: \"Finalized verify review.\",\n        }}\n        artifact={null}\n        currentRunLabel=\"run-1234\"\n        finalizedAt=\"2026-03-25T00:10:00Z\"\n        reviewedRuleCount={1}\n        linkedEvidenceCount={2}\n        wizard={getVerifyWizardStepDetails({\n          selectedRuleId: \"R-1\",\n          aoiHash: \"aoi\",\n          stacItemIds: [\"item-1\"],\n          selectedStacItemId: \"item-1\",\n          linkedRuleIds: [\"R-1\"],\n          reviewerArtifactSavedAt: \"2026-03-25T00:05:00Z\",\n          finalizedAt: \"2026-03-25T00:10:00Z\",\n        })}\n        onDownloadJson={() => {}}\n        onDownloadPdf={() "
+        },
+        {
+          "file": "tests/components/finalReviewSummaryPanel.test.tsx",
+          "start_line": 186,
+          "end_line": 227,
+          "start_col": 10,
+          "end_col": 26,
+          "fragment": "withoutExport = renderToStaticMarkup(\n      <FinalReviewSummaryPanel\n        summary={{\n          methodCode: \"AR-ACM0003\",\n          version: \"v02-0\",\n          ruleId: \"R-1\",\n          ruleSection: \"Monitoring period\",\n          ruleText: \"Evidence must fall inside the monitoring period.\",\n          selectedEvidenceId: \"stac-1\",\n          selectedEvidenceDatetime: \"2026-03-25T00:00:00Z\",\n          cloudCover: 4.5,\n          aoiLabel: \"Project AOI\",\n          reviewState: \"finalized\",\n          generatedAt: \"2026-03-25T00:10:00Z\",\n          outcomeNote: \"Stable result.\",\n          stacSearchResultCount: 3,\n          linkedRuleCount: 1,\n          selectedEvidenceLinkedRules: [\"R-1\"],\n          stacSupportFactsStatus: null,\n          linkedStacSupportFactCount: null,\n          unlinkedStacSupportFactCount: null,\n          checklistStatus: \"unused\",\n          reconciliationStatus: \"Supported\",\n          reconciliationReason: \"All expected evidence is linked.\",\n          narrative: \"Finalized verify review.\",\n        }}\n        artifact={null}\n        currentRunLabel=\"run-1234\"\n        finalizedAt=\"2026-03-25T00:10:00Z\"\n        reviewedRuleCount={1}\n        linkedEvidenceCount={2}\n        wizard={getVerifyWizardStepDetails({\n          selectedRuleId: \"R-1\",\n          aoiHash: \"aoi\",\n          stacItemIds: [\"item-1\"],\n          selectedStacItemId: \"item-1\",\n          linkedRuleIds: [\"R-1\"],\n          reviewerArtifactSavedAt: \"2026-03-25T00:05:00Z\",\n          finalizedAt: \"2026-03-25T00:10:00Z\",\n        })}\n        onDownloadJson={() => {}}\n        onDownloadPdf={() "
+        }
+      ],
+      "token_count": 97,
+      "line_count": 42,
+      "fingerprint": "dup:30782ed3",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (42 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+          "start_line": 120,
+          "end_line": 138,
+          "start_col": 4,
+          "end_col": 16,
+          "fragment": "window.localStorage.clear();\n\n    createAndStoreEvidenceAttachmentMock.mockReset();\n    createAndStoreEvidenceAttachmentMock.mockImplementation(async (input: { pin_id: string; file: File }) => {\n      const bytes = new Uint8Array(await input.file.arrayBuffer());\n      const attachment = {\n        id: `att-${input.pin_id}`,\n        pin_id: input.pin_id,\n        filename: input.file.name,\n        mime: input.file.type || \"application/pdf\",\n        size: bytes.byteLength,\n        sha256: `sha-${input.pin_id}`,\n        created_at: \"2026-04-04T00:00:00Z\",\n      };\n      await putAttachmentBytes(attachment.id, asArrayBuffer(bytes));\n      return { ok: true, attachment };\n    });\n\n    global.fetch"
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 167,
+          "end_line": 184,
+          "start_col": 4,
+          "end_col": 17,
+          "fragment": "(window as any).location = { assign: jest.fn(), replace: jest.fn(), href: \"http://localhost/\" };\n    createAndStoreEvidenceAttachmentMock.mockReset();\n    createAndStoreEvidenceAttachmentMock.mockImplementation(async (input: { pin_id: string; file: File }) => {\n      const bytes = new Uint8Array(await input.file.arrayBuffer());\n      const attachment = {\n        id: `att-${input.pin_id}`,\n        pin_id: input.pin_id,\n        filename: input.file.name,\n        mime: input.file.type || \"application/pdf\",\n        size: bytes.byteLength,\n        sha256: `sha-${input.pin_id}`,\n        created_at: \"2026-04-04T00:00:00Z\",\n      };\n      await putAttachmentBytes(attachment.id, asArrayBuffer(bytes));\n      return { ok: true, attachment };\n    });\n\n    (global.fetch"
+        },
+        {
+          "file": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+          "start_line": 87,
+          "end_line": 105,
+          "start_col": 4,
+          "end_col": 16,
+          "fragment": "window.localStorage.clear();\n\n    createAndStoreEvidenceAttachmentMock.mockReset();\n    createAndStoreEvidenceAttachmentMock.mockImplementation(async (input: { pin_id: string; file: File }) => {\n      const bytes = new Uint8Array(await input.file.arrayBuffer());\n      const attachment = {\n        id: `att-${input.pin_id}`,\n        pin_id: input.pin_id,\n        filename: input.file.name,\n        mime: input.file.type || \"application/pdf\",\n        size: bytes.byteLength,\n        sha256: `sha-${input.pin_id}`,\n        created_at: \"2026-04-04T00:00:00Z\",\n      };\n      await putAttachmentBytes(attachment.id, asArrayBuffer(bytes));\n      return { ok: true, attachment };\n    });\n\n    global.fetch"
+        }
+      ],
+      "token_count": 112,
+      "line_count": 19,
+      "fingerprint": "dup:aa359a1f",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (19 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+          "start_line": 138,
+          "end_line": 171,
+          "start_col": 4,
+          "end_col": 5,
+          "fragment": "global.fetch = jest.fn(async (input: RequestInfo | URL) => {\n      const url = String(input);\n      if (url.includes(\"/api/methods/inventory\")) {\n        return new Response(JSON.stringify({\n          methods: [\n            { code: \"VM0007\", latestVersion: \"v1-0\", versions: [\"v1-0\"] },\n            { code: \"ACM0010\", latestVersion: \"v01-0\", versions: [\"v01-0\"] },\n          ],\n        }), { status: 200 });\n      }\n      if (url.includes(\"/api/quick-check/semantic-evidence\")) {\n        return new Response(JSON.stringify({\n          status: \"disabled\",\n          candidates: [],\n          warning: \"HF_API_KEY is not configured; semantic evidence suggestions are disabled.\",\n        }), { status: 200 });\n      }\n      if (url.includes(\"/api/query?text=\")) {\n        return new Response(JSON.stringify({ engineTag: \"test\", metrics: [], results: [] }), { status: 200 });\n      }\n      throw new Error(`Unhandled fetch ${url}`);\n    }) as typeof fetch;\n  });\n\n  afterEach(async () => {\n    await act(async () => {\n      root.unmount();\n    });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });\n\n  it("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.upload-errors.test.tsx",
+          "start_line": 50,
+          "end_line": 66,
+          "start_col": 4,
+          "end_col": 5,
+          "fragment": "(global.fetch as any) = jest.fn(async (input: RequestInfo | URL) => {\n      const url = String(input);\n      if (url.includes(\"/api/methods/inventory\")) {\n        return new Response(JSON.stringify({ methods: [] }), { status: 200 });\n      }\n      return new Response(\"{}\", { status: 200 });\n    });\n  });\n\n  afterEach(async () => {\n    await act(async () => { root.unmount(); });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });\n\n  it("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+          "start_line": 177,
+          "end_line": 221,
+          "start_col": 4,
+          "end_col": 5,
+          "fragment": "window.localStorage.setItem(\n      \"a6:quick-check:claim-first:v1\",\n      JSON.stringify({\n        draft: {\n          id: \"draft-stale-recovery\",\n          claimText: \"unsupported claim\",\n          methodologyId: \"\",\n          methodologyVersion: \"\",\n          evidenceIds: [\"upload-1\"],\n          status: \"draft\",\n          createdAt: \"2026-04-04T00:00:00Z\",\n          updatedAt: \"2026-04-04T00:00:00Z\",\n        },\n        result: null,\n        stagedUploads: [\n          {\n            evidenceId: \"upload-1\",\n            filename: \"opaque-scan.pdf\",\n            mime: \"application/pdf\",\n            createdAt: \"2026-04-04T00:00:00Z\",\n            attachment: {\n              id: \"att-upload-1\",\n              pin_id: \"upload-1\",\n              filename: \"opaque-scan.pdf\",\n              mime: \"application/pdf\",\n              size: 128,\n              sha256: \"sha-upload-1\",\n              created_at: \"2026-04-04T00:00:00Z\",\n            },\n          },\n        ],\n      }),\n    );\n  });\n\n  afterEach(async () => {\n    await act(async () => {\n      root.unmount();\n    });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });\n\n  it("
+        }
+      ],
+      "token_count": 51,
+      "line_count": 45,
+      "fingerprint": "dup:53fd1f96",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (45 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+          "start_line": 176,
+          "end_line": 190,
+          "start_col": 62,
+          "end_col": 27,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUntilText(\"Document Q&A\");\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+          "start_line": 202,
+          "end_line": 216,
+          "start_col": 114,
+          "end_col": 27,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUntilText(\"Document Q&A\");\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+          "start_line": 232,
+          "end_line": 246,
+          "start_col": 114,
+          "end_col": 27,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUntilText(\"Document Q&A\");\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+          "start_line": 261,
+          "end_line": 275,
+          "start_col": 114,
+          "end_col": 27,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUntilText(\"Document Q&A\");\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        }
+      ],
+      "token_count": 68,
+      "line_count": 15,
+      "fingerprint": "dup:6cfafb45",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (15 lines, 4 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 852,
+          "end_line": 863,
+          "start_col": 7,
+          "end_col": 5,
+          "fragment": "),\n    );\n  });\n\n  afterEach(async () => {\n    await act(async () => {\n      root.unmount();\n    });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });"
+        },
+        {
+          "file": "tests/components/quickCheckPanel.upload-errors.test.tsx",
+          "start_line": 55,
+          "end_line": 64,
+          "start_col": 47,
+          "end_col": 5,
+          "fragment": ");\n    });\n  });\n\n  afterEach(async () => {\n    await act(async () => { root.unmount(); });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });"
+        },
+        {
+          "file": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+          "start_line": 208,
+          "end_line": 219,
+          "start_col": 7,
+          "end_col": 5,
+          "fragment": "),\n    );\n  });\n\n  afterEach(async () => {\n    await act(async () => {\n      root.unmount();\n    });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });"
+        }
+      ],
+      "token_count": 53,
+      "line_count": 12,
+      "fingerprint": "dup:d080376d",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (12 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 875,
+          "end_line": 879,
+          "start_col": 23,
+          "end_col": 5,
+          "fragment": "label: string) {\n    const normalizedLabel = label.toLowerCase();\n    const button = Array.from(container.querySelectorAll(\"button\")).find((node) =>\n      node.textContent?.toLowerCase().includes(normalizedLabel),\n    )"
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 884,
+          "end_line": 888,
+          "start_col": 32,
+          "end_col": 5,
+          "fragment": "label: string) {\n    const normalizedLabel = label.toLowerCase();\n    const button = Array.from(container.querySelectorAll(\"button\")).find((node) =>\n      node.textContent?.toLowerCase().includes(normalizedLabel),\n    )"
+        },
+        {
+          "file": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+          "start_line": 74,
+          "end_line": 78,
+          "start_col": 23,
+          "end_col": 5,
+          "fragment": "label: string) {\n    const normalizedLabel = label.toLowerCase();\n    const button = Array.from(container.querySelectorAll(\"button\")).find((node) =>\n      node.textContent?.toLowerCase().includes(normalizedLabel),\n    )"
+        }
+      ],
+      "token_count": 54,
+      "line_count": 5,
+      "fingerprint": "dup:101bd30e",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (5 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1022,
+          "end_line": 1037,
+          "start_col": 79,
+          "end_col": 27,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1051,
+          "end_line": 1066,
+          "start_col": 88,
+          "end_col": 27,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1082,
+          "end_line": 1097,
+          "start_col": 81,
+          "end_col": 27,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1172,
+          "end_line": 1187,
+          "start_col": 51,
+          "end_col": 27,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 2252,
+          "end_line": 2268,
+          "start_col": 5,
+          "end_col": 27,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 2282,
+          "end_line": 2298,
+          "start_col": 5,
+          "end_col": 27,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        }
+      ],
+      "token_count": 66,
+      "line_count": 17,
+      "fingerprint": "dup:b06be296",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (17 lines, 6 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1390,
+          "end_line": 1405,
+          "start_col": 78,
+          "end_col": 34,
+          "fragment": ",\n    );\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    expect(primaryCta().disabled).toBe(false);\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent)."
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1414,
+          "end_line": 1428,
+          "start_col": 118,
+          "end_col": 34,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    expect(primaryCta().disabled).toBe(false);\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent)."
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1434,
+          "end_line": 1448,
+          "start_col": 118,
+          "end_col": 34,
+          "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    expect(primaryCta().disabled).toBe(false);\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent)."
+        }
+      ],
+      "token_count": 68,
+      "line_count": 16,
+      "fingerprint": "dup:e4ebf594",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (16 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1422,
+          "end_line": 1432,
+          "start_col": 44,
+          "end_col": 5,
+          "fragment": ");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent).toMatch(/Needs review|Partial|Supported/);\n    expect(container.textContent).toContain(\"Open full review\");\n  });\n\n  it("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1519,
+          "end_line": 1529,
+          "start_col": 5,
+          "end_col": 5,
+          "fragment": ");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent).toMatch(/Supported|Needs review|Partial/);\n    expect(container.textContent).toContain(\"Open full review\");\n  });\n\n  it("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1576,
+          "end_line": 1586,
+          "start_col": 5,
+          "end_col": 5,
+          "fragment": ");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent).toMatch(/Supported|Needs review|Partial/);\n    expect(container.textContent).toContain(\"Open full review\");\n  });\n\n  it("
+        }
+      ],
+      "token_count": 52,
+      "line_count": 11,
+      "fingerprint": "dup:5d0dc031",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (11 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1707,
+          "end_line": 1723,
+          "start_col": 6,
+          "end_col": 25,
+          "fragment": "filename: \"kenya-second-check-evidence.pdf\",\n    });\n    await seedAttachmentFixture(\"att-upload-1\", \"kenya-second-check-evidence.pdf\");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await flushUntilText(\"The PDF states a monitoring or reporting period\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    await flushUntilText("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1771,
+          "end_line": 1787,
+          "start_col": 6,
+          "end_col": 25,
+          "fragment": "filename: \"kenya-second-check-evidence.pdf\",\n    });\n    await seedAttachmentFixture(\"att-upload-1\", \"kenya-second-check-evidence.pdf\");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await flushUntilText(\"The PDF states a monitoring or reporting period\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    await flushUntilText("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1801,
+          "end_line": 1817,
+          "start_col": 6,
+          "end_col": 25,
+          "fragment": "filename: \"kenya-second-check-evidence.pdf\",\n    });\n    await seedAttachmentFixture(\"att-upload-1\", \"kenya-second-check-evidence.pdf\");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await flushUntilText(\"The PDF states a monitoring or reporting period\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    await flushUntilText("
+        }
+      ],
+      "token_count": 71,
+      "line_count": 17,
+      "fingerprint": "dup:3d86848e",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (17 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1877,
+          "end_line": 1893,
+          "start_col": 258,
+          "end_col": 20,
+          "fragment": ",\n    );\n\n    await act(async () => {\n      root.render(<QuickCheckPanel initialMethod=\"AR-ACM0003\" initialVersion=\"v02-0\" />);\n    });\n\n    await act(async () => {\n      openOptions();\n    });\n    const inventorySelect = savedEvidenceSelect();\n    await act(async () => {\n      inventorySelect.value = \"ev-pdd-malawi\";\n      inventorySelect.dispatchEvent(new Event(\"change\", { bubbles: true }));\n    });\n    await act(async () => {\n      setClaimValue("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1914,
+          "end_line": 1930,
+          "start_col": 305,
+          "end_col": 20,
+          "fragment": ",\n    );\n\n    await act(async () => {\n      root.render(<QuickCheckPanel initialMethod=\"AR-ACM0003\" initialVersion=\"v02-0\" />);\n    });\n\n    await act(async () => {\n      openOptions();\n    });\n    const inventorySelect = savedEvidenceSelect();\n    await act(async () => {\n      inventorySelect.value = \"ev-pdd-malawi\";\n      inventorySelect.dispatchEvent(new Event(\"change\", { bubbles: true }));\n    });\n    await act(async () => {\n      setClaimValue("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 1950,
+          "end_line": 1966,
+          "start_col": 258,
+          "end_col": 20,
+          "fragment": ",\n    );\n\n    await act(async () => {\n      root.render(<QuickCheckPanel initialMethod=\"AR-ACM0003\" initialVersion=\"v02-0\" />);\n    });\n\n    await act(async () => {\n      openOptions();\n    });\n    const inventorySelect = savedEvidenceSelect();\n    await act(async () => {\n      inventorySelect.value = \"ev-pdd-malawi\";\n      inventorySelect.dispatchEvent(new Event(\"change\", { bubbles: true }));\n    });\n    await act(async () => {\n      setClaimValue("
+        }
+      ],
+      "token_count": 91,
+      "line_count": 17,
+      "fingerprint": "dup:accb708f",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (17 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 2249,
+          "end_line": 2268,
+          "start_col": 16,
+          "end_col": 27,
+          "fragment": "{\n      claimText: \"The boundary description matches the mapped project area.\",\n      filename: \"plum-verra-demo-excerpt.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 2279,
+          "end_line": 2298,
+          "start_col": 16,
+          "end_col": 27,
+          "fragment": "{\n      claimText: \"The monitoring report covers the full reporting period.\",\n      filename: \"plum-verra-demo-excerpt.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 2337,
+          "end_line": 2356,
+          "start_col": 16,
+          "end_col": 27,
+          "fragment": "{\n      claimText: \"The monitoring report covers the full reporting period.\",\n      filename: \"ambiguous-methods.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Methodology confirmation banner conditional on strong extraction signals in current flow\n    // expect(container.textContent).toContain(\"Methodology needs confirmation. Requirement matches are limited to VM0007, GS-VER1.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+        }
+      ],
+      "token_count": 67,
+      "line_count": 20,
+      "fingerprint": "dup:5d8a8590",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (20 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 2249,
+          "end_line": 2268,
+          "start_col": 16,
+          "end_col": 17,
+          "fragment": "{\n      claimText: \"The boundary description matches the mapped project area.\",\n      filename: \"plum-verra-demo-excerpt.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text)."
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 2279,
+          "end_line": 2298,
+          "start_col": 16,
+          "end_col": 17,
+          "fragment": "{\n      claimText: \"The monitoring report covers the full reporting period.\",\n      filename: \"plum-verra-demo-excerpt.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text)."
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 2337,
+          "end_line": 2356,
+          "start_col": 16,
+          "end_col": 17,
+          "fragment": "{\n      claimText: \"The monitoring report covers the full reporting period.\",\n      filename: \"ambiguous-methods.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Methodology confirmation banner conditional on strong extraction signals in current flow\n    // expect(container.textContent).toContain(\"Methodology needs confirmation. Requirement matches are limited to VM0007, GS-VER1.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text)."
+        },
+        {
+          "file": "tests/components/quickCheckPanel.test.tsx",
+          "start_line": 2363,
+          "end_line": 2383,
+          "start_col": 16,
+          "end_col": 17,
+          "fragment": "{\n      claimText: \"The monitoring report covers the full reporting period.\",\n      filename: \"unknown-acm0010.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core checks below\n    // expect(container.textContent).toContain(\"Primary detected methodology: ACM0010. No matching method pack is available.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    // Banner conditional on state in this flow\n    expect(text)."
+        }
+      ],
+      "token_count": 65,
+      "line_count": 21,
+      "fingerprint": "dup:179738d2",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (21 lines, 4 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/ruleDetailModal.test.tsx",
+          "start_line": 95,
+          "end_line": 118,
+          "start_col": 0,
+          "end_col": 9,
+          "fragment": "function ensureLocalStorage(): Storage {\n  if (typeof localStorage !== \"undefined\") return localStorage;\n  let store: Record<string, string> = {};\n  const memoryStorage = {\n    getItem: (key: string) => (key in store ? store[key] : null),\n    setItem: (key: string, value: string) => {\n      store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage;\n  (globalThis as unknown as { localStorage: Storage }).localStorage = memoryStorage;\n  return memoryStorage;\n}\n\ndescribe("
+        },
+        {
+          "file": "tests/lib/coverage.tasks.test.ts",
+          "start_line": 4,
+          "end_line": 27,
+          "start_col": 0,
+          "end_col": 9,
+          "fragment": "function ensureLocalStorage(): Storage {\n  if (typeof localStorage !== \"undefined\") return localStorage;\n  let store: Record<string, string> = {};\n  const memoryStorage = {\n    getItem: (key: string) => (key in store ? store[key] : null),\n    setItem: (key: string, value: string) => {\n      store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage;\n  (globalThis as unknown as { localStorage: Storage }).localStorage = memoryStorage;\n  return memoryStorage;\n}\n\ndescribe("
+        },
+        {
+          "file": "tests/lib/verify.runState.test.ts",
+          "start_line": 28,
+          "end_line": 51,
+          "start_col": 0,
+          "end_col": 9,
+          "fragment": "function ensureLocalStorage(): Storage {\n  if (typeof localStorage !== \"undefined\") return localStorage;\n  let store: Record<string, string> = {};\n  const memoryStorage = {\n    getItem: (key: string) => (key in store ? store[key] : null),\n    setItem: (key: string, value: string) => {\n      store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage;\n  (globalThis as unknown as { localStorage: Storage }).localStorage = memoryStorage;\n  return memoryStorage;\n}\n\ndescribe("
+        }
+      ],
+      "token_count": 152,
+      "line_count": 24,
+      "fingerprint": "dup:3d97c641",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (24 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/components/ruleDetailModal.test.tsx",
+          "start_line": 101,
+          "end_line": 113,
+          "start_col": 6,
+          "end_col": 14,
+          "fragment": "store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage"
+        },
+        {
+          "file": "tests/components/ruleReviewPanel.test.tsx",
+          "start_line": 14,
+          "end_line": 26,
+          "start_col": 6,
+          "end_col": 14,
+          "fragment": "store[key] = value;\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage"
+        },
+        {
+          "file": "tests/lib/coverage.tasks.test.ts",
+          "start_line": 10,
+          "end_line": 22,
+          "start_col": 6,
+          "end_col": 14,
+          "fragment": "store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage"
+        },
+        {
+          "file": "tests/lib/verify.runState.test.ts",
+          "start_line": 34,
+          "end_line": 46,
+          "start_col": 6,
+          "end_col": 14,
+          "fragment": "store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage"
+        }
+      ],
+      "token_count": 64,
+      "line_count": 13,
+      "fingerprint": "dup:c7ec1397",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (13 lines, 4 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+          "start_line": 41,
+          "end_line": 47,
+          "start_col": 61,
+          "end_col": 34,
+          "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text).toContain("
+        },
+        {
+          "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+          "start_line": 65,
+          "end_line": 71,
+          "start_col": 50,
+          "end_col": 34,
+          "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text).toContain("
+        },
+        {
+          "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+          "start_line": 87,
+          "end_line": 93,
+          "start_col": 70,
+          "end_col": 34,
+          "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text).toContain("
+        }
+      ],
+      "token_count": 70,
+      "line_count": 7,
+      "fingerprint": "dup:e050eb3c",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (7 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+          "start_line": 41,
+          "end_line": 47,
+          "start_col": 61,
+          "end_col": 24,
+          "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+        },
+        {
+          "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+          "start_line": 56,
+          "end_line": 62,
+          "start_col": 61,
+          "end_col": 24,
+          "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+        },
+        {
+          "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+          "start_line": 65,
+          "end_line": 71,
+          "start_col": 50,
+          "end_col": 24,
+          "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+        },
+        {
+          "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+          "start_line": 87,
+          "end_line": 93,
+          "start_col": 70,
+          "end_col": 24,
+          "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+        }
+      ],
+      "token_count": 68,
+      "line_count": 7,
+      "fingerprint": "dup:97ad49d0",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (7 lines, 4 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/lib/evidence/export/premiumExport.test.ts",
+          "start_line": 219,
+          "end_line": 224,
+          "start_col": 54,
+          "end_col": 27,
+          "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/lib/evidence/export/premiumExport.test.ts",
+          "start_line": 235,
+          "end_line": 240,
+          "start_col": 43,
+          "end_col": 27,
+          "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/lib/evidence/export/premiumExport.test.ts",
+          "start_line": 246,
+          "end_line": 251,
+          "start_col": 40,
+          "end_col": 27,
+          "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/lib/evidence/export/premiumExport.test.ts",
+          "start_line": 257,
+          "end_line": 262,
+          "start_col": 47,
+          "end_col": 27,
+          "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/lib/evidence/export/premiumExport.test.ts",
+          "start_line": 269,
+          "end_line": 274,
+          "start_col": 50,
+          "end_col": 27,
+          "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/lib/evidence/export/premiumExport.test.ts",
+          "start_line": 282,
+          "end_line": 287,
+          "start_col": 34,
+          "end_col": 27,
+          "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+        },
+        {
+          "file": "tests/lib/evidence/export/premiumExport.test.ts",
+          "start_line": 437,
+          "end_line": 442,
+          "start_col": 64,
+          "end_col": 27,
+          "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+        }
+      ],
+      "token_count": 57,
+      "line_count": 6,
+      "fingerprint": "dup:bf440f4c",
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (6 lines, 7 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    }
+  ],
+  "clone_families": [
+    {
+      "files": [
+        "scripts/build-derived-artifacts.mjs",
+        "scripts/build-derived-manifest.mjs",
+        "scripts/test-derived-determinism.mjs",
+        "scripts/verify-derived-artifacts.mjs"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "scripts/build-derived-artifacts.mjs",
+              "start_line": 31,
+              "end_line": 44,
+              "start_col": 0,
+              "end_col": 33,
+              "fragment": "function collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values())"
+            },
+            {
+              "file": "scripts/build-derived-manifest.mjs",
+              "start_line": 21,
+              "end_line": 34,
+              "start_col": 0,
+              "end_col": 33,
+              "fragment": "function collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values())"
+            },
+            {
+              "file": "scripts/test-derived-determinism.mjs",
+              "start_line": 21,
+              "end_line": 34,
+              "start_col": 0,
+              "end_col": 33,
+              "fragment": "function collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values())"
+            },
+            {
+              "file": "scripts/verify-derived-artifacts.mjs",
+              "start_line": 21,
+              "end_line": 34,
+              "start_col": 0,
+              "end_col": 33,
+              "fragment": "function collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values())"
+            }
+          ],
+          "token_count": 142,
+          "line_count": 14,
+          "fingerprint": "dup:f2ffa934",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (14 lines, 4 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 14,
+      "total_duplicated_tokens": 142,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (14 lines) from build-derived-artifacts.mjs, build-derived-manifest.mjs, test-derived-determinism.mjs, verify-derived-artifacts.mjs",
+          "estimated_savings": 42
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (14 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (14 lines) from build-derived-artifacts.mjs, build-derived-manifest.mjs, test-derived-determinism.mjs, verify-derived-artifacts.mjs"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "scripts/build-derived-artifacts.mjs",
+        "scripts/build-derived-manifest.mjs",
+        "scripts/verify-derived-artifacts.mjs"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "scripts/build-derived-artifacts.mjs",
+              "start_line": 5,
+              "end_line": 25,
+              "start_col": 42,
+              "end_col": 1,
+              "fragment": "\"./_stable-json.mjs\";\n\nasync function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction extractList(input, key) {\n  if (Array.isArray(input)) return input;\n  if (input && typeof input === \"object\" && Array.isArray(input[key])) return input[key];\n  return [];\n}"
+            },
+            {
+              "file": "scripts/build-derived-manifest.mjs",
+              "start_line": 5,
+              "end_line": 35,
+              "start_col": 56,
+              "end_col": 1,
+              "fragment": "\"./_stable-json.mjs\";\n\nasync function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values());\n}"
+            },
+            {
+              "file": "scripts/verify-derived-artifacts.mjs",
+              "start_line": 5,
+              "end_line": 35,
+              "start_col": 27,
+              "end_col": 1,
+              "fragment": "\"./_stable-json.mjs\";\n\nasync function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values());\n}"
+            }
+          ],
+          "token_count": 63,
+          "line_count": 31,
+          "fingerprint": "dup:933cfb21",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (31 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 31,
+      "total_duplicated_tokens": 63,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (31 lines) from build-derived-artifacts.mjs, build-derived-manifest.mjs, verify-derived-artifacts.mjs",
+          "estimated_savings": 62
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (31 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (31 lines) from build-derived-artifacts.mjs, build-derived-manifest.mjs, verify-derived-artifacts.mjs"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "scripts/build-derived-manifest.mjs",
+        "scripts/test-derived-determinism.mjs",
+        "scripts/verify-derived-artifacts.mjs"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "scripts/build-derived-manifest.mjs",
+              "start_line": 7,
+              "end_line": 78,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "async function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values());\n}\n\nasync function main() {\n  const manifestPath = path.join(process.cwd(), \"public\", \"manifest\", \"index.json\");\n  if (!(await fileExists(manifestPath))) {\n    throw new Error(\"Derived manifest: manifest index missing.\");\n  }\n  const manifest = await readJson(manifestPath);\n  if (!Array.isArray(manifest)) {\n    throw new Error(\"Derived manifest: manifest index invalid.\");\n  }\n\n  const datasets = collectDatasets(manifest);\n\n  for (const dataset of datasets) {\n    const derivedDir = path.join(dataset.baseDir, \"derived\");\n    if (!(await fileExists(derivedDir))) {\n      throw new Error(`Derived manifest: missing derived directory at ${derivedDir}`);\n    }\n\n    const entries = await readdir(derivedDir, { withFileTypes: true });\n    const files = entries.filter((entry) => entry.isFile()).map((entry) => entry.name);\n    const derivedFiles = files.filter((name) => name !== \"manifest.json\");\n\n    const derivedRecords = [];\n    for (const name of derivedFiles) {\n      const fullPath = path.join(derivedDir, name);\n      const stats = await stat(fullPath);\n      const sha256 = await sha256File(fullPath);\n      derivedRecords.push({ path: `derived/${name}`, sha256, bytes: stats.size });\n    }\n\n    derivedRecords.sort(sortByPath);\n\n    const manifestOut = {\n      version: 1,\n      derived_files: derivedRecords,\n      note: \"sha256 over exact file bytes\",\n    };\n\n    const manifestOutPath = path.join(derivedDir, \"manifest.json\");\n    await writeFile(manifestOutPath, stableStringify(manifestOut), \"utf8\");\n  }\n}"
+            },
+            {
+              "file": "scripts/test-derived-determinism.mjs",
+              "start_line": 7,
+              "end_line": 57,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "async function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values());\n}\n\nasync function loadManifestTexts() {\n  const manifestPath = path.join(process.cwd(), \"public\", \"manifest\", \"index.json\");\n  if (!(await fileExists(manifestPath))) {\n    throw new Error(\"Determinism: manifest index missing.\");\n  }\n  const manifest = await readJson(manifestPath);\n  if (!Array.isArray(manifest)) {\n    throw new Error(\"Determinism: manifest index invalid.\");\n  }\n  const datasets = collectDatasets(manifest);\n  const output = new Map();\n  for (const dataset of datasets) {\n    const manifestFile = path.join(dataset.baseDir, \"derived\", \"manifest.json\");\n    if (!(await fileExists(manifestFile))) {\n      throw new Error(`Determinism: missing manifest at ${manifestFile}`);\n    }\n    const text = await readFile(manifestFile, \"utf8\");\n    output.set(manifestFile, text);\n  }\n  return output;\n}"
+            },
+            {
+              "file": "scripts/verify-derived-artifacts.mjs",
+              "start_line": 7,
+              "end_line": 96,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "async function fileExists(filePath) {\n  try {\n    await access(filePath, fsConstants.F_OK);\n    return true;\n  } catch {\n    return false;\n  }\n}\n\nasync function readJson(filePath) {\n  const raw = await readFile(filePath, \"utf8\");\n  return JSON.parse(raw);\n}\n\nfunction collectDatasets(manifest) {\n  const map = new Map();\n  for (const entry of manifest) {\n    if (!entry || typeof entry !== \"object\") continue;\n    const methodCode = entry.methodology;\n    const version = entry.version;\n    const rulesPath = entry.path;\n    if (!methodCode || !version || !rulesPath) continue;\n    const key = `${methodCode}@${version}`;\n    if (map.has(key)) continue;\n    const baseDir = path.join(process.cwd(), \"public\", path.dirname(rulesPath));\n    map.set(key, { methodCode, version, baseDir });\n  }\n  return Array.from(map.values());\n}\n\nasync function main() {\n  const manifestPath = path.join(process.cwd(), \"public\", \"manifest\", \"index.json\");\n  if (!(await fileExists(manifestPath))) {\n    throw new Error(\"Derived verifier: manifest index missing.\");\n  }\n  const manifest = await readJson(manifestPath);\n  if (!Array.isArray(manifest)) {\n    throw new Error(\"Derived verifier: manifest index invalid.\");\n  }\n\n  const datasets = collectDatasets(manifest);\n\n  for (const dataset of datasets) {\n    const derivedDir = path.join(dataset.baseDir, \"derived\");\n    const manifestFile = path.join(derivedDir, \"manifest.json\");\n    if (!(await fileExists(manifestFile))) {\n      throw new Error(`Derived verifier: missing manifest.json at ${manifestFile}`);\n    }\n\n    const manifestJson = await readJson(manifestFile);\n    const derivedFiles = Array.isArray(manifestJson?.derived_files) ? manifestJson.derived_files : null;\n    if (!derivedFiles) {\n      throw new Error(`Derived verifier: invalid manifest at ${manifestFile}`);\n    }\n\n    const listed = new Map();\n    for (const entry of derivedFiles) {\n      if (!entry || typeof entry !== \"object\") continue;\n      const relPath = typeof entry.path === \"string\" ? entry.path : null;\n      const sha256 = typeof entry.sha256 === \"string\" ? entry.sha256 : null;\n      if (!relPath || !sha256) {\n        throw new Error(`Derived verifier: invalid manifest entry in ${manifestFile}`);\n      }\n      listed.set(relPath, sha256);\n    }\n\n    const entries = await readdir(derivedDir, { withFileTypes: true });\n    const files = entries.filter((entry) => entry.isFile()).map((entry) => entry.name);\n    const derivedFileNames = files.filter((name) => name !== \"manifest.json\");\n\n    for (const name of derivedFileNames) {\n      const relPath = `derived/${name}`;\n      if (!listed.has(relPath)) {\n        throw new Error(`Derived verifier: extra file ${relPath} in ${derivedDir}`);\n      }\n    }\n\n    for (const [relPath, expectedSha] of listed.entries()) {\n      const name = relPath.replace(/^derived\\//, \"\");\n      const fullPath = path.join(derivedDir, name);\n      if (!(await fileExists(fullPath))) {\n        throw new Error(`Derived verifier: missing file ${relPath} in ${derivedDir}`);\n      }\n      const actualSha = await sha256File(fullPath);\n      if (actualSha !== expectedSha) {\n        throw new Error(`Derived verifier: sha mismatch for ${relPath}`);\n      }\n    }\n  }\n}"
+            }
+          ],
+          "token_count": 203,
+          "line_count": 90,
+          "fingerprint": "dup:86cd13c3",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (90 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 90,
+      "total_duplicated_tokens": 203,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 1 shared clone group (90 lines) from build-derived-manifest.mjs, test-derived-determinism.mjs, verify-derived-artifacts.mjs into scripts",
+          "estimated_savings": 180
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (90 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 1 shared clone group (90 lines) from build-derived-manifest.mjs, test-derived-determinism.mjs, verify-derived-artifacts.mjs into scripts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/app/m/_lib/methodInventory.ts",
+        "src/app/m/_lib/methodRules.ts",
+        "src/app/m/_lib/methodSections.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/app/m/_lib/methodInventory.ts",
+              "start_line": 52,
+              "end_line": 60,
+              "start_col": 56,
+              "end_col": 18,
+              "fragment": ");\n}\n\nfunction pickString(entry: Record<string, unknown>, keys: string[]): string | undefined {\n  for (const key of keys) {\n    const value = entry[key];\n    if (typeof value === \"string\" && value.trim()) return value.trim();\n  }\n  return undefined"
+            },
+            {
+              "file": "src/app/m/_lib/methodRules.ts",
+              "start_line": 62,
+              "end_line": 70,
+              "start_col": 45,
+              "end_col": 18,
+              "fragment": ")}…`;\n}\n\nfunction pickString(entry: Record<string, unknown>, keys: string[]): string | undefined {\n  for (const key of keys) {\n    const value = entry[key];\n    if (typeof value === \"string\" && value.trim()) return value.trim();\n  }\n  return undefined"
+            },
+            {
+              "file": "src/app/m/_lib/methodSections.ts",
+              "start_line": 34,
+              "end_line": 42,
+              "start_col": 45,
+              "end_col": 18,
+              "fragment": ")}…`;\n}\n\nfunction pickString(entry: Record<string, unknown>, keys: string[]): string | undefined {\n  for (const key of keys) {\n    const value = entry[key];\n    if (typeof value === \"string\" && value.trim()) return value.trim();\n  }\n  return undefined"
+            }
+          ],
+          "token_count": 60,
+          "line_count": 9,
+          "fingerprint": "dup:22b46640",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 9,
+      "total_duplicated_tokens": 60,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (9 lines) from methodInventory.ts, methodRules.ts, methodSections.ts",
+          "estimated_savings": 18
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (9 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (9 lines) from methodInventory.ts, methodRules.ts, methodSections.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/app/m/_lib/methodRich.ts",
+        "src/app/m/_lib/methodRules.ts",
+        "src/app/m/_lib/methodSections.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/app/m/_lib/methodRich.ts",
+              "start_line": 33,
+              "end_line": 41,
+              "start_col": 0,
+              "end_col": 3,
+              "fragment": "async function readJsonFile(filePath: string): Promise<unknown> {\n  const raw = await readFile(filePath, \"utf8\");\n  try {\n    return JSON.parse(raw);\n  } catch (error) {\n    throw new Error(\n      `Failed to parse rich JSON at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,\n    );\n  }"
+            },
+            {
+              "file": "src/app/m/_lib/methodRules.ts",
+              "start_line": 176,
+              "end_line": 184,
+              "start_col": 0,
+              "end_col": 3,
+              "fragment": "async function readJsonFile(filePath: string): Promise<unknown> {\n  const raw = await readFile(filePath, \"utf8\");\n  try {\n    return JSON.parse(raw);\n  } catch (error) {\n    throw new Error(\n      `Failed to parse rules JSON at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,\n    );\n  }"
+            },
+            {
+              "file": "src/app/m/_lib/methodSections.ts",
+              "start_line": 65,
+              "end_line": 73,
+              "start_col": 0,
+              "end_col": 3,
+              "fragment": "async function readJsonFile(filePath: string): Promise<unknown> {\n  const raw = await readFile(filePath, \"utf8\");\n  try {\n    return JSON.parse(raw);\n  } catch (error) {\n    throw new Error(\n      `Failed to parse sections JSON at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,\n    );\n  }"
+            }
+          ],
+          "token_count": 62,
+          "line_count": 9,
+          "fingerprint": "dup:7d115d0d",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        },
+        {
+          "instances": [
+            {
+              "file": "src/app/m/_lib/methodRich.ts",
+              "start_line": 96,
+              "end_line": 113,
+              "start_col": 8,
+              "end_col": 3,
+              "fragment": "manifestPath =\n    entries\n      .map((entry) =>\n        typeof (entry as Record<string, unknown>).path === \"string\"\n          ? ((entry as Record<string, unknown>).path as string)\n          : null,\n      )\n      .find((value): value is string => Boolean(value)) ?? undefined;\n\n  if (!manifestPath) {\n    return {\n      ok: false,\n      sources: [],\n      attempted: [\"(manifest missing path field for this method/version)\"],\n      missing: [\"rich.json\", \"rules.rich.json\", \"sections.rich.json\"],\n      data: null,\n    };\n  }"
+            },
+            {
+              "file": "src/app/m/_lib/methodRules.ts",
+              "start_line": 317,
+              "end_line": 331,
+              "start_col": 6,
+              "end_col": 3,
+              "fragment": "manifestPath =\n    entries\n      .map((entry) =>\n        typeof (entry as Record<string, unknown>).path === \"string\"\n          ? ((entry as Record<string, unknown>).path as string)\n          : null,\n      )\n      .find((value): value is string => Boolean(value)) ?? undefined;\n\n  if (!manifestPath) {\n    const resolved = await resolveMethodVersionFiles(normalizedCode, normalizedVersion);\n    if (resolved) {\n      manifestPath = path.relative(process.cwd(), path.join(resolved.dir, \"rules.json\"));\n    }\n  }"
+            },
+            {
+              "file": "src/app/m/_lib/methodSections.ts",
+              "start_line": 206,
+              "end_line": 220,
+              "start_col": 6,
+              "end_col": 3,
+              "fragment": "manifestPath =\n    entries\n      .map((entry) =>\n        typeof (entry as Record<string, unknown>).path === \"string\"\n          ? ((entry as Record<string, unknown>).path as string)\n          : null,\n      )\n      .find((value): value is string => Boolean(value)) ?? undefined;\n\n  if (!manifestPath) {\n    const resolved = await resolveMethodVersionFiles(normalizedCode, normalizedVersion);\n    if (resolved) {\n      manifestPath = path.relative(process.cwd(), path.join(resolved.dir, \"rules.json\"));\n    }\n  }"
+            }
+          ],
+          "token_count": 67,
+          "line_count": 18,
+          "fingerprint": "dup:f6a19a1c",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (18 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 27,
+      "total_duplicated_tokens": 129,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (18 lines) from methodRich.ts, methodRules.ts, methodSections.ts",
+          "estimated_savings": 36
+        },
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (9 lines) from methodRich.ts, methodRules.ts, methodSections.ts",
+          "estimated_savings": 18
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 2 duplicated code blocks (27 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (18 lines) from methodRich.ts, methodRules.ts, methodSections.ts"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (9 lines) from methodRich.ts, methodRules.ts, methodSections.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/exports/verificationPackContract.ts",
+        "src/lib/evidence/export/verificationPackIntegration.ts",
+        "src/lib/readiness/reportHtmlTheme.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/exports/verificationPackContract.ts",
+              "start_line": 811,
+              "end_line": 817,
+              "start_col": 0,
+              "end_col": 29,
+              "fragment": "function escapeHtml(value: string): string {\n  return value\n    .replaceAll(\"&\", \"&amp;\")\n    .replaceAll(\"<\", \"&lt;\")\n    .replaceAll(\">\", \"&gt;\")\n    .replaceAll('\"', \"&quot;\")\n    .replaceAll(\"'\", \"&#39;\")"
+            },
+            {
+              "file": "src/lib/evidence/export/verificationPackIntegration.ts",
+              "start_line": 21,
+              "end_line": 27,
+              "start_col": 0,
+              "end_col": 29,
+              "fragment": "function escapeHtml(value: string): string {\n  return value\n    .replaceAll('&', '&amp;')\n    .replaceAll('<', '&lt;')\n    .replaceAll('>', '&gt;')\n    .replaceAll('\"', '&quot;')\n    .replaceAll(\"'\", '&#39;')"
+            },
+            {
+              "file": "src/lib/readiness/reportHtmlTheme.ts",
+              "start_line": 1,
+              "end_line": 7,
+              "start_col": 7,
+              "end_col": 29,
+              "fragment": "function escapeHtml(value: string): string {\n  return value\n    .replaceAll(\"&\", \"&amp;\")\n    .replaceAll(\"<\", \"&lt;\")\n    .replaceAll(\">\", \"&gt;\")\n    .replaceAll('\"', \"&quot;\")\n    .replaceAll(\"'\", \"&#39;\")"
+            }
+          ],
+          "token_count": 54,
+          "line_count": 7,
+          "fingerprint": "dup:27431e87",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (7 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 7,
+      "total_duplicated_tokens": 54,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (7 lines) from verificationPackContract.ts, verificationPackIntegration.ts, reportHtmlTheme.ts",
+          "estimated_savings": 14
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (7 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (7 lines) from verificationPackContract.ts, verificationPackIntegration.ts, reportHtmlTheme.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/lib/chat/quickCheckEvidence.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/lib/chat/quickCheckEvidence.ts",
+              "start_line": 629,
+              "end_line": 640,
+              "start_col": 25,
+              "end_col": 26,
+              "fragment": ");\n  }\n\n  // VM-prefixed methodology codes: VM0007, VM 0007\n  for (const match of text.matchAll(/\\b(VM\\d{4})\\b/g)) {\n    mentions.add(match[1]);\n  }\n  for (const match of text.matchAll(/\\b(VM)\\s+(\\d{4})\\b/g)) {\n    mentions.add(`${match[1]}${match[2]}`);\n  }\n  for (const match of text.matchAll(/\\b(AR-AMS\\d{4}|AR-ACM\\d{4})\\b/gi)) {\n    mentions.add((match[1]"
+            },
+            {
+              "file": "src/lib/chat/quickCheckEvidence.ts",
+              "start_line": 645,
+              "end_line": 654,
+              "start_col": 52,
+              "end_col": 25,
+              "fragment": ");\n  }\n  for (const match of text.matchAll(/\\b(VMD\\d{4})\\b/g)) {\n    mentions.add(match[1]);\n  }\n  for (const match of text.matchAll(/\\b(VMD)\\s+(\\d{4})\\b/g)) {\n    mentions.add(`${match[1]}${match[2]}`);\n  }\n  for (const match of text.matchAll(/\\b(APD|ARR|RWE|APWD)\\b/g)) {\n    mentions.add(match[1]"
+            },
+            {
+              "file": "src/lib/chat/quickCheckEvidence.ts",
+              "start_line": 663,
+              "end_line": 676,
+              "start_col": 44,
+              "end_col": 25,
+              "fragment": ");\n  }\n\n  // VMR-prefixed methodology codes: VMR001, VMR 001\n  for (const match of text.matchAll(/\\b(VMR\\d{3,4})\\b/g)) {\n    mentions.add(match[1]);\n  }\n  for (const match of text.matchAll(/\\b(VMR)\\s+(\\d{3,4})\\b/g)) {\n    mentions.add(`${match[1]}${match[2]}`);\n  }\n\n  // Gold Standard for the Global Goals (GS4GG) and related\n  for (const match of text.matchAll(/\\b(GS4GG|Gold Standard for the Global Goals)\\b/gi)) {\n    mentions.add(match[1]"
+            }
+          ],
+          "token_count": 86,
+          "line_count": 14,
+          "fingerprint": "dup:c6e4fe8a",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (14 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 14,
+      "total_duplicated_tokens": 86,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (14 lines) from quickCheckEvidence.ts, quickCheckEvidence.ts, quickCheckEvidence.ts",
+          "estimated_savings": 28
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (14 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (14 lines) from quickCheckEvidence.ts, quickCheckEvidence.ts, quickCheckEvidence.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/lib/composers/composeGoldStandardVerificationReport.ts",
+        "src/lib/composers/composeVerraVerificationReport.ts",
+        "src/lib/projects/verificationReport.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/lib/composers/composeGoldStandardVerificationReport.ts",
+              "start_line": 92,
+              "end_line": 100,
+              "start_col": 2,
+              "end_col": 11,
+              "fragment": "const reviewedCount = coverage.verified + coverage.gap;\n  const findings = buildFindings(project);\n  const findingCounts = countFindings(findings);\n  const status: VerificationReportStatus = reviewedCount === 0 ? 'insufficient_source_content' : 'ready';\n  const provenance = buildProvenance(project, coverage, registry, status, exportTime);\n\n  const meta = project.methodCode && project.methodVersion && project.methodCategory\n    ? loadMethodologyMetadata('Gold Standard', project.methodCategory, project.methodCode, project.methodVersion)\n    : null;"
+            },
+            {
+              "file": "src/lib/composers/composeVerraVerificationReport.ts",
+              "start_line": 96,
+              "end_line": 104,
+              "start_col": 2,
+              "end_col": 11,
+              "fragment": "const reviewedCount = coverage.verified + coverage.gap;\n  const findings = buildFindings(project);\n  const findingCounts = countFindings(findings);\n  const status: VerificationReportStatus = reviewedCount === 0 ? 'insufficient_source_content' : 'ready';\n  const provenance = buildProvenance(project, coverage, registry, status, exportTime);\n\n  const meta = project.methodCode && project.methodVersion && project.methodCategory\n    ? loadMethodologyMetadata('Verra', project.methodCategory, project.methodCode, project.methodVersion)\n    : null;"
+            },
+            {
+              "file": "src/lib/projects/verificationReport.ts",
+              "start_line": 346,
+              "end_line": 351,
+              "start_col": 2,
+              "end_col": 209,
+              "fragment": "const reviewedCount = coverage.verified + coverage.gap;\n  const findings = buildFindings(project);\n  const findingCounts = countFindings(findings);\n  const status: VerificationReportStatus = reviewedCount === 0 ? 'insufficient_source_content' : 'ready';\n  const provenance = buildProvenance(project, coverage, registry, status, exportTime);\n  const limitation = 'This draft readiness report summarizes reviewer-entered project review data. It is not a formal certification, validation, verification opinion, issuance approval, or registry decision.';"
+            }
+          ],
+          "token_count": 58,
+          "line_count": 9,
+          "fingerprint": "dup:104c2ea2",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 9,
+      "total_duplicated_tokens": 58,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (9 lines) from composeGoldStandardVerificationReport.ts, composeVerraVerificationReport.ts, verificationReport.ts",
+          "estimated_savings": 18
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (9 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (9 lines) from composeGoldStandardVerificationReport.ts, composeVerraVerificationReport.ts, verificationReport.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/lib/evidence/export/pdfExporter.ts",
+        "src/lib/evidence/export/verificationPackIntegration.ts",
+        "src/lib/projects/exportPdf.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/lib/evidence/export/pdfExporter.ts",
+              "start_line": 102,
+              "end_line": 110,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function safeDate(iso: string | undefined): string {\n  if (!iso) return 'n/a';\n  const d = iso.slice(0, 10);\n  return /^\\d{4}-\\d{2}-\\d{2}$/.test(d) ? d : iso.slice(0, 16);\n}\n\nfunction exportTimestamp(input: PremiumExportInput): string {\n  return resolveProjectExportTimestamp(input.project, input.exportTime);\n}"
+            },
+            {
+              "file": "src/lib/evidence/export/verificationPackIntegration.ts",
+              "start_line": 30,
+              "end_line": 38,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function safeDate(iso: string | undefined): string {\n  if (!iso) return 'n/a';\n  const d = iso.slice(0, 10);\n  return /^\\d{4}-\\d{2}-\\d{2}$/.test(d) ? d : iso.slice(0, 16);\n}\n\nfunction truncate(s: string, max: number): string {\n  return s.length > max ? s.slice(0, max - 3) + '...' : s;\n}"
+            },
+            {
+              "file": "src/lib/projects/exportPdf.ts",
+              "start_line": 64,
+              "end_line": 72,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function safeDate(iso: string | undefined): string {\n  if (!iso) return 'n/a';\n  const d = iso.slice(0, 10);\n  return /^\\d{4}-\\d{2}-\\d{2}$/.test(d) ? d : iso.slice(0, 16);\n}\n\nfunction truncate(s: string, max: number): string {\n  return s.length > max ? s.slice(0, max - 3) + '...' : s;\n}"
+            }
+          ],
+          "token_count": 54,
+          "line_count": 9,
+          "fingerprint": "dup:4106b9a3",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 9,
+      "total_duplicated_tokens": 54,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (9 lines) from pdfExporter.ts, verificationPackIntegration.ts, exportPdf.ts",
+          "estimated_savings": 18
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (9 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (9 lines) from pdfExporter.ts, verificationPackIntegration.ts, exportPdf.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/lib/evidence/export/pdfExporter.ts",
+        "src/lib/projects/exportPdf.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/lib/evidence/export/pdfExporter.ts",
+              "start_line": 134,
+              "end_line": 138,
+              "start_col": 8,
+              "end_col": 41,
+              "fragment": "lines = state.ln;\n\n  lines.push(...centerText(520, 'FB', 10, 'ARTICLE6', '0.5 0.5 0.5 rg'));\n  lines.push(RC(cx - 150, 498, 300, 1, 0.8));\n  lines.push(...centerText(470, 'FB', 24,"
+            },
+            {
+              "file": "src/lib/projects/exportPdf.ts",
+              "start_line": 134,
+              "end_line": 138,
+              "start_col": 8,
+              "end_col": 41,
+              "fragment": "reportLabel = report.title;\n\n  lines.push(...centerText(520, 'FB', 10, 'ARTICLE6', '0.5 0.5 0.5 rg'));\n  lines.push(RC(cx - 150, 498, 300, 1, 0.8));\n  lines.push(...centerText(470, 'FB', 24,"
+            },
+            {
+              "file": "src/lib/projects/exportPdf.ts",
+              "start_line": 160,
+              "end_line": 164,
+              "start_col": 8,
+              "end_col": 41,
+              "fragment": "metaR = cx + 40;\n\n  lines.push(...centerText(520, 'FB', 10, 'ARTICLE6', '0.5 0.5 0.5 rg'));\n  lines.push(RC(cx - 150, 498, 300, 1, 0.8));\n  lines.push(...centerText(470, 'FB', 24,"
+            }
+          ],
+          "token_count": 57,
+          "line_count": 5,
+          "fingerprint": "dup:4e83f70b",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (5 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 5,
+      "total_duplicated_tokens": 57,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (5 lines) from pdfExporter.ts, exportPdf.ts, exportPdf.ts",
+          "estimated_savings": 10
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (5 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (5 lines) from pdfExporter.ts, exportPdf.ts, exportPdf.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/lib/evidence/export/projectExportData.ts",
+        "src/lib/evidence/export/verificationPackDerivation.ts",
+        "src/lib/snapshot/builder_v2.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/lib/evidence/export/projectExportData.ts",
+              "start_line": 13,
+              "end_line": 20,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function sortByString<T>(items: T[], select: (item: T) => string): T[] {\n  return [...items].sort((a, b) => select(a).localeCompare(select(b)));\n}\n\nfunction sanitizeId(value: string): string {\n  const normalized = value.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');\n  return normalized || 'item';\n}"
+            },
+            {
+              "file": "src/lib/evidence/export/verificationPackDerivation.ts",
+              "start_line": 17,
+              "end_line": 24,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function sortByString<T>(items: T[], select: (item: T) => string): T[] {\n  return [...items].sort((a, b) => select(a).localeCompare(select(b)));\n}\n\nfunction sanitizeId(value: string): string {\n  const normalized = value.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');\n  return normalized || 'item';\n}"
+            },
+            {
+              "file": "src/lib/snapshot/builder_v2.ts",
+              "start_line": 24,
+              "end_line": 33,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function sortByString<T>(items: T[], select: (item: T) => string): T[] {\n  return [...items].sort((a, b) => select(a).localeCompare(select(b)));\n}\n\nfunction latestTimestamp(values: Array<string | undefined | null>): string {\n  const ordered = values\n    .filter((value): value is string => Boolean(value))\n    .sort((a, b) => a.localeCompare(b));\n  return ordered.at(-1) ?? EPOCH;\n}"
+            }
+          ],
+          "token_count": 58,
+          "line_count": 10,
+          "fingerprint": "dup:972f20f1",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (10 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 10,
+      "total_duplicated_tokens": 58,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (10 lines) from projectExportData.ts, verificationPackDerivation.ts, builder_v2.ts",
+          "estimated_savings": 20
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (10 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (10 lines) from projectExportData.ts, verificationPackDerivation.ts, builder_v2.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/lib/export/canonicalJson.ts",
+        "src/lib/proof/bundle.ts",
+        "src/lib/proof/fingerprints.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/lib/export/canonicalJson.ts",
+              "start_line": 1,
+              "end_line": 16,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function canonicalizeValue(value: unknown): unknown {\n  if (value === null) return null;\n  if (typeof value !== \"object\") return value;\n  if (Array.isArray(value)) return value.map(canonicalizeValue);\n\n  const record = value as Record<string, unknown>;\n  const out: Record<string, unknown> = {};\n  for (const key of Object.keys(record).sort()) {\n    out[key] = canonicalizeValue(record[key]);\n  }\n  return out;\n}\n\nexport function canonicalJsonStringify(value: unknown): string {\n  return JSON.stringify(canonicalizeValue(value), null, 2);\n}"
+            },
+            {
+              "file": "src/lib/proof/bundle.ts",
+              "start_line": 125,
+              "end_line": 150,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function canonicalizeValue(value: unknown): unknown {\n  if (value === null) return null;\n  if (typeof value !== \"object\") return value;\n  if (Array.isArray(value)) return value.map(canonicalizeValue);\n\n  const record = value as Record<string, unknown>;\n  const out: Record<string, unknown> = {};\n  for (const key of Object.keys(record).sort()) {\n    out[key] = canonicalizeValue(record[key]);\n  }\n  return out;\n}\n\nexport function canonicalizeProofBundleForHash(bundle: Omit<ProofBundleV1, \"integrity\"> & { integrity?: unknown }): string {\n  const withoutSha: Record<string, unknown> = { ...(bundle as Record<string, unknown>) };\n  const rawIntegrity = (withoutSha.integrity ?? {}) as Record<string, unknown>;\n  withoutSha.integrity = {\n    ...rawIntegrity,\n    bundle_sha256: \"\",\n    zip_sha256: \"\",\n    manifest_sha256: \"\",\n    sha256: \"\",\n    sha256_meaning: \"\",\n  };\n  return JSON.stringify(canonicalizeValue(withoutSha));\n}"
+            },
+            {
+              "file": "src/lib/proof/fingerprints.ts",
+              "start_line": 3,
+              "end_line": 18,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function canonicalizeValue(value: unknown): unknown {\n  if (value === null) return null;\n  if (typeof value !== \"object\") return value;\n  if (Array.isArray(value)) return value.map(canonicalizeValue);\n\n  const record = value as Record<string, unknown>;\n  const out: Record<string, unknown> = {};\n  for (const key of Object.keys(record).sort()) {\n    out[key] = canonicalizeValue(record[key]);\n  }\n  return out;\n}\n\nexport function canonicalJson(value: unknown): string {\n  return JSON.stringify(canonicalizeValue(value));\n}"
+            }
+          ],
+          "token_count": 100,
+          "line_count": 26,
+          "fingerprint": "dup:ff0810ed",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (26 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 26,
+      "total_duplicated_tokens": 100,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (26 lines) from canonicalJson.ts, bundle.ts, fingerprints.ts",
+          "estimated_savings": 52
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (26 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (26 lines) from canonicalJson.ts, bundle.ts, fingerprints.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/lib/proofMap/aoi.test.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/lib/proofMap/aoi.test.ts",
+              "start_line": 11,
+              "end_line": 16,
+              "start_col": 47,
+              "end_col": 22,
+              "fragment": ");\n  expect(result.ok).toBe(true);\n  if (!result.ok) return;\n  const resolved = resolvePrimaryAreaFeature(result.aoi);\n  expect(resolved.ok).toBe(true);\n  expect(resolved.aoi."
+            },
+            {
+              "file": "src/lib/proofMap/aoi.test.ts",
+              "start_line": 90,
+              "end_line": 95,
+              "start_col": 47,
+              "end_col": 22,
+              "fragment": ");\n  expect(result.ok).toBe(true);\n  if (!result.ok) return;\n  const resolved = resolvePrimaryAreaFeature(result.aoi);\n  expect(resolved.ok).toBe(true);\n  expect(resolved.aoi."
+            },
+            {
+              "file": "src/lib/proofMap/aoi.test.ts",
+              "start_line": 144,
+              "end_line": 149,
+              "start_col": 52,
+              "end_col": 22,
+              "fragment": ");\n  expect(result.ok).toBe(true);\n  if (!result.ok) return;\n  const resolved = resolvePrimaryAreaFeature(result.aoi);\n  expect(resolved.ok).toBe(true);\n  expect(resolved.aoi."
+            }
+          ],
+          "token_count": 56,
+          "line_count": 6,
+          "fingerprint": "dup:9f338725",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (6 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 6,
+      "total_duplicated_tokens": 56,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (6 lines) from aoi.test.ts, aoi.test.ts, aoi.test.ts",
+          "estimated_savings": 12
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (6 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (6 lines) from aoi.test.ts, aoi.test.ts, aoi.test.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "src/lib/verify/runState.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "src/lib/verify/runState.ts",
+              "start_line": 307,
+              "end_line": 314,
+              "start_col": 34,
+              "end_col": 56,
+              "fragment": "methodCode: string, version: string, workspaceId?: string | null): string {\n  const normalizedMethod = normalizeMethodCode(methodCode);\n  const normalizedVersion = normalizeVersion(version);\n  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);\n  if (normalizedWorkspaceId) {\n    return `verify:workspace:${normalizedWorkspaceId}`;\n  }\n  return `verify:${normalizedMethod}:${normalizedVersion"
+            },
+            {
+              "file": "src/lib/verify/runState.ts",
+              "start_line": 317,
+              "end_line": 324,
+              "start_col": 28,
+              "end_col": 66,
+              "fragment": "methodCode: string, version: string, workspaceId?: string | null): string {\n  const normalizedMethod = normalizeMethodCode(methodCode);\n  const normalizedVersion = normalizeVersion(version);\n  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);\n  if (normalizedWorkspaceId) {\n    return `verifyRunHistory:workspace:${normalizedWorkspaceId}`;\n  }\n  return `verifyRunHistory:${normalizedMethod}:${normalizedVersion"
+            },
+            {
+              "file": "src/lib/verify/runState.ts",
+              "start_line": 339,
+              "end_line": 346,
+              "start_col": 36,
+              "end_col": 67,
+              "fragment": "methodCode: string, version: string, workspaceId?: string | null): string {\n  const normalizedMethod = normalizeMethodCode(methodCode);\n  const normalizedVersion = normalizeVersion(version);\n  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);\n  if (normalizedWorkspaceId) {\n    return `verifyLinkedRules:workspace:${normalizedWorkspaceId}`;\n  }\n  return `verifyLinkedRules:${normalizedMethod}:${normalizedVersion"
+            }
+          ],
+          "token_count": 52,
+          "line_count": 8,
+          "fingerprint": "dup:57ceb1cb",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (8 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 8,
+      "total_duplicated_tokens": 52,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (8 lines) from runState.ts, runState.ts, runState.ts",
+          "estimated_savings": 16
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (8 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (8 lines) from runState.ts, runState.ts, runState.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/api/manifest.test.ts",
+        "tests/api/route.health.test.ts",
+        "tests/api/route.manifest.test.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/api/manifest.test.ts",
+              "start_line": 1,
+              "end_line": 10,
+              "start_col": 0,
+              "end_col": 12,
+              "fragment": "import { beforeEach, describe, expect, jest, test } from '@jest/globals';\nimport { NextRequest } from 'next/server';\n\nconst loadManifestAllMock = jest.fn();\n\njest.mock('@/lib/manifestSource', () => ({\n  loadManifestAll: (...args: unknown[]) => loadManifestAllMock(...args),\n}));\n\nimport { GET"
+            },
+            {
+              "file": "tests/api/route.health.test.ts",
+              "start_line": 1,
+              "end_line": 10,
+              "start_col": 0,
+              "end_col": 12,
+              "fragment": "import { beforeEach, describe, expect, jest, test } from '@jest/globals';\nimport { NextRequest } from 'next/server';\n\nconst loadManifestAllMock = jest.fn();\n\njest.mock('@/lib/manifestSource', () => ({\n  loadManifestAll: (...args: unknown[]) => loadManifestAllMock(...args),\n}));\n\nimport { GET"
+            },
+            {
+              "file": "tests/api/route.manifest.test.ts",
+              "start_line": 1,
+              "end_line": 10,
+              "start_col": 0,
+              "end_col": 12,
+              "fragment": "import { beforeEach, describe, expect, jest, test } from '@jest/globals';\nimport { NextRequest } from 'next/server';\n\nconst loadManifestAllMock = jest.fn();\n\njest.mock('@/lib/manifestSource', () => ({\n  loadManifestAll: (...args: unknown[]) => loadManifestAllMock(...args),\n}));\n\nimport { GET"
+            }
+          ],
+          "token_count": 60,
+          "line_count": 10,
+          "fingerprint": "dup:0f53ca58",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (10 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 10,
+      "total_duplicated_tokens": 60,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (10 lines) from manifest.test.ts, route.health.test.ts, route.manifest.test.ts",
+          "estimated_savings": 20
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (10 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (10 lines) from manifest.test.ts, route.health.test.ts, route.manifest.test.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/api/project.export-pdf.route.test.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 42,
+              "end_line": 50,
+              "start_col": 41,
+              "end_col": 31,
+              "fragment": ", async () => {\n    const project = makeProject();\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n\n    const res = await POST(req)"
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 95,
+              "end_line": 102,
+              "start_col": 57,
+              "end_col": 31,
+              "fragment": ", async () => {\n    const project = makeProject();\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req)"
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 434,
+              "end_line": 441,
+              "start_col": 54,
+              "end_col": 31,
+              "fragment": ", async () => {\n    const project = makeProject();\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req)"
+            }
+          ],
+          "token_count": 53,
+          "line_count": 9,
+          "fingerprint": "dup:84468538",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 97,
+              "end_line": 106,
+              "start_col": 87,
+              "end_col": 11,
+              "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 118,
+              "end_line": 127,
+              "start_col": 87,
+              "end_col": 11,
+              "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 144,
+              "end_line": 153,
+              "start_col": 87,
+              "end_col": 11,
+              "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 169,
+              "end_line": 177,
+              "start_col": 89,
+              "end_col": 13,
+              "fragment": ", {\n        method: 'POST',\n        headers: { 'Content-Type': 'application/json' },\n        body: JSON.stringify({ project }),\n      });\n      const res = await POST(req);\n      const bytes = await res.arrayBuffer();\n      const parsed = await extractPdfTextWithPdfParse({ bytes });\n      expect("
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 222,
+              "end_line": 231,
+              "start_col": 87,
+              "end_col": 11,
+              "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 288,
+              "end_line": 297,
+              "start_col": 92,
+              "end_col": 11,
+              "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 370,
+              "end_line": 379,
+              "start_col": 87,
+              "end_col": 11,
+              "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 436,
+              "end_line": 445,
+              "start_col": 87,
+              "end_col": 11,
+              "fragment": ", {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect("
+            }
+          ],
+          "token_count": 59,
+          "line_count": 10,
+          "fingerprint": "dup:05d8d0eb",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (10 lines, 8 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 113,
+              "end_line": 127,
+              "start_col": 20,
+              "end_col": 24,
+              "fragment": "{\n      ...makeProject(),\n      methodCode: 'VM0007',\n      registry: 'Verra' as const,\n    };\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 137,
+              "end_line": 153,
+              "start_col": 20,
+              "end_col": 24,
+              "fragment": "{\n      ...makeProject(),\n      methodCode: 'GS-00XX',\n      methodVersion: 'v1-0',\n      methodCategory: 'AFOLU',\n      registry: 'Gold Standard' as const,\n    };\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 162,
+              "end_line": 177,
+              "start_col": 22,
+              "end_col": 26,
+              "fragment": "{\n        ...makeProject(),\n        registry,\n        methodCode: registry === 'UNFCCC' ? 'AR-AMS0007' : registry === 'Verra' ? 'VM0007' : 'GS-00XX',\n        methodVersion: registry === 'Gold Standard' ? 'v1-0' : makeProject().methodVersion,\n        methodCategory: registry === 'Gold Standard' ? 'AFOLU' : undefined,\n      };\n      const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n        method: 'POST',\n        headers: { 'Content-Type': 'application/json' },\n        body: JSON.stringify({ project }),\n      });\n      const res = await POST(req);\n      const bytes = await res.arrayBuffer();\n      const parsed = await extractPdfTextWithPdfParse({ bytes });\n      expect(parsed.text)."
+            },
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 365,
+              "end_line": 379,
+              "start_col": 25,
+              "end_col": 24,
+              "fragment": "{\n      ...project.reviews[1],\n      status: 'gap',\n      note: 'Boundary worksheet not provided.',\n    };\n    const req = new Request('http://localhost/api/projects/project-12345678/export-pdf', {\n      method: 'POST',\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify({ project }),\n    });\n    const res = await POST(req);\n    const bytes = await res.arrayBuffer();\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+            }
+          ],
+          "token_count": 74,
+          "line_count": 17,
+          "fingerprint": "dup:4b5be01f",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (17 lines, 4 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 36,
+      "total_duplicated_tokens": 186,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (17 lines) from project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts",
+          "estimated_savings": 51
+        },
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (10 lines) from project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts",
+          "estimated_savings": 70
+        },
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (9 lines) from project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts",
+          "estimated_savings": 18
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 3 duplicated code blocks (36 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (17 lines) from project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (10 lines) from project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (9 lines) from project.export-pdf.route.test.ts, project.export-pdf.route.test.ts, project.export-pdf.route.test.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/api/project.export-pdf.route.test.ts",
+        "tests/lib/evidence/export/premiumExport.test.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/api/project.export-pdf.route.test.ts",
+              "start_line": 47,
+              "end_line": 53,
+              "start_col": 38,
+              "end_col": 68,
+              "fragment": "),\n    });\n\n    const res = await POST(req);\n\n    expect(res.status).toBe(200);\n    expect(res.headers.get('Content-Type')).toBe('application/pdf');"
+            },
+            {
+              "file": "tests/lib/evidence/export/premiumExport.test.ts",
+              "start_line": 454,
+              "end_line": 459,
+              "start_col": 54,
+              "end_col": 68,
+              "fragment": "),\n    });\n\n    const res = await POST(req);\n    expect(res.status).toBe(200);\n    expect(res.headers.get('Content-Type')).toBe('application/pdf');"
+            },
+            {
+              "file": "tests/lib/evidence/export/premiumExport.test.ts",
+              "start_line": 496,
+              "end_line": 501,
+              "start_col": 32,
+              "end_col": 68,
+              "fragment": "),\n    });\n\n    const res = await POST(req);\n    expect(res.status).toBe(200);\n    expect(res.headers.get('Content-Type')).toBe('application/pdf');"
+            }
+          ],
+          "token_count": 50,
+          "line_count": 7,
+          "fingerprint": "dup:551171ec",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (7 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 7,
+      "total_duplicated_tokens": 50,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (7 lines) from project.export-pdf.route.test.ts, premiumExport.test.ts, premiumExport.test.ts",
+          "estimated_savings": 14
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (7 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (7 lines) from project.export-pdf.route.test.ts, premiumExport.test.ts, premiumExport.test.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/app/api/exports/audit-pack.route.test.ts",
+        "tests/app/api/exports/client-readiness-report.route.test.ts",
+        "tests/app/api/exports/vvb-workpaper.route.test.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/app/api/exports/audit-pack.route.test.ts",
+              "start_line": 133,
+              "end_line": 141,
+              "start_col": 59,
+              "end_col": 44,
+              "fragment": ", {\n        method: \"POST\",\n        headers: { \"Content-Type\": \"application/json\" },\n        body: JSON.stringify({}),\n      }),\n    );\n\n    expect(response.status).toBe(400);\n    expect(await response.text()).toContain("
+            },
+            {
+              "file": "tests/app/api/exports/client-readiness-report.route.test.ts",
+              "start_line": 57,
+              "end_line": 65,
+              "start_col": 72,
+              "end_col": 44,
+              "fragment": ", {\n        method: \"POST\",\n        headers: { \"Content-Type\": \"application/json\" },\n        body: JSON.stringify({}),\n      }),\n    );\n\n    expect(response.status).toBe(400);\n    expect(await response.text()).toContain("
+            },
+            {
+              "file": "tests/app/api/exports/vvb-workpaper.route.test.ts",
+              "start_line": 61,
+              "end_line": 69,
+              "start_col": 62,
+              "end_col": 44,
+              "fragment": ", {\n        method: \"POST\",\n        headers: { \"Content-Type\": \"application/json\" },\n        body: JSON.stringify({}),\n      }),\n    );\n\n    expect(response.status).toBe(400);\n    expect(await response.text()).toContain("
+            }
+          ],
+          "token_count": 51,
+          "line_count": 9,
+          "fingerprint": "dup:f53f6b16",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 9,
+      "total_duplicated_tokens": 51,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (9 lines) from audit-pack.route.test.ts, client-readiness-report.route.test.ts, vvb-workpaper.route.test.ts",
+          "estimated_savings": 18
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (9 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (9 lines) from audit-pack.route.test.ts, client-readiness-report.route.test.ts, vvb-workpaper.route.test.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/components/finalReviewSummaryPanel.test.tsx"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/components/finalReviewSummaryPanel.test.tsx",
+              "start_line": 19,
+              "end_line": 60,
+              "start_col": 10,
+              "end_col": 26,
+              "fragment": "html = renderToStaticMarkup(\n      <FinalReviewSummaryPanel\n        summary={{\n          methodCode: \"AR-ACM0003\",\n          version: \"v02-0\",\n          ruleId: \"R-1\",\n          ruleSection: \"Monitoring period\",\n          ruleText: \"Evidence must fall inside the monitoring period.\",\n          selectedEvidenceId: \"stac-1\",\n          selectedEvidenceDatetime: \"2026-03-25T00:00:00Z\",\n          cloudCover: 4.5,\n          aoiLabel: \"Project AOI\",\n          reviewState: \"finalized\",\n          generatedAt: \"2026-03-25T00:10:00Z\",\n          outcomeNote: \"Stable result.\",\n          stacSearchResultCount: 3,\n          linkedRuleCount: 1,\n          selectedEvidenceLinkedRules: [\"R-1\"],\n          stacSupportFactsStatus: null,\n          linkedStacSupportFactCount: null,\n          unlinkedStacSupportFactCount: null,\n          checklistStatus: \"unused\",\n          reconciliationStatus: \"Supported\",\n          reconciliationReason: \"All expected evidence is linked.\",\n          narrative: \"Finalized verify review.\",\n        }}\n        artifact={null}\n        currentRunLabel=\"run-1234\"\n        finalizedAt=\"2026-03-25T00:10:00Z\"\n        reviewedRuleCount={1}\n        linkedEvidenceCount={2}\n        wizard={getVerifyWizardStepDetails({\n          selectedRuleId: \"R-1\",\n          aoiHash: \"aoi\",\n          stacItemIds: [\"item-1\"],\n          selectedStacItemId: \"item-1\",\n          linkedRuleIds: [\"R-1\"],\n          reviewerArtifactSavedAt: \"2026-03-25T00:05:00Z\",\n          finalizedAt: \"2026-03-25T00:10:00Z\",\n        })}\n        onDownloadJson={() => {}}\n        onDownloadPdf={() "
+            },
+            {
+              "file": "tests/components/finalReviewSummaryPanel.test.tsx",
+              "start_line": 87,
+              "end_line": 128,
+              "start_col": 10,
+              "end_col": 26,
+              "fragment": "withoutExport = renderToStaticMarkup(\n      <FinalReviewSummaryPanel\n        summary={{\n          methodCode: \"AR-ACM0003\",\n          version: \"v02-0\",\n          ruleId: \"R-1\",\n          ruleSection: \"Monitoring period\",\n          ruleText: \"Evidence must fall inside the monitoring period.\",\n          selectedEvidenceId: \"stac-1\",\n          selectedEvidenceDatetime: \"2026-03-25T00:00:00Z\",\n          cloudCover: 4.5,\n          aoiLabel: \"Project AOI\",\n          reviewState: \"finalized\",\n          generatedAt: \"2026-03-25T00:10:00Z\",\n          outcomeNote: \"Stable result.\",\n          stacSearchResultCount: 3,\n          linkedRuleCount: 1,\n          selectedEvidenceLinkedRules: [\"R-1\"],\n          stacSupportFactsStatus: null,\n          linkedStacSupportFactCount: null,\n          unlinkedStacSupportFactCount: null,\n          checklistStatus: \"unused\",\n          reconciliationStatus: \"Supported\",\n          reconciliationReason: \"All expected evidence is linked.\",\n          narrative: \"Finalized verify review.\",\n        }}\n        artifact={null}\n        currentRunLabel=\"run-1234\"\n        finalizedAt=\"2026-03-25T00:10:00Z\"\n        reviewedRuleCount={1}\n        linkedEvidenceCount={2}\n        wizard={getVerifyWizardStepDetails({\n          selectedRuleId: \"R-1\",\n          aoiHash: \"aoi\",\n          stacItemIds: [\"item-1\"],\n          selectedStacItemId: \"item-1\",\n          linkedRuleIds: [\"R-1\"],\n          reviewerArtifactSavedAt: \"2026-03-25T00:05:00Z\",\n          finalizedAt: \"2026-03-25T00:10:00Z\",\n        })}\n        onDownloadJson={() => {}}\n        onDownloadPdf={() "
+            },
+            {
+              "file": "tests/components/finalReviewSummaryPanel.test.tsx",
+              "start_line": 186,
+              "end_line": 227,
+              "start_col": 10,
+              "end_col": 26,
+              "fragment": "withoutExport = renderToStaticMarkup(\n      <FinalReviewSummaryPanel\n        summary={{\n          methodCode: \"AR-ACM0003\",\n          version: \"v02-0\",\n          ruleId: \"R-1\",\n          ruleSection: \"Monitoring period\",\n          ruleText: \"Evidence must fall inside the monitoring period.\",\n          selectedEvidenceId: \"stac-1\",\n          selectedEvidenceDatetime: \"2026-03-25T00:00:00Z\",\n          cloudCover: 4.5,\n          aoiLabel: \"Project AOI\",\n          reviewState: \"finalized\",\n          generatedAt: \"2026-03-25T00:10:00Z\",\n          outcomeNote: \"Stable result.\",\n          stacSearchResultCount: 3,\n          linkedRuleCount: 1,\n          selectedEvidenceLinkedRules: [\"R-1\"],\n          stacSupportFactsStatus: null,\n          linkedStacSupportFactCount: null,\n          unlinkedStacSupportFactCount: null,\n          checklistStatus: \"unused\",\n          reconciliationStatus: \"Supported\",\n          reconciliationReason: \"All expected evidence is linked.\",\n          narrative: \"Finalized verify review.\",\n        }}\n        artifact={null}\n        currentRunLabel=\"run-1234\"\n        finalizedAt=\"2026-03-25T00:10:00Z\"\n        reviewedRuleCount={1}\n        linkedEvidenceCount={2}\n        wizard={getVerifyWizardStepDetails({\n          selectedRuleId: \"R-1\",\n          aoiHash: \"aoi\",\n          stacItemIds: [\"item-1\"],\n          selectedStacItemId: \"item-1\",\n          linkedRuleIds: [\"R-1\"],\n          reviewerArtifactSavedAt: \"2026-03-25T00:05:00Z\",\n          finalizedAt: \"2026-03-25T00:10:00Z\",\n        })}\n        onDownloadJson={() => {}}\n        onDownloadPdf={() "
+            }
+          ],
+          "token_count": 97,
+          "line_count": 42,
+          "fingerprint": "dup:30782ed3",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (42 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 42,
+      "total_duplicated_tokens": 97,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (42 lines) from finalReviewSummaryPanel.test.tsx, finalReviewSummaryPanel.test.tsx, finalReviewSummaryPanel.test.tsx",
+          "estimated_savings": 84
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (42 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (42 lines) from finalReviewSummaryPanel.test.tsx, finalReviewSummaryPanel.test.tsx, finalReviewSummaryPanel.test.tsx"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/components/quickCheckPanel.review-question-fallback.test.tsx"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+              "start_line": 176,
+              "end_line": 190,
+              "start_col": 62,
+              "end_col": 27,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUntilText(\"Document Q&A\");\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+              "start_line": 202,
+              "end_line": 216,
+              "start_col": 114,
+              "end_col": 27,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUntilText(\"Document Q&A\");\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+              "start_line": 232,
+              "end_line": 246,
+              "start_col": 114,
+              "end_col": 27,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUntilText(\"Document Q&A\");\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+              "start_line": 261,
+              "end_line": 275,
+              "start_col": 114,
+              "end_col": 27,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUntilText(\"Document Q&A\");\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            }
+          ],
+          "token_count": 68,
+          "line_count": 15,
+          "fingerprint": "dup:6cfafb45",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (15 lines, 4 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 15,
+      "total_duplicated_tokens": 68,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (15 lines) from quickCheckPanel.review-question-fallback.test.tsx, quickCheckPanel.review-question-fallback.test.tsx, quickCheckPanel.review-question-fallback.test.tsx, quickCheckPanel.review-question-fallback.test.tsx",
+          "estimated_savings": 45
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (15 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (15 lines) from quickCheckPanel.review-question-fallback.test.tsx, quickCheckPanel.review-question-fallback.test.tsx, quickCheckPanel.review-question-fallback.test.tsx, quickCheckPanel.review-question-fallback.test.tsx"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+        "tests/components/quickCheckPanel.test.tsx",
+        "tests/components/quickCheckPanel.upload-regression.test.tsx"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+              "start_line": 120,
+              "end_line": 138,
+              "start_col": 4,
+              "end_col": 16,
+              "fragment": "window.localStorage.clear();\n\n    createAndStoreEvidenceAttachmentMock.mockReset();\n    createAndStoreEvidenceAttachmentMock.mockImplementation(async (input: { pin_id: string; file: File }) => {\n      const bytes = new Uint8Array(await input.file.arrayBuffer());\n      const attachment = {\n        id: `att-${input.pin_id}`,\n        pin_id: input.pin_id,\n        filename: input.file.name,\n        mime: input.file.type || \"application/pdf\",\n        size: bytes.byteLength,\n        sha256: `sha-${input.pin_id}`,\n        created_at: \"2026-04-04T00:00:00Z\",\n      };\n      await putAttachmentBytes(attachment.id, asArrayBuffer(bytes));\n      return { ok: true, attachment };\n    });\n\n    global.fetch"
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 167,
+              "end_line": 184,
+              "start_col": 4,
+              "end_col": 17,
+              "fragment": "(window as any).location = { assign: jest.fn(), replace: jest.fn(), href: \"http://localhost/\" };\n    createAndStoreEvidenceAttachmentMock.mockReset();\n    createAndStoreEvidenceAttachmentMock.mockImplementation(async (input: { pin_id: string; file: File }) => {\n      const bytes = new Uint8Array(await input.file.arrayBuffer());\n      const attachment = {\n        id: `att-${input.pin_id}`,\n        pin_id: input.pin_id,\n        filename: input.file.name,\n        mime: input.file.type || \"application/pdf\",\n        size: bytes.byteLength,\n        sha256: `sha-${input.pin_id}`,\n        created_at: \"2026-04-04T00:00:00Z\",\n      };\n      await putAttachmentBytes(attachment.id, asArrayBuffer(bytes));\n      return { ok: true, attachment };\n    });\n\n    (global.fetch"
+            },
+            {
+              "file": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+              "start_line": 87,
+              "end_line": 105,
+              "start_col": 4,
+              "end_col": 16,
+              "fragment": "window.localStorage.clear();\n\n    createAndStoreEvidenceAttachmentMock.mockReset();\n    createAndStoreEvidenceAttachmentMock.mockImplementation(async (input: { pin_id: string; file: File }) => {\n      const bytes = new Uint8Array(await input.file.arrayBuffer());\n      const attachment = {\n        id: `att-${input.pin_id}`,\n        pin_id: input.pin_id,\n        filename: input.file.name,\n        mime: input.file.type || \"application/pdf\",\n        size: bytes.byteLength,\n        sha256: `sha-${input.pin_id}`,\n        created_at: \"2026-04-04T00:00:00Z\",\n      };\n      await putAttachmentBytes(attachment.id, asArrayBuffer(bytes));\n      return { ok: true, attachment };\n    });\n\n    global.fetch"
+            }
+          ],
+          "token_count": 112,
+          "line_count": 19,
+          "fingerprint": "dup:aa359a1f",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (19 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 19,
+      "total_duplicated_tokens": 112,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (19 lines) from quickCheckPanel.review-question-fallback.test.tsx, quickCheckPanel.test.tsx, quickCheckPanel.upload-regression.test.tsx",
+          "estimated_savings": 38
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (19 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (19 lines) from quickCheckPanel.review-question-fallback.test.tsx, quickCheckPanel.test.tsx, quickCheckPanel.upload-regression.test.tsx"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+        "tests/components/quickCheckPanel.upload-errors.test.tsx",
+        "tests/components/quickCheckPanel.upload-regression.test.tsx"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+              "start_line": 138,
+              "end_line": 171,
+              "start_col": 4,
+              "end_col": 5,
+              "fragment": "global.fetch = jest.fn(async (input: RequestInfo | URL) => {\n      const url = String(input);\n      if (url.includes(\"/api/methods/inventory\")) {\n        return new Response(JSON.stringify({\n          methods: [\n            { code: \"VM0007\", latestVersion: \"v1-0\", versions: [\"v1-0\"] },\n            { code: \"ACM0010\", latestVersion: \"v01-0\", versions: [\"v01-0\"] },\n          ],\n        }), { status: 200 });\n      }\n      if (url.includes(\"/api/quick-check/semantic-evidence\")) {\n        return new Response(JSON.stringify({\n          status: \"disabled\",\n          candidates: [],\n          warning: \"HF_API_KEY is not configured; semantic evidence suggestions are disabled.\",\n        }), { status: 200 });\n      }\n      if (url.includes(\"/api/query?text=\")) {\n        return new Response(JSON.stringify({ engineTag: \"test\", metrics: [], results: [] }), { status: 200 });\n      }\n      throw new Error(`Unhandled fetch ${url}`);\n    }) as typeof fetch;\n  });\n\n  afterEach(async () => {\n    await act(async () => {\n      root.unmount();\n    });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });\n\n  it("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.upload-errors.test.tsx",
+              "start_line": 50,
+              "end_line": 66,
+              "start_col": 4,
+              "end_col": 5,
+              "fragment": "(global.fetch as any) = jest.fn(async (input: RequestInfo | URL) => {\n      const url = String(input);\n      if (url.includes(\"/api/methods/inventory\")) {\n        return new Response(JSON.stringify({ methods: [] }), { status: 200 });\n      }\n      return new Response(\"{}\", { status: 200 });\n    });\n  });\n\n  afterEach(async () => {\n    await act(async () => { root.unmount(); });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });\n\n  it("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+              "start_line": 177,
+              "end_line": 221,
+              "start_col": 4,
+              "end_col": 5,
+              "fragment": "window.localStorage.setItem(\n      \"a6:quick-check:claim-first:v1\",\n      JSON.stringify({\n        draft: {\n          id: \"draft-stale-recovery\",\n          claimText: \"unsupported claim\",\n          methodologyId: \"\",\n          methodologyVersion: \"\",\n          evidenceIds: [\"upload-1\"],\n          status: \"draft\",\n          createdAt: \"2026-04-04T00:00:00Z\",\n          updatedAt: \"2026-04-04T00:00:00Z\",\n        },\n        result: null,\n        stagedUploads: [\n          {\n            evidenceId: \"upload-1\",\n            filename: \"opaque-scan.pdf\",\n            mime: \"application/pdf\",\n            createdAt: \"2026-04-04T00:00:00Z\",\n            attachment: {\n              id: \"att-upload-1\",\n              pin_id: \"upload-1\",\n              filename: \"opaque-scan.pdf\",\n              mime: \"application/pdf\",\n              size: 128,\n              sha256: \"sha-upload-1\",\n              created_at: \"2026-04-04T00:00:00Z\",\n            },\n          },\n        ],\n      }),\n    );\n  });\n\n  afterEach(async () => {\n    await act(async () => {\n      root.unmount();\n    });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });\n\n  it("
+            }
+          ],
+          "token_count": 51,
+          "line_count": 45,
+          "fingerprint": "dup:53fd1f96",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (45 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 45,
+      "total_duplicated_tokens": 51,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (45 lines) from quickCheckPanel.review-question-fallback.test.tsx, quickCheckPanel.upload-errors.test.tsx, quickCheckPanel.upload-regression.test.tsx",
+          "estimated_savings": 90
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (45 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (45 lines) from quickCheckPanel.review-question-fallback.test.tsx, quickCheckPanel.upload-errors.test.tsx, quickCheckPanel.upload-regression.test.tsx"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/components/quickCheckPanel.test.tsx"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1022,
+              "end_line": 1037,
+              "start_col": 79,
+              "end_col": 27,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1051,
+              "end_line": 1066,
+              "start_col": 88,
+              "end_col": 27,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1082,
+              "end_line": 1097,
+              "start_col": 81,
+              "end_col": 27,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1172,
+              "end_line": 1187,
+              "start_col": 51,
+              "end_col": 27,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 2252,
+              "end_line": 2268,
+              "start_col": 5,
+              "end_col": 27,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 2282,
+              "end_line": 2298,
+              "start_col": 5,
+              "end_col": 27,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            }
+          ],
+          "token_count": 66,
+          "line_count": 17,
+          "fingerprint": "dup:b06be296",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (17 lines, 6 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1390,
+              "end_line": 1405,
+              "start_col": 78,
+              "end_col": 34,
+              "fragment": ",\n    );\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    expect(primaryCta().disabled).toBe(false);\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent)."
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1414,
+              "end_line": 1428,
+              "start_col": 118,
+              "end_col": 34,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    expect(primaryCta().disabled).toBe(false);\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent)."
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1434,
+              "end_line": 1448,
+              "start_col": 118,
+              "end_col": 34,
+              "fragment": ");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n\n    expect(primaryCta().disabled).toBe(false);\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent)."
+            }
+          ],
+          "token_count": 68,
+          "line_count": 16,
+          "fingerprint": "dup:e4ebf594",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (16 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1422,
+              "end_line": 1432,
+              "start_col": 44,
+              "end_col": 5,
+              "fragment": ");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent).toMatch(/Needs review|Partial|Supported/);\n    expect(container.textContent).toContain(\"Open full review\");\n  });\n\n  it("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1519,
+              "end_line": 1529,
+              "start_col": 5,
+              "end_col": 5,
+              "fragment": ");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent).toMatch(/Supported|Needs review|Partial/);\n    expect(container.textContent).toContain(\"Open full review\");\n  });\n\n  it("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1576,
+              "end_line": 1586,
+              "start_col": 5,
+              "end_col": 5,
+              "fragment": ");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    expect(container.textContent).toMatch(/Supported|Needs review|Partial/);\n    expect(container.textContent).toContain(\"Open full review\");\n  });\n\n  it("
+            }
+          ],
+          "token_count": 52,
+          "line_count": 11,
+          "fingerprint": "dup:5d0dc031",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (11 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1707,
+              "end_line": 1723,
+              "start_col": 6,
+              "end_col": 25,
+              "fragment": "filename: \"kenya-second-check-evidence.pdf\",\n    });\n    await seedAttachmentFixture(\"att-upload-1\", \"kenya-second-check-evidence.pdf\");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await flushUntilText(\"The PDF states a monitoring or reporting period\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    await flushUntilText("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1771,
+              "end_line": 1787,
+              "start_col": 6,
+              "end_col": 25,
+              "fragment": "filename: \"kenya-second-check-evidence.pdf\",\n    });\n    await seedAttachmentFixture(\"att-upload-1\", \"kenya-second-check-evidence.pdf\");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await flushUntilText(\"The PDF states a monitoring or reporting period\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    await flushUntilText("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1801,
+              "end_line": 1817,
+              "start_col": 6,
+              "end_col": 25,
+              "fragment": "filename: \"kenya-second-check-evidence.pdf\",\n    });\n    await seedAttachmentFixture(\"att-upload-1\", \"kenya-second-check-evidence.pdf\");\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    await flushUntilText(\"The PDF states a monitoring or reporting period\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    await flushUntilText("
+            }
+          ],
+          "token_count": 71,
+          "line_count": 17,
+          "fingerprint": "dup:3d86848e",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (17 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1877,
+              "end_line": 1893,
+              "start_col": 258,
+              "end_col": 20,
+              "fragment": ",\n    );\n\n    await act(async () => {\n      root.render(<QuickCheckPanel initialMethod=\"AR-ACM0003\" initialVersion=\"v02-0\" />);\n    });\n\n    await act(async () => {\n      openOptions();\n    });\n    const inventorySelect = savedEvidenceSelect();\n    await act(async () => {\n      inventorySelect.value = \"ev-pdd-malawi\";\n      inventorySelect.dispatchEvent(new Event(\"change\", { bubbles: true }));\n    });\n    await act(async () => {\n      setClaimValue("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1914,
+              "end_line": 1930,
+              "start_col": 305,
+              "end_col": 20,
+              "fragment": ",\n    );\n\n    await act(async () => {\n      root.render(<QuickCheckPanel initialMethod=\"AR-ACM0003\" initialVersion=\"v02-0\" />);\n    });\n\n    await act(async () => {\n      openOptions();\n    });\n    const inventorySelect = savedEvidenceSelect();\n    await act(async () => {\n      inventorySelect.value = \"ev-pdd-malawi\";\n      inventorySelect.dispatchEvent(new Event(\"change\", { bubbles: true }));\n    });\n    await act(async () => {\n      setClaimValue("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 1950,
+              "end_line": 1966,
+              "start_col": 258,
+              "end_col": 20,
+              "fragment": ",\n    );\n\n    await act(async () => {\n      root.render(<QuickCheckPanel initialMethod=\"AR-ACM0003\" initialVersion=\"v02-0\" />);\n    });\n\n    await act(async () => {\n      openOptions();\n    });\n    const inventorySelect = savedEvidenceSelect();\n    await act(async () => {\n      inventorySelect.value = \"ev-pdd-malawi\";\n      inventorySelect.dispatchEvent(new Event(\"change\", { bubbles: true }));\n    });\n    await act(async () => {\n      setClaimValue("
+            }
+          ],
+          "token_count": 91,
+          "line_count": 17,
+          "fingerprint": "dup:accb708f",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (17 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 2249,
+              "end_line": 2268,
+              "start_col": 16,
+              "end_col": 27,
+              "fragment": "{\n      claimText: \"The boundary description matches the mapped project area.\",\n      filename: \"plum-verra-demo-excerpt.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 2279,
+              "end_line": 2298,
+              "start_col": 16,
+              "end_col": 27,
+              "fragment": "{\n      claimText: \"The monitoring report covers the full reporting period.\",\n      filename: \"plum-verra-demo-excerpt.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 2337,
+              "end_line": 2356,
+              "start_col": 16,
+              "end_col": 27,
+              "fragment": "{\n      claimText: \"The monitoring report covers the full reporting period.\",\n      filename: \"ambiguous-methods.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Methodology confirmation banner conditional on strong extraction signals in current flow\n    // expect(container.textContent).toContain(\"Methodology needs confirmation. Requirement matches are limited to VM0007, GS-VER1.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text).toContain("
+            }
+          ],
+          "token_count": 67,
+          "line_count": 20,
+          "fingerprint": "dup:5d8a8590",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (20 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 2249,
+              "end_line": 2268,
+              "start_col": 16,
+              "end_col": 17,
+              "fragment": "{\n      claimText: \"The boundary description matches the mapped project area.\",\n      filename: \"plum-verra-demo-excerpt.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text)."
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 2279,
+              "end_line": 2298,
+              "start_col": 16,
+              "end_col": 17,
+              "fragment": "{\n      claimText: \"The monitoring report covers the full reporting period.\",\n      filename: \"plum-verra-demo-excerpt.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core narrowing verified post-run below\n    // expect(container.textContent).toContain(\"Primary detected methodology: VM0007. Requirement matches are narrowed to VM0007.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text)."
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 2337,
+              "end_line": 2356,
+              "start_col": 16,
+              "end_col": 17,
+              "fragment": "{\n      claimText: \"The monitoring report covers the full reporting period.\",\n      filename: \"ambiguous-methods.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Methodology confirmation banner conditional on strong extraction signals in current flow\n    // expect(container.textContent).toContain(\"Methodology needs confirmation. Requirement matches are limited to VM0007, GS-VER1.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    expect(text)."
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 2363,
+              "end_line": 2383,
+              "start_col": 16,
+              "end_col": 17,
+              "fragment": "{\n      claimText: \"The monitoring report covers the full reporting period.\",\n      filename: \"unknown-acm0010.pdf\",\n    });\n\n    await act(async () => {\n      root.render(<QuickCheckPanel />);\n    });\n\n    await flushUi();\n    // Banner text is conditional on extraction state; core checks below\n    // expect(container.textContent).toContain(\"Primary detected methodology: ACM0010. No matching method pack is available.\");\n\n    await act(async () => {\n      clickButton(\"Run quick check\");\n    });\n\n    await flushUi();\n    const text = container.textContent ?? \"\";\n    // Banner conditional on state in this flow\n    expect(text)."
+            }
+          ],
+          "token_count": 65,
+          "line_count": 21,
+          "fingerprint": "dup:179738d2",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (21 lines, 4 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 119,
+      "total_duplicated_tokens": 480,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 7 shared clone groups (119 lines) from quickCheckPanel.test.tsx into tests/components",
+          "estimated_savings": 310
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 7 duplicated code blocks (119 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 7 shared clone groups (119 lines) from quickCheckPanel.test.tsx into tests/components"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/components/quickCheckPanel.test.tsx",
+        "tests/components/quickCheckPanel.upload-errors.test.tsx",
+        "tests/components/quickCheckPanel.upload-regression.test.tsx"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 852,
+              "end_line": 863,
+              "start_col": 7,
+              "end_col": 5,
+              "fragment": "),\n    );\n  });\n\n  afterEach(async () => {\n    await act(async () => {\n      root.unmount();\n    });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });"
+            },
+            {
+              "file": "tests/components/quickCheckPanel.upload-errors.test.tsx",
+              "start_line": 55,
+              "end_line": 64,
+              "start_col": 47,
+              "end_col": 5,
+              "fragment": ");\n    });\n  });\n\n  afterEach(async () => {\n    await act(async () => { root.unmount(); });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });"
+            },
+            {
+              "file": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+              "start_line": 208,
+              "end_line": 219,
+              "start_col": 7,
+              "end_col": 5,
+              "fragment": "),\n    );\n  });\n\n  afterEach(async () => {\n    await act(async () => {\n      root.unmount();\n    });\n    container.remove();\n    jest.clearAllMocks();\n    window.localStorage.clear();\n  });"
+            }
+          ],
+          "token_count": 53,
+          "line_count": 12,
+          "fingerprint": "dup:d080376d",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (12 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 12,
+      "total_duplicated_tokens": 53,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (12 lines) from quickCheckPanel.test.tsx, quickCheckPanel.upload-errors.test.tsx, quickCheckPanel.upload-regression.test.tsx",
+          "estimated_savings": 24
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (12 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (12 lines) from quickCheckPanel.test.tsx, quickCheckPanel.upload-errors.test.tsx, quickCheckPanel.upload-regression.test.tsx"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/components/quickCheckPanel.test.tsx",
+        "tests/components/quickCheckPanel.upload-regression.test.tsx"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 875,
+              "end_line": 879,
+              "start_col": 23,
+              "end_col": 5,
+              "fragment": "label: string) {\n    const normalizedLabel = label.toLowerCase();\n    const button = Array.from(container.querySelectorAll(\"button\")).find((node) =>\n      node.textContent?.toLowerCase().includes(normalizedLabel),\n    )"
+            },
+            {
+              "file": "tests/components/quickCheckPanel.test.tsx",
+              "start_line": 884,
+              "end_line": 888,
+              "start_col": 32,
+              "end_col": 5,
+              "fragment": "label: string) {\n    const normalizedLabel = label.toLowerCase();\n    const button = Array.from(container.querySelectorAll(\"button\")).find((node) =>\n      node.textContent?.toLowerCase().includes(normalizedLabel),\n    )"
+            },
+            {
+              "file": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+              "start_line": 74,
+              "end_line": 78,
+              "start_col": 23,
+              "end_col": 5,
+              "fragment": "label: string) {\n    const normalizedLabel = label.toLowerCase();\n    const button = Array.from(container.querySelectorAll(\"button\")).find((node) =>\n      node.textContent?.toLowerCase().includes(normalizedLabel),\n    )"
+            }
+          ],
+          "token_count": 54,
+          "line_count": 5,
+          "fingerprint": "dup:101bd30e",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (5 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 5,
+      "total_duplicated_tokens": 54,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (5 lines) from quickCheckPanel.test.tsx, quickCheckPanel.test.tsx, quickCheckPanel.upload-regression.test.tsx",
+          "estimated_savings": 10
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (5 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (5 lines) from quickCheckPanel.test.tsx, quickCheckPanel.test.tsx, quickCheckPanel.upload-regression.test.tsx"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/components/ruleDetailModal.test.tsx",
+        "tests/components/ruleReviewPanel.test.tsx",
+        "tests/lib/coverage.tasks.test.ts",
+        "tests/lib/verify.runState.test.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/components/ruleDetailModal.test.tsx",
+              "start_line": 101,
+              "end_line": 113,
+              "start_col": 6,
+              "end_col": 14,
+              "fragment": "store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage"
+            },
+            {
+              "file": "tests/components/ruleReviewPanel.test.tsx",
+              "start_line": 14,
+              "end_line": 26,
+              "start_col": 6,
+              "end_col": 14,
+              "fragment": "store[key] = value;\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage"
+            },
+            {
+              "file": "tests/lib/coverage.tasks.test.ts",
+              "start_line": 10,
+              "end_line": 22,
+              "start_col": 6,
+              "end_col": 14,
+              "fragment": "store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage"
+            },
+            {
+              "file": "tests/lib/verify.runState.test.ts",
+              "start_line": 34,
+              "end_line": 46,
+              "start_col": 6,
+              "end_col": 14,
+              "fragment": "store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage"
+            }
+          ],
+          "token_count": 64,
+          "line_count": 13,
+          "fingerprint": "dup:c7ec1397",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (13 lines, 4 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 13,
+      "total_duplicated_tokens": 64,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (13 lines) from ruleDetailModal.test.tsx, ruleReviewPanel.test.tsx, coverage.tasks.test.ts, verify.runState.test.ts",
+          "estimated_savings": 39
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (13 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (13 lines) from ruleDetailModal.test.tsx, ruleReviewPanel.test.tsx, coverage.tasks.test.ts, verify.runState.test.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/components/ruleDetailModal.test.tsx",
+        "tests/lib/coverage.tasks.test.ts",
+        "tests/lib/verify.runState.test.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/components/ruleDetailModal.test.tsx",
+              "start_line": 95,
+              "end_line": 118,
+              "start_col": 0,
+              "end_col": 9,
+              "fragment": "function ensureLocalStorage(): Storage {\n  if (typeof localStorage !== \"undefined\") return localStorage;\n  let store: Record<string, string> = {};\n  const memoryStorage = {\n    getItem: (key: string) => (key in store ? store[key] : null),\n    setItem: (key: string, value: string) => {\n      store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage;\n  (globalThis as unknown as { localStorage: Storage }).localStorage = memoryStorage;\n  return memoryStorage;\n}\n\ndescribe("
+            },
+            {
+              "file": "tests/lib/coverage.tasks.test.ts",
+              "start_line": 4,
+              "end_line": 27,
+              "start_col": 0,
+              "end_col": 9,
+              "fragment": "function ensureLocalStorage(): Storage {\n  if (typeof localStorage !== \"undefined\") return localStorage;\n  let store: Record<string, string> = {};\n  const memoryStorage = {\n    getItem: (key: string) => (key in store ? store[key] : null),\n    setItem: (key: string, value: string) => {\n      store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage;\n  (globalThis as unknown as { localStorage: Storage }).localStorage = memoryStorage;\n  return memoryStorage;\n}\n\ndescribe("
+            },
+            {
+              "file": "tests/lib/verify.runState.test.ts",
+              "start_line": 28,
+              "end_line": 51,
+              "start_col": 0,
+              "end_col": 9,
+              "fragment": "function ensureLocalStorage(): Storage {\n  if (typeof localStorage !== \"undefined\") return localStorage;\n  let store: Record<string, string> = {};\n  const memoryStorage = {\n    getItem: (key: string) => (key in store ? store[key] : null),\n    setItem: (key: string, value: string) => {\n      store[key] = String(value);\n    },\n    removeItem: (key: string) => {\n      delete store[key];\n    },\n    clear: () => {\n      store = {};\n    },\n    key: (index: number) => Object.keys(store)[index] ?? null,\n    get length() {\n      return Object.keys(store).length;\n    },\n  } as Storage;\n  (globalThis as unknown as { localStorage: Storage }).localStorage = memoryStorage;\n  return memoryStorage;\n}\n\ndescribe("
+            }
+          ],
+          "token_count": 152,
+          "line_count": 24,
+          "fingerprint": "dup:3d97c641",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (24 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 24,
+      "total_duplicated_tokens": 152,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (24 lines) from ruleDetailModal.test.tsx, coverage.tasks.test.ts, verify.runState.test.ts",
+          "estimated_savings": 48
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (24 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (24 lines) from ruleDetailModal.test.tsx, coverage.tasks.test.ts, verify.runState.test.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/lib/composers/composerPdfIntegration.test.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+              "start_line": 41,
+              "end_line": 47,
+              "start_col": 61,
+              "end_col": 34,
+              "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text).toContain("
+            },
+            {
+              "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+              "start_line": 65,
+              "end_line": 71,
+              "start_col": 50,
+              "end_col": 34,
+              "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text).toContain("
+            },
+            {
+              "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+              "start_line": 87,
+              "end_line": 93,
+              "start_col": 70,
+              "end_col": 34,
+              "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text).toContain("
+            }
+          ],
+          "token_count": 70,
+          "line_count": 7,
+          "fingerprint": "dup:e050eb3c",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (7 lines, 3 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+              "start_line": 41,
+              "end_line": 47,
+              "start_col": 61,
+              "end_col": 24,
+              "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+            },
+            {
+              "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+              "start_line": 56,
+              "end_line": 62,
+              "start_col": 61,
+              "end_col": 24,
+              "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+            },
+            {
+              "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+              "start_line": 65,
+              "end_line": 71,
+              "start_col": 50,
+              "end_col": 24,
+              "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+            },
+            {
+              "file": "tests/lib/composers/composerPdfIntegration.test.ts",
+              "start_line": 87,
+              "end_line": 93,
+              "start_col": 70,
+              "end_col": 24,
+              "fragment": ", async () => {\n    const project = makeProject();\n    const pdf = await buildProjectExportPdf(project, coverage);\n    const bytes = pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength);\n    const parsed = await extractPdfTextWithPdfParse({ bytes });\n\n    expect(parsed.text)."
+            }
+          ],
+          "token_count": 68,
+          "line_count": 7,
+          "fingerprint": "dup:97ad49d0",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (7 lines, 4 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 14,
+      "total_duplicated_tokens": 138,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (7 lines) from composerPdfIntegration.test.ts, composerPdfIntegration.test.ts, composerPdfIntegration.test.ts",
+          "estimated_savings": 14
+        },
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (7 lines) from composerPdfIntegration.test.ts, composerPdfIntegration.test.ts, composerPdfIntegration.test.ts, composerPdfIntegration.test.ts",
+          "estimated_savings": 21
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 2 duplicated code blocks (14 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (7 lines) from composerPdfIntegration.test.ts, composerPdfIntegration.test.ts, composerPdfIntegration.test.ts"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (7 lines) from composerPdfIntegration.test.ts, composerPdfIntegration.test.ts, composerPdfIntegration.test.ts, composerPdfIntegration.test.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/lib/evidence/export/premiumExport.test.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/lib/evidence/export/premiumExport.test.ts",
+              "start_line": 219,
+              "end_line": 224,
+              "start_col": 54,
+              "end_col": 27,
+              "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/lib/evidence/export/premiumExport.test.ts",
+              "start_line": 235,
+              "end_line": 240,
+              "start_col": 43,
+              "end_col": 27,
+              "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/lib/evidence/export/premiumExport.test.ts",
+              "start_line": 246,
+              "end_line": 251,
+              "start_col": 40,
+              "end_col": 27,
+              "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/lib/evidence/export/premiumExport.test.ts",
+              "start_line": 257,
+              "end_line": 262,
+              "start_col": 47,
+              "end_col": 27,
+              "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/lib/evidence/export/premiumExport.test.ts",
+              "start_line": 269,
+              "end_line": 274,
+              "start_col": 50,
+              "end_col": 27,
+              "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/lib/evidence/export/premiumExport.test.ts",
+              "start_line": 282,
+              "end_line": 287,
+              "start_col": 34,
+              "end_col": 27,
+              "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+            },
+            {
+              "file": "tests/lib/evidence/export/premiumExport.test.ts",
+              "start_line": 437,
+              "end_line": 442,
+              "start_col": 64,
+              "end_col": 27,
+              "fragment": ", async () => {\n    const input = makeInput();\n    const pdf = buildPremiumPdf(input);\n    const text = await extractPdfText(pdf.buffer.slice(pdf.byteOffset, pdf.byteOffset + pdf.byteLength));\n\n    expect(text).toContain("
+            }
+          ],
+          "token_count": 57,
+          "line_count": 6,
+          "fingerprint": "dup:bf440f4c",
+          "actions": [
+            {
+              "type": "extract-shared",
+              "auto_fixable": false,
+              "description": "Extract duplicated code (6 lines, 7 instances) into a shared function"
+            },
+            {
+              "type": "suppress-line",
+              "auto_fixable": false,
+              "description": "Suppress with an inline comment above the duplicated code",
+              "comment": "// fallow-ignore-next-line code-duplication"
+            }
+          ]
+        }
+      ],
+      "total_duplicated_lines": 6,
+      "total_duplicated_tokens": 57,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (6 lines) from premiumExport.test.ts, premiumExport.test.ts, premiumExport.test.ts, premiumExport.test.ts, premiumExport.test.ts, premiumExport.test.ts, premiumExport.test.ts",
+          "estimated_savings": 36
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (6 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship; refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (6 lines) from premiumExport.test.ts, premiumExport.test.ts, premiumExport.test.ts, premiumExport.test.ts, premiumExport.test.ts, premiumExport.test.ts, premiumExport.test.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    }
+  ],
+  "stats": {
+    "total_files": 462,
+    "files_with_clones": 175,
+    "total_lines": 91552,
+    "duplicated_lines": 9697,
+    "total_tokens": 524761,
+    "duplicated_tokens": 29648,
+    "clone_groups": 39,
+    "clone_instances": 135,
+    "duplication_percentage": 10.591794826983572,
+    "clone_groups_below_min_occurrences": 269
+  }
+}

--- a/artifacts/fallow/health.json
+++ b/artifacts/fallow/health.json
@@ -1,0 +1,8910 @@
+{
+  "kind": "health",
+  "schema_version": 7,
+  "version": "2.86.0",
+  "elapsed_ms": 1494,
+  "findings": [
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "ProofMapTab",
+      "line": 426,
+      "col": 15,
+      "cyclomatic": 224,
+      "cognitive": 235,
+      "line_count": 4932,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 11062.0,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `ProofMapTab` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/app/m/_components/MethodDetailPane.tsx",
+      "name": "MethodDetailPane",
+      "line": 129,
+      "col": 15,
+      "cyclomatic": 151,
+      "cognitive": 131,
+      "line_count": 1861,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 22952.0,
+      "coverage_tier": "none",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `MethodDetailPane` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "name": "QuickCheckPanel",
+      "line": 564,
+      "col": 15,
+      "cyclomatic": 121,
+      "cognitive": 193,
+      "line_count": 2160,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 3283.5,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `QuickCheckPanel` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/exports/verificationPackContract.ts",
+      "name": "buildVerificationPackContract",
+      "line": 1306,
+      "col": 7,
+      "cyclomatic": 113,
+      "cognitive": 95,
+      "line_count": 404,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 156.1,
+      "coverage_tier": "high",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `buildVerificationPackContract` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/app/m/_components/RuleDetailModal.tsx",
+      "name": "RuleDetailModal",
+      "line": 251,
+      "col": 15,
+      "cyclomatic": 106,
+      "cognitive": 120,
+      "line_count": 558,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 2533.0,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `RuleDetailModal` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/buildReviewSummary.ts",
+      "name": "buildReviewSummary",
+      "line": 94,
+      "col": 7,
+      "cyclomatic": 85,
+      "cognitive": 66,
+      "line_count": 98,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 109.4,
+      "coverage_tier": "high",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `buildReviewSummary` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "name": "runQuickCheck",
+      "line": 1432,
+      "col": 2,
+      "cyclomatic": 75,
+      "cognitive": 78,
+      "line_count": 315,
+      "param_count": 0,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 1290.0,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `runQuickCheck` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/components/verify/EvidenceWorkflowStepper.tsx",
+      "name": "EvidenceWorkflowStepper",
+      "line": 375,
+      "col": 15,
+      "cyclomatic": 72,
+      "cognitive": 98,
+      "line_count": 535,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 1191.7,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `EvidenceWorkflowStepper` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "verifyReadinessChips",
+      "line": 2119,
+      "col": 62,
+      "cyclomatic": 61,
+      "cognitive": 107,
+      "line_count": 115,
+      "param_count": 0,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 864.7,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `verifyReadinessChips` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/components/trust/TrustStrip.tsx",
+      "name": "TrustStrip",
+      "line": 286,
+      "col": 15,
+      "cyclomatic": 61,
+      "cognitive": 58,
+      "line_count": 583,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 864.7,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `TrustStrip` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "<arrow>",
+      "line": 3698,
+      "col": 36,
+      "cyclomatic": 53,
+      "cognitive": 66,
+      "line_count": 406,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 659.7,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `<arrow>` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "name": "boostForEvidenceFacts",
+      "line": 190,
+      "col": 0,
+      "cyclomatic": 52,
+      "cognitive": 69,
+      "line_count": 31,
+      "param_count": 3,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 636.1,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `boostForEvidenceFacts` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/components/verify/RuleReviewPanel.tsx",
+      "name": "RuleReviewPanel",
+      "line": 69,
+      "col": 15,
+      "cyclomatic": 51,
+      "cognitive": 50,
+      "line_count": 808,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 612.8,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `RuleReviewPanel` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/export/verificationPackDerivation.ts",
+      "name": "buildDecisionRun",
+      "line": 420,
+      "col": 0,
+      "cyclomatic": 50,
+      "cognitive": 26,
+      "line_count": 91,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 590.0,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `buildDecisionRun` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "tests/components/quickCheckPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 184,
+      "col": 57,
+      "cyclomatic": 49,
+      "cognitive": 66,
+      "line_count": 605,
+      "param_count": 2,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 567.6,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `<arrow>` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckUi.ts",
+      "name": "signalLabelFromFact",
+      "line": 183,
+      "col": 0,
+      "cyclomatic": 48,
+      "cognitive": 52,
+      "line_count": 73,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 545.7,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `signalLabelFromFact` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "scripts/gate-link-resolver.mjs",
+      "name": "main",
+      "line": 97,
+      "col": 0,
+      "cyclomatic": 47,
+      "cognitive": 93,
+      "line_count": 118,
+      "param_count": 0,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 2256.0,
+      "coverage_tier": "none",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `main` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckEvidence.ts",
+      "name": "scoreRuleAgainstFacts",
+      "line": 1159,
+      "col": 0,
+      "cyclomatic": 47,
+      "cognitive": 46,
+      "line_count": 50,
+      "param_count": 2,
+      "exceeded": "all",
+      "severity": "critical",
+      "crap": 524.1,
+      "coverage_tier": "partial",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `scoreRuleAgainstFacts` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/runState.ts",
+      "name": "buildRunSummary",
+      "line": 816,
+      "col": 7,
+      "cyclomatic": 47,
+      "cognitive": 22,
+      "line_count": 40,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "high",
+      "crap": 54.5,
+      "coverage_tier": "high",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `buildRunSummary` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/evidenceSnapshot.ts",
+      "name": "buildEvidenceSnapshot",
+      "line": 350,
+      "col": 7,
+      "cyclomatic": 45,
+      "cognitive": 37,
+      "line_count": 132,
+      "param_count": 1,
+      "exceeded": "all",
+      "severity": "high",
+      "crap": 51.8,
+      "coverage_tier": "high",
+      "coverage_source": "estimated",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `buildEvidenceSnapshot` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "files_analyzed": 487,
+    "functions_analyzed": 6907,
+    "functions_above_threshold": 419,
+    "max_cyclomatic_threshold": 25,
+    "max_cognitive_threshold": 20,
+    "max_crap_threshold": 30.0,
+    "files_scored": 437,
+    "average_maintainability": 89.5,
+    "coverage_model": "static_estimated",
+    "coverage_source_consistency": "uniform",
+    "severity_critical_count": 147,
+    "severity_high_count": 114,
+    "severity_moderate_count": 158
+  },
+  "vital_signs": {
+    "dead_file_pct": 4.3,
+    "dead_export_pct": 10.1,
+    "avg_cyclomatic": 2.9,
+    "critical_complexity_pct": 0.2,
+    "p90_cyclomatic": 6,
+    "duplication_pct": 10.6,
+    "hotspot_count": 2,
+    "hotspot_top_pct_count": 5,
+    "maintainability_avg": 89.5,
+    "maintainability_low_pct": 1.4,
+    "unused_dep_count": 2,
+    "unused_deps_per_k_files": 4.1,
+    "circular_dep_count": 0,
+    "circular_deps_per_k_files": 0.0,
+    "counts": {
+      "total_files": 487,
+      "total_exports": 1199,
+      "dead_files": 21,
+      "dead_exports": 121,
+      "duplicated_lines": 9697,
+      "total_lines": 92510,
+      "files_scored": 437,
+      "total_deps": 0
+    },
+    "unit_size_profile": {
+      "low_risk": 77.2,
+      "medium_risk": 11.5,
+      "high_risk": 6.5,
+      "very_high_risk": 4.8
+    },
+    "functions_over_60_loc_per_k": 48.4,
+    "unit_interfacing_profile": {
+      "low_risk": 97.3,
+      "medium_risk": 2.4,
+      "high_risk": 0.3,
+      "very_high_risk": 0.0
+    },
+    "p95_fan_in": 8,
+    "coupling_high_pct": 3.4,
+    "total_loc": 92510
+  },
+  "health_score": {
+    "formula_version": 2,
+    "score": 64.8,
+    "grade": "C",
+    "penalties": {
+      "dead_files": 0.9,
+      "dead_exports": 2.0,
+      "complexity": 0.8,
+      "p90_complexity": 0.0,
+      "maintainability": 2.1,
+      "hotspots": 10.0,
+      "unused_deps": 2.1,
+      "circular_deps": 0.0,
+      "unit_size": 10.0,
+      "coupling": 1.7,
+      "duplication": 5.6
+    }
+  },
+  "file_scores": [
+    {
+      "path": "src/app/m/_components/MethodDetailPane.tsx",
+      "fan_in": 2,
+      "fan_out": 34,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.33,
+      "maintainability_index": 75.9,
+      "total_cyclomatic": 647,
+      "total_cognitive": 500,
+      "function_count": 156,
+      "lines": 1990,
+      "crap_max": 22952.0,
+      "crap_above_threshold": 27
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "fan_in": 2,
+      "fan_out": 53,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.31,
+      "maintainability_index": 75.7,
+      "total_cyclomatic": 1681,
+      "total_cognitive": 1190,
+      "function_count": 437,
+      "lines": 5358,
+      "crap_max": 11062.0,
+      "crap_above_threshold": 31
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "fan_in": 5,
+      "fan_out": 17,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.3,
+      "maintainability_index": 79.4,
+      "total_cyclomatic": 804,
+      "total_cognitive": 671,
+      "function_count": 206,
+      "lines": 2724,
+      "crap_max": 3283.5,
+      "crap_above_threshold": 8
+    },
+    {
+      "path": "src/app/m/_components/RuleDetailModal.tsx",
+      "fan_in": 2,
+      "fan_out": 9,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.3,
+      "maintainability_index": 81.8,
+      "total_cyclomatic": 239,
+      "total_cognitive": 217,
+      "function_count": 40,
+      "lines": 809,
+      "crap_max": 2533.0,
+      "crap_above_threshold": 3
+    },
+    {
+      "path": "scripts/gate-link-resolver.mjs",
+      "fan_in": 0,
+      "fan_out": 0,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.42,
+      "maintainability_index": 87.4,
+      "total_cyclomatic": 93,
+      "total_cognitive": 136,
+      "function_count": 10,
+      "lines": 220,
+      "crap_max": 2256.0,
+      "crap_above_threshold": 6
+    },
+    {
+      "path": "scripts/compute-coverage.mjs",
+      "fan_in": 0,
+      "fan_out": 0,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.43,
+      "maintainability_index": 87.1,
+      "total_cyclomatic": 97,
+      "total_cognitive": 74,
+      "function_count": 19,
+      "lines": 227,
+      "crap_max": 1482.0,
+      "crap_above_threshold": 7
+    },
+    {
+      "path": "scripts/verify-audit-pack.mjs",
+      "fan_in": 0,
+      "fan_out": 1,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.38,
+      "maintainability_index": 85.8,
+      "total_cyclomatic": 201,
+      "total_cognitive": 214,
+      "function_count": 32,
+      "lines": 525,
+      "crap_max": 1406.0,
+      "crap_above_threshold": 7
+    },
+    {
+      "path": "src/components/verify/EvidenceWorkflowStepper.tsx",
+      "fan_in": 2,
+      "fan_out": 3,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.16,
+      "maintainability_index": 89.7,
+      "total_cyclomatic": 146,
+      "total_cognitive": 142,
+      "function_count": 26,
+      "lines": 910,
+      "crap_max": 1191.7,
+      "crap_above_threshold": 2
+    },
+    {
+      "path": "src/components/trust/TrustStrip.tsx",
+      "fan_in": 1,
+      "fan_out": 7,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.27,
+      "maintainability_index": 83.6,
+      "total_cyclomatic": 238,
+      "total_cognitive": 162,
+      "function_count": 66,
+      "lines": 869,
+      "crap_max": 864.7,
+      "crap_above_threshold": 2
+    },
+    {
+      "path": "src/lib/rich/normalize.ts",
+      "fan_in": 1,
+      "fan_out": 0,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.4,
+      "maintainability_index": 88.0,
+      "total_cyclomatic": 117,
+      "total_cognitive": 153,
+      "function_count": 13,
+      "lines": 293,
+      "crap_max": 702.0,
+      "crap_above_threshold": 9
+    },
+    {
+      "path": "src/components/verify/RuleReviewPanel.tsx",
+      "fan_in": 3,
+      "fan_out": 10,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.17,
+      "maintainability_index": 85.3,
+      "total_cyclomatic": 145,
+      "total_cognitive": 96,
+      "function_count": 37,
+      "lines": 877,
+      "crap_max": 612.8,
+      "crap_above_threshold": 4
+    },
+    {
+      "path": "scripts/roadmap/rgei-readiness-report.mjs",
+      "fan_in": 0,
+      "fan_out": 0,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.31,
+      "maintainability_index": 90.7,
+      "total_cyclomatic": 101,
+      "total_cognitive": 104,
+      "function_count": 18,
+      "lines": 324,
+      "crap_max": 600.0,
+      "crap_above_threshold": 5
+    },
+    {
+      "path": "src/lib/evidence/export/verificationPackDerivation.ts",
+      "fan_in": 1,
+      "fan_out": 10,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.43,
+      "maintainability_index": 77.5,
+      "total_cyclomatic": 296,
+      "total_cognitive": 210,
+      "function_count": 70,
+      "lines": 684,
+      "crap_max": 590.0,
+      "crap_above_threshold": 5
+    },
+    {
+      "path": "tests/components/quickCheckPanel.test.tsx",
+      "fan_in": 0,
+      "fan_out": 4,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.13,
+      "maintainability_index": 89.7,
+      "total_cyclomatic": 305,
+      "total_cognitive": 110,
+      "function_count": 211,
+      "lines": 2404,
+      "crap_max": 567.6,
+      "crap_above_threshold": 1
+    },
+    {
+      "path": "src/lib/chat/quickCheckUi.ts",
+      "fan_in": 3,
+      "fan_out": 3,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.37,
+      "maintainability_index": 83.4,
+      "total_cyclomatic": 222,
+      "total_cognitive": 152,
+      "function_count": 31,
+      "lines": 601,
+      "crap_max": 545.7,
+      "crap_above_threshold": 5
+    },
+    {
+      "path": "src/lib/chat/quickCheckEvidence.ts",
+      "fan_in": 6,
+      "fan_out": 3,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.34,
+      "maintainability_index": 84.3,
+      "total_cyclomatic": 436,
+      "total_cognitive": 502,
+      "function_count": 71,
+      "lines": 1283,
+      "crap_max": 524.1,
+      "crap_above_threshold": 11
+    },
+    {
+      "path": "src/components/RuleCard.tsx",
+      "fan_in": 1,
+      "fan_out": 6,
+      "dead_code_ratio": 1.0,
+      "complexity_density": 0.22,
+      "maintainability_index": 65.6,
+      "total_cyclomatic": 59,
+      "total_cognitive": 40,
+      "function_count": 19,
+      "lines": 265,
+      "crap_max": 506.0,
+      "crap_above_threshold": 4
+    },
+    {
+      "path": "src/lib/export/assertVerificationSnapshotInvariants.ts",
+      "fan_in": 2,
+      "fan_out": 0,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.5,
+      "maintainability_index": 85.0,
+      "total_cyclomatic": 113,
+      "total_cognitive": 135,
+      "function_count": 9,
+      "lines": 225,
+      "crap_max": 462.2,
+      "crap_above_threshold": 2
+    },
+    {
+      "path": "src/app/m/_components/MethodsFinder.tsx",
+      "fan_in": 3,
+      "fan_out": 8,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.24,
+      "maintainability_index": 84.0,
+      "total_cyclomatic": 37,
+      "total_cognitive": 32,
+      "function_count": 6,
+      "lines": 156,
+      "crap_max": 462.0,
+      "crap_above_threshold": 3
+    },
+    {
+      "path": "src/app/api/quick-check/semantic-evidence/route.ts",
+      "fan_in": 0,
+      "fan_out": 2,
+      "dead_code_ratio": 0.0,
+      "complexity_density": 0.5,
+      "maintainability_index": 83.0,
+      "total_cyclomatic": 21,
+      "total_cognitive": 11,
+      "function_count": 2,
+      "lines": 42,
+      "crap_max": 420.0,
+      "crap_above_threshold": 1
+    }
+  ],
+  "coverage_gaps": {
+    "summary": {
+      "runtime_files": 312,
+      "covered_files": 219,
+      "file_coverage_pct": 70.2,
+      "untested_files": 93,
+      "untested_exports": 138
+    },
+    "files": [
+      {
+        "path": "scripts/_stable-json.mjs",
+        "value_export_count": 4,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/_stable-json.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/_stable-json.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/assert-derived-present.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/assert-derived-present.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/assert-derived-present.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/audit-pack/diff-manifests.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/audit-pack/diff-manifests.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/audit-pack/diff-manifests.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/audit-pack/gen-trace-index.mjs",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/audit-pack/gen-trace-index.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/audit-pack/gen-trace-index.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/build-audit-pack.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/build-audit-pack.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/build-audit-pack.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/build-derived-artifacts.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/build-derived-artifacts.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/build-derived-artifacts.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/build-derived-manifest.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/build-derived-manifest.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/build-derived-manifest.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/check-docs-layout.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/check-docs-layout.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/check-docs-layout.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/check-quick-check-pdf-trace.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/check-quick-check-pdf-trace.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/check-quick-check-pdf-trace.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/ci-verify-run-summary.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/ci-verify-run-summary.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/ci-verify-run-summary.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/compute-coverage.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/compute-coverage.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/compute-coverage.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/determinism-audit-pack.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/determinism-audit-pack.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/determinism-audit-pack.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/drift-artifacts.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/drift-artifacts.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/drift-artifacts.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/extract-quick-check-pdf.cjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/extract-quick-check-pdf.cjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/extract-quick-check-pdf.cjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/gate-coverage-ratchet.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/gate-coverage-ratchet.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/gate-coverage-ratchet.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/gate-link-resolver.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/gate-link-resolver.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/gate-link-resolver.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/generate-manifest-from-pack.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/generate-manifest-from-pack.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/generate-manifest-from-pack.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/guard-methodology-boundary.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/guard-methodology-boundary.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/guard-methodology-boundary.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/manual-review-extract-local.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/manual-review-extract-local.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/manual-review-extract-local.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/node-version-shim.js",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/node-version-shim.js`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/node-version-shim.js`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/ops/codex-run-log.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/ops/codex-run-log.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/ops/codex-run-log.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/pr-gate.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/pr-gate.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/pr-gate.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/apply-merged-pr.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/apply-merged-pr.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/apply-merged-pr.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/autopilot-merge.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/autopilot-merge.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/autopilot-merge.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/check-roadmap-directive.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/check-roadmap-directive.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/check-roadmap-directive.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/check-roadmap-status.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/check-roadmap-status.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/check-roadmap-status.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/find-ssot-for-pr.mjs",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/find-ssot-for-pr.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/find-ssot-for-pr.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/gate-roadmap-monotonic.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/gate-roadmap-monotonic.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/gate-roadmap-monotonic.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/gen-roadmap.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/gen-roadmap.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/gen-roadmap.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/infer-pr-key.mjs",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/infer-pr-key.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/infer-pr-key.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/init-roadmap.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/init-roadmap.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/init-roadmap.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/rgei-readiness-report.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/rgei-readiness-report.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/rgei-readiness-report.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/roadmap-update.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/roadmap-update.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/roadmap-update.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/status.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/status.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/status.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/validate-pr-evidence.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/validate-pr-evidence.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/validate-pr-evidence.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/validate-ssot.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/roadmap/validate-ssot.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/validate-ssot.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/status-check.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/status-check.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/status-check.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/test-audit-pack-smoke.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/test-audit-pack-smoke.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/test-audit-pack-smoke.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/test-audit-pack-trail-smoke.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/test-audit-pack-trail-smoke.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/test-audit-pack-trail-smoke.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/test-derived-determinism.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/test-derived-determinism.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/test-derived-determinism.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/test-evidence-map-smoke.cjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/test-evidence-map-smoke.cjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/test-evidence-map-smoke.cjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/tickets/list-tickets.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/tickets/list-tickets.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/tickets/list-tickets.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/tickets/new-ticket.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/tickets/new-ticket.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/tickets/new-ticket.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/validate-artifacts.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/validate-artifacts.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/validate-artifacts.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/verify-artifacts.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/verify-artifacts.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/verify-artifacts.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/verify-audit-pack.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/verify-audit-pack.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/verify-audit-pack.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/verify-derived-artifacts.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/verify-derived-artifacts.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/verify-derived-artifacts.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/verify-export-snapshot.mjs",
+        "value_export_count": 0,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `scripts/verify-export-snapshot.mjs`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/verify-export-snapshot.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/chat/route.ts",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/api/chat/route.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/chat/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/health/route.ts",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/api/health/route.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/health/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/rule/[sha]/route.ts",
+        "value_export_count": 4,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/api/manifest/rule/[sha]/route.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/rule/[sha]/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/extract-evidence/route.ts",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/api/projects/extract-evidence/route.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/extract-evidence/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/reconcile-evidence/route.ts",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/api/projects/reconcile-evidence/route.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/reconcile-evidence/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/record-decision/route.ts",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/api/projects/record-decision/route.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/record-decision/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/quick-check/semantic-evidence/route.ts",
+        "value_export_count": 3,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/api/quick-check/semantic-evidence/route.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/quick-check/semantic-evidence/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/audit/page.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/audit/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/audit/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/dashboard/page.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/dashboard/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/dashboard/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/layout.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/layout.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/layout.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/page.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/[code]/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/v/[ver]/evidence/EvidenceCanonicalizer.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/[code]/v/[ver]/evidence/EvidenceCanonicalizer.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/v/[ver]/evidence/EvidenceCanonicalizer.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/v/[ver]/evidence/page.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/[code]/v/[ver]/evidence/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/v/[ver]/evidence/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/v/[ver]/page.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/[code]/v/[ver]/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/v/[ver]/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/EvidenceView.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/_components/EvidenceView.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/EvidenceView.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/IntegrityDiffPanel.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/_components/IntegrityDiffPanel.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/IntegrityDiffPanel.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/MethodDetailPane.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/_components/MethodDetailPane.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/MethodDetailPane.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/MethodsFinder.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/_components/MethodsFinder.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/MethodsFinder.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/MethodsFinderShell.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/_components/MethodsFinderShell.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/MethodsFinderShell.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/MethodsLayoutContext.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/_components/MethodsLayoutContext.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/MethodsLayoutContext.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/VerifyHeader.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/_components/VerifyHeader.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/VerifyHeader.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/VersionSelector.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/_components/VersionSelector.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/VersionSelector.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/page.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/m/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/manifest/page.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/manifest/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/manifest/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/page.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/pdf/[id]/route.ts",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/pdf/[id]/route.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/pdf/[id]/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/projects/[id]/page.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/projects/[id]/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/projects/[id]/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/projects/new/page.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/projects/new/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/projects/new/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/projects/page.tsx",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/app/projects/page.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/projects/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/FooterHealth.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/components/FooterHealth.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/FooterHealth.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/HealthBadge.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/components/HealthBadge.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/HealthBadge.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/audit/AuditApp.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/components/audit/AuditApp.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/audit/AuditApp.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/audit/Checklist.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/components/audit/Checklist.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/audit/Checklist.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/intake/IntakeDashboard.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/components/intake/IntakeDashboard.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/intake/IntakeDashboard.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/verify/ReviewProgressIndicator.tsx",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/components/verify/ReviewProgressIndicator.tsx`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/verify/ReviewProgressIndicator.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/hooks/useHealth.ts",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/hooks/useHealth.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/hooks/useHealth.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/audit/checklist.ts",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/lib/audit/checklist.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/audit/checklist.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/audit/sample.ts",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/lib/audit/sample.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/audit/sample.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/auditTrail/store.ts",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/lib/auditTrail/store.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/auditTrail/store.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/manifestDiff.ts",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/lib/manifestDiff.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/manifestDiff.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/mode.ts",
+        "value_export_count": 2,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/lib/mode.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/mode.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/nav/canonicalEvidence.ts",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/lib/nav/canonicalEvidence.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/nav/canonicalEvidence.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/quickCheck/semanticEvidence/huggingFace.ts",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/lib/quickCheck/semanticEvidence/huggingFace.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/quickCheck/semanticEvidence/huggingFace.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/rich/normalize.ts",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/lib/rich/normalize.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/rich/normalize.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/ruleJump.ts",
+        "value_export_count": 1,
+        "actions": [
+          {
+            "type": "add-tests",
+            "auto_fixable": false,
+            "description": "Add test coverage for `src/lib/ruleJump.ts`",
+            "note": "No test dependency path reaches this runtime file"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/ruleJump.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      }
+    ],
+    "exports": [
+      {
+        "path": "scripts/_stable-json.mjs",
+        "export_name": "sha256File",
+        "line": 34,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `sha256File` from `scripts/_stable-json.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/_stable-json.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/_stable-json.mjs",
+        "export_name": "sortById",
+        "line": 30,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `sortById` from `scripts/_stable-json.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/_stable-json.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/_stable-json.mjs",
+        "export_name": "sortByPath",
+        "line": 26,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `sortByPath` from `scripts/_stable-json.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/_stable-json.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/_stable-json.mjs",
+        "export_name": "stableStringify",
+        "line": 21,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `stableStringify` from `scripts/_stable-json.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/_stable-json.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/audit-pack/gen-trace-index.mjs",
+        "export_name": "genTrace",
+        "line": 123,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `genTrace` from `scripts/audit-pack/gen-trace-index.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/audit-pack/gen-trace-index.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/find-ssot-for-pr.mjs",
+        "export_name": "findSsotForPr",
+        "line": 6,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `findSsotForPr` from `scripts/roadmap/find-ssot-for-pr.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/find-ssot-for-pr.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/infer-pr-key.mjs",
+        "export_name": "inferPrKey",
+        "line": 3,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `inferPrKey` from `scripts/roadmap/infer-pr-key.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/infer-pr-key.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/roadmap-lib.mjs",
+        "export_name": "findPlanPath",
+        "line": 146,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `findPlanPath` from `scripts/roadmap/roadmap-lib.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/roadmap-lib.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/roadmap-lib.mjs",
+        "export_name": "formatPrId",
+        "line": 42,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `formatPrId` from `scripts/roadmap/roadmap-lib.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/roadmap-lib.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/roadmap-lib.mjs",
+        "export_name": "generateRoadmapContent",
+        "line": 188,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `generateRoadmapContent` from `scripts/roadmap/roadmap-lib.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/roadmap-lib.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/roadmap-lib.mjs",
+        "export_name": "getPhaseKeyForId",
+        "line": 77,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `getPhaseKeyForId` from `scripts/roadmap/roadmap-lib.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/roadmap-lib.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/roadmap-lib.mjs",
+        "export_name": "listSsotFiles",
+        "line": 154,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `listSsotFiles` from `scripts/roadmap/roadmap-lib.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/roadmap-lib.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/roadmap-lib.mjs",
+        "export_name": "normalizePhaseId",
+        "line": 32,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `normalizePhaseId` from `scripts/roadmap/roadmap-lib.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/roadmap-lib.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/roadmap-lib.mjs",
+        "export_name": "parsePlanTitles",
+        "line": 131,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `parsePlanTitles` from `scripts/roadmap/roadmap-lib.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/roadmap-lib.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/roadmap-lib.mjs",
+        "export_name": "prSortKey",
+        "line": 48,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `prSortKey` from `scripts/roadmap/roadmap-lib.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/roadmap-lib.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "scripts/roadmap/roadmap-lib.mjs",
+        "export_name": "statusLabel",
+        "line": 71,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `statusLabel` from `scripts/roadmap/roadmap-lib.mjs`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `scripts/roadmap/roadmap-lib.mjs`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/chat/route.ts",
+        "export_name": "POST",
+        "line": 38,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `POST` from `src/app/api/chat/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/chat/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/exports/audit-pack/route.ts",
+        "export_name": "dynamic",
+        "line": 8,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/exports/audit-pack/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/exports/audit-pack/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/exports/audit-pack/route.ts",
+        "export_name": "runtime",
+        "line": 7,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/exports/audit-pack/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/exports/audit-pack/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/exports/client-readiness-report/route.ts",
+        "export_name": "dynamic",
+        "line": 6,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/exports/client-readiness-report/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/exports/client-readiness-report/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/exports/client-readiness-report/route.ts",
+        "export_name": "runtime",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/exports/client-readiness-report/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/exports/client-readiness-report/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/exports/vvb-workpaper/route.ts",
+        "export_name": "dynamic",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/exports/vvb-workpaper/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/exports/vvb-workpaper/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/exports/vvb-workpaper/route.ts",
+        "export_name": "runtime",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/exports/vvb-workpaper/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/exports/vvb-workpaper/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/health/route.ts",
+        "export_name": "GET",
+        "line": 59,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/health/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/health/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/health/route.ts",
+        "export_name": "runtime",
+        "line": 1,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/health/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/health/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/health/route.ts",
+        "export_name": "dynamic",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/manifest/health/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/health/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/health/route.ts",
+        "export_name": "revalidate",
+        "line": 6,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `revalidate` from `src/app/api/manifest/health/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/health/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/health/route.ts",
+        "export_name": "runtime",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/manifest/health/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/health/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/route.ts",
+        "export_name": "dynamic",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/manifest/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/route.ts",
+        "export_name": "revalidate",
+        "line": 6,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `revalidate` from `src/app/api/manifest/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/route.ts",
+        "export_name": "runtime",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/manifest/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/rule/[sha]/route.ts",
+        "export_name": "GET",
+        "line": 13,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/manifest/rule/[sha]/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/rule/[sha]/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/rule/[sha]/route.ts",
+        "export_name": "dynamic",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/manifest/rule/[sha]/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/rule/[sha]/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/rule/[sha]/route.ts",
+        "export_name": "revalidate",
+        "line": 6,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `revalidate` from `src/app/api/manifest/rule/[sha]/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/rule/[sha]/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/manifest/rule/[sha]/route.ts",
+        "export_name": "runtime",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/manifest/rule/[sha]/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/manifest/rule/[sha]/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/rich/route.ts",
+        "export_name": "GET",
+        "line": 12,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/methods/[code]/v/[ver]/rich/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/rich/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/rich/route.ts",
+        "export_name": "dynamic",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/methods/[code]/v/[ver]/rich/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/rich/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/rich/route.ts",
+        "export_name": "revalidate",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `revalidate` from `src/app/api/methods/[code]/v/[ver]/rich/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/rich/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/rules/route.ts",
+        "export_name": "GET",
+        "line": 12,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/methods/[code]/v/[ver]/rules/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/rules/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/rules/route.ts",
+        "export_name": "dynamic",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/methods/[code]/v/[ver]/rules/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/rules/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/rules/route.ts",
+        "export_name": "revalidate",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `revalidate` from `src/app/api/methods/[code]/v/[ver]/rules/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/rules/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/sections/route.ts",
+        "export_name": "GET",
+        "line": 12,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/methods/[code]/v/[ver]/sections/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/sections/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/sections/route.ts",
+        "export_name": "dynamic",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/methods/[code]/v/[ver]/sections/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/sections/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/sections/route.ts",
+        "export_name": "revalidate",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `revalidate` from `src/app/api/methods/[code]/v/[ver]/sections/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/sections/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/trace/route.ts",
+        "export_name": "GET",
+        "line": 12,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/methods/[code]/v/[ver]/trace/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/trace/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/trace/route.ts",
+        "export_name": "dynamic",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/methods/[code]/v/[ver]/trace/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/trace/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/[code]/v/[ver]/trace/route.ts",
+        "export_name": "revalidate",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `revalidate` from `src/app/api/methods/[code]/v/[ver]/trace/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/[code]/v/[ver]/trace/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/inventory/route.ts",
+        "export_name": "GET",
+        "line": 7,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/methods/inventory/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/inventory/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/inventory/route.ts",
+        "export_name": "dynamic",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/methods/inventory/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/inventory/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/methods/inventory/route.ts",
+        "export_name": "revalidate",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `revalidate` from `src/app/api/methods/inventory/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/methods/inventory/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/[id]/export-pdf/route.ts",
+        "export_name": "runtime",
+        "line": 6,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/projects/[id]/export-pdf/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/[id]/export-pdf/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/[id]/export-premium/route.ts",
+        "export_name": "runtime",
+        "line": 1,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/projects/[id]/export-premium/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/[id]/export-premium/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/extract-evidence/route.ts",
+        "export_name": "POST",
+        "line": 50,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `POST` from `src/app/api/projects/extract-evidence/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/extract-evidence/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/extract-evidence/route.ts",
+        "export_name": "runtime",
+        "line": 1,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/projects/extract-evidence/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/extract-evidence/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/method-rules/route.ts",
+        "export_name": "GET",
+        "line": 9,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/projects/method-rules/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/method-rules/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/method-rules/route.ts",
+        "export_name": "dynamic",
+        "line": 6,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/projects/method-rules/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/method-rules/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/method-rules/route.ts",
+        "export_name": "revalidate",
+        "line": 7,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `revalidate` from `src/app/api/projects/method-rules/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/method-rules/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/method-rules/route.ts",
+        "export_name": "runtime",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/projects/method-rules/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/method-rules/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/methods/route.ts",
+        "export_name": "GET",
+        "line": 9,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/projects/methods/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/methods/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/methods/route.ts",
+        "export_name": "dynamic",
+        "line": 6,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `dynamic` from `src/app/api/projects/methods/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/methods/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/methods/route.ts",
+        "export_name": "revalidate",
+        "line": 7,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `revalidate` from `src/app/api/projects/methods/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/methods/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/methods/route.ts",
+        "export_name": "runtime",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/projects/methods/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/methods/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/reconcile-evidence/route.ts",
+        "export_name": "POST",
+        "line": 44,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `POST` from `src/app/api/projects/reconcile-evidence/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/reconcile-evidence/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/reconcile-evidence/route.ts",
+        "export_name": "runtime",
+        "line": 1,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/projects/reconcile-evidence/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/reconcile-evidence/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/record-decision/route.ts",
+        "export_name": "POST",
+        "line": 65,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `POST` from `src/app/api/projects/record-decision/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/record-decision/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/projects/record-decision/route.ts",
+        "export_name": "runtime",
+        "line": 1,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/projects/record-decision/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/projects/record-decision/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/query/route.ts",
+        "export_name": "runtime",
+        "line": 1,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/query/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/query/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/quick-check/pdf-extract/route.ts",
+        "export_name": "GET",
+        "line": 125,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/quick-check/pdf-extract/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/quick-check/pdf-extract/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/quick-check/pdf-extract/route.ts",
+        "export_name": "runtime",
+        "line": 1,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/quick-check/pdf-extract/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/quick-check/pdf-extract/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/quick-check/semantic-evidence/route.ts",
+        "export_name": "GET",
+        "line": 41,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/api/quick-check/semantic-evidence/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/quick-check/semantic-evidence/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/quick-check/semantic-evidence/route.ts",
+        "export_name": "POST",
+        "line": 40,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `POST` from `src/app/api/quick-check/semantic-evidence/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/quick-check/semantic-evidence/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/quick-check/semantic-evidence/route.ts",
+        "export_name": "runtime",
+        "line": 1,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/quick-check/semantic-evidence/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/quick-check/semantic-evidence/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/api/stac/search/route.ts",
+        "export_name": "runtime",
+        "line": 1,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/api/stac/search/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/api/stac/search/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/audit/page.tsx",
+        "export_name": "default",
+        "line": 12,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/audit/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/audit/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/audit/page.tsx",
+        "export_name": "metadata",
+        "line": 7,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `metadata` from `src/app/audit/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/audit/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/dashboard/page.tsx",
+        "export_name": "default",
+        "line": 4,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/dashboard/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/dashboard/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/layout.tsx",
+        "export_name": "default",
+        "line": 16,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/layout.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/layout.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/layout.tsx",
+        "export_name": "metadata",
+        "line": 8,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `metadata` from `src/app/layout.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/layout.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/page.tsx",
+        "export_name": "default",
+        "line": 14,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/[code]/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/page.tsx",
+        "export_name": "metadata",
+        "line": 9,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `metadata` from `src/app/m/[code]/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/v/[ver]/evidence/EvidenceCanonicalizer.tsx",
+        "export_name": "default",
+        "line": 12,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/[code]/v/[ver]/evidence/EvidenceCanonicalizer.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/v/[ver]/evidence/EvidenceCanonicalizer.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/v/[ver]/evidence/page.tsx",
+        "export_name": "default",
+        "line": 14,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/[code]/v/[ver]/evidence/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/v/[ver]/evidence/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/v/[ver]/evidence/page.tsx",
+        "export_name": "metadata",
+        "line": 9,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `metadata` from `src/app/m/[code]/v/[ver]/evidence/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/v/[ver]/evidence/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/v/[ver]/page.tsx",
+        "export_name": "default",
+        "line": 14,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/[code]/v/[ver]/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/v/[ver]/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/[code]/v/[ver]/page.tsx",
+        "export_name": "metadata",
+        "line": 9,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `metadata` from `src/app/m/[code]/v/[ver]/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/[code]/v/[ver]/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/EvidenceView.tsx",
+        "export_name": "default",
+        "line": 36,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/_components/EvidenceView.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/EvidenceView.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/IntegrityDiffPanel.tsx",
+        "export_name": "IntegrityDiffPanel",
+        "line": 30,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `IntegrityDiffPanel` from `src/app/m/_components/IntegrityDiffPanel.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/IntegrityDiffPanel.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/MethodDetailPane.tsx",
+        "export_name": "default",
+        "line": 129,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/_components/MethodDetailPane.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/MethodDetailPane.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/MethodsFinder.tsx",
+        "export_name": "default",
+        "line": 42,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/_components/MethodsFinder.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/MethodsFinder.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/MethodsFinderShell.tsx",
+        "export_name": "default",
+        "line": 18,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/_components/MethodsFinderShell.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/MethodsFinderShell.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/MethodsLayoutContext.tsx",
+        "export_name": "MethodsLayoutProvider",
+        "line": 13,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `MethodsLayoutProvider` from `src/app/m/_components/MethodsLayoutContext.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/MethodsLayoutContext.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/MethodsLayoutContext.tsx",
+        "export_name": "useMethodsLayout",
+        "line": 23,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `useMethodsLayout` from `src/app/m/_components/MethodsLayoutContext.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/MethodsLayoutContext.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/VerifyHeader.tsx",
+        "export_name": "default",
+        "line": 12,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/_components/VerifyHeader.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/VerifyHeader.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_components/VersionSelector.tsx",
+        "export_name": "default",
+        "line": 15,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/_components/VersionSelector.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_components/VersionSelector.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/_lib/methodVersionMetadata.ts",
+        "export_name": "loadMethodVersionLineage",
+        "line": 138,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `loadMethodVersionLineage` from `src/app/m/_lib/methodVersionMetadata.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/_lib/methodVersionMetadata.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/page.tsx",
+        "export_name": "default",
+        "line": 9,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/m/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/m/page.tsx",
+        "export_name": "metadata",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `metadata` from `src/app/m/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/m/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/manifest/page.tsx",
+        "export_name": "default",
+        "line": 11,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/manifest/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/manifest/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/manifest/page.tsx",
+        "export_name": "metadata",
+        "line": 6,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `metadata` from `src/app/manifest/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/manifest/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/page.tsx",
+        "export_name": "default",
+        "line": 5,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/pdf/[id]/route.ts",
+        "export_name": "GET",
+        "line": 10,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `GET` from `src/app/pdf/[id]/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/pdf/[id]/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/pdf/[id]/route.ts",
+        "export_name": "runtime",
+        "line": 6,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `runtime` from `src/app/pdf/[id]/route.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/pdf/[id]/route.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/projects/[id]/page.tsx",
+        "export_name": "default",
+        "line": 12,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/projects/[id]/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/projects/[id]/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/projects/[id]/page.tsx",
+        "export_name": "metadata",
+        "line": 8,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `metadata` from `src/app/projects/[id]/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/projects/[id]/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/projects/new/page.tsx",
+        "export_name": "default",
+        "line": 9,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/projects/new/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/projects/new/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/projects/new/page.tsx",
+        "export_name": "metadata",
+        "line": 5,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `metadata` from `src/app/projects/new/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/projects/new/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/projects/page.tsx",
+        "export_name": "default",
+        "line": 9,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/app/projects/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/projects/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/app/projects/page.tsx",
+        "export_name": "metadata",
+        "line": 4,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `metadata` from `src/app/projects/page.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/app/projects/page.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/FooterHealth.tsx",
+        "export_name": "default",
+        "line": 21,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/components/FooterHealth.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/FooterHealth.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/HealthBadge.tsx",
+        "export_name": "default",
+        "line": 20,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/components/HealthBadge.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/HealthBadge.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/audit/AuditApp.tsx",
+        "export_name": "default",
+        "line": 29,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/components/audit/AuditApp.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/audit/AuditApp.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/audit/Checklist.tsx",
+        "export_name": "default",
+        "line": 19,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/components/audit/Checklist.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/audit/Checklist.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/intake/IntakeDashboard.tsx",
+        "export_name": "default",
+        "line": 41,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/components/intake/IntakeDashboard.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/intake/IntakeDashboard.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/manifest/MethodsInventoryApp.tsx",
+        "export_name": "default",
+        "line": 86,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/components/manifest/MethodsInventoryApp.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/manifest/MethodsInventoryApp.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/map/ProofMapTab.tsx",
+        "export_name": "default",
+        "line": 426,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/components/map/ProofMapTab.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/map/ProofMapTab.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/components/verify/ReviewProgressIndicator.tsx",
+        "export_name": "default",
+        "line": 9,
+        "col": 0,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `default` from `src/components/verify/ReviewProgressIndicator.tsx`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/components/verify/ReviewProgressIndicator.tsx`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/hooks/useHealth.ts",
+        "export_name": "useHealth",
+        "line": 7,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `useHealth` from `src/hooks/useHealth.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/hooks/useHealth.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/audit/checklist.ts",
+        "export_name": "CHECKLIST_ITEMS",
+        "line": 8,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `CHECKLIST_ITEMS` from `src/lib/audit/checklist.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/audit/checklist.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/audit/sample.ts",
+        "export_name": "EXTRACTED_VARIABLES",
+        "line": 60,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `EXTRACTED_VARIABLES` from `src/lib/audit/sample.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/audit/sample.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/audit/sample.ts",
+        "export_name": "SAMPLE_RULES",
+        "line": 24,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `SAMPLE_RULES` from `src/lib/audit/sample.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/audit/sample.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/auditTrail/store.ts",
+        "export_name": "useAuditTrail",
+        "line": 36,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `useAuditTrail` from `src/lib/auditTrail/store.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/auditTrail/store.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/flags.ts",
+        "export_name": "ALWAYS_SHOW_HEALTH",
+        "line": 2,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `ALWAYS_SHOW_HEALTH` from `src/lib/flags.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/flags.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/flags.ts",
+        "export_name": "AUDIT_FEATURE_ENABLED",
+        "line": 1,
+        "col": 13,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `AUDIT_FEATURE_ENABLED` from `src/lib/flags.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/flags.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/intake/storage.ts",
+        "export_name": "loadIntakeRegistry",
+        "line": 28,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `loadIntakeRegistry` from `src/lib/intake/storage.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/intake/storage.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/intake/storage.ts",
+        "export_name": "loadPilotCadence",
+        "line": 72,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `loadPilotCadence` from `src/lib/intake/storage.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/intake/storage.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/intake/storage.ts",
+        "export_name": "savePilotCadence",
+        "line": 89,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `savePilotCadence` from `src/lib/intake/storage.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/intake/storage.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/intake/storage.ts",
+        "export_name": "updateIntakeItem",
+        "line": 65,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `updateIntakeItem` from `src/lib/intake/storage.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/intake/storage.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/manifestDiff.ts",
+        "export_name": "diffIndexes",
+        "line": 22,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `diffIndexes` from `src/lib/manifestDiff.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/manifestDiff.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/manifestDiff.ts",
+        "export_name": "indexManifest",
+        "line": 3,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `indexManifest` from `src/lib/manifestDiff.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/manifestDiff.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/mode.ts",
+        "export_name": "getVerifyView",
+        "line": 7,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `getVerifyView` from `src/lib/mode.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/mode.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/mode.ts",
+        "export_name": "isVerifierMode",
+        "line": 3,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `isVerifierMode` from `src/lib/mode.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/mode.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/nav/canonicalEvidence.ts",
+        "export_name": "canonicalEvidencePath",
+        "line": 7,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `canonicalEvidencePath` from `src/lib/nav/canonicalEvidence.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/nav/canonicalEvidence.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/pdf/metadata.ts",
+        "export_name": "getPdfRecord",
+        "line": 99,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `getPdfRecord` from `src/lib/pdf/metadata.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/pdf/metadata.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/quickCheck/semanticEvidence/huggingFace.ts",
+        "export_name": "suggestSemanticEvidence",
+        "line": 110,
+        "col": 22,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `suggestSemanticEvidence` from `src/lib/quickCheck/semanticEvidence/huggingFace.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/quickCheck/semanticEvidence/huggingFace.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/reviewWorkspaces/storage.ts",
+        "export_name": "getReviewWorkspace",
+        "line": 67,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `getReviewWorkspace` from `src/lib/reviewWorkspaces/storage.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/reviewWorkspaces/storage.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/reviewWorkspaces/storage.ts",
+        "export_name": "touchReviewWorkspace",
+        "line": 168,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `touchReviewWorkspace` from `src/lib/reviewWorkspaces/storage.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/reviewWorkspaces/storage.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/rich/normalize.ts",
+        "export_name": "normalizeRichEvidence",
+        "line": 276,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `normalizeRichEvidence` from `src/lib/rich/normalize.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/rich/normalize.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      },
+      {
+        "path": "src/lib/ruleJump.ts",
+        "export_name": "jumpToRule",
+        "line": 4,
+        "col": 16,
+        "actions": [
+          {
+            "type": "add-test-import",
+            "auto_fixable": false,
+            "description": "Import and test `jumpToRule` from `src/lib/ruleJump.ts`",
+            "note": "This export is runtime-reachable but no test-reachable module references it"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress coverage gap reporting for `src/lib/ruleJump.ts`",
+            "comment": "// fallow-ignore-file coverage-gaps"
+          }
+        ]
+      }
+    ]
+  },
+  "hotspots": [
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "score": 56.4,
+      "commits": 95,
+      "weighted_commits": 46.96,
+      "lines_added": 10557,
+      "lines_deleted": 4304,
+      "complexity_density": 0.31,
+      "fan_in": 2,
+      "trend": "cooling",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/components/map/ProofMapTab.tsx`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/components/map/ProofMapTab.tsx` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/app/m/_components/MethodDetailPane.tsx",
+      "score": 53.6,
+      "commits": 92,
+      "weighted_commits": 41.95,
+      "lines_added": 5189,
+      "lines_deleted": 3196,
+      "complexity_density": 0.33,
+      "fan_in": 2,
+      "trend": "cooling",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/app/m/_components/MethodDetailPane.tsx`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/app/m/_components/MethodDetailPane.tsx` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "score": 37.3,
+      "commits": 36,
+      "weighted_commits": 32.12,
+      "lines_added": 4197,
+      "lines_deleted": 1371,
+      "complexity_density": 0.3,
+      "fan_in": 5,
+      "trend": "accelerating",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/components/chat/QuickCheckPanel.tsx`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/components/chat/QuickCheckPanel.tsx` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckUi.ts",
+      "score": 16.4,
+      "commits": 14,
+      "weighted_commits": 11.46,
+      "lines_added": 779,
+      "lines_deleted": 133,
+      "complexity_density": 0.37,
+      "fan_in": 3,
+      "trend": "stable",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/lib/chat/quickCheckUi.ts`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/lib/chat/quickCheckUi.ts` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/runState.ts",
+      "score": 15.9,
+      "commits": 21,
+      "weighted_commits": 11.72,
+      "lines_added": 1258,
+      "lines_deleted": 71,
+      "complexity_density": 0.35,
+      "fan_in": 27,
+      "trend": "cooling",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/lib/verify/runState.ts`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/lib/verify/runState.ts` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/quickCheck/retrieval/retrieveSections.ts",
+      "score": 15.0,
+      "commits": 15,
+      "weighted_commits": 14.87,
+      "lines_added": 824,
+      "lines_deleted": 178,
+      "complexity_density": 0.26,
+      "fan_in": 1,
+      "trend": "cooling",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/lib/quickCheck/retrieval/retrieveSections.ts`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/lib/quickCheck/retrieval/retrieveSections.ts` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/app/m/_components/RuleDetailModal.tsx",
+      "score": 14.7,
+      "commits": 18,
+      "weighted_commits": 12.68,
+      "lines_added": 1204,
+      "lines_deleted": 396,
+      "complexity_density": 0.3,
+      "fan_in": 2,
+      "trend": "cooling",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/app/m/_components/RuleDetailModal.tsx`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/app/m/_components/RuleDetailModal.tsx` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/inventory.ts",
+      "score": 11.7,
+      "commits": 9,
+      "weighted_commits": 6.02,
+      "lines_added": 592,
+      "lines_deleted": 60,
+      "complexity_density": 0.5,
+      "fan_in": 25,
+      "trend": "cooling",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/lib/evidence/inventory.ts`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/lib/evidence/inventory.ts` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "tests/lib/quickCheckReviewQuestion.test.ts",
+      "score": 11.5,
+      "commits": 25,
+      "weighted_commits": 24.7,
+      "lines_added": 1802,
+      "lines_deleted": 265,
+      "complexity_density": 0.12,
+      "fan_in": 0,
+      "trend": "accelerating",
+      "is_test_path": true,
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `tests/lib/quickCheckReviewQuestion.test.ts`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `tests/lib/quickCheckReviewQuestion.test.ts` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheckEvidence.ts",
+      "score": 10.5,
+      "commits": 9,
+      "weighted_commits": 7.96,
+      "lines_added": 1299,
+      "lines_deleted": 17,
+      "complexity_density": 0.34,
+      "fan_in": 6,
+      "trend": "accelerating",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/lib/chat/quickCheckEvidence.ts`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/lib/chat/quickCheckEvidence.ts` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/components/projects/ProjectDetail.tsx",
+      "score": 10.3,
+      "commits": 15,
+      "weighted_commits": 12.61,
+      "lines_added": 1493,
+      "lines_deleted": 227,
+      "complexity_density": 0.21,
+      "fan_in": 4,
+      "trend": "accelerating",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/components/projects/ProjectDetail.tsx`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/components/projects/ProjectDetail.tsx` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/app/m/_components/RequirementCoverageWorkspace.tsx",
+      "score": 9.7,
+      "commits": 15,
+      "weighted_commits": 10.44,
+      "lines_added": 843,
+      "lines_deleted": 110,
+      "complexity_density": 0.24,
+      "fan_in": 2,
+      "trend": "cooling",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/app/m/_components/RequirementCoverageWorkspace.tsx`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/app/m/_components/RequirementCoverageWorkspace.tsx` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/exports/verificationPackContract.ts",
+      "score": 9.6,
+      "commits": 10,
+      "weighted_commits": 8.26,
+      "lines_added": 1981,
+      "lines_deleted": 221,
+      "complexity_density": 0.3,
+      "fan_in": 6,
+      "trend": "cooling",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/exports/verificationPackContract.ts`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/exports/verificationPackContract.ts` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "scripts/roadmap/roadmap-lib.mjs",
+      "score": 9.3,
+      "commits": 12,
+      "weighted_commits": 5.2,
+      "lines_added": 398,
+      "lines_deleted": 31,
+      "complexity_density": 0.46,
+      "fan_in": 12,
+      "trend": "cooling",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `scripts/roadmap/roadmap-lib.mjs`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `scripts/roadmap/roadmap-lib.mjs` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/components/map/MapCanvas.tsx",
+      "score": 8.7,
+      "commits": 13,
+      "weighted_commits": 5.47,
+      "lines_added": 1175,
+      "lines_deleted": 268,
+      "complexity_density": 0.41,
+      "fan_in": 1,
+      "trend": "cooling",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/components/map/MapCanvas.tsx`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/components/map/MapCanvas.tsx` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/projects/verificationReport.ts",
+      "score": 8.7,
+      "commits": 10,
+      "weighted_commits": 8.31,
+      "lines_added": 733,
+      "lines_deleted": 166,
+      "complexity_density": 0.27,
+      "fan_in": 10,
+      "trend": "stable",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/lib/projects/verificationReport.ts`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/lib/projects/verificationReport.ts` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/evidenceSnapshot.ts",
+      "score": 8.4,
+      "commits": 17,
+      "weighted_commits": 8.68,
+      "lines_added": 541,
+      "lines_deleted": 37,
+      "complexity_density": 0.25,
+      "fan_in": 13,
+      "trend": "stable",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/lib/proofMap/evidenceSnapshot.ts`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/lib/proofMap/evidenceSnapshot.ts` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "tests/components/quickCheckPanel.test.tsx",
+      "score": 8.3,
+      "commits": 19,
+      "weighted_commits": 16.52,
+      "lines_added": 2637,
+      "lines_deleted": 234,
+      "complexity_density": 0.13,
+      "fan_in": 0,
+      "trend": "accelerating",
+      "is_test_path": true,
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `tests/components/quickCheckPanel.test.tsx`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `tests/components/quickCheckPanel.test.tsx` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/components/trust/TrustStrip.tsx",
+      "score": 7.8,
+      "commits": 14,
+      "weighted_commits": 7.45,
+      "lines_added": 1421,
+      "lines_deleted": 553,
+      "complexity_density": 0.27,
+      "fan_in": 1,
+      "trend": "stable",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/components/trust/TrustStrip.tsx`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/components/trust/TrustStrip.tsx` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/projects/storage.ts",
+      "score": 7.6,
+      "commits": 8,
+      "weighted_commits": 6.56,
+      "lines_added": 430,
+      "lines_deleted": 7,
+      "complexity_density": 0.3,
+      "fan_in": 9,
+      "trend": "accelerating",
+      "actions": [
+        {
+          "type": "refactor-file",
+          "auto_fixable": false,
+          "description": "Refactor `src/lib/projects/storage.ts`, high complexity combined with frequent changes makes this a maintenance risk",
+          "note": "Prioritize extracting complex functions, adding tests, or splitting the module"
+        },
+        {
+          "type": "add-tests",
+          "auto_fixable": false,
+          "description": "Add test coverage for `src/lib/projects/storage.ts` to reduce change risk",
+          "note": "Frequently changed complex files benefit most from comprehensive test coverage"
+        }
+      ]
+    }
+  ],
+  "hotspot_summary": {
+    "since": "6 months",
+    "min_commits": 3,
+    "files_analyzed": 155,
+    "files_excluded": 250,
+    "shallow_clone": false
+  },
+  "large_functions": [
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "ProofMapTab",
+      "line": 426,
+      "line_count": 4932
+    },
+    {
+      "path": "tests/components/quickCheckPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 92,
+      "line_count": 2312
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "name": "QuickCheckPanel",
+      "line": 564,
+      "line_count": 2160
+    },
+    {
+      "path": "src/app/m/_components/MethodDetailPane.tsx",
+      "name": "MethodDetailPane",
+      "line": 129,
+      "line_count": 1861
+    },
+    {
+      "path": "src/components/projects/ProjectDetail.tsx",
+      "name": "ProjectDetail",
+      "line": 104,
+      "line_count": 959
+    },
+    {
+      "path": "tests/exports/auditPack.contract.test.ts",
+      "name": "<arrow>",
+      "line": 113,
+      "line_count": 949
+    },
+    {
+      "path": "src/components/verify/RuleReviewPanel.tsx",
+      "name": "RuleReviewPanel",
+      "line": 69,
+      "line_count": 808
+    },
+    {
+      "path": "tests/components/quickCheckPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 157,
+      "line_count": 698
+    },
+    {
+      "path": "src/components/map/MapCanvas.tsx",
+      "name": "MapCanvas",
+      "line": 221,
+      "line_count": 685
+    },
+    {
+      "path": "src/app/m/_components/RequirementCoverageWorkspace.tsx",
+      "name": "RequirementCoverageWorkspace",
+      "line": 79,
+      "line_count": 655
+    },
+    {
+      "path": "tests/lib/quickCheckEvidence.test.ts",
+      "name": "<arrow>",
+      "line": 19,
+      "line_count": 611
+    },
+    {
+      "path": "tests/components/quickCheckPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 184,
+      "line_count": 605
+    },
+    {
+      "path": "src/components/trust/TrustStrip.tsx",
+      "name": "TrustStrip",
+      "line": 286,
+      "line_count": 583
+    },
+    {
+      "path": "src/app/m/_components/RuleDetailModal.tsx",
+      "name": "RuleDetailModal",
+      "line": 251,
+      "line_count": 558
+    },
+    {
+      "path": "tests/lib/quickCheckUi.test.ts",
+      "name": "<arrow>",
+      "line": 11,
+      "line_count": 554
+    },
+    {
+      "path": "src/components/verify/EvidenceWorkflowStepper.tsx",
+      "name": "EvidenceWorkflowStepper",
+      "line": 375,
+      "line_count": 535
+    },
+    {
+      "path": "tests/api/project.export-pdf.route.test.ts",
+      "name": "<arrow>",
+      "line": 41,
+      "line_count": 465
+    },
+    {
+      "path": "tests/lib/quickCheckReviewQuestion.test.ts",
+      "name": "<arrow>",
+      "line": 587,
+      "line_count": 436
+    },
+    {
+      "path": "tests/components/finalReviewSummaryPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 12,
+      "line_count": 421
+    },
+    {
+      "path": "tests/components/evidenceWorkflowStepper.test.tsx",
+      "name": "<arrow>",
+      "line": 10,
+      "line_count": 415
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "<arrow>",
+      "line": 3698,
+      "line_count": 406
+    },
+    {
+      "path": "src/exports/verificationPackContract.ts",
+      "name": "buildVerificationPackContract",
+      "line": 1306,
+      "line_count": 404
+    },
+    {
+      "path": "src/components/intake/IntakeDashboard.tsx",
+      "name": "IntakeDashboard",
+      "line": 41,
+      "line_count": 392
+    },
+    {
+      "path": "tests/lib/proof.auditZip.test.ts",
+      "name": "<arrow>",
+      "line": 21,
+      "line_count": 387
+    },
+    {
+      "path": "src/components/readiness/ClientReadinessReportView.tsx",
+      "name": "ClientReadinessReportView",
+      "line": 102,
+      "line_count": 346
+    },
+    {
+      "path": "tests/components/ruleDetailModal.test.tsx",
+      "name": "<arrow>",
+      "line": 118,
+      "line_count": 341
+    },
+    {
+      "path": "src/components/assistant/AssistantPanel.tsx",
+      "name": "AssistantPanel",
+      "line": 55,
+      "line_count": 339
+    },
+    {
+      "path": "src/exports/verificationPackContract.ts",
+      "name": "renderVerificationReportHtml",
+      "line": 918,
+      "line_count": 318
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "name": "runQuickCheck",
+      "line": 1432,
+      "line_count": 315
+    },
+    {
+      "path": "src/components/projects/NewProjectForm.tsx",
+      "name": "NewProjectForm",
+      "line": 33,
+      "line_count": 298
+    },
+    {
+      "path": "tests/lib/projects/verificationReport.test.ts",
+      "name": "<arrow>",
+      "line": 100,
+      "line_count": 293
+    },
+    {
+      "path": "tests/exports/auditPack.contract.test.ts",
+      "name": "<arrow>",
+      "line": 151,
+      "line_count": 287
+    },
+    {
+      "path": "src/lib/projects/exportPdf.ts",
+      "name": "buildProjectExportPdf",
+      "line": 198,
+      "line_count": 285
+    },
+    {
+      "path": "tests/lib/evidenceInventory.test.ts",
+      "name": "<arrow>",
+      "line": 93,
+      "line_count": 281
+    },
+    {
+      "path": "tests/lib/projects/manualFindingExtraction.test.ts",
+      "name": "<arrow>",
+      "line": 41,
+      "line_count": 271
+    },
+    {
+      "path": "src/components/manifest/ManifestApp.tsx",
+      "name": "ManifestApp",
+      "line": 17,
+      "line_count": 270
+    },
+    {
+      "path": "tests/lib/evidence/metrics/compute.test.ts",
+      "name": "<arrow>",
+      "line": 31,
+      "line_count": 260
+    },
+    {
+      "path": "src/components/snapshot/SnapshotTimeline.tsx",
+      "name": "SnapshotTimeline",
+      "line": 23,
+      "line_count": 251
+    },
+    {
+      "path": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+      "name": "<arrow>",
+      "line": 48,
+      "line_count": 243
+    },
+    {
+      "path": "tests/components/quickCheckPanel.review-question-fallback.test.tsx",
+      "name": "<arrow>",
+      "line": 44,
+      "line_count": 241
+    },
+    {
+      "path": "tests/lib/quickCheckPdfExtractor.test.ts",
+      "name": "<arrow>",
+      "line": 6,
+      "line_count": 230
+    },
+    {
+      "path": "tests/api/projects.manual-review.extract-findings.route.test.ts",
+      "name": "<arrow>",
+      "line": 21,
+      "line_count": 222
+    },
+    {
+      "path": "tests/lib/stacSupportFacts.test.ts",
+      "name": "<arrow>",
+      "line": 3,
+      "line_count": 221
+    },
+    {
+      "path": "src/app/m/_lib/requirementCoverage.test.ts",
+      "name": "<arrow>",
+      "line": 12,
+      "line_count": 219
+    },
+    {
+      "path": "tests/lib/readiness/gapEngine.test.ts",
+      "name": "<arrow>",
+      "line": 26,
+      "line_count": 217
+    },
+    {
+      "path": "src/components/verify/OutcomeWidget.tsx",
+      "name": "OutcomeWidget",
+      "line": 46,
+      "line_count": 210
+    },
+    {
+      "path": "src/lib/chat/quickCheckEvidence.ts",
+      "name": "derivePdfFactsFromText",
+      "line": 715,
+      "line_count": 209
+    },
+    {
+      "path": "src/components/verify/FinalReviewSummaryPanel.tsx",
+      "name": "FinalReviewSummaryPanel",
+      "line": 82,
+      "line_count": 206
+    },
+    {
+      "path": "tests/components/requirementCoverageWorkspace.test.tsx",
+      "name": "<arrow>",
+      "line": 140,
+      "line_count": 206
+    },
+    {
+      "path": "tests/lib/proofMap.verificationRuns.test.ts",
+      "name": "<arrow>",
+      "line": 6,
+      "line_count": 203
+    },
+    {
+      "path": "tests/lib/readiness/vvbWorkpaperExport.test.ts",
+      "name": "<arrow>",
+      "line": 108,
+      "line_count": 202
+    },
+    {
+      "path": "tests/lib/buildReviewSummary.test.ts",
+      "name": "<arrow>",
+      "line": 9,
+      "line_count": 196
+    },
+    {
+      "path": "src/components/manifest/MethodsInventoryApp.tsx",
+      "name": "MethodsInventoryApp",
+      "line": 86,
+      "line_count": 193
+    },
+    {
+      "path": "src/components/verify/ReviewSummaryCard.tsx",
+      "name": "ReviewSummaryCard",
+      "line": 56,
+      "line_count": 192
+    },
+    {
+      "path": "tests/lib/quickCheckReviewQuestion.test.ts",
+      "name": "<arrow>",
+      "line": 1115,
+      "line_count": 189
+    },
+    {
+      "path": "src/lib/documentModel/buildArticle6DocumentModel.ts",
+      "name": "buildArticle6DocumentModel",
+      "line": 60,
+      "line_count": 185
+    },
+    {
+      "path": "src/lib/readiness/clientReadinessExport.tsx",
+      "name": "reportHtmlDocument",
+      "line": 169,
+      "line_count": 185
+    },
+    {
+      "path": "tests/app/api/exports/audit-pack.route.test.ts",
+      "name": "<arrow>",
+      "line": 115,
+      "line_count": 177
+    },
+    {
+      "path": "tests/lib/readiness/clientReadinessReport.test.ts",
+      "name": "<arrow>",
+      "line": 27,
+      "line_count": 168
+    },
+    {
+      "path": "src/lib/evidence/export/verificationPackIntegration.ts",
+      "name": "renderEvidenceIntelligenceHtmlSections",
+      "line": 216,
+      "line_count": 167
+    },
+    {
+      "path": "src/lib/readiness/vvbWorkpaperReport.ts",
+      "name": "buildVvbWorkpaperReport",
+      "line": 325,
+      "line_count": 167
+    },
+    {
+      "path": "src/app/m/_components/MethodLibraryPanel.tsx",
+      "name": "MethodLibraryPanel",
+      "line": 30,
+      "line_count": 166
+    },
+    {
+      "path": "tests/lib/verify.runState.test.ts",
+      "name": "<arrow>",
+      "line": 314,
+      "line_count": 166
+    },
+    {
+      "path": "tests/lib/evidence/reconciliation/reconciler.test.ts",
+      "name": "<arrow>",
+      "line": 57,
+      "line_count": 163
+    },
+    {
+      "path": "src/lib/readiness/vvbWorkpaperExport.tsx",
+      "name": "reportHtmlDocument",
+      "line": 196,
+      "line_count": 162
+    },
+    {
+      "path": "src/components/RuleCard.tsx",
+      "name": "RuleCard",
+      "line": 107,
+      "line_count": 158
+    },
+    {
+      "path": "tests/components/requirementCoverageWorkspace.test.tsx",
+      "name": "<arrow>",
+      "line": 187,
+      "line_count": 158
+    },
+    {
+      "path": "src/components/verify/EvidenceWorkflowStepper.tsx",
+      "name": "CompletedWorkflowDetail",
+      "line": 218,
+      "line_count": 156
+    },
+    {
+      "path": "tests/components/trustStrip.test.tsx",
+      "name": "<arrow>",
+      "line": 24,
+      "line_count": 155
+    },
+    {
+      "path": "src/components/projects/ProjectsList.tsx",
+      "name": "ProjectsList",
+      "line": 10,
+      "line_count": 153
+    },
+    {
+      "path": "src/components/ManifestHealthBadge.tsx",
+      "name": "ManifestHealthBadge",
+      "line": 43,
+      "line_count": 151
+    },
+    {
+      "path": "tests/api/stac.search.route.test.ts",
+      "name": "<arrow>",
+      "line": 23,
+      "line_count": 151
+    },
+    {
+      "path": "tests/components/ruleReviewPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 46,
+      "line_count": 151
+    },
+    {
+      "path": "tests/components/finalReviewSummaryPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 284,
+      "line_count": 148
+    },
+    {
+      "path": "tests/lib/evidence/metrics/compute.test.ts",
+      "name": "<arrow>",
+      "line": 32,
+      "line_count": 148
+    },
+    {
+      "path": "src/app/m/_components/RequirementCoverageWorkspace.tsx",
+      "name": "<arrow>",
+      "line": 552,
+      "line_count": 147
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "buildFinalReviewArtifact",
+      "line": 2401,
+      "line_count": 146
+    },
+    {
+      "path": "src/components/projects/ProjectDetail.tsx",
+      "name": "<arrow>",
+      "line": 650,
+      "line_count": 145
+    },
+    {
+      "path": "src/lib/chat/quickCheckMethodology.ts",
+      "name": "resolveQuickCheckMethodology",
+      "line": 371,
+      "line_count": 144
+    },
+    {
+      "path": "tests/lib/evidence/extraction/pipeline.test.ts",
+      "name": "<arrow>",
+      "line": 26,
+      "line_count": 144
+    },
+    {
+      "path": "src/components/map/MapCanvas.tsx",
+      "name": "<arrow>",
+      "line": 390,
+      "line_count": 143
+    },
+    {
+      "path": "tests/exports/auditPack.contract.test.ts",
+      "name": "<arrow>",
+      "line": 543,
+      "line_count": 143
+    },
+    {
+      "path": "tests/lib/quickCheckBaselineRubric.test.ts",
+      "name": "<arrow>",
+      "line": 32,
+      "line_count": 142
+    },
+    {
+      "path": "scripts/roadmap/roadmap-lib.mjs",
+      "name": "generateRoadmapContent",
+      "line": 188,
+      "line_count": 140
+    },
+    {
+      "path": "src/components/projects/ProjectDetail.tsx",
+      "name": "<arrow>",
+      "line": 909,
+      "line_count": 140
+    },
+    {
+      "path": "tests/lib/evidence/decisions/engine.test.ts",
+      "name": "<arrow>",
+      "line": 20,
+      "line_count": 139
+    },
+    {
+      "path": "tests/lib/quickCheckReviewQuestion.test.ts",
+      "name": "<arrow>",
+      "line": 346,
+      "line_count": 136
+    },
+    {
+      "path": "src/lib/export/assertVerificationSnapshotInvariants.test.ts",
+      "name": "<arrow>",
+      "line": 24,
+      "line_count": 135
+    },
+    {
+      "path": "src/lib/composers/composeVerraVerificationReport.ts",
+      "name": "composeVerraVerificationReport",
+      "line": 90,
+      "line_count": 134
+    },
+    {
+      "path": "src/components/projects/ProjectDetail.tsx",
+      "name": "MethodologyLinkedReview",
+      "line": 1064,
+      "line_count": 133
+    },
+    {
+      "path": "tests/lib/reviewSuggestion.test.ts",
+      "name": "<arrow>",
+      "line": 28,
+      "line_count": 133
+    },
+    {
+      "path": "tests/lib/stacSupportFacts.test.ts",
+      "name": "<arrow>",
+      "line": 90,
+      "line_count": 133
+    },
+    {
+      "path": "src/lib/proofMap/evidenceSnapshot.ts",
+      "name": "buildEvidenceSnapshot",
+      "line": 350,
+      "line_count": 132
+    },
+    {
+      "path": "tests/components/projectDetailManualExtraction.test.tsx",
+      "name": "<arrow>",
+      "line": 32,
+      "line_count": 132
+    },
+    {
+      "path": "tests/lib/evidence/export/premiumExport.test.ts",
+      "name": "<arrow>",
+      "line": 199,
+      "line_count": 131
+    },
+    {
+      "path": "tests/lib/proof.bundle.test.ts",
+      "name": "<arrow>",
+      "line": 4,
+      "line_count": 131
+    },
+    {
+      "path": "tests/lib/reviewStore.test.ts",
+      "name": "<arrow>",
+      "line": 42,
+      "line_count": 130
+    },
+    {
+      "path": "src/components/chat/SidePane.tsx",
+      "name": "SidePane",
+      "line": 110,
+      "line_count": 129
+    },
+    {
+      "path": "tests/api/quick-check.pdf-extract.route.test.ts",
+      "name": "<arrow>",
+      "line": 8,
+      "line_count": 129
+    },
+    {
+      "path": "src/components/verify/DeltaImpactTasksPanel.tsx",
+      "name": "DeltaImpactTasksPanel",
+      "line": 30,
+      "line_count": 128
+    },
+    {
+      "path": "src/lib/projects/learningCase.ts",
+      "name": "buildManualReviewLearningCase",
+      "line": 87,
+      "line_count": 128
+    },
+    {
+      "path": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+      "name": "<arrow>",
+      "line": 83,
+      "line_count": 128
+    },
+    {
+      "path": "tests/components/reviewSummaryCard.test.tsx",
+      "name": "<arrow>",
+      "line": 5,
+      "line_count": 128
+    },
+    {
+      "path": "src/lib/composers/composeGoldStandardVerificationReport.ts",
+      "name": "composeGoldStandardVerificationReport",
+      "line": 86,
+      "line_count": 127
+    },
+    {
+      "path": "src/app/api/stac/search/route.ts",
+      "name": "POST",
+      "line": 106,
+      "line_count": 125
+    },
+    {
+      "path": "src/components/verify/StacSupportSection.tsx",
+      "name": "StacSupportSection",
+      "line": 37,
+      "line_count": 125
+    },
+    {
+      "path": "tests/lib/projects/learningCase.test.ts",
+      "name": "<arrow>",
+      "line": 98,
+      "line_count": 125
+    },
+    {
+      "path": "tests/lib/quickCheckBaselineRubric.test.ts",
+      "name": "<arrow>",
+      "line": 269,
+      "line_count": 125
+    },
+    {
+      "path": "tests/lib/evidence/export/verificationPackIntegration.test.ts",
+      "name": "<arrow>",
+      "line": 194,
+      "line_count": 124
+    },
+    {
+      "path": "tests/lib/documentSupport.test.ts",
+      "name": "<arrow>",
+      "line": 87,
+      "line_count": 121
+    },
+    {
+      "path": "src/exports/auditPack.ts",
+      "name": "buildAuditPackZip",
+      "line": 82,
+      "line_count": 120
+    },
+    {
+      "path": "tests/lib/verify.runState.test.ts",
+      "name": "<arrow>",
+      "line": 491,
+      "line_count": 120
+    },
+    {
+      "path": "src/lib/evidence/export/zipExporter.ts",
+      "name": "buildExportJson",
+      "line": 28,
+      "line_count": 119
+    },
+    {
+      "path": "src/lib/readiness/clientReadinessReport.ts",
+      "name": "buildClientReadinessReport",
+      "line": 291,
+      "line_count": 119
+    },
+    {
+      "path": "tests/lib/quickCheckMethodSignals.test.ts",
+      "name": "<arrow>",
+      "line": 408,
+      "line_count": 119
+    },
+    {
+      "path": "scripts/gate-link-resolver.mjs",
+      "name": "main",
+      "line": 97,
+      "line_count": 118
+    },
+    {
+      "path": "tests/api/query.route.test.ts",
+      "name": "<arrow>",
+      "line": 29,
+      "line_count": 118
+    },
+    {
+      "path": "tests/demo/demo-stability.test.ts",
+      "name": "<arrow>",
+      "line": 19,
+      "line_count": 118
+    },
+    {
+      "path": "src/lib/evidence/export/verificationPackDerivation.ts",
+      "name": "buildReconciliationRun",
+      "line": 512,
+      "line_count": 117
+    },
+    {
+      "path": "src/lib/proof/auditZip.ts",
+      "name": "buildAuditZipBytes",
+      "line": 282,
+      "line_count": 117
+    },
+    {
+      "path": "scripts/roadmap/rgei-readiness-report.mjs",
+      "name": "generateReport",
+      "line": 197,
+      "line_count": 116
+    },
+    {
+      "path": "src/lib/proof/auditZip.ts",
+      "name": "readAuditZipBytes",
+      "line": 504,
+      "line_count": 116
+    },
+    {
+      "path": "tests/lib/snapshot.test.ts",
+      "name": "makeProject",
+      "line": 12,
+      "line_count": 116
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "verifyReadinessChips",
+      "line": 2119,
+      "line_count": 115
+    },
+    {
+      "path": "src/components/projects/ProjectsList.tsx",
+      "name": "<arrow>",
+      "line": 43,
+      "line_count": 115
+    },
+    {
+      "path": "src/lib/projects/verificationReport.ts",
+      "name": "composeUnfcccVerificationReport",
+      "line": 214,
+      "line_count": 115
+    },
+    {
+      "path": "tests/lib/evidence/export/premiumExport.test.ts",
+      "name": "<arrow>",
+      "line": 331,
+      "line_count": 115
+    },
+    {
+      "path": "tests/lib/projects.reviewHandoff.test.ts",
+      "name": "<arrow>",
+      "line": 24,
+      "line_count": 115
+    },
+    {
+      "path": "src/app/m/_components/MethodsFinder.tsx",
+      "name": "MethodsFinder",
+      "line": 42,
+      "line_count": 114
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "handleSearchStac",
+      "line": 1206,
+      "line_count": 114
+    },
+    {
+      "path": "src/lib/export/assertVerificationSnapshotInvariants.ts",
+      "name": "assertVerificationSnapshotInvariants",
+      "line": 111,
+      "line_count": 114
+    },
+    {
+      "path": "src/lib/projects/verificationReport.ts",
+      "name": "composeManualVerificationReport",
+      "line": 436,
+      "line_count": 114
+    },
+    {
+      "path": "tests/components/projects/NewProjectForm.handoff.test.tsx",
+      "name": "<arrow>",
+      "line": 22,
+      "line_count": 113
+    },
+    {
+      "path": "src/app/manifest/_state/useManifestFilters.ts",
+      "name": "useManifestFilters",
+      "line": 71,
+      "line_count": 112
+    },
+    {
+      "path": "tests/components/trustStrip.test.tsx",
+      "name": "<arrow>",
+      "line": 51,
+      "line_count": 112
+    },
+    {
+      "path": "scripts/compute-coverage.mjs",
+      "name": "main",
+      "line": 111,
+      "line_count": 111
+    },
+    {
+      "path": "src/app/m/_components/IntegrityDiffPanel.tsx",
+      "name": "IntegrityDiffPanel",
+      "line": 30,
+      "line_count": 111
+    },
+    {
+      "path": "src/app/m/_lib/requirementCoverage.test.ts",
+      "name": "<arrow>",
+      "line": 13,
+      "line_count": 111
+    },
+    {
+      "path": "src/lib/verify/stacSupportFacts.ts",
+      "name": "buildStacSupportFactsState",
+      "line": 316,
+      "line_count": 110
+    },
+    {
+      "path": "tests/lib/composers/composeVerraVerificationReport.test.ts",
+      "name": "<arrow>",
+      "line": 44,
+      "line_count": 110
+    },
+    {
+      "path": "tests/lib/snapshot.test.ts",
+      "name": "<arrow>",
+      "line": 287,
+      "line_count": 110
+    },
+    {
+      "path": "tests/lib/documentModel.test.ts",
+      "name": "<arrow>",
+      "line": 18,
+      "line_count": 108
+    },
+    {
+      "path": "tests/lib/documentParsing.test.ts",
+      "name": "<arrow>",
+      "line": 29,
+      "line_count": 108
+    },
+    {
+      "path": "tests/lib/projects.reviewHandoff.test.ts",
+      "name": "<arrow>",
+      "line": 30,
+      "line_count": 108
+    },
+    {
+      "path": "src/app/api/quick-check/pdf-extract/route.ts",
+      "name": "handlePost",
+      "line": 9,
+      "line_count": 106
+    },
+    {
+      "path": "src/app/m/_components/MethodDetailPane.tsx",
+      "name": "ensureRulesLoaded",
+      "line": 887,
+      "line_count": 106
+    },
+    {
+      "path": "src/app/m/_lib/methodInventory.ts",
+      "name": "getMethodInventory",
+      "line": 96,
+      "line_count": 106
+    },
+    {
+      "path": "tests/components/requirementCoverageWorkspace.test.tsx",
+      "name": "Harness",
+      "line": 198,
+      "line_count": 106
+    },
+    {
+      "path": "tests/lib/quickCheckMethodSignals.test.ts",
+      "name": "<arrow>",
+      "line": 26,
+      "line_count": 106
+    },
+    {
+      "path": "tests/lib/quickCheckPdfClient.test.ts",
+      "name": "<arrow>",
+      "line": 9,
+      "line_count": 106
+    },
+    {
+      "path": "src/components/MethodologiesPackProvenance.tsx",
+      "name": "MethodologiesPackProvenance",
+      "line": 53,
+      "line_count": 104
+    },
+    {
+      "path": "tests/components/proofMapTab.reviewArtifact.test.ts",
+      "name": "<arrow>",
+      "line": 79,
+      "line_count": 104
+    },
+    {
+      "path": "tests/components/stacSupportSection.test.tsx",
+      "name": "<arrow>",
+      "line": 5,
+      "line_count": 104
+    },
+    {
+      "path": "tests/diagnostics/quick-check-matching.diagnostic.test.ts",
+      "name": "printFullDiagnosticReport",
+      "line": 168,
+      "line_count": 103
+    },
+    {
+      "path": "tests/diagnostics/quick-check-matching.diagnostic.test.ts",
+      "name": "printPreciseFailureAnalysis",
+      "line": 450,
+      "line_count": 103
+    },
+    {
+      "path": "tests/exports/auditPack.contract.test.ts",
+      "name": "<arrow>",
+      "line": 439,
+      "line_count": 103
+    },
+    {
+      "path": "tests/e2e/verify-evidence-regression.pw.ts",
+      "name": "<arrow>",
+      "line": 169,
+      "line_count": 102
+    },
+    {
+      "path": "src/components/chat/SidePane.tsx",
+      "name": "<arrow>",
+      "line": 129,
+      "line_count": 101
+    },
+    {
+      "path": "src/components/manifest/VersionDiffModal.tsx",
+      "name": "VersionDiffModal",
+      "line": 106,
+      "line_count": 101
+    },
+    {
+      "path": "src/lib/chat/quickCheckEvidence.ts",
+      "name": "analyzeQuickCheckEvidence",
+      "line": 1023,
+      "line_count": 101
+    },
+    {
+      "path": "src/lib/readiness/reportHtmlTheme.ts",
+      "name": "renderReportHtmlDocument",
+      "line": 43,
+      "line_count": 101
+    },
+    {
+      "path": "tests/e2e/verify-evidence-regression.pw.ts",
+      "name": "<arrow>",
+      "line": 272,
+      "line_count": 101
+    },
+    {
+      "path": "src/lib/evidence/export/verificationPackDerivation.ts",
+      "name": "buildCandidateLinks",
+      "line": 287,
+      "line_count": 100
+    },
+    {
+      "path": "tests/lib/assistant.bundle.test.ts",
+      "name": "<arrow>",
+      "line": 5,
+      "line_count": 100
+    },
+    {
+      "path": "src/lib/chat/quickCheckUi.ts",
+      "name": "normalizeQuickCheckUiResult",
+      "line": 502,
+      "line_count": 99
+    },
+    {
+      "path": "tests/lib/quickCheckSectionExtractor.test.ts",
+      "name": "<arrow>",
+      "line": 726,
+      "line_count": 99
+    },
+    {
+      "path": "src/app/m/_components/MethodsFinderShell.tsx",
+      "name": "MethodsFinderShell",
+      "line": 18,
+      "line_count": 98
+    },
+    {
+      "path": "src/components/verifier/AuditTrailPanel.tsx",
+      "name": "AuditTrailPanel",
+      "line": 36,
+      "line_count": 98
+    },
+    {
+      "path": "src/lib/verify/buildReviewSummary.ts",
+      "name": "buildReviewSummary",
+      "line": 94,
+      "line_count": 98
+    },
+    {
+      "path": "tests/components/finalReviewSummaryPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 86,
+      "line_count": 98
+    },
+    {
+      "path": "tests/components/finalReviewSummaryPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 185,
+      "line_count": 98
+    },
+    {
+      "path": "tests/lib/quickCheckResolver.test.ts",
+      "name": "<arrow>",
+      "line": 6,
+      "line_count": 98
+    },
+    {
+      "path": "src/components/snapshot/SnapshotTimeline.tsx",
+      "name": "<arrow>",
+      "line": 167,
+      "line_count": 96
+    },
+    {
+      "path": "src/lib/assistant/generateAnswer.ts",
+      "name": "generateAnswer",
+      "line": 136,
+      "line_count": 96
+    },
+    {
+      "path": "tests/exports/auditPack.contract.test.ts",
+      "name": "<arrow>",
+      "line": 965,
+      "line_count": 96
+    },
+    {
+      "path": "tests/lib/quickCheckReviewPolicy.test.ts",
+      "name": "<arrow>",
+      "line": 15,
+      "line_count": 96
+    },
+    {
+      "path": "src/components/map/MapCanvas.tsx",
+      "name": "<arrow>",
+      "line": 676,
+      "line_count": 94
+    },
+    {
+      "path": "src/lib/chat/quickCheckMethodSignals.ts",
+      "name": "resolveMethodologySignals",
+      "line": 194,
+      "line_count": 94
+    },
+    {
+      "path": "src/lib/proof/auditZip.ts",
+      "name": "exportAuditZipFromStorage",
+      "line": 400,
+      "line_count": 94
+    },
+    {
+      "path": "tests/components/evidenceWorkflowStepper.test.tsx",
+      "name": "<arrow>",
+      "line": 239,
+      "line_count": 94
+    },
+    {
+      "path": "tests/exports/auditPack.contract.test.ts",
+      "name": "<arrow>",
+      "line": 687,
+      "line_count": 94
+    },
+    {
+      "path": "tests/lib/quickCheckSectionExtractor.test.ts",
+      "name": "<arrow>",
+      "line": 143,
+      "line_count": 94
+    },
+    {
+      "path": "tests/lib/snapshot.test.ts",
+      "name": "makePins",
+      "line": 129,
+      "line_count": 94
+    },
+    {
+      "path": "src/components/map/MapCanvas.tsx",
+      "name": "upsertStacEvidence",
+      "line": 128,
+      "line_count": 92
+    },
+    {
+      "path": "src/components/map/MapCanvas.tsx",
+      "name": "initMap",
+      "line": 404,
+      "line_count": 92
+    },
+    {
+      "path": "tests/lib/verify.runState.test.ts",
+      "name": "<arrow>",
+      "line": 63,
+      "line_count": 92
+    },
+    {
+      "path": "src/app/m/_components/MethodDetailPane.tsx",
+      "name": "loadRuleDetail",
+      "line": 1010,
+      "line_count": 91
+    },
+    {
+      "path": "src/components/audit/AuditApp.tsx",
+      "name": "AuditApp",
+      "line": 29,
+      "line_count": 91
+    },
+    {
+      "path": "src/components/audit/AuditApp.tsx",
+      "name": "ResultsPanel",
+      "line": 215,
+      "line_count": 91
+    },
+    {
+      "path": "src/components/verify/VerifierMinutesPanel.tsx",
+      "name": "VerifierMinutesPanel",
+      "line": 19,
+      "line_count": 91
+    },
+    {
+      "path": "src/lib/chat/quickCheckPdfClient.ts",
+      "name": "resolveQuickCheckPdfText",
+      "line": 11,
+      "line_count": 91
+    },
+    {
+      "path": "src/lib/evidence/export/verificationPackDerivation.ts",
+      "name": "buildDecisionRun",
+      "line": 420,
+      "line_count": 91
+    },
+    {
+      "path": "tests/lib/quickCheckEvidence.test.ts",
+      "name": "<arrow>",
+      "line": 631,
+      "line_count": 91
+    },
+    {
+      "path": "src/components/map/MapCanvas.tsx",
+      "name": "<arrow>",
+      "line": 129,
+      "line_count": 90
+    },
+    {
+      "path": "src/components/verify/RuleReadinessFacts.tsx",
+      "name": "RuleReadinessFacts",
+      "line": 43,
+      "line_count": 90
+    },
+    {
+      "path": "tests/components/evidenceWorkflowStepper.test.tsx",
+      "name": "<arrow>",
+      "line": 334,
+      "line_count": 90
+    },
+    {
+      "path": "tests/lib/quickCheckReviewQuestion.test.ts",
+      "name": "<arrow>",
+      "line": 1024,
+      "line_count": 90
+    },
+    {
+      "path": "tests/lib/workbookIntake.test.ts",
+      "name": "<arrow>",
+      "line": 65,
+      "line_count": 90
+    },
+    {
+      "path": "src/lib/evidence/export/projectExportData.ts",
+      "name": "buildPremiumExportInputFromProject",
+      "line": 370,
+      "line_count": 89
+    },
+    {
+      "path": "tests/components/ruleDetailModal.test.tsx",
+      "name": "<arrow>",
+      "line": 369,
+      "line_count": 89
+    },
+    {
+      "path": "tests/lib/projects/learningCase.test.ts",
+      "name": "makeManualProject",
+      "line": 8,
+      "line_count": 89
+    },
+    {
+      "path": "src/app/m/_lib/methodRich.ts",
+      "name": "probeMethodRich",
+      "line": 85,
+      "line_count": 88
+    },
+    {
+      "path": "tests/lib/projects/manifestConsumption.test.ts",
+      "name": "<arrow>",
+      "line": 24,
+      "line_count": 88
+    },
+    {
+      "path": "src/components/projects/NewProjectForm.tsx",
+      "name": "handleSubmit",
+      "line": 70,
+      "line_count": 87
+    },
+    {
+      "path": "src/lib/evidence/export/verificationPackIntegration.ts",
+      "name": "buildEvidenceIntelligenceFiles",
+      "line": 128,
+      "line_count": 87
+    },
+    {
+      "path": "src/lib/projects/verificationReport.ts",
+      "name": "composeGenericStandardAwareReport",
+      "line": 340,
+      "line_count": 87
+    },
+    {
+      "path": "tests/components/stacSupportSection.test.tsx",
+      "name": "<arrow>",
+      "line": 21,
+      "line_count": 87
+    },
+    {
+      "path": "tests/lib/composers/composeGoldStandardVerificationReport.test.ts",
+      "name": "<arrow>",
+      "line": 43,
+      "line_count": 87
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "buildReadinessExportContext",
+      "line": 3155,
+      "line_count": 86
+    },
+    {
+      "path": "src/exports/verificationPackContract.ts",
+      "name": "evidenceRefsFromPinsForRule",
+      "line": 446,
+      "line_count": 86
+    },
+    {
+      "path": "src/lib/chat/quickCheckEvidence.ts",
+      "name": "extractMethodologyMentions",
+      "line": 600,
+      "line_count": 86
+    },
+    {
+      "path": "src/lib/chat/quickCheckSectionExtractor.ts",
+      "name": "scoreHeadingAgainstQuery",
+      "line": 773,
+      "line_count": 86
+    },
+    {
+      "path": "src/lib/evidence/reconciliation/reconciler.ts",
+      "name": "reconcileEvidence",
+      "line": 74,
+      "line_count": 86
+    },
+    {
+      "path": "tests/diagnostics/quick-check-matching.diagnostic.test.ts",
+      "name": "buildPreciseFailureReport",
+      "line": 363,
+      "line_count": 86
+    },
+    {
+      "path": "src/components/projects/ProjectDetail.tsx",
+      "name": "<arrow>",
+      "line": 1109,
+      "line_count": 85
+    },
+    {
+      "path": "src/lib/chat/quickCheckMethodology.ts",
+      "name": "resolvePrimaryMethodology",
+      "line": 285,
+      "line_count": 85
+    },
+    {
+      "path": "src/lib/evidence/export/zipExporter.ts",
+      "name": "buildPremiumZip",
+      "line": 148,
+      "line_count": 85
+    },
+    {
+      "path": "tests/lib/evidence/export/premiumExport.test.ts",
+      "name": "makeInput",
+      "line": 107,
+      "line_count": 85
+    },
+    {
+      "path": "tests/lib/readiness/clientReadinessReportExport.test.ts",
+      "name": "<arrow>",
+      "line": 77,
+      "line_count": 85
+    },
+    {
+      "path": "src/lib/projects/reviewHandoff.ts",
+      "name": "importMethodologyReviewIntoProject",
+      "line": 224,
+      "line_count": 84
+    },
+    {
+      "path": "tests/components/projects/NewProjectForm.handoff.test.tsx",
+      "name": "<arrow>",
+      "line": 50,
+      "line_count": 84
+    },
+    {
+      "path": "tests/components/verifyReadinessStrip.test.tsx",
+      "name": "<arrow>",
+      "line": 5,
+      "line_count": 84
+    },
+    {
+      "path": "src/app/api/projects/[id]/export-premium/route.ts",
+      "name": "handlePost",
+      "line": 12,
+      "line_count": 83
+    },
+    {
+      "path": "src/lib/runs/selectLatestStacRun.test.ts",
+      "name": "<arrow>",
+      "line": 5,
+      "line_count": 83
+    },
+    {
+      "path": "src/lib/evidence/export/verificationPackIntegration.ts",
+      "name": "buildEvidenceIntelligenceJson",
+      "line": 45,
+      "line_count": 82
+    },
+    {
+      "path": "tests/components/projects/projectReviewRouting.test.tsx",
+      "name": "<arrow>",
+      "line": 19,
+      "line_count": 82
+    },
+    {
+      "path": "tests/lib/readiness/clientReadinessReport.test.ts",
+      "name": "<arrow>",
+      "line": 28,
+      "line_count": 82
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "name": "completeQuickCheck",
+      "line": 1227,
+      "line_count": 81
+    },
+    {
+      "path": "src/components/projects/ProjectDetail.tsx",
+      "name": "handleUploadDocuments",
+      "line": 233,
+      "line_count": 81
+    },
+    {
+      "path": "src/lib/export/extractStacArtifacts.test.ts",
+      "name": "<arrow>",
+      "line": 5,
+      "line_count": 81
+    },
+    {
+      "path": "src/app/m/_lib/methodRules.ts",
+      "name": "loadMethodRules",
+      "line": 303,
+      "line_count": 79
+    },
+    {
+      "path": "src/components/verify/RunHistoryPanel.tsx",
+      "name": "RunHistoryPanel",
+      "line": 22,
+      "line_count": 79
+    },
+    {
+      "path": "tests/components/proofMapTab.reviewArtifact.test.ts",
+      "name": "<arrow>",
+      "line": 103,
+      "line_count": 79
+    },
+    {
+      "path": "src/app/api/projects/manual-review/extract-findings/route.ts",
+      "name": "handlePost",
+      "line": 65,
+      "line_count": 78
+    },
+    {
+      "path": "src/app/m/_components/VersionSelector.tsx",
+      "name": "VersionSelector",
+      "line": 15,
+      "line_count": 78
+    },
+    {
+      "path": "src/lib/proofMap/evidenceSnapshot.test.ts",
+      "name": "<arrow>",
+      "line": 160,
+      "line_count": 78
+    },
+    {
+      "path": "src/lib/verify/runState.ts",
+      "name": "readVerifierRunBundle",
+      "line": 571,
+      "line_count": 78
+    },
+    {
+      "path": "tests/components/projects/NewProjectForm.test.tsx",
+      "name": "<arrow>",
+      "line": 23,
+      "line_count": 78
+    },
+    {
+      "path": "tests/lib/quickCheckMethodology.test.ts",
+      "name": "<arrow>",
+      "line": 75,
+      "line_count": 78
+    },
+    {
+      "path": "tests/lib/readiness/vvbWorkpaperExport.test.ts",
+      "name": "buildSampleReport",
+      "line": 29,
+      "line_count": 78
+    },
+    {
+      "path": "tests/components/ruleDetailModal.test.tsx",
+      "name": "<arrow>",
+      "line": 291,
+      "line_count": 77
+    },
+    {
+      "path": "tests/lib/quickCheckSectionExtractor.test.ts",
+      "name": "<arrow>",
+      "line": 477,
+      "line_count": 77
+    },
+    {
+      "path": "src/components/projects/ProjectDetail.tsx",
+      "name": "<arrow>",
+      "line": 1115,
+      "line_count": 76
+    },
+    {
+      "path": "src/lib/evidence/metrics/compute.ts",
+      "name": "computeMetrics",
+      "line": 91,
+      "line_count": 76
+    },
+    {
+      "path": "src/lib/evidence/workbook.ts",
+      "name": "parseXlsxWorkbook",
+      "line": 327,
+      "line_count": 76
+    },
+    {
+      "path": "src/lib/proof/bundle.ts",
+      "name": "buildProofBundleV1",
+      "line": 176,
+      "line_count": 76
+    },
+    {
+      "path": "src/lib/proofMap/aoi.ts",
+      "name": "resolvePrimaryAreaFeature",
+      "line": 341,
+      "line_count": 76
+    },
+    {
+      "path": "tests/lib/verify.runState.test.ts",
+      "name": "<arrow>",
+      "line": 156,
+      "line_count": 76
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "handleExportSnapshot",
+      "line": 3045,
+      "line_count": 75
+    },
+    {
+      "path": "src/components/snapshot/SnapshotDiffViewV2.tsx",
+      "name": "SnapshotDiffView",
+      "line": 142,
+      "line_count": 75
+    },
+    {
+      "path": "src/lib/chat/quickCheckSectionExtractor.ts",
+      "name": "extractPddSections",
+      "line": 249,
+      "line_count": 75
+    },
+    {
+      "path": "tests/api/project.export-pdf.route.test.ts",
+      "name": "<arrow>",
+      "line": 181,
+      "line_count": 75
+    },
+    {
+      "path": "tests/lib/quickCheckReviewQuestion.test.ts",
+      "name": "<arrow>",
+      "line": 128,
+      "line_count": 74
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "name": "<arrow>",
+      "line": 1076,
+      "line_count": 73
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "badgeForRun",
+      "line": 2647,
+      "line_count": 73
+    },
+    {
+      "path": "src/lib/chat/quickCheckUi.ts",
+      "name": "signalLabelFromFact",
+      "line": 183,
+      "line_count": 73
+    },
+    {
+      "path": "src/lib/evidence/workbook.ts",
+      "name": "buildRecordGroup",
+      "line": 191,
+      "line_count": 73
+    },
+    {
+      "path": "src/lib/proofMap/evidenceSnapshot.test.ts",
+      "name": "<arrow>",
+      "line": 239,
+      "line_count": 73
+    },
+    {
+      "path": "tests/app/api/exports/audit-pack.route.test.ts",
+      "name": "buildArtifact",
+      "line": 9,
+      "line_count": 73
+    },
+    {
+      "path": "tests/components/proofMapTab.reviewArtifact.test.ts",
+      "name": "buildArtifact",
+      "line": 5,
+      "line_count": 73
+    },
+    {
+      "path": "tests/lib/evidence/export/verificationPackIntegration.test.ts",
+      "name": "<arrow>",
+      "line": 66,
+      "line_count": 73
+    },
+    {
+      "path": "src/components/verify/VerifyReadinessStrip.tsx",
+      "name": "VerifyReadinessStrip",
+      "line": 35,
+      "line_count": 72
+    },
+    {
+      "path": "tests/lib/chat.quickCheck.test.ts",
+      "name": "<arrow>",
+      "line": 7,
+      "line_count": 72
+    },
+    {
+      "path": "tests/lib/documentSupport.test.ts",
+      "name": "<arrow>",
+      "line": 135,
+      "line_count": 72
+    },
+    {
+      "path": "tests/lib/proof.import.test.ts",
+      "name": "<arrow>",
+      "line": 8,
+      "line_count": 72
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "name": "extractionDiagnostic",
+      "line": 812,
+      "line_count": 71
+    },
+    {
+      "path": "src/lib/chat/quickCheckPdfExtractor.ts",
+      "name": "extractPdfTextWithPdfParse",
+      "line": 267,
+      "line_count": 71
+    },
+    {
+      "path": "src/lib/evidence/export/projectExportData.ts",
+      "name": "buildInventory",
+      "line": 137,
+      "line_count": 71
+    },
+    {
+      "path": "src/lib/export/extractStacArtifacts.ts",
+      "name": "extractStacArtifacts",
+      "line": 59,
+      "line_count": 71
+    },
+    {
+      "path": "src/lib/manifestSource.ts",
+      "name": "loadManifestAll",
+      "line": 16,
+      "line_count": 71
+    },
+    {
+      "path": "src/lib/quickCheck/semanticEvidence/huggingFace.ts",
+      "name": "suggestSemanticEvidence",
+      "line": 110,
+      "line_count": 71
+    },
+    {
+      "path": "src/lib/verify/documentSupport.ts",
+      "name": "deriveDocumentSupport",
+      "line": 43,
+      "line_count": 71
+    },
+    {
+      "path": "tests/components/quickCheckPanel.upload-regression.test.tsx",
+      "name": "<arrow>",
+      "line": 105,
+      "line_count": 71
+    },
+    {
+      "path": "tests/exports/auditPack.contract.test.ts",
+      "name": "<arrow>",
+      "line": 893,
+      "line_count": 71
+    },
+    {
+      "path": "tests/lib/quickCheckBaselineRubric.test.ts",
+      "name": "<arrow>",
+      "line": 191,
+      "line_count": 71
+    },
+    {
+      "path": "src/components/map/MapCanvas.tsx",
+      "name": "<arrow>",
+      "line": 301,
+      "line_count": 70
+    },
+    {
+      "path": "src/lib/chat/quickCheckPdfExtractor.ts",
+      "name": "extractPdfPagesWithPdfParse",
+      "line": 339,
+      "line_count": 70
+    },
+    {
+      "path": "src/lib/evidence/export/verificationPackDerivation.ts",
+      "name": "buildFragments",
+      "line": 111,
+      "line_count": 70
+    },
+    {
+      "path": "src/components/chat/Composer.tsx",
+      "name": "Composer",
+      "line": 4,
+      "line_count": 69
+    },
+    {
+      "path": "src/components/ui/Tooltip.tsx",
+      "name": "Tooltip",
+      "line": 29,
+      "line_count": 69
+    },
+    {
+      "path": "src/lib/evidence/export/pdfExporter.ts",
+      "name": "addCoverageMatrix",
+      "line": 406,
+      "line_count": 69
+    },
+    {
+      "path": "src/app/m/_lib/requirementCoverage.ts",
+      "name": "reconcileRequirement",
+      "line": 392,
+      "line_count": 68
+    },
+    {
+      "path": "src/components/map/MapCanvas.tsx",
+      "name": "<arrow>",
+      "line": 302,
+      "line_count": 68
+    },
+    {
+      "path": "src/components/map/MapCanvas.tsx",
+      "name": "<arrow>",
+      "line": 771,
+      "line_count": 68
+    },
+    {
+      "path": "src/exports/verificationPackContract.ts",
+      "name": "buildTrailEntries",
+      "line": 1237,
+      "line_count": 68
+    },
+    {
+      "path": "src/lib/verify/stacSupportFacts.ts",
+      "name": "extractStacSupportFacts",
+      "line": 247,
+      "line_count": 68
+    },
+    {
+      "path": "src/app/m/_components/RuleDetailModal.tsx",
+      "name": "resolveRuleReviewReviewerArtifact",
+      "line": 183,
+      "line_count": 67
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "<arrow>",
+      "line": 3948,
+      "line_count": 67
+    },
+    {
+      "path": "src/exports/verificationPackContract.ts",
+      "name": "currentRequirementRules",
+      "line": 1521,
+      "line_count": 67
+    },
+    {
+      "path": "src/lib/evidence/export/projectExportData.ts",
+      "name": "buildDecisionRunFromProject",
+      "line": 302,
+      "line_count": 67
+    },
+    {
+      "path": "src/lib/quickCheck/retrieval/retrieveSections.ts",
+      "name": "buildReviewQuestionSectionRetrieval",
+      "line": 559,
+      "line_count": 67
+    },
+    {
+      "path": "tests/components/clientReadinessReportView.test.tsx",
+      "name": "<arrow>",
+      "line": 75,
+      "line_count": 67
+    },
+    {
+      "path": "tests/components/finalReviewSummaryPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 18,
+      "line_count": 67
+    },
+    {
+      "path": "tests/components/quickCheckPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 1219,
+      "line_count": 67
+    },
+    {
+      "path": "tests/demo/demo-stability.test.ts",
+      "name": "<arrow>",
+      "line": 69,
+      "line_count": 67
+    },
+    {
+      "path": "tests/lib/buildReviewSummary.test.ts",
+      "name": "<arrow>",
+      "line": 10,
+      "line_count": 67
+    },
+    {
+      "path": "tests/lib/finalizedExport.test.ts",
+      "name": "<arrow>",
+      "line": 28,
+      "line_count": 67
+    },
+    {
+      "path": "tests/lib/quickCheckUi.test.ts",
+      "name": "<arrow>",
+      "line": 251,
+      "line_count": 67
+    },
+    {
+      "path": "tests/lib/snapshot.test.ts",
+      "name": "<arrow>",
+      "line": 329,
+      "line_count": 67
+    },
+    {
+      "path": "src/app/m/_lib/requirementCoverage.test.ts",
+      "name": "<arrow>",
+      "line": 164,
+      "line_count": 66
+    },
+    {
+      "path": "src/lib/chat/quickCheckUi.ts",
+      "name": "buildExtractionPreviewViewModel",
+      "line": 290,
+      "line_count": 66
+    },
+    {
+      "path": "src/lib/composers/metadata.ts",
+      "name": "loadMethodologyMetadata",
+      "line": 113,
+      "line_count": 66
+    },
+    {
+      "path": "src/lib/quickCheck/retrieval/retrieveSections.ts",
+      "name": "scoreSemanticHeading",
+      "line": 239,
+      "line_count": 66
+    },
+    {
+      "path": "tests/api/projects.manual-review.extract-findings.route.test.ts",
+      "name": "<arrow>",
+      "line": 150,
+      "line_count": 66
+    },
+    {
+      "path": "tests/components/ruleReviewPanel.test.tsx",
+      "name": "<arrow>",
+      "line": 76,
+      "line_count": 66
+    },
+    {
+      "path": "tests/lib/quickCheckUi.test.ts",
+      "name": "<arrow>",
+      "line": 104,
+      "line_count": 66
+    },
+    {
+      "path": "src/components/HealthBadge.tsx",
+      "name": "HealthBadge",
+      "line": 20,
+      "line_count": 65
+    },
+    {
+      "path": "src/components/verify/EvidenceWorkflowStepper.tsx",
+      "name": "CompletedWorkflowSummary",
+      "line": 152,
+      "line_count": 65
+    },
+    {
+      "path": "src/lib/chat/quickCheckSectionExtractor.ts",
+      "name": "analyzeSectionCandidates",
+      "line": 492,
+      "line_count": 65
+    },
+    {
+      "path": "src/lib/evidence/export/pdfExporter.ts",
+      "name": "addEvidenceInventory",
+      "line": 295,
+      "line_count": 65
+    },
+    {
+      "path": "tests/components/evidenceWorkflowStepper.test.tsx",
+      "name": "<arrow>",
+      "line": 65,
+      "line_count": 65
+    },
+    {
+      "path": "tests/exports/auditPack.contract.test.ts",
+      "name": "<arrow>",
+      "line": 782,
+      "line_count": 65
+    },
+    {
+      "path": "tests/lib/quickCheckSectionExtractor.test.ts",
+      "name": "<arrow>",
+      "line": 660,
+      "line_count": 65
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "name": "buildMatchCandidates",
+      "line": 249,
+      "line_count": 64
+    },
+    {
+      "path": "src/lib/chat/quickCheckEvidence.ts",
+      "name": "extractEncodedPdfText",
+      "line": 480,
+      "line_count": 64
+    },
+    {
+      "path": "tests/lib/proofMap.verificationRuns.test.ts",
+      "name": "<arrow>",
+      "line": 144,
+      "line_count": 64
+    },
+    {
+      "path": "tests/lib/quickCheckMethodSignals.test.ts",
+      "name": "<arrow>",
+      "line": 135,
+      "line_count": 64
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "name": "fetchSelectedRuleContext",
+      "line": 622,
+      "line_count": 63
+    },
+    {
+      "path": "src/lib/chat/quickCheckSectionExtractor.ts",
+      "name": "findRejectedHeadingMatches",
+      "line": 913,
+      "line_count": 63
+    },
+    {
+      "path": "src/lib/readiness/vvbWorkpaperReport.ts",
+      "name": "buildEvidenceReferenceIndex",
+      "line": 261,
+      "line_count": 63
+    },
+    {
+      "path": "tests/diagnostics/quick-check-matching.diagnostic.test.ts",
+      "name": "buildDiagnosticReport",
+      "line": 104,
+      "line_count": 63
+    },
+    {
+      "path": "tests/lib/evidenceInventory.test.ts",
+      "name": "<arrow>",
+      "line": 232,
+      "line_count": 63
+    },
+    {
+      "path": "scripts/audit-pack/gen-trace-index.mjs",
+      "name": "genTrace",
+      "line": 123,
+      "line_count": 62
+    },
+    {
+      "path": "scripts/build-derived-artifacts.mjs",
+      "name": "main",
+      "line": 83,
+      "line_count": 62
+    },
+    {
+      "path": "src/components/verify/FinalizeGateBanner.tsx",
+      "name": "FinalizeGateBanner",
+      "line": 12,
+      "line_count": 62
+    },
+    {
+      "path": "tests/components/projects/projectReviewRouting.test.tsx",
+      "name": "<arrow>",
+      "line": 38,
+      "line_count": 62
+    },
+    {
+      "path": "tests/lib/methodBadge.test.ts",
+      "name": "<arrow>",
+      "line": 91,
+      "line_count": 62
+    },
+    {
+      "path": "tests/lib/proof.auditZip.test.ts",
+      "name": "<arrow>",
+      "line": 117,
+      "line_count": 62
+    },
+    {
+      "path": "src/hooks/useHealth.ts",
+      "name": "useHealth",
+      "line": 7,
+      "line_count": 61
+    },
+    {
+      "path": "src/lib/proof/auditZip.ts",
+      "name": "buildRuleEvidenceMap",
+      "line": 186,
+      "line_count": 61
+    },
+    {
+      "path": "src/lib/readiness/clientReadinessExport.tsx",
+      "name": "buildClientReadinessReportExport",
+      "line": 419,
+      "line_count": 61
+    },
+    {
+      "path": "src/lib/trace/traceIndex.ts",
+      "name": "buildTraceIndex",
+      "line": 142,
+      "line_count": 61
+    },
+    {
+      "path": "src/lib/verify/snapshotExport.ts",
+      "name": "buildOutcomeSnapshot",
+      "line": 6,
+      "line_count": 61
+    },
+    {
+      "path": "tests/lib/quickCheckMethodSignals.test.ts",
+      "name": "<arrow>",
+      "line": 202,
+      "line_count": 61
+    }
+  ],
+  "targets": [
+    {
+      "path": "src/lib/trace/evidenceLinks.ts",
+      "priority": 35.7,
+      "efficiency": 17.9,
+      "recommendation": "2 complex functions lack test coverage path, add tests before modifying",
+      "category": "add_test_coverage",
+      "effort": "medium",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.48,
+          "threshold": 0.3,
+          "detail": "density 0.48 exceeds 0.3"
+        },
+        {
+          "metric": "crap_max",
+          "value": 72.0,
+          "threshold": 30.0,
+          "detail": "2 functions with untested complexity risk"
+        }
+      ],
+      "evidence": {
+        "complex_functions": [
+          {
+            "name": "normalizeEvidenceIds",
+            "line": 3,
+            "cognitive": 9
+          },
+          {
+            "name": "buildEvidenceRuleIndex",
+            "line": 20,
+            "cognitive": 8
+          },
+          {
+            "name": "<arrow>",
+            "line": 6,
+            "cognitive": 0
+          }
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "2 complex functions lack test coverage path, add tests before modifying",
+          "category": "add_test_coverage"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/manifestDiff.ts",
+      "priority": 16.6,
+      "efficiency": 16.6,
+      "recommendation": "2 complex functions lack test coverage path, add tests before modifying",
+      "category": "add_test_coverage",
+      "effort": "low",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.49,
+          "threshold": 0.3,
+          "detail": "density 0.49 exceeds 0.3"
+        },
+        {
+          "metric": "crap_max",
+          "value": 182.0,
+          "threshold": 30.0,
+          "detail": "2 functions with untested complexity risk"
+        }
+      ],
+      "evidence": {
+        "complex_functions": [
+          {
+            "name": "indexManifest",
+            "line": 3,
+            "cognitive": 13
+          },
+          {
+            "name": "diffIndexes",
+            "line": 22,
+            "cognitive": 10
+          }
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "2 complex functions lack test coverage path, add tests before modifying",
+          "category": "add_test_coverage"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/buildReviewSummary.ts",
+      "priority": 31.0,
+      "efficiency": 15.5,
+      "recommendation": "Split high-impact file (253 LOC) — 7 dependents amplify every change",
+      "category": "split_high_impact",
+      "effort": "medium",
+      "confidence": "medium",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.47,
+          "threshold": 0.3,
+          "detail": "density 0.47 exceeds 0.3"
+        },
+        {
+          "metric": "fan_in",
+          "value": 7.0,
+          "threshold": 3.0,
+          "detail": "7 files depend on this"
+        },
+        {
+          "metric": "cognitive_complexity",
+          "value": 66.0,
+          "threshold": 30.0,
+          "detail": "buildReviewSummary has cognitive complexity 66"
+        }
+      ],
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Split high-impact file (253 LOC) — 7 dependents amplify every change",
+          "category": "split_high_impact"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/export/conventions.ts",
+      "priority": 29.4,
+      "efficiency": 14.7,
+      "recommendation": "Remove 4 unused exports to reduce surface area (57% dead)",
+      "category": "remove_dead_code",
+      "effort": "medium",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "fan_in",
+          "value": 7.0,
+          "threshold": 3.0,
+          "detail": "7 files depend on this"
+        },
+        {
+          "metric": "dead_code_ratio",
+          "value": 0.57,
+          "threshold": 0.5,
+          "detail": "4 unused of 7 value exports (57%)"
+        }
+      ],
+      "evidence": {
+        "unused_exports": [
+          "EXPORT_TIMESTAMP_FALLBACK",
+          "CANONICAL_EXPORT_TERMINOLOGY",
+          "exportSchemaVersion",
+          "exportSectionOrder"
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Remove 4 unused exports to reduce surface area (57% dead)",
+          "category": "remove_dead_code"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/chat/quickCheck.ts",
+      "priority": 29.0,
+      "efficiency": 14.5,
+      "recommendation": "Split high-impact file (487 LOC) — 4 dependents amplify every change",
+      "category": "split_high_impact",
+      "effort": "medium",
+      "confidence": "medium",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.34,
+          "threshold": 0.3,
+          "detail": "density 0.34 exceeds 0.3"
+        },
+        {
+          "metric": "fan_in",
+          "value": 4.0,
+          "threshold": 3.0,
+          "detail": "4 files depend on this"
+        },
+        {
+          "metric": "fan_out",
+          "value": 5.0,
+          "threshold": 5.0,
+          "detail": "imports 5 modules"
+        },
+        {
+          "metric": "crap_max",
+          "value": 97.0,
+          "threshold": 30.0,
+          "detail": "5 functions with untested complexity risk"
+        }
+      ],
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Split high-impact file (487 LOC) — 4 dependents amplify every change",
+          "category": "split_high_impact"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/reviewValidation.ts",
+      "priority": 28.3,
+      "efficiency": 14.2,
+      "recommendation": "Remove 3 unused exports to reduce surface area (60% dead)",
+      "category": "remove_dead_code",
+      "effort": "medium",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "fan_in",
+          "value": 4.0,
+          "threshold": 3.0,
+          "detail": "4 files depend on this"
+        },
+        {
+          "metric": "dead_code_ratio",
+          "value": 0.6,
+          "threshold": 0.5,
+          "detail": "3 unused of 5 value exports (60%)"
+        }
+      ],
+      "evidence": {
+        "unused_exports": [
+          "isValid",
+          "requiresRationale",
+          "statusColor"
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Remove 3 unused exports to reduce surface area (60% dead)",
+          "category": "remove_dead_code"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/projects/exportPdf.ts",
+      "priority": 27.3,
+      "efficiency": 13.7,
+      "recommendation": "Extract buildProjectExportPdf (cognitive: 84) in 483-LOC file into smaller functions",
+      "category": "extract_complex_functions",
+      "effort": "medium",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "fan_in",
+          "value": 3.0,
+          "threshold": 3.0,
+          "detail": "3 files depend on this"
+        },
+        {
+          "metric": "fan_out",
+          "value": 5.0,
+          "threshold": 5.0,
+          "detail": "imports 5 modules"
+        },
+        {
+          "metric": "cognitive_complexity",
+          "value": 84.0,
+          "threshold": 30.0,
+          "detail": "buildProjectExportPdf has cognitive complexity 84"
+        }
+      ],
+      "evidence": {
+        "complex_functions": [
+          {
+            "name": "buildProjectExportPdf",
+            "line": 198,
+            "cognitive": 84
+          }
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Extract buildProjectExportPdf (cognitive: 84) in 483-LOC file into smaller functions",
+          "category": "extract_complex_functions"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/components/chat/QuickCheckPanel.tsx",
+      "priority": 37.7,
+      "efficiency": 12.6,
+      "recommendation": "Extract QuickCheckPanel (cognitive: 193) and runQuickCheck (cognitive: 78) in 2724-LOC file into smaller functions",
+      "category": "extract_complex_functions",
+      "effort": "high",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "fan_in",
+          "value": 5.0,
+          "threshold": 3.0,
+          "detail": "5 files depend on this"
+        },
+        {
+          "metric": "fan_out",
+          "value": 17.0,
+          "threshold": 5.0,
+          "detail": "imports 17 modules"
+        },
+        {
+          "metric": "hotspot_score",
+          "value": 37.3,
+          "threshold": 30.0,
+          "detail": "hotspot score 37 (36 commits, accelerating trend)"
+        },
+        {
+          "metric": "cognitive_complexity",
+          "value": 193.0,
+          "threshold": 30.0,
+          "detail": "QuickCheckPanel has cognitive complexity 193"
+        },
+        {
+          "metric": "crap_max",
+          "value": 3283.5,
+          "threshold": 30.0,
+          "detail": "8 functions with untested complexity risk"
+        }
+      ],
+      "evidence": {
+        "complex_functions": [
+          {
+            "name": "QuickCheckPanel",
+            "line": 564,
+            "cognitive": 193
+          },
+          {
+            "name": "runQuickCheck",
+            "line": 1432,
+            "cognitive": 78
+          },
+          {
+            "name": "boostForEvidenceFacts",
+            "line": 190,
+            "cognitive": 69
+          }
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Extract QuickCheckPanel (cognitive: 193) and runQuickCheck (cognitive: 78) in 2724-LOC file into smaller functions",
+          "category": "extract_complex_functions"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/evidenceSnapshot.ts",
+      "priority": 37.5,
+      "efficiency": 12.5,
+      "recommendation": "Extract buildEvidenceSnapshot (cognitive: 37) in 482-LOC file into smaller functions",
+      "category": "extract_complex_functions",
+      "effort": "high",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "fan_in",
+          "value": 13.0,
+          "threshold": 3.0,
+          "detail": "13 files depend on this"
+        },
+        {
+          "metric": "fan_out",
+          "value": 5.0,
+          "threshold": 5.0,
+          "detail": "imports 5 modules"
+        },
+        {
+          "metric": "cognitive_complexity",
+          "value": 37.0,
+          "threshold": 30.0,
+          "detail": "buildEvidenceSnapshot has cognitive complexity 37"
+        },
+        {
+          "metric": "crap_max",
+          "value": 106.4,
+          "threshold": 30.0,
+          "detail": "4 functions with untested complexity risk"
+        }
+      ],
+      "evidence": {
+        "complex_functions": [
+          {
+            "name": "buildEvidenceSnapshot",
+            "line": 350,
+            "cognitive": 37
+          }
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Extract buildEvidenceSnapshot (cognitive: 37) in 482-LOC file into smaller functions",
+          "category": "extract_complex_functions"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/app/m/_lib/methodRules.ts",
+      "priority": 24.9,
+      "efficiency": 12.5,
+      "recommendation": "Split high-impact file (382 LOC) — 6 dependents amplify every change",
+      "category": "split_high_impact",
+      "effort": "medium",
+      "confidence": "medium",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.37,
+          "threshold": 0.3,
+          "detail": "density 0.37 exceeds 0.3"
+        },
+        {
+          "metric": "fan_in",
+          "value": 6.0,
+          "threshold": 3.0,
+          "detail": "6 files depend on this"
+        },
+        {
+          "metric": "crap_max",
+          "value": 184.5,
+          "threshold": 30.0,
+          "detail": "4 functions with untested complexity risk"
+        }
+      ],
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Split high-impact file (382 LOC) — 6 dependents amplify every change",
+          "category": "split_high_impact"
+        }
+      ]
+    },
+    {
+      "path": "src/components/map/ProofMapTab.tsx",
+      "priority": 37.2,
+      "efficiency": 12.4,
+      "recommendation": "Extract ProofMapTab (cognitive: 235) and verifyReadinessChips (cognitive: 107) in 5358-LOC file into smaller functions",
+      "category": "extract_complex_functions",
+      "effort": "high",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.31,
+          "threshold": 0.3,
+          "detail": "density 0.31 exceeds 0.3"
+        },
+        {
+          "metric": "fan_out",
+          "value": 53.0,
+          "threshold": 5.0,
+          "detail": "imports 53 modules"
+        },
+        {
+          "metric": "hotspot_score",
+          "value": 56.4,
+          "threshold": 30.0,
+          "detail": "hotspot score 56 (95 commits, cooling trend)"
+        },
+        {
+          "metric": "cognitive_complexity",
+          "value": 235.0,
+          "threshold": 30.0,
+          "detail": "ProofMapTab has cognitive complexity 235"
+        },
+        {
+          "metric": "crap_max",
+          "value": 11062.0,
+          "threshold": 30.0,
+          "detail": "31 functions with untested complexity risk"
+        }
+      ],
+      "evidence": {
+        "complex_functions": [
+          {
+            "name": "ProofMapTab",
+            "line": 426,
+            "cognitive": 235
+          },
+          {
+            "name": "verifyReadinessChips",
+            "line": 2119,
+            "cognitive": 107
+          },
+          {
+            "name": "<arrow>",
+            "line": 3698,
+            "cognitive": 66
+          }
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Extract ProofMapTab (cognitive: 235) and verifyReadinessChips (cognitive: 107) in 5358-LOC file into smaller functions",
+          "category": "extract_complex_functions"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/app/m/_components/MethodDetailPane.tsx",
+      "priority": 37.1,
+      "efficiency": 12.4,
+      "recommendation": "Extract MethodDetailPane (cognitive: 131) and ensureRulesLoaded (cognitive: 60) in 1990-LOC file into smaller functions",
+      "category": "extract_complex_functions",
+      "effort": "high",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.33,
+          "threshold": 0.3,
+          "detail": "density 0.33 exceeds 0.3"
+        },
+        {
+          "metric": "fan_out",
+          "value": 34.0,
+          "threshold": 5.0,
+          "detail": "imports 34 modules"
+        },
+        {
+          "metric": "hotspot_score",
+          "value": 53.6,
+          "threshold": 30.0,
+          "detail": "hotspot score 54 (92 commits, cooling trend)"
+        },
+        {
+          "metric": "cognitive_complexity",
+          "value": 131.0,
+          "threshold": 30.0,
+          "detail": "MethodDetailPane has cognitive complexity 131"
+        },
+        {
+          "metric": "crap_max",
+          "value": 22952.0,
+          "threshold": 30.0,
+          "detail": "27 functions with untested complexity risk"
+        }
+      ],
+      "evidence": {
+        "complex_functions": [
+          {
+            "name": "MethodDetailPane",
+            "line": 129,
+            "cognitive": 131
+          },
+          {
+            "name": "ensureRulesLoaded",
+            "line": 887,
+            "cognitive": 60
+          },
+          {
+            "name": "loadRuleDetail",
+            "line": 1010,
+            "cognitive": 36
+          }
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Extract MethodDetailPane (cognitive: 131) and ensureRulesLoaded (cognitive: 60) in 1990-LOC file into smaller functions",
+          "category": "extract_complex_functions"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/inventory.ts",
+      "priority": 37.0,
+      "efficiency": 12.3,
+      "recommendation": "Split high-impact file (533 LOC) — 25 dependents amplify every change",
+      "category": "split_high_impact",
+      "effort": "high",
+      "confidence": "medium",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.5,
+          "threshold": 0.3,
+          "detail": "density 0.50 exceeds 0.3"
+        },
+        {
+          "metric": "fan_in",
+          "value": 25.0,
+          "threshold": 3.0,
+          "detail": "25 files depend on this"
+        },
+        {
+          "metric": "crap_max",
+          "value": 106.4,
+          "threshold": 30.0,
+          "detail": "4 functions with untested complexity risk"
+        }
+      ],
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Split high-impact file (533 LOC) — 25 dependents amplify every change",
+          "category": "split_high_impact"
+        }
+      ]
+    },
+    {
+      "path": "src/app/m/_lib/methodVersionMetadata.ts",
+      "priority": 24.6,
+      "efficiency": 12.3,
+      "recommendation": "Split high-impact file (195 LOC) — 7 dependents amplify every change",
+      "category": "split_high_impact",
+      "effort": "medium",
+      "confidence": "medium",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.34,
+          "threshold": 0.3,
+          "detail": "density 0.34 exceeds 0.3"
+        },
+        {
+          "metric": "fan_in",
+          "value": 7.0,
+          "threshold": 3.0,
+          "detail": "7 files depend on this"
+        }
+      ],
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Split high-impact file (195 LOC) — 7 dependents amplify every change",
+          "category": "split_high_impact"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/composers/metadata.ts",
+      "priority": 24.0,
+      "efficiency": 12.0,
+      "recommendation": "2 complex functions lack test coverage path, add tests before modifying",
+      "category": "add_test_coverage",
+      "effort": "medium",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.34,
+          "threshold": 0.3,
+          "detail": "density 0.34 exceeds 0.3"
+        },
+        {
+          "metric": "crap_max",
+          "value": 43.1,
+          "threshold": 30.0,
+          "detail": "2 functions with untested complexity risk"
+        }
+      ],
+      "evidence": {
+        "complex_functions": [
+          {
+            "name": "loadManifestPathCache",
+            "line": 67,
+            "cognitive": 21
+          },
+          {
+            "name": "loadMethodologyMetadata",
+            "line": 113,
+            "cognitive": 20
+          },
+          {
+            "name": "sections",
+            "line": 125,
+            "cognitive": 7
+          }
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "2 complex functions lack test coverage path, add tests before modifying",
+          "category": "add_test_coverage"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/proofMap/attachments.ts",
+      "priority": 35.6,
+      "efficiency": 11.9,
+      "recommendation": "Split high-impact file (134 LOC) — 11 dependents amplify every change",
+      "category": "split_high_impact",
+      "effort": "high",
+      "confidence": "medium",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.34,
+          "threshold": 0.3,
+          "detail": "density 0.34 exceeds 0.3"
+        },
+        {
+          "metric": "fan_in",
+          "value": 11.0,
+          "threshold": 3.0,
+          "detail": "11 files depend on this"
+        }
+      ],
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Split high-impact file (134 LOC) — 11 dependents amplify every change",
+          "category": "split_high_impact"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/documentSupport.ts",
+      "priority": 23.7,
+      "efficiency": 11.9,
+      "recommendation": "Split high-impact file (114 LOC) — 7 dependents amplify every change",
+      "category": "split_high_impact",
+      "effort": "medium",
+      "confidence": "medium",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.31,
+          "threshold": 0.3,
+          "detail": "density 0.31 exceeds 0.3"
+        },
+        {
+          "metric": "fan_in",
+          "value": 7.0,
+          "threshold": 3.0,
+          "detail": "7 files depend on this"
+        },
+        {
+          "metric": "cognitive_complexity",
+          "value": 39.0,
+          "threshold": 30.0,
+          "detail": "deriveDocumentSupport has cognitive complexity 39"
+        }
+      ],
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Split high-impact file (114 LOC) — 7 dependents amplify every change",
+          "category": "split_high_impact"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/evidence/export/projectExportData.ts",
+      "priority": 22.7,
+      "efficiency": 11.4,
+      "recommendation": "3 complex functions lack test coverage path, add tests before modifying",
+      "category": "add_test_coverage",
+      "effort": "medium",
+      "confidence": "high",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.36,
+          "threshold": 0.3,
+          "detail": "density 0.36 exceeds 0.3"
+        },
+        {
+          "metric": "fan_out",
+          "value": 11.0,
+          "threshold": 5.0,
+          "detail": "imports 11 modules"
+        },
+        {
+          "metric": "crap_max",
+          "value": 88.0,
+          "threshold": 30.0,
+          "detail": "3 functions with untested complexity risk"
+        }
+      ],
+      "evidence": {
+        "complex_functions": [
+          {
+            "name": "buildDecisionRunFromProject",
+            "line": 302,
+            "cognitive": 16
+          },
+          {
+            "name": "<arrow>",
+            "line": 162,
+            "cognitive": 13
+          },
+          {
+            "name": "buildPremiumExportInputFromProject",
+            "line": 370,
+            "cognitive": 13
+          }
+        ]
+      },
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "3 complex functions lack test coverage path, add tests before modifying",
+          "category": "add_test_coverage"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress the underlying complexity finding",
+          "comment": "// fallow-ignore-next-line complexity"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/nav/urlState.ts",
+      "priority": 33.9,
+      "efficiency": 11.3,
+      "recommendation": "Split high-impact file (56 LOC) — 8 dependents amplify every change",
+      "category": "split_high_impact",
+      "effort": "high",
+      "confidence": "medium",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.63,
+          "threshold": 0.3,
+          "detail": "density 0.63 exceeds 0.3"
+        },
+        {
+          "metric": "fan_in",
+          "value": 8.0,
+          "threshold": 3.0,
+          "detail": "8 files depend on this"
+        }
+      ],
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Split high-impact file (56 LOC) — 8 dependents amplify every change",
+          "category": "split_high_impact"
+        }
+      ]
+    },
+    {
+      "path": "src/lib/verify/runState.ts",
+      "priority": 33.8,
+      "efficiency": 11.3,
+      "recommendation": "Split high-impact file (1005 LOC) — 27 dependents amplify every change",
+      "category": "split_high_impact",
+      "effort": "high",
+      "confidence": "medium",
+      "factors": [
+        {
+          "metric": "complexity_density",
+          "value": 0.35,
+          "threshold": 0.3,
+          "detail": "density 0.35 exceeds 0.3"
+        },
+        {
+          "metric": "fan_in",
+          "value": 27.0,
+          "threshold": 3.0,
+          "detail": "27 files depend on this"
+        },
+        {
+          "metric": "cognitive_complexity",
+          "value": 31.0,
+          "threshold": 30.0,
+          "detail": "migrateLinkedRulesKey has cognitive complexity 31"
+        },
+        {
+          "metric": "crap_max",
+          "value": 97.0,
+          "threshold": 30.0,
+          "detail": "3 functions with untested complexity risk"
+        }
+      ],
+      "actions": [
+        {
+          "type": "apply-refactoring",
+          "auto_fixable": false,
+          "description": "Split high-impact file (1005 LOC) — 27 dependents amplify every change",
+          "category": "split_high_impact"
+        }
+      ]
+    }
+  ],
+  "target_thresholds": {
+    "fan_in_p95": 8.0,
+    "fan_in_p75": 3.0,
+    "fan_out_p95": 8.0,
+    "fan_out_p90": 5
+  }
+}

--- a/docs/codebase-cleanup.md
+++ b/docs/codebase-cleanup.md
@@ -1,0 +1,103 @@
+# Codebase Cleanup with Fallow
+
+Fallow provides deterministic static codebase intelligence for this TypeScript/Next.js project (unused code, dependencies, duplication, complexity, circular dependencies, hotspots).
+
+It is a **development-only** tool. No production impact.
+
+## Installation & Scripts
+
+- Added as `devDependency` (local binary via npm).
+- Configured via [.fallowrc.json](../.fallowrc.json) (entry points for scripts, ignore patterns for build artifacts, relaxed severities to `warn` during rollout, tuned dupes/health thresholds).
+- `.fallow/` (cache, snapshots) is gitignored.
+
+### npm scripts
+
+```bash
+npm run analyze:fallow        # Human-readable compact + summary for dead-code, dupes, health (top issues)
+npm run analyze:fallow:json   # (Re)generates machine-readable reports to artifacts/fallow/*.json
+```
+
+The `:json` variant always refreshes the committed snapshots under `artifacts/fallow/`.
+
+Run via `npx fallow ...` directly for ad-hoc (supports `--format json|compact|markdown`, `--production`, `--trace`, `--top N`, `--explain`, etc.).
+
+Note: You may see transient "WARN invalid entry pattern" lines on stderr (originating from complex `node -e "..."` values inside package.json `"scripts"`). These are discovery noise only and do not affect the analysis results or JSON reports.
+
+## Generated Reports
+
+Reports are (re)generated locally and committed as snapshots so Codex / future work has deterministic input:
+
+- [artifacts/fallow/dead-code.json](artifacts/fallow/dead-code.json) — unused files/exports/types, unused/unlisted deps, duplicate exports, etc. (circulars: 0)
+- [artifacts/fallow/dupes.json](artifacts/fallow/dupes.json) — clone groups (currently ~10.6% duplication, min 3 occurrences, audit-pack mirrors excluded)
+- [artifacts/fallow/health.json](artifacts/fallow/health.json) — complexity findings, file scores, hotspots (churn + complexity), refactoring targets
+
+Re-run `npm run analyze:fallow:json` after any source changes or before proposing cleanup to update baseline.
+
+(Compact human output also available on demand; full JSON includes `actions` for auto-fix hints and agent use.)
+
+## Interpreting Findings
+
+- **Unused code / files / exports**: Candidates for deletion or modeling as intentional (entry points, public API, dynamically loaded). Scripts/ are now declared entries so their files are not spuriously "unused". Review `unused_exports` and `unused_files` from dead-code report. Use `fallow dead-code --trace src/foo.ts:bar` or `--trace-file` to understand reachability.
+- **Unused / unlisted dependencies**: `unlisted_dependencies` in dead-code (e.g. `@napi-rs/canvas`, `tsconfig-paths` at time of snapshot) indicate imports without `package.json` entry — add them or remove usage.
+- **Duplicate code**: Focus on higher `line_count` + `occurrences >= 3`. Many small clones are noise; current actionable ones live in build/roadmap scripts. Duplication % from stats.
+- **Complexity hotspots & targets**: Functions exceeding ~25 cyclomatic / ~20 cognitive. Hotspots combine with git churn (ProofMapTab.tsx is the largest by far — interactive map component; also QuickCheck panels, some lib extractors). Targets ranked by priority/effort suggest extracts + tests.
+- **Circular dependencies / re-export cycles**: Currently clean (0).
+- Cross-reference via `fallow health --file-scores`, `--hotspots`, `--targets`, or `--score`.
+
+See upstream:
+- https://docs.fallow.tools/analysis/dead-code
+- https://docs.fallow.tools/analysis/duplication
+- https://docs.fallow.tools/explanations/health
+- https://docs.fallow.tools/cli/dead-code (and health/dupes)
+
+## Future Cleanup PR Guidelines
+
+This first PR **only establishes visibility and tooling**. No files, exports, routes, components, or dependencies were deleted.
+
+Subsequent PRs must follow:
+
+1. **Category at a time, scoped tightly**:
+   - One PR: "dead-code: remove 3 proven-unused components in src/components/ (FinderShell, RuleCard, ...)" 
+   - Separate: "health: extract helpers from QuickCheckPanel and buildReviewSummary"
+   - Separate: "dupes: dedupe 14-line manifest diff logic between scripts/ and src/lib/"
+   - Do not mix deletions + refactors + dep bumps in one PR.
+
+2. **Evidence required**:
+   - Cite the exact report (e.g. "dead-code.json unused-file:src/components/Foo.tsx + verify no other references").
+   - Reproduce locally: `npm run analyze:fallow:json`, `git diff artifacts/fallow/`.
+   - For agents/Codex: feed the relevant JSON slice + `fallow explain ...`.
+
+3. **Safety & verification (mandatory)**:
+   - Confirm with `fallow dead-code --trace-file <path>` + manual `rg` / `git grep`.
+   - For exports: check runtime (dynamic import, next routes, test coverage, public API surface).
+   - Never delete without existing tests or add smoke coverage.
+   - Run: `npm run typecheck && npm run lint && npm test && npm run build`.
+   - `npm run ci` subset if full slow.
+   - If a finding is intentional (e.g. future API, test-only kept for coverage), model it narrowly: `@expected-unused`, `ignoreExports` in config, or `entry`/`dynamicallyLoaded`, not broad ignores.
+
+4. **Report updates**:
+   - Cleanup PRs should re-run `npm run analyze:fallow:json` and include updated snapshots so the "debt ledger" shrinks visibly.
+   - Prefer narrowing exceptions in `.fallowrc.json` over accumulating inline suppressions.
+
+5. **Order of operations (recommended)**:
+   - Unresolved/unlisted deps first (high confidence).
+   - Truly unused files (after entry modeling).
+   - Unused exports/types (model public surface with tags/config).
+   - Duplication consolidation.
+   - Hotspot refactors (extracts, not deletes).
+
+6. **No whack-a-mole**:
+   - Every change must be justified by Fallow output + verification that it does not regress the existing `ci` gate or app behavior.
+   - Large components (e.g. ProofMapTab) are refactor targets, not delete candidates.
+
+## Rolling out stricter policy
+
+- Current rules are `warn` for visibility without blocking.
+- Once a category is cleaned and stable for a while, promote matching rule(s) to `"error"` in `.fallowrc.json`.
+- Consider adding regression baselines (see Fallow `--save-regression-baseline`) or `fallow audit` for PR gates in follow-ups.
+
+Questions? Run `npx fallow explain unused-export` (or any code) or consult the docs linked above.
+
+---
+
+*Added as part of establishing evidence-based cleanup foundation. No application behavior changes.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "ajv": "^8.17.1",
         "eslint": "^9",
         "eslint-config-next": "15.4.10",
+        "fallow": "^2.86.0",
         "globby": "^16.1.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
@@ -1137,6 +1138,118 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fallow-cli/darwin-arm64": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.86.0.tgz",
+      "integrity": "sha512-MOAi1tP+pho98AUEgmA5ziWSDsbr0KWQXNuk9GrptYDBsH0H+Jf9qdW8m3ilJXcgL5+RO8RTH/5Nfkhq0uoMYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/darwin-x64": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.86.0.tgz",
+      "integrity": "sha512-8mzvGhbZZ8KSG2ZEKnVpiL3Vp9lX4fep2HI8eHt3VDuhMkz8t5n3WRBaBS7LLGTCfLDZ9QPDWhSNCTkx/Llhxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-gnu": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.86.0.tgz",
+      "integrity": "sha512-1N/GCf48xp0Rh9T1JrBvKXAwn1V/+UdCsc2QgF5IrUnwD1JjTG1+/mMg5XwKmrJNPfznJzgzyYGlyfdBeJlqwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-musl": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.86.0.tgz",
+      "integrity": "sha512-/H8eK3JpLOq3l5ccEoVVuRssM528vYjk06fy9AcjIvVAGnESErfHQkmGkzAU3nquNL/tlqz88OoBvX+rayDKzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-gnu": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.86.0.tgz",
+      "integrity": "sha512-svu6wYoCnb1zjZFGjWGtmf8PMiN3SLBn7HYrkA/hXsFK3VRQLFXzts2dJOJ2kHN18rhCExBCQcqukuc/SOoKiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-musl": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.86.0.tgz",
+      "integrity": "sha512-pOr4ka4lUIdExkxG0/5cofETE1QY0DI1hbnGJxfLu3Ui0gr9A0H1Dl+ipo5oMJbMFaUiEMAFRCrtNx/j3tA/fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-arm64-msvc": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.86.0.tgz",
+      "integrity": "sha512-GmUU/l3euQkNcp5i6ZaUttjTrg2WEYohRCLMqWOUrY0CNaj/ejZ3bhDC+ZZIJZVuWg7sEFACi8wbXhc0rwVb9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-x64-msvc": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.86.0.tgz",
+      "integrity": "sha512-6c+y+QrhfiRQGiqo0QbZ5uoMxuSFichOVzPbZtagvUSO6LGogyB0qH+vNL2kk74NpD6knSXO8vrebhnsBJeI7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -6155,6 +6268,34 @@
       "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/fallow": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/fallow/-/fallow-2.86.0.tgz",
+      "integrity": "sha512-jHSTWCrvU2Llq7M0bDniTR2aqxWOwJO8BsV2IIl4lOfysJ0bd/3APu3qZ5wJZ+FE40t5DKlMEFQeURMpEb0Rig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "fallow": "bin/fallow",
+        "fallow-lsp": "bin/fallow-lsp",
+        "fallow-mcp": "bin/fallow-mcp"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@fallow-cli/darwin-arm64": "2.86.0",
+        "@fallow-cli/darwin-x64": "2.86.0",
+        "@fallow-cli/linux-arm64-gnu": "2.86.0",
+        "@fallow-cli/linux-arm64-musl": "2.86.0",
+        "@fallow-cli/linux-x64-gnu": "2.86.0",
+        "@fallow-cli/linux-x64-musl": "2.86.0",
+        "@fallow-cli/win32-arm64-msvc": "2.86.0",
+        "@fallow-cli/win32-x64-msvc": "2.86.0"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "roadmap:gen": "node scripts/roadmap/gen-roadmap.mjs",
     "roadmap:update": "node scripts/roadmap/roadmap-update.mjs",
     "test:derived:determinism": "node scripts/test-derived-determinism.mjs",
-    "test:audit-pack:trail-smoke": "node scripts/test-audit-pack-trail-smoke.mjs"
+    "test:audit-pack:trail-smoke": "node scripts/test-audit-pack-trail-smoke.mjs",
+    "analyze:fallow": "fallow dead-code --format compact --summary || true; fallow dupes --format compact --summary || true; fallow health --format compact --summary --top 10 || true",
+    "analyze:fallow:json": "mkdir -p artifacts/fallow && fallow dead-code --format json --quiet --summary > artifacts/fallow/dead-code.json 2>/dev/null || true; fallow dupes --format json --quiet --summary > artifacts/fallow/dupes.json 2>/dev/null || true; fallow health --format json --quiet --summary --top 20 > artifacts/fallow/health.json 2>/dev/null || true; echo 'Fallow JSON reports written to artifacts/fallow/{dead-code,dupes,health}.json'"
   },
   "engines": {
     "node": ">=20 <21",
@@ -86,6 +88,7 @@
     "ajv": "^8.17.1",
     "eslint": "^9",
     "eslint-config-next": "15.4.10",
+    "fallow": "^2.86.0",
     "globby": "^16.1.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",

--- a/scripts/roadmap/check-roadmap-directive.mjs
+++ b/scripts/roadmap/check-roadmap-directive.mjs
@@ -94,6 +94,14 @@ if (!directive && prNumber && repoName) {
 }
 console.log("[roadmap-directive] fetchedBodyLength=", fetchedBodyLength);
 
+if (directive) {
+  const s = (directive.slug || "").trim().toLowerCase();
+  if (!s || ["n/a", "na", "none"].includes(s)) {
+    console.log("[roadmap-directive] Roadmap-Update slug marked N/A; skipping (non-roadmap PR)");
+    process.exit(0);
+  }
+}
+
 if (!directive) {
   fail("Missing '### Roadmap-Update' block in PR body (roadmap-tracked PR).");
 }


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- no roadmap item for this dev tooling / chore PR -->

Allowed statuses: planned | next | in_progress | done | blocked

## WHAT

- Add Fallow as a development-only codebase analysis tool for `app.article6`.
- Run Fallow locally against the current repo and generate reports for:
  - code health
  - unused code
  - unused dependencies
  - duplicate code
  - complexity hotspots
  - circular dependencies
- Do not modify application behavior in this first PR.
- Add a documented npm script such as:
  - `npm run analyze:fallow`
  - `npm run analyze:fallow:json`
- Store generated reports only if they are useful and not noisy.
- Add a short `docs/codebase-cleanup.md` explaining how to interpret the reports and how future cleanup PRs should be scoped.
- Do not delete files, exports, routes, components, or dependencies yet unless they are proven safe and covered by existing checks.

## WHY

- We need evidence-based cleanup instead of random whack-a-mole refactors.
- Fallow gives deterministic JS/TS codebase intelligence that Codex can use as input.
- The first PR should only establish visibility, not mix analysis setup with risky code deletion.
- Follow-up PRs can remove dead code, reduce duplication, and refactor hotspots one category at a time.

## Testing

- `npm run analyze:fallow` and `npm run analyze:fallow:json` execute cleanly and produce the expected reports.
- Reports stored in `artifacts/fallow/` (dead-code.json, dupes.json, health.json).
- `npm run lint && npm run typecheck` pass.
- No changes to application code, routes, or runtime behavior.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>