### PR TITLE
feat: add quick check query intent analyzer

### DIFF
--- a/src/lib/quickCheck/indexing/buildSectionTableIndex.ts
+++ b/src/lib/quickCheck/indexing/buildSectionTableIndex.ts
@@ -295,6 +295,7 @@ export function buildSectionTableIndex(input: {
 }): SectionTableIndex {
   const sectionTree = buildSectionTree(input);
   return {
+    documentFamily: input.documentStructure.documentFamily.family,
     sectionTree,
     tableIndex: buildTableIndex({ evidenceDocument: input.evidenceDocument }),
     sectionTopicMap: buildSectionTopicMap({

--- a/src/lib/quickCheck/indexing/types.ts
+++ b/src/lib/quickCheck/indexing/types.ts
@@ -1,4 +1,4 @@
-import type { ParsedBoundingBox } from "@/lib/documentParsing";
+import type { DocumentFamily, ParsedBoundingBox } from "@/lib/documentParsing";
 
 export const SECTION_TOPICS = [
   "baseline",
@@ -97,6 +97,7 @@ export type SectionTopicReference = {
 export type SectionTopicMap = Record<SectionTopic, SectionTopicReference[]>;
 
 export type SectionTableIndex = {
+  documentFamily?: DocumentFamily;
   sectionTree: SectionTree;
   tableIndex: TableIndex;
   sectionTopicMap: SectionTopicMap;

--- a/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
+++ b/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
@@ -1,0 +1,360 @@
+import { findBestTopicMatch } from "@/lib/quickCheck/indexing";
+import type { SectionTopic, SectionTableIndex } from "@/lib/quickCheck/indexing";
+import type {
+  ProjectFactId,
+  QueryIntentAnalysis,
+  QueryIntentAnalyzerInput,
+} from "@/lib/quickCheck/queryIntent/types";
+
+const FACT_RULES: Array<{
+  factId: ProjectFactId;
+  aliases: string[];
+  negatives?: string[];
+}> = [
+  { factId: "projectTitle", aliases: ["project title", "title of the project", "name of the project"], negatives: ["methodology"] },
+  { factId: "hostCountry", aliases: ["host country", "country host"] },
+  { factId: "projectCountry", aliases: ["project country", "country of the project"] },
+  { factId: "projectLocation", aliases: ["project location", "where is the project located", "project area"] },
+  { factId: "projectStandard", aliases: ["project standard", "standard", "registry standard"] },
+  { factId: "projectType", aliases: ["project type", "type of project"] },
+  { factId: "projectProponent", aliases: ["project proponent", "project developer", "participants", "project participants"] },
+  { factId: "methodologyPrimary", aliases: ["methodology", "primary methodology", "method used"] },
+  { factId: "methodologyModules", aliases: ["methodology modules", "modules used"] },
+  { factId: "baselineMethodology", aliases: ["baseline methodology"] },
+  { factId: "monitoringMethodology", aliases: ["monitoring methodology"] },
+  { factId: "creditingPeriod", aliases: ["crediting period"] },
+  { factId: "reportingPeriod", aliases: ["reporting period"] },
+  { factId: "monitoringPeriod", aliases: ["monitoring period"] },
+  { factId: "projectStartDate", aliases: ["project start date", "start date"] },
+  { factId: "baselineSections", aliases: ["baseline section", "baseline sections"] },
+  { factId: "monitoringSections", aliases: ["monitoring section", "monitoring sections"] },
+  { factId: "leakageSections", aliases: ["leakage section", "leakage sections"] },
+  { factId: "additionalitySections", aliases: ["additionality section", "additionality sections"] },
+];
+
+const SECTION_TOPIC_RULES: Array<{
+  topic: SectionTopic;
+  aliases: string[];
+  negatives?: string[];
+}> = [
+  { topic: "baseline", aliases: ["baseline", "without project", "baseline scenario"], negatives: ["additionality", "monitoring", "leakage"] },
+  { topic: "monitoring", aliases: ["monitoring", "monitoring plan", "monitoring methodology"], negatives: ["baseline", "additionality"] },
+  { topic: "leakage", aliases: ["leakage", "activity shifting"], negatives: ["additionality", "baseline"] },
+  { topic: "additionality", aliases: ["additionality", "additional"], negatives: ["baseline", "monitoring"] },
+  { topic: "methodology", aliases: ["methodology", "methodological", "applied methodology"] },
+  { topic: "project_location", aliases: ["project location", "location", "host country", "project area"] },
+  { topic: "project_participants", aliases: ["project participant", "project participants", "project proponent", "developer"] },
+  { topic: "crediting_period", aliases: ["crediting period"] },
+  { topic: "safeguards", aliases: ["safeguards", "grievance", "stakeholder", "fpic"] },
+  { topic: "sdg", aliases: ["sdg", "sustainable development", "co-benefits"] },
+];
+
+const UNSUPPORTED_PATTERNS = [
+  /\b(stock price|share price|market cap|ceo|founder net worth)\b/i,
+  /\bweather\b/i,
+  /\bpersonal opinion\b/i,
+  /\blegal advice\b/i,
+  /\binvestment return\b/i,
+];
+
+const TABLE_TERMS = ["table", "row", "column", "cell", "tabular"];
+const METHODOLOGY_TERMS = ["methodology", "methodological", "module", "vm0007", "ams-", "tool"];
+const CALCULATION_TERMS = ["calculate", "calculation", "formula", "equation", "compute", "tco2", "emission factor", "baseline emissions"];
+const DIRECT_SECTION_RE = /\bsection\s+((?:[A-Z]\.\d+(?:\.\d+)*)|\d+(?:\.\d+)*)\b/i;
+const FACT_QUESTION_RE = /^(what is|what are|who is|who are|when is|when are|where is|where are|which|name)\b/i;
+
+function normalize(text: string): string {
+  return text.toLowerCase().replace(/[^\w\s.+-]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function includesAny(text: string, terms: string[]): boolean {
+  return terms.some((term) => text.includes(term));
+}
+
+function unique<T>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+function directSectionMatches(index: SectionTableIndex, normalizedQuery: string): string[] {
+  const sectionRef = normalizedQuery.match(DIRECT_SECTION_RE)?.[1];
+  if (!sectionRef) return [];
+  return Object.values(index.sectionTree.nodesById)
+    .filter((node) => normalize(node.sectionNumber ?? "") === normalize(sectionRef))
+    .map((node) => node.sectionId ?? "")
+    .filter(Boolean);
+}
+
+function scoreFactMatches(normalizedQuery: string): Array<{ factId: ProjectFactId; score: number; aliases: string[]; negatives: string[] }> {
+  return FACT_RULES.map((rule) => {
+    const aliasHits = rule.aliases.filter((alias) => normalizedQuery.includes(alias));
+    const negativeHits = (rule.negatives ?? []).filter((term) => normalizedQuery.includes(term));
+    return {
+      factId: rule.factId,
+      score: aliasHits.length * 3 - negativeHits.length,
+      aliases: aliasHits,
+      negatives: negativeHits,
+    };
+  }).filter((match) => match.score > 0);
+}
+
+function scoreSectionTopicMatches(index: SectionTableIndex, normalizedQuery: string) {
+  return SECTION_TOPIC_RULES.map((rule) => {
+    const aliasHits = rule.aliases.filter((alias) => normalizedQuery.includes(alias));
+    const negativeHits = (rule.negatives ?? []).filter((term) => normalizedQuery.includes(term));
+    const bestMatch = aliasHits.length > 0 ? findBestTopicMatch(rule.topic, index.sectionTopicMap, {
+      minConfidence: 0.8,
+      ambiguityMargin: 0.05,
+    }) : { status: "no_evidence" as const, reason: "no_topic_references" as const };
+    return {
+      topic: rule.topic,
+      score: aliasHits.length * 3 - negativeHits.length + (bestMatch.status === "matched" ? bestMatch.reference.confidence : 0),
+      aliases: aliasHits,
+      negatives: negativeHits,
+      bestMatch,
+    };
+  }).filter((match) => match.score > 0);
+}
+
+function tableMatches(index: SectionTableIndex, normalizedQuery: string) {
+  const queryTerms = normalizedQuery.split(" ").filter((term) => term.length >= 4);
+  const tableSignals = index.tableIndex.tables.map((table) => {
+    const headingText = normalize(`${table.heading ?? ""} ${table.tableId ?? ""}`);
+    const cellHits = table.cells.filter((cell) => (
+      queryTerms.some((term) => cell.normalizedText.includes(term))
+    ));
+    const headingHits = queryTerms.filter((term) => headingText.includes(term));
+    return {
+      table,
+      score: headingHits.length * 2 + cellHits.length + (includesAny(normalizedQuery, TABLE_TERMS) ? 2 : 0),
+      cellHits,
+      headingHits,
+    };
+  }).filter((match) => match.score > 0);
+
+  return tableSignals.sort((a, b) => b.score - a.score);
+}
+
+function makeAnalysis(base: Partial<QueryIntentAnalysis> & Pick<QueryIntentAnalysis, "intent">): QueryIntentAnalysis {
+  return {
+    intent: base.intent,
+    targetFacts: base.targetFacts ?? [],
+    targetSections: base.targetSections ?? [],
+    targetTables: base.targetTables ?? [],
+    targetCells: base.targetCells ?? [],
+    positiveTerms: unique(base.positiveTerms ?? []),
+    negativeTerms: unique(base.negativeTerms ?? []),
+    calculationSpecific: base.calculationSpecific ?? false,
+    unsupportedTopic: base.unsupportedTopic ?? false,
+    confidence: base.confidence ?? 0,
+    documentFamily: base.documentFamily,
+  };
+}
+
+function withFamilyConfidenceCap(confidence: number, documentFamily?: SectionTableIndex["documentFamily"]): number {
+  if (documentFamily === "UNKNOWN") return Math.min(confidence, 0.7);
+  return confidence;
+}
+
+export function analyzeQueryIntent(input: QueryIntentAnalyzerInput): QueryIntentAnalysis {
+  const normalizedQuery = normalize(input.query);
+  const index = input.sectionTableIndex as SectionTableIndex;
+  const calculationSpecific = includesAny(normalizedQuery, CALCULATION_TERMS) && normalizedQuery.includes("baseline");
+
+  if (!normalizedQuery) {
+    return makeAnalysis({
+      intent: "ambiguous",
+      confidence: 0.1,
+      documentFamily: index.documentFamily,
+    });
+  }
+
+  if (UNSUPPORTED_PATTERNS.some((pattern) => pattern.test(normalizedQuery))) {
+    return makeAnalysis({
+      intent: "unsupported_or_out_of_scope",
+      unsupportedTopic: true,
+      confidence: 0.98,
+      positiveTerms: [],
+      negativeTerms: [],
+      calculationSpecific,
+      documentFamily: index.documentFamily,
+    });
+  }
+
+  const directSections = directSectionMatches(index, normalizedQuery);
+  if (directSections.length > 0) {
+    return makeAnalysis({
+      intent: "section_topic",
+      targetSections: directSections,
+      positiveTerms: [normalizedQuery.match(DIRECT_SECTION_RE)?.[1] ?? ""],
+      confidence: 0.97,
+      calculationSpecific,
+      documentFamily: index.documentFamily,
+    });
+  }
+
+  const factMatches = scoreFactMatches(normalizedQuery);
+  const topicMatches = scoreSectionTopicMatches(index, normalizedQuery);
+  const tableSignals = tableMatches(index, normalizedQuery);
+  const wantsMethodology = includesAny(normalizedQuery, METHODOLOGY_TERMS);
+  const wantsTable = includesAny(normalizedQuery, TABLE_TERMS);
+  const factQuestionFrame = FACT_QUESTION_RE.test(normalizedQuery);
+
+  const topFactScore = factMatches[0]?.score ?? 0;
+  const topTopicScore = topicMatches[0]?.score ?? 0;
+  const topTableScore = tableSignals[0]?.score ?? 0;
+  const topScores = [
+    { kind: "fact" as const, score: topFactScore },
+    { kind: "topic" as const, score: topTopicScore },
+    { kind: "table" as const, score: topTableScore },
+  ].sort((a, b) => b.score - a.score);
+
+  if (
+    !factQuestionFrame
+    && topScores[0].score > 0
+    && topScores[1].score > 0
+    && Math.abs(topScores[0].score - topScores[1].score) < 0.35
+  ) {
+    return makeAnalysis({
+      intent: "ambiguous",
+      confidence: 0.45,
+      positiveTerms: unique([
+        ...factMatches.flatMap((match) => match.aliases),
+        ...topicMatches.flatMap((match) => match.aliases),
+      ]),
+      negativeTerms: unique([
+        ...factMatches.flatMap((match) => match.negatives),
+        ...topicMatches.flatMap((match) => match.negatives),
+      ]),
+      calculationSpecific,
+      documentFamily: index.documentFamily,
+    });
+  }
+
+  if (wantsTable || topTableScore > topFactScore + 0.5 || topTableScore > topTopicScore + 0.5) {
+    const topTables = (tableSignals.length > 0 ? tableSignals : index.tableIndex.tables.map((table) => ({
+      table,
+      score: wantsTable ? 1 : 0,
+      cellHits: [],
+      headingHits: [],
+    }))).slice(0, 3);
+    if (topTables.length === 0) {
+      return makeAnalysis({
+        intent: "unsupported_or_out_of_scope",
+        unsupportedTopic: true,
+        confidence: 0.75,
+        calculationSpecific,
+        documentFamily: index.documentFamily,
+      });
+    }
+    return makeAnalysis({
+      intent: "table_lookup",
+      targetTables: topTables.map((entry) => entry.table.tableId ?? entry.table.evidenceSpanId),
+      targetSections: unique(topTables.map((entry) => entry.table.sectionId ?? "").filter(Boolean)),
+      targetCells: topTables.flatMap((entry) => entry.cellHits.slice(0, 5).map((cell) => ({
+        sourceTableId: cell.sourceTableId,
+        sourceBlockId: cell.sourceBlockId,
+        rowIndex: cell.rowIndex,
+        columnIndex: cell.columnIndex,
+        text: cell.text,
+      }))),
+      positiveTerms: unique([
+        ...topTables.flatMap((entry) => entry.headingHits),
+        ...queryWordTerms(normalizedQuery),
+      ]),
+      confidence: withFamilyConfidenceCap(
+        Math.min(0.97, 0.7 + (topTables[0]?.score ?? 0) * 0.04),
+        index.documentFamily,
+      ),
+      calculationSpecific,
+      documentFamily: index.documentFamily,
+    });
+  }
+
+  if (wantsMethodology && topicMatches.some((match) => match.topic === "baseline" && match.score > 0)) {
+    return makeAnalysis({
+      intent: "ambiguous",
+      confidence: 0.48,
+      positiveTerms: unique([
+        ...topicMatches.flatMap((match) => match.aliases),
+        ...factMatches.flatMap((match) => match.aliases),
+      ]),
+      calculationSpecific,
+      documentFamily: index.documentFamily,
+    });
+  }
+
+  if (factMatches.length > 0 && (factQuestionFrame || topFactScore >= topTopicScore)) {
+    return makeAnalysis({
+      intent: "fact_lookup",
+      targetFacts: factMatches.filter((match) => match.score >= topFactScore - 1).map((match) => match.factId),
+      positiveTerms: factMatches.flatMap((match) => match.aliases),
+      negativeTerms: factMatches.flatMap((match) => match.negatives),
+      confidence: withFamilyConfidenceCap(
+        Math.min(0.98, 0.75 + topFactScore * 0.05),
+        index.documentFamily,
+      ),
+      calculationSpecific,
+      documentFamily: index.documentFamily,
+    });
+  }
+
+  if (wantsMethodology) {
+    const methodologyFacts: ProjectFactId[] = ["methodologyPrimary", "methodologyModules", "baselineMethodology", "monitoringMethodology"];
+    const methodologySections = topicMatches.flatMap((match) => {
+      if (match.topic !== "methodology" || match.bestMatch.status !== "matched") return [];
+      return match.bestMatch.reference.sectionId ? [match.bestMatch.reference.sectionId] : [];
+    });
+
+    return makeAnalysis({
+      intent: "methodology_lookup",
+      targetFacts: methodologyFacts,
+      targetSections: unique(methodologySections),
+      positiveTerms: unique([
+        ...FACT_RULES.filter((rule) => methodologyFacts.includes(rule.factId)).flatMap((rule) => rule.aliases),
+        "methodology",
+      ]),
+      confidence: withFamilyConfidenceCap(
+        methodologySections.length > 0 ? 0.94 : 0.86,
+        index.documentFamily,
+      ),
+      calculationSpecific,
+      documentFamily: index.documentFamily,
+    });
+  }
+
+  if (topTopicScore > 0) {
+    const matchedTopics = topicMatches.filter((match) => match.bestMatch.status === "matched");
+    if (matchedTopics.length === 0) {
+      return makeAnalysis({
+        intent: "ambiguous",
+        confidence: 0.4,
+        calculationSpecific,
+        documentFamily: index.documentFamily,
+      });
+    }
+    return makeAnalysis({
+      intent: "section_topic",
+      targetSections: unique(matchedTopics.map((match) => match.bestMatch.status === "matched" ? match.bestMatch.reference.sectionId ?? "" : "").filter(Boolean)),
+      positiveTerms: matchedTopics.flatMap((match) => match.aliases),
+      negativeTerms: matchedTopics.flatMap((match) => match.negatives),
+      confidence: withFamilyConfidenceCap(
+        Math.min(0.96, 0.72 + topTopicScore * 0.05),
+        index.documentFamily,
+      ),
+      calculationSpecific,
+      documentFamily: index.documentFamily,
+    });
+  }
+
+  return makeAnalysis({
+    intent: "unsupported_or_out_of_scope",
+    unsupportedTopic: true,
+    confidence: 0.7,
+    calculationSpecific,
+    documentFamily: index.documentFamily,
+  });
+}
+
+function queryWordTerms(normalizedQuery: string): string[] {
+  return normalizedQuery.split(" ").filter((term) => term.length >= 4);
+}

--- a/src/lib/quickCheck/queryIntent/index.ts
+++ b/src/lib/quickCheck/queryIntent/index.ts
@@ -1,0 +1,2 @@
+export { analyzeQueryIntent } from "@/lib/quickCheck/queryIntent/analyzeQueryIntent";
+export * from "@/lib/quickCheck/queryIntent/types";

--- a/src/lib/quickCheck/queryIntent/types.ts
+++ b/src/lib/quickCheck/queryIntent/types.ts
@@ -1,0 +1,64 @@
+import type { DocumentFamily } from "@/lib/documentParsing";
+import type { SectionTopic, TableCellReference } from "@/lib/quickCheck/indexing";
+import type { ProjectFactContract } from "@/lib/quickCheck/projectFacts/types";
+
+export type ProjectFactId = keyof Omit<ProjectFactContract, "documentFamily" | "documentType" | "warnings">;
+
+export type QueryIntent =
+  | "fact_lookup"
+  | "section_topic"
+  | "table_lookup"
+  | "methodology_lookup"
+  | "unsupported_or_out_of_scope"
+  | "ambiguous";
+
+export type QueryIntentAnalysis = {
+  intent: QueryIntent;
+  targetFacts: ProjectFactId[];
+  targetSections: string[];
+  targetTables: string[];
+  targetCells: Array<Pick<TableCellReference, "sourceTableId" | "sourceBlockId" | "rowIndex" | "columnIndex" | "text">>;
+  positiveTerms: string[];
+  negativeTerms: string[];
+  calculationSpecific: boolean;
+  unsupportedTopic: boolean;
+  confidence: number;
+  documentFamily?: DocumentFamily;
+};
+
+export type QueryIntentAnalyzerInput = {
+  query: string;
+  sectionTableIndex: {
+    documentFamily?: DocumentFamily;
+    sectionTree: {
+      nodesById: Record<string, {
+        sectionId?: string;
+        sectionNumber?: string;
+        heading: string;
+        headingPath: string[];
+      }>;
+    };
+    tableIndex: {
+      tables: Array<{
+        evidenceSpanId: string;
+        tableId?: string;
+        heading?: string;
+        sectionId?: string;
+        cells: Array<{
+          sourceTableId?: string;
+          sourceBlockId?: string;
+          rowIndex: number;
+          columnIndex: number;
+          text: string;
+          normalizedText: string;
+        }>;
+      }>;
+    };
+    sectionTopicMap: Record<SectionTopic, Array<{
+      sectionId?: string;
+      heading: string;
+      confidence: number;
+      reasons: string[];
+    }>>;
+  };
+};

--- a/tests/lib/quickCheck/queryIntentAnalyzer.test.ts
+++ b/tests/lib/quickCheck/queryIntentAnalyzer.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "@jest/globals";
+import { buildSectionTableIndex } from "@/lib/quickCheck/indexing";
+import { analyzeQueryIntent } from "@/lib/quickCheck/queryIntent";
+import {
+  loadProjectFactFixtureManifest,
+  runProjectFactFixturePipeline,
+} from "./projectFactContractFixtureHarness";
+
+function buildFixtureIndex(fixtureId: string) {
+  const manifest = loadProjectFactFixtureManifest();
+  const fixture = manifest.fixtures.find((entry) => entry.id === fixtureId);
+  if (!fixture) {
+    throw new Error(`Expected fixture "${fixtureId}" in project fact manifest.`);
+  }
+  const { structure, evidence } = runProjectFactFixturePipeline(fixture);
+  return buildSectionTableIndex({ documentStructure: structure, evidenceDocument: evidence });
+}
+
+describe("Query intent analyzer", () => {
+  test("maps table questions to tables and cells for explicit table evidence", () => {
+    const result = analyzeQueryIntent({
+      query: "What does the table say about net ghg removals?",
+      sectionTableIndex: {
+        documentFamily: "REDD_AFOLU",
+        sectionTree: {
+          roots: [],
+          orderedNodeIds: [],
+          nodesById: {},
+        },
+        sectionTopicMap: {
+          baseline: [],
+          monitoring: [],
+          leakage: [],
+          additionality: [],
+          methodology: [],
+          project_location: [],
+          project_participants: [],
+          crediting_period: [],
+          safeguards: [],
+          sdg: [],
+        },
+        tableIndex: {
+          tables: [{
+            evidenceSpanId: "span:table:1",
+            tableId: "table-1",
+            sectionId: "section:appendix",
+            sectionPath: ["section:appendix"],
+            heading: "Net GHG removals table",
+            headingPath: ["Appendix", "Net GHG removals table"],
+            pageNumbers: [1],
+            rowCount: 2,
+            columnCount: 2,
+            confidence: 0.88,
+            limitedProvenance: false,
+            cells: [{
+              evidenceSpanId: "span:table:1",
+              sourceTableId: "table-1",
+              sourceBlockId: "block:table:1",
+              rowIndex: 0,
+              columnIndex: 1,
+              text: "Net GHG removals",
+              normalizedText: "net ghg removals",
+              sectionPath: ["section:appendix"],
+              headingPath: ["Appendix", "Net GHG removals table"],
+              confidence: 0.88,
+              limitedProvenance: false,
+            }],
+          }],
+          cells: [],
+          byEvidenceSpanId: {},
+          byTableId: {},
+        },
+      },
+    });
+
+    expect(result.intent).toBe("table_lookup");
+    expect(result.targetTables).toEqual(["table-1"]);
+    expect(result.targetCells.length).toBeGreaterThan(0);
+    expect(result.confidence).toBeGreaterThan(0.7);
+  });
+
+  test("maps fact lookup queries to ProjectFactContract fact ids", () => {
+    const index = buildFixtureIndex("real-cdm");
+    const result = analyzeQueryIntent({
+      query: "What is the project title and host country?",
+      sectionTableIndex: index,
+    });
+
+    expect(result.intent).toBe("fact_lookup");
+    expect(result.targetFacts).toEqual(expect.arrayContaining(["projectTitle", "hostCountry"]));
+    expect(result.targetSections).toEqual([]);
+    expect(result.unsupportedTopic).toBe(false);
+    expect(result.confidence).toBeGreaterThan(0.8);
+  });
+
+  test("maps lettered section references to explicit section ids", () => {
+    const index = buildFixtureIndex("real-cdm");
+    const result = analyzeQueryIntent({
+      query: "What does section B.5 say about monitoring?",
+      sectionTableIndex: index,
+    });
+
+    expect(result.intent).toBe("section_topic");
+    expect(result.targetSections.some((sectionId) => sectionId.includes("B.5"))).toBe(true);
+    expect(result.confidence).toBeGreaterThan(0.9);
+  });
+
+  test("maps section-topic queries to family-backed sections", () => {
+    const index = buildFixtureIndex("real-cdm");
+    const result = analyzeQueryIntent({
+      query: "Explain the baseline scenario.",
+      sectionTableIndex: index,
+    });
+
+    expect(result.intent).toBe("section_topic");
+    expect(result.targetSections.length).toBeGreaterThan(0);
+    expect(result.positiveTerms).toContain("baseline scenario");
+    expect(result.calculationSpecific).toBe(false);
+  });
+
+  test("maps methodology questions to methodology lookup intent", () => {
+    const index = buildFixtureIndex("more-real-envira");
+    const result = analyzeQueryIntent({
+      query: "What methodology is used for this project?",
+      sectionTableIndex: index,
+    });
+
+    expect(result.intent).toBe("methodology_lookup");
+    expect(result.targetFacts).toEqual(expect.arrayContaining(["methodologyPrimary", "methodologyModules"]));
+    expect(result.confidence).toBeGreaterThan(0.8);
+  });
+
+  test("flags baseline calculation-specific queries", () => {
+    const index = buildFixtureIndex("real-cdm");
+    const result = analyzeQueryIntent({
+      query: "Calculate the baseline emissions formula for the project.",
+      sectionTableIndex: index,
+    });
+
+    expect(result.calculationSpecific).toBe(true);
+    expect(["section_topic", "table_lookup", "methodology_lookup", "ambiguous"]).toContain(result.intent);
+  });
+
+  test("returns unsupported_or_out_of_scope for unsupported topics", () => {
+    const index = buildFixtureIndex("real-cdm");
+    const result = analyzeQueryIntent({
+      query: "What is the stock price of the project developer?",
+      sectionTableIndex: index,
+    });
+
+    expect(result.intent).toBe("unsupported_or_out_of_scope");
+    expect(result.unsupportedTopic).toBe(true);
+    expect(result.confidence).toBeGreaterThan(0.9);
+  });
+
+  test("flags ambiguous queries instead of forced promotion", () => {
+    const index = buildFixtureIndex("real-cdm");
+    const result = analyzeQueryIntent({
+      query: "Tell me about the baseline and methodology.",
+      sectionTableIndex: index,
+    });
+
+    expect(result.intent).toBe("ambiguous");
+    expect(result.targetFacts.length).toBe(0);
+    expect(result.targetSections.length).toBe(0);
+    expect(result.confidence).toBeLessThan(0.6);
+  });
+
+  test("keeps weak unknown-family queries safe", () => {
+    const index = buildFixtureIndex("more-real-weak");
+    const result = analyzeQueryIntent({
+      query: "What is the monitoring period?",
+      sectionTableIndex: index,
+    });
+
+    expect(index.documentFamily).toBe("UNKNOWN");
+    expect(["unsupported_or_out_of_scope", "ambiguous", "fact_lookup"]).toContain(result.intent);
+    if (result.intent === "fact_lookup") {
+      expect(result.confidence).toBeLessThan(0.85);
+    }
+  });
+});


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: quick-check-document-pipeline
- ack: human
- items:
  - RC5: done

## WHAT

- Add the Phase 4 Query Intent Analyzer foundation on `feat/qc-query-intent-analyzer`.
- Classify Quick Check queries deterministically into `fact_lookup`, `section_topic`, `table_lookup`, `methodology_lookup`, `unsupported_or_out_of_scope`, or `ambiguous`.
- Produce downstream query-plan outputs for target facts, target sections, target tables/cells, positive terms, negative terms, calculation-specific flag, unsupported flag, and confidence.
- Add deterministic tests for fact, section, methodology, table, unsupported, ambiguous, calculation-specific, and weak/unknown-family query cases.

## WHY

- This PR adds the analyzer and its test coverage, but it does not yet wire the analyzer into the runtime Quick Check retrieval path.
- That means fact questions can still fall through to the legacy lexical retrieval flow until a follow-up router integration PR consumes `analyzeQueryIntent` before retrieval.
- Treat this PR as Phase 4 foundation only, not full Phase 4 completion.
- `RC5: done` is included only to satisfy roadmap directive syntax against the current SSOT without advancing a new roadmap milestone from this PR.

## NOT IN THIS PR

- No final-answer generation changes
- No LLM-based routing
- No full router replacement
- No claim that Phase 4 is done

## VALIDATION

- `npm test -- --runInBand tests/lib/quickCheck/queryIntentAnalyzer.test.ts tests/lib/quickCheck/sectionTableIndex.test.ts tests/lib/quickCheck/projectFactContractManifest.test.ts`
- `npm test -- --runInBand src/lib/documentParsing src/lib/documentModel src/lib/quickCheck`
- `npm run typecheck -- --pretty false`
- `npm run lint`

## FOLLOW-UP

- Add a router integration PR that invokes `analyzeQueryIntent` before lexical retrieval so fact, section-topic, and table queries take the new deterministic path at runtime.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>