### PR TITLE
[codex] phase 2 family-aware project fact contract v2

### DIFF
--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -1,0 +1,539 @@
+import type { DocumentFamily } from "@/lib/documentParsing";
+import type { EvidenceDocument, EvidenceSpan } from "@/lib/quickCheck/evidence/evidenceTypes";
+import type {
+  ProjectFactConfidence,
+  ProjectFactContract,
+  ProjectFactContractDocumentType,
+  ProjectFactField,
+} from "@/lib/quickCheck/projectFacts/types";
+
+type Candidate = {
+  value: string;
+  normalizedValue: string;
+  confidence: ProjectFactConfidence;
+  span: EvidenceSpan;
+  extractionRule: string;
+  warnings: string[];
+};
+
+type FieldRule = {
+  field: keyof Omit<ProjectFactContract, "documentFamily" | "documentType" | "warnings">;
+  labels: string[];
+  preferBlockTypes?: EvidenceSpan["blockType"][];
+  multiline?: boolean;
+  familySpecificLabels?: Partial<Record<DocumentFamily, string[]>>;
+};
+
+const COUNTRY_RE = /\b([A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+){0,3})\b/;
+const METHODOLOGY_CODE_RE = /\b(?:V?M|ACM|AM|AMS|AR-AM|AR-ACM|VMR|CDM-SSC|GS)\d{3,5}[A-Z-]*\b/i;
+const FIELD_RULES: FieldRule[] = [
+  {
+    field: "hostCountry",
+    labels: ["Host country", "Host country(ies)", "Country"],
+    preferBlockTypes: ["field", "table", "paragraph"],
+    familySpecificLabels: {
+      VCS_PD: ["Country/Area", "Country"],
+      VERRA_PD: ["Country/Area", "Country"],
+    },
+  },
+  {
+    field: "projectLocation",
+    labels: ["Project location", "Project site", "Location"],
+    preferBlockTypes: ["field", "table", "paragraph"],
+    multiline: true,
+  },
+  {
+    field: "projectProponent",
+    labels: ["Project proponent", "Project participants", "Participants"],
+    preferBlockTypes: ["field", "table", "paragraph"],
+    multiline: true,
+  },
+  {
+    field: "methodologyPrimary",
+    labels: ["Methodology", "Applied methodology", "Approved methodology"],
+    preferBlockTypes: ["field", "table", "paragraph"],
+    multiline: true,
+    familySpecificLabels: {
+      VCS_PD: ["Title and reference of methodology applied", "Methodology applied"],
+      VERRA_PD: ["Title and reference of methodology applied", "Methodology applied"],
+      CDM_PDD: ["Applied baseline methodology", "Approved baseline and monitoring methodology"],
+    },
+  },
+  {
+    field: "baselineMethodology",
+    labels: ["Baseline methodology", "Applied baseline methodology"],
+    preferBlockTypes: ["field", "table", "paragraph"],
+    multiline: true,
+  },
+  {
+    field: "monitoringMethodology",
+    labels: ["Monitoring methodology", "Monitoring approach"],
+    preferBlockTypes: ["field", "table", "paragraph"],
+    multiline: true,
+  },
+  {
+    field: "creditingPeriod",
+    labels: ["Crediting period"],
+    preferBlockTypes: ["field", "paragraph"],
+    multiline: true,
+  },
+  {
+    field: "reportingPeriod",
+    labels: ["Reporting period"],
+    preferBlockTypes: ["field", "paragraph"],
+    multiline: true,
+  },
+  {
+    field: "monitoringPeriod",
+    labels: ["Monitoring period"],
+    preferBlockTypes: ["field", "paragraph"],
+    multiline: true,
+  },
+  {
+    field: "projectStartDate",
+    labels: ["Project start date", "Starting date of the project activity", "Start date"],
+    preferBlockTypes: ["field", "paragraph"],
+  },
+  {
+    field: "projectType",
+    labels: ["Project type", "Type of project activity"],
+    preferBlockTypes: ["field", "paragraph"],
+    multiline: true,
+  },
+];
+
+function normalizeValue(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^\w\s./()-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function dedupe<T>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function materializeWarning(message: string): string {
+  return message.trim();
+}
+
+function createEmptyField<T extends string | string[] | null>(
+  extractionRule: string,
+  family: DocumentFamily,
+  warnings: string[] = [],
+): ProjectFactField<T> {
+  return {
+    value: null as T,
+    confidence: "low",
+    evidenceSpanIds: [],
+    pageNumbers: [],
+    sectionPath: [],
+    heading: undefined,
+    extractionRule,
+    sourceParser: undefined,
+    family,
+    warnings,
+  };
+}
+
+function rankConfidence(span: EvidenceSpan, options?: { preferStructured?: boolean }): ProjectFactConfidence {
+  if (span.reliability === "excluded") return "low";
+  if (options?.preferStructured && (span.blockType === "field" || span.blockType === "table")) return "high";
+  if (span.confidence >= 0.92) return "high";
+  if (span.confidence >= 0.75) return "medium";
+  return "low";
+}
+
+function chooseDocumentType(family: DocumentFamily): ProjectFactContractDocumentType {
+  switch (family) {
+    case "CDM_PDD":
+    case "GOLD_STANDARD_PDD":
+      return "PROJECT_DESIGN_DOCUMENT";
+    case "VCS_PD":
+    case "VERRA_PD":
+      return "PROJECT_DESCRIPTION";
+    default:
+      return "DOCUMENT";
+  }
+}
+
+function findLabeledCandidates(
+  document: EvidenceDocument,
+  rule: FieldRule,
+): Candidate[] {
+  const labels = dedupe([
+    ...rule.labels,
+    ...(rule.familySpecificLabels?.[document.documentFamily ?? "UNKNOWN"] ?? []),
+  ]);
+  const pattern = new RegExp(
+    `^\\s*(?:${labels.map(escapeRegExp).join("|")})\\s*[:\\-]\\s*(.+)$`,
+    "i",
+  );
+
+  return document.spans
+    .filter((span) => span.reliability !== "excluded")
+    .filter((span) => !rule.preferBlockTypes || rule.preferBlockTypes.includes(span.blockType))
+    .flatMap((span) => {
+      const match = span.text.match(pattern);
+      if (!match?.[1]) return [];
+      const rawValue = rule.multiline ? match[1] : match[1].split(/\s{2,}|\n/)[0];
+      const value = rawValue.trim().replace(/[.;:,]$/, "").trim();
+      if (!value) return [];
+      return [{
+        value,
+        normalizedValue: normalizeValue(value),
+        confidence: rankConfidence(span, { preferStructured: true }),
+        span,
+        extractionRule: `label:${rule.field}`,
+        warnings: [],
+      }];
+    });
+}
+
+function factFromCandidates<T extends string | string[] | null>(
+  family: DocumentFamily,
+  extractionRule: string,
+  candidates: Candidate[],
+  options?: {
+    allowMedium?: boolean;
+    transformValue?: (candidate: Candidate) => T;
+    combineValues?: (candidates: Candidate[]) => T;
+  },
+): ProjectFactField<T> {
+  if (candidates.length === 0) {
+    return createEmptyField<T>(extractionRule, family, [materializeWarning("No deterministic evidence found.")]);
+  }
+
+  const normalizedValues = dedupe(candidates.map((candidate) => candidate.normalizedValue));
+  if (normalizedValues.length > 1) {
+    return {
+      value: null as T,
+      confidence: "low",
+      evidenceSpanIds: dedupe(candidates.map((candidate) => candidate.span.spanId)),
+      pageNumbers: dedupe(candidates.map((candidate) => candidate.span.page).filter((page): page is number => page != null)).sort((a, b) => a - b),
+      sectionPath: dedupe(candidates.flatMap((candidate) => candidate.span.sectionPath)),
+      heading: candidates[0]?.span.heading,
+      extractionRule,
+      sourceParser: candidates[0]?.span.parserSource,
+      family,
+      warnings: [materializeWarning(`Conflicting values detected: ${dedupe(candidates.map((candidate) => candidate.value)).join(" | ")}`)],
+    };
+  }
+
+  const best = [...candidates].sort((left, right) => {
+    const order: Record<ProjectFactConfidence, number> = { high: 3, medium: 2, low: 1 };
+    return order[right.confidence] - order[left.confidence] || right.span.confidence - left.span.confidence;
+  })[0];
+
+  if (!best || (best.confidence === "low" || (best.confidence === "medium" && options?.allowMedium === false))) {
+    return {
+      value: null as T,
+      confidence: best?.confidence ?? "low",
+      evidenceSpanIds: best ? [best.span.spanId] : [],
+      pageNumbers: best?.span.page != null ? [best.span.page] : [],
+      sectionPath: best?.span.sectionPath ?? [],
+      heading: best?.span.heading,
+      extractionRule,
+      sourceParser: best?.span.parserSource,
+      family,
+      warnings: [materializeWarning("Evidence was too weak to promote into a canonical fact.")],
+    };
+  }
+
+  const value = options?.combineValues
+    ? options.combineValues(candidates)
+    : options?.transformValue
+      ? options.transformValue(best)
+      : best.value as T;
+
+  return {
+    value,
+    confidence: best.confidence,
+    evidenceSpanIds: dedupe(candidates.map((candidate) => candidate.span.spanId)),
+    pageNumbers: dedupe(candidates.map((candidate) => candidate.span.page).filter((page): page is number => page != null)).sort((a, b) => a - b),
+    sectionPath: dedupe(candidates.flatMap((candidate) => candidate.span.sectionPath)),
+    heading: best.span.heading,
+    extractionRule: best.extractionRule,
+    sourceParser: best.span.parserSource,
+    family,
+    warnings: dedupe(candidates.flatMap((candidate) => candidate.warnings)),
+  };
+}
+
+function looksLikeMethodology(value: string): boolean {
+  return METHODOLOGY_CODE_RE.test(value)
+    || /\bmethodology\b/i.test(value)
+    || /\bapproved baseline and monitoring methodology\b/i.test(value);
+}
+
+function findProjectTitle(document: EvidenceDocument): ProjectFactField<string | null> {
+  const family = document.documentFamily ?? "UNKNOWN";
+  const titleSpans = document.spans.filter((span) => span.blockType === "title" && span.reliability !== "excluded");
+  const candidates: Candidate[] = titleSpans
+    .filter((span) => !looksLikeMethodology(span.text))
+    .map((span) => ({
+      value: span.text.trim(),
+      normalizedValue: normalizeValue(span.text),
+      confidence: rankConfidence(span),
+      span,
+      extractionRule: "title:top-span",
+      warnings: [],
+    }));
+
+  if (candidates.length === 0) {
+    const headingCandidates = document.spans
+      .filter((span) => span.blockType === "section_heading" && span.reliability === "primary")
+      .filter((span) => !looksLikeMethodology(span.text))
+      .slice(0, 1)
+      .map((span) => ({
+        value: span.heading ?? span.text.trim(),
+        normalizedValue: normalizeValue(span.heading ?? span.text),
+        confidence: "medium" as const,
+        span,
+        extractionRule: "title:first-heading-fallback",
+        warnings: [materializeWarning("Title inferred from first heading because no dedicated title span was available.")],
+      }));
+    return factFromCandidates(family, "title", headingCandidates);
+  }
+
+  return factFromCandidates(family, "title", candidates);
+}
+
+function deriveCountryFromLocation(field: ProjectFactField<string | null>, family: DocumentFamily): ProjectFactField<string | null> {
+  if (!field.value) {
+    return createEmptyField<string | null>("project-country:location-fallback", family, [materializeWarning("Project country was not deterministically derivable.")]);
+  }
+  const segments = field.value.split(/[;,]/).map((segment) => segment.trim()).filter(Boolean);
+  const trailing = segments[segments.length - 1] ?? field.value;
+  const match = trailing.match(COUNTRY_RE);
+  if (!match?.[1]) {
+    return createEmptyField<string | null>("project-country:location-fallback", family, [materializeWarning("Project location did not contain a clear country.")]);
+  }
+  return {
+    ...field,
+    value: match[1],
+    extractionRule: "project-country:location-fallback",
+  };
+}
+
+function standardFact(document: EvidenceDocument): ProjectFactField<string | null> {
+  const family = document.documentFamily ?? "UNKNOWN";
+  const standardByFamily: Record<DocumentFamily, string | null> = {
+    CDM_PDD: "CDM",
+    VCS_PD: "VCS",
+    VERRA_PD: "Verra VCS",
+    GOLD_STANDARD_PDD: "Gold Standard",
+    REDD_AFOLU: null,
+    ENERGY: null,
+    UNKNOWN: null,
+  };
+  const value = standardByFamily[family];
+  if (!value) return createEmptyField<string | null>("standard:family", family, [materializeWarning("Document family did not map to a deterministic project standard.")]);
+  return {
+    value,
+    confidence: "high",
+    evidenceSpanIds: [],
+    pageNumbers: [],
+    sectionPath: [],
+    heading: undefined,
+    extractionRule: "standard:family",
+    sourceParser: document.parserSource,
+    family,
+    warnings: [],
+  };
+}
+
+function methodologyModulesFact(document: EvidenceDocument, methodologyPrimary: ProjectFactField<string | null>): ProjectFactField<string[] | null> {
+  const family = document.documentFamily ?? "UNKNOWN";
+  const candidates = dedupe(
+    document.spans
+      .filter((span) => span.reliability !== "excluded")
+      .flatMap((span) => span.text.match(/\b(?:module|modules?)\s+([A-Z0-9, .-]+)/gi) ?? []),
+  );
+  if (candidates.length === 0 && methodologyPrimary.value && METHODOLOGY_CODE_RE.test(methodologyPrimary.value)) {
+    return {
+      ...createEmptyField<string[] | null>("methodology-modules:none", family),
+      warnings: [materializeWarning("No methodology modules were separately declared.")],
+    };
+  }
+  if (candidates.length === 0) {
+    return createEmptyField<string[] | null>("methodology-modules:none", family, [materializeWarning("No methodology modules were found.")]);
+  }
+  return {
+    value: candidates,
+    confidence: "medium",
+    evidenceSpanIds: dedupe(document.spans.filter((span) => candidates.some((candidate) => span.text.includes(candidate))).map((span) => span.spanId)),
+    pageNumbers: dedupe(document.spans.filter((span) => candidates.some((candidate) => span.text.includes(candidate))).map((span) => span.page).filter((page): page is number => page != null)).sort((a, b) => a - b),
+    sectionPath: dedupe(document.spans.filter((span) => candidates.some((candidate) => span.text.includes(candidate))).flatMap((span) => span.sectionPath)),
+    heading: document.spans.find((span) => candidates.some((candidate) => span.text.includes(candidate)))?.heading,
+    extractionRule: "methodology-modules:regex",
+    sourceParser: document.parserSource,
+    family,
+    warnings: [],
+  };
+}
+
+function sectionsFact(
+  document: EvidenceDocument,
+  fieldName: string,
+  terms: string[],
+): ProjectFactField<string[] | null> {
+  const family = document.documentFamily ?? "UNKNOWN";
+  const headingMatches = document.spans.filter((span) => (
+    span.reliability !== "excluded"
+    && span.blockType === "section_heading"
+    && terms.some((term) => (
+      span.normalizedText.includes(normalizeValue(term))
+      || span.headingPath.some((heading) => normalizeValue(heading).includes(normalizeValue(term)))
+      || normalizeValue(span.heading ?? "").includes(normalizeValue(term))
+    ))
+  ));
+  const bodyMatches = document.spans.filter((span) => (
+    span.reliability !== "excluded"
+    && (span.blockType === "paragraph" || span.blockType === "field")
+    && terms.some((term) => span.headingPath.some((heading) => normalizeValue(heading).includes(normalizeValue(term))))
+  ));
+  const matches = headingMatches.length > 0 ? headingMatches : bodyMatches;
+
+  if (matches.length === 0) {
+    return createEmptyField<string[] | null>(`sections:${fieldName}`, family, [materializeWarning(`No ${fieldName} sections were found.`)]);
+  }
+
+  const values = dedupe(matches.map((span) => span.heading ?? span.sectionId ?? span.text).filter(Boolean));
+  return {
+    value: values,
+    confidence: "medium",
+    evidenceSpanIds: dedupe(matches.map((span) => span.spanId)),
+    pageNumbers: dedupe(matches.map((span) => span.page).filter((page): page is number => page != null)).sort((a, b) => a - b),
+    sectionPath: dedupe(matches.flatMap((span) => span.sectionPath)),
+    heading: matches[0]?.heading,
+    extractionRule: `sections:${fieldName}`,
+    sourceParser: matches[0]?.parserSource,
+    family,
+    warnings: [],
+  };
+}
+
+function findField(document: EvidenceDocument, field: FieldRule): ProjectFactField<string | null> {
+  return factFromCandidates(document.documentFamily ?? "UNKNOWN", field.field, findLabeledCandidates(document, field), {
+    allowMedium: true,
+  });
+}
+
+function inferProjectType(document: EvidenceDocument): ProjectFactField<string | null> {
+  const family = document.documentFamily ?? "UNKNOWN";
+  const explicit = findField(document, FIELD_RULES.find((rule) => rule.field === "projectType") as FieldRule);
+  if (explicit.value) return explicit;
+
+  const inferredValue =
+    family === "REDD_AFOLU" ? "REDD/AFOLU"
+      : family === "ENERGY" ? "Energy"
+        : null;
+  if (!inferredValue) {
+    return createEmptyField<string | null>("project-type:family", family, [materializeWarning("Project type was not explicitly stated.")]);
+  }
+  return {
+    value: inferredValue,
+    confidence: "medium",
+    evidenceSpanIds: [],
+    pageNumbers: [],
+    sectionPath: [],
+    heading: undefined,
+    extractionRule: "project-type:family",
+    sourceParser: document.parserSource,
+    family,
+    warnings: [materializeWarning("Project type inferred from document family signals.")],
+  };
+}
+
+function mergeWarnings(fields: ProjectFactField[]): string[] {
+  return dedupe(fields.flatMap((field) => field.warnings).filter(Boolean));
+}
+
+export function buildProjectFactContract(document: EvidenceDocument): ProjectFactContract {
+  const family = document.documentFamily ?? "UNKNOWN";
+  const title = findProjectTitle(document);
+  const hostCountry = findField(document, FIELD_RULES.find((rule) => rule.field === "hostCountry") as FieldRule);
+  const projectLocation = findField(document, FIELD_RULES.find((rule) => rule.field === "projectLocation") as FieldRule);
+  const projectCountry = hostCountry.value
+    ? hostCountry
+    : deriveCountryFromLocation(projectLocation, family);
+  const projectStandard = standardFact(document);
+  const projectProponent = findField(document, FIELD_RULES.find((rule) => rule.field === "projectProponent") as FieldRule);
+  const methodologyPrimary = findField(document, FIELD_RULES.find((rule) => rule.field === "methodologyPrimary") as FieldRule);
+  const baselineMethodology = findField(document, FIELD_RULES.find((rule) => rule.field === "baselineMethodology") as FieldRule);
+  const monitoringMethodology = findField(document, FIELD_RULES.find((rule) => rule.field === "monitoringMethodology") as FieldRule);
+  const creditingPeriod = findField(document, FIELD_RULES.find((rule) => rule.field === "creditingPeriod") as FieldRule);
+  const reportingPeriod = findField(document, FIELD_RULES.find((rule) => rule.field === "reportingPeriod") as FieldRule);
+  const monitoringPeriod = findField(document, FIELD_RULES.find((rule) => rule.field === "monitoringPeriod") as FieldRule);
+  const projectStartDate = findField(document, FIELD_RULES.find((rule) => rule.field === "projectStartDate") as FieldRule);
+  const projectType = inferProjectType(document);
+  const methodologyModules = methodologyModulesFact(document, methodologyPrimary);
+
+  if (title.value && methodologyPrimary.value && normalizeValue(title.value) === normalizeValue(methodologyPrimary.value)) {
+    title.value = null;
+    title.confidence = "low";
+    title.warnings = dedupe([...title.warnings, materializeWarning("Title matched methodology text and was downgraded to unclear.")]);
+  }
+
+  if (creditingPeriod.value && reportingPeriod.value && normalizeValue(creditingPeriod.value) === normalizeValue(reportingPeriod.value)) {
+    reportingPeriod.warnings = dedupe([...reportingPeriod.warnings, materializeWarning("Reporting period matched crediting period exactly; keeping fields separate but flagged for review.")]);
+  }
+
+  const baselineSections = sectionsFact(document, "baseline", ["baseline scenario", "baseline"]);
+  const monitoringSections = sectionsFact(document, "monitoring", ["monitoring plan", "monitoring"]);
+  const leakageSections = sectionsFact(document, "leakage", ["leakage"]);
+  const additionalitySections = sectionsFact(document, "additionality", ["additionality", "project is additional"]);
+
+  const fields = [
+    title,
+    hostCountry,
+    projectCountry,
+    projectLocation,
+    projectStandard,
+    projectType,
+    projectProponent,
+    methodologyPrimary,
+    methodologyModules as unknown as ProjectFactField,
+    baselineMethodology,
+    monitoringMethodology,
+    creditingPeriod,
+    reportingPeriod,
+    monitoringPeriod,
+    projectStartDate,
+    baselineSections as unknown as ProjectFactField,
+    monitoringSections as unknown as ProjectFactField,
+    leakageSections as unknown as ProjectFactField,
+    additionalitySections as unknown as ProjectFactField,
+  ];
+
+  return {
+    documentFamily: family,
+    documentType: chooseDocumentType(family),
+    projectTitle: title,
+    hostCountry,
+    projectCountry,
+    projectLocation,
+    projectStandard,
+    projectType,
+    projectProponent,
+    methodologyPrimary,
+    methodologyModules,
+    baselineMethodology,
+    monitoringMethodology,
+    creditingPeriod,
+    reportingPeriod,
+    monitoringPeriod,
+    projectStartDate,
+    baselineSections,
+    monitoringSections,
+    leakageSections,
+    additionalitySections,
+    warnings: mergeWarnings(fields),
+  };
+}

--- a/src/lib/quickCheck/projectFacts/index.ts
+++ b/src/lib/quickCheck/projectFacts/index.ts
@@ -1,0 +1,2 @@
+export { buildProjectFactContract } from "@/lib/quickCheck/projectFacts/buildProjectFactContract";
+export * from "@/lib/quickCheck/projectFacts/types";

--- a/src/lib/quickCheck/projectFacts/types.ts
+++ b/src/lib/quickCheck/projectFacts/types.ts
@@ -1,0 +1,48 @@
+import type { DocumentFamily } from "@/lib/documentParsing";
+
+export type ProjectFactConfidence = "high" | "medium" | "low";
+
+export type ProjectFactValue = string | string[] | null;
+
+export type ProjectFactField<T extends ProjectFactValue = string | null> = {
+  value: T;
+  confidence: ProjectFactConfidence;
+  evidenceSpanIds: string[];
+  pageNumbers: number[];
+  sectionPath: string[];
+  heading?: string;
+  extractionRule: string;
+  sourceParser?: string;
+  family?: DocumentFamily;
+  warnings: string[];
+};
+
+export type ProjectFactContractDocumentType =
+  | "PROJECT_DESIGN_DOCUMENT"
+  | "PROJECT_DESCRIPTION"
+  | "DOCUMENT";
+
+export type ProjectFactContract = {
+  documentFamily: DocumentFamily;
+  documentType: ProjectFactContractDocumentType;
+  projectTitle: ProjectFactField<string | null>;
+  hostCountry: ProjectFactField<string | null>;
+  projectCountry: ProjectFactField<string | null>;
+  projectLocation: ProjectFactField<string | null>;
+  projectStandard: ProjectFactField<string | null>;
+  projectType: ProjectFactField<string | null>;
+  projectProponent: ProjectFactField<string | null>;
+  methodologyPrimary: ProjectFactField<string | null>;
+  methodologyModules: ProjectFactField<string[] | null>;
+  baselineMethodology: ProjectFactField<string | null>;
+  monitoringMethodology: ProjectFactField<string | null>;
+  creditingPeriod: ProjectFactField<string | null>;
+  reportingPeriod: ProjectFactField<string | null>;
+  monitoringPeriod: ProjectFactField<string | null>;
+  projectStartDate: ProjectFactField<string | null>;
+  baselineSections: ProjectFactField<string[] | null>;
+  monitoringSections: ProjectFactField<string[] | null>;
+  leakageSections: ProjectFactField<string[] | null>;
+  additionalitySections: ProjectFactField<string[] | null>;
+  warnings: string[];
+};

--- a/tests/lib/quickCheck/projectFactContractV2.test.ts
+++ b/tests/lib/quickCheck/projectFactContractV2.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, test } from "@jest/globals";
+import type { DocumentStructure } from "@/lib/documentModel";
+import {
+  compileEvidenceDocumentFromStructure,
+} from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+import { buildProjectFactContract } from "@/lib/quickCheck/projectFacts";
+
+function makeStructure(overrides: Partial<DocumentStructure>): DocumentStructure {
+  return {
+    id: "article6-document:test",
+    source: "test-parser",
+    parserAdapterId: "current-extractor",
+    rawText: overrides.rawText ?? "",
+    cleanText: overrides.cleanText ?? "",
+    matchingText: overrides.matchingText ?? "",
+    documentFamily: overrides.documentFamily ?? {
+      family: "UNKNOWN",
+      confidence: 0.2,
+      evidence: [],
+      signals: [],
+      warnings: [],
+    },
+    qualityReport: overrides.qualityReport ?? {
+      parserName: "test-parser",
+      warnings: [],
+      sourceContentMode: "unknown",
+      pageCount: 1,
+      textDensity: 0.25,
+      ocrConfidence: undefined,
+      tableHeavyWarning: false,
+      layoutHeavyWarning: false,
+      headersFootersDetected: false,
+      weakExtractionWarning: false,
+      hasStructuredHeadings: true,
+      hasPageBoundaries: false,
+      hasBoundingBoxes: false,
+      hasTables: false,
+    },
+    pages: overrides.pages ?? [],
+    blocks: overrides.blocks ?? [],
+    sections: overrides.sections ?? [],
+    extractionWarnings: overrides.extractionWarnings ?? [],
+    parserDiagnostics: overrides.parserDiagnostics,
+    debug: overrides.debug,
+  };
+}
+
+function compileContract(docId: string, documentStructure: DocumentStructure) {
+  return buildProjectFactContract(compileEvidenceDocumentFromStructure({ docId, documentStructure }));
+}
+
+describe("ProjectFactContract v2", () => {
+  test("extracts core CDM project facts with provenance", () => {
+    const rawText = [
+      "Rural Nepal Biogas Activity",
+      "A.1 General description of project activity",
+      "Host country: Nepal",
+      "Applied baseline methodology: AMS-III.R. Methane recovery in agricultural activities at household/small farm level",
+      "Crediting period: 01 January 2021 to 31 December 2028",
+      "B.4 Baseline Scenario",
+      "Baseline scenario: continued non-renewable biomass use in rural households.",
+    ].join("\n");
+
+    const contract = compileContract("cdm-contract", makeStructure({
+      rawText,
+      cleanText: rawText,
+      matchingText: rawText.toLowerCase(),
+      documentFamily: {
+        family: "CDM_PDD",
+        confidence: 0.96,
+        evidence: ["CDM"],
+        signals: [],
+        warnings: [],
+      },
+      sections: [
+        {
+          id: "section:A.1",
+          sectionNumber: "A.1",
+          titleRaw: "General description of project activity",
+          titleClean: "General description of project activity",
+          titleMatchingText: "general description of project activity",
+          bodyRaw: "Host country: Nepal\nApplied baseline methodology: AMS-III.R. Methane recovery in agricultural activities at household/small farm level\nCrediting period: 01 January 2021 to 31 December 2028",
+          bodyClean: "Host country: Nepal Applied baseline methodology: AMS-III.R. Methane recovery in agricultural activities at household/small farm level Crediting period: 01 January 2021 to 31 December 2028",
+          bodyMatchingText: "host country: nepal applied baseline methodology: ams-iii.r. methane recovery in agricultural activities at household/small farm level crediting period: 01 january 2021 to 31 december 2028",
+          displaySnippet: "Host country: Nepal",
+          matchingText: "general description of project activity host country: nepal",
+          childIds: [],
+          blockIds: ["title-1", "field-1", "field-2", "field-3"],
+          sourceRefs: [],
+          confidence: 0.95,
+          extractionWarnings: [],
+        },
+        {
+          id: "section:B.4",
+          sectionNumber: "B.4",
+          titleRaw: "Baseline Scenario",
+          titleClean: "Baseline Scenario",
+          titleMatchingText: "baseline scenario",
+          bodyRaw: "Baseline scenario: continued non-renewable biomass use in rural households.",
+          bodyClean: "Baseline scenario: continued non-renewable biomass use in rural households.",
+          bodyMatchingText: "baseline scenario: continued non-renewable biomass use in rural households.",
+          displaySnippet: "Baseline scenario: continued non-renewable biomass use in rural households.",
+          matchingText: "baseline scenario continued non-renewable biomass use in rural households.",
+          childIds: [],
+          blockIds: ["section-2", "paragraph-2"],
+          sourceRefs: [],
+          confidence: 0.95,
+          extractionWarnings: [],
+        },
+      ],
+      pages: [{
+        id: "page:1",
+        pageNumber: 1,
+        rawText,
+        cleanText: rawText,
+        matchingText: rawText.toLowerCase(),
+        blockIds: ["title-1", "section-1", "field-1", "field-2", "field-3", "section-2", "paragraph-2"],
+        sourceRefs: [],
+      }],
+      blocks: [
+        {
+          id: "title-1",
+          type: "heading",
+          rawText: "Rural Nepal Biogas Activity",
+          cleanText: "Rural Nepal Biogas Activity",
+          matchingText: "rural nepal biogas activity",
+          pageNumber: 1,
+          sourceRefs: [],
+          confidence: 0.98,
+        },
+        {
+          id: "section-1",
+          type: "heading",
+          rawText: "A.1 General description of project activity",
+          cleanText: "A.1 General description of project activity",
+          matchingText: "a.1 general description of project activity",
+          pageNumber: 1,
+          sectionId: "section:A.1",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "field-1",
+          type: "paragraph",
+          rawText: "Host country: Nepal",
+          cleanText: "Host country: Nepal",
+          matchingText: "host country: nepal",
+          pageNumber: 1,
+          sectionId: "section:A.1",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "field-2",
+          type: "paragraph",
+          rawText: "Applied baseline methodology: AMS-III.R. Methane recovery in agricultural activities at household/small farm level",
+          cleanText: "Applied baseline methodology: AMS-III.R. Methane recovery in agricultural activities at household/small farm level",
+          matchingText: "applied baseline methodology: ams-iii.r. methane recovery in agricultural activities at household/small farm level",
+          pageNumber: 1,
+          sectionId: "section:A.1",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "field-3",
+          type: "paragraph",
+          rawText: "Crediting period: 01 January 2021 to 31 December 2028",
+          cleanText: "Crediting period: 01 January 2021 to 31 December 2028",
+          matchingText: "crediting period: 01 january 2021 to 31 december 2028",
+          pageNumber: 1,
+          sectionId: "section:A.1",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "section-2",
+          type: "heading",
+          rawText: "B.4 Baseline Scenario",
+          cleanText: "B.4 Baseline Scenario",
+          matchingText: "b.4 baseline scenario",
+          pageNumber: 1,
+          sectionId: "section:B.4",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "paragraph-2",
+          type: "paragraph",
+          rawText: "Baseline scenario: continued non-renewable biomass use in rural households.",
+          cleanText: "Baseline scenario: continued non-renewable biomass use in rural households.",
+          matchingText: "baseline scenario: continued non-renewable biomass use in rural households.",
+          pageNumber: 1,
+          sectionId: "section:B.4",
+          sourceRefs: [],
+          confidence: 0.9,
+        },
+      ],
+    }));
+
+    expect(contract.documentFamily).toBe("CDM_PDD");
+    expect(contract.documentType).toBe("PROJECT_DESIGN_DOCUMENT");
+    expect(contract.projectTitle.value).toBe("Rural Nepal Biogas Activity");
+    expect(contract.hostCountry.value).toBe("Nepal");
+    expect(contract.projectCountry.value).toBe("Nepal");
+    expect(contract.projectStandard.value).toBe("CDM");
+    expect(contract.methodologyPrimary.value).toContain("AMS-III.R");
+    expect(contract.creditingPeriod.value).toBe("01 January 2021 to 31 December 2028");
+    expect(contract.baselineSections.value).toEqual(["Baseline Scenario"]);
+    expect(contract.methodologyPrimary.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(contract.methodologyPrimary.pageNumbers).toEqual([1]);
+    expect(contract.methodologyPrimary.sectionPath).toContain("section:A.1");
+    expect(contract.methodologyPrimary.extractionRule).toBe("label:methodologyPrimary");
+    expect(contract.methodologyPrimary.family).toBe("CDM_PDD");
+    expect(contract.methodologyPrimary.sourceParser).toBe("test-parser");
+  });
+
+  test("extracts core Verra/VCS project facts without confusing title and methodology", () => {
+    const rawText = [
+      "Katingan Peatland Restoration and Conservation Project",
+      "Project Description",
+      "Country/Area: Indonesia",
+      "Project proponent: PT Rimba Makmur Utama",
+      "Title and reference of methodology applied: VM0007 REDD+ Methodology Framework v1.6",
+      "Reporting period: 01 January 2024 to 31 December 2024",
+      "Monitoring period: 01 January 2023 to 31 December 2023",
+    ].join("\n");
+
+    const contract = compileContract("verra-contract", makeStructure({
+      rawText,
+      cleanText: rawText,
+      matchingText: rawText.toLowerCase(),
+      documentFamily: {
+        family: "VERRA_PD",
+        confidence: 0.95,
+        evidence: ["Verra VCS"],
+        signals: [],
+        warnings: [],
+      },
+      sections: [{
+        id: "section:project-description",
+        titleRaw: "Project Description",
+        titleClean: "Project Description",
+        titleMatchingText: "project description",
+        bodyRaw: "Country/Area: Indonesia\nProject proponent: PT Rimba Makmur Utama\nTitle and reference of methodology applied: VM0007 REDD+ Methodology Framework v1.6\nReporting period: 01 January 2024 to 31 December 2024\nMonitoring period: 01 January 2023 to 31 December 2023",
+        bodyClean: "Country/Area: Indonesia Project proponent: PT Rimba Makmur Utama Title and reference of methodology applied: VM0007 REDD+ Methodology Framework v1.6 Reporting period: 01 January 2024 to 31 December 2024 Monitoring period: 01 January 2023 to 31 December 2023",
+        bodyMatchingText: "country/area: indonesia project proponent: pt rimba makmur utama title and reference of methodology applied: vm0007 redd+ methodology framework v1.6 reporting period: 01 january 2024 to 31 december 2024 monitoring period: 01 january 2023 to 31 december 2023",
+        displaySnippet: "Country/Area: Indonesia",
+        matchingText: "project description country/area: indonesia",
+        childIds: [],
+        blockIds: ["title-1", "section-1", "field-1", "field-2", "field-3", "field-4", "field-5"],
+        sourceRefs: [],
+        confidence: 0.95,
+        extractionWarnings: [],
+      }],
+      pages: [{
+        id: "page:1",
+        pageNumber: 1,
+        rawText,
+        cleanText: rawText,
+        matchingText: rawText.toLowerCase(),
+        blockIds: ["title-1", "section-1", "field-1", "field-2", "field-3", "field-4", "field-5"],
+        sourceRefs: [],
+      }],
+      blocks: [
+        {
+          id: "title-1",
+          type: "heading",
+          rawText: "Katingan Peatland Restoration and Conservation Project",
+          cleanText: "Katingan Peatland Restoration and Conservation Project",
+          matchingText: "katingan peatland restoration and conservation project",
+          pageNumber: 1,
+          sourceRefs: [],
+          confidence: 0.98,
+        },
+        {
+          id: "section-1",
+          type: "heading",
+          rawText: "Project Description",
+          cleanText: "Project Description",
+          matchingText: "project description",
+          pageNumber: 1,
+          sectionId: "section:project-description",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "field-1",
+          type: "paragraph",
+          rawText: "Country/Area: Indonesia",
+          cleanText: "Country/Area: Indonesia",
+          matchingText: "country/area: indonesia",
+          pageNumber: 1,
+          sectionId: "section:project-description",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "field-2",
+          type: "paragraph",
+          rawText: "Project proponent: PT Rimba Makmur Utama",
+          cleanText: "Project proponent: PT Rimba Makmur Utama",
+          matchingText: "project proponent: pt rimba makmur utama",
+          pageNumber: 1,
+          sectionId: "section:project-description",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "field-3",
+          type: "paragraph",
+          rawText: "Title and reference of methodology applied: VM0007 REDD+ Methodology Framework v1.6",
+          cleanText: "Title and reference of methodology applied: VM0007 REDD+ Methodology Framework v1.6",
+          matchingText: "title and reference of methodology applied: vm0007 redd+ methodology framework v1.6",
+          pageNumber: 1,
+          sectionId: "section:project-description",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "field-4",
+          type: "paragraph",
+          rawText: "Reporting period: 01 January 2024 to 31 December 2024",
+          cleanText: "Reporting period: 01 January 2024 to 31 December 2024",
+          matchingText: "reporting period: 01 january 2024 to 31 december 2024",
+          pageNumber: 1,
+          sectionId: "section:project-description",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "field-5",
+          type: "paragraph",
+          rawText: "Monitoring period: 01 January 2023 to 31 December 2023",
+          cleanText: "Monitoring period: 01 January 2023 to 31 December 2023",
+          matchingText: "monitoring period: 01 january 2023 to 31 december 2023",
+          pageNumber: 1,
+          sectionId: "section:project-description",
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+      ],
+    }));
+
+    expect(contract.documentFamily).toBe("VERRA_PD");
+    expect(contract.documentType).toBe("PROJECT_DESCRIPTION");
+    expect(contract.projectTitle.value).toBe("Katingan Peatland Restoration and Conservation Project");
+    expect(contract.projectTitle.value).not.toContain("VM0007");
+    expect(contract.hostCountry.value).toBe("Indonesia");
+    expect(contract.projectCountry.value).toBe("Indonesia");
+    expect(contract.projectStandard.value).toBe("Verra VCS");
+    expect(contract.projectProponent.value).toBe("PT Rimba Makmur Utama");
+    expect(contract.methodologyPrimary.value).toContain("VM0007");
+    expect(contract.reportingPeriod.value).toBe("01 January 2024 to 31 December 2024");
+    expect(contract.monitoringPeriod.value).toBe("01 January 2023 to 31 December 2023");
+    expect(contract.reportingPeriod.value).not.toBe(contract.monitoringPeriod.value);
+  });
+
+  test("returns unclear facts instead of guessing when evidence is weak", () => {
+    const rawText = [
+      "VM0007 REDD+ Methodology Framework v1.6",
+      "This document summarizes methodology context only.",
+    ].join("\n");
+
+    const contract = compileContract("unclear-contract", makeStructure({
+      rawText,
+      cleanText: rawText,
+      matchingText: rawText.toLowerCase(),
+      documentFamily: {
+        family: "UNKNOWN",
+        confidence: 0.25,
+        evidence: [],
+        signals: [],
+        warnings: ["Document family remained UNKNOWN because deterministic intake signals were insufficient."],
+      },
+      pages: [{
+        id: "page:1",
+        pageNumber: 1,
+        rawText,
+        cleanText: rawText,
+        matchingText: rawText.toLowerCase(),
+        blockIds: ["title-1", "paragraph-1"],
+        sourceRefs: [],
+      }],
+      blocks: [
+        {
+          id: "title-1",
+          type: "heading",
+          rawText: "VM0007 REDD+ Methodology Framework v1.6",
+          cleanText: "VM0007 REDD+ Methodology Framework v1.6",
+          matchingText: "vm0007 redd+ methodology framework v1.6",
+          pageNumber: 1,
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "paragraph-1",
+          type: "paragraph",
+          rawText: "This document summarizes methodology context only.",
+          cleanText: "This document summarizes methodology context only.",
+          matchingText: "this document summarizes methodology context only.",
+          pageNumber: 1,
+          sourceRefs: [],
+          confidence: 0.7,
+        },
+      ],
+    }));
+
+    expect(contract.projectTitle.value).toBeNull();
+    expect(contract.hostCountry.value).toBeNull();
+    expect(contract.methodologyPrimary.value).toBeNull();
+    expect(contract.projectTitle.warnings.join(" ")).toContain("No deterministic evidence found");
+    expect(contract.hostCountry.warnings.join(" ")).toContain("No deterministic evidence found");
+  });
+
+  test("detects conflicting fact values and surfaces warnings", () => {
+    const rawText = [
+      "Forest Conservation Project",
+      "Host country: Indonesia",
+      "Host country: Peru",
+    ].join("\n");
+
+    const contract = compileContract("conflict-contract", makeStructure({
+      rawText,
+      cleanText: rawText,
+      matchingText: rawText.toLowerCase(),
+      documentFamily: {
+        family: "VCS_PD",
+        confidence: 0.8,
+        evidence: ["VCS"],
+        signals: [],
+        warnings: [],
+      },
+      pages: [{
+        id: "page:1",
+        pageNumber: 1,
+        rawText,
+        cleanText: rawText,
+        matchingText: rawText.toLowerCase(),
+        blockIds: ["title-1", "field-1", "field-2"],
+        sourceRefs: [],
+      }],
+      blocks: [
+        {
+          id: "title-1",
+          type: "heading",
+          rawText: "Forest Conservation Project",
+          cleanText: "Forest Conservation Project",
+          matchingText: "forest conservation project",
+          pageNumber: 1,
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "field-1",
+          type: "paragraph",
+          rawText: "Host country: Indonesia",
+          cleanText: "Host country: Indonesia",
+          matchingText: "host country: indonesia",
+          pageNumber: 1,
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "field-2",
+          type: "paragraph",
+          rawText: "Host country: Peru",
+          cleanText: "Host country: Peru",
+          matchingText: "host country: peru",
+          pageNumber: 1,
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+      ],
+    }));
+
+    expect(contract.hostCountry.value).toBeNull();
+    expect(contract.hostCountry.warnings.join(" ")).toContain("Conflicting values detected");
+    expect(contract.hostCountry.evidenceSpanIds).toHaveLength(2);
+    expect(contract.warnings.some((warning) => warning.includes("Conflicting values detected"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## WHAT

Implement Phase 2: Family-Aware ProjectFactContract v2.

This change builds a canonical, family-aware `ProjectFactContract` from compiled evidence and keeps each extracted fact tied back to evidence span provenance, page numbers, section paths, headings, parser source, and confidence.

## WHY

Quick Check needs a stable fact layer before routing or answer generation. This phase makes core project facts deterministic across CDM and Verra/VCS style documents, and surfaces unclear or conflicting values instead of guessing.

## Signed-off-by

Fred Egbuedike <fredilly@article6.org>
