### PR TITLE
Feat/qc project fact contract real fixtures

### DIFF
--- a/src/lib/documentClassification/buildDocumentQualityReport.ts
+++ b/src/lib/documentClassification/buildDocumentQualityReport.ts
@@ -49,12 +49,20 @@ function detectTableHeavyWarning(parsedDocument: ParsedDocument): boolean {
   const tableElements = parsedDocument.elements.filter((element) => element.elementType === "table").length;
   if (tableElements >= 3) return true;
 
-  const tableLikeLines = parsedDocument.rawText
+  const lines = parsedDocument.rawText
     .split("\n")
     .map((line) => line.trim())
-    .filter((line) => /\|/.test(line) || /\S(?:\s{2,}|\t)\S/.test(line));
+    .filter(Boolean);
+  const tableLikeLines = lines.filter((line) => /\|/.test(line) || /\S(?:\s{2,}|\t)\S/.test(line));
+  const numericMatrixLines = lines.filter((line) => (
+    /^(?:\d{4}|total)\b.*(?:-\s+\d[\d.,]*){2,}/i.test(line)
+    || (line.match(/\b\d[\d.,]*\b/g)?.length ?? 0) >= 4
+  ));
 
-  return tableLikeLines.length >= Math.max(4, parsedDocument.pages.length * 2);
+  return (
+    tableLikeLines.length >= Math.max(4, parsedDocument.pages.length * 2)
+    || numericMatrixLines.length >= Math.max(3, Math.ceil(parsedDocument.pages.length / 3))
+  );
 }
 
 function detectWeakExtractionWarning(parsedDocument: ParsedDocument, qualityReport: DocumentQualityReport): boolean {

--- a/src/lib/documentParsing/adapters/currentExtractor.ts
+++ b/src/lib/documentParsing/adapters/currentExtractor.ts
@@ -8,6 +8,7 @@ import type {
   ParseDocumentTextInput,
   ParsedDocument,
   ParsedElement,
+  ParsedElementType,
   ParsedPage,
   ParserAdapter,
 } from "@/lib/documentParsing/types";
@@ -85,6 +86,116 @@ function findSequentialOffset(haystack: string, needle: string, fromIndex: numbe
   return fromIndex;
 }
 
+const TITLE_LABEL_RE = /^(?:project description(?: document| \/ pd)?|project document|table of contents|contents)$/i;
+const STANDALONE_METHOD_LABEL_RE =
+  /^(?:title and reference of methodology applied|methodology applied|applied methodology|approved methodology|applied baseline methodology)$/i;
+const PAGE_MARKER_RE = /^page\s+\d+(?:\s+of\s+\d+)?$/i;
+const SECTION_HEADING_LINE_RE = /^\s*(?:(?:[A-Z]\.)?\d+(?:\.\d+)*|annex\s+[A-Z0-9]+|appendix\s+[A-Z0-9]+)\s*[.:)]?\s+\S/i;
+const FIELD_LIKE_LINE_RE = /^[A-Z][A-Za-z0-9/ (),.+-]{1,80}:\s+\S/;
+
+function introLineElementType(line: string): ParsedElementType {
+  const trimmed = line.trim();
+  if (!trimmed) return "unknown";
+  if (TITLE_LABEL_RE.test(trimmed)) return "paragraph";
+  if (PAGE_MARKER_RE.test(trimmed)) return "paragraph";
+  if (FIELD_LIKE_LINE_RE.test(trimmed)) return "paragraph";
+  if (/^(?:verra|vcs|ccb|gold standard|clean development mechanism)\b/i.test(trimmed)) return "paragraph";
+  if (/^v(?:ersion)?\s*\d/i.test(trimmed) || /^vm\d{4}\b/i.test(trimmed)) return "paragraph";
+  if (/^\d+(?:\s+of\s+\d+)?$/.test(trimmed) || /^--\s*\d+\s+of\s+\d+\s*--$/.test(trimmed)) return "paragraph";
+  const wordCount = trimmed.split(/\s+/).filter(Boolean).length;
+  if (trimmed.length <= 140 && wordCount >= 2 && !STANDALONE_METHOD_LABEL_RE.test(trimmed)) return "heading";
+  return "paragraph";
+}
+
+type IntroLine = {
+  text: string;
+  charStart: number;
+  charEnd: number;
+};
+
+function collectIntroLines(rawText: string, headingIndex: ReturnType<typeof buildPddHeadingIndex>): IntroLine[] {
+  if (!rawText.trim()) return [];
+  let introEnd = rawText.length;
+  if (headingIndex.length > 0) {
+    const headingOffsets = headingIndex
+      .map((heading) => rawText.indexOf(heading.title))
+      .filter((offset) => offset >= 0);
+    if (headingOffsets.length > 0) {
+      introEnd = Math.min(...headingOffsets);
+    }
+  }
+  let scanCursor = 0;
+  for (const line of rawText.split("\n")) {
+    if (SECTION_HEADING_LINE_RE.test(line.trim())) {
+      introEnd = Math.min(introEnd, scanCursor);
+      break;
+    }
+    scanCursor += line.length + 1;
+  }
+  const introText = rawText.slice(0, introEnd);
+  if (!introText.trim()) return [];
+
+  const lines: IntroLine[] = [];
+  let cursor = 0;
+  for (const line of introText.split("\n")) {
+    const charStart = cursor;
+    const charEnd = charStart + line.length;
+    cursor = charEnd + 1;
+    if (!line.trim()) continue;
+    lines.push({ text: line.trim(), charStart, charEnd });
+  }
+  return lines;
+}
+
+function buildIntroElements(input: {
+  rawText: string;
+  normalizedText: string;
+  parserName: string;
+  pageBoundaries: PageBoundary[];
+  headingIndex: ReturnType<typeof buildPddHeadingIndex>;
+}): ParsedElement[] {
+  const introLines = collectIntroLines(input.rawText, input.headingIndex);
+  const elements: ParsedElement[] = [];
+
+  for (let index = 0; index < introLines.length; index += 1) {
+    const line = introLines[index]!;
+    const nextLine = introLines[index + 1];
+    const pageNumber = pageNumberForOffset(line.charStart, input.pageBoundaries);
+
+    if (STANDALONE_METHOD_LABEL_RE.test(line.text) && nextLine) {
+      const combinedText = `${line.text}: ${nextLine.text}`;
+      elements.push({
+        id: `element:intro:${index}`,
+        pageNumber,
+        text: combinedText,
+        normalizedText: normalizeParserText(combinedText).replace(/\s+/g, " ").trim(),
+        charStart: line.charStart,
+        charEnd: nextLine.charEnd,
+        elementType: "paragraph",
+        sourceParser: input.parserName,
+        confidence: 0.85,
+      });
+      index += 1;
+      continue;
+    }
+
+    const elementType = introLineElementType(line.text);
+    elements.push({
+      id: `element:intro:${index}`,
+      pageNumber,
+      text: line.text,
+      normalizedText: normalizeParserText(line.text).replace(/\s+/g, " ").trim(),
+      charStart: line.charStart,
+      charEnd: line.charEnd,
+      elementType,
+      sourceParser: input.parserName,
+      confidence: elementType === "heading" ? 0.92 : 0.8,
+    });
+  }
+
+  return elements;
+}
+
 export const currentExtractorAdapter: ParserAdapter = {
   id: "current-extractor",
   parseText(input: ParseDocumentTextInput): ParsedDocument {
@@ -101,7 +212,23 @@ export const currentExtractorAdapter: ParserAdapter = {
       level: headingLevel(heading.sectionNumber),
       sectionNumber: heading.sectionNumber,
     }));
-    const blocks = headingIndex.flatMap((heading) => {
+    const introElements = buildIntroElements({
+      rawText,
+      normalizedText,
+      parserName,
+      pageBoundaries,
+      headingIndex,
+    });
+    const introBlocks = introElements.map((element) => ({
+      id: element.id,
+      type: element.elementType === "heading" ? "heading" as const : "paragraph" as const,
+      text: element.text,
+      normalizedText: element.normalizedText,
+      pageNumber: element.pageNumber,
+    }));
+    const blocks = [
+      ...introBlocks,
+      ...headingIndex.flatMap((heading) => {
       const headingBlock = {
         id: `block:heading:${heading.sectionNumber}`,
         type: "heading" as const,
@@ -120,9 +247,10 @@ export const currentExtractorAdapter: ParserAdapter = {
           }]
         : [];
       return [headingBlock, ...bodyBlocks];
-    });
+    }),
+    ];
     let searchCursor = 0;
-    const elements: ParsedElement[] = headingIndex.flatMap((heading) => {
+    const sectionElements: ParsedElement[] = headingIndex.flatMap((heading) => {
       const sectionPath = buildSectionPath(heading.sectionNumber);
       const headingOffset = findSequentialOffset(normalizedText, heading.title, searchCursor);
       const headingPageNumber = pageNumberForOffset(headingOffset, pageBoundaries);
@@ -163,6 +291,7 @@ export const currentExtractorAdapter: ParserAdapter = {
         : [];
       return [headingElement, ...bodyElements];
     });
+    const elements: ParsedElement[] = [...introElements, ...sectionElements];
     const pages = splitRawTextIntoPages(rawText).map((page) => ({
       ...page,
       elements: elements.filter((element) => element.pageNumber === page.pageNumber),

--- a/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
+++ b/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
@@ -435,13 +435,13 @@ function buildEvidenceTableCells(input: {
 
 function inferStructureBlockType(
   block: DocumentStructure["blocks"][number],
-  index: number,
+  options: { treatAsTitle: boolean },
 ): EvidenceBlockType | null {
   if (!block.rawText.trim()) return null;
 
   switch (block.type) {
     case "heading":
-      return index === 0 && !block.sectionId ? "title" : "section_heading";
+      return options.treatAsTitle ? "title" : "section_heading";
     case "paragraph":
       if (FIELD_RE.test(block.rawText.trim())) return "field";
       if (FORMULA_RE.test(block.rawText.trim())) return "formula";
@@ -533,10 +533,18 @@ export function compileEvidenceDocumentFromStructure(input: {
   const rawText = normalizeNewlines(input.documentStructure.rawText ?? "");
   const headingPathBySectionId = buildSectionHeadingLookup(input.documentStructure);
   let cursor = 0;
+  let hasSeenSectionedHeading = false;
 
   const spans: EvidenceSpan[] = input.documentStructure.blocks.flatMap((block, index) => {
-    const blockType = inferStructureBlockType(block, index);
+    const treatAsTitle =
+      block.type === "heading"
+      && !block.sectionId
+      && !hasSeenSectionedHeading;
+    const blockType = inferStructureBlockType(block, { treatAsTitle });
     if (!blockType) return [];
+    if (block.type === "heading" && block.sectionId) {
+      hasSeenSectionedHeading = true;
+    }
 
     const charStart = block.charStart ?? findCharStart(rawText, block.rawText, cursor);
     const charEnd = block.charEnd ?? (charStart == null ? null : charStart + block.rawText.length);

--- a/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
+++ b/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
@@ -535,7 +535,7 @@ export function compileEvidenceDocumentFromStructure(input: {
   let cursor = 0;
   let hasSeenSectionedHeading = false;
 
-  const spans: EvidenceSpan[] = input.documentStructure.blocks.flatMap((block, index) => {
+  const spans: EvidenceSpan[] = input.documentStructure.blocks.flatMap((block) => {
     const treatAsTitle =
       block.type === "heading"
       && !block.sectionId

--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -5,6 +5,7 @@ import type {
   ProjectFactContract,
   ProjectFactContractDocumentType,
   ProjectFactField,
+  ProjectFactValue,
 } from "@/lib/quickCheck/projectFacts/types";
 
 type Candidate = {
@@ -195,6 +196,29 @@ function findLabeledCandidates(
     });
 }
 
+function findMethodologyCodeFallbackCandidates(document: EvidenceDocument): Candidate[] {
+  if (!document.documentFamily || document.documentFamily === "UNKNOWN") {
+    return [];
+  }
+  return document.spans
+    .filter((span) => span.reliability !== "excluded")
+    .filter((span) => span.sectionPath.length === 0)
+    .flatMap((span) => {
+      const match = span.text.match(METHODOLOGY_CODE_RE);
+      if (!match?.[0]) return [];
+      return [{
+        value: span.text.trim(),
+        normalizedValue: normalizeValue(span.text),
+        confidence: span.sectionPath.length === 0 ? "medium" as const : "low" as const,
+        span,
+        extractionRule: "methodology:code-fallback",
+        warnings: [
+          materializeWarning("Methodology inferred from a top-of-document code reference because no explicit methodology label was found."),
+        ],
+      }];
+    });
+}
+
 function factFromCandidates<T extends string | string[] | null>(
   family: DocumentFamily,
   extractionRule: string,
@@ -271,6 +295,20 @@ function looksLikeMethodology(value: string): boolean {
     || /\bapproved baseline and monitoring methodology\b/i.test(value);
 }
 
+function looksLikeGenericSectionHeading(value: string): boolean {
+  const normalized = normalizeValue(value);
+  return [
+    "project background",
+    "project boundary",
+    "baseline scenario",
+    "additionality",
+    "leakage",
+    "monitoring",
+    "monitoring plan",
+    "stakeholder comments",
+  ].includes(normalized);
+}
+
 function findProjectTitle(document: EvidenceDocument): ProjectFactField<string | null> {
   const family = document.documentFamily ?? "UNKNOWN";
   const titleSpans = document.spans.filter((span) => span.blockType === "title" && span.reliability !== "excluded");
@@ -286,9 +324,29 @@ function findProjectTitle(document: EvidenceDocument): ProjectFactField<string |
     }));
 
   if (candidates.length === 0) {
+    const labeledDocumentCandidates = document.spans
+      .filter((span) => span.reliability !== "excluded")
+      .filter((span) => span.sectionPath.length === 0)
+      .filter((span) => span.blockType === "field" || span.blockType === "paragraph")
+      .filter((span) => /^(?:project description document|project design document)\s*:\s*\S/i.test(span.text.trim()))
+      .map((span) => ({
+        value: span.text.trim(),
+        normalizedValue: normalizeValue(span.text),
+        confidence: rankConfidence(span, { preferStructured: span.blockType === "field" }),
+        span,
+        extractionRule: "title:labeled-document",
+        warnings: [],
+      }));
+    if (labeledDocumentCandidates.length > 0) {
+      return factFromCandidates<string | null>(family, "title", labeledDocumentCandidates);
+    }
+  }
+
+  if (candidates.length === 0) {
     const headingCandidates = document.spans
       .filter((span) => span.blockType === "section_heading" && span.reliability === "primary")
       .filter((span) => !looksLikeMethodology(span.text))
+      .filter((span) => !looksLikeGenericSectionHeading(span.heading ?? span.text))
       .slice(0, 1)
       .map((span) => ({
         value: span.heading ?? span.text.trim(),
@@ -298,10 +356,10 @@ function findProjectTitle(document: EvidenceDocument): ProjectFactField<string |
         extractionRule: "title:first-heading-fallback",
         warnings: [materializeWarning("Title inferred from first heading because no dedicated title span was available.")],
       }));
-    return factFromCandidates(family, "title", headingCandidates);
+    return factFromCandidates<string | null>(family, "title", headingCandidates);
   }
 
-  return factFromCandidates(family, "title", candidates);
+  return factFromCandidates<string | null>(family, "title", candidates);
 }
 
 function deriveCountryFromLocation(field: ProjectFactField<string | null>, family: DocumentFamily): ProjectFactField<string | null> {
@@ -451,7 +509,7 @@ function inferProjectType(document: EvidenceDocument): ProjectFactField<string |
   };
 }
 
-function mergeWarnings(fields: ProjectFactField[]): string[] {
+function mergeWarnings(fields: ProjectFactField<ProjectFactValue>[]): string[] {
   return dedupe(fields.flatMap((field) => field.warnings).filter(Boolean));
 }
 
@@ -465,7 +523,16 @@ export function buildProjectFactContract(document: EvidenceDocument): ProjectFac
     : deriveCountryFromLocation(projectLocation, family);
   const projectStandard = standardFact(document);
   const projectProponent = findField(document, FIELD_RULES.find((rule) => rule.field === "projectProponent") as FieldRule);
-  const methodologyPrimary = findField(document, FIELD_RULES.find((rule) => rule.field === "methodologyPrimary") as FieldRule);
+  const methodologyPrimaryRule = FIELD_RULES.find((rule) => rule.field === "methodologyPrimary") as FieldRule;
+  const methodologyPrimary = factFromCandidates<string | null>(
+    family,
+    "methodologyPrimary",
+    [
+      ...findLabeledCandidates(document, methodologyPrimaryRule),
+      ...findMethodologyCodeFallbackCandidates(document),
+    ],
+    { allowMedium: true },
+  );
   const baselineMethodology = findField(document, FIELD_RULES.find((rule) => rule.field === "baselineMethodology") as FieldRule);
   const monitoringMethodology = findField(document, FIELD_RULES.find((rule) => rule.field === "monitoringMethodology") as FieldRule);
   const creditingPeriod = findField(document, FIELD_RULES.find((rule) => rule.field === "creditingPeriod") as FieldRule);
@@ -485,7 +552,12 @@ export function buildProjectFactContract(document: EvidenceDocument): ProjectFac
     reportingPeriod.warnings = dedupe([...reportingPeriod.warnings, materializeWarning("Reporting period matched crediting period exactly; keeping fields separate but flagged for review.")]);
   }
 
-  const baselineSections = sectionsFact(document, "baseline", ["baseline scenario", "baseline"]);
+  const baselineSections = sectionsFact(document, "baseline", [
+    "baseline scenario",
+    "baseline",
+    "without-project land use scenario",
+    "without project land use scenario",
+  ]);
   const monitoringSections = sectionsFact(document, "monitoring", ["monitoring plan", "monitoring"]);
   const leakageSections = sectionsFact(document, "leakage", ["leakage"]);
   const additionalitySections = sectionsFact(document, "additionality", ["additionality", "project is additional"]);

--- a/tests/fixtures/quick-check/bsp-nepal-activity3-cdm-excerpt.txt
+++ b/tests/fixtures/quick-check/bsp-nepal-activity3-cdm-excerpt.txt
@@ -1,0 +1,22 @@
+Biogas Support Program - Nepal Activity-3
+Clean Development Mechanism Project Design Document
+CDM-PDD-FORM
+
+Host country: Nepal
+Applied baseline methodology: AMS-I.E. Switch from non-renewable biomass for thermal applications by the user
+Crediting period: 13 Dec 2011 - 12 Dec 2018
+
+A.1 General description of project activity
+The Biogas Support Program - Nepal Activity-3 installs household biogas digesters in rural Nepal to replace non-renewable biomass used for cooking.
+
+B.4 Baseline scenario
+Without the project activity, rural households would continue to use non-renewable biomass and traditional stoves.
+
+B.5 Demonstration of additionality
+The project is additional because upfront household investment barriers and dissemination constraints prevent the baseline transition without carbon finance.
+
+B.6 Leakage
+Leakage emissions are expected to be negligible because the project replaces non-renewable biomass at household level.
+
+D.1 Monitoring methodology and plan
+Monitoring includes digester operation checks, household surveys, and sampling of fuel consumption records.

--- a/tests/lib/quickCheck/projectFactContractRealFixtures.test.ts
+++ b/tests/lib/quickCheck/projectFactContractRealFixtures.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parseDocumentText } from "@/lib/documentParsing";
+import { buildDocumentStructure } from "@/lib/documentModel";
+import { compileEvidenceDocumentFromStructure } from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+import { buildProjectFactContract } from "@/lib/quickCheck/projectFacts";
+import type { ProjectFactContract, ProjectFactField, ProjectFactValue } from "@/lib/quickCheck/projectFacts/types";
+
+type FixtureResult = {
+  evidence: EvidenceDocument;
+  contract: ProjectFactContract;
+  qualityWarnings: string[];
+  qualityReport: ReturnType<typeof buildDocumentStructure>["qualityReport"];
+};
+
+function loadFixtureText(relativePath: string): string {
+  return readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+function loadJsonPagesFixture(relativePath: string): string {
+  const parsed = JSON.parse(loadFixtureText(relativePath)) as { pages: Array<{ text?: string }> };
+  return parsed.pages.map((page) => page.text ?? "").join("\f");
+}
+
+function compileFixture(input: { fixturePath: string; docId: string; kind?: "text" | "json-pages" }): FixtureResult {
+  const rawText = input.kind === "json-pages"
+    ? loadJsonPagesFixture(input.fixturePath)
+    : loadFixtureText(input.fixturePath);
+  const parsed = parseDocumentText({ rawText, sourceName: input.fixturePath });
+  const structure = buildDocumentStructure({ parsedDocument: parsed });
+  const evidence = compileEvidenceDocumentFromStructure({ docId: input.docId, documentStructure: structure });
+  const contract = buildProjectFactContract(evidence);
+
+  return {
+    evidence,
+    contract,
+    qualityWarnings: structure.qualityReport.warnings,
+    qualityReport: structure.qualityReport,
+  };
+}
+
+function hasPromotedValue(field: ProjectFactField<ProjectFactValue>): boolean {
+  if (Array.isArray(field.value)) return field.value.length > 0;
+  return field.value !== null;
+}
+
+function expectPromotedFactProvenance(
+  evidence: EvidenceDocument,
+  field: ProjectFactField<ProjectFactValue>,
+): void {
+  if (!hasPromotedValue(field)) return;
+  if (field.extractionRule === "standard:family" || field.extractionRule === "project-type:family") return;
+
+  expect(field.evidenceSpanIds.length).toBeGreaterThan(0);
+  expect(field.pageNumbers.length).toBeGreaterThan(0);
+  expect(field.sourceParser).toBeTruthy();
+  expect(field.family).toBeTruthy();
+
+  const spans = field.evidenceSpanIds
+    .map((spanId) => evidence.spans.find((span) => span.spanId === spanId))
+    .filter((span): span is EvidenceDocument["spans"][number] => Boolean(span));
+  expect(spans.length).toBe(field.evidenceSpanIds.length);
+  expect(new Set(spans.map((span) => span.page).filter((page): page is number => page != null))).toEqual(
+    new Set(field.pageNumbers),
+  );
+}
+
+function expectContractProvenance(evidence: EvidenceDocument, contract: ProjectFactContract): void {
+  const fields: ProjectFactField<ProjectFactValue>[] = [
+    contract.projectTitle,
+    contract.hostCountry,
+    contract.projectCountry,
+    contract.projectLocation,
+    contract.projectStandard,
+    contract.projectType,
+    contract.projectProponent,
+    contract.methodologyPrimary,
+    contract.methodologyModules,
+    contract.baselineMethodology,
+    contract.monitoringMethodology,
+    contract.creditingPeriod,
+    contract.reportingPeriod,
+    contract.monitoringPeriod,
+    contract.projectStartDate,
+    contract.baselineSections,
+    contract.monitoringSections,
+    contract.leakageSections,
+    contract.additionalitySections,
+  ];
+
+  for (const field of fields) {
+    expectPromotedFactProvenance(evidence, field);
+  }
+}
+
+describe("ProjectFactContract real fixtures", () => {
+  test("keeps a CDM PDD excerpt grounded through title, country, methodology, and section facts", () => {
+    const { evidence, contract } = compileFixture({
+      fixturePath: "tests/fixtures/quick-check/bsp-nepal-activity3-cdm-excerpt.txt",
+      docId: "real-cdm",
+    });
+
+    expect(contract.documentFamily).toBe("CDM_PDD");
+    expect(contract.projectTitle.value).toBe("Biogas Support Program - Nepal Activity-3");
+    expect(contract.hostCountry.value).toBe("Nepal");
+    expect(contract.projectCountry.value).toBe("Nepal");
+    expect(contract.methodologyPrimary.value).toContain("AMS-I.E.");
+    expect(contract.creditingPeriod.value).toBe("13 Dec 2011 - 12 Dec 2018");
+    expect(contract.reportingPeriod.value).toBeNull();
+    expect(contract.monitoringPeriod.value).toBeNull();
+    expect(contract.baselineSections.value).toEqual(["Baseline scenario"]);
+    expect(contract.monitoringSections.value).toEqual(["Monitoring methodology and plan"]);
+    expect(contract.leakageSections.value).toEqual(["Leakage"]);
+    expect(contract.additionalitySections.value).toEqual(["Demonstration of additionality"]);
+    expect(contract.warnings).not.toContainEqual(expect.stringContaining("Conflicting values detected"));
+
+    expectContractProvenance(evidence, contract);
+  });
+
+  test("keeps a Verra/VCS project description grounded while leaving missing country facts unclear", () => {
+    const { evidence, contract } = compileFixture({
+      fixturePath: "tests/fixtures/quick-check/plum-pdd-regression.txt",
+      docId: "real-plum",
+    });
+
+    expect(contract.documentFamily).toBe("VERRA_PD");
+    expect(contract.projectTitle.value).toBe("PLUM Project");
+    expect(contract.hostCountry.value).toBeNull();
+    expect(contract.projectCountry.value).toBeNull();
+    expect(contract.methodologyPrimary.value).toBe("VM0007");
+    expect(contract.creditingPeriod.value).toBeNull();
+    expect(contract.reportingPeriod.value).toBeNull();
+    expect(contract.monitoringPeriod.value).toBeNull();
+    expect(contract.baselineSections.value).toEqual(["Without-project Land Use Scenario and Additionality"]);
+    expect(contract.monitoringSections.value).toEqual(["Monitoring", "Monitoring Plan"]);
+    expect(contract.leakageSections.value).toBeNull();
+    expect(contract.additionalitySections.value).toEqual(["Without-project Land Use Scenario and Additionality"]);
+    expect(contract.warnings).toContain("Project country was not deterministically derivable.");
+    expect(contract.warnings).toContain("Methodology inferred from a top-of-document code reference because no explicit methodology label was found.");
+
+    expectContractProvenance(evidence, contract);
+  });
+
+  test("keeps a REDD/AFOLU project description grounded through title, methodology, and section facts", () => {
+    const { evidence, contract } = compileFixture({
+      fixturePath: "tests/fixtures/quick-check/pd_redd_v1_130-extracted.txt",
+      docId: "real-pd-redd",
+    });
+
+    expect(contract.documentFamily).toBe("REDD_AFOLU");
+    expect(contract.projectTitle.value).toBe("Project Description Document: PD_REDD_v1_130");
+    expect(contract.hostCountry.value).toBeNull();
+    expect(contract.projectCountry.value).toBeNull();
+    expect(contract.methodologyPrimary.value).toBe("VM0007 REDD+ Methodology Modules");
+    expect(contract.creditingPeriod.value).toBeNull();
+    expect(contract.reportingPeriod.value).toBeNull();
+    expect(contract.monitoringPeriod.value).toBeNull();
+    expect(contract.baselineSections.value).toEqual(["(Baseline Scenario)"]);
+    expect(contract.monitoringSections.value).toEqual(["Monitoring"]);
+    expect(contract.leakageSections.value).toEqual(["(Leakage)"]);
+    expect(contract.additionalitySections.value).toEqual(["(Additionality)"]);
+    expect(contract.warnings).toContain("Project country was not deterministically derivable.");
+    expect(contract.warnings).toContain("Methodology inferred from a top-of-document code reference because no explicit methodology label was found.");
+
+    expectContractProvenance(evidence, contract);
+  });
+
+  test("keeps a table-heavy appendix conservative and surfaces quality and conflict warnings", () => {
+    const { evidence, contract, qualityReport, qualityWarnings } = compileFixture({
+      fixturePath: "tests/fixtures/projects/ccb1530-appendix1-pages.json",
+      docId: "real-ccb1530",
+      kind: "json-pages",
+    });
+
+    expect(contract.documentFamily).toBe("REDD_AFOLU");
+    expect(contract.projectTitle.value).toBeNull();
+    expect(contract.hostCountry.value).toBeNull();
+    expect(contract.projectCountry.value).toBeNull();
+    expect(contract.methodologyPrimary.value).toBeNull();
+    expect(contract.creditingPeriod.value).toBeNull();
+    expect(contract.reportingPeriod.value).toBeNull();
+    expect(contract.monitoringPeriod.value).toBeNull();
+    expect(contract.baselineSections.value).toBeNull();
+    expect(contract.monitoringSections.value).toBeNull();
+    expect(contract.leakageSections.value).toBeNull();
+    expect(contract.additionalitySections.value).toBeNull();
+    expect(contract.warnings).toContainEqual(expect.stringContaining("Conflicting values detected"));
+    expect(qualityReport.pageCount).toBeGreaterThan(1);
+    expect(qualityReport.headersFootersDetected).toBe(true);
+    expect(qualityReport.tableHeavyWarning).toBe(true);
+    expect(qualityWarnings).toContain("Repeated headers or footers detected across pages.");
+    expect(qualityWarnings).toContain("Document appears table-heavy; extraction may need table-aware handling.");
+
+    expectContractProvenance(evidence, contract);
+  });
+});


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- - RC5: in_progress -->
  <!-- - PR12: done -->
  <!-- - PR13: in_progress -->

For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactors with no SSOT impact), leave `slug: N/A`. The roadmap gates will skip.

Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

Visible UI changes to look for:
