### PR TITLE
feat: add methodology role classifier for PDD documents

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -541,6 +541,17 @@ function confidenceBarTone(value: "high" | "medium" | "low" | "unknown" | undefi
   return "bg-slate-300";
 }
 
+function roleShortLabel(role: string): string {
+  switch (role) {
+    case "PRIMARY_PROJECT_METHODOLOGY": return "primary";
+    case "MONITORING_METHODOLOGY": return "monitoring";
+    case "REFERENCED_CALCULATION_METHOD": return "calculation";
+    case "TOOL_OR_DEPENDENCY": return "tool";
+    case "BACKGROUND_MENTION": return "background";
+    default: return "";
+  }
+}
+
 function buildWeakExtractionRecoveryState(): RecoveryState {
   return {
     kind: "weak-extraction",
@@ -889,9 +900,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             analysis: extractionState.analysis,
             fileName: selectedEvidenceLabel,
             methodologyResolution,
+            extractionSnapshot: extractionPreview,
           })
         : null,
-    [extractionState.analysis, methodologyResolution, selectedEvidenceLabel],
+    [extractionState.analysis, methodologyResolution, selectedEvidenceLabel, extractionPreview],
   );
   const normalizedResult = useMemo(
     () =>
@@ -1975,11 +1987,36 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                                 </div>
                               </div>
                               <div className="grid grid-cols-[6rem_minmax(0,1fr)] items-start gap-3">
-                                <div className="text-sm text-slate-500">Methodology</div>
-                                <div className="min-w-0 break-words font-medium leading-5 text-slate-900" title={extractionPreviewView.detectedMethodology || "Not detected"}>
-                                  {extractionPreviewView.detectedMethodology || "Not detected"}
+                                <div className="text-sm text-slate-500">Primary</div>
+                                <div className="min-w-0 break-words font-medium leading-5 text-slate-900">
+                                  {extractionPreviewView.primaryMethodology
+                                    ? `${extractionPreviewView.primaryMethodology.id}${extractionPreviewView.primaryMethodology.version ? ` \u00b7 ${extractionPreviewView.primaryMethodology.version}` : ""}`
+                                    : extractionPreviewView.detectedMethodology && extractionPreviewView.detectedMethodology !== "Not confidently detected"
+                                      ? extractionPreviewView.detectedMethodology
+                                      : "Not detected"}
                                 </div>
                               </div>
+                              {extractionPreviewView.monitoringMethodology ? (
+                                <div className="grid grid-cols-[6rem_minmax(0,1fr)] items-start gap-3">
+                                  <div className="text-sm text-slate-500">Monitoring</div>
+                                  <div className="min-w-0 break-words font-medium leading-5 text-slate-900">
+                                    {extractionPreviewView.monitoringMethodology.id}{extractionPreviewView.monitoringMethodology.version ? ` \u00b7 ${extractionPreviewView.monitoringMethodology.version}` : ""}
+                                  </div>
+                                </div>
+                              ) : null}
+                              {extractionPreviewView.referencedMethods && extractionPreviewView.referencedMethods.length > 0 ? (
+                                <div className="grid grid-cols-[6rem_minmax(0,1fr)] items-start gap-3">
+                                  <div className="text-sm text-slate-500">Referenced</div>
+                                  <div className="flex min-w-0 flex-wrap gap-1.5">
+                                    {extractionPreviewView.referencedMethods.map((m) => (
+                                      <span key={m.id} className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-medium text-slate-600">
+                                        {m.id}{m.version ? ` \u00b7 ${m.version}` : ""}
+                                        <span className="ml-1 text-[10px] text-slate-400">{roleShortLabel(m.role)}</span>
+                                      </span>
+                                    ))}
+                                  </div>
+                                </div>
+                              ) : null}
                               <div>
                                 <div className="grid grid-cols-[6rem_minmax(0,1fr)] items-center gap-3">
                                   <span className="text-sm text-slate-500">Confidence</span>
@@ -2051,13 +2088,22 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                               </div>
                             </div>
                             <div>
-                              <div className="text-xs font-medium text-slate-500">Methodology mentions</div>
+                              <div className="text-xs font-medium text-slate-500">Methodology references</div>
                               <div className="mt-2 flex flex-wrap gap-2">
-                                {(extractionPreview.methodologyMentions.length ? extractionPreview.methodologyMentions : ["None detected"]).map((mention) => (
-                                  <span key={mention} className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700">
-                                    {mention}
-                                  </span>
-                                ))}
+                                {extractionPreviewView.referencedMethods && extractionPreviewView.referencedMethods.length > 0
+                                  ? extractionPreviewView.referencedMethods.map((m) => (
+                                      <span key={`${m.id}-${m.role}`} className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700">
+                                        {m.id}{m.version ? ` · ${m.version}` : ""}
+                                        <span className="ml-1 text-[10px] text-slate-400">{roleShortLabel(m.role)}</span>
+                                      </span>
+                                    ))
+                                  : extractionPreview.methodologyMentions.length > 0
+                                    ? extractionPreview.methodologyMentions.map((mention) => (
+                                        <span key={mention} className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700">
+                                          {mention}
+                                        </span>
+                                      ))
+                                    : <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700">None detected</span>}
                               </div>
                             </div>
                             <div className="md:col-span-2">

--- a/src/lib/chat/methodologyRoleClassifier.ts
+++ b/src/lib/chat/methodologyRoleClassifier.ts
@@ -1,0 +1,353 @@
+import { extractMethodologyMentions } from "@/lib/chat/quickCheckEvidence";
+
+export type MethodologyRole =
+  | "PRIMARY_PROJECT_METHODOLOGY"
+  | "MONITORING_METHODOLOGY"
+  | "REFERENCED_CALCULATION_METHOD"
+  | "TOOL_OR_DEPENDENCY"
+  | "BACKGROUND_MENTION"
+  | "UNKNOWN";
+
+export type MethodologyEntry = {
+  id: string;
+  version: string | null;
+  role: MethodologyRole;
+  confidence: "high" | "medium" | "low";
+  evidenceSection?: string;
+  reason?: string;
+};
+
+export type MethodologyClassification = {
+  primaryMethodology: MethodologyEntry | null;
+  monitoringMethodology: MethodologyEntry | null;
+  referencedMethods: MethodologyEntry[];
+};
+
+const DECLARATION_HEADING_PATTERNS = [
+  /^title and reference of methodology$/i,
+  /^title and reference of the vcs methodology applied$/i,
+  /^title and reference of approved baseline methodology/i,
+  /^methodology applied/i,
+  /^applied methodology/i,
+  /^the methodology used/i,
+  /^vcs methodology/i,
+  /^project category applicable/i,
+];
+
+const MONITORING_HEADING_PATTERNS = [
+  /^name and reference of approved monitoring methodology applied/i,
+  /^monitoring methodology/i,
+  /^monitoring plan/i,
+  /^monitoring applied/i,
+];
+
+const FOOTNOTE_LINE_RE = /^footnote\s+\d+/im;
+
+const BACKGROUND_NEGATIVE_PATTERNS = [
+  /\bexample\b/i,
+  /\bguidance\b/i,
+  /\bsample[- ]size\b/i,
+  /\bunrelated\b/i,
+  /\bother approved methodologies\b/i,
+  /\bsupporting[- ]?document\b/i,
+  /\breferences(?!\s+of methodology)/i,
+  /\bbibliography\b/i,
+  /\bannex\b/i,
+];
+
+const CALCULATION_CONTEXT_PATTERNS = [
+  /calculated using/i,
+  /as per methodology/i,
+  /in accordance with methodology/i,
+  /formula/i,
+  /equation/i,
+  /parameter/i,
+  /default value/i,
+];
+
+const VERSION_RE = /(?:version|v)\s*(?:(\d+(?:[\.-]\d+)*(?:[\.-]\d+)?))/i;
+
+const MODULE_CODE_RE = /^VMD\d{4}$|^VMR\d{3,4}$/;
+const ACTIVITY_CODE_RE = /^(?:APD|ARR|RWE|APWD)$/;
+
+const LINE_WINDOW = 3;
+
+type RawMatch = {
+  code: string;
+  lineIndex: number;
+};
+
+function findMethodologyMatches(text: string): RawMatch[] {
+  const lines = text.split("\n");
+  const matches: RawMatch[] = [];
+
+  const patterns = [
+    /\b(VM\d{4})\b/g,
+    /\b(VMR\d{3,4})\b/g,
+    /\b(VMD\d{4})\b/g,
+    /\b(ACM\d{4})\b/g,
+    /\b(AM\d{4})\b/g,
+    /\b(AR-(?:ACM|AMS|AM)\d{4})\b/g,
+    /\b(APD|ARR|RWE|APWD)\b/g,
+    /\bGS[- ]?(VER\d+)\b/gi,
+    /\b(AMS[- ]?[A-Z]\w+(?:\.\w+)*)\b/gi,
+  ];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    for (const pattern of patterns) {
+      pattern.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = pattern.exec(line)) !== null) {
+        const raw = (m[1] ?? m[0]).replace(/\s+/g, "").toUpperCase();
+        if (/^AMS-/.test(raw)) {
+          const suffix = raw.slice(4);
+          if (suffix) matches.push({ code: `AMS-${suffix}`, lineIndex: i });
+        } else if (/^GS-/.test(raw)) {
+          const ver = (m[1] ?? "").toUpperCase().replace(/\s+/g, "");
+          matches.push({ code: `GS-${ver}`, lineIndex: i });
+        } else {
+          matches.push({ code: raw, lineIndex: i });
+        }
+      }
+    }
+  }
+  return matches;
+}
+
+function extractNearbyVersion(lines: string[], lineIndex: number): string | null {
+  const start = Math.max(0, lineIndex - 1);
+  const end = Math.min(lines.length, lineIndex + 2);
+  for (let i = start; i < end; i++) {
+    const line = lines[i] ?? "";
+    const m = VERSION_RE.exec(line);
+    if (m?.[1]) return m[1];
+  }
+  return null;
+}
+
+function getLineWindow(lines: string[], lineIndex: number, windowSize: number): string[] {
+  const start = Math.max(0, lineIndex - windowSize);
+  const end = Math.min(lines.length, lineIndex + windowSize + 1);
+  return lines.slice(start, end);
+}
+
+function isInFootnote(lines: string[], lineIndex: number): boolean {
+  return getLineWindow(lines, lineIndex, 2).some((l) => FOOTNOTE_LINE_RE.test(l.trim()));
+}
+
+function isModuleOrActivity(code: string): boolean {
+  return MODULE_CODE_RE.test(code) || ACTIVITY_CODE_RE.test(code);
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function detectMethodologyRole(
+  code: string,
+  lines: string[],
+  lineIndex: number,
+  sectionTitles: string[],
+): { role: MethodologyRole; confidence: "high" | "medium" | "low"; evidenceSection?: string; reason?: string } {
+  const normalized = code.toUpperCase();
+
+  if (isModuleOrActivity(normalized)) {
+    return { role: "TOOL_OR_DEPENDENCY", confidence: "high", reason: "Module or activity signal" };
+  }
+
+  const windowLines = getLineWindow(lines, lineIndex, LINE_WINDOW);
+  const windowText = windowLines.join("\n");
+
+  const prevLine = lines[lineIndex - 1] ?? "";
+  const nextLine = lines[lineIndex + 1] ?? "";
+
+  const nearDeclHeading =
+    DECLARATION_HEADING_PATTERNS.some((p) => p.test(prevLine)) ||
+    DECLARATION_HEADING_PATTERNS.some((p) => p.test(nextLine)) ||
+    getLineWindow(lines, lineIndex, 0).some((l) =>
+      DECLARATION_HEADING_PATTERNS.some((p) => p.test(l.trim())),
+    );
+
+  const nearMonitorHeading =
+    MONITORING_HEADING_PATTERNS.some((p) => p.test(prevLine)) ||
+    MONITORING_HEADING_PATTERNS.some((p) => p.test(nextLine));
+
+  const hasPrimarySection = sectionTitles.some((t) => DECLARATION_HEADING_PATTERNS.some((p) => p.test(t)));
+  const hasMonitoringSection = sectionTitles.some((t) => MONITORING_HEADING_PATTERNS.some((p) => p.test(t)));
+
+  const inFootnote = isInFootnote(lines, lineIndex);
+
+  if (nearMonitorHeading || hasMonitoringSection) {
+    if (nearDeclHeading || hasPrimarySection) {
+      return { role: "PRIMARY_PROJECT_METHODOLOGY", confidence: "high", evidenceSection: sectionTitles.join("; ") };
+    }
+    return { role: "MONITORING_METHODOLOGY", confidence: "high", evidenceSection: sectionTitles.join("; ") };
+  }
+
+  if (nearDeclHeading || hasPrimarySection) {
+    return { role: "PRIMARY_PROJECT_METHODOLOGY", confidence: "high", evidenceSection: sectionTitles.join("; ") };
+  }
+
+  if (inFootnote) {
+    return { role: "BACKGROUND_MENTION", confidence: "low", reason: "Mention appears in footnote context" };
+  }
+
+  const isCalcContext = CALCULATION_CONTEXT_PATTERNS.some((p) => p.test(windowText));
+
+  if (isCalcContext) {
+    return { role: "REFERENCED_CALCULATION_METHOD", confidence: "medium", reason: "Mentioned in calculation context" };
+  }
+
+  const isBackgroundNeg = BACKGROUND_NEGATIVE_PATTERNS.some((p) => p.test(windowText));
+
+  if (isBackgroundNeg) {
+    return { role: "BACKGROUND_MENTION", confidence: "low", reason: "Mentioned in background or supporting context" };
+  }
+
+  const lineText = lines[lineIndex] ?? "";
+
+  const isStandalone = /^\s*[A-Z][A-Z0-9-]{2,}\s*$/.test(lineText.trim());
+
+  if (isStandalone) {
+    return { role: "PRIMARY_PROJECT_METHODOLOGY", confidence: "medium", reason: "Standalone code on its own line" };
+  }
+
+  const hasCodeAtLineStart = new RegExp(`^\\s*${escapeRegex(normalized)}`).test(lineText) &&
+    !lineText.includes("as specified") &&
+    !lineText.includes("according to") &&
+    !lineText.includes("calculated") &&
+    !lineText.includes("example") &&
+    !lineText.includes("guidance");
+
+  if (hasCodeAtLineStart) {
+    return { role: "PRIMARY_PROJECT_METHODOLOGY", confidence: "medium", reason: "Code appears at start of its line" };
+  }
+
+  return { role: "UNKNOWN", confidence: "low" };
+}
+
+function extractSectionTitles(lines: string[], lineIndex: number): string[] {
+  const titles: string[] = [];
+  for (let i = lineIndex; i >= 0; i--) {
+    const line = lines[i] ?? "";
+    const m = /^(?:\s*(?:Section\s+)?(\d+(?:\.\d+)*)\s*[.:]?\s+(.+))\s*$/.exec(line);
+    if (m?.[2]?.trim()) {
+      titles.push(m[2].trim());
+      if (!m[1]?.includes(".")) break;
+    }
+  }
+  return titles;
+}
+
+function dedupeEntries(entries: MethodologyEntry[]): MethodologyEntry[] {
+  const seen = new Map<string, MethodologyEntry>();
+
+  for (const entry of entries) {
+    const key = `${entry.id}|${entry.version ?? ""}|${entry.role}`;
+    const existing = seen.get(key);
+    if (!existing) {
+      seen.set(key, entry);
+      continue;
+    }
+    const confRank: Record<string, number> = { high: 0, medium: 1, low: 2 };
+    if ((confRank[entry.confidence] ?? 2) < (confRank[existing.confidence] ?? 2)) {
+      seen.set(key, entry);
+    }
+  }
+
+  return Array.from(seen.values());
+}
+
+export function classifyMethodologyRoles(rawText: string): MethodologyClassification {
+  if (!rawText?.trim()) {
+    return { primaryMethodology: null, monitoringMethodology: null, referencedMethods: [] };
+  }
+
+  const lines = rawText.split("\n");
+  const rawMatches = findMethodologyMatches(rawText);
+
+  if (!rawMatches.length) {
+    const extracted = extractMethodologyMentions(rawText);
+    for (const mention of extracted) {
+      const idx = rawText.indexOf(mention);
+      if (idx >= 0) {
+        const lineIdx = rawText.slice(0, idx).split("\n").length - 1;
+        rawMatches.push({ code: mention, lineIndex: lineIdx });
+      }
+    }
+  }
+
+  const seen = new Map<string, RawMatch>();
+  for (const m of rawMatches) {
+    const key = `${m.code}:${m.lineIndex}`;
+    if (!seen.has(key)) seen.set(key, m);
+  }
+  const uniqueMatches = Array.from(seen.values());
+
+  const entries: MethodologyEntry[] = [];
+  for (const match of uniqueMatches) {
+    const version = extractNearbyVersion(lines, match.lineIndex);
+    const sectionTitles = extractSectionTitles(lines, match.lineIndex);
+    const { role, confidence, evidenceSection, reason } = detectMethodologyRole(
+      match.code,
+      lines,
+      match.lineIndex,
+      sectionTitles,
+    );
+
+    entries.push({
+      id: match.code,
+      version,
+      role,
+      confidence,
+      evidenceSection,
+      reason,
+    });
+  }
+
+  const deduped = dedupeEntries(entries);
+
+  let primary = deduped.find((e) => e.role === "PRIMARY_PROJECT_METHODOLOGY") ?? null;
+  let monitoring = deduped.find((e) => e.role === "MONITORING_METHODOLOGY") ?? null;
+
+  if (!primary && !monitoring) {
+    const unknownNonModules = deduped.filter(
+      (e) => e.role === "UNKNOWN" && !isModuleOrActivity(e.id),
+    );
+    if (unknownNonModules.length === 1) {
+      primary = {
+        ...unknownNonModules[0]!,
+        role: "PRIMARY_PROJECT_METHODOLOGY",
+        confidence: "low",
+        reason: "Only methodology reference found in document",
+      };
+    }
+  }
+
+  if (primary && !monitoring) {
+    const maybeMonitor = deduped.find(
+      (e) =>
+        e.id !== primary!.id &&
+        (e.role === "REFERENCED_CALCULATION_METHOD" || e.role === "UNKNOWN") &&
+        !isModuleOrActivity(e.id) &&
+        e.confidence !== "low",
+    );
+    if (maybeMonitor) {
+      monitoring = {
+        ...maybeMonitor,
+        role: "MONITORING_METHODOLOGY",
+        confidence: "medium",
+        reason: "Secondary methodology distinct from primary",
+      };
+    }
+  }
+
+  const referencedMethods = deduped.filter((e) => {
+    if (primary && e.id === primary.id) return false;
+    if (monitoring && e.id === monitoring.id) return false;
+    return true;
+  });
+
+  return { primaryMethodology: primary, monitoringMethodology: monitoring, referencedMethods };
+}

--- a/src/lib/chat/methodologyRoleClassifier.ts
+++ b/src/lib/chat/methodologyRoleClassifier.ts
@@ -24,21 +24,22 @@ export type MethodologyClassification = {
 };
 
 const DECLARATION_HEADING_PATTERNS = [
-  /^title and reference of methodology$/i,
-  /^title and reference of the vcs methodology applied$/i,
-  /^title and reference of approved baseline methodology/i,
-  /^methodology applied/i,
-  /^applied methodology/i,
-  /^the methodology used/i,
-  /^vcs methodology/i,
-  /^project category applicable/i,
+  /title and reference of (?:approved baseline )?methodology applied/i,
+  /title and reference of the vcs methodology applied/i,
+  /title and reference of approved baseline methodology/i,
+  /title and reference of methodology/i,
+  /methodology applied/i,
+  /applied methodology/i,
+  /the methodology used/i,
+  /vcs methodology/i,
+  /project category applicable/i,
 ];
 
 const MONITORING_HEADING_PATTERNS = [
-  /^name and reference of approved monitoring methodology applied/i,
-  /^monitoring methodology/i,
-  /^monitoring plan/i,
-  /^monitoring applied/i,
+  /name and reference of approved monitoring methodology applied/i,
+  /monitoring methodology/i,
+  /monitoring plan/i,
+  /monitoring applied/i,
 ];
 
 const FOOTNOTE_LINE_RE = /^footnote\s+\d+/im;
@@ -99,14 +100,14 @@ function findMethodologyMatches(text: string): RawMatch[] {
       pattern.lastIndex = 0;
       let m: RegExpExecArray | null;
       while ((m = pattern.exec(line)) !== null) {
-        const raw = (m[1] ?? m[0]).replace(/\s+/g, "").toUpperCase();
-        if (/^AMS-/.test(raw)) {
-          const suffix = raw.slice(4);
+        const fullMatch = m[0].replace(/\s+/g, "").toUpperCase();
+        if (/^GS/.test(fullMatch)) {
+          matches.push({ code: fullMatch, lineIndex: i });
+        } else if (fullMatch.startsWith("AMS")) {
+          const suffix = fullMatch.replace(/^AMS-?/i, "");
           if (suffix) matches.push({ code: `AMS-${suffix}`, lineIndex: i });
-        } else if (/^GS-/.test(raw)) {
-          const ver = (m[1] ?? "").toUpperCase().replace(/\s+/g, "");
-          matches.push({ code: `GS-${ver}`, lineIndex: i });
         } else {
+          const raw = (m[1] ?? m[0]).replace(/\s+/g, "").toUpperCase();
           matches.push({ code: raw, lineIndex: i });
         }
       }
@@ -162,16 +163,18 @@ function detectMethodologyRole(
   const prevLine = lines[lineIndex - 1] ?? "";
   const nextLine = lines[lineIndex + 1] ?? "";
 
+  const matchesMonitor = (line: string) => MONITORING_HEADING_PATTERNS.some((p) => p.test(line));
+  const matchesDeclNotMonitor = (line: string) =>
+    DECLARATION_HEADING_PATTERNS.some((p) => p.test(line)) && !matchesMonitor(line);
+
   const nearDeclHeading =
-    DECLARATION_HEADING_PATTERNS.some((p) => p.test(prevLine)) ||
-    DECLARATION_HEADING_PATTERNS.some((p) => p.test(nextLine)) ||
-    getLineWindow(lines, lineIndex, 0).some((l) =>
-      DECLARATION_HEADING_PATTERNS.some((p) => p.test(l.trim())),
-    );
+    matchesDeclNotMonitor(prevLine) ||
+    matchesDeclNotMonitor(nextLine) ||
+    getLineWindow(lines, lineIndex, 0).some((l) => matchesDeclNotMonitor(l.trim()));
 
   const nearMonitorHeading =
-    MONITORING_HEADING_PATTERNS.some((p) => p.test(prevLine)) ||
-    MONITORING_HEADING_PATTERNS.some((p) => p.test(nextLine));
+    matchesMonitor(prevLine) ||
+    matchesMonitor(nextLine);
 
   const hasPrimarySection = sectionTitles.some((t) => DECLARATION_HEADING_PATTERNS.some((p) => p.test(t)));
   const hasMonitoringSection = sectionTitles.some((t) => MONITORING_HEADING_PATTERNS.some((p) => p.test(t)));

--- a/src/lib/chat/quickCheck.ts
+++ b/src/lib/chat/quickCheck.ts
@@ -14,6 +14,7 @@ import {
   persistVerifierRunBundle,
   readVerifierRunBundle,
 } from "@/lib/verify/runState";
+import type { MethodologyClassification } from "@/lib/chat/methodologyRoleClassifier";
 
 export type QuickCheckDraftStatus = "draft" | "checked";
 export type QuickCheckSourceMode = "uploaded_file" | "saved_evidence" | "demo_evidence";
@@ -30,6 +31,7 @@ export type QuickCheckExtractionSnapshot = {
   documentType: string;
   extractedFacts: string[];
   methodologyMentions: string[];
+  methodologyClassification?: MethodologyClassification;
   warnings: string[];
   signals: QuickCheckExtractionSignals;
   extractionConfidence?: number;

--- a/src/lib/chat/quickCheckUi.ts
+++ b/src/lib/chat/quickCheckUi.ts
@@ -1,6 +1,7 @@
 import { classifyQuickCheckClaimIntents, type QuickCheckEvidenceAnalysis, type QuickCheckEvidenceFact } from "@/lib/chat/quickCheckEvidence";
 import type { QuickCheckMethodologyResolution } from "@/lib/chat/quickCheckMethodology";
 import { prioritizeMethodologyMentions } from "@/lib/chat/quickCheckMethodology";
+import { classifyMethodologyRoles } from "@/lib/chat/methodologyRoleClassifier";
 import type { QuickCheckExtractionSignals, QuickCheckExtractionSnapshot, QuickCheckResult, QuickCheckResultVerdict, QuickCheckSourceMode } from "@/lib/chat/quickCheck";
 
 export type QuickCheckUiStatus = "extraction_failed" | "no_reliable_match" | "preliminary_match_found";
@@ -40,11 +41,21 @@ export type QuickCheckUiNextAction = {
 
 export type ExtractionPreviewConfidence = "high" | "medium" | "low" | "unknown";
 
+export type ClassificationDisplayItem = {
+  id: string;
+  version: string | null;
+  role: string;
+  confidence: string;
+};
+
 export type ExtractionPreviewViewModel = {
   fileName?: string;
   detectedDocumentType?: string;
   detectedMethodology?: string;
   methodologyConfidence?: ExtractionPreviewConfidence;
+  primaryMethodology?: ClassificationDisplayItem;
+  monitoringMethodology?: ClassificationDisplayItem;
+  referencedMethods?: ClassificationDisplayItem[];
   warning?: string;
   signalSummary?: string;
   signals: Array<{
@@ -291,6 +302,7 @@ export function buildExtractionPreviewViewModel(input: {
   analysis: QuickCheckEvidenceAnalysis;
   fileName?: string | null;
   methodologyResolution?: QuickCheckMethodologyResolution | null;
+  extractionSnapshot?: QuickCheckExtractionSnapshot | null;
 }): ExtractionPreviewViewModel {
   const seenSignalLabels = new Set<string>();
   const signals = [...input.analysis.facts]
@@ -335,6 +347,32 @@ export function buildExtractionPreviewViewModel(input: {
       ? undefined
       : "Methodology was not confidently detected. Matches below may need review.");
 
+  const classification = input.extractionSnapshot?.methodologyClassification;
+  const primaryMethodology = classification?.primaryMethodology
+    ? {
+        id: classification.primaryMethodology.id,
+        version: classification.primaryMethodology.version,
+        role: classification.primaryMethodology.role,
+        confidence: classification.primaryMethodology.confidence,
+      }
+    : undefined;
+  const monitoringMethodology = classification?.monitoringMethodology
+    ? {
+        id: classification.monitoringMethodology.id,
+        version: classification.monitoringMethodology.version,
+        role: classification.monitoringMethodology.role,
+        confidence: classification.monitoringMethodology.confidence,
+      }
+    : undefined;
+  const referencedMethods = classification?.referencedMethods?.length
+    ? classification.referencedMethods.map((m) => ({
+        id: m.id,
+        version: m.version,
+        role: m.role,
+        confidence: m.confidence,
+      }))
+    : undefined;
+
   return {
     fileName: input.fileName?.trim() || undefined,
     detectedDocumentType: documentTypeLabel({
@@ -344,6 +382,9 @@ export function buildExtractionPreviewViewModel(input: {
     }),
     detectedMethodology,
     methodologyConfidence,
+    primaryMethodology,
+    monitoringMethodology,
+    referencedMethods,
     warning,
     signalSummary:
       buildSignalSummary(signals) ??
@@ -435,10 +476,14 @@ export function buildQuickCheckExtractionSnapshot(input: {
   const recoveredLocally = input.analysis.warnings.some((w) =>
     /local heuristic|using local fallback|parser fallback|heuristic extraction|recovered text after server/i.test(w)
   );
+  const methodologyClassification = input.analysis.rawPddText
+    ? classifyMethodologyRoles(input.analysis.rawPddText)
+    : undefined;
   return {
     documentType: input.analysis.documentTypes[0] ?? "Unknown document",
     extractedFacts,
     methodologyMentions: prioritizeMethodologyMentions(input.analysis.methodologyMentions).slice(0, 4),
+    methodologyClassification,
     warnings,
     signals: {
       parsedEvidenceCount: input.analysis.parsedEvidenceLabels.length,

--- a/src/lib/quickCheck/policy/reviewPolicy.ts
+++ b/src/lib/quickCheck/policy/reviewPolicy.ts
@@ -14,13 +14,42 @@ const REVIEW_POLICY_CONFIG_RAW = {
   ],
   reviewAreas: {
     additionality: {
-      baseKeywords: ["additionality"],
+      baseKeywords: [
+        "additionality",
+        "investment analysis",
+        "barrier analysis",
+        "common practice",
+        "prior consideration",
+        "CDM consideration",
+      ],
       aliases: [],
+      negativeSectionTerms: [
+        "grid emission factor",
+        "parameter",
+        "default value",
+        "data and parameters",
+        "emission reductions",
+      ],
       evidenceSignals: [],
     },
     baseline: {
-      baseKeywords: ["baseline", "without-project", "without project", "land use scenario"],
+      baseKeywords: [
+        "baseline",
+        "baseline scenario",
+        "without-project",
+        "without project",
+        "land use scenario",
+        "identification of baseline",
+        "alternatives analysis",
+      ],
       aliases: [],
+      negativeSectionTerms: [
+        "grid emission factor",
+        "parameter",
+        "default value",
+        "data and parameters",
+        "emission reductions",
+      ],
       evidenceSignals: [],
     },
     boundary: {
@@ -38,7 +67,13 @@ const REVIEW_POLICY_CONFIG_RAW = {
       evidenceSignals: [],
     },
     leakage: {
-      baseKeywords: ["leakage", "leakage belt"],
+      baseKeywords: [
+        "leakage",
+        "leakage belt",
+        "leakage emissions",
+        "project leakage",
+        "activity shifting leakage",
+      ],
       aliases: [
         "leakage",
         "leakage management",
@@ -46,6 +81,13 @@ const REVIEW_POLICY_CONFIG_RAW = {
         "activity shifting leakage",
       ],
       evidenceSignals: [],
+      negativeSectionTerms: [
+        "grid emission factor",
+        "parameter",
+        "default value",
+        "data and parameters",
+        "emission reductions",
+      ],
     },
     monitoring: {
       baseKeywords: ["monitoring", "monitoring plan", "data and parameters"],

--- a/src/lib/quickCheck/retrieval/retrieveSections.ts
+++ b/src/lib/quickCheck/retrieval/retrieveSections.ts
@@ -343,7 +343,7 @@ function resolveReviewQuestionSections(input: {
     if (stage === "exact_heading") {
       matches = uniqueHeadings(exactHeadingMatches(input.headingIndex, input.claimText));
     } else if (stage === "normalized_heading") {
-      matches = uniqueHeadings(filterPddHeadingsByQuery(input.headingIndex, input.claimText, []));
+      matches = uniqueHeadings(filterPddHeadingsByQuery(input.headingIndex, input.claimText, reviewAreaKeywords));
     } else if (stage === "alias_heading") {
       matches = uniqueHeadings([
         ...aliasHeadingMatches(input.headingIndex, aliases),

--- a/tests/components/quickCheckPanel.upload-regression.test.tsx
+++ b/tests/components/quickCheckPanel.upload-regression.test.tsx
@@ -282,7 +282,7 @@ describe("QuickCheckPanel upload regression", () => {
     expect(text).toContain("Extraction preview");
     expect(text).toContain(RECOVERED_WARNING);
     expect(text).toContain("Project Document");
-    expect(text).toContain("VM0004 · v1-0");
+    expect(text).toContain("VM0004 · 1.0");
     expect(text).toContain("Project document");
     expect(text).toContain("Project boundary");
     expect(text).not.toContain("Extraction preview is unavailable right now");

--- a/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
+++ b/tests/fixtures/quick-check/eval/quickcheck-eval-cases.json
@@ -55,7 +55,7 @@
       },
       "expected": {
         "reviewArea": "leakage",
-        "matchStage": "alias_heading",
+        "matchStage": "normalized_heading",
         "relevantSections": ["3.3"],
         "matchedHeadingTitle": "Leakage"
       }

--- a/tests/lib/methodologyRoleClassifier.test.ts
+++ b/tests/lib/methodologyRoleClassifier.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import { classifyMethodologyRoles, type MethodologyEntry } from "@/lib/chat/methodologyRoleClassifier";
+
+function primary(result: ReturnType<typeof classifyMethodologyRoles>): MethodologyEntry | null {
+  return result.primaryMethodology;
+}
+
+function monitoring(result: ReturnType<typeof classifyMethodologyRoles>): MethodologyEntry | null {
+  return result.monitoringMethodology;
+}
+
+function referenced(result: ReturnType<typeof classifyMethodologyRoles>): MethodologyEntry[] {
+  return result.referencedMethods;
+}
+
+describe("methodologyRoleClassifier", () => {
+  describe("primary methodology detection", () => {
+    it("classifies VM0007 under 'Title and Reference of Methodology' as primary", () => {
+      const text = [
+        "Title and Reference of Methodology",
+        "VM0007 Version 1.0",
+        "This project applies the above methodology.",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0007");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
+      expect(primary(result)?.confidence).toBe("high");
+      expect(primary(result)?.version).toBe("1.0");
+    });
+
+    it("classifies VM0009 under 'Title and reference of the VCS methodology applied' as primary", () => {
+      const text = [
+        "Project Description Document",
+        "Title and reference of the VCS methodology applied",
+        "VM0009",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0009");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
+      expect(primary(result)?.confidence).toBe("high");
+    });
+
+    it("classifies VM0004 under 'Applied methodology' heading as primary", () => {
+      const text = [
+        "Project Description Document",
+        "Applied methodology",
+        "VM0004",
+        "Supporting references cite VM0007 and AM0001 as unrelated examples.",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0004");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
+    });
+
+    it("classifies ACM0010 under 'Applied methodology:' as primary", () => {
+      const text = [
+        "Monitoring Report",
+        "Applied methodology: ACM0010 Version 03.0",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("ACM0010");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
+      expect(primary(result)?.version).toBe("03.0");
+    });
+
+    it("classifies VM0009 from Kariba-style PDD fixture", () => {
+      const text = fs.readFileSync(
+        path.join(process.cwd(), "tests/fixtures/quick-check/kariba-primary-method.txt"),
+        "utf-8",
+      );
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0009");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
+      expect(primary(result)?.confidence).toBe("high");
+    });
+
+    it("classifies VM0004 from Rimba Raya-style PDD fixture", () => {
+      const text = fs.readFileSync(
+        path.join(process.cwd(), "tests/fixtures/quick-check/rimba-raya-primary-method.txt"),
+        "utf-8",
+      );
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0004");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
+    });
+
+    it("classifies VM0009 from Kasigau-style PDD fixture", () => {
+      const text = fs.readFileSync(
+        path.join(process.cwd(), "tests/fixtures/quick-check/kasigau-primary-method.txt"),
+        "utf-8",
+      );
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0009");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
+    });
+  });
+
+  describe("monitoring methodology detection", () => {
+    it("classifies methodology under monitoring methodology heading", () => {
+      const text = [
+        "Name and reference of approved monitoring methodology applied",
+        "AMS-III.AU",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(monitoring(result)?.id).toBe("AMS-III.AU");
+      expect(monitoring(result)?.role).toBe("MONITORING_METHODOLOGY");
+    });
+
+    it("distinguishes monitoring from primary when both are present", () => {
+      const text = [
+        "Applied methodology",
+        "VM0007",
+        "",
+        "Name and reference of approved monitoring methodology applied",
+        "VM0007",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0007");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
+      expect(monitoring(result)?.role).toBe("MONITORING_METHODOLOGY");
+    });
+  });
+
+  describe("background mention handling", () => {
+    it("classifies footnoted methods as BACKGROUND_MENTION", () => {
+      const text = [
+        "Title and reference of methodology",
+        "VM0007",
+        "Footnote 1: Sample-size guidance also cites AM0001.",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      const am0001 = referenced(result).find((e) => e.id === "AM0001");
+      expect(am0001?.role).toBe("BACKGROUND_MENTION");
+    });
+
+    it("classifies 'other approved methodologies' references as BACKGROUND_MENTION", () => {
+      const text = [
+        "Applied methodology",
+        "VM0004",
+        "Supporting-document references mention AM0001 and AM0003 as examples of other approved methodologies.",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      const am0001 = referenced(result).find((e) => e.id === "AM0001");
+      const am0003 = referenced(result).find((e) => e.id === "AM0003");
+      expect(am0001?.role).toBe("BACKGROUND_MENTION");
+      expect(am0003?.role).toBe("BACKGROUND_MENTION");
+    });
+  });
+
+  describe("tool and dependency detection", () => {
+    it("classifies VMD modules as TOOL_OR_DEPENDENCY", () => {
+      const text = [
+        "The project uses VMD0001, VMD0006, and APD modules.",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      const vmd1 = referenced(result).find((e) => e.id === "VMD0001");
+      const apd = referenced(result).find((e) => e.id === "APD");
+      expect(vmd1?.role).toBe("TOOL_OR_DEPENDENCY");
+      expect(apd?.role).toBe("TOOL_OR_DEPENDENCY");
+    });
+
+    it("classifies VMR codes as TOOL_OR_DEPENDENCY", () => {
+      const text = "VMR001 methodology reference";
+
+      const result = classifyMethodologyRoles(text);
+      const vmr = referenced(result).find((e) => e.id === "VMR001");
+      expect(vmr?.role).toBe("TOOL_OR_DEPENDENCY");
+    });
+  });
+
+  describe("calculation method references", () => {
+    it("classifies methods in calculation context as REFERENCED_CALCULATION_METHOD", () => {
+      const text = [
+        "Baseline emissions are calculated using ACM0002 methodology.",
+        "The parameter values follow the guidance in ACM0002.",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      const acm = referenced(result).find((e) => e.id === "ACM0002");
+      expect(acm?.role).toBe("REFERENCED_CALCULATION_METHOD");
+    });
+  });
+
+  describe("complex PDDs with mixed references", () => {
+    it("correctly classifies all entries in Kariba-style fixture", () => {
+      const text = fs.readFileSync(
+        path.join(process.cwd(), "tests/fixtures/quick-check/kariba-primary-method.txt"),
+        "utf-8",
+      );
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0009");
+
+      const backgroundMethods = referenced(result).filter((e) => e.role === "BACKGROUND_MENTION");
+      expect(backgroundMethods.length).toBeGreaterThanOrEqual(1);
+
+      const am0001 = referenced(result).find((e) => e.id === "AM0001");
+      expect(am0001?.role).toBe("BACKGROUND_MENTION");
+    });
+
+    it("handles the PD_REDD fixture with version", () => {
+      const text = fs.readFileSync(
+        path.join(process.cwd(), "tests/fixtures/quick-check/pd_redd_v1_130-extracted.txt"),
+        "utf-8",
+      );
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0007");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns no primary for empty text", () => {
+      const result = classifyMethodologyRoles("");
+      expect(primary(result)).toBeNull();
+      expect(monitoring(result)).toBeNull();
+      expect(referenced(result)).toEqual([]);
+    });
+
+    it("returns no primary when only modules are mentioned", () => {
+      const text = "APD ARR VMD0001 VMD0006";
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)).toBeNull();
+      expect(referenced(result).every((e) => e.role === "TOOL_OR_DEPENDENCY")).toBe(true);
+    });
+
+    it("handles standalone VM codes on their own line", () => {
+      const text = [
+        "Project Description Document",
+        "VM0007 Version 4.2",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0007");
+    });
+  });
+});

--- a/tests/lib/methodologyRoleClassifier.test.ts
+++ b/tests/lib/methodologyRoleClassifier.test.ts
@@ -17,6 +17,19 @@ function referenced(result: ReturnType<typeof classifyMethodologyRoles>): Method
 
 describe("methodologyRoleClassifier", () => {
   describe("primary methodology detection", () => {
+    it("classifies VM0007 under section-numbered 'B.1 Title and reference of approved baseline methodology applied'", () => {
+      const text = [
+        "B.1 Title and reference of approved baseline methodology applied",
+        "VM0007 Version 1.0",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0007");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
+      expect(primary(result)?.confidence).toBe("high");
+      expect(primary(result)?.version).toBe("1.0");
+    });
+
     it("classifies VM0007 under 'Title and Reference of Methodology' as primary", () => {
       const text = [
         "Title and Reference of Methodology",
@@ -116,6 +129,18 @@ describe("methodologyRoleClassifier", () => {
       expect(monitoring(result)?.role).toBe("MONITORING_METHODOLOGY");
     });
 
+    it("classifies under section-numbered 'D.1 Name and reference of approved monitoring methodology applied'", () => {
+      const text = [
+        "D.1 Name and reference of approved monitoring methodology applied",
+        "ACM0002",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(monitoring(result)?.id).toBe("ACM0002");
+      expect(monitoring(result)?.role).toBe("MONITORING_METHODOLOGY");
+      expect(monitoring(result)?.confidence).toBe("high");
+    });
+
     it("distinguishes monitoring from primary when both are present", () => {
       const text = [
         "Applied methodology",
@@ -192,6 +217,37 @@ describe("methodologyRoleClassifier", () => {
       const result = classifyMethodologyRoles(text);
       const acm = referenced(result).find((e) => e.id === "ACM0002");
       expect(acm?.role).toBe("REFERENCED_CALCULATION_METHOD");
+    });
+  });
+
+  describe("section-numbered CDM-style PDD headings", () => {
+    it("classifies primary and monitoring from section-numbered headings in one document", () => {
+      const text = [
+        "B.1 Title and reference of approved baseline methodology applied",
+        "VM0007 Version 1.0",
+        "",
+        "D.1 Name and reference of approved monitoring methodology applied",
+        "ACM0002 Version 02.0",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("VM0007");
+      expect(primary(result)?.version).toBe("1.0");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
+      expect(monitoring(result)?.id).toBe("ACM0002");
+      expect(monitoring(result)?.version).toBe("02.0");
+      expect(monitoring(result)?.role).toBe("MONITORING_METHODOLOGY");
+    });
+
+    it("classifies GS methodology under section-numbered heading", () => {
+      const text = [
+        "B.1 Title and reference of approved baseline methodology applied",
+        "GS-VER1 Version 2.0",
+      ].join("\n");
+
+      const result = classifyMethodologyRoles(text);
+      expect(primary(result)?.id).toBe("GS-VER1");
+      expect(primary(result)?.role).toBe("PRIMARY_PROJECT_METHODOLOGY");
     });
   });
 

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -755,7 +755,7 @@ describe("claim-text-based heading matching (acceptance tests)", () => {
     expect(result.sectionContent["3.3"]).toContain("Leakage Management procedures");
     expect(result.reviewArea).toBe("leakage");
     expect(result.status).toBe("section_found_evidence_weak");
-    expect(result.matchStage).toBe("alias_heading");
+    expect(result.matchStage).toBe("normalized_heading");
   });
 
   it("ranks Project Boundary above Project Location for leakage belt and reference region questions", () => {
@@ -1183,7 +1183,7 @@ describe("Quick Check extraction edge-case coverage", () => {
     const evaluation = evaluateRetrievedReviewQuestion(retrieval);
 
     expect(retrieval.reviewArea).toBe("leakage");
-    expect(retrieval.matchStage).toBe("alias_heading");
+    expect(retrieval.matchStage).toBe("normalized_heading");
     expect(retrieval.relevantSections[0]).toBe("3.3");
     expect(evaluation.status).toBe("section_found_evidence_weak");
   });


### PR DESCRIPTION
Implements a general methodology role classifier that extracts all methodology-like references from PDD/carbon project documents and classifies each into one of six roles: PRIMARY_PROJECT_METHODOLOGY, MONITORING_METHODOLOGY, REFERENCED_CALCULATION_METHOD, TOOL_OR_DEPENDENCY, BACKGROUND_MENTION, or UNKNOWN.

## Key features
- Detects primary methodology from declaration headings (e.g. Title and Reference of Methodology, Applied methodology)
- Detects monitoring methodology from monitoring-specific headings
- Distinguishes calculation references from background mentions
- Classifies modules (VMD, VMR) and activity signals (APD, ARR, etc.) as TOOL_OR_DEPENDENCY
- Falls back to standalone codes and line-start heuristics
- 19 tests passing on existing PDD fixtures