### PR TITLE
feat: add quick check parser adapter boundary

### DIFF
--- a/src/lib/documentModel/buildArticle6DocumentModel.ts
+++ b/src/lib/documentModel/buildArticle6DocumentModel.ts
@@ -63,8 +63,35 @@ export function buildArticle6DocumentModel(
   const { parsedDocument, includeDebugPayload = false } = input;
   const parserAdapterId = parsedDocument.adapterId;
   const source = parsedDocument.source;
+  const parsedElements = parsedDocument.elements ?? [];
 
-  const blocks: Article6DocumentBlock[] = parsedDocument.blocks.map((block) => {
+  const blockSource: Array<{
+    id: string;
+    type: "heading" | "paragraph" | "unknown";
+    text: string;
+    normalizedText: string;
+    pageNumber?: number;
+    headingLevel?: number;
+    sectionNumber?: string;
+    confidence?: number;
+  }> = parsedElements.length > 0
+    ? parsedElements.map((element) => ({
+        id: element.id,
+        type: element.elementType === "heading"
+          ? "heading" as const
+          : element.elementType === "paragraph"
+            ? "paragraph" as const
+            : "unknown" as const,
+        text: element.text,
+        normalizedText: element.normalizedText,
+        pageNumber: element.pageNumber,
+        headingLevel: element.headingLevel,
+        sectionNumber: element.sectionNumber,
+        confidence: element.confidence,
+      }))
+    : parsedDocument.blocks;
+
+  const blocks: Article6DocumentBlock[] = blockSource.map((block) => {
     const sectionId = sectionIdFromNumber(block.sectionNumber);
     return {
       id: block.id,
@@ -84,7 +111,7 @@ export function buildArticle6DocumentModel(
         sectionId,
         sectionNumber: block.sectionNumber,
       }],
-      confidence: block.type === "heading" ? 0.95 : 0.8,
+      confidence: block.confidence ?? (block.type === "heading" ? 0.95 : 0.8),
     };
   });
 
@@ -241,4 +268,10 @@ export function buildArticle6DocumentModel(
     parserDiagnostics: parsedDocument.diagnostics,
     debug: includeDebugPayload ? { parserOutput: parsedDocument } : undefined,
   };
+}
+
+export function buildDocumentStructure(
+  input: BuildArticle6DocumentModelInput,
+): Article6DocumentModel {
+  return buildArticle6DocumentModel(input);
 }

--- a/src/lib/documentModel/index.ts
+++ b/src/lib/documentModel/index.ts
@@ -1,2 +1,2 @@
-export { buildArticle6DocumentModel } from "@/lib/documentModel/buildArticle6DocumentModel";
+export { buildArticle6DocumentModel, buildDocumentStructure } from "@/lib/documentModel/buildArticle6DocumentModel";
 export * from "@/lib/documentModel/types";

--- a/src/lib/documentModel/types.ts
+++ b/src/lib/documentModel/types.ts
@@ -1,4 +1,11 @@
-import type { DocumentParserAdapterId, ParsedBlock, ParsedDocument, ParsedHeading, ParsedPage, ParserDiagnostics } from "@/lib/documentParsing";
+import type {
+  DocumentParserAdapterId,
+  ParsedBlock,
+  ParsedDocument,
+  ParsedHeading,
+  ParsedPage,
+  ParserDiagnostics,
+} from "@/lib/documentParsing";
 
 export type Article6SourceRef = {
   source: string;
@@ -76,6 +83,8 @@ export type Article6DocumentModel = {
     parserOutput: ParsedDocument;
   };
 };
+
+export type DocumentStructure = Article6DocumentModel;
 
 export type BuildArticle6DocumentModelInput = {
   parsedDocument: ParsedDocument;

--- a/src/lib/documentParsing/adapters/currentExtractor.ts
+++ b/src/lib/documentParsing/adapters/currentExtractor.ts
@@ -40,12 +40,57 @@ function splitRawTextIntoPages(rawText: string): ParsedPage[] {
   }));
 }
 
+type PageBoundary = {
+  pageNumber: number;
+  charStart: number;
+  charEnd: number;
+};
+
+function buildPageBoundaries(rawText: string): PageBoundary[] {
+  const normalized = rawText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const pageTexts = normalized.split("\f");
+  const boundaries: PageBoundary[] = [];
+  let cursor = 0;
+
+  for (let index = 0; index < pageTexts.length; index += 1) {
+    const pageText = pageTexts[index] ?? "";
+    const charStart = cursor;
+    const charEnd = charStart + pageText.length;
+    boundaries.push({
+      pageNumber: pageTexts.length > 1 ? index + 1 : 1,
+      charStart,
+      charEnd,
+    });
+    cursor = charEnd + (index < pageTexts.length - 1 ? 1 : 0);
+  }
+
+  return boundaries;
+}
+
+function pageNumberForOffset(offset: number, boundaries: PageBoundary[]): number {
+  const boundary = boundaries.find((candidate) => offset >= candidate.charStart && offset <= candidate.charEnd);
+  return boundary?.pageNumber ?? boundaries[boundaries.length - 1]?.pageNumber ?? 1;
+}
+
+function findSequentialOffset(haystack: string, needle: string, fromIndex: number): number {
+  if (!needle.trim()) return fromIndex;
+  const exactIndex = haystack.indexOf(needle, fromIndex);
+  if (exactIndex >= 0) return exactIndex;
+
+  const trimmedNeedle = needle.trim();
+  const trimmedIndex = haystack.indexOf(trimmedNeedle, fromIndex);
+  if (trimmedIndex >= 0) return trimmedIndex;
+
+  return fromIndex;
+}
+
 export const currentExtractorAdapter: ParserAdapter = {
   id: "current-extractor",
   parseText(input: ParseDocumentTextInput): ParsedDocument {
     const rawText = input.rawText ?? "";
     const normalizedText = normalizeParserText(rawText);
     const parserName = "current-extractor";
+    const pageBoundaries = buildPageBoundaries(rawText);
     const sectionsByNumber = extractPddSections(rawText);
     const headingIndex = buildPddHeadingIndex(rawText);
     const headings = headingIndex.map((heading) => ({
@@ -75,11 +120,15 @@ export const currentExtractorAdapter: ParserAdapter = {
         : [];
       return [headingBlock, ...bodyBlocks];
     });
+    let searchCursor = 0;
     const elements: ParsedElement[] = headingIndex.flatMap((heading) => {
       const sectionPath = buildSectionPath(heading.sectionNumber);
+      const headingOffset = findSequentialOffset(normalizedText, heading.title, searchCursor);
+      const headingPageNumber = pageNumberForOffset(headingOffset, pageBoundaries);
+      searchCursor = headingOffset + heading.title.length;
       const headingElement: ParsedElement = {
         id: `element:heading:${heading.sectionNumber}`,
-        pageNumber: 1,
+        pageNumber: headingPageNumber,
         text: heading.title,
         normalizedText: heading.normalizedTitle,
         elementType: "heading",
@@ -90,17 +139,22 @@ export const currentExtractorAdapter: ParserAdapter = {
         confidence: 0.95,
       };
       const bodyElements = heading.bodyText
-        ? [{
-            id: `element:paragraph:${heading.sectionNumber}`,
-            pageNumber: 1,
-            text: heading.bodyText,
-            normalizedText: normalizeParserText(heading.bodyText).replace(/\s+/g, " ").trim(),
-            elementType: "paragraph" as const,
-            sectionNumber: heading.sectionNumber,
-            sectionPath,
-            sourceParser: parserName,
-            confidence: 0.8,
-          }]
+        ? (() => {
+            const bodyOffset = findSequentialOffset(normalizedText, heading.bodyText, searchCursor);
+            const bodyPageNumber = pageNumberForOffset(bodyOffset, pageBoundaries);
+            searchCursor = bodyOffset + heading.bodyText.length;
+            return [{
+              id: `element:paragraph:${heading.sectionNumber}`,
+              pageNumber: bodyPageNumber,
+              text: heading.bodyText,
+              normalizedText: normalizeParserText(heading.bodyText).replace(/\s+/g, " ").trim(),
+              elementType: "paragraph" as const,
+              sectionNumber: heading.sectionNumber,
+              sectionPath,
+              sourceParser: parserName,
+              confidence: 0.8,
+            }];
+          })()
         : [];
       return [headingElement, ...bodyElements];
     });

--- a/src/lib/documentParsing/adapters/currentExtractor.ts
+++ b/src/lib/documentParsing/adapters/currentExtractor.ts
@@ -3,11 +3,16 @@ import {
   debugSectionExtraction,
   extractPddSections,
 } from "@/lib/chat/quickCheckSectionExtractor";
-import type { DocumentParserAdapter, ParseDocumentTextInput, ParsedDocument } from "@/lib/documentParsing/types";
+import type {
+  ParseDocumentTextInput,
+  ParsedDocument,
+  ParsedElement,
+  ParsedPage,
+  ParserAdapter,
+} from "@/lib/documentParsing/types";
 
 function normalizeParserText(rawText: string): string {
   return rawText
-    .replace(/\f/g, "\n")
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n");
 }
@@ -17,11 +22,30 @@ function headingLevel(sectionNumber?: string): number | undefined {
   return sectionNumber.split(".").length;
 }
 
-export const currentExtractorAdapter: DocumentParserAdapter = {
+function buildSectionPath(sectionNumber?: string): string[] | undefined {
+  if (!sectionNumber) return undefined;
+  const parts = sectionNumber.split(".");
+  return parts.map((_, index) => parts.slice(0, index + 1).join("."));
+}
+
+function splitRawTextIntoPages(rawText: string): ParsedPage[] {
+  const normalized = rawText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const pageTexts = normalized.split("\f");
+
+  return pageTexts.map((pageText, index) => ({
+    pageNumber: pageTexts.length > 1 ? index + 1 : 1,
+    rawText: pageText,
+    normalizedText: pageText,
+    elements: [],
+  }));
+}
+
+export const currentExtractorAdapter: ParserAdapter = {
   id: "current-extractor",
   parseText(input: ParseDocumentTextInput): ParsedDocument {
     const rawText = input.rawText ?? "";
     const normalizedText = normalizeParserText(rawText);
+    const parserName = "current-extractor";
     const sectionsByNumber = extractPddSections(rawText);
     const headingIndex = buildPddHeadingIndex(rawText);
     const headings = headingIndex.map((heading) => ({
@@ -51,23 +75,67 @@ export const currentExtractorAdapter: DocumentParserAdapter = {
         : [];
       return [headingBlock, ...bodyBlocks];
     });
+    const elements: ParsedElement[] = headingIndex.flatMap((heading) => {
+      const sectionPath = buildSectionPath(heading.sectionNumber);
+      const headingElement: ParsedElement = {
+        id: `element:heading:${heading.sectionNumber}`,
+        pageNumber: 1,
+        text: heading.title,
+        normalizedText: heading.normalizedTitle,
+        elementType: "heading",
+        headingLevel: headingLevel(heading.sectionNumber),
+        sectionNumber: heading.sectionNumber,
+        sectionPath,
+        sourceParser: parserName,
+        confidence: 0.95,
+      };
+      const bodyElements = heading.bodyText
+        ? [{
+            id: `element:paragraph:${heading.sectionNumber}`,
+            pageNumber: 1,
+            text: heading.bodyText,
+            normalizedText: normalizeParserText(heading.bodyText).replace(/\s+/g, " ").trim(),
+            elementType: "paragraph" as const,
+            sectionNumber: heading.sectionNumber,
+            sectionPath,
+            sourceParser: parserName,
+            confidence: 0.8,
+          }]
+        : [];
+      return [headingElement, ...bodyElements];
+    });
+    const pages = splitRawTextIntoPages(rawText).map((page) => ({
+      ...page,
+      elements: elements.filter((element) => element.pageNumber === page.pageNumber),
+    }));
+    const warnings = rawText.trim() ? [] : [];
+    const diagnostics = rawText.trim()
+      ? {
+          metadata: debugSectionExtraction(rawText),
+        }
+      : undefined;
+
     return {
       adapterId: "current-extractor",
-      source: "current-extractor",
+      source: parserName,
       rawText,
       normalizedText,
-      pages: [{
-        pageNumber: 1,
-        rawText,
-        normalizedText,
-      }],
+      pages,
+      elements,
+      tables: [],
+      parserName,
+      qualityReport: {
+        parserName,
+        warnings,
+        metadata: diagnostics?.metadata,
+        hasStructuredHeadings: headings.length > 0,
+        hasPageBoundaries: pages.length > 1,
+        hasBoundingBoxes: false,
+        hasTables: false,
+      },
       blocks,
       headings,
-      diagnostics: rawText.trim()
-        ? {
-            metadata: debugSectionExtraction(rawText),
-          }
-        : undefined,
+      diagnostics,
       sectionsByNumber,
       headingIndex,
     };

--- a/src/lib/documentParsing/types.ts
+++ b/src/lib/documentParsing/types.ts
@@ -13,10 +13,65 @@ export type ParseDocumentTextInput = {
   rawText: string;
 };
 
+export type ParsedBoundingBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type ParsedCell = {
+  rowIndex: number;
+  columnIndex: number;
+  text: string;
+  rowSpan?: number;
+  colSpan?: number;
+  boundingBox?: ParsedBoundingBox;
+  confidence?: number;
+};
+
+export type ParsedTable = {
+  id: string;
+  pageNumber: number;
+  caption?: string;
+  columnCount?: number;
+  rowCount?: number;
+  headerRowCount?: number;
+  boundingBox?: ParsedBoundingBox;
+  cells: ParsedCell[];
+  confidence?: number;
+};
+
+export type ParsedElementType =
+  | "heading"
+  | "paragraph"
+  | "table"
+  | "list_item"
+  | "footer"
+  | "header"
+  | "unknown";
+
+export type ParsedElement = {
+  id: string;
+  pageNumber: number;
+  text: string;
+  normalizedText: string;
+  elementType: ParsedElementType;
+  headingLevel?: number;
+  sectionNumber?: string;
+  sectionPath?: string[];
+  boundingBox?: ParsedBoundingBox;
+  tableId?: string;
+  table?: ParsedTable;
+  sourceParser: string;
+  confidence?: number;
+};
+
 export type ParsedPage = {
   pageNumber: number;
   rawText: string;
   normalizedText: string;
+  elements: ParsedElement[];
 };
 
 export type ParsedBlock = {
@@ -43,12 +98,26 @@ export type ParserDiagnostics = {
   metadata?: Record<string, string>;
 };
 
+export type DocumentQualityReport = {
+  parserName: string;
+  warnings: string[];
+  metadata?: Record<string, string>;
+  hasStructuredHeadings: boolean;
+  hasPageBoundaries: boolean;
+  hasBoundingBoxes: boolean;
+  hasTables: boolean;
+};
+
 export type ParsedDocument = {
   adapterId: DocumentParserAdapterId;
   source: string;
   rawText: string;
   normalizedText: string;
   pages: ParsedPage[];
+  elements: ParsedElement[];
+  tables: ParsedTable[];
+  parserName: string;
+  qualityReport: DocumentQualityReport;
   blocks: ParsedBlock[];
   headings: ParsedHeading[];
   diagnostics?: ParserDiagnostics;
@@ -57,7 +126,9 @@ export type ParsedDocument = {
   headingIndex?: DocumentHeading[];
 };
 
-export interface DocumentParserAdapter {
+export interface ParserAdapter {
   readonly id: DocumentParserAdapterId;
   parseText(input: ParseDocumentTextInput): ParsedDocument;
 }
+
+export type DocumentParserAdapter = ParserAdapter;

--- a/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
+++ b/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
@@ -1,4 +1,5 @@
 import { normalizeSectionKey } from "@/lib/chat/quickCheckSectionExtractor";
+import type { DocumentStructure } from "@/lib/documentModel";
 import type {
   CompileEvidenceDocumentInput,
   EvidenceBlockType,
@@ -242,6 +243,28 @@ function buildSpanId(docId: string, page: number | null, charStart: number, bloc
   return [safeDocId, `p${page ?? 0}`, blockType, `${charStart}`].join(":");
 }
 
+function mapDocumentStructureBlockType(type: DocumentStructure["blocks"][number]["type"]): EvidenceBlockType {
+  switch (type) {
+    case "heading":
+      return "section_heading";
+    case "paragraph":
+      return "paragraph";
+    case "unknown":
+    default:
+      return "paragraph";
+  }
+}
+
+function findCharStart(rawText: string, blockText: string, fallbackCursor: number): number {
+  const trimmed = blockText.trim();
+  if (!trimmed) return fallbackCursor;
+  const exactIndex = rawText.indexOf(blockText, fallbackCursor);
+  if (exactIndex >= 0) return exactIndex;
+  const trimmedIndex = rawText.indexOf(trimmed, fallbackCursor);
+  if (trimmedIndex >= 0) return trimmedIndex;
+  return fallbackCursor;
+}
+
 export function compileEvidenceDocument(input: CompileEvidenceDocumentInput): EvidenceDocument {
   const rawText = normalizeNewlines(input.rawText ?? "");
   const spans: EvidenceSpan[] = buildCandidateBlocks({ ...input, rawText }).map((block) => ({
@@ -257,6 +280,44 @@ export function compileEvidenceDocument(input: CompileEvidenceDocumentInput): Ev
     charEnd: block.charEnd,
     confidence: block.confidence,
   }));
+
+  return {
+    docId: input.docId,
+    rawText,
+    spans,
+  };
+}
+
+export function compileEvidenceDocumentFromStructure(input: {
+  docId: string;
+  documentStructure: DocumentStructure;
+}): EvidenceDocument {
+  const rawText = normalizeNewlines(input.documentStructure.rawText ?? "");
+  let cursor = 0;
+  const spans: EvidenceSpan[] = input.documentStructure.blocks.map((block) => {
+    const blockType = mapDocumentStructureBlockType(block.type);
+    const charStart = findCharStart(rawText, block.rawText, cursor);
+    const charEnd = charStart + block.rawText.length;
+    cursor = charEnd;
+
+    const section = block.sectionId
+      ? input.documentStructure.sections.find((candidate) => candidate.id === block.sectionId)
+      : undefined;
+
+    return {
+      spanId: buildSpanId(input.docId, block.pageNumber ?? null, charStart, blockType),
+      docId: input.docId,
+      page: block.pageNumber ?? null,
+      sectionId: block.sectionId,
+      heading: section?.titleRaw,
+      blockType,
+      text: block.rawText,
+      normalizedText: normalizeEvidenceText(block.rawText),
+      charStart,
+      charEnd,
+      confidence: block.confidence,
+    };
+  });
 
   return {
     docId: input.docId,

--- a/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
+++ b/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "@jest/globals";
-import { compileEvidenceDocument } from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+import { buildDocumentStructure } from "@/lib/documentModel";
+import { parseDocumentText } from "@/lib/documentParsing";
+import {
+  compileEvidenceDocument,
+  compileEvidenceDocumentFromStructure,
+} from "@/lib/quickCheck/evidence/compileEvidenceDocument";
 import { extractDocumentFacts } from "@/lib/quickCheck/evidence/extractDocumentFacts";
 import { validateQuotes } from "@/lib/quickCheck/evidence/validateQuotes";
 
@@ -40,6 +45,22 @@ describe("compileEvidenceDocument", () => {
     expect(compiled.spans.some((span) => span.blockType === "footer")).toBe(true);
     expect(compiled.spans.some((span) => span.blockType === "section_heading" && span.sectionId === "1")).toBe(true);
     expect(compiled.spans.some((span) => span.blockType === "field" && span.heading === "Project Details")).toBe(true);
+  });
+
+  test("adapts DocumentStructure into the evidence compiler with provenance intact", () => {
+    const parsedDocument = parseDocumentText({ rawText: SAMPLE_TEXT });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "doc-structure-1",
+      documentStructure,
+    });
+
+    expect(compiled.rawText).toBe(SAMPLE_TEXT);
+    expect(compiled.spans.some((span) => span.page === 1)).toBe(true);
+    expect(compiled.spans.some((span) => span.blockType === "section_heading")).toBe(true);
+    expect(compiled.spans.some((span) => span.sectionId === "section:1")).toBe(true);
+    expect(compiled.spans.some((span) => span.heading === "Project Details")).toBe(true);
   });
 
   test("keeps a leading numbered section heading out of the title slot", () => {

--- a/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
+++ b/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
@@ -63,6 +63,27 @@ describe("compileEvidenceDocument", () => {
     expect(compiled.spans.some((span) => span.heading === "Project Details")).toBe(true);
   });
 
+  test("preserves page provenance when evidence spans are compiled from multi-page structure", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1 Project Details",
+        "Host country: Indonesia",
+        "\f",
+        "2 Baseline Scenario",
+        "Baseline scenario: forest conversion.",
+      ].join("\n"),
+    });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "doc-structure-2",
+      documentStructure,
+    });
+
+    expect(compiled.spans.some((span) => span.page === 2)).toBe(true);
+    expect(compiled.spans.some((span) => span.page === 2 && span.heading === "Baseline Scenario")).toBe(true);
+  });
+
   test("keeps a leading numbered section heading out of the title slot", () => {
     const compiled = compileEvidenceDocument({
       docId: "doc-2",

--- a/tests/lib/documentModel.test.ts
+++ b/tests/lib/documentModel.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "@jest/globals";
 import { parseDocumentText } from "@/lib/documentParsing";
-import { buildArticle6DocumentModel } from "@/lib/documentModel";
+import { buildArticle6DocumentModel, buildDocumentStructure } from "@/lib/documentModel";
 import { currentExtractorAdapter } from "@/lib/documentParsing/adapters/currentExtractor";
 import { setLiteParseImplementationForTests } from "@/lib/documentParsing/adapters/liteParse";
 
@@ -23,7 +23,7 @@ describe("buildArticle6DocumentModel", () => {
 
   it("converts parser output into a canonical Article6 document model", () => {
     const parsedDocument = parseDocumentText({ rawText: NESTED_PDD_TEXT });
-    const model = buildArticle6DocumentModel({ parsedDocument });
+    const model = buildDocumentStructure({ parsedDocument });
 
     expect(model.parserAdapterId).toBe("current-extractor");
     expect(model.source).toBe("current-extractor");
@@ -33,6 +33,7 @@ describe("buildArticle6DocumentModel", () => {
     expect(model.pages).toHaveLength(1);
     expect(model.blocks.some((block) => block.type === "heading")).toBe(true);
     expect(model.blocks.some((block) => block.type === "paragraph")).toBe(true);
+    expect(model.blocks[0]?.pageNumber).toBe(1);
     expect(model.debug).toBeUndefined();
 
     const monitoringPlan = model.sections.find((section) => section.sectionNumber === "4.3");
@@ -51,6 +52,7 @@ describe("buildArticle6DocumentModel", () => {
     expect(monitoringPlan?.confidence).toBeGreaterThan(0.9);
     expect(model.pages[0]?.sourceRefs[0]?.quality).toBe("synthetic");
     expect(model.blocks[0]?.sourceRefs[0]?.quality).toBe("synthetic");
+    expect(model.blocks[0]?.sourceRefs[0]?.pageNumber).toBe(1);
   });
 
   it("preserves raw parser text separately from clean and matching text", () => {
@@ -74,7 +76,19 @@ describe("buildArticle6DocumentModel", () => {
           pageNumber: 1,
           rawText: "Loose body text without recoverable headings.",
           normalizedText: "Loose body text without recoverable headings.",
+          elements: [],
         }],
+        elements: [],
+        tables: [],
+        parserName: "test-parser",
+        qualityReport: {
+          parserName: "test-parser",
+          warnings: ["heuristic fallback used"],
+          hasStructuredHeadings: false,
+          hasPageBoundaries: false,
+          hasBoundingBoxes: false,
+          hasTables: false,
+        },
         blocks: [],
         headings: [],
         diagnostics: {
@@ -121,5 +135,35 @@ describe("buildArticle6DocumentModel", () => {
     expect(model.sections.map((section) => section.sectionNumber)).toEqual(expect.arrayContaining(["4.3", "4.3.1", "6"]));
     expect(model.blocks.some((block) => block.type === "heading")).toBe(true);
     expect(model.pages).toHaveLength(1);
+  });
+
+  it("normalizes parsed page provenance into document structure pages", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1 Project Details",
+        "Host country: Indonesia",
+        "\f",
+        "2 Baseline Scenario",
+        "Baseline scenario: forest conversion.",
+      ].join("\n"),
+    });
+
+    const model = buildDocumentStructure({ parsedDocument });
+
+    expect(model.pages).toHaveLength(2);
+    expect(model.pages[0]).toEqual(expect.objectContaining({
+      pageNumber: 1,
+    }));
+    expect(model.pages[1]).toEqual(expect.objectContaining({
+      pageNumber: 2,
+    }));
+    expect(model.pages[0]?.sourceRefs[0]).toEqual(expect.objectContaining({
+      parserAdapterId: "current-extractor",
+      pageNumber: 1,
+    }));
+    expect(model.pages[1]?.sourceRefs[0]).toEqual(expect.objectContaining({
+      parserAdapterId: "current-extractor",
+      pageNumber: 2,
+    }));
   });
 });

--- a/tests/lib/documentModel.test.ts
+++ b/tests/lib/documentModel.test.ts
@@ -165,5 +165,7 @@ describe("buildArticle6DocumentModel", () => {
       parserAdapterId: "current-extractor",
       pageNumber: 2,
     }));
+    expect(model.blocks.some((block) => block.pageNumber === 2)).toBe(true);
+    expect(model.blocks.some((block) => block.sourceRefs.some((ref) => ref.pageNumber === 2))).toBe(true);
   });
 });

--- a/tests/lib/documentParsing.test.ts
+++ b/tests/lib/documentParsing.test.ts
@@ -124,6 +124,9 @@ describe("documentParsing current extractor adapter", () => {
 
     expect(parsed.pages).toHaveLength(2);
     expect(parsed.pages.map((page) => page.pageNumber)).toEqual([1, 2]);
+    expect(parsed.pages[1]?.elements.length).toBeGreaterThan(0);
+    expect(parsed.pages[1]?.elements.some((element) => element.pageNumber === 2)).toBe(true);
+    expect(parsed.elements.some((element) => element.pageNumber === 2)).toBe(true);
     expect(parsed.qualityReport.hasPageBoundaries).toBe(true);
   });
 

--- a/tests/lib/documentParsing.test.ts
+++ b/tests/lib/documentParsing.test.ts
@@ -49,6 +49,7 @@ describe("documentParsing current extractor adapter", () => {
 
     expect(parsed.adapterId).toBe("current-extractor");
     expect(parsed.source).toBe("current-extractor");
+    expect(parsed.parserName).toBe("current-extractor");
     expect(parsed.rawText).toBe(VM0007_TEXT);
     expect(parsed.normalizedText).toBe(VM0007_TEXT);
     expect(parsed.pages).toEqual([
@@ -56,8 +57,25 @@ describe("documentParsing current extractor adapter", () => {
         pageNumber: 1,
         rawText: VM0007_TEXT,
         normalizedText: VM0007_TEXT,
+        elements: parsed.elements,
       },
     ]);
+    expect(parsed.elements[0]).toEqual(expect.objectContaining({
+      pageNumber: 1,
+      elementType: "heading",
+      sectionNumber: "1.9",
+      sectionPath: ["1", "1.9"],
+      sourceParser: "current-extractor",
+    }));
+    expect(parsed.elements.some((element) => element.elementType === "paragraph")).toBe(true);
+    expect(parsed.tables).toEqual([]);
+    expect(parsed.qualityReport).toEqual(expect.objectContaining({
+      parserName: "current-extractor",
+      hasStructuredHeadings: true,
+      hasPageBoundaries: false,
+      hasBoundingBoxes: false,
+      hasTables: false,
+    }));
     expect(parsed.headings.map((heading) => heading.sectionNumber)).toEqual(["1.9", "2.4", "4.3"]);
     expect(parsed.blocks.some((block) => block.type === "heading")).toBe(true);
     expect(parsed.blocks.some((block) => block.type === "paragraph")).toBe(true);
@@ -77,13 +95,36 @@ describe("documentParsing current extractor adapter", () => {
         pageNumber: 1,
         rawText: "   ",
         normalizedText: "   ",
+        elements: [],
       },
     ]);
+    expect(parsed.elements).toEqual([]);
+    expect(parsed.tables).toEqual([]);
     expect(parsed.blocks).toEqual([]);
     expect(parsed.headings).toEqual([]);
     expect(parsed.sectionsByNumber).toEqual({});
     expect(parsed.headingIndex).toEqual([]);
     expect(parsed.diagnostics).toBeUndefined();
+    expect(parsed.qualityReport).toEqual(expect.objectContaining({
+      parserName: "current-extractor",
+      hasStructuredHeadings: false,
+    }));
+  });
+
+  it("preserves page metadata when raw text already contains page breaks", () => {
+    const parsed = parseDocumentText({
+      rawText: [
+        "1 Project Details",
+        "Host country: Indonesia",
+        "\f",
+        "2 Baseline Scenario",
+        "Baseline scenario: forest conversion.",
+      ].join("\n"),
+    });
+
+    expect(parsed.pages).toHaveLength(2);
+    expect(parsed.pages.map((page) => page.pageNumber)).toEqual([1, 2]);
+    expect(parsed.qualityReport.hasPageBoundaries).toBe(true);
   });
 
   it("selects liteparse from QUICK_CHECK_PARSER without changing the parsed-document contract", () => {


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: quick-check-document-pipeline
- ack: human
- items:
  - RC1: in_progress

Phase reference: Quick Check Phase 0A: Parser Adapter Boundary

## WHAT

- Retarget PR #719 from `main` to `quickcheck-roadmap`.
- Update the PR roadmap metadata so it explicitly references Quick Check Phase 0A: Parser Adapter Boundary instead of `slug: N/A`.
- Fix `currentExtractorAdapter` so `ParsedElement.pageNumber` is derived from the raw text/page boundary position, not hard-coded to `1`.
- Add a regression test with text containing `\f` where:
  - `parsed.pages` has page 1 and page 2
  - page 2 has its own elements
  - at least one page 2 element has `pageNumber: 2`
  - `buildDocumentStructure()` preserves that page provenance
  - evidence spans compiled from structure preserve the correct page

## WHY

- The PR implements the right Phase 0A direction, but it currently violates the roadmap branch rule by targeting `main`.
- The PR body incorrectly marks the change as roadmap `N/A`, even though it clearly implements a known roadmap item.
- The parser boundary cannot be considered done while element-level page provenance is wrong for multi-page inputs.
- Merge readiness confirmed for `quickcheck-roadmap`.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>