### PR TITLE
[codex] quick check evidence compiler foundation

### DIFF
--- a/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
+++ b/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
@@ -1,0 +1,266 @@
+import { normalizeSectionKey } from "@/lib/chat/quickCheckSectionExtractor";
+import type {
+  CompileEvidenceDocumentInput,
+  EvidenceBlockType,
+  EvidenceDocument,
+  EvidenceSpan,
+} from "@/lib/quickCheck/evidence/evidenceTypes";
+
+type PageSlice = {
+  index: number;
+  page: number;
+  text: string;
+  charStart: number;
+};
+
+type CandidateBlock = {
+  page: number;
+  blockType: EvidenceBlockType;
+  text: string;
+  charStart: number;
+  charEnd: number;
+  sectionId?: string;
+  heading?: string;
+  confidence: number;
+};
+
+const SECTION_HEADING_RE = /^\s*(?:section\s+)?((?:[A-Z]\.)?\d+(?:\.\d+)*)\s*[.:)]?\s+(.+?)\s*$/i;
+const ANNEX_HEADING_RE = /^\s*(annex|appendix)\s+([A-Z0-9]+)\s*[.:)]?\s*(.*)$/i;
+const FOOTER_RE =
+  /^(?:page\s+\d+(?:\s+of\s+\d+)?|\d+\s+of\s+\d+|v\d+(?:\.\d+)+(?:\s+.*)?|project description document)$/i;
+const FIELD_RE = /^[A-Z][A-Za-z0-9/ (),-]{1,80}:\s+\S/;
+const FORMULA_RE = /(?:^|[\s(])(?:[A-Za-z][A-Za-z0-9_]*\s*=\s*.+|\d+(?:\.\d+)?\s*[+\-/*]\s*\d+)/;
+
+function normalizeNewlines(value: string): string {
+  return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function normalizeUnicode(value: string): string {
+  return value
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/[\u2012\u2013\u2014\u2212]/g, "-");
+}
+
+export function normalizeEvidenceText(value: string): string {
+  return normalizeUnicode(value)
+    .replace(/\f/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function splitPages(rawText: string): PageSlice[] {
+  const normalized = normalizeNewlines(rawText);
+  const parts = normalized.split("\f");
+  const pages: PageSlice[] = [];
+  let cursor = 0;
+  for (let index = 0; index < parts.length; index += 1) {
+    const text = parts[index] ?? "";
+    pages.push({
+      index,
+      page: parts.length > 1 ? index + 1 : 1,
+      text,
+      charStart: cursor,
+    });
+    cursor += text.length;
+    if (index < parts.length - 1) cursor += 1;
+  }
+  return pages;
+}
+
+function isLikelyTocLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  if (/^(table of contents|contents)$/i.test(trimmed)) return true;
+  if (/\.{3,}\s*\d+\s*$/.test(trimmed)) return true;
+  return /^(?:section\s+)?(?:[A-Z]\.)?\d+(?:\.\d+)*\s+.+\s+\d+\s*$/.test(trimmed);
+}
+
+function detectBlockType(line: string, page: number, isFirstContentLine: boolean): EvidenceBlockType {
+  const trimmed = line.trim();
+  if (FOOTER_RE.test(trimmed)) return "footer";
+  if (isLikelyTocLine(trimmed)) return "toc";
+  if (ANNEX_HEADING_RE.test(trimmed)) return "annex";
+  if (SECTION_HEADING_RE.test(trimmed)) return isFirstContentLine ? "title" : "section_heading";
+  if (isFirstContentLine && trimmed.length <= 180) return "title";
+  if (FIELD_RE.test(trimmed)) return "field";
+  if (FORMULA_RE.test(trimmed)) return "formula";
+  if (/\|/.test(trimmed) || /\S(?:\s{2,}|\t)\S/.test(trimmed)) return "table";
+  return "paragraph";
+}
+
+function blockConfidence(blockType: EvidenceBlockType, text: string): number {
+  if (!text.trim()) return 0.2;
+  switch (blockType) {
+    case "title":
+    case "section_heading":
+    case "annex":
+      return 0.95;
+    case "field":
+      return 0.92;
+    case "table":
+      return 0.82;
+    case "formula":
+      return 0.78;
+    case "toc":
+    case "footer":
+      return 0.72;
+    case "paragraph":
+    default:
+      return 0.88;
+  }
+}
+
+function flushParagraphBuffer(
+  blocks: CandidateBlock[],
+  buffer: { lines: string[]; start: number; end: number; page: number; sectionId?: string; heading?: string } | null,
+): null {
+  if (!buffer || buffer.lines.length === 0) return null;
+  const text = buffer.lines.join(" ").replace(/\s+/g, " ").trim();
+  if (!text) return null;
+  blocks.push({
+    page: buffer.page,
+    blockType: "paragraph",
+    text,
+    charStart: buffer.start,
+    charEnd: buffer.end,
+    sectionId: buffer.sectionId,
+    heading: buffer.heading,
+    confidence: blockConfidence("paragraph", text),
+  });
+  return null;
+}
+
+function extractSectionContext(text: string): { sectionId?: string; heading?: string } {
+  const annexMatch = text.match(ANNEX_HEADING_RE);
+  if (annexMatch) {
+    const annexId = `${annexMatch[1]} ${annexMatch[2]}`.trim();
+    const heading = annexMatch[3]?.trim() || annexId;
+    return {
+      sectionId: annexId.toLowerCase().replace(/\s+/g, "-"),
+      heading,
+    };
+  }
+
+  const headingMatch = text.match(SECTION_HEADING_RE);
+  if (!headingMatch) return {};
+  return {
+    sectionId: normalizeSectionKey(headingMatch[1] ?? ""),
+    heading: headingMatch[2]?.trim() ?? "",
+  };
+}
+
+function buildCandidateBlocks(input: CompileEvidenceDocumentInput): CandidateBlock[] {
+  const pages = splitPages(input.rawText);
+  const blocks: CandidateBlock[] = [];
+  let currentSectionId: string | undefined;
+  let currentHeading: string | undefined;
+  let hasSeenPrimaryContent = false;
+
+  for (const page of pages) {
+    const lines = page.text.split("\n");
+    let pageOffset = page.charStart;
+    let paragraphBuffer: {
+      lines: string[];
+      start: number;
+      end: number;
+      page: number;
+      sectionId?: string;
+      heading?: string;
+    } | null = null;
+
+    for (const line of lines) {
+      const lineStart = pageOffset;
+      const lineEnd = lineStart + line.length;
+      pageOffset = lineEnd + 1;
+
+      const trimmed = line.trim();
+      if (!trimmed) {
+        paragraphBuffer = flushParagraphBuffer(blocks, paragraphBuffer);
+        continue;
+      }
+
+      const blockType = detectBlockType(trimmed, page.page, !hasSeenPrimaryContent);
+      const isStandalone = blockType !== "paragraph";
+
+      if (isStandalone) {
+        paragraphBuffer = flushParagraphBuffer(blocks, paragraphBuffer);
+      }
+
+      if (blockType === "paragraph") {
+        if (
+          !paragraphBuffer ||
+          paragraphBuffer.page !== page.page ||
+          paragraphBuffer.sectionId !== currentSectionId ||
+          paragraphBuffer.heading !== currentHeading
+        ) {
+          paragraphBuffer = {
+            lines: [trimmed],
+            start: lineStart,
+            end: lineEnd,
+            page: page.page,
+            sectionId: currentSectionId,
+            heading: currentHeading,
+          };
+        } else {
+          paragraphBuffer.lines.push(trimmed);
+          paragraphBuffer.end = lineEnd;
+        }
+        hasSeenPrimaryContent = true;
+        continue;
+      }
+
+      const sectionContext = extractSectionContext(trimmed);
+      if (sectionContext.sectionId) currentSectionId = sectionContext.sectionId;
+      if (sectionContext.heading) currentHeading = sectionContext.heading;
+
+      blocks.push({
+        page: page.page,
+        blockType,
+        text: trimmed,
+        charStart: lineStart,
+        charEnd: lineEnd,
+        sectionId: sectionContext.sectionId ?? currentSectionId,
+        heading: sectionContext.heading ?? currentHeading,
+        confidence: blockConfidence(blockType, trimmed),
+      });
+
+      if (blockType !== "footer" && blockType !== "toc") {
+        hasSeenPrimaryContent = true;
+      }
+    }
+
+    flushParagraphBuffer(blocks, paragraphBuffer);
+  }
+
+  return blocks;
+}
+
+function buildSpanId(docId: string, page: number | null, charStart: number, blockType: EvidenceBlockType): string {
+  const safeDocId = docId.replace(/[^a-zA-Z0-9_-]+/g, "-");
+  return [safeDocId, `p${page ?? 0}`, blockType, `${charStart}`].join(":");
+}
+
+export function compileEvidenceDocument(input: CompileEvidenceDocumentInput): EvidenceDocument {
+  const rawText = normalizeNewlines(input.rawText ?? "");
+  const spans: EvidenceSpan[] = buildCandidateBlocks({ ...input, rawText }).map((block) => ({
+    spanId: buildSpanId(input.docId, block.page, block.charStart, block.blockType),
+    docId: input.docId,
+    page: block.page,
+    sectionId: block.sectionId,
+    heading: block.heading,
+    blockType: block.blockType,
+    text: block.text,
+    normalizedText: normalizeEvidenceText(block.text),
+    charStart: block.charStart,
+    charEnd: block.charEnd,
+    confidence: block.confidence,
+  }));
+
+  return {
+    docId: input.docId,
+    rawText,
+    spans,
+  };
+}

--- a/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
+++ b/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
@@ -77,16 +77,16 @@ function isLikelyTocLine(line: string): boolean {
   return /^(?:section\s+)?(?:[A-Z]\.)?\d+(?:\.\d+)*\s+.+\s+\d+\s*$/.test(trimmed);
 }
 
-function detectBlockType(line: string, page: number, isFirstContentLine: boolean): EvidenceBlockType {
+function detectBlockType(line: string, isFirstContentLine: boolean): EvidenceBlockType {
   const trimmed = line.trim();
   if (FOOTER_RE.test(trimmed)) return "footer";
   if (isLikelyTocLine(trimmed)) return "toc";
   if (ANNEX_HEADING_RE.test(trimmed)) return "annex";
-  if (SECTION_HEADING_RE.test(trimmed)) return isFirstContentLine ? "title" : "section_heading";
-  if (isFirstContentLine && trimmed.length <= 180) return "title";
+  if (SECTION_HEADING_RE.test(trimmed)) return "section_heading";
   if (FIELD_RE.test(trimmed)) return "field";
   if (FORMULA_RE.test(trimmed)) return "formula";
   if (/\|/.test(trimmed) || /\S(?:\s{2,}|\t)\S/.test(trimmed)) return "table";
+  if (isFirstContentLine && trimmed.length <= 180) return "title";
   return "paragraph";
 }
 
@@ -181,7 +181,7 @@ function buildCandidateBlocks(input: CompileEvidenceDocumentInput): CandidateBlo
         continue;
       }
 
-      const blockType = detectBlockType(trimmed, page.page, !hasSeenPrimaryContent);
+      const blockType = detectBlockType(trimmed, !hasSeenPrimaryContent);
       const isStandalone = blockType !== "paragraph";
 
       if (isStandalone) {

--- a/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
+++ b/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
@@ -94,6 +94,20 @@ describe("extractDocumentFacts", () => {
 
     expect(facts.every((fact) => fact.evidenceSpanIds.length > 0)).toBe(true);
   });
+
+  test("does not extract labeled facts from mid-sentence prose mentions", () => {
+    const compiled = compileEvidenceDocument({
+      docId: "doc-3",
+      rawText: [
+        "Project narrative",
+        "",
+        "The host country: Indonesia is referenced in the narrative but not declared as a labeled field.",
+      ].join("\n"),
+    });
+
+    const facts = extractDocumentFacts(compiled);
+    expect(facts.some((fact) => fact.kind === "host_country")).toBe(false);
+  });
 });
 
 describe("validateQuotes", () => {

--- a/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
+++ b/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "@jest/globals";
+import { compileEvidenceDocument } from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+import { extractDocumentFacts } from "@/lib/quickCheck/evidence/extractDocumentFacts";
+import { validateQuotes } from "@/lib/quickCheck/evidence/validateQuotes";
+
+const SAMPLE_TEXT = [
+  "Katingan Peatland Restoration and Conservation Project",
+  "",
+  "Table of Contents",
+  "1 Project Details ........ 2",
+  "",
+  "1 Project Details",
+  "Host country: Indonesia",
+  "Project location: Central Kalimantan, Indonesia",
+  "Project participants: PT Rimba Makmur Utama; Permian Global",
+  "Methodology: VM0007 REDD+ Methodology Framework (v1.6)",
+  "Crediting period: 01 January 2021 to 31 December 2030",
+  "Reporting period: 01 January 2024 to 31 December 2024",
+  "Monitoring period: 01 January 2024 to 31 December 2024",
+  "Leakage value: 0 tCO2e",
+  "",
+  "2 Baseline Scenario",
+  "Baseline scenario: Conversion of peat swamp forest to plantations without project intervention.",
+  "",
+  "3 Additionality",
+  "The project is additional because investment barriers and land-use pressure would otherwise prevent conservation.",
+  "",
+  "Page 1 of 10",
+].join("\n");
+
+describe("compileEvidenceDocument", () => {
+  test("builds canonical spans with section context", () => {
+    const compiled = compileEvidenceDocument({
+      docId: "doc-1",
+      rawText: SAMPLE_TEXT,
+    });
+
+    expect(compiled.spans.some((span) => span.blockType === "title")).toBe(true);
+    expect(compiled.spans.some((span) => span.blockType === "toc")).toBe(true);
+    expect(compiled.spans.some((span) => span.blockType === "footer")).toBe(true);
+    expect(compiled.spans.some((span) => span.blockType === "section_heading" && span.sectionId === "1")).toBe(true);
+    expect(compiled.spans.some((span) => span.blockType === "field" && span.heading === "Project Details")).toBe(true);
+  });
+});
+
+describe("extractDocumentFacts", () => {
+  test("extracts deterministic facts with span provenance", () => {
+    const compiled = compileEvidenceDocument({
+      docId: "doc-1",
+      rawText: SAMPLE_TEXT,
+    });
+
+    const facts = extractDocumentFacts(compiled);
+
+    expect(facts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "project_title", value: "Katingan Peatland Restoration and Conservation Project" }),
+        expect.objectContaining({ kind: "host_country", value: "Indonesia", confidence: "high" }),
+        expect.objectContaining({ kind: "methodology", value: "VM0007 REDD+ Methodology Framework (v1.6)" }),
+        expect.objectContaining({ kind: "crediting_period", value: "01 January 2021 to 31 December 2030" }),
+        expect.objectContaining({
+          kind: "baseline_scenario",
+          value: expect.stringContaining("Baseline scenario: Conversion of peat swamp forest to plantations"),
+        }),
+      ]),
+    );
+
+    expect(facts.every((fact) => fact.evidenceSpanIds.length > 0)).toBe(true);
+  });
+});
+
+describe("validateQuotes", () => {
+  test("validates exact and normalized quotes against compiled spans", () => {
+    const compiled = compileEvidenceDocument({
+      docId: "doc-1",
+      rawText: SAMPLE_TEXT,
+    });
+
+    const [exact, normalized, missing] = validateQuotes(compiled, [
+      { quote: "Host country: Indonesia" },
+      { quote: "the project is additional because investment barriers and land-use pressure would otherwise prevent conservation" },
+      { quote: "This sentence is not in the document." },
+    ]);
+
+    expect(exact).toEqual(expect.objectContaining({ valid: true, matchType: "exact", confidence: "high" }));
+    expect(normalized).toEqual(expect.objectContaining({ valid: true }));
+    expect(missing).toEqual(expect.objectContaining({ valid: false, matchType: "missing" }));
+  });
+});

--- a/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
+++ b/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
@@ -83,7 +83,7 @@ describe("validateQuotes", () => {
     ]);
 
     expect(exact).toEqual(expect.objectContaining({ valid: true, matchType: "exact", confidence: "high" }));
-    expect(normalized).toEqual(expect.objectContaining({ valid: true }));
+    expect(normalized).toEqual(expect.objectContaining({ valid: true, matchType: "normalized", confidence: "medium" }));
     expect(missing).toEqual(expect.objectContaining({ valid: false, matchType: "missing" }));
   });
 });

--- a/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
+++ b/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
@@ -41,6 +41,33 @@ describe("compileEvidenceDocument", () => {
     expect(compiled.spans.some((span) => span.blockType === "section_heading" && span.sectionId === "1")).toBe(true);
     expect(compiled.spans.some((span) => span.blockType === "field" && span.heading === "Project Details")).toBe(true);
   });
+
+  test("keeps a leading numbered section heading out of the title slot", () => {
+    const compiled = compileEvidenceDocument({
+      docId: "doc-2",
+      rawText: [
+        "1 Project Details",
+        "Host country: Indonesia",
+      ].join("\n"),
+    });
+
+    expect(compiled.spans[0]).toEqual(
+      expect.objectContaining({
+        blockType: "section_heading",
+        sectionId: "1",
+        heading: "Project Details",
+        text: "1 Project Details",
+      }),
+    );
+    expect(compiled.spans.some((span) => span.blockType === "title")).toBe(false);
+    expect(compiled.spans[1]).toEqual(
+      expect.objectContaining({
+        blockType: "field",
+        heading: "Project Details",
+        text: "Host country: Indonesia",
+      }),
+    );
+  });
 });
 
 describe("extractDocumentFacts", () => {

--- a/src/lib/quickCheck/evidence/evidenceTypes.ts
+++ b/src/lib/quickCheck/evidence/evidenceTypes.ts
@@ -1,0 +1,71 @@
+export type EvidenceBlockType =
+  | "title"
+  | "section_heading"
+  | "paragraph"
+  | "table"
+  | "field"
+  | "formula"
+  | "annex"
+  | "toc"
+  | "footer";
+
+export type EvidenceSpan = {
+  spanId: string;
+  docId: string;
+  page: number | null;
+  sectionId?: string;
+  heading?: string;
+  blockType: EvidenceBlockType;
+  text: string;
+  normalizedText: string;
+  charStart: number;
+  charEnd: number;
+  confidence: number;
+};
+
+export type EvidenceDocument = {
+  docId: string;
+  rawText: string;
+  spans: EvidenceSpan[];
+};
+
+export type DocumentFactKind =
+  | "project_title"
+  | "host_country"
+  | "project_location"
+  | "project_participants"
+  | "methodology"
+  | "monitoring_methodology"
+  | "crediting_period"
+  | "reporting_period"
+  | "monitoring_period"
+  | "leakage_value"
+  | "baseline_scenario"
+  | "additionality_claim";
+
+export type DocumentFact = {
+  kind: DocumentFactKind;
+  value: string;
+  evidenceSpanIds: string[];
+  confidence: "high" | "medium" | "low";
+};
+
+export type CompileEvidenceDocumentInput = {
+  docId: string;
+  rawText: string;
+};
+
+export type QuoteValidationInput = {
+  quote: string;
+  page?: number | null;
+  sectionId?: string;
+  heading?: string;
+};
+
+export type QuoteValidationResult = {
+  quote: string;
+  valid: boolean;
+  matchedSpanIds: string[];
+  matchType: "exact" | "normalized" | "fuzzy" | "missing";
+  confidence: "high" | "medium" | "low";
+};

--- a/src/lib/quickCheck/evidence/extractDocumentFacts.ts
+++ b/src/lib/quickCheck/evidence/extractDocumentFacts.ts
@@ -38,7 +38,7 @@ function findLabeledValue(
   options?: { allowMultiline?: boolean; preferBlockTypes?: EvidenceSpan["blockType"][] },
 ): SpanMatch | null {
   const labelPattern = labels.map((label) => label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
-  const pattern = new RegExp(`(?:${labelPattern})\\s*[:\\-]\\s*(.+)$`, "i");
+  const pattern = new RegExp(`^\\s*(?:${labelPattern})\\s*[:\\-]\\s*(.+)$`, "i");
   const candidates: SpanMatch[] = [];
 
   for (const span of spans) {

--- a/src/lib/quickCheck/evidence/extractDocumentFacts.ts
+++ b/src/lib/quickCheck/evidence/extractDocumentFacts.ts
@@ -1,0 +1,152 @@
+import type {
+  DocumentFact,
+  DocumentFactKind,
+  EvidenceDocument,
+  EvidenceSpan,
+} from "@/lib/quickCheck/evidence/evidenceTypes";
+import { normalizeEvidenceText } from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+
+type FactConfidence = DocumentFact["confidence"];
+
+type SpanMatch = {
+  span: EvidenceSpan;
+  value: string;
+  confidence: FactConfidence;
+};
+
+function cleanValue(value: string): string {
+  return value
+    .replace(/\s+/g, " ")
+    .replace(/\s*([,:;])\s*/g, "$1 ")
+    .replace(/\s*\.\s+/g, ". ")
+    .trim()
+    .replace(/[.;:,]$/, "")
+    .trim();
+}
+
+function sentenceFromSpan(span: EvidenceSpan, pattern: RegExp): string | null {
+  const match = pattern.exec(span.text);
+  if (!match || typeof match.index !== "number") return null;
+  const tail = span.text.slice(match.index).trim();
+  const sentence = tail.match(/^[^.!?\n]+[.!?]?/)?.[0] ?? tail;
+  return cleanValue(sentence);
+}
+
+function findLabeledValue(
+  spans: EvidenceSpan[],
+  labels: string[],
+  options?: { allowMultiline?: boolean; preferBlockTypes?: EvidenceSpan["blockType"][] },
+): SpanMatch | null {
+  const labelPattern = labels.map((label) => label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+  const pattern = new RegExp(`(?:${labelPattern})\\s*[:\\-]\\s*(.+)$`, "i");
+  const candidates: SpanMatch[] = [];
+
+  for (const span of spans) {
+    if (options?.preferBlockTypes && !options.preferBlockTypes.includes(span.blockType)) continue;
+    const match = span.text.match(pattern);
+    if (!match?.[1]) continue;
+    const rawValue = options?.allowMultiline ? match[1] : match[1].split(/\s{2,}|\n/)[0];
+    const value = cleanValue(rawValue);
+    if (!value) continue;
+    const confidence: FactConfidence =
+      span.blockType === "field" || span.blockType === "table" ? "high" : "medium";
+    candidates.push({ span, value, confidence });
+  }
+
+  return candidates[0] ?? null;
+}
+
+function findTitleFact(spans: EvidenceSpan[]): SpanMatch | null {
+  const title = spans.find((span) => span.blockType === "title" && cleanValue(span.text));
+  if (!title) return null;
+  return { span: title, value: cleanValue(title.text), confidence: "high" };
+}
+
+function findPeriodFact(spans: EvidenceSpan[], labels: string[]): SpanMatch | null {
+  const labeled = findLabeledValue(spans, labels, { allowMultiline: true });
+  if (labeled) return labeled;
+
+  const periodPattern =
+    /\b(\d{1,2}\s+[A-Z][a-z]+\s+\d{4}\s*(?:to|-)\s*\d{1,2}\s+[A-Z][a-z]+\s+\d{4}|\d{4}\s*Q[1-4]\s*(?:to|-)\s*\d{4}\s*Q[1-4]|\d{4}\s*(?:to|-)\s*\d{4})\b/;
+  for (const span of spans) {
+    if (!labels.some((label) => normalizeEvidenceText(span.text).includes(label))) continue;
+    const match = span.text.match(periodPattern);
+    if (match?.[1]) {
+      return { span, value: cleanValue(match[1]), confidence: "medium" };
+    }
+  }
+  return null;
+}
+
+function findLeakageValue(spans: EvidenceSpan[]): SpanMatch | null {
+  const labeled = findLabeledValue(spans, ["Leakage", "Leakage value", "Leakage emissions"], {
+    allowMultiline: true,
+  });
+  if (labeled) return labeled;
+
+  for (const span of spans) {
+    if (!/\bleakage\b/i.test(span.text)) continue;
+    const match = span.text.match(/\bleakage\b[^.\n:]*[:\-]?\s*([^.\n]+)/i);
+    if (match?.[1]) {
+      return {
+        span,
+        value: cleanValue(match[1]),
+        confidence: span.blockType === "paragraph" ? "low" : "medium",
+      };
+    }
+  }
+  return null;
+}
+
+function findNarrativeFact(spans: EvidenceSpan[], labels: string[], kind: "baseline" | "additionality"): SpanMatch | null {
+  const labelPattern = labels.map((label) => label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+  const sentencePattern = new RegExp(`(?:${labelPattern})`, "i");
+
+  const orderedSpans = [
+    ...spans.filter((span) => span.blockType !== "section_heading"),
+    ...spans.filter((span) => span.blockType === "section_heading"),
+  ];
+
+  for (const span of orderedSpans) {
+    if (!sentencePattern.test(span.text)) continue;
+    const value = sentenceFromSpan(span, sentencePattern);
+    if (!value) continue;
+    return {
+      span,
+      value,
+      confidence: span.blockType === "section_heading" ? "low" : kind === "baseline" ? "medium" : "high",
+    };
+  }
+
+  return null;
+}
+
+function toFact(kind: DocumentFactKind, match: SpanMatch | null): DocumentFact | null {
+  if (!match) return null;
+  return {
+    kind,
+    value: match.value,
+    evidenceSpanIds: [match.span.spanId],
+    confidence: match.confidence,
+  };
+}
+
+export function extractDocumentFacts(document: EvidenceDocument): DocumentFact[] {
+  const spans = document.spans.filter((span) => span.blockType !== "toc" && span.blockType !== "footer");
+  const facts: Array<DocumentFact | null> = [
+    toFact("project_title", findTitleFact(spans)),
+    toFact("host_country", findLabeledValue(spans, ["Host country", "Country"], { preferBlockTypes: ["field", "table", "paragraph"] })),
+    toFact("project_location", findLabeledValue(spans, ["Project location", "Location", "Project site"], { allowMultiline: true })),
+    toFact("project_participants", findLabeledValue(spans, ["Project participants", "Participants", "Project proponent"], { allowMultiline: true })),
+    toFact("methodology", findLabeledValue(spans, ["Methodology", "Applied methodology", "Approved methodology"], { allowMultiline: true })),
+    toFact("monitoring_methodology", findLabeledValue(spans, ["Monitoring methodology", "Monitoring approach"], { allowMultiline: true })),
+    toFact("crediting_period", findPeriodFact(spans, ["crediting period"])),
+    toFact("reporting_period", findPeriodFact(spans, ["reporting period"])),
+    toFact("monitoring_period", findPeriodFact(spans, ["monitoring period"])),
+    toFact("leakage_value", findLeakageValue(spans)),
+    toFact("baseline_scenario", findNarrativeFact(spans, ["Baseline scenario", "Baseline scenario is", "Baseline"], "baseline")),
+    toFact("additionality_claim", findNarrativeFact(spans, ["Additionality", "Project is additional", "Additional"], "additionality")),
+  ];
+
+  return facts.filter((fact): fact is DocumentFact => Boolean(fact));
+}

--- a/src/lib/quickCheck/evidence/validateQuotes.ts
+++ b/src/lib/quickCheck/evidence/validateQuotes.ts
@@ -34,9 +34,7 @@ function tokenOverlapScore(left: string, right: string): number {
 }
 
 function findExactMatch(candidates: EvidenceSpan[], normalizedQuote: string): EvidenceSpan[] {
-  return candidates.filter(
-    (span) => span.text.includes(normalizedQuote) || span.normalizedText.includes(normalizedQuote),
-  );
+  return candidates.filter((span) => span.normalizedText.includes(normalizedQuote));
 }
 
 function normalizeRawQuote(quote: string): string {
@@ -61,27 +59,14 @@ export function validateQuotes(
     }
 
     const candidates = filterCandidateSpans(document, quote);
-    const exactMatches = candidates.filter(
-      (span) => span.text.includes(rawQuote) || span.normalizedText.includes(normalizedQuote),
-    );
+    const exactMatches = candidates.filter((span) => span.text.includes(rawQuote));
     if (exactMatches.length) {
       return {
         quote: quote.quote,
         valid: true,
         matchedSpanIds: dedupe(exactMatches.map((span) => span.spanId)),
-        matchType: rawQuote === normalizedQuote ? "normalized" : "exact",
+        matchType: "exact",
         confidence: "high",
-      };
-    }
-
-    const fuzzyMatches = candidates.filter((span) => tokenOverlapScore(span.normalizedText, normalizedQuote) >= 0.8);
-    if (fuzzyMatches.length) {
-      return {
-        quote: quote.quote,
-        valid: true,
-        matchedSpanIds: dedupe(fuzzyMatches.map((span) => span.spanId)),
-        matchType: "fuzzy",
-        confidence: "medium",
       };
     }
 
@@ -92,6 +77,17 @@ export function validateQuotes(
         valid: true,
         matchedSpanIds: dedupe(normalizedMatches.map((span) => span.spanId)),
         matchType: "normalized",
+        confidence: "medium",
+      };
+    }
+
+    const fuzzyMatches = candidates.filter((span) => tokenOverlapScore(span.normalizedText, normalizedQuote) >= 0.8);
+    if (fuzzyMatches.length) {
+      return {
+        quote: quote.quote,
+        valid: true,
+        matchedSpanIds: dedupe(fuzzyMatches.map((span) => span.spanId)),
+        matchType: "fuzzy",
         confidence: "medium",
       };
     }

--- a/src/lib/quickCheck/evidence/validateQuotes.ts
+++ b/src/lib/quickCheck/evidence/validateQuotes.ts
@@ -1,0 +1,107 @@
+import {
+  normalizeEvidenceText,
+} from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+import type {
+  EvidenceDocument,
+  EvidenceSpan,
+  QuoteValidationInput,
+  QuoteValidationResult,
+} from "@/lib/quickCheck/evidence/evidenceTypes";
+
+function dedupe(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function filterCandidateSpans(document: EvidenceDocument, quote: QuoteValidationInput): EvidenceSpan[] {
+  return document.spans.filter((span) => {
+    if (quote.page != null && span.page !== quote.page) return false;
+    if (quote.sectionId && span.sectionId !== quote.sectionId) return false;
+    if (quote.heading && span.heading !== quote.heading) return false;
+    return span.blockType !== "toc" && span.blockType !== "footer";
+  });
+}
+
+function tokenOverlapScore(left: string, right: string): number {
+  const leftTokens = new Set(left.split(" ").filter(Boolean));
+  const rightTokens = new Set(right.split(" ").filter(Boolean));
+  if (!leftTokens.size || !rightTokens.size) return 0;
+
+  let overlap = 0;
+  for (const token of leftTokens) {
+    if (rightTokens.has(token)) overlap += 1;
+  }
+  return overlap / Math.max(leftTokens.size, rightTokens.size);
+}
+
+function findExactMatch(candidates: EvidenceSpan[], normalizedQuote: string): EvidenceSpan[] {
+  return candidates.filter(
+    (span) => span.text.includes(normalizedQuote) || span.normalizedText.includes(normalizedQuote),
+  );
+}
+
+function normalizeRawQuote(quote: string): string {
+  return quote.replace(/\s+/g, " ").trim();
+}
+
+export function validateQuotes(
+  document: EvidenceDocument,
+  quotes: QuoteValidationInput[],
+): QuoteValidationResult[] {
+  return quotes.map((quote) => {
+    const rawQuote = normalizeRawQuote(quote.quote);
+    const normalizedQuote = normalizeEvidenceText(rawQuote);
+    if (!normalizedQuote) {
+      return {
+        quote: quote.quote,
+        valid: false,
+        matchedSpanIds: [],
+        matchType: "missing",
+        confidence: "low",
+      };
+    }
+
+    const candidates = filterCandidateSpans(document, quote);
+    const exactMatches = candidates.filter(
+      (span) => span.text.includes(rawQuote) || span.normalizedText.includes(normalizedQuote),
+    );
+    if (exactMatches.length) {
+      return {
+        quote: quote.quote,
+        valid: true,
+        matchedSpanIds: dedupe(exactMatches.map((span) => span.spanId)),
+        matchType: rawQuote === normalizedQuote ? "normalized" : "exact",
+        confidence: "high",
+      };
+    }
+
+    const fuzzyMatches = candidates.filter((span) => tokenOverlapScore(span.normalizedText, normalizedQuote) >= 0.8);
+    if (fuzzyMatches.length) {
+      return {
+        quote: quote.quote,
+        valid: true,
+        matchedSpanIds: dedupe(fuzzyMatches.map((span) => span.spanId)),
+        matchType: "fuzzy",
+        confidence: "medium",
+      };
+    }
+
+    const normalizedMatches = findExactMatch(candidates, normalizedQuote);
+    if (normalizedMatches.length) {
+      return {
+        quote: quote.quote,
+        valid: true,
+        matchedSpanIds: dedupe(normalizedMatches.map((span) => span.spanId)),
+        matchType: "normalized",
+        confidence: "medium",
+      };
+    }
+
+    return {
+      quote: quote.quote,
+      valid: false,
+      matchedSpanIds: [],
+      matchType: "missing",
+      confidence: "low",
+    };
+  });
+}


### PR DESCRIPTION
## What
Build the deterministic Quick Check evidence foundation:
- compile raw PDF text into canonical evidence spans
- extract document facts from those spans
- validate quotes against canonical normalized text

## Why
Quick Check already has section-aware ranking and clearer CDM sections, but it still lacked a reliable compiled evidence model. This foundation is the deterministic layer needed before any broader retrieval or RAG work.

## Impact
- Adds a typed evidence model for spans, facts, and quote validation.
- Keeps the implementation deterministic and self-contained.
- Provides focused tests for compilation, fact extraction, and quote validation.

## Signed-off-by
Signed-off-by: Codex <codex@openai.com>