### PR TITLE
feat: add section and table index

### DIFF
--- a/src/lib/quickCheck/indexing/buildSectionTableIndex.ts
+++ b/src/lib/quickCheck/indexing/buildSectionTableIndex.ts
@@ -1,0 +1,305 @@
+import type { DocumentStructure } from "@/lib/documentModel";
+import type { EvidenceDocument, EvidenceSpan } from "@/lib/quickCheck/evidence/evidenceTypes";
+import type {
+  IndexedTable,
+  SectionNode,
+  SectionTableIndex,
+  SectionTopic,
+  SectionTopicMap,
+  SectionTopicReference,
+  SectionTree,
+  TableCellReference,
+  TableIndex,
+} from "@/lib/quickCheck/indexing/types";
+
+const TOPIC_PATTERNS: Record<SectionTopic, RegExp[]> = {
+  baseline: [/\bbaseline\b/i, /\bwithout the project\b/i],
+  monitoring: [/\bmonitoring\b/i, /\bmonitoring plan\b/i],
+  leakage: [/\bleakage\b/i],
+  additionality: [/\badditionality\b/i, /\badditional\b/i],
+  methodology: [/\bmethodology\b/i, /\bapplied methodology\b/i, /\bmethodological\b/i],
+  project_location: [/\bproject location\b/i, /\blocation\b/i, /\bhost country\b/i, /\bproject area\b/i],
+  project_participants: [/\bproject participants?\b/i, /\bproject proponent\b/i, /\bparticipants?\b/i, /\bdeveloper\b/i],
+  crediting_period: [/\bcrediting period\b/i, /\bcrediting\b/i],
+  safeguards: [/\bsafeguards?\b/i, /\bstakeholders?\b/i, /\bgrievance\b/i, /\bfpic\b/i],
+  sdg: [/\bsdgs?\b/i, /\bsustainable development\b/i, /\bco-benefits?\b/i],
+};
+
+function uniqueNumbers(values: Array<number | null | undefined>): number[] {
+  return Array.from(new Set(values.filter((value): value is number => typeof value === "number"))).sort((a, b) => a - b);
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value))));
+}
+
+function normalizeForSearch(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function inferNodeId(span: EvidenceSpan): string {
+  if (span.sectionId) return span.sectionId;
+  return `section:span:${span.spanId}`;
+}
+
+function buildSectionNumberLookup(documentStructure: DocumentStructure): Map<string, string | undefined> {
+  return new Map(documentStructure.sections.map((section) => [section.id, section.sectionNumber]));
+}
+
+function buildSectionBodyLookup(documentStructure: DocumentStructure): Map<string, string> {
+  return new Map(documentStructure.sections.map((section) => [section.id, section.matchingText]));
+}
+
+function sortNodes(a: SectionNode, b: SectionNode): number {
+  const aPage = a.pageNumbers[0] ?? Number.MAX_SAFE_INTEGER;
+  const bPage = b.pageNumbers[0] ?? Number.MAX_SAFE_INTEGER;
+  if (aPage !== bPage) return aPage - bPage;
+  return a.heading.localeCompare(b.heading);
+}
+
+export function buildSectionTree(input: {
+  documentStructure: DocumentStructure;
+  evidenceDocument: EvidenceDocument;
+}): SectionTree {
+  const nodes = new Map<string, SectionNode>();
+  const sectionNumberById = buildSectionNumberLookup(input.documentStructure);
+
+  const ensureNode = (seed: Omit<SectionNode, "children">): SectionNode => {
+    const existing = nodes.get(seed.id);
+    if (existing) {
+      existing.parentId = existing.parentId ?? seed.parentId;
+      existing.sectionId = existing.sectionId ?? seed.sectionId;
+      existing.sectionNumber = existing.sectionNumber ?? seed.sectionNumber;
+      existing.heading = existing.heading || seed.heading;
+      existing.headingPath = existing.headingPath.length > 0 ? existing.headingPath : seed.headingPath;
+      existing.sectionPath = existing.sectionPath.length > 0 ? existing.sectionPath : seed.sectionPath;
+      existing.evidenceSpanIds = uniqueStrings([...existing.evidenceSpanIds, ...seed.evidenceSpanIds]);
+      existing.sourceBlockIds = uniqueStrings([...existing.sourceBlockIds, ...seed.sourceBlockIds]);
+      existing.pageNumbers = uniqueNumbers([...existing.pageNumbers, ...seed.pageNumbers]);
+      existing.confidence = Math.max(existing.confidence, seed.confidence);
+      return existing;
+    }
+
+    const created: SectionNode = {
+      ...seed,
+      children: [],
+    };
+    nodes.set(seed.id, created);
+    return created;
+  };
+
+  for (const section of input.documentStructure.sections) {
+    const spans = input.evidenceDocument.spans.filter((span) => span.sectionId === section.id);
+    const headingSpan = spans.find((span) => span.blockType === "section_heading" || span.blockType === "annex");
+    ensureNode({
+      id: section.id,
+      parentId: section.parentId,
+      sectionId: section.id,
+      sectionNumber: section.sectionNumber,
+      heading: headingSpan?.heading ?? section.titleRaw,
+      headingPath: headingSpan?.headingPath ?? [section.titleRaw],
+      sectionPath: headingSpan?.sectionPath ?? [section.id],
+      evidenceSpanIds: spans.map((span) => span.spanId),
+      sourceBlockIds: spans.map((span) => span.sourceBlockId).filter((value): value is string => Boolean(value)),
+      pageNumbers: uniqueNumbers(spans.map((span) => span.page)),
+      confidence: Math.max(section.confidence, ...spans.map((span) => span.confidence), 0.5),
+    });
+  }
+
+  for (const span of input.evidenceDocument.spans) {
+    if (span.blockType !== "section_heading" && span.blockType !== "annex") continue;
+    const id = inferNodeId(span);
+    const parentId = span.sectionPath.length > 1 ? span.sectionPath[span.sectionPath.length - 2] : undefined;
+    ensureNode({
+      id,
+      parentId,
+      sectionId: span.sectionId,
+      sectionNumber: span.sectionId ? sectionNumberById.get(span.sectionId) : undefined,
+      heading: span.heading ?? span.text,
+      headingPath: span.headingPath,
+      sectionPath: span.sectionPath.length > 0 ? span.sectionPath : [id],
+      evidenceSpanIds: [span.spanId],
+      sourceBlockIds: span.sourceBlockId ? [span.sourceBlockId] : [],
+      pageNumbers: uniqueNumbers([span.page]),
+      confidence: span.confidence,
+    });
+  }
+
+  for (const node of nodes.values()) {
+    node.children = [];
+  }
+  for (const node of nodes.values()) {
+    if (!node.parentId) continue;
+    const parent = nodes.get(node.parentId);
+    if (!parent) continue;
+    parent.children.push(node);
+  }
+  for (const node of nodes.values()) {
+    node.children.sort(sortNodes);
+  }
+
+  const orderedNodeIds = [
+    ...input.documentStructure.sections
+      .map((section) => section.id)
+      .filter((sectionId) => nodes.has(sectionId)),
+    ...Array.from(nodes.keys()).filter((sectionId) => (
+      !input.documentStructure.sections.some((section) => section.id === sectionId)
+    )),
+  ];
+  const orderedNodes = orderedNodeIds
+    .map((nodeId) => nodes.get(nodeId))
+    .filter((node): node is SectionNode => Boolean(node));
+  const roots = orderedNodes.filter((node) => !node.parentId || !nodes.has(node.parentId));
+
+  return {
+    roots,
+    orderedNodeIds: orderedNodes.map((node) => node.id),
+    nodesById: Object.fromEntries(orderedNodes.map((node) => [node.id, node])),
+  };
+}
+
+export function buildTableIndex(input: {
+  evidenceDocument: EvidenceDocument;
+}): TableIndex {
+  const tables: IndexedTable[] = input.evidenceDocument.spans
+    .filter((span) => span.blockType === "table")
+    .map((span) => {
+      const cells: TableCellReference[] = (span.table?.cells ?? []).map((cell) => ({
+        evidenceSpanId: span.spanId,
+        rowIndex: cell.rowIndex,
+        columnIndex: cell.columnIndex,
+        text: cell.text,
+        normalizedText: cell.normalizedText,
+        pageNumber: cell.pageNumber ?? span.page ?? undefined,
+        boundingBox: cell.boundingBox,
+        sourceTableId: cell.sourceTableId ?? span.table?.tableId,
+        sourceBlockId: cell.sourceBlockId ?? span.sourceBlockId,
+        parserSource: cell.parserSource ?? span.parserSource,
+        sectionId: span.sectionId,
+        sectionPath: span.sectionPath,
+        heading: span.heading,
+        headingPath: span.headingPath,
+        confidence: span.confidence,
+        limitedProvenance: span.table?.limitedProvenance ?? span.reliability !== "primary",
+      }));
+
+      return {
+        evidenceSpanId: span.spanId,
+        tableId: span.table?.tableId,
+        sourceBlockId: span.sourceBlockId,
+        parserSource: span.parserSource,
+        sectionId: span.sectionId,
+        sectionPath: span.sectionPath,
+        heading: span.heading,
+        headingPath: span.headingPath,
+        pageNumbers: uniqueNumbers([span.page, ...cells.map((cell) => cell.pageNumber)]),
+        rowCount: span.table?.rowCount,
+        columnCount: span.table?.columnCount,
+        headerRowCount: span.table?.headerRowCount,
+        confidence: span.confidence,
+        limitedProvenance: span.table?.limitedProvenance ?? span.reliability !== "primary",
+        cells,
+      };
+    });
+
+  return {
+    tables,
+    cells: tables.flatMap((table) => table.cells),
+    byEvidenceSpanId: Object.fromEntries(tables.map((table) => [table.evidenceSpanId, table])),
+    byTableId: Object.fromEntries(
+      tables
+        .filter((table) => Boolean(table.tableId))
+        .map((table) => [table.tableId as string, table]),
+    ),
+  };
+}
+
+function collectTopicReference(input: {
+  node: SectionNode;
+  searchableText: string;
+  topic: SectionTopic;
+}): SectionTopicReference | null {
+  const patterns = TOPIC_PATTERNS[input.topic];
+  const matchedPatterns = patterns.filter((pattern) => pattern.test(input.searchableText));
+  if (matchedPatterns.length === 0) return null;
+
+  const headingText = normalizeForSearch(input.node.heading);
+  const headingPathText = normalizeForSearch(input.node.headingPath.join(" "));
+  const confidence = matchedPatterns.some((pattern) => pattern.test(headingText))
+    ? 0.95
+    : matchedPatterns.some((pattern) => pattern.test(headingPathText))
+      ? 0.88
+      : 0.78;
+
+  return {
+    topic: input.topic,
+    sectionId: input.node.sectionId,
+    heading: input.node.heading,
+    headingPath: input.node.headingPath,
+    sectionPath: input.node.sectionPath,
+    evidenceSpanIds: input.node.evidenceSpanIds,
+    pageNumbers: input.node.pageNumbers,
+    confidence,
+    reasons: matchedPatterns.map((pattern) => pattern.source),
+  };
+}
+
+export function buildSectionTopicMap(input: {
+  documentStructure: DocumentStructure;
+  sectionTree: SectionTree;
+}): SectionTopicMap {
+  const bodyBySectionId = buildSectionBodyLookup(input.documentStructure);
+  const topicMap: SectionTopicMap = {
+    baseline: [],
+    monitoring: [],
+    leakage: [],
+    additionality: [],
+    methodology: [],
+    project_location: [],
+    project_participants: [],
+    crediting_period: [],
+    safeguards: [],
+    sdg: [],
+  };
+
+  for (const nodeId of input.sectionTree.orderedNodeIds) {
+    const node = input.sectionTree.nodesById[nodeId];
+    const searchableText = normalizeForSearch([
+      node.heading,
+      node.headingPath.join(" "),
+      node.sectionId ? bodyBySectionId.get(node.sectionId) ?? "" : "",
+    ].join(" "));
+
+    for (const topic of Object.keys(TOPIC_PATTERNS) as SectionTopic[]) {
+      const match = collectTopicReference({ node, searchableText, topic });
+      if (match) topicMap[topic].push(match);
+    }
+  }
+
+  for (const topic of Object.keys(topicMap) as SectionTopic[]) {
+    topicMap[topic].sort((a, b) => {
+      if (b.confidence !== a.confidence) return b.confidence - a.confidence;
+      const aPage = a.pageNumbers[0] ?? Number.MAX_SAFE_INTEGER;
+      const bPage = b.pageNumbers[0] ?? Number.MAX_SAFE_INTEGER;
+      if (aPage !== bPage) return aPage - bPage;
+      return a.heading.localeCompare(b.heading);
+    });
+  }
+
+  return topicMap;
+}
+
+export function buildSectionTableIndex(input: {
+  documentStructure: DocumentStructure;
+  evidenceDocument: EvidenceDocument;
+}): SectionTableIndex {
+  const sectionTree = buildSectionTree(input);
+  return {
+    sectionTree,
+    tableIndex: buildTableIndex({ evidenceDocument: input.evidenceDocument }),
+    sectionTopicMap: buildSectionTopicMap({
+      documentStructure: input.documentStructure,
+      sectionTree,
+    }),
+  };
+}

--- a/src/lib/quickCheck/indexing/index.ts
+++ b/src/lib/quickCheck/indexing/index.ts
@@ -1,0 +1,7 @@
+export {
+  buildSectionTableIndex,
+  buildSectionTopicMap,
+  buildSectionTree,
+  buildTableIndex,
+} from "@/lib/quickCheck/indexing/buildSectionTableIndex";
+export * from "@/lib/quickCheck/indexing/types";

--- a/src/lib/quickCheck/indexing/index.ts
+++ b/src/lib/quickCheck/indexing/index.ts
@@ -4,4 +4,9 @@ export {
   buildSectionTree,
   buildTableIndex,
 } from "@/lib/quickCheck/indexing/buildSectionTableIndex";
+export { findBestTopicMatch } from "@/lib/quickCheck/indexing/selectTopicEvidence";
+export {
+  validateSectionTree,
+  validateTableIndex,
+} from "@/lib/quickCheck/indexing/validateIndices";
 export * from "@/lib/quickCheck/indexing/types";

--- a/src/lib/quickCheck/indexing/selectTopicEvidence.ts
+++ b/src/lib/quickCheck/indexing/selectTopicEvidence.ts
@@ -1,0 +1,52 @@
+import {
+  SECTION_TOPICS,
+  type SectionTopic,
+  type SectionTopicMap,
+  type TopicSelectionResult,
+} from "@/lib/quickCheck/indexing/types";
+
+function isSectionTopic(value: string): value is SectionTopic {
+  return (SECTION_TOPICS as readonly string[]).includes(value);
+}
+
+export function findBestTopicMatch(
+  topic: string,
+  sectionTopicMap: SectionTopicMap,
+  options: {
+    minConfidence?: number;
+    ambiguityMargin?: number;
+  } = {},
+): TopicSelectionResult {
+  if (!isSectionTopic(topic)) {
+    return { status: "no_evidence", reason: "unsupported_topic" };
+  }
+
+  const matches = [...sectionTopicMap[topic]].sort((a, b) => {
+    if (b.confidence !== a.confidence) return b.confidence - a.confidence;
+    const aPage = a.pageNumbers[0] ?? Number.MAX_SAFE_INTEGER;
+    const bPage = b.pageNumbers[0] ?? Number.MAX_SAFE_INTEGER;
+    if (aPage !== bPage) return aPage - bPage;
+    return a.heading.localeCompare(b.heading);
+  });
+
+  if (matches.length === 0) {
+    return { status: "no_evidence", reason: "no_topic_references" };
+  }
+
+  const minConfidence = options.minConfidence ?? 0.85;
+  const ambiguityMargin = options.ambiguityMargin ?? 0.08;
+  const best = matches[0];
+  const second = matches[1];
+
+  if (best.confidence < minConfidence) {
+    return { status: "no_evidence", reason: "weak_match" };
+  }
+  if (second && (best.confidence - second.confidence) < ambiguityMargin) {
+    return { status: "no_evidence", reason: "ambiguous_match" };
+  }
+
+  return {
+    status: "matched",
+    reference: best,
+  };
+}

--- a/src/lib/quickCheck/indexing/types.ts
+++ b/src/lib/quickCheck/indexing/types.ts
@@ -101,3 +101,44 @@ export type SectionTableIndex = {
   tableIndex: TableIndex;
   sectionTopicMap: SectionTopicMap;
 };
+
+export type IndexValidationIssueCode =
+  | "orphan_parent_id"
+  | "duplicate_node_id"
+  | "missing_heading"
+  | "missing_evidence_span_ids"
+  | "missing_page_provenance"
+  | "duplicate_table_id"
+  | "missing_cell_coordinates"
+  | "missing_cell_span_reference"
+  | "missing_cell_provenance"
+  | "missing_table_provenance";
+
+export type IndexValidationIssue = {
+  code: IndexValidationIssueCode;
+  message: string;
+  affectedId?: string;
+  affectedPath?: string[];
+};
+
+export type IndexValidationResult = {
+  valid: boolean;
+  errors: IndexValidationIssue[];
+  warnings: IndexValidationIssue[];
+};
+
+export type TopicSelectionNoEvidenceReason =
+  | "unsupported_topic"
+  | "no_topic_references"
+  | "weak_match"
+  | "ambiguous_match";
+
+export type TopicSelectionResult =
+  | {
+      status: "matched";
+      reference: SectionTopicReference;
+    }
+  | {
+      status: "no_evidence";
+      reason: TopicSelectionNoEvidenceReason;
+    };

--- a/src/lib/quickCheck/indexing/types.ts
+++ b/src/lib/quickCheck/indexing/types.ts
@@ -1,0 +1,103 @@
+import type { ParsedBoundingBox } from "@/lib/documentParsing";
+
+export const SECTION_TOPICS = [
+  "baseline",
+  "monitoring",
+  "leakage",
+  "additionality",
+  "methodology",
+  "project_location",
+  "project_participants",
+  "crediting_period",
+  "safeguards",
+  "sdg",
+] as const;
+
+export type SectionTopic = (typeof SECTION_TOPICS)[number];
+
+export type SectionPath = string[];
+
+export type SectionNode = {
+  id: string;
+  parentId?: string;
+  sectionId?: string;
+  sectionNumber?: string;
+  heading: string;
+  headingPath: string[];
+  sectionPath: SectionPath;
+  evidenceSpanIds: string[];
+  sourceBlockIds: string[];
+  pageNumbers: number[];
+  confidence: number;
+  children: SectionNode[];
+};
+
+export type SectionTree = {
+  roots: SectionNode[];
+  orderedNodeIds: string[];
+  nodesById: Record<string, SectionNode>;
+};
+
+export type TableCellReference = {
+  evidenceSpanId: string;
+  rowIndex: number;
+  columnIndex: number;
+  text: string;
+  normalizedText: string;
+  pageNumber?: number;
+  boundingBox?: ParsedBoundingBox;
+  sourceTableId?: string;
+  sourceBlockId?: string;
+  parserSource?: string;
+  sectionId?: string;
+  sectionPath: SectionPath;
+  heading?: string;
+  headingPath: string[];
+  confidence: number;
+  limitedProvenance: boolean;
+};
+
+export type IndexedTable = {
+  evidenceSpanId: string;
+  tableId?: string;
+  sourceBlockId?: string;
+  parserSource?: string;
+  sectionId?: string;
+  sectionPath: SectionPath;
+  heading?: string;
+  headingPath: string[];
+  pageNumbers: number[];
+  rowCount?: number;
+  columnCount?: number;
+  headerRowCount?: number;
+  confidence: number;
+  limitedProvenance: boolean;
+  cells: TableCellReference[];
+};
+
+export type TableIndex = {
+  tables: IndexedTable[];
+  cells: TableCellReference[];
+  byEvidenceSpanId: Record<string, IndexedTable>;
+  byTableId: Record<string, IndexedTable>;
+};
+
+export type SectionTopicReference = {
+  topic: SectionTopic;
+  sectionId?: string;
+  heading: string;
+  headingPath: string[];
+  sectionPath: SectionPath;
+  evidenceSpanIds: string[];
+  pageNumbers: number[];
+  confidence: number;
+  reasons: string[];
+};
+
+export type SectionTopicMap = Record<SectionTopic, SectionTopicReference[]>;
+
+export type SectionTableIndex = {
+  sectionTree: SectionTree;
+  tableIndex: TableIndex;
+  sectionTopicMap: SectionTopicMap;
+};

--- a/src/lib/quickCheck/indexing/validateIndices.ts
+++ b/src/lib/quickCheck/indexing/validateIndices.ts
@@ -1,0 +1,129 @@
+import type {
+  IndexValidationIssue,
+  IndexValidationResult,
+  SectionTree,
+  TableIndex,
+} from "@/lib/quickCheck/indexing/types";
+
+function makeResult(errors: IndexValidationIssue[], warnings: IndexValidationIssue[]): IndexValidationResult {
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+export function validateSectionTree(sectionTree: SectionTree): IndexValidationResult {
+  const errors: IndexValidationIssue[] = [];
+  const warnings: IndexValidationIssue[] = [];
+  const seenNodeIds = new Set<string>();
+
+  for (const nodeId of sectionTree.orderedNodeIds) {
+    if (seenNodeIds.has(nodeId)) {
+      errors.push({
+        code: "duplicate_node_id",
+        message: `Section tree orderedNodeIds contains duplicate node id "${nodeId}".`,
+        affectedId: nodeId,
+      });
+      continue;
+    }
+    seenNodeIds.add(nodeId);
+  }
+
+  for (const [nodeId, node] of Object.entries(sectionTree.nodesById)) {
+    if (node.parentId && !sectionTree.nodesById[node.parentId]) {
+      errors.push({
+        code: "orphan_parent_id",
+        message: `Section node "${nodeId}" points to missing parent "${node.parentId}".`,
+        affectedId: nodeId,
+        affectedPath: node.sectionPath,
+      });
+    }
+    if (!node.heading.trim()) {
+      errors.push({
+        code: "missing_heading",
+        message: `Section node "${nodeId}" has an empty heading.`,
+        affectedId: nodeId,
+        affectedPath: node.sectionPath,
+      });
+    }
+    if (node.evidenceSpanIds.length === 0) {
+      errors.push({
+        code: "missing_evidence_span_ids",
+        message: `Section node "${nodeId}" has no evidence span ids.`,
+        affectedId: nodeId,
+        affectedPath: node.sectionPath,
+      });
+    }
+    if (node.pageNumbers.length === 0) {
+      warnings.push({
+        code: "missing_page_provenance",
+        message: `Section node "${nodeId}" has no page provenance.`,
+        affectedId: nodeId,
+        affectedPath: node.sectionPath,
+      });
+    }
+  }
+
+  return makeResult(errors, warnings);
+}
+
+export function validateTableIndex(tableIndex: TableIndex): IndexValidationResult {
+  const errors: IndexValidationIssue[] = [];
+  const warnings: IndexValidationIssue[] = [];
+  const tableIds = new Map<string, string[]>();
+
+  for (const table of tableIndex.tables) {
+    if (table.tableId) {
+      tableIds.set(table.tableId, [...(tableIds.get(table.tableId) ?? []), table.evidenceSpanId]);
+    }
+
+    if (!table.limitedProvenance && table.pageNumbers.length === 0) {
+      warnings.push({
+        code: "missing_table_provenance",
+        message: `Table "${table.tableId ?? table.evidenceSpanId}" is missing page provenance.`,
+        affectedId: table.tableId ?? table.evidenceSpanId,
+        affectedPath: table.sectionPath,
+      });
+    }
+
+    for (const cell of table.cells) {
+      if (!Number.isInteger(cell.rowIndex) || !Number.isInteger(cell.columnIndex)) {
+        errors.push({
+          code: "missing_cell_coordinates",
+          message: `Table cell in "${table.tableId ?? table.evidenceSpanId}" is missing rowIndex or columnIndex.`,
+          affectedId: table.tableId ?? table.evidenceSpanId,
+          affectedPath: cell.sectionPath,
+        });
+      }
+      if (!tableIndex.byEvidenceSpanId[cell.evidenceSpanId]) {
+        errors.push({
+          code: "missing_cell_span_reference",
+          message: `Table cell in "${table.tableId ?? table.evidenceSpanId}" points to missing evidence span "${cell.evidenceSpanId}".`,
+          affectedId: table.tableId ?? table.evidenceSpanId,
+          affectedPath: cell.sectionPath,
+        });
+      }
+      if (!cell.limitedProvenance && (cell.pageNumber == null || (!cell.sourceBlockId && !cell.sourceTableId))) {
+        warnings.push({
+          code: "missing_cell_provenance",
+          message: `Table cell in "${table.tableId ?? table.evidenceSpanId}" is missing page or source provenance.`,
+          affectedId: table.tableId ?? table.evidenceSpanId,
+          affectedPath: cell.sectionPath,
+        });
+      }
+    }
+  }
+
+  for (const [tableId, evidenceSpanIds] of tableIds.entries()) {
+    if (evidenceSpanIds.length > 1) {
+      errors.push({
+        code: "duplicate_table_id",
+        message: `Table id "${tableId}" is duplicated across evidence spans: ${evidenceSpanIds.join(", ")}.`,
+        affectedId: tableId,
+      });
+    }
+  }
+
+  return makeResult(errors, warnings);
+}

--- a/tests/lib/quickCheck/projectFactContractFixtureHarness.ts
+++ b/tests/lib/quickCheck/projectFactContractFixtureHarness.ts
@@ -75,13 +75,14 @@ type FixtureRunResult = {
   contract: ProjectFactContract;
   qualityWarnings: string[];
   qualityReport: ReturnType<typeof buildDocumentStructure>["qualityReport"];
+  structure: ReturnType<typeof buildDocumentStructure>;
 };
 
-function loadFixtureText(relativePath: string): string {
+export function loadFixtureText(relativePath: string): string {
   return readFileSync(path.join(process.cwd(), relativePath), "utf8");
 }
 
-function loadFixtureInput(entry: ProjectFactFixtureManifestEntry): string {
+export function loadFixtureInput(entry: ProjectFactFixtureManifestEntry): string {
   if (entry.kind === "json-pages") {
     const parsed = JSON.parse(loadFixtureText(entry.fixturePath)) as { pages: Array<{ text?: string }> };
     return parsed.pages.map((page) => page.text ?? "").join("\f");
@@ -89,7 +90,7 @@ function loadFixtureInput(entry: ProjectFactFixtureManifestEntry): string {
   return loadFixtureText(entry.fixturePath);
 }
 
-function runFixture(entry: ProjectFactFixtureManifestEntry): FixtureRunResult {
+export function runProjectFactFixturePipeline(entry: ProjectFactFixtureManifestEntry): FixtureRunResult {
   const rawText = loadFixtureInput(entry);
   const parsed = parseDocumentText(
     { rawText, sourceName: entry.fixturePath },
@@ -104,6 +105,7 @@ function runFixture(entry: ProjectFactFixtureManifestEntry): FixtureRunResult {
     contract,
     qualityWarnings: structure.qualityReport.warnings,
     qualityReport: structure.qualityReport,
+    structure,
   };
 }
 
@@ -219,7 +221,7 @@ export function loadProjectFactFixtureManifest(): ProjectFactFixtureManifest {
 }
 
 export function runProjectFactFixtureExpectation(entry: ProjectFactFixtureManifestEntry): void {
-  const { evidence, contract, qualityWarnings, qualityReport } = runFixture(entry);
+  const { evidence, contract, qualityWarnings, qualityReport } = runProjectFactFixturePipeline(entry);
 
   expect(contract.documentFamily).toBe(entry.expectedDocumentFamily);
 

--- a/tests/lib/quickCheck/sectionTableIndex.test.ts
+++ b/tests/lib/quickCheck/sectionTableIndex.test.ts
@@ -8,6 +8,9 @@ import {
   buildSectionTopicMap,
   buildSectionTree,
   buildTableIndex,
+  findBestTopicMatch,
+  validateSectionTree,
+  validateTableIndex,
 } from "@/lib/quickCheck/indexing";
 import {
   loadProjectFactFixtureManifest,
@@ -52,6 +55,15 @@ function makeStructure(overrides: Partial<DocumentStructure>): DocumentStructure
     parserDiagnostics: overrides.parserDiagnostics,
     debug: overrides.debug,
   };
+}
+
+function findFixture(fixtureId: string) {
+  const manifest = loadProjectFactFixtureManifest();
+  const fixture = manifest.fixtures.find((entry) => entry.id === fixtureId);
+  if (!fixture) {
+    throw new Error(`Expected fixture "${fixtureId}" to exist in the project fact manifest.`);
+  }
+  return fixture;
 }
 
 describe("Section and table index", () => {
@@ -253,12 +265,7 @@ describe("Section and table index", () => {
   });
 
   test("reuses the real-fixture pipeline and maps core topics without a new parser path", () => {
-    const manifest = loadProjectFactFixtureManifest();
-    const cdmFixture = manifest.fixtures.find((entry) => entry.id === "real-cdm");
-    if (!cdmFixture) {
-      throw new Error("Expected real-cdm fixture to exist in the project fact manifest.");
-    }
-
+    const cdmFixture = findFixture("real-cdm");
     const { structure, evidence } = runProjectFactFixturePipeline(cdmFixture);
     const index = buildSectionTableIndex({ documentStructure: structure, evidenceDocument: evidence });
 
@@ -277,5 +284,198 @@ describe("Section and table index", () => {
       heading: "Demonstration of additionality",
     }));
     expect(index.sectionTree.roots.length).toBeGreaterThan(0);
+  });
+
+  test("validateSectionTree flags orphan parent ids and missing provenance", () => {
+    const validation = validateSectionTree({
+      roots: [],
+      orderedNodeIds: ["section:orphan"],
+      nodesById: {
+        "section:orphan": {
+          id: "section:orphan",
+          parentId: "section:missing",
+          sectionId: "section:orphan",
+          heading: "Orphan Section",
+          headingPath: ["Orphan Section"],
+          sectionPath: ["section:orphan"],
+          evidenceSpanIds: ["span:1"],
+          sourceBlockIds: [],
+          pageNumbers: [],
+          confidence: 0.75,
+          children: [],
+        },
+      },
+    });
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors).toContainEqual(expect.objectContaining({
+      code: "orphan_parent_id",
+      affectedId: "section:orphan",
+    }));
+    expect(validation.warnings).toContainEqual(expect.objectContaining({
+      code: "missing_page_provenance",
+      affectedId: "section:orphan",
+    }));
+  });
+
+  test("validateTableIndex flags duplicate table ids and missing cell provenance", () => {
+    const validation = validateTableIndex({
+      tables: [
+        {
+          evidenceSpanId: "span:table:1",
+          tableId: "dup-table",
+          sectionPath: ["section:1"],
+          headingPath: ["Project Details"],
+          pageNumbers: [],
+          confidence: 0.9,
+          limitedProvenance: false,
+          cells: [{
+            evidenceSpanId: "span:table:missing",
+            rowIndex: 0,
+            columnIndex: 0,
+            text: "Host country",
+            normalizedText: "host country",
+            sectionPath: ["section:1"],
+            headingPath: ["Project Details"],
+            confidence: 0.9,
+            limitedProvenance: false,
+          }],
+        },
+        {
+          evidenceSpanId: "span:table:2",
+          tableId: "dup-table",
+          sectionPath: ["section:1"],
+          headingPath: ["Project Details"],
+          pageNumbers: [1],
+          confidence: 0.8,
+          limitedProvenance: true,
+          cells: [],
+        },
+      ],
+      cells: [],
+      byEvidenceSpanId: {
+        "span:table:1": {
+          evidenceSpanId: "span:table:1",
+          tableId: "dup-table",
+          sectionPath: ["section:1"],
+          headingPath: ["Project Details"],
+          pageNumbers: [],
+          confidence: 0.9,
+          limitedProvenance: false,
+          cells: [],
+        },
+        "span:table:2": {
+          evidenceSpanId: "span:table:2",
+          tableId: "dup-table",
+          sectionPath: ["section:1"],
+          headingPath: ["Project Details"],
+          pageNumbers: [1],
+          confidence: 0.8,
+          limitedProvenance: true,
+          cells: [],
+        },
+      },
+      byTableId: {},
+    });
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors).toContainEqual(expect.objectContaining({
+      code: "duplicate_table_id",
+      affectedId: "dup-table",
+    }));
+    expect(validation.errors).toContainEqual(expect.objectContaining({
+      code: "missing_cell_span_reference",
+      affectedId: "dup-table",
+    }));
+    expect(validation.warnings).toContainEqual(expect.objectContaining({
+      code: "missing_table_provenance",
+      affectedId: "dup-table",
+    }));
+    expect(validation.warnings).toContainEqual(expect.objectContaining({
+      code: "missing_cell_provenance",
+      affectedId: "dup-table",
+    }));
+  });
+
+  test("findBestTopicMatch returns no_evidence for unsupported topics", () => {
+    const parsed = parseDocumentText({
+      rawText: [
+        "2 Baseline Scenario",
+        "Without the project, baseline emissions remain high.",
+      ].join("\n"),
+    });
+    const structure = buildDocumentStructure({ parsedDocument: parsed });
+    const evidence = compileEvidenceDocumentFromStructure({ docId: "unsupported-topic", documentStructure: structure });
+    const index = buildSectionTableIndex({ documentStructure: structure, evidenceDocument: evidence });
+
+    expect(findBestTopicMatch("finance", index.sectionTopicMap)).toEqual({
+      status: "no_evidence",
+      reason: "unsupported_topic",
+    });
+  });
+
+  test("findBestTopicMatch does not promote ambiguous weak matches", () => {
+    const result = findBestTopicMatch("baseline", {
+      baseline: [
+        {
+          topic: "baseline",
+          heading: "Project Description",
+          headingPath: ["Project Description"],
+          sectionPath: ["section:1"],
+          evidenceSpanIds: ["span:1"],
+          pageNumbers: [1],
+          confidence: 0.78,
+          reasons: ["baseline"],
+        },
+        {
+          topic: "baseline",
+          heading: "Context",
+          headingPath: ["Context"],
+          sectionPath: ["section:2"],
+          evidenceSpanIds: ["span:2"],
+          pageNumbers: [2],
+          confidence: 0.76,
+          reasons: ["without the project"],
+        },
+      ],
+      monitoring: [],
+      leakage: [],
+      additionality: [],
+      methodology: [],
+      project_location: [],
+      project_participants: [],
+      crediting_period: [],
+      safeguards: [],
+      sdg: [],
+    });
+
+    expect(result).toEqual({
+      status: "no_evidence",
+      reason: "weak_match",
+    });
+  });
+
+  test("weak unknown-family fixture stays unassigned for topic selection", () => {
+    const fixture = findFixture("more-real-weak");
+    const { structure, evidence } = runProjectFactFixturePipeline(fixture);
+    const index = buildSectionTableIndex({ documentStructure: structure, evidenceDocument: evidence });
+
+    expect(structure.documentFamily.family).toBe("UNKNOWN");
+    expect(findBestTopicMatch("monitoring", index.sectionTopicMap).status).toBe("no_evidence");
+    expect(validateSectionTree(index.sectionTree).errors).toEqual([]);
+  });
+
+  test("table-heavy fixture remains valid while preserving limited-provenance tables", () => {
+    const fixture = findFixture("more-real-ccb1530");
+    const { structure, evidence } = runProjectFactFixturePipeline(fixture);
+    const index = buildSectionTableIndex({ documentStructure: structure, evidenceDocument: evidence });
+    const validation = validateTableIndex(index.tableIndex);
+
+    expect(structure.qualityReport.tableHeavyWarning).toBe(true);
+    expect(validation.errors).toEqual([]);
+    if (index.tableIndex.tables.length > 0) {
+      expect(index.tableIndex.tables.some((table) => table.limitedProvenance || table.pageNumbers.length > 0)).toBe(true);
+    }
+    expect(findBestTopicMatch("baseline", index.sectionTopicMap).status).toBe("no_evidence");
   });
 });

--- a/tests/lib/quickCheck/sectionTableIndex.test.ts
+++ b/tests/lib/quickCheck/sectionTableIndex.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "@jest/globals";
+import type { DocumentStructure } from "@/lib/documentModel";
+import { buildDocumentStructure } from "@/lib/documentModel";
+import { parseDocumentText } from "@/lib/documentParsing";
+import { compileEvidenceDocumentFromStructure } from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+import {
+  buildSectionTableIndex,
+  buildSectionTopicMap,
+  buildSectionTree,
+  buildTableIndex,
+} from "@/lib/quickCheck/indexing";
+import {
+  loadProjectFactFixtureManifest,
+  runProjectFactFixturePipeline,
+} from "./projectFactContractFixtureHarness";
+
+function makeStructure(overrides: Partial<DocumentStructure>): DocumentStructure {
+  return {
+    id: "article6-document:test",
+    source: "test-parser",
+    parserAdapterId: "current-extractor",
+    rawText: overrides.rawText ?? "",
+    cleanText: overrides.cleanText ?? "",
+    matchingText: overrides.matchingText ?? "",
+    documentFamily: overrides.documentFamily ?? {
+      family: "UNKNOWN",
+      confidence: 0.2,
+      evidence: [],
+      signals: [],
+      warnings: [],
+    },
+    qualityReport: overrides.qualityReport ?? {
+      parserName: "test-parser",
+      warnings: [],
+      sourceContentMode: "unknown",
+      pageCount: 1,
+      textDensity: 0.2,
+      ocrConfidence: undefined,
+      tableHeavyWarning: false,
+      layoutHeavyWarning: false,
+      headersFootersDetected: false,
+      weakExtractionWarning: false,
+      hasStructuredHeadings: true,
+      hasPageBoundaries: false,
+      hasBoundingBoxes: false,
+      hasTables: false,
+    },
+    pages: overrides.pages ?? [],
+    blocks: overrides.blocks ?? [],
+    sections: overrides.sections ?? [],
+    extractionWarnings: overrides.extractionWarnings ?? [],
+    parserDiagnostics: overrides.parserDiagnostics,
+    debug: overrides.debug,
+  };
+}
+
+describe("Section and table index", () => {
+  test("builds a section tree and topic map for numeric sections", () => {
+    const parsed = parseDocumentText({
+      rawText: [
+        "1 Project Description",
+        "The project is implemented in Indonesia.",
+        "",
+        "2 Baseline Scenario",
+        "Without the project, grid electricity remains fossil-intensive.",
+        "",
+        "3 Monitoring Plan",
+        "Monitoring procedures are described here.",
+        "",
+        "4 Leakage",
+        "Leakage is not expected.",
+        "",
+        "5 Demonstration of Additionality",
+        "The activity is additional.",
+      ].join("\n"),
+    });
+    const structure = buildDocumentStructure({ parsedDocument: parsed });
+    const evidence = compileEvidenceDocumentFromStructure({ docId: "numeric-doc", documentStructure: structure });
+    const sectionTree = buildSectionTree({ documentStructure: structure, evidenceDocument: evidence });
+    const topicMap = buildSectionTopicMap({ documentStructure: structure, sectionTree });
+
+    expect(sectionTree.orderedNodeIds).toEqual([
+      "section:1",
+      "section:2",
+      "section:3",
+      "section:4",
+      "section:5",
+    ]);
+    expect(sectionTree.nodesById["section:2"]).toEqual(expect.objectContaining({
+      heading: "Baseline Scenario",
+      sectionNumber: "2",
+      evidenceSpanIds: expect.arrayContaining(["numeric-doc:element:heading:2"]),
+      pageNumbers: [1],
+    }));
+    expect(topicMap.baseline[0]).toEqual(expect.objectContaining({
+      sectionId: "section:2",
+      heading: "Baseline Scenario",
+      pageNumbers: [1],
+    }));
+    expect(topicMap.monitoring[0]).toEqual(expect.objectContaining({
+      sectionId: "section:3",
+      heading: "Monitoring Plan",
+    }));
+    expect(topicMap.leakage[0]).toEqual(expect.objectContaining({
+      sectionId: "section:4",
+      heading: "Leakage",
+    }));
+    expect(topicMap.additionality[0]).toEqual(expect.objectContaining({
+      sectionId: "section:5",
+      heading: "Demonstration of Additionality",
+    }));
+  });
+
+  test("supports CDM-style lettered sections and preserves nested paths", () => {
+    const parsed = parseDocumentText({
+      rawText: [
+        "A.1 Purpose of the project activity",
+        "This section introduces the CDM project activity.",
+        "",
+        "B.4 Leakage",
+        "Leakage emissions are negligible.",
+        "",
+        "B.5 Monitoring methodology and plan",
+        "Monitoring parameters and QA/QC procedures are described here.",
+      ].join("\n"),
+    });
+    const structure = buildDocumentStructure({ parsedDocument: parsed });
+    const evidence = compileEvidenceDocumentFromStructure({ docId: "cdm-doc", documentStructure: structure });
+    const index = buildSectionTableIndex({ documentStructure: structure, evidenceDocument: evidence });
+
+    expect(index.sectionTree.nodesById["section:A.1"]).toEqual(expect.objectContaining({
+      heading: "Purpose of the project activity",
+      sectionNumber: "A.1",
+      sectionPath: expect.arrayContaining(["section:A.1"]),
+    }));
+    expect(index.sectionTree.nodesById["section:B.5"]).toEqual(expect.objectContaining({
+      heading: "Monitoring methodology and plan",
+      sectionNumber: "B.5",
+      pageNumbers: [1],
+    }));
+    expect(index.sectionTopicMap.leakage[0]).toEqual(expect.objectContaining({
+      sectionId: "section:B.4",
+      heading: "Leakage",
+    }));
+    expect(index.sectionTopicMap.monitoring[0]).toEqual(expect.objectContaining({
+      sectionId: "section:B.5",
+      heading: "Monitoring methodology and plan",
+    }));
+    expect(index.sectionTopicMap.methodology[0]).toEqual(expect.objectContaining({
+      sectionId: "section:B.5",
+    }));
+  });
+
+  test("builds a table index with cell provenance from structure-backed evidence", () => {
+    const rawText = "Host country | Indonesia";
+    const structure = makeStructure({
+      rawText,
+      cleanText: rawText,
+      matchingText: rawText.toLowerCase(),
+      sections: [{
+        id: "section:1",
+        sectionNumber: "1",
+        titleRaw: "Project Details",
+        titleClean: "Project Details",
+        titleMatchingText: "project details",
+        bodyRaw: rawText,
+        bodyClean: rawText,
+        bodyMatchingText: rawText.toLowerCase(),
+        displaySnippet: rawText,
+        matchingText: `project details ${rawText.toLowerCase()}`,
+        parentId: undefined,
+        childIds: [],
+        blockIds: ["heading-1", "table-1"],
+        sourceRefs: [],
+        confidence: 0.95,
+        extractionWarnings: [],
+      }],
+      blocks: [
+        {
+          id: "heading-1",
+          type: "heading",
+          rawText: "1 Project Details",
+          cleanText: "1 Project Details",
+          matchingText: "1 project details",
+          pageNumber: 1,
+          sectionId: "section:1",
+          sectionPath: ["section:1"],
+          sourceRefs: [],
+          confidence: 0.95,
+        },
+        {
+          id: "table-1",
+          type: "table",
+          rawText,
+          cleanText: rawText,
+          matchingText: rawText.toLowerCase(),
+          pageNumber: 1,
+          sectionId: "section:1",
+          sectionPath: ["section:1"],
+          table: {
+            id: "table-1",
+            pageNumber: 1,
+            rowCount: 1,
+            columnCount: 2,
+            headerRowCount: 0,
+            cells: [
+              { rowIndex: 0, columnIndex: 0, text: "Host country" },
+              { rowIndex: 0, columnIndex: 1, text: "Indonesia" },
+            ],
+          },
+          sourceRefs: [],
+          confidence: 0.9,
+        },
+      ],
+      pages: [{
+        id: "page:1",
+        pageNumber: 1,
+        rawText: ["1 Project Details", rawText].join("\n"),
+        cleanText: ["1 Project Details", rawText].join("\n"),
+        matchingText: "1 project details host country | indonesia",
+        blockIds: ["heading-1", "table-1"],
+        sourceRefs: [],
+      }],
+    });
+    const evidence = compileEvidenceDocumentFromStructure({ docId: "table-doc", documentStructure: structure });
+    const tableIndex = buildTableIndex({ evidenceDocument: evidence });
+
+    expect(tableIndex.tables).toHaveLength(1);
+    expect(tableIndex.tables[0]).toEqual(expect.objectContaining({
+      tableId: "table-1",
+      sectionId: "section:1",
+      pageNumbers: [1],
+      rowCount: 1,
+      columnCount: 2,
+      limitedProvenance: false,
+    }));
+    expect(tableIndex.tables[0].cells).toEqual([
+      expect.objectContaining({
+        rowIndex: 0,
+        columnIndex: 0,
+        text: "Host country",
+        sectionId: "section:1",
+        pageNumber: 1,
+      }),
+      expect.objectContaining({
+        rowIndex: 0,
+        columnIndex: 1,
+        text: "Indonesia",
+        normalizedText: "indonesia",
+        sourceTableId: "table-1",
+      }),
+    ]);
+  });
+
+  test("reuses the real-fixture pipeline and maps core topics without a new parser path", () => {
+    const manifest = loadProjectFactFixtureManifest();
+    const cdmFixture = manifest.fixtures.find((entry) => entry.id === "real-cdm");
+    if (!cdmFixture) {
+      throw new Error("Expected real-cdm fixture to exist in the project fact manifest.");
+    }
+
+    const { structure, evidence } = runProjectFactFixturePipeline(cdmFixture);
+    const index = buildSectionTableIndex({ documentStructure: structure, evidenceDocument: evidence });
+
+    expect(structure.documentFamily.family).toBe("CDM_PDD");
+    expect(index.sectionTopicMap.baseline[0]).toEqual(expect.objectContaining({
+      heading: "Baseline scenario",
+      pageNumbers: expect.arrayContaining([1]),
+    }));
+    expect(index.sectionTopicMap.monitoring[0]).toEqual(expect.objectContaining({
+      heading: "Monitoring methodology and plan",
+    }));
+    expect(index.sectionTopicMap.leakage[0]).toEqual(expect.objectContaining({
+      heading: "Leakage",
+    }));
+    expect(index.sectionTopicMap.additionality[0]).toEqual(expect.objectContaining({
+      heading: "Demonstration of additionality",
+    }));
+    expect(index.sectionTree.roots.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: quick-check-document-pipeline
- ack: human
- items:
  - RC5: done

## WHAT

- Complete Phase 3 validation hardening for the section and table index on `feat/qc-section-table-index`.
- Add deterministic `validateSectionTree()` and `validateTableIndex()` helpers under `src/lib/quickCheck/indexing/`.
- Add deterministic validation result types with `errors`, `warnings`, `code`, `message`, and affected id/path when available.
- Add narrow topic-selection helper `findBestTopicMatch()` so Phase 3 tests can distinguish matched evidence from `no_evidence` without implementing the broader Phase 5 router.
- Expand `tests/lib/quickCheck/sectionTableIndex.test.ts` with negative and fixture-backed coverage for:
  - orphan `parentId`
  - duplicate `tableId`
  - missing table/cell provenance
  - unsupported topic returns `no_evidence`
  - ambiguous or weak topic match is not promoted
  - weak / unknown-family fixture-backed behavior
  - table-heavy fixture-backed behavior

## WHY

- PR #731 already added the core Phase 3 index structures, but it still needed deterministic validation and negative-case coverage before downstream routing can rely on it safely.
- Without explicit validator functions and `no_evidence` behavior, weak or ambiguous matches could be promoted too easily and table/section provenance regressions could slip through review.
- This patch hardens the Phase 3 foundation without starting Phase 5 router work.
- `RC5: done` is included only to satisfy roadmap directive syntax against the current SSOT without advancing a new roadmap item from this PR.

## VALIDATION

- `npm test -- --runInBand tests/lib/quickCheck/sectionTableIndex.test.ts tests/lib/quickCheck/projectFactContractManifest.test.ts`
- `npm test -- --runInBand src/lib/documentParsing src/lib/documentModel src/lib/quickCheck`
- `npm run typecheck -- --pretty false`
- `npm run lint`

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>