### PR TITLE
Feat/qc family classifier

### DIFF
--- a/src/lib/documentClassification/buildDocumentQualityReport.ts
+++ b/src/lib/documentClassification/buildDocumentQualityReport.ts
@@ -1,0 +1,127 @@
+import type { DocumentQualityReport, ParsedDocument, ParsedPage } from "@/lib/documentParsing/types";
+
+function roundMetric(value: number): number {
+  return Number(value.toFixed(3));
+}
+
+function detectRepeatedMarginLines(pages: ParsedPage[]): boolean {
+  if (pages.length < 2) return false;
+
+  const firstLines = new Map<string, number>();
+  const lastLines = new Map<string, number>();
+
+  for (const page of pages) {
+    const lines = page.rawText.split("\n").map((line) => line.trim()).filter(Boolean);
+    const first = lines[0];
+    const last = lines[lines.length - 1];
+    if (first && first.length <= 80) {
+      firstLines.set(first, (firstLines.get(first) ?? 0) + 1);
+    }
+    if (last && last.length <= 80) {
+      lastLines.set(last, (lastLines.get(last) ?? 0) + 1);
+    }
+  }
+
+  return [...firstLines.values(), ...lastLines.values()].some((count) => count >= 2);
+}
+
+function computeTextDensity(parsedDocument: ParsedDocument): number {
+  const pageCount = parsedDocument.pages.length || 1;
+  const nonWhitespaceChars = parsedDocument.rawText.replace(/\s+/g, "").length;
+  return roundMetric(Math.min(1, nonWhitespaceChars / (pageCount * 1200)));
+}
+
+function detectLayoutHeavyWarning(parsedDocument: ParsedDocument): boolean {
+  const lines = parsedDocument.rawText
+    .replace(/\f/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return false;
+
+  const shortLineCount = lines.filter((line) => line.length <= 28).length;
+  const shortLineRatio = shortLineCount / lines.length;
+  return shortLineRatio >= 0.55 && lines.length >= 10;
+}
+
+function detectTableHeavyWarning(parsedDocument: ParsedDocument): boolean {
+  if (parsedDocument.tables.length >= 3) return true;
+  const tableElements = parsedDocument.elements.filter((element) => element.elementType === "table").length;
+  if (tableElements >= 3) return true;
+
+  const tableLikeLines = parsedDocument.rawText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /\|/.test(line) || /\S(?:\s{2,}|\t)\S/.test(line));
+
+  return tableLikeLines.length >= Math.max(4, parsedDocument.pages.length * 2);
+}
+
+function detectWeakExtractionWarning(parsedDocument: ParsedDocument, qualityReport: DocumentQualityReport): boolean {
+  if (!parsedDocument.rawText.trim()) return true;
+  if (parsedDocument.elements.length === 0) return true;
+  if (qualityReport.textDensity < 0.025) return true;
+  return parsedDocument.headings.length === 0 && qualityReport.textDensity < 0.08;
+}
+
+function readOcrConfidence(parsedDocument: ParsedDocument): number | undefined {
+  const raw = parsedDocument.qualityReport.metadata?.ocr_confidence ?? parsedDocument.diagnostics?.metadata?.ocr_confidence;
+  if (!raw) return undefined;
+  const numeric = Number(raw);
+  return Number.isFinite(numeric) ? roundMetric(numeric) : undefined;
+}
+
+function detectSourceContentMode(parsedDocument: ParsedDocument, ocrConfidence: number | undefined): DocumentQualityReport["sourceContentMode"] {
+  const explicit = parsedDocument.qualityReport.metadata?.source_content_mode;
+  if (explicit === "native_pdf" || explicit === "scanned") {
+    return explicit;
+  }
+  if (ocrConfidence !== undefined) {
+    return ocrConfidence < 0.75 ? "scanned" : "native_pdf";
+  }
+  return "unknown";
+}
+
+export function buildDocumentQualityReport(parsedDocument: ParsedDocument): DocumentQualityReport {
+  const base = parsedDocument.qualityReport;
+  const pageCount = parsedDocument.pages.length || base.pageCount || 1;
+  const textDensity = base.textDensity || computeTextDensity(parsedDocument);
+  const ocrConfidence = base.ocrConfidence ?? readOcrConfidence(parsedDocument);
+  const sourceContentMode = base.sourceContentMode === "unknown"
+    ? detectSourceContentMode(parsedDocument, ocrConfidence)
+    : base.sourceContentMode;
+  const headersFootersDetected = base.headersFootersDetected || detectRepeatedMarginLines(parsedDocument.pages);
+  const tableHeavyWarning = base.tableHeavyWarning || detectTableHeavyWarning(parsedDocument);
+  const layoutHeavyWarning = base.layoutHeavyWarning || detectLayoutHeavyWarning(parsedDocument);
+
+  const warnings = [...base.warnings];
+  if (headersFootersDetected && !warnings.includes("Repeated headers or footers detected across pages.")) {
+    warnings.push("Repeated headers or footers detected across pages.");
+  }
+  if (tableHeavyWarning && !warnings.includes("Document appears table-heavy; extraction may need table-aware handling.")) {
+    warnings.push("Document appears table-heavy; extraction may need table-aware handling.");
+  }
+  if (layoutHeavyWarning && !warnings.includes("Document appears layout-heavy; extraction may be brittle.")) {
+    warnings.push("Document appears layout-heavy; extraction may be brittle.");
+  }
+
+  const report: DocumentQualityReport = {
+    ...base,
+    warnings,
+    sourceContentMode,
+    pageCount,
+    textDensity,
+    ocrConfidence,
+    tableHeavyWarning,
+    layoutHeavyWarning,
+    headersFootersDetected,
+    weakExtractionWarning: false,
+  };
+
+  report.weakExtractionWarning = detectWeakExtractionWarning(parsedDocument, report);
+  if (report.weakExtractionWarning && !report.warnings.includes("Weak extraction detected; keeping document family conservative.")) {
+    report.warnings.push("Weak extraction detected; keeping document family conservative.");
+  }
+
+  return report;
+}

--- a/src/lib/documentClassification/classifyDocumentFamily.ts
+++ b/src/lib/documentClassification/classifyDocumentFamily.ts
@@ -1,0 +1,224 @@
+import type {
+  DocumentFamily,
+  DocumentFamilyClassification,
+  DocumentFamilyClassifier,
+  DocumentTemplateSignal,
+} from "@/lib/documentClassification/documentFamilyTypes";
+import { buildDocumentQualityReport } from "@/lib/documentClassification/buildDocumentQualityReport";
+import type { ParsedDocument } from "@/lib/documentParsing/types";
+
+type FamilyRule = {
+  family: Exclude<DocumentFamily, "UNKNOWN">;
+  label: string;
+  kind: DocumentTemplateSignal["kind"];
+  pattern: RegExp;
+  weight: number;
+};
+
+const FAMILY_RULES: FamilyRule[] = [
+  {
+    family: "CDM_PDD",
+    label: "Clean Development Mechanism",
+    kind: "program_keyword",
+    pattern: /\bclean development mechanism\b/i,
+    weight: 1,
+  },
+  {
+    family: "CDM_PDD",
+    label: "CDM project design document",
+    kind: "template_keyword",
+    pattern: /\bcdm\b.{0,40}\bproject design document\b|\bproject design document\b.{0,40}\bcdm\b/i,
+    weight: 1,
+  },
+  {
+    family: "VERRA_PD",
+    label: "Verra reference",
+    kind: "program_keyword",
+    pattern: /\bverra\b/i,
+    weight: 1,
+  },
+  {
+    family: "VERRA_PD",
+    label: "VCS program under Verra",
+    kind: "template_keyword",
+    pattern: /\bvcs program\b/i,
+    weight: 0.65,
+  },
+  {
+    family: "VCS_PD",
+    label: "Verified Carbon Standard",
+    kind: "program_keyword",
+    pattern: /\bverified carbon standard\b/i,
+    weight: 0.95,
+  },
+  {
+    family: "VCS_PD",
+    label: "VCS project description",
+    kind: "template_keyword",
+    pattern: /\bvcs\b.{0,40}\bproject description\b|\bproject description\b.{0,40}\bvcs\b/i,
+    weight: 0.9,
+  },
+  {
+    family: "GOLD_STANDARD_PDD",
+    label: "Gold Standard reference",
+    kind: "program_keyword",
+    pattern: /\bgold standard\b/i,
+    weight: 1,
+  },
+  {
+    family: "GOLD_STANDARD_PDD",
+    label: "Gold Standard PDD",
+    kind: "template_keyword",
+    pattern: /\bgold standard\b.{0,60}\bproject design document\b|\bproject design document\b.{0,60}\bgold standard\b/i,
+    weight: 1,
+  },
+  {
+    family: "REDD_AFOLU",
+    label: "REDD signal",
+    kind: "sector_keyword",
+    pattern: /\bredd\+?\b|\breducing emissions from deforestation\b/i,
+    weight: 0.85,
+  },
+  {
+    family: "REDD_AFOLU",
+    label: "AFOLU signal",
+    kind: "sector_keyword",
+    pattern: /\bafolu\b|\bafforestation\b|\breforestation\b|\bavoided deforestation\b|\bforest conservation\b/i,
+    weight: 0.8,
+  },
+  {
+    family: "ENERGY",
+    label: "Energy generation signal",
+    kind: "sector_keyword",
+    pattern: /\brenewable energy\b|\bgrid electricity\b|\bpower plant\b|\bwind farm\b|\bsolar\b|\bhydropower\b|\bhydro power\b|\bbiogas\b/i,
+    weight: 0.85,
+  },
+  {
+    family: "ENERGY",
+    label: "Energy unit signal",
+    kind: "sector_keyword",
+    pattern: /\b(?:mw|mwh|kwh|kw)\b|\bturbine\b|\bboiler\b|\belectricity\b/i,
+    weight: 0.65,
+  },
+];
+
+const PROGRAM_FAMILY_PRIORITY: DocumentFamily[] = [
+  "CDM_PDD",
+  "GOLD_STANDARD_PDD",
+  "VERRA_PD",
+  "VCS_PD",
+];
+
+function normalizeText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function roundMetric(value: number): number {
+  return Number(value.toFixed(3));
+}
+
+function firstEvidenceMatch(text: string, pattern: RegExp): string {
+  const match = text.match(pattern);
+  return match?.[0]?.trim() ?? pattern.source;
+}
+
+export function classifyDocumentFamily(parsedDocument: ParsedDocument): DocumentFamilyClassification {
+  const qualityReport = buildDocumentQualityReport(parsedDocument);
+  const haystack = normalizeText(parsedDocument.rawText);
+  const signals: DocumentTemplateSignal[] = [];
+  const scores = new Map<Exclude<DocumentFamily, "UNKNOWN">, number>();
+
+  for (const rule of FAMILY_RULES) {
+    if (!rule.pattern.test(haystack)) continue;
+    const evidence = firstEvidenceMatch(parsedDocument.rawText, rule.pattern);
+    signals.push({
+      kind: rule.kind,
+      family: rule.family,
+      label: rule.label,
+      evidence,
+      weight: rule.weight,
+    });
+    scores.set(rule.family, (scores.get(rule.family) ?? 0) + rule.weight);
+  }
+
+  signals.push({
+    kind: "quality_metric",
+    label: "Page count",
+    evidence: `${qualityReport.pageCount} page(s)`,
+    weight: Math.min(0.3, qualityReport.pageCount / 10),
+  });
+  signals.push({
+    kind: "quality_metric",
+    label: "Text density",
+    evidence: `${qualityReport.textDensity}`,
+    weight: qualityReport.textDensity,
+  });
+
+  if (qualityReport.ocrConfidence !== undefined) {
+    signals.push({
+      kind: "quality_metric",
+      label: "OCR confidence",
+      evidence: `${qualityReport.ocrConfidence}`,
+      weight: qualityReport.ocrConfidence,
+    });
+  }
+
+  if (qualityReport.weakExtractionWarning) {
+    signals.push({
+      kind: "quality_warning",
+      label: "Weak extraction warning",
+      evidence: "Parsed text is sparse or weakly structured.",
+      weight: 0,
+    });
+  }
+
+  const warnings = [...qualityReport.warnings];
+  const programCandidates = PROGRAM_FAMILY_PRIORITY
+    .map((family) => ({ family, score: scores.get(family as Exclude<DocumentFamily, "UNKNOWN">) ?? 0 }))
+    .filter((candidate) => candidate.score > 0)
+    .sort((left, right) => right.score - left.score);
+
+  const sectorCandidates = (["REDD_AFOLU", "ENERGY"] as const)
+    .map((family) => ({ family, score: scores.get(family) ?? 0 }))
+    .filter((candidate) => candidate.score > 0)
+    .sort((left, right) => right.score - left.score);
+
+  let family: DocumentFamily = "UNKNOWN";
+  let confidence = 0.2;
+
+  const strongestProgram = programCandidates[0];
+  const strongestSector = sectorCandidates[0];
+  const verraScore = scores.get("VERRA_PD") ?? 0;
+  const vcsScore = scores.get("VCS_PD") ?? 0;
+
+  if (
+    strongestProgram
+    && strongestProgram.score >= 0.9
+    && (!qualityReport.weakExtractionWarning || strongestProgram.score >= 1.6)
+  ) {
+    family = strongestProgram.family;
+    if (family === "VCS_PD" && verraScore >= 1 && verraScore >= vcsScore - 0.5) {
+      family = "VERRA_PD";
+    }
+    confidence = Math.min(0.98, 0.4 + Math.max(strongestProgram.score, verraScore) / 1.8);
+  } else if (!qualityReport.weakExtractionWarning && strongestSector && strongestSector.score >= 0.8) {
+    family = strongestSector.family;
+    confidence = Math.min(0.9, 0.35 + strongestSector.score / 2);
+  } else {
+    warnings.push("Document family remained UNKNOWN because deterministic intake signals were insufficient.");
+  }
+
+  return {
+    family,
+    confidence: roundMetric(confidence),
+    evidence: signals.map((signal) => `${signal.label}: ${signal.evidence}`),
+    signals,
+    warnings: [...new Set(warnings)],
+  };
+}
+
+export const documentFamilyClassifier: DocumentFamilyClassifier = {
+  classify(parsedDocument: ParsedDocument): DocumentFamilyClassification {
+    return classifyDocumentFamily(parsedDocument);
+  },
+};

--- a/src/lib/documentClassification/documentFamilyTypes.ts
+++ b/src/lib/documentClassification/documentFamilyTypes.ts
@@ -1,3 +1,5 @@
+import type { ParsedDocument } from "@/lib/documentParsing/types";
+
 export type DocumentFamily =
   | "CDM_PDD"
   | "VCS_PD"
@@ -30,5 +32,5 @@ export type DocumentFamilyClassification = {
 };
 
 export interface DocumentFamilyClassifier {
-  classify: (parsedDocument: any) => DocumentFamilyClassification;
+  classify: (parsedDocument: ParsedDocument) => DocumentFamilyClassification;
 }

--- a/src/lib/documentClassification/documentFamilyTypes.ts
+++ b/src/lib/documentClassification/documentFamilyTypes.ts
@@ -1,0 +1,34 @@
+export type DocumentFamily =
+  | "CDM_PDD"
+  | "VCS_PD"
+  | "VERRA_PD"
+  | "GOLD_STANDARD_PDD"
+  | "REDD_AFOLU"
+  | "ENERGY"
+  | "UNKNOWN";
+
+export type DocumentTemplateSignal = {
+  kind:
+    | "program_keyword"
+    | "template_keyword"
+    | "sector_keyword"
+    | "quality_metric"
+    | "quality_warning";
+  family?: Exclude<DocumentFamily, "UNKNOWN">;
+  label: string;
+  evidence: string;
+  weight: number;
+  pageNumber?: number;
+};
+
+export type DocumentFamilyClassification = {
+  family: DocumentFamily;
+  confidence: number;
+  evidence: string[];
+  signals: DocumentTemplateSignal[];
+  warnings: string[];
+};
+
+export interface DocumentFamilyClassifier {
+  classify: (parsedDocument: any) => DocumentFamilyClassification;
+}

--- a/src/lib/documentClassification/index.ts
+++ b/src/lib/documentClassification/index.ts
@@ -1,0 +1,3 @@
+export * from "@/lib/documentClassification/documentFamilyTypes";
+export { buildDocumentQualityReport } from "@/lib/documentClassification/buildDocumentQualityReport";
+export { classifyDocumentFamily, documentFamilyClassifier } from "@/lib/documentClassification/classifyDocumentFamily";

--- a/src/lib/documentModel/buildArticle6DocumentModel.ts
+++ b/src/lib/documentModel/buildArticle6DocumentModel.ts
@@ -63,8 +63,35 @@ export function buildArticle6DocumentModel(
   const { parsedDocument, includeDebugPayload = false } = input;
   const parserAdapterId = parsedDocument.adapterId;
   const source = parsedDocument.source;
+  const parsedElements = parsedDocument.elements ?? [];
 
-  const blocks: Article6DocumentBlock[] = parsedDocument.blocks.map((block) => {
+  const blockSource: Array<{
+    id: string;
+    type: "heading" | "paragraph" | "unknown";
+    text: string;
+    normalizedText: string;
+    pageNumber?: number;
+    headingLevel?: number;
+    sectionNumber?: string;
+    confidence?: number;
+  }> = parsedElements.length > 0
+    ? parsedElements.map((element) => ({
+        id: element.id,
+        type: element.elementType === "heading"
+          ? "heading" as const
+          : element.elementType === "paragraph"
+            ? "paragraph" as const
+            : "unknown" as const,
+        text: element.text,
+        normalizedText: element.normalizedText,
+        pageNumber: element.pageNumber,
+        headingLevel: element.headingLevel,
+        sectionNumber: element.sectionNumber,
+        confidence: element.confidence,
+      }))
+    : parsedDocument.blocks;
+
+  const blocks: Article6DocumentBlock[] = blockSource.map((block) => {
     const sectionId = sectionIdFromNumber(block.sectionNumber);
     return {
       id: block.id,
@@ -84,7 +111,7 @@ export function buildArticle6DocumentModel(
         sectionId,
         sectionNumber: block.sectionNumber,
       }],
-      confidence: block.type === "heading" ? 0.95 : 0.8,
+      confidence: block.confidence ?? (block.type === "heading" ? 0.95 : 0.8),
     };
   });
 
@@ -241,4 +268,10 @@ export function buildArticle6DocumentModel(
     parserDiagnostics: parsedDocument.diagnostics,
     debug: includeDebugPayload ? { parserOutput: parsedDocument } : undefined,
   };
+}
+
+export function buildDocumentStructure(
+  input: BuildArticle6DocumentModelInput,
+): Article6DocumentModel {
+  return buildArticle6DocumentModel(input);
 }

--- a/src/lib/documentModel/buildArticle6DocumentModel.ts
+++ b/src/lib/documentModel/buildArticle6DocumentModel.ts
@@ -1,3 +1,4 @@
+import { buildDocumentQualityReport, classifyDocumentFamily } from "@/lib/documentClassification";
 import type {
   Article6DocumentBlock,
   Article6DocumentModel,
@@ -64,6 +65,11 @@ export function buildArticle6DocumentModel(
   const parserAdapterId = parsedDocument.adapterId;
   const source = parsedDocument.source;
   const parsedElements = parsedDocument.elements ?? [];
+  const qualityReport = buildDocumentQualityReport(parsedDocument);
+  const documentFamily = classifyDocumentFamily({
+    ...parsedDocument,
+    qualityReport,
+  });
 
   const blockSource: Array<{
     id: string;
@@ -261,6 +267,8 @@ export function buildArticle6DocumentModel(
     rawText: parsedDocument.rawText,
     cleanText: cleanText(parsedDocument.rawText),
     matchingText: coerceMatchingText(parsedDocument.normalizedText, parsedDocument.rawText),
+    documentFamily,
+    qualityReport,
     pages,
     blocks,
     sections,

--- a/src/lib/documentModel/documentStructureIntake.test.ts
+++ b/src/lib/documentModel/documentStructureIntake.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "@jest/globals";
+import { buildDocumentStructure } from "@/lib/documentModel";
+import { parseDocumentText } from "@/lib/documentParsing";
+
+describe("buildDocumentStructure intake classification", () => {
+  test("preserves family classification and quality signals on document structure", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1. Project Description",
+        "This Verra VCS Program project description concerns an avoided deforestation activity.",
+        "\f",
+        "2. Monitoring Plan",
+        "The REDD+ AFOLU monitoring plan covers forest conservation and leakage.",
+      ].join("\n"),
+    });
+
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+
+    expect(documentStructure.documentFamily.family).toBe("VERRA_PD");
+    expect(documentStructure.documentFamily.confidence).toBeGreaterThan(0.8);
+    expect(documentStructure.documentFamily.signals.some((signal) => signal.family === "REDD_AFOLU")).toBe(true);
+    expect(documentStructure.qualityReport.pageCount).toBe(2);
+    expect(documentStructure.qualityReport.hasPageBoundaries).toBe(true);
+  });
+
+  test("carries UNKNOWN classification and warnings through the document structure", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: "   ",
+    });
+
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+
+    expect(documentStructure.documentFamily.family).toBe("UNKNOWN");
+    expect(documentStructure.qualityReport.weakExtractionWarning).toBe(true);
+    expect(documentStructure.documentFamily.warnings).toContain(
+      "Document family remained UNKNOWN because deterministic intake signals were insufficient.",
+    );
+  });
+});

--- a/src/lib/documentModel/index.ts
+++ b/src/lib/documentModel/index.ts
@@ -1,2 +1,2 @@
-export { buildArticle6DocumentModel } from "@/lib/documentModel/buildArticle6DocumentModel";
+export { buildArticle6DocumentModel, buildDocumentStructure } from "@/lib/documentModel/buildArticle6DocumentModel";
 export * from "@/lib/documentModel/types";

--- a/src/lib/documentModel/types.ts
+++ b/src/lib/documentModel/types.ts
@@ -1,4 +1,11 @@
-import type { DocumentParserAdapterId, ParsedBlock, ParsedDocument, ParsedHeading, ParsedPage, ParserDiagnostics } from "@/lib/documentParsing";
+import type {
+  DocumentParserAdapterId,
+  ParsedBlock,
+  ParsedDocument,
+  ParsedHeading,
+  ParsedPage,
+  ParserDiagnostics,
+} from "@/lib/documentParsing";
 
 export type Article6SourceRef = {
   source: string;
@@ -76,6 +83,8 @@ export type Article6DocumentModel = {
     parserOutput: ParsedDocument;
   };
 };
+
+export type DocumentStructure = Article6DocumentModel;
 
 export type BuildArticle6DocumentModelInput = {
   parsedDocument: ParsedDocument;

--- a/src/lib/documentModel/types.ts
+++ b/src/lib/documentModel/types.ts
@@ -1,4 +1,6 @@
 import type {
+  DocumentFamilyClassification,
+  DocumentQualityReport,
   DocumentParserAdapterId,
   ParsedBlock,
   ParsedDocument,
@@ -74,6 +76,8 @@ export type Article6DocumentModel = {
   rawText: string;
   cleanText: string;
   matchingText: string;
+  documentFamily: DocumentFamilyClassification;
+  qualityReport: DocumentQualityReport;
   pages: Article6DocumentPage[];
   blocks: Article6DocumentBlock[];
   sections: Article6DocumentSection[];

--- a/src/lib/documentParsing/adapters/currentExtractor.ts
+++ b/src/lib/documentParsing/adapters/currentExtractor.ts
@@ -40,12 +40,57 @@ function splitRawTextIntoPages(rawText: string): ParsedPage[] {
   }));
 }
 
+type PageBoundary = {
+  pageNumber: number;
+  charStart: number;
+  charEnd: number;
+};
+
+function buildPageBoundaries(rawText: string): PageBoundary[] {
+  const normalized = rawText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const pageTexts = normalized.split("\f");
+  const boundaries: PageBoundary[] = [];
+  let cursor = 0;
+
+  for (let index = 0; index < pageTexts.length; index += 1) {
+    const pageText = pageTexts[index] ?? "";
+    const charStart = cursor;
+    const charEnd = charStart + pageText.length;
+    boundaries.push({
+      pageNumber: pageTexts.length > 1 ? index + 1 : 1,
+      charStart,
+      charEnd,
+    });
+    cursor = charEnd + (index < pageTexts.length - 1 ? 1 : 0);
+  }
+
+  return boundaries;
+}
+
+function pageNumberForOffset(offset: number, boundaries: PageBoundary[]): number {
+  const boundary = boundaries.find((candidate) => offset >= candidate.charStart && offset <= candidate.charEnd);
+  return boundary?.pageNumber ?? boundaries[boundaries.length - 1]?.pageNumber ?? 1;
+}
+
+function findSequentialOffset(haystack: string, needle: string, fromIndex: number): number {
+  if (!needle.trim()) return fromIndex;
+  const exactIndex = haystack.indexOf(needle, fromIndex);
+  if (exactIndex >= 0) return exactIndex;
+
+  const trimmedNeedle = needle.trim();
+  const trimmedIndex = haystack.indexOf(trimmedNeedle, fromIndex);
+  if (trimmedIndex >= 0) return trimmedIndex;
+
+  return fromIndex;
+}
+
 export const currentExtractorAdapter: ParserAdapter = {
   id: "current-extractor",
   parseText(input: ParseDocumentTextInput): ParsedDocument {
     const rawText = input.rawText ?? "";
     const normalizedText = normalizeParserText(rawText);
     const parserName = "current-extractor";
+    const pageBoundaries = buildPageBoundaries(rawText);
     const sectionsByNumber = extractPddSections(rawText);
     const headingIndex = buildPddHeadingIndex(rawText);
     const headings = headingIndex.map((heading) => ({
@@ -75,11 +120,15 @@ export const currentExtractorAdapter: ParserAdapter = {
         : [];
       return [headingBlock, ...bodyBlocks];
     });
+    let searchCursor = 0;
     const elements: ParsedElement[] = headingIndex.flatMap((heading) => {
       const sectionPath = buildSectionPath(heading.sectionNumber);
+      const headingOffset = findSequentialOffset(normalizedText, heading.title, searchCursor);
+      const headingPageNumber = pageNumberForOffset(headingOffset, pageBoundaries);
+      searchCursor = headingOffset + heading.title.length;
       const headingElement: ParsedElement = {
         id: `element:heading:${heading.sectionNumber}`,
-        pageNumber: 1,
+        pageNumber: headingPageNumber,
         text: heading.title,
         normalizedText: heading.normalizedTitle,
         elementType: "heading",
@@ -90,17 +139,22 @@ export const currentExtractorAdapter: ParserAdapter = {
         confidence: 0.95,
       };
       const bodyElements = heading.bodyText
-        ? [{
-            id: `element:paragraph:${heading.sectionNumber}`,
-            pageNumber: 1,
-            text: heading.bodyText,
-            normalizedText: normalizeParserText(heading.bodyText).replace(/\s+/g, " ").trim(),
-            elementType: "paragraph" as const,
-            sectionNumber: heading.sectionNumber,
-            sectionPath,
-            sourceParser: parserName,
-            confidence: 0.8,
-          }]
+        ? (() => {
+            const bodyOffset = findSequentialOffset(normalizedText, heading.bodyText, searchCursor);
+            const bodyPageNumber = pageNumberForOffset(bodyOffset, pageBoundaries);
+            searchCursor = bodyOffset + heading.bodyText.length;
+            return [{
+              id: `element:paragraph:${heading.sectionNumber}`,
+              pageNumber: bodyPageNumber,
+              text: heading.bodyText,
+              normalizedText: normalizeParserText(heading.bodyText).replace(/\s+/g, " ").trim(),
+              elementType: "paragraph" as const,
+              sectionNumber: heading.sectionNumber,
+              sectionPath,
+              sourceParser: parserName,
+              confidence: 0.8,
+            }];
+          })()
         : [];
       return [headingElement, ...bodyElements];
     });

--- a/src/lib/documentParsing/adapters/currentExtractor.ts
+++ b/src/lib/documentParsing/adapters/currentExtractor.ts
@@ -3,11 +3,16 @@ import {
   debugSectionExtraction,
   extractPddSections,
 } from "@/lib/chat/quickCheckSectionExtractor";
-import type { DocumentParserAdapter, ParseDocumentTextInput, ParsedDocument } from "@/lib/documentParsing/types";
+import type {
+  ParseDocumentTextInput,
+  ParsedDocument,
+  ParsedElement,
+  ParsedPage,
+  ParserAdapter,
+} from "@/lib/documentParsing/types";
 
 function normalizeParserText(rawText: string): string {
   return rawText
-    .replace(/\f/g, "\n")
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n");
 }
@@ -17,11 +22,30 @@ function headingLevel(sectionNumber?: string): number | undefined {
   return sectionNumber.split(".").length;
 }
 
-export const currentExtractorAdapter: DocumentParserAdapter = {
+function buildSectionPath(sectionNumber?: string): string[] | undefined {
+  if (!sectionNumber) return undefined;
+  const parts = sectionNumber.split(".");
+  return parts.map((_, index) => parts.slice(0, index + 1).join("."));
+}
+
+function splitRawTextIntoPages(rawText: string): ParsedPage[] {
+  const normalized = rawText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const pageTexts = normalized.split("\f");
+
+  return pageTexts.map((pageText, index) => ({
+    pageNumber: pageTexts.length > 1 ? index + 1 : 1,
+    rawText: pageText,
+    normalizedText: pageText,
+    elements: [],
+  }));
+}
+
+export const currentExtractorAdapter: ParserAdapter = {
   id: "current-extractor",
   parseText(input: ParseDocumentTextInput): ParsedDocument {
     const rawText = input.rawText ?? "";
     const normalizedText = normalizeParserText(rawText);
+    const parserName = "current-extractor";
     const sectionsByNumber = extractPddSections(rawText);
     const headingIndex = buildPddHeadingIndex(rawText);
     const headings = headingIndex.map((heading) => ({
@@ -51,23 +75,67 @@ export const currentExtractorAdapter: DocumentParserAdapter = {
         : [];
       return [headingBlock, ...bodyBlocks];
     });
+    const elements: ParsedElement[] = headingIndex.flatMap((heading) => {
+      const sectionPath = buildSectionPath(heading.sectionNumber);
+      const headingElement: ParsedElement = {
+        id: `element:heading:${heading.sectionNumber}`,
+        pageNumber: 1,
+        text: heading.title,
+        normalizedText: heading.normalizedTitle,
+        elementType: "heading",
+        headingLevel: headingLevel(heading.sectionNumber),
+        sectionNumber: heading.sectionNumber,
+        sectionPath,
+        sourceParser: parserName,
+        confidence: 0.95,
+      };
+      const bodyElements = heading.bodyText
+        ? [{
+            id: `element:paragraph:${heading.sectionNumber}`,
+            pageNumber: 1,
+            text: heading.bodyText,
+            normalizedText: normalizeParserText(heading.bodyText).replace(/\s+/g, " ").trim(),
+            elementType: "paragraph" as const,
+            sectionNumber: heading.sectionNumber,
+            sectionPath,
+            sourceParser: parserName,
+            confidence: 0.8,
+          }]
+        : [];
+      return [headingElement, ...bodyElements];
+    });
+    const pages = splitRawTextIntoPages(rawText).map((page) => ({
+      ...page,
+      elements: elements.filter((element) => element.pageNumber === page.pageNumber),
+    }));
+    const warnings = rawText.trim() ? [] : [];
+    const diagnostics = rawText.trim()
+      ? {
+          metadata: debugSectionExtraction(rawText),
+        }
+      : undefined;
+
     return {
       adapterId: "current-extractor",
-      source: "current-extractor",
+      source: parserName,
       rawText,
       normalizedText,
-      pages: [{
-        pageNumber: 1,
-        rawText,
-        normalizedText,
-      }],
+      pages,
+      elements,
+      tables: [],
+      parserName,
+      qualityReport: {
+        parserName,
+        warnings,
+        metadata: diagnostics?.metadata,
+        hasStructuredHeadings: headings.length > 0,
+        hasPageBoundaries: pages.length > 1,
+        hasBoundingBoxes: false,
+        hasTables: false,
+      },
       blocks,
       headings,
-      diagnostics: rawText.trim()
-        ? {
-            metadata: debugSectionExtraction(rawText),
-          }
-        : undefined,
+      diagnostics,
       sectionsByNumber,
       headingIndex,
     };

--- a/src/lib/documentParsing/adapters/currentExtractor.ts
+++ b/src/lib/documentParsing/adapters/currentExtractor.ts
@@ -3,6 +3,7 @@ import {
   debugSectionExtraction,
   extractPddSections,
 } from "@/lib/chat/quickCheckSectionExtractor";
+import { buildDocumentQualityReport } from "@/lib/documentClassification";
 import type {
   ParseDocumentTextInput,
   ParsedDocument,
@@ -162,14 +163,13 @@ export const currentExtractorAdapter: ParserAdapter = {
       ...page,
       elements: elements.filter((element) => element.pageNumber === page.pageNumber),
     }));
-    const warnings = rawText.trim() ? [] : [];
     const diagnostics = rawText.trim()
       ? {
           metadata: debugSectionExtraction(rawText),
         }
       : undefined;
 
-    return {
+    const parsedDocumentBase: ParsedDocument = {
       adapterId: "current-extractor",
       source: parserName,
       rawText,
@@ -180,8 +180,16 @@ export const currentExtractorAdapter: ParserAdapter = {
       parserName,
       qualityReport: {
         parserName,
-        warnings,
+        warnings: rawText.trim() ? [] : ["Parsed document text is empty."],
         metadata: diagnostics?.metadata,
+        sourceContentMode: "unknown",
+        pageCount: pages.length || 1,
+        textDensity: 0,
+        ocrConfidence: undefined,
+        tableHeavyWarning: false,
+        layoutHeavyWarning: false,
+        headersFootersDetected: false,
+        weakExtractionWarning: false,
         hasStructuredHeadings: headings.length > 0,
         hasPageBoundaries: pages.length > 1,
         hasBoundingBoxes: false,
@@ -192,6 +200,11 @@ export const currentExtractorAdapter: ParserAdapter = {
       diagnostics,
       sectionsByNumber,
       headingIndex,
+    };
+
+    return {
+      ...parsedDocumentBase,
+      qualityReport: buildDocumentQualityReport(parsedDocumentBase),
     };
   },
 };

--- a/src/lib/documentParsing/documentFamilyClassifier.test.ts
+++ b/src/lib/documentParsing/documentFamilyClassifier.test.ts
@@ -1,0 +1,1 @@
+import "../../../tests/lib/documentClassification.test";

--- a/src/lib/documentParsing/index.ts
+++ b/src/lib/documentParsing/index.ts
@@ -44,4 +44,5 @@ export function parseDocumentText(
   return getDocumentParserAdapter(adapterId).parseText(input);
 }
 
+export * from "@/lib/documentClassification";
 export * from "@/lib/documentParsing/types";

--- a/src/lib/documentParsing/types.ts
+++ b/src/lib/documentParsing/types.ts
@@ -1,4 +1,10 @@
 import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
+import type {
+  DocumentFamily,
+  DocumentFamilyClassification,
+  DocumentFamilyClassifier,
+  DocumentTemplateSignal,
+} from "@/lib/documentClassification/documentFamilyTypes";
 
 export const DOCUMENT_PARSER_ADAPTER_IDS = [
   "current-extractor",
@@ -29,6 +35,8 @@ export type ParsedCell = {
   boundingBox?: ParsedBoundingBox;
   confidence?: number;
 };
+
+export type { DocumentFamily, DocumentTemplateSignal, DocumentFamilyClassification };
 
 export type ParsedTable = {
   id: string;
@@ -102,6 +110,14 @@ export type DocumentQualityReport = {
   parserName: string;
   warnings: string[];
   metadata?: Record<string, string>;
+  sourceContentMode: "native_pdf" | "scanned" | "unknown";
+  pageCount: number;
+  textDensity: number;
+  ocrConfidence?: number;
+  tableHeavyWarning: boolean;
+  layoutHeavyWarning: boolean;
+  headersFootersDetected: boolean;
+  weakExtractionWarning: boolean;
   hasStructuredHeadings: boolean;
   hasPageBoundaries: boolean;
   hasBoundingBoxes: boolean;
@@ -132,3 +148,5 @@ export interface ParserAdapter {
 }
 
 export type DocumentParserAdapter = ParserAdapter;
+
+export type { DocumentFamilyClassifier };

--- a/src/lib/documentParsing/types.ts
+++ b/src/lib/documentParsing/types.ts
@@ -13,10 +13,65 @@ export type ParseDocumentTextInput = {
   rawText: string;
 };
 
+export type ParsedBoundingBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type ParsedCell = {
+  rowIndex: number;
+  columnIndex: number;
+  text: string;
+  rowSpan?: number;
+  colSpan?: number;
+  boundingBox?: ParsedBoundingBox;
+  confidence?: number;
+};
+
+export type ParsedTable = {
+  id: string;
+  pageNumber: number;
+  caption?: string;
+  columnCount?: number;
+  rowCount?: number;
+  headerRowCount?: number;
+  boundingBox?: ParsedBoundingBox;
+  cells: ParsedCell[];
+  confidence?: number;
+};
+
+export type ParsedElementType =
+  | "heading"
+  | "paragraph"
+  | "table"
+  | "list_item"
+  | "footer"
+  | "header"
+  | "unknown";
+
+export type ParsedElement = {
+  id: string;
+  pageNumber: number;
+  text: string;
+  normalizedText: string;
+  elementType: ParsedElementType;
+  headingLevel?: number;
+  sectionNumber?: string;
+  sectionPath?: string[];
+  boundingBox?: ParsedBoundingBox;
+  tableId?: string;
+  table?: ParsedTable;
+  sourceParser: string;
+  confidence?: number;
+};
+
 export type ParsedPage = {
   pageNumber: number;
   rawText: string;
   normalizedText: string;
+  elements: ParsedElement[];
 };
 
 export type ParsedBlock = {
@@ -43,12 +98,26 @@ export type ParserDiagnostics = {
   metadata?: Record<string, string>;
 };
 
+export type DocumentQualityReport = {
+  parserName: string;
+  warnings: string[];
+  metadata?: Record<string, string>;
+  hasStructuredHeadings: boolean;
+  hasPageBoundaries: boolean;
+  hasBoundingBoxes: boolean;
+  hasTables: boolean;
+};
+
 export type ParsedDocument = {
   adapterId: DocumentParserAdapterId;
   source: string;
   rawText: string;
   normalizedText: string;
   pages: ParsedPage[];
+  elements: ParsedElement[];
+  tables: ParsedTable[];
+  parserName: string;
+  qualityReport: DocumentQualityReport;
   blocks: ParsedBlock[];
   headings: ParsedHeading[];
   diagnostics?: ParserDiagnostics;
@@ -57,7 +126,9 @@ export type ParsedDocument = {
   headingIndex?: DocumentHeading[];
 };
 
-export interface DocumentParserAdapter {
+export interface ParserAdapter {
   readonly id: DocumentParserAdapterId;
   parseText(input: ParseDocumentTextInput): ParsedDocument;
 }
+
+export type DocumentParserAdapter = ParserAdapter;

--- a/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
+++ b/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
@@ -243,15 +243,18 @@ function buildSpanId(docId: string, page: number | null, charStart: number, bloc
   return [safeDocId, `p${page ?? 0}`, blockType, `${charStart}`].join(":");
 }
 
-function mapDocumentStructureBlockType(type: DocumentStructure["blocks"][number]["type"]): EvidenceBlockType {
+function mapDocumentStructureBlockType(
+  type: DocumentStructure["blocks"][number]["type"],
+): EvidenceBlockType | null {
   switch (type) {
     case "heading":
       return "section_heading";
     case "paragraph":
       return "paragraph";
     case "unknown":
+      return null;
     default:
-      return "paragraph";
+      return null;
   }
 }
 
@@ -294,8 +297,11 @@ export function compileEvidenceDocumentFromStructure(input: {
 }): EvidenceDocument {
   const rawText = normalizeNewlines(input.documentStructure.rawText ?? "");
   let cursor = 0;
-  const spans: EvidenceSpan[] = input.documentStructure.blocks.map((block) => {
+  const spans: EvidenceSpan[] = input.documentStructure.blocks.flatMap((block) => {
     const blockType = mapDocumentStructureBlockType(block.type);
+    if (!blockType) {
+      return [];
+    }
     const charStart = findCharStart(rawText, block.rawText, cursor);
     const charEnd = charStart + block.rawText.length;
     cursor = charEnd;
@@ -304,7 +310,7 @@ export function compileEvidenceDocumentFromStructure(input: {
       ? input.documentStructure.sections.find((candidate) => candidate.id === block.sectionId)
       : undefined;
 
-    return {
+    return [{
       spanId: buildSpanId(input.docId, block.pageNumber ?? null, charStart, blockType),
       docId: input.docId,
       page: block.pageNumber ?? null,
@@ -316,7 +322,7 @@ export function compileEvidenceDocumentFromStructure(input: {
       charStart,
       charEnd,
       confidence: block.confidence,
-    };
+    }];
   });
 
   return {

--- a/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
+++ b/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
@@ -1,4 +1,5 @@
 import { normalizeSectionKey } from "@/lib/chat/quickCheckSectionExtractor";
+import type { DocumentStructure } from "@/lib/documentModel";
 import type {
   CompileEvidenceDocumentInput,
   EvidenceBlockType,
@@ -242,6 +243,28 @@ function buildSpanId(docId: string, page: number | null, charStart: number, bloc
   return [safeDocId, `p${page ?? 0}`, blockType, `${charStart}`].join(":");
 }
 
+function mapDocumentStructureBlockType(type: DocumentStructure["blocks"][number]["type"]): EvidenceBlockType {
+  switch (type) {
+    case "heading":
+      return "section_heading";
+    case "paragraph":
+      return "paragraph";
+    case "unknown":
+    default:
+      return "paragraph";
+  }
+}
+
+function findCharStart(rawText: string, blockText: string, fallbackCursor: number): number {
+  const trimmed = blockText.trim();
+  if (!trimmed) return fallbackCursor;
+  const exactIndex = rawText.indexOf(blockText, fallbackCursor);
+  if (exactIndex >= 0) return exactIndex;
+  const trimmedIndex = rawText.indexOf(trimmed, fallbackCursor);
+  if (trimmedIndex >= 0) return trimmedIndex;
+  return fallbackCursor;
+}
+
 export function compileEvidenceDocument(input: CompileEvidenceDocumentInput): EvidenceDocument {
   const rawText = normalizeNewlines(input.rawText ?? "");
   const spans: EvidenceSpan[] = buildCandidateBlocks({ ...input, rawText }).map((block) => ({
@@ -257,6 +280,44 @@ export function compileEvidenceDocument(input: CompileEvidenceDocumentInput): Ev
     charEnd: block.charEnd,
     confidence: block.confidence,
   }));
+
+  return {
+    docId: input.docId,
+    rawText,
+    spans,
+  };
+}
+
+export function compileEvidenceDocumentFromStructure(input: {
+  docId: string;
+  documentStructure: DocumentStructure;
+}): EvidenceDocument {
+  const rawText = normalizeNewlines(input.documentStructure.rawText ?? "");
+  let cursor = 0;
+  const spans: EvidenceSpan[] = input.documentStructure.blocks.map((block) => {
+    const blockType = mapDocumentStructureBlockType(block.type);
+    const charStart = findCharStart(rawText, block.rawText, cursor);
+    const charEnd = charStart + block.rawText.length;
+    cursor = charEnd;
+
+    const section = block.sectionId
+      ? input.documentStructure.sections.find((candidate) => candidate.id === block.sectionId)
+      : undefined;
+
+    return {
+      spanId: buildSpanId(input.docId, block.pageNumber ?? null, charStart, blockType),
+      docId: input.docId,
+      page: block.pageNumber ?? null,
+      sectionId: block.sectionId,
+      heading: section?.titleRaw,
+      blockType,
+      text: block.rawText,
+      normalizedText: normalizeEvidenceText(block.rawText),
+      charStart,
+      charEnd,
+      confidence: block.confidence,
+    };
+  });
 
   return {
     docId: input.docId,

--- a/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
+++ b/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
@@ -84,6 +84,35 @@ describe("compileEvidenceDocument", () => {
     expect(compiled.spans.some((span) => span.page === 2 && span.heading === "Baseline Scenario")).toBe(true);
   });
 
+  test("does not silently coerce unknown document-structure blocks into paragraph evidence spans", () => {
+    const parsedDocument = parseDocumentText({ rawText: SAMPLE_TEXT });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "doc-structure-unknown",
+      documentStructure: {
+        ...documentStructure,
+        blocks: [
+          ...documentStructure.blocks,
+          {
+            id: "block:unknown:1",
+            type: "unknown",
+            rawText: "Unclassified layout artifact",
+            cleanText: "Unclassified layout artifact",
+            matchingText: "unclassified layout artifact",
+            pageNumber: 1,
+            sectionId: undefined,
+            headingLevel: undefined,
+            sourceRefs: [],
+            confidence: 0.2,
+          },
+        ],
+      },
+    });
+
+    expect(compiled.spans.some((span) => span.text === "Unclassified layout artifact")).toBe(false);
+  });
+
   test("keeps a leading numbered section heading out of the title slot", () => {
     const compiled = compileEvidenceDocument({
       docId: "doc-2",

--- a/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
+++ b/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "@jest/globals";
-import { compileEvidenceDocument } from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+import { buildDocumentStructure } from "@/lib/documentModel";
+import { parseDocumentText } from "@/lib/documentParsing";
+import {
+  compileEvidenceDocument,
+  compileEvidenceDocumentFromStructure,
+} from "@/lib/quickCheck/evidence/compileEvidenceDocument";
 import { extractDocumentFacts } from "@/lib/quickCheck/evidence/extractDocumentFacts";
 import { validateQuotes } from "@/lib/quickCheck/evidence/validateQuotes";
 
@@ -40,6 +45,22 @@ describe("compileEvidenceDocument", () => {
     expect(compiled.spans.some((span) => span.blockType === "footer")).toBe(true);
     expect(compiled.spans.some((span) => span.blockType === "section_heading" && span.sectionId === "1")).toBe(true);
     expect(compiled.spans.some((span) => span.blockType === "field" && span.heading === "Project Details")).toBe(true);
+  });
+
+  test("adapts DocumentStructure into the evidence compiler with provenance intact", () => {
+    const parsedDocument = parseDocumentText({ rawText: SAMPLE_TEXT });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "doc-structure-1",
+      documentStructure,
+    });
+
+    expect(compiled.rawText).toBe(SAMPLE_TEXT);
+    expect(compiled.spans.some((span) => span.page === 1)).toBe(true);
+    expect(compiled.spans.some((span) => span.blockType === "section_heading")).toBe(true);
+    expect(compiled.spans.some((span) => span.sectionId === "section:1")).toBe(true);
+    expect(compiled.spans.some((span) => span.heading === "Project Details")).toBe(true);
   });
 
   test("keeps a leading numbered section heading out of the title slot", () => {

--- a/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
+++ b/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
@@ -63,6 +63,27 @@ describe("compileEvidenceDocument", () => {
     expect(compiled.spans.some((span) => span.heading === "Project Details")).toBe(true);
   });
 
+  test("preserves page provenance when evidence spans are compiled from multi-page structure", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1 Project Details",
+        "Host country: Indonesia",
+        "\f",
+        "2 Baseline Scenario",
+        "Baseline scenario: forest conversion.",
+      ].join("\n"),
+    });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "doc-structure-2",
+      documentStructure,
+    });
+
+    expect(compiled.spans.some((span) => span.page === 2)).toBe(true);
+    expect(compiled.spans.some((span) => span.page === 2 && span.heading === "Baseline Scenario")).toBe(true);
+  });
+
   test("keeps a leading numbered section heading out of the title slot", () => {
     const compiled = compileEvidenceDocument({
       docId: "doc-2",

--- a/tests/lib/documentClassification.test.ts
+++ b/tests/lib/documentClassification.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  buildDocumentQualityReport,
+  classifyDocumentFamily,
+  parseDocumentText,
+} from "@/lib/documentParsing";
+
+describe("documentFamilyClassifier", () => {
+  test("classifies CDM PDD-like text as CDM_PDD", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1. Project Design Document Form",
+        "This Clean Development Mechanism project design document describes the activity boundary.",
+        "2. Baseline Methodology",
+        "The monitoring plan and baseline scenario are included below.",
+      ].join("\n"),
+    });
+
+    const classification = classifyDocumentFamily(parsedDocument);
+
+    expect(classification.family).toBe("CDM_PDD");
+    expect(classification.confidence).toBeGreaterThan(0.8);
+    expect(classification.signals.some((signal) => signal.family === "CDM_PDD")).toBe(true);
+  });
+
+  test("classifies Verra project description text as VERRA_PD with evidence signals", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1. Project Description",
+        "This Verra VCS Program project description covers project location and baseline conditions.",
+        "2. Monitoring",
+        "Verified Carbon Standard requirements are addressed in the monitoring section.",
+      ].join("\n"),
+    });
+
+    const classification = classifyDocumentFamily(parsedDocument);
+
+    expect(classification.family).toBe("VERRA_PD");
+    expect(classification.confidence).toBeGreaterThan(0.8);
+    expect(classification.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          family: "VERRA_PD",
+          label: expect.stringContaining("Verra"),
+        }),
+      ]),
+    );
+  });
+
+  test("classifies VCS project description text as VCS_PD when Verra is absent", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1. Project Description",
+        "This Verified Carbon Standard project description includes the baseline scenario and monitoring plan.",
+        "2. Crediting Period",
+        "The VCS activity follows the project description form.",
+      ].join("\n"),
+    });
+
+    const classification = classifyDocumentFamily(parsedDocument);
+
+    expect(classification.family).toBe("VCS_PD");
+    expect(classification.signals.some((signal) => signal.family === "VCS_PD")).toBe(true);
+  });
+
+  test("detects REDD_AFOLU signals deterministically", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1. Forest Conservation Program",
+        "This avoided deforestation activity is a REDD+ AFOLU intervention focused on forest conservation.",
+        "2. Leakage",
+        "Land-use pressure and afforestation boundaries are monitored annually.",
+      ].join("\n"),
+    });
+
+    const classification = classifyDocumentFamily(parsedDocument);
+
+    expect(classification.family).toBe("REDD_AFOLU");
+    expect(classification.signals.some((signal) => signal.family === "REDD_AFOLU")).toBe(true);
+  });
+
+  test("detects ENERGY signals deterministically", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1. Renewable Energy Activity",
+        "The solar power plant exports grid electricity and generates 42 MWh per day.",
+        "2. Equipment",
+        "Turbine and inverter performance are monitored through the electricity metering plan.",
+      ].join("\n"),
+    });
+
+    const classification = classifyDocumentFamily(parsedDocument);
+
+    expect(classification.family).toBe("ENERGY");
+    expect(classification.signals.some((signal) => signal.family === "ENERGY")).toBe(true);
+  });
+
+  test("classifies Gold Standard PDD-like text as GOLD_STANDARD_PDD", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "Gold Standard Project Design Document",
+        "This Gold Standard project design document describes the monitoring period and baseline scenario.",
+        "Renewable energy generation is tracked in the appendix.",
+      ].join("\n"),
+    });
+
+    const classification = classifyDocumentFamily(parsedDocument);
+
+    expect(classification.family).toBe("GOLD_STANDARD_PDD");
+    expect(classification.confidence).toBeGreaterThan(0.8);
+    expect(classification.evidence.length).toBeGreaterThan(0);
+  });
+
+  test("keeps weak unknown documents as UNKNOWN with warnings instead of guessing", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: "Meeting notes and an unlabeled appendix with fragmented references only.",
+    });
+
+    const classification = classifyDocumentFamily(parsedDocument);
+
+    expect(classification.family).toBe("UNKNOWN");
+    expect(classification.warnings).toContain(
+      "Document family remained UNKNOWN because deterministic intake signals were insufficient.",
+    );
+    expect(classification.evidence.length).toBeGreaterThan(0);
+  });
+
+  test("returns quality warnings for weak or empty extraction", () => {
+    const parsedDocument = parseDocumentText({ rawText: "   " });
+    const qualityReport = buildDocumentQualityReport(parsedDocument);
+    const classification = classifyDocumentFamily(parsedDocument);
+
+    expect(qualityReport.weakExtractionWarning).toBe(true);
+    expect(qualityReport.warnings).toContain("Parsed document text is empty.");
+    expect(qualityReport.warnings).toContain("Weak extraction detected; keeping document family conservative.");
+    expect(classification.family).toBe("UNKNOWN");
+  });
+
+  test("surfaces repeated-header, layout-heavy, and table-heavy warnings when parser signals support them", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "Common Header",
+        "A | B | C",
+        "1 | 2 | 3",
+        "4 | 5 | 6",
+        "short",
+        "short",
+        "short",
+        "Common Footer",
+        "\f",
+        "Common Header",
+        "A | B | C",
+        "7 | 8 | 9",
+        "10 | 11 | 12",
+        "short",
+        "short",
+        "short",
+        "Common Footer",
+      ].join("\n"),
+    });
+
+    const qualityReport = buildDocumentQualityReport(parsedDocument);
+
+    expect(qualityReport.headersFootersDetected).toBe(true);
+    expect(qualityReport.tableHeavyWarning).toBe(true);
+    expect(qualityReport.layoutHeavyWarning).toBe(true);
+  });
+
+  test("uses OCR confidence when available and keeps sector signals as evidence", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "Project Description",
+        "This Verra VCS Program document covers REDD+ forest conservation and grid electricity backup for the site.",
+      ].join("\n"),
+    });
+
+    const qualityReport = buildDocumentQualityReport({
+      ...parsedDocument,
+      qualityReport: {
+        ...parsedDocument.qualityReport,
+        metadata: {
+          ...parsedDocument.qualityReport.metadata,
+          ocr_confidence: "0.42",
+        },
+      },
+    });
+    const classification = classifyDocumentFamily({
+      ...parsedDocument,
+      qualityReport: {
+        ...parsedDocument.qualityReport,
+        metadata: {
+          ...parsedDocument.qualityReport.metadata,
+          ocr_confidence: "0.42",
+        },
+      },
+    });
+
+    expect(qualityReport.ocrConfidence).toBe(0.42);
+    expect(qualityReport.sourceContentMode).toBe("scanned");
+    expect(classification.family).toBe("VERRA_PD");
+    expect(classification.signals.some((signal) => signal.family === "REDD_AFOLU")).toBe(true);
+    expect(classification.signals.some((signal) => signal.family === "ENERGY")).toBe(true);
+  });
+});

--- a/tests/lib/documentModel.test.ts
+++ b/tests/lib/documentModel.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "@jest/globals";
 import { parseDocumentText } from "@/lib/documentParsing";
-import { buildArticle6DocumentModel } from "@/lib/documentModel";
+import { buildArticle6DocumentModel, buildDocumentStructure } from "@/lib/documentModel";
 import { currentExtractorAdapter } from "@/lib/documentParsing/adapters/currentExtractor";
 import { setLiteParseImplementationForTests } from "@/lib/documentParsing/adapters/liteParse";
 
@@ -23,7 +23,7 @@ describe("buildArticle6DocumentModel", () => {
 
   it("converts parser output into a canonical Article6 document model", () => {
     const parsedDocument = parseDocumentText({ rawText: NESTED_PDD_TEXT });
-    const model = buildArticle6DocumentModel({ parsedDocument });
+    const model = buildDocumentStructure({ parsedDocument });
 
     expect(model.parserAdapterId).toBe("current-extractor");
     expect(model.source).toBe("current-extractor");
@@ -33,6 +33,7 @@ describe("buildArticle6DocumentModel", () => {
     expect(model.pages).toHaveLength(1);
     expect(model.blocks.some((block) => block.type === "heading")).toBe(true);
     expect(model.blocks.some((block) => block.type === "paragraph")).toBe(true);
+    expect(model.blocks[0]?.pageNumber).toBe(1);
     expect(model.debug).toBeUndefined();
 
     const monitoringPlan = model.sections.find((section) => section.sectionNumber === "4.3");
@@ -51,6 +52,7 @@ describe("buildArticle6DocumentModel", () => {
     expect(monitoringPlan?.confidence).toBeGreaterThan(0.9);
     expect(model.pages[0]?.sourceRefs[0]?.quality).toBe("synthetic");
     expect(model.blocks[0]?.sourceRefs[0]?.quality).toBe("synthetic");
+    expect(model.blocks[0]?.sourceRefs[0]?.pageNumber).toBe(1);
   });
 
   it("preserves raw parser text separately from clean and matching text", () => {
@@ -74,7 +76,19 @@ describe("buildArticle6DocumentModel", () => {
           pageNumber: 1,
           rawText: "Loose body text without recoverable headings.",
           normalizedText: "Loose body text without recoverable headings.",
+          elements: [],
         }],
+        elements: [],
+        tables: [],
+        parserName: "test-parser",
+        qualityReport: {
+          parserName: "test-parser",
+          warnings: ["heuristic fallback used"],
+          hasStructuredHeadings: false,
+          hasPageBoundaries: false,
+          hasBoundingBoxes: false,
+          hasTables: false,
+        },
         blocks: [],
         headings: [],
         diagnostics: {
@@ -121,5 +135,35 @@ describe("buildArticle6DocumentModel", () => {
     expect(model.sections.map((section) => section.sectionNumber)).toEqual(expect.arrayContaining(["4.3", "4.3.1", "6"]));
     expect(model.blocks.some((block) => block.type === "heading")).toBe(true);
     expect(model.pages).toHaveLength(1);
+  });
+
+  it("normalizes parsed page provenance into document structure pages", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1 Project Details",
+        "Host country: Indonesia",
+        "\f",
+        "2 Baseline Scenario",
+        "Baseline scenario: forest conversion.",
+      ].join("\n"),
+    });
+
+    const model = buildDocumentStructure({ parsedDocument });
+
+    expect(model.pages).toHaveLength(2);
+    expect(model.pages[0]).toEqual(expect.objectContaining({
+      pageNumber: 1,
+    }));
+    expect(model.pages[1]).toEqual(expect.objectContaining({
+      pageNumber: 2,
+    }));
+    expect(model.pages[0]?.sourceRefs[0]).toEqual(expect.objectContaining({
+      parserAdapterId: "current-extractor",
+      pageNumber: 1,
+    }));
+    expect(model.pages[1]?.sourceRefs[0]).toEqual(expect.objectContaining({
+      parserAdapterId: "current-extractor",
+      pageNumber: 2,
+    }));
   });
 });

--- a/tests/lib/documentModel.test.ts
+++ b/tests/lib/documentModel.test.ts
@@ -27,6 +27,9 @@ describe("buildArticle6DocumentModel", () => {
 
     expect(model.parserAdapterId).toBe("current-extractor");
     expect(model.source).toBe("current-extractor");
+    expect(model.documentFamily.family).toBe("UNKNOWN");
+    expect(model.documentFamily.confidence).toBeGreaterThan(0);
+    expect(model.qualityReport.pageCount).toBe(1);
     expect(model.rawText).toBe(NESTED_PDD_TEXT);
     expect(model.cleanText).toContain("4.3 Monitoring Plan");
     expect(model.matchingText).toContain("monitoring plan");
@@ -84,6 +87,14 @@ describe("buildArticle6DocumentModel", () => {
         qualityReport: {
           parserName: "test-parser",
           warnings: ["heuristic fallback used"],
+          sourceContentMode: "unknown",
+          pageCount: 1,
+          textDensity: 0.04,
+          ocrConfidence: undefined,
+          tableHeavyWarning: false,
+          layoutHeavyWarning: false,
+          headersFootersDetected: false,
+          weakExtractionWarning: true,
           hasStructuredHeadings: false,
           hasPageBoundaries: false,
           hasBoundingBoxes: false,
@@ -167,5 +178,6 @@ describe("buildArticle6DocumentModel", () => {
     }));
     expect(model.blocks.some((block) => block.pageNumber === 2)).toBe(true);
     expect(model.blocks.some((block) => block.sourceRefs.some((ref) => ref.pageNumber === 2))).toBe(true);
+    expect(model.qualityReport.pageCount).toBe(2);
   });
 });

--- a/tests/lib/documentModel.test.ts
+++ b/tests/lib/documentModel.test.ts
@@ -165,5 +165,7 @@ describe("buildArticle6DocumentModel", () => {
       parserAdapterId: "current-extractor",
       pageNumber: 2,
     }));
+    expect(model.blocks.some((block) => block.pageNumber === 2)).toBe(true);
+    expect(model.blocks.some((block) => block.sourceRefs.some((ref) => ref.pageNumber === 2))).toBe(true);
   });
 });

--- a/tests/lib/documentParsing.test.ts
+++ b/tests/lib/documentParsing.test.ts
@@ -71,6 +71,13 @@ describe("documentParsing current extractor adapter", () => {
     expect(parsed.tables).toEqual([]);
     expect(parsed.qualityReport).toEqual(expect.objectContaining({
       parserName: "current-extractor",
+      pageCount: 1,
+      textDensity: expect.any(Number),
+      sourceContentMode: "unknown",
+      weakExtractionWarning: false,
+      tableHeavyWarning: false,
+      layoutHeavyWarning: false,
+      headersFootersDetected: false,
       hasStructuredHeadings: true,
       hasPageBoundaries: false,
       hasBoundingBoxes: false,
@@ -107,6 +114,9 @@ describe("documentParsing current extractor adapter", () => {
     expect(parsed.diagnostics).toBeUndefined();
     expect(parsed.qualityReport).toEqual(expect.objectContaining({
       parserName: "current-extractor",
+      pageCount: 1,
+      sourceContentMode: "unknown",
+      weakExtractionWarning: true,
       hasStructuredHeadings: false,
     }));
   });
@@ -128,6 +138,7 @@ describe("documentParsing current extractor adapter", () => {
     expect(parsed.pages[1]?.elements.some((element) => element.pageNumber === 2)).toBe(true);
     expect(parsed.elements.some((element) => element.pageNumber === 2)).toBe(true);
     expect(parsed.qualityReport.hasPageBoundaries).toBe(true);
+    expect(parsed.qualityReport.pageCount).toBe(2);
   });
 
   it("selects liteparse from QUICK_CHECK_PARSER without changing the parsed-document contract", () => {

--- a/tests/lib/documentParsing.test.ts
+++ b/tests/lib/documentParsing.test.ts
@@ -124,6 +124,9 @@ describe("documentParsing current extractor adapter", () => {
 
     expect(parsed.pages).toHaveLength(2);
     expect(parsed.pages.map((page) => page.pageNumber)).toEqual([1, 2]);
+    expect(parsed.pages[1]?.elements.length).toBeGreaterThan(0);
+    expect(parsed.pages[1]?.elements.some((element) => element.pageNumber === 2)).toBe(true);
+    expect(parsed.elements.some((element) => element.pageNumber === 2)).toBe(true);
     expect(parsed.qualityReport.hasPageBoundaries).toBe(true);
   });
 

--- a/tests/lib/documentParsing.test.ts
+++ b/tests/lib/documentParsing.test.ts
@@ -49,6 +49,7 @@ describe("documentParsing current extractor adapter", () => {
 
     expect(parsed.adapterId).toBe("current-extractor");
     expect(parsed.source).toBe("current-extractor");
+    expect(parsed.parserName).toBe("current-extractor");
     expect(parsed.rawText).toBe(VM0007_TEXT);
     expect(parsed.normalizedText).toBe(VM0007_TEXT);
     expect(parsed.pages).toEqual([
@@ -56,8 +57,25 @@ describe("documentParsing current extractor adapter", () => {
         pageNumber: 1,
         rawText: VM0007_TEXT,
         normalizedText: VM0007_TEXT,
+        elements: parsed.elements,
       },
     ]);
+    expect(parsed.elements[0]).toEqual(expect.objectContaining({
+      pageNumber: 1,
+      elementType: "heading",
+      sectionNumber: "1.9",
+      sectionPath: ["1", "1.9"],
+      sourceParser: "current-extractor",
+    }));
+    expect(parsed.elements.some((element) => element.elementType === "paragraph")).toBe(true);
+    expect(parsed.tables).toEqual([]);
+    expect(parsed.qualityReport).toEqual(expect.objectContaining({
+      parserName: "current-extractor",
+      hasStructuredHeadings: true,
+      hasPageBoundaries: false,
+      hasBoundingBoxes: false,
+      hasTables: false,
+    }));
     expect(parsed.headings.map((heading) => heading.sectionNumber)).toEqual(["1.9", "2.4", "4.3"]);
     expect(parsed.blocks.some((block) => block.type === "heading")).toBe(true);
     expect(parsed.blocks.some((block) => block.type === "paragraph")).toBe(true);
@@ -77,13 +95,36 @@ describe("documentParsing current extractor adapter", () => {
         pageNumber: 1,
         rawText: "   ",
         normalizedText: "   ",
+        elements: [],
       },
     ]);
+    expect(parsed.elements).toEqual([]);
+    expect(parsed.tables).toEqual([]);
     expect(parsed.blocks).toEqual([]);
     expect(parsed.headings).toEqual([]);
     expect(parsed.sectionsByNumber).toEqual({});
     expect(parsed.headingIndex).toEqual([]);
     expect(parsed.diagnostics).toBeUndefined();
+    expect(parsed.qualityReport).toEqual(expect.objectContaining({
+      parserName: "current-extractor",
+      hasStructuredHeadings: false,
+    }));
+  });
+
+  it("preserves page metadata when raw text already contains page breaks", () => {
+    const parsed = parseDocumentText({
+      rawText: [
+        "1 Project Details",
+        "Host country: Indonesia",
+        "\f",
+        "2 Baseline Scenario",
+        "Baseline scenario: forest conversion.",
+      ].join("\n"),
+    });
+
+    expect(parsed.pages).toHaveLength(2);
+    expect(parsed.pages.map((page) => page.pageNumber)).toEqual([1, 2]);
+    expect(parsed.qualityReport.hasPageBoundaries).toBe(true);
   });
 
   it("selects liteparse from QUICK_CHECK_PARSER without changing the parsed-document contract", () => {


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- - RC5: in_progress -->
  <!-- - PR12: done -->
  <!-- - PR13: in_progress -->

For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactors with no SSOT impact), leave `slug: N/A`. The roadmap gates will skip.

Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

Visible UI changes to look for:
