### PR TITLE
feat(quick-check): calibrate Document Q&A for high-burden question wording

### DIFF
--- a/src/lib/quickCheck/documentQa.ts
+++ b/src/lib/quickCheck/documentQa.ts
@@ -56,7 +56,7 @@ function isHighBurdenQuestion(claimText: string): boolean {
 }
 
 function hasJustificationEvidence(evidence: DocumentAnswerEvidence[]): boolean {
-  const text = evidence.map((e) => `${e.snippet || ""} ${e.heading || ""}`).join(" ");
+  const text = evidence.map((e) => e.snippet || "").join(" ");
   return JUSTIFICATION_PATTERNS.some((pattern) => pattern.test(text));
 }
 

--- a/src/lib/quickCheck/documentQa.ts
+++ b/src/lib/quickCheck/documentQa.ts
@@ -17,6 +17,49 @@ import type { ReviewQuestionEvaluationResult } from "@/lib/quickCheck/evaluation
 const MAX_EVIDENCE_ITEMS = 3;
 const MAX_SNIPPET_CHARS = 280;
 
+const HIGH_BURDEN_TERMS = [
+  "prove", "proved", "proven", "proves", "proving",
+  "confirm", "confirmed", "confirms", "confirming", "confirmation",
+  "justify", "justified", "justifies", "justifying", "justification",
+  "validate", "validated", "validates", "validating", "validation",
+  "sufficient evidence",
+  "enough evidence",
+];
+
+const JUSTIFICATION_PATTERNS = [
+  /\bbecause\b/i,
+  /\btherefore\b/i,
+  /\bbased on\b/i,
+  /\bcalculated\b/i,
+  /\bestimated\b/i,
+  /\bderived\b/i,
+  /\bdue to\b/i,
+  /\bdemonstrat\w+\b/i,
+  /\bjustif\w+\b/i,
+  /\brationale\b/i,
+  /\banalysis\b/i,
+  /\bassessment\b/i,
+  /\bassum\w+\b/i,
+  /\b\d+(?:\.\d+)?%/,
+  /\bmodule\b/i,
+  /\bequation\b/i,
+  /\bformula\b/i,
+  /\bmethodolog\w+\b/i,
+];
+
+function isHighBurdenQuestion(claimText: string): boolean {
+  const lower = claimText.toLowerCase();
+  return HIGH_BURDEN_TERMS.some((term) => {
+    if (term.includes(" ")) return lower.includes(term);
+    return new RegExp(`\\b${term}\\b`).test(lower);
+  });
+}
+
+function hasJustificationEvidence(evidence: DocumentAnswerEvidence[]): boolean {
+  const text = evidence.map((e) => `${e.snippet || ""} ${e.heading || ""}`).join(" ");
+  return JUSTIFICATION_PATTERNS.some((pattern) => pattern.test(text));
+}
+
 function normalizeText(value: string): string {
   return value.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
 }
@@ -39,7 +82,10 @@ function keywordizeClaim(claimText: string): string[] {
         "support", "include", "provide", "demonstrate", "define", "disclose",
         "address", "discuss", "mention", "outline", "summarize", "present",
         "relate", "involve", "cover", "detail", "contain", "regard", "concern",
-        "about", "regarding",
+        "about", "regarding", "prove", "proved", "proven", "proving",
+        "confirm", "confirmed", "confirms", "confirming",
+        "justify", "justified", "justifies", "justifying",
+        "validate", "validated", "validates", "validating",
       ]).has(token)),
   )];
 }
@@ -197,15 +243,19 @@ function deriveAnswerStatus(input: {
   evaluation: ReviewQuestionEvaluationResult;
   result: ReviewQuestionRetrievalResult;
   directlyRelevant?: boolean;
+  highBurden?: boolean;
+  justificationEvidence?: boolean;
 }): DocumentQuestionAnswer["status"] {
   const verdict = input.evaluation.reviewAreaReview?.verdict ?? input.evaluation.baselineReview?.verdict;
   const relevant = input.directlyRelevant ?? true;
   if (verdict === "supported") {
+    if (input.highBurden && !input.justificationEvidence) return "unclear";
     return relevant ? "likely_yes" : "unclear";
   }
   if (verdict === "partial") return "unclear";
   if (verdict === "missing" && input.evidence.length > 0) return "likely_no";
   if (input.result.matchedHeadings.length > 0 || input.evidence.length >= 2) {
+    if (input.highBurden && !input.justificationEvidence) return "unclear";
     return relevant ? "likely_yes" : "unclear";
   }
   if (input.evidence.length === 1) return "unclear";
@@ -238,15 +288,27 @@ export function buildDocumentQuestionAnswer(input: {
   const specificTerms = getSpecificClaimTerms(input.claimText, input.retrieval.reviewArea);
   const directlyRelevant = specificTerms.length === 0 || hasDirectSemanticSupport(evidence, specificTerms);
 
+  const highBurden = isHighBurdenQuestion(input.claimText);
+  const justificationEvidence = highBurden && hasJustificationEvidence(evidence);
+
   const status = deriveAnswerStatus({
     evidence,
     evaluation: input.evaluation,
     result: input.retrieval,
     directlyRelevant,
+    highBurden,
+    justificationEvidence,
   });
 
   const methodologyRuleMatched = Boolean(input.evaluation.reviewAreaReview);
   const rawPddTextAvailable = Boolean(input.rawPddText?.trim());
+
+  const highBurdenExplanation = evidence.length > 0 && directlyRelevant && highBurden
+    ? justificationEvidence
+      ? "Quick Check found document-grounded evidence with supporting justification relevant to the question."
+      : "The question uses high-burden wording and the retrieved evidence does not include supporting justification."
+    : null;
+
   return {
     status,
     methodologyRuleMatched,
@@ -257,13 +319,14 @@ export function buildDocumentQuestionAnswer(input: {
         : rawPddTextAvailable
           ? "No methodology rule was confidently matched, and Quick Check could not recover relevant document evidence from the uploaded text."
           : "No methodology rule was confidently matched, and parsed document text was unavailable for document-first review.",
-    explanation: evidence.length > 0
-      ? directlyRelevant
-        ? "Quick Check found document-grounded evidence relevant to the question."
-        : "The retrieved document evidence does not directly address the question."
-      : rawPddTextAvailable
-        ? "Quick Check could not recover useful document-grounded evidence for this question from the uploaded file."
-        : "Quick Check could not run the document-first evidence search because parsed document text was unavailable.",
+    explanation: highBurdenExplanation
+      ?? (evidence.length > 0
+        ? directlyRelevant
+          ? "Quick Check found document-grounded evidence relevant to the question."
+          : "The retrieved document evidence does not directly address the question."
+        : rawPddTextAvailable
+          ? "Quick Check could not recover useful document-grounded evidence for this question from the uploaded file."
+          : "Quick Check could not run the document-first evidence search because parsed document text was unavailable."),
     evidence,
     diagnostic: {
       reviewQuestionRoutingFired: true,

--- a/tests/fixtures/quick-check/eval/leakage-prove-heading-only.txt
+++ b/tests/fixtures/quick-check/eval/leakage-prove-heading-only.txt
@@ -1,0 +1,3 @@
+3.3  Leakage Assessment
+Leakage from market effects is treated as zero.
+Market leakage for this project activity is zero.

--- a/tests/fixtures/quick-check/eval/leakage-prove-strong.txt
+++ b/tests/fixtures/quick-check/eval/leakage-prove-strong.txt
@@ -1,0 +1,2 @@
+3.3  Leakage
+Leakage due to market effects is considered zero, based on the displacement analysis in Appendix G. The assessment calculated net market leakage at 0 tCO2 using the methodology equation.

--- a/tests/fixtures/quick-check/eval/leakage-prove-weak.txt
+++ b/tests/fixtures/quick-check/eval/leakage-prove-weak.txt
@@ -1,0 +1,3 @@
+3.3  Leakage
+Leakage from market effects is treated as zero.
+Market leakage for this project activity is zero.

--- a/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
+++ b/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
@@ -324,6 +324,62 @@
         "explanationContains": "The retrieved document evidence does not directly address the question.",
         "evidenceCountMin": 1
       }
+    },
+    {
+      "id": "leakage_prove_market_zero_weak",
+      "fixture": "leakage-prove-weak.txt",
+      "input": {
+        "claimText": "Does the leakage section prove that market leakage is zero?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "unclear",
+        "explanationContains": "high-burden wording",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "leakage_prove_market_zero_strong",
+      "fixture": "leakage-prove-strong.txt",
+      "input": {
+        "claimText": "Does the leakage section prove that market leakage is zero?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "justification",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "describe_leakage_likely_yes",
+      "fixture": "leakage-semantic.txt",
+      "input": {
+        "claimText": "Does this PDD describe leakage?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "document-grounded evidence relevant to the question.",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "say_market_leakage_zero_likely_yes",
+      "fixture": "leakage-prove-weak.txt",
+      "input": {
+        "claimText": "Does the leakage section say that market leakage is zero?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "document-grounded evidence relevant to the question.",
+        "evidenceCountMin": 1
+      }
     }
   ]
 }

--- a/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
+++ b/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
@@ -380,6 +380,20 @@
         "explanationContains": "document-grounded evidence relevant to the question.",
         "evidenceCountMin": 1
       }
+    },
+    {
+      "id": "leakage_prove_heading_looks_like_justification_but_snippet_asserts_only",
+      "fixture": "leakage-prove-heading-only.txt",
+      "input": {
+        "claimText": "Does the leakage section prove that market leakage is zero?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "unclear",
+        "explanationContains": "high-burden wording",
+        "evidenceCountMin": 1
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Quick Check currently treats stronger questions (e.g., "prove that market leakage is zero") the same as simple mention questions (e.g., "describe leakage"). A statement that "leakage is zero" supports the latter but not the former, which requires justification.

This PR adds high-burden wording detection and requires justification evidence before returning `LIKELY_YES`.

## Changes

### High-burden term detection (`documentQa.ts`)
- **`HIGH_BURDEN_TERMS`**: `prove`, `confirm`, `justify`, `validate`, `sufficient evidence`, `enough evidence` (with inflections)
- **`isHighBurdenQuestion()`**: Detects these terms in `claimText`

### Justification evidence detection
- **`JUSTIFICATION_PATTERNS`**: Regex patterns for `because`, `therefore`, `based on`, `calculated`, `estimated`, `derived`, `analysis`, `assessment`, `assumption`, `methodology`, percentages, equations, etc.
- **`hasJustificationEvidence()`**: Returns `true` when evidence snippets/headings match any pattern

### Answer classification
- **`deriveAnswerStatus`**: When `highBurden=true` && `justificationEvidence=false`, demotes `likely_yes` → `unclear` in both the fallback path and the rubric-supported path
- **`buildDocumentQuestionAnswer`**: Computes flags and sets appropriate explanation: "The question uses high-burden wording and the retrieved evidence does not include supporting justification."

### Keyword cleanup
- Added high-burden terms to `keywordizeClaim` stop words so they aren't used as evidence-matching keywords

### Tests
| Test | Question | Expected | Fixture |
|------|----------|----------|---------|
| `leakage_prove_market_zero_weak` | "prove that market leakage is zero" | `unclear` | assertion-only |
| `leakage_prove_market_zero_strong` | "prove that market leakage is zero" | `likely_yes` | justification evidence |
| `describe_leakage_likely_yes` | "describe leakage" | `likely_yes` | unchanged behavior |
| `say_market_leakage_zero_likely_yes` | "say that market leakage is zero" | `likely_yes` | not high-burden |

## Acceptance criteria
- ✅ No visual/UI regression (no UI code touched)
- ✅ `describe leakage` → `LIKELY_YES`
- ✅ `say market leakage is zero` → `LIKELY_YES`
- ✅ `prove market leakage is zero` (assertion only) → `UNCLEAR`
- ✅ `prove market leakage is zero` (with justification) → `LIKELY_YES`
- ✅ Existing golden evals unchanged
- ✅ typecheck + lint + quickcheck:eval + full test suite pass