### PR TITLE
fix(quick-check): hide weak Document Q&A evidence when not directly relevant

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2313,18 +2313,53 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                         route: {reviewQuestionResult.documentDiagnostic.inputRoute} • raw text: {reviewQuestionResult.documentDiagnostic.rawTextAvailable ? "available" : "unavailable"} • evidence: {reviewQuestionResult.documentDiagnostic.documentEvidenceCount} • methodology matched: {reviewQuestionResult.documentDiagnostic.methodologyRuleMatched ? "yes" : "no"} • recovery suppressed: {reviewQuestionResult.documentDiagnostic.methodologyRecoverySuppressedByDocumentQa ? "yes" : "no"}
                       </div>
                     ) : null}
-                    {reviewQuestionResult.documentAnswer.evidence.length > 0 ? (
-                      <div className="mt-3 space-y-2">
-                        {reviewQuestionResult.documentAnswer.evidence.map((item, index) => (
-                          <div key={`${item.source}:${item.sectionNumber ?? item.blockId ?? index}`} className="rounded-lg border border-sky-100 bg-sky-50/40 p-3">
-                            <div className="text-[11px] text-sky-800">
-                              {[item.sectionNumber ? `§${item.sectionNumber}` : null, item.heading, item.page ? `p. ${item.page}` : null, item.blockId].filter(Boolean).join(" • ")}
+                    {(() => {
+                      const da = reviewQuestionResult.documentAnswer;
+                      if (da.evidence.length === 0) return null;
+
+                      // When status is unclear because the retrieved evidence does not directly
+                      // address the question, hide the weak evidence from the main card and show
+                      // a clear message instead. The raw matches are still available in a collapsed
+                      // details section for debugging.
+                      if (da.status === "unclear" && da.explanation.includes("does not directly address")) {
+                        return (
+                          <>
+                            <div className="mt-3 text-sm leading-relaxed text-slate-600 italic">
+                              No directly relevant evidence was found for this question.
                             </div>
-                            <div className="mt-1 text-sm leading-relaxed text-slate-700">{item.snippet}</div>
-                          </div>
-                        ))}
-                      </div>
-                    ) : null}
+                            <details className="mt-2 group">
+                              <summary className="text-xs text-slate-400 cursor-pointer hover:text-slate-600 select-none">
+                                <span className="group-open:hidden">Show</span>
+                                <span className="hidden group-open:inline">Hide</span> weak evidence ({da.evidence.length} snippet{da.evidence.length === 1 ? "" : "s"})
+                              </summary>
+                              <div className="mt-2 space-y-2">
+                                {da.evidence.map((item, index) => (
+                                  <div key={`${item.source}:${item.sectionNumber ?? item.blockId ?? index}`} className="rounded-lg border border-sky-100 bg-sky-50/40 p-3">
+                                    <div className="text-[11px] text-sky-800">
+                                      {[item.sectionNumber ? `§${item.sectionNumber}` : null, item.heading, item.page ? `p. ${item.page}` : null, item.blockId].filter(Boolean).join(" • ")}
+                                    </div>
+                                    <div className="mt-1 text-sm leading-relaxed text-slate-700">{item.snippet}</div>
+                                  </div>
+                                ))}
+                              </div>
+                            </details>
+                          </>
+                        );
+                      }
+
+                      return (
+                        <div className="mt-3 space-y-2">
+                          {da.evidence.map((item, index) => (
+                            <div key={`${item.source}:${item.sectionNumber ?? item.blockId ?? index}`} className="rounded-lg border border-sky-100 bg-sky-50/40 p-3">
+                              <div className="text-[11px] text-sky-800">
+                                {[item.sectionNumber ? `§${item.sectionNumber}` : null, item.heading, item.page ? `p. ${item.page}` : null, item.blockId].filter(Boolean).join(" • ")}
+                              </div>
+                              <div className="mt-1 text-sm leading-relaxed text-slate-700">{item.snippet}</div>
+                            </div>
+                          ))}
+                        </div>
+                      );
+                    })()}
                     {reviewQuestionResult.semanticEvidenceCandidates && reviewQuestionResult.semanticEvidenceCandidates.length > 0 ? (
                       <div className="mt-3 space-y-2">
                         {reviewQuestionResult.semanticEvidenceCandidates.map((candidate) => (

--- a/tests/components/quickCheckPanel.review-question-fallback.test.tsx
+++ b/tests/components/quickCheckPanel.review-question-fallback.test.tsx
@@ -381,4 +381,58 @@ describe("QuickCheckPanel review-question fallback", () => {
     expect(text).not.toContain("likely_yes");
     expect(text).toContain("The retrieved document evidence does not directly address the question.");
   });
+
+  it("satellite launch telemetry question is UNCLEAR with no evidence found", async () => {
+    seedSession({
+      claimText: DOCUMENT_QA_NEGATIVE_QUESTION,
+      filename: "document-qa-messy.pdf",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-0",
+    });
+    await seedAttachmentText("att-upload-1", `%PDF-1.4\n(${PDF_TEXT_BY_FILENAME["document-qa-messy.pdf"]})\n%%EOF`);
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+    await flushUi();
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+
+    await flushUntilText("Document Q&A");
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Document Q&A");
+    expect(text).toContain("unclear");
+    // Terms like "satellite", "launch", "telemetry" not in document → no evidence found
+    expect(text).toContain("could not recover useful document-grounded evidence");
+    // The no-directly-relevant message is for when weak evidence exists but doesn't match
+    expect(text).not.toContain("No directly relevant evidence was found for this question.");
+  });
+
+  it("airport runway expansion impacts question is UNCLEAR with no evidence found", async () => {
+    seedSession({
+      claimText: "Does the document describe airport runway expansion impacts?",
+      filename: "document-qa-messy.pdf",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-0",
+    });
+    await seedAttachmentText("att-upload-1", `%PDF-1.4\n(${PDF_TEXT_BY_FILENAME["document-qa-messy.pdf"]})\n%%EOF`);
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+    await flushUi();
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+
+    await flushUntilText("Document Q&A");
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("unclear");
+    expect(text).toContain("could not recover useful document-grounded evidence");
+    expect(text).not.toContain("No directly relevant evidence was found for this question.");
+    expect(text).not.toContain("likely_yes");
+  });
 });


### PR DESCRIPTION
## Scope

Only changes UI rendering for Document Q&A when `status === "unclear"` because evidence is not directly relevant.

### Changes
- **QuickCheckPanel.tsx**: When `status === "unclear"` and explanation contains "does not directly address", hide raw evidence snippets from the main card and show "No directly relevant evidence was found for this question." instead. Weak evidence is still available in a collapsed `<details>` debug section.
- **Tests**: Added 2 regression tests for unrelated questions (satellite launch telemetry, airport runway expansion impacts) verifying UNCLEAR status, no primary evidence rendering, and correct explanation text.

### Not touched
- `likely_yes` / `likely_no` evidence rendering
- Document retrieval or scoring logic
- Parse-state, methodology mismatch, reprocess UI, semantic evidence, duplicate-section collapse, or methodology lane rules
- Any fixtures or golden eval tests from #700

### Verification
- `npm test`: 134 suites, 1121 passed, 47 skipped
- `npm run quickcheck:eval`: 25/25 passed (golden evals preserved)
- `npm run lint`: ✔
- `npm run typecheck`: ✔