### PR TITLE
feat: wire quick check query intent routing

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -58,7 +58,7 @@ import { loadPins, savePins } from "@/lib/proofMap/storage";
 import type { EvidencePin, PddFragment } from "@/lib/proofMap/types";
 import {
   buildReviewQuestionResult,
-  detectReviewPath,
+  detectRuntimeReviewPath,
   reviewAreaLabel,
   type ReviewQuestionResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
@@ -1460,7 +1460,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const evidenceAnalysis = await analyzeQuickCheckEvidence(selectedEvidenceSources, { resolvePdfText });
       const reviewFieldText = draft.claimText.trim();
       const claimIntents = classifyQuickCheckClaimIntents(effectiveClaimText);
-      const isReviewQuestion = detectReviewPath(reviewFieldText, { inputContext: "review_question_field" }) === "review_question_answering";
+      const isReviewQuestion = detectRuntimeReviewPath({
+        claimText: reviewFieldText,
+        rawPddText: evidenceAnalysis.rawPddText,
+        inputContext: "review_question_field",
+      }) === "review_question_answering";
       const currentMethodologyResolution = resolveQuickCheckMethodology({
         mentions: methodologyMentionsForDetection({ analysis: evidenceAnalysis, extraction: null }),
         methods,

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -223,6 +223,7 @@ export function buildReviewQuestionResult(input: {
   evidenceSourceLabel?: string;
   evidenceDocumentType?: string;
 }): ReviewQuestionResult {
+  const baseRetrieval = buildReviewQuestionSectionRetrieval(input);
   const structuredContext = input.rawPddText?.trim() ? buildStructuredQueryContext(input.rawPddText) : undefined;
   const queryIntentAnalysis = structuredContext
     ? analyzeQueryIntent({
@@ -239,15 +240,25 @@ export function buildReviewQuestionResult(input: {
           && hasIntentBackedEvidence({ queryIntentAnalysis, structuredContext })
         )
         || (
-          (queryIntentAnalysis.intent === "unsupported_or_out_of_scope" || queryIntentAnalysis.intent === "ambiguous")
+          queryIntentAnalysis.intent === "unsupported_or_out_of_scope"
           && !isQuestionStyled(input.claimText)
           && isLabelStyleIntentQuery(input.claimText)
+        )
+        || (
+          queryIntentAnalysis.intent === "ambiguous"
+          && !isQuestionStyled(input.claimText)
+          && isLabelStyleIntentQuery(input.claimText)
+          && (
+            baseRetrieval.matchedHeadings.length === 0
+            || queryIntentAnalysis.positiveTerms.length > 0
+            || queryIntentAnalysis.negativeTerms.length > 0
+          )
         )
       )
     : false;
   const appliedQueryIntentAnalysis = shouldApplyIntentRouting ? queryIntentAnalysis : undefined;
   const retrieval = applyIntentToRetrieval({
-    retrieval: buildReviewQuestionSectionRetrieval(input),
+    retrieval: baseRetrieval,
     queryIntentAnalysis: appliedQueryIntentAnalysis,
     structuredContext,
   });

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,17 +1,26 @@
 import {
   buildReviewQuestionSectionRetrieval,
+  detectReviewPath,
 } from "@/lib/quickCheck/retrieval/retrieveSections";
+import { buildDocumentStructure } from "@/lib/documentModel";
+import { compileEvidenceDocumentFromStructure } from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+import { buildSectionTableIndex } from "@/lib/quickCheck/indexing";
+import { buildProjectFactContract } from "@/lib/quickCheck/projectFacts";
+import { analyzeQueryIntent } from "@/lib/quickCheck/queryIntent";
 import type {
+  QuickCheckInputContext,
   ReviewQuestionResult,
+  ReviewQuestionRetrievalResult,
 } from "@/lib/quickCheck/retrieval/types";
 import {
   evaluateRetrievedReviewQuestion,
 } from "@/lib/quickCheck/evaluation/evaluateEvidence";
 import { parseDocumentText } from "@/lib/documentParsing";
 import { buildDocumentQuestionAnswer, buildReviewQuestionDocumentDiagnostic } from "@/lib/quickCheck/documentQa";
+import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
+import type { QueryIntentAnalysis } from "@/lib/quickCheck/queryIntent";
 
 export type {
-  BuildReviewQuestionSectionRetrievalInput,
   QuickCheckPath,
   ReviewArea,
   ReviewQuestionDiagnostic,
@@ -35,6 +44,177 @@ export {
 } from "@/lib/quickCheck/retrieval/retrieveSections";
 export { evaluateRetrievedReviewQuestion } from "@/lib/quickCheck/evaluation/evaluateEvidence";
 
+function buildStructuredQueryContext(rawPddText: string) {
+  const parsedDocument = parseDocumentText({ rawText: rawPddText });
+  const documentStructure = buildDocumentStructure({ parsedDocument });
+  const evidenceDocument = compileEvidenceDocumentFromStructure({
+    docId: "quick-check-review-question",
+    documentStructure,
+  });
+  const projectFactContract = buildProjectFactContract(evidenceDocument);
+  const sectionTableIndex = buildSectionTableIndex({
+    documentStructure,
+    evidenceDocument,
+  });
+  return {
+    parsedDocument,
+    documentStructure,
+    evidenceDocument,
+    projectFactContract,
+    sectionTableIndex,
+  };
+}
+
+function isQuestionStyled(text: string): boolean {
+  const trimmed = text.trim();
+  return trimmed.endsWith("?") || /^(?:does|do|did|is|are|was|were|what|which|who|where|when|why|how|can|could|should|would|will)\b/i.test(trimmed);
+}
+
+function isLabelStyleIntentQuery(text: string): boolean {
+  return text.trim().split(/\s+/).filter(Boolean).length <= 5;
+}
+
+export function detectRuntimeReviewPath(input: {
+  claimText: string;
+  rawPddText?: string;
+  inputContext?: QuickCheckInputContext;
+}): "claim_to_requirement_match" | "review_question_answering" {
+  const basePath = detectReviewPath(input.claimText, { inputContext: input.inputContext });
+  if (basePath === "review_question_answering") return basePath;
+  if (input.inputContext !== "review_question_field" || !input.rawPddText?.trim()) return basePath;
+
+  const context = buildStructuredQueryContext(input.rawPddText);
+  const queryIntent = analyzeQueryIntent({
+    query: input.claimText,
+    sectionTableIndex: context.sectionTableIndex,
+  });
+  return queryIntent.intent === "fact_lookup"
+    || queryIntent.intent === "section_topic"
+    || queryIntent.intent === "table_lookup"
+    || queryIntent.intent === "methodology_lookup"
+    || queryIntent.intent === "unsupported_or_out_of_scope"
+    || queryIntent.intent === "ambiguous"
+    ? "review_question_answering"
+    : basePath;
+}
+
+function toSyntheticHeading(input: {
+  sectionNumber: string;
+  title: string;
+  bodyText: string;
+}): DocumentHeading {
+  const normalizedTitle = input.title.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
+  const normalizedBodyText = input.bodyText.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
+  return {
+    sectionNumber: input.sectionNumber,
+    title: input.title,
+    originalTitle: input.title,
+    normalizedTitle,
+    bodyPreview: input.bodyText.slice(0, 220),
+    bodyText: input.bodyText,
+    originalBodyText: input.bodyText,
+    normalizedBodyText,
+  };
+}
+
+function applyIntentToRetrieval(input: {
+  retrieval: ReviewQuestionRetrievalResult;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+  structuredContext?: ReturnType<typeof buildStructuredQueryContext>;
+}): ReviewQuestionRetrievalResult {
+  if (!input.queryIntentAnalysis || !input.structuredContext) {
+    return input.retrieval;
+  }
+
+  const { documentStructure, evidenceDocument, projectFactContract } = input.structuredContext;
+  const relevantSectionIds = new Set<string>();
+
+  for (const sectionId of input.queryIntentAnalysis.targetSections) {
+    if (sectionId) relevantSectionIds.add(sectionId);
+  }
+
+  if (input.queryIntentAnalysis.intent === "fact_lookup" || input.queryIntentAnalysis.intent === "methodology_lookup") {
+    for (const factId of input.queryIntentAnalysis.targetFacts) {
+      const field = projectFactContract[factId];
+      for (const spanId of field.evidenceSpanIds) {
+        const span = evidenceDocument.spans.find((candidate) => candidate.spanId === spanId);
+        if (span?.sectionId) relevantSectionIds.add(span.sectionId);
+      }
+    }
+  }
+
+  if (input.queryIntentAnalysis.intent === "table_lookup") {
+    for (const tableKey of input.queryIntentAnalysis.targetTables) {
+      const table = input.structuredContext.sectionTableIndex.tableIndex.byTableId[tableKey]
+        ?? input.structuredContext.sectionTableIndex.tableIndex.byEvidenceSpanId[tableKey];
+      if (table?.sectionId) relevantSectionIds.add(table.sectionId);
+    }
+  }
+
+  if (relevantSectionIds.size === 0) {
+    return {
+      ...input.retrieval,
+      queryIntentAnalysis: input.queryIntentAnalysis,
+    };
+  }
+
+  const matchedHeadings = documentStructure.sections
+    .filter((section) => relevantSectionIds.has(section.id) && Boolean(section.sectionNumber))
+    .map((section) => toSyntheticHeading({
+      sectionNumber: section.sectionNumber ?? section.id,
+      title: section.titleClean,
+      bodyText: section.bodyClean || section.displaySnippet || section.titleClean,
+    }));
+
+  if (matchedHeadings.length === 0) {
+    return {
+      ...input.retrieval,
+      queryIntentAnalysis: input.queryIntentAnalysis,
+    };
+  }
+
+  const relevantSections = matchedHeadings.map((heading) => heading.sectionNumber);
+  const sectionContent = Object.fromEntries(matchedHeadings.map((heading) => [
+    heading.sectionNumber,
+    heading.bodyText ? `${heading.title}\n${heading.bodyText}` : heading.title,
+  ]));
+
+  return {
+    ...input.retrieval,
+    queryIntentAnalysis: input.queryIntentAnalysis,
+    matchStage: input.queryIntentAnalysis.intent === "section_topic" ? "semantic_fallback" : input.retrieval.matchStage,
+    relevantSections,
+    sectionContent,
+    matchedHeadings,
+  };
+}
+
+function hasIntentBackedEvidence(input: {
+  queryIntentAnalysis?: QueryIntentAnalysis;
+  structuredContext?: ReturnType<typeof buildStructuredQueryContext>;
+}): boolean {
+  if (!input.queryIntentAnalysis || !input.structuredContext) {
+    return false;
+  }
+
+  const { evidenceDocument, projectFactContract, sectionTableIndex } = input.structuredContext;
+
+  if (input.queryIntentAnalysis.intent === "fact_lookup" || input.queryIntentAnalysis.intent === "methodology_lookup") {
+    return input.queryIntentAnalysis.targetFacts.some((factId) => {
+      const field = projectFactContract[factId];
+      return field.evidenceSpanIds.some((spanId) => evidenceDocument.spans.some((span) => span.spanId === spanId));
+    });
+  }
+
+  if (input.queryIntentAnalysis.intent === "table_lookup") {
+    return input.queryIntentAnalysis.targetTables.some((tableKey) => (
+      Boolean(sectionTableIndex.tableIndex.byTableId[tableKey] ?? sectionTableIndex.tableIndex.byEvidenceSpanId[tableKey])
+    ));
+  }
+
+  return false;
+}
+
 export function buildReviewQuestionResult(input: {
   claimText: string;
   methodologyId: string;
@@ -43,20 +223,52 @@ export function buildReviewQuestionResult(input: {
   evidenceSourceLabel?: string;
   evidenceDocumentType?: string;
 }): ReviewQuestionResult {
-  const retrieval = buildReviewQuestionSectionRetrieval(input);
+  const structuredContext = input.rawPddText?.trim() ? buildStructuredQueryContext(input.rawPddText) : undefined;
+  const queryIntentAnalysis = structuredContext
+    ? analyzeQueryIntent({
+        query: input.claimText,
+        sectionTableIndex: structuredContext.sectionTableIndex,
+      })
+    : undefined;
+  const shouldApplyIntentRouting = queryIntentAnalysis
+    ? (
+        (
+          (queryIntentAnalysis.intent === "fact_lookup"
+          || queryIntentAnalysis.intent === "methodology_lookup"
+          || queryIntentAnalysis.intent === "table_lookup")
+          && hasIntentBackedEvidence({ queryIntentAnalysis, structuredContext })
+        )
+        || (
+          (queryIntentAnalysis.intent === "unsupported_or_out_of_scope" || queryIntentAnalysis.intent === "ambiguous")
+          && !isQuestionStyled(input.claimText)
+          && isLabelStyleIntentQuery(input.claimText)
+        )
+      )
+    : false;
+  const appliedQueryIntentAnalysis = shouldApplyIntentRouting ? queryIntentAnalysis : undefined;
+  const retrieval = applyIntentToRetrieval({
+    retrieval: buildReviewQuestionSectionRetrieval(input),
+    queryIntentAnalysis: appliedQueryIntentAnalysis,
+    structuredContext,
+  });
   const evaluation = evaluateRetrievedReviewQuestion(retrieval);
-  const parsedDocument = input.rawPddText ? parseDocumentText({ rawText: input.rawPddText }) : undefined;
+  const parsedDocument = structuredContext?.parsedDocument ?? (input.rawPddText ? parseDocumentText({ rawText: input.rawPddText }) : undefined);
   const documentAnswer = buildDocumentQuestionAnswer({
     retrieval,
     evaluation,
     parsedDocument,
     claimText: input.claimText,
     rawPddText: input.rawPddText,
+    queryIntentAnalysis: appliedQueryIntentAnalysis,
+    evidenceDocument: structuredContext?.evidenceDocument,
+    projectFactContract: structuredContext?.projectFactContract,
+    sectionTableIndex: structuredContext?.sectionTableIndex,
   });
 
   return {
     ...retrieval,
     ...evaluation,
+    queryIntentAnalysis,
     documentAnswer,
     documentDiagnostic: buildReviewQuestionDocumentDiagnostic(documentAnswer),
   };

--- a/src/lib/quickCheck/documentQa.ts
+++ b/src/lib/quickCheck/documentQa.ts
@@ -1,10 +1,14 @@
 import { buildArticle6DocumentModel } from "@/lib/documentModel";
 import type { Article6DocumentModel, Article6DocumentSection } from "@/lib/documentModel";
 import type { ParsedDocument } from "@/lib/documentParsing";
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+import type { SectionTableIndex } from "@/lib/quickCheck/indexing";
 import {
   getReviewAreaAliases,
   getReviewAreaKeywords,
 } from "@/lib/quickCheck/policy/reviewPolicy";
+import type { ProjectFactContract } from "@/lib/quickCheck/projectFacts/types";
+import type { QueryIntentAnalysis } from "@/lib/quickCheck/queryIntent";
 import type {
   DocumentAnswerEvidence,
   DocumentQuestionAnswer,
@@ -238,6 +242,64 @@ function findRawTextEvidence(rawPddText: string | undefined, claimText: string, 
   return snippets;
 }
 
+function buildFactIntentEvidence(input: {
+  evidenceDocument?: EvidenceDocument;
+  projectFactContract?: ProjectFactContract;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+}): DocumentAnswerEvidence[] {
+  if (!input.evidenceDocument || !input.projectFactContract || !input.queryIntentAnalysis) return [];
+  const snippets: DocumentAnswerEvidence[] = [];
+  for (const factId of input.queryIntentAnalysis.targetFacts) {
+    const field = input.projectFactContract[factId];
+    for (const spanId of field.evidenceSpanIds) {
+      const span = input.evidenceDocument.spans.find((candidate) => candidate.spanId === spanId);
+      if (!span) continue;
+      snippets.push({
+        snippet: trimSnippet(span.text),
+        page: span.page ?? undefined,
+        heading: span.heading,
+        sectionNumber: span.sectionId?.replace(/^section:/, ""),
+        blockId: span.sourceBlockId,
+        source: "block",
+      });
+    }
+  }
+  return snippets.slice(0, MAX_EVIDENCE_ITEMS);
+}
+
+function buildTableIntentEvidence(input: {
+  sectionTableIndex?: SectionTableIndex;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+}): DocumentAnswerEvidence[] {
+  if (!input.sectionTableIndex || !input.queryIntentAnalysis) return [];
+  const snippets: DocumentAnswerEvidence[] = [];
+  for (const tableKey of input.queryIntentAnalysis.targetTables) {
+    const table = input.sectionTableIndex.tableIndex.byTableId[tableKey]
+      ?? input.sectionTableIndex.tableIndex.byEvidenceSpanId[tableKey];
+    if (!table) continue;
+    const tableCells = input.queryIntentAnalysis.targetCells.length > 0
+      ? input.queryIntentAnalysis.targetCells
+      : table.cells.slice(0, 3).map((cell) => ({
+          sourceTableId: cell.sourceTableId,
+          sourceBlockId: cell.sourceBlockId,
+          rowIndex: cell.rowIndex,
+          columnIndex: cell.columnIndex,
+          text: cell.text,
+        }));
+    for (const cell of tableCells) {
+      snippets.push({
+        snippet: trimSnippet(`${table.heading ?? "Table"} row ${cell.rowIndex + 1} column ${cell.columnIndex + 1}: ${cell.text}`),
+        page: table.pageNumbers[0],
+        heading: table.heading,
+        sectionNumber: table.sectionId?.replace(/^section:/, ""),
+        blockId: cell.sourceBlockId,
+        source: "block",
+      });
+    }
+  }
+  return snippets.slice(0, MAX_EVIDENCE_ITEMS);
+}
+
 function deriveAnswerStatus(input: {
   evidence: DocumentAnswerEvidence[];
   evaluation: ReviewQuestionEvaluationResult;
@@ -268,10 +330,58 @@ export function buildDocumentQuestionAnswer(input: {
   parsedDocument?: ParsedDocument;
   claimText: string;
   rawPddText?: string;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+  evidenceDocument?: EvidenceDocument;
+  projectFactContract?: ProjectFactContract;
+  sectionTableIndex?: SectionTableIndex;
 }): DocumentQuestionAnswer {
+  if (input.queryIntentAnalysis?.intent === "unsupported_or_out_of_scope") {
+    return {
+      status: "unclear",
+      methodologyRuleMatched: false,
+      methodologyExplanation: "Quick Check classified this request as outside document-grounded review scope.",
+      explanation: "Quick Check classified this question as unsupported or out of scope for evidence-grounded document review.",
+      evidence: [],
+      diagnostic: {
+        reviewQuestionRoutingFired: true,
+        rawPddTextAvailable: Boolean(input.rawPddText?.trim()),
+        documentEvidenceCount: 0,
+        methodologyRuleMatched: false,
+      },
+    };
+  }
+
+  if (input.queryIntentAnalysis?.intent === "ambiguous") {
+    return {
+      status: "unclear",
+      methodologyRuleMatched: false,
+      methodologyExplanation: "Quick Check found multiple plausible intent targets and did not force a retrieval path.",
+      explanation: "Quick Check classified this question as ambiguous and did not promote a single evidence path.",
+      evidence: [],
+      diagnostic: {
+        reviewQuestionRoutingFired: true,
+        rawPddTextAvailable: Boolean(input.rawPddText?.trim()),
+        documentEvidenceCount: 0,
+        methodologyRuleMatched: false,
+      },
+    };
+  }
+
   const headingEvidence = buildHeadingEvidence(input.retrieval);
+  const intentEvidence = input.queryIntentAnalysis?.intent === "fact_lookup" || input.queryIntentAnalysis?.intent === "methodology_lookup"
+    ? buildFactIntentEvidence({
+        evidenceDocument: input.evidenceDocument,
+        projectFactContract: input.projectFactContract,
+        queryIntentAnalysis: input.queryIntentAnalysis,
+      })
+    : input.queryIntentAnalysis?.intent === "table_lookup"
+      ? buildTableIntentEvidence({
+          sectionTableIndex: input.sectionTableIndex,
+          queryIntentAnalysis: input.queryIntentAnalysis,
+        })
+      : [];
   const model = input.parsedDocument ? buildArticle6DocumentModel({ parsedDocument: input.parsedDocument }) : null;
-  const blockEvidence = headingEvidence.length > 0 || !model
+  const blockEvidence = headingEvidence.length > 0 || intentEvidence.length > 0 || !model
     ? []
     : buildBlockEvidence({
         model,
@@ -280,10 +390,10 @@ export function buildDocumentQuestionAnswer(input: {
         rawPddText: input.rawPddText,
         claimText: input.claimText,
       });
-  const rawTextEvidence = headingEvidence.length > 0 || blockEvidence.length > 0
+  const rawTextEvidence = headingEvidence.length > 0 || intentEvidence.length > 0 || blockEvidence.length > 0
     ? []
     : findRawTextEvidence(input.rawPddText, input.claimText, input.retrieval.reviewArea);
-  const evidence = [...headingEvidence, ...blockEvidence, ...rawTextEvidence].slice(0, MAX_EVIDENCE_ITEMS);
+  const evidence = [...intentEvidence, ...headingEvidence, ...blockEvidence, ...rawTextEvidence].slice(0, MAX_EVIDENCE_ITEMS);
 
   const specificTerms = getSpecificClaimTerms(input.claimText, input.retrieval.reviewArea);
   const directlyRelevant = specificTerms.length === 0 || hasDirectSemanticSupport(evidence, specificTerms);
@@ -314,6 +424,12 @@ export function buildDocumentQuestionAnswer(input: {
     methodologyRuleMatched,
     methodologyExplanation: methodologyRuleMatched
       ? "Quick Check found a methodology-aware review path and evaluated the matched document sections."
+      : input.queryIntentAnalysis?.intent === "methodology_lookup"
+        ? "Quick Check used the deterministic query intent analyzer to route this question to methodology evidence."
+        : input.queryIntentAnalysis?.intent === "fact_lookup"
+          ? "Quick Check used the deterministic query intent analyzer to route this question to extracted project facts."
+          : input.queryIntentAnalysis?.intent === "table_lookup"
+            ? "Quick Check used the deterministic query intent analyzer to route this question to table evidence."
       : evidence.length > 0
         ? "No methodology rule was confidently matched, but the uploaded document contains relevant evidence."
         : rawPddTextAvailable

--- a/src/lib/quickCheck/retrieval/types.ts
+++ b/src/lib/quickCheck/retrieval/types.ts
@@ -1,6 +1,7 @@
 import type { DocumentHeading, RejectedHeadingQueryMatch, SectionCandidateDebug } from "@/lib/chat/quickCheckSectionExtractor";
 import type { BaselineReviewResult } from "@/lib/chat/quickCheckBaselineRubric";
 import type { ReviewRubricResult } from "@/lib/chat/quickCheckReviewRubric";
+import type { QueryIntentAnalysis } from "@/lib/quickCheck/queryIntent";
 
 export type ReviewArea =
   | "additionality"
@@ -145,6 +146,7 @@ export type ReviewQuestionResult = {
   reviewArea: ReviewArea;
   status: ReviewQuestionStatus;
   matchStage: ReviewQuestionMatchStage;
+  queryIntentAnalysis?: QueryIntentAnalysis;
   methodologyId: string;
   methodologyVersion: string;
   relevantSections: string[];

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -7,6 +7,7 @@ import {
   classifyReviewArea,
   computeSectionMatchResults,
   detectReviewPath,
+  detectRuntimeReviewPath,
   evaluateRetrievedReviewQuestion,
   extractClaimKeywords,
   findMatchedSectionNumbers,
@@ -95,6 +96,22 @@ const ENVIRA_TEXT = fs.readFileSync(
   path.join(__dirname, "../fixtures/quick-check/envira-amazonia-vm0007-extracted.txt"),
   "utf8",
 );
+
+const FACT_AND_METHOD_PDD_TEXT = [
+  "Project Title: Coastal Mangrove Restoration Project",
+  "Host Country: Kenya",
+  "Project Proponent: Blue Carbon Initiative",
+  "Methodology Applied: VM0007 REDD+ Methodology Framework",
+  "",
+  "2.2 Project Location",
+  "The project is located in Lamu County, Kenya.",
+  "",
+  "2.4 Baseline Scenario",
+  "Without the project activity, mangrove clearing would continue and emissions would increase.",
+  "",
+  "3.1 Monitoring Plan",
+  "The monitoring plan measures forest cover change and biomass annually.",
+].join("\n");
 
 afterEach(() => {
   delete process.env.QUICK_CHECK_PARSER;
@@ -1381,5 +1398,104 @@ describe("PR #657 - article-prefixed baseline question detection", () => {
       methodologyVersion: "4.2",
     });
     expect(additionalityResult.reviewArea).toBe("additionality");
+  });
+});
+
+describe("Phase 4 router integration groundwork", () => {
+  it("routes claim-style fact questions through runtime document q&a when parsed text is available", () => {
+    expect(detectRuntimeReviewPath({
+      claimText: "What is the project title?",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      inputContext: "review_question_field",
+    })).toBe("review_question_answering");
+  });
+
+  it("preserves the legacy review-question path when parsed text is unavailable", () => {
+    expect(detectRuntimeReviewPath({
+      claimText: "project title",
+      inputContext: "review_question_field",
+    })).toBe("review_question_answering");
+  });
+
+  it("routes fact lookups to extracted project fact evidence", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "project title",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("fact_lookup");
+    expect(result.queryIntentAnalysis?.targetFacts).toContain("projectTitle");
+    expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
+    expect(result.documentAnswer.methodologyExplanation).toContain("extracted project facts");
+  });
+
+  it("routes section-topic lookups to section-backed evidence", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "baseline scenario",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("section_topic");
+    expect(result.relevantSections.length).toBeGreaterThan(0);
+    expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
+  });
+
+  it("routes methodology lookups to methodology evidence", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "applied methodology",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("methodology_lookup");
+    expect(result.queryIntentAnalysis?.targetFacts).toEqual(expect.arrayContaining(["methodologyPrimary", "methodologyModules"]));
+    expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
+    expect(result.documentAnswer.methodologyExplanation).toContain("methodology evidence");
+  });
+
+  it("keeps explicit table questions safe when no indexed table evidence exists in the raw-text path", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "table baseline emissions",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
+    expect(result.documentAnswer.status).toBe("unclear");
+    expect(result.documentAnswer.evidence).toEqual([]);
+  });
+
+  it("returns unsupported questions as unclear without forcing lexical recovery", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "stock price",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
+    expect(result.documentAnswer.status).toBe("unclear");
+    expect(result.documentAnswer.explanation).toContain("unsupported or out of scope");
+    expect(result.documentAnswer.evidence).toEqual([]);
+  });
+
+  it("returns ambiguous questions as unclear without promoting a single path", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "baseline methodology",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("ambiguous");
+    expect(result.documentAnswer.status).toBe("unclear");
+    expect(result.documentAnswer.explanation).toContain("ambiguous");
+    expect(result.documentAnswer.evidence).toEqual([]);
   });
 });


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: quick-check-document-pipeline
- ack: human
- items:
  - RC5: in_progress

## WHAT

- Wire `analyzeQueryIntent` into the runtime Quick Check review-question path before legacy lexical retrieval.
- Route fact, methodology, and table-style intents through structured document context built from the existing parser/document/evidence pipeline.
- Preserve legacy section-topic review behavior while surfacing `queryIntentAnalysis` on runtime review results.
- Keep unsupported and ambiguous short-form intent queries safe by returning document-first `unclear` results instead of silently promoting lexical matches.
- Add runtime integration coverage in `tests/lib/quickCheckReviewQuestion.test.ts` for fact, section-topic, methodology, table-safe, unsupported, and ambiguous cases.

## WHY

- PR #733 added the deterministic Query Intent Analyzer foundation, but Quick Check still fell back to legacy lexical behavior at runtime.
- This follow-up PR is the router integration layer that makes intent analysis affect product behavior before retrieval.
- It keeps Phase 4 in progress rather than done, because this is the runtime wiring step, not a claim that all later router work is complete.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>