### PR TITLE
test(quick-check): messy PDF stress eval fixtures for high-burden calibration

### DIFF
--- a/tests/fixtures/quick-check/eval/assertion-only-additionality.txt
+++ b/tests/fixtures/quick-check/eval/assertion-only-additionality.txt
@@ -1,0 +1,3 @@
+3.1  Additionality
+The project passes the additionality test.
+The activity is considered additional under the methodology.

--- a/tests/fixtures/quick-check/eval/broken-heading-baseline.txt
+++ b/tests/fixtures/quick-check/eval/broken-heading-baseline.txt
@@ -1,0 +1,4 @@
+2.4
+Baseline Scenario
+The baseline scenario is the most likely land-use scenario in the absence of the project activity.
+Historical deforestation rates from satellite imagery show a 1.2% annual loss in the reference region.

--- a/tests/fixtures/quick-check/eval/irrelevant-methodology-leakage.txt
+++ b/tests/fixtures/quick-check/eval/irrelevant-methodology-leakage.txt
@@ -1,0 +1,3 @@
+3.3  Leakage
+The methodology VM0007 provides the equation for baseline emission reduction calculations.
+The assessment method is described in the module.

--- a/tests/fixtures/quick-check/eval/justification-leakage.txt
+++ b/tests/fixtures/quick-check/eval/justification-leakage.txt
@@ -1,0 +1,3 @@
+3.3  Leakage
+Leakage due to market effects is considered zero, based on the displacement analysis in Appendix G.
+The assessment calculated net market leakage at 0 tCO2 using the methodology equation.

--- a/tests/fixtures/quick-check/eval/ocr-noisy-leakage.txt
+++ b/tests/fixtures/quick-check/eval/ocr-noisy-leakage.txt
@@ -1,0 +1,3 @@
+3.3  Leakage
+Leakage from rnarket effects is treated as zero.
+Market 1eakage for this project activity is zero.

--- a/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
+++ b/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
@@ -394,6 +394,160 @@
         "explanationContains": "high-burden wording",
         "evidenceCountMin": 1
       }
+    },
+    {
+      "id": "ocr_noisy_prove_market_zero",
+      "fixture": "ocr-noisy-leakage.txt",
+      "input": {
+        "claimText": "Does the leakage section prove that market leakage is zero?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "unclear",
+        "explanationContains": "high-burden wording",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "ocr_noisy_say_market_zero",
+      "fixture": "ocr-noisy-leakage.txt",
+      "input": {
+        "claimText": "Does the leakage section say that market leakage is zero?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "document-grounded evidence relevant to the question.",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "broken_heading_justify_baseline_scenario",
+      "fixture": "broken-heading-baseline.txt",
+      "input": {
+        "claimText": "Does the PDD justify the baseline scenario?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "justification",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "broken_heading_describe_baseline",
+      "fixture": "broken-heading-baseline.txt",
+      "input": {
+        "claimText": "Does this PDD describe baseline scenario?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "document-grounded evidence relevant to the question.",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "repeated_headers_prove_market_zero",
+      "fixture": "repeated-headers-leakage.txt",
+      "input": {
+        "claimText": "Does the leakage section prove that market leakage is zero?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "justification",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "repeated_headers_say_market_zero",
+      "fixture": "repeated-headers-leakage.txt",
+      "input": {
+        "claimText": "Does the leakage section say that market leakage is zero?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "document-grounded evidence relevant to the question.",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "assertion_additionality_sufficient_evidence",
+      "fixture": "assertion-only-additionality.txt",
+      "input": {
+        "claimText": "Does the document provide sufficient evidence for additionality?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "unclear",
+        "explanationContains": "does not directly address",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "assertion_additionality_describe",
+      "fixture": "assertion-only-additionality.txt",
+      "input": {
+        "claimText": "Does this PDD describe additionality?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "document-grounded evidence relevant to the question.",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "justification_leakage_validate_market_zero",
+      "fixture": "justification-leakage.txt",
+      "input": {
+        "claimText": "Does the leakage section validate that market leakage is zero?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "justification",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "irrelevant_methodology_prove_market_zero",
+      "fixture": "irrelevant-methodology-leakage.txt",
+      "input": {
+        "claimText": "Does the leakage section prove that market leakage is zero?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "unclear",
+        "explanationContains": "does not directly address",
+        "evidenceCountMin": 1
+      }
+    },
+    {
+      "id": "irrelevant_methodology_describe_leakage",
+      "fixture": "irrelevant-methodology-leakage.txt",
+      "input": {
+        "claimText": "Does this PDD describe leakage?",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "1.0"
+      },
+      "expected": {
+        "status": "likely_yes",
+        "explanationContains": "document-grounded evidence relevant to the question.",
+        "evidenceCountMin": 1
+      }
     }
   ]
 }

--- a/tests/fixtures/quick-check/eval/repeated-headers-leakage.txt
+++ b/tests/fixtures/quick-check/eval/repeated-headers-leakage.txt
@@ -1,0 +1,8 @@
+Page 1 of 3
+Project Description Document
+VM0007 Version 1.0
+3.3  Leakage
+Page 2 of 3
+Leakage due to market effects is considered zero, based on the displacement analysis.
+The assessment calculated net market leakage at 0 tCO2.
+Page 3 of 3


### PR DESCRIPTION
## Summary

Add 6 messy real-world PDD extraction fixture files and 11 golden eval cases to stress-test the high-burden calibration from PR #706 against realistic PDF extraction issues.

No source code changed — this is a **test-only** PR.

## Fixtures

| Fixture | Simulated issue |
|---|---|
| `ocr-noisy-leakage.txt` | OCR artifacts (rn→m, 1→l) in body text |
| `broken-heading-baseline.txt` | Section number and title on separate lines (parser fallback) |
| `repeated-headers-leakage.txt` | Page headers/footers mixed in (filtered by `stripHeaderFooterNoise`) |
| `assertion-only-additionality.txt` | Body only asserts the claim, no justification |
| `justification-leakage.txt` | Body with real justification (analysis, calculated, equation) |
| `irrelevant-methodology-leakage.txt` | Text has methodology keywords but doesn't answer the question |

## Eval cases (11 new, 41 total)

| Test | Question | Expected |
|---|---|---|
| `ocr_noisy_prove_market_zero` | prove (OCR body, no justification) | UNCLEAR |
| `ocr_noisy_say_market_zero` | say (OCR body, relevant) | LIKELY_YES |
| `broken_heading_justify_baseline_scenario` | justify (broken heading, calc data) | LIKELY_YES |
| `broken_heading_describe_baseline` | describe (broken heading) | LIKELY_YES |
| `repeated_headers_prove_market_zero` | prove (with justification) | LIKELY_YES |
| `repeated_headers_say_market_zero` | say (headers stripped) | LIKELY_YES |
| `assertion_additionality_sufficient_evidence` | sufficient evidence (irrelevant) | UNCLEAR |
| `assertion_additionality_describe` | describe (relevant) | LIKELY_YES |
| `justification_leakage_validate_market_zero` | validate (with justification) | LIKELY_YES |
| `irrelevant_methodology_prove_market_zero` | prove (irrelevant evidence) | UNCLEAR |
| `irrelevant_methodology_describe_leakage` | describe (relevant heading) | LIKELY_YES |

## Validation
- No source code changes
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run quickcheck:eval` — 41/41 ✅
- `npm test` — 134/134 suites, 1137/1137 ✅