### PR TITLE
Codex/qc structured context followup

### DIFF
--- a/docs/roadmaps/phase-assurance-surface-mvp/phase-status.json
+++ b/docs/roadmaps/phase-assurance-surface-mvp/phase-status.json
@@ -6,7 +6,7 @@
   "PR16": "done",
   "PR17": "done",
   "PR14_1": "done",
-  "RC5": "done",
+  "RC5": "in_progress",
   "pr_evidence": {
     "PR12": [
       326

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -59,6 +59,7 @@ import type { EvidencePin, PddFragment } from "@/lib/proofMap/types";
 import {
   buildReviewQuestionResult,
   detectRuntimeReviewPath,
+  getStructuredQueryContext,
   reviewAreaLabel,
   type ReviewQuestionResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
@@ -1460,10 +1461,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const evidenceAnalysis = await analyzeQuickCheckEvidence(selectedEvidenceSources, { resolvePdfText });
       const reviewFieldText = draft.claimText.trim();
       const claimIntents = classifyQuickCheckClaimIntents(effectiveClaimText);
+      const structuredQueryContext = evidenceAnalysis.rawPddText?.trim()
+        ? getStructuredQueryContext(evidenceAnalysis.rawPddText)
+        : undefined;
       const isReviewQuestion = detectRuntimeReviewPath({
         claimText: reviewFieldText,
         rawPddText: evidenceAnalysis.rawPddText,
         inputContext: "review_question_field",
+        structuredQueryContext,
       }) === "review_question_answering";
       const currentMethodologyResolution = resolveQuickCheckMethodology({
         mentions: methodologyMentionsForDetection({ analysis: evidenceAnalysis, extraction: null }),
@@ -1489,6 +1494,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           rawPddText: evidenceAnalysis.rawPddText,
           evidenceSourceLabel: firstSource?.sourceLabel,
           evidenceDocumentType: evidenceAnalysis.documentTypes[0],
+          structuredQueryContext,
         });
         const runId = reviewQuestionRunRef.current + 1;
         reviewQuestionRunRef.current = runId;

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -44,9 +44,6 @@ export {
 } from "@/lib/quickCheck/retrieval/retrieveSections";
 export { evaluateRetrievedReviewQuestion } from "@/lib/quickCheck/evaluation/evaluateEvidence";
 
-let structuredQueryContextCache: { rawPddText: string; context: StructuredQueryContext } | null = null;
-let structuredQueryContextBuildCountForTests = 0;
-
 function buildStructuredQueryContext(rawPddText: string) {
   const parsedDocument = parseDocumentText({ rawText: rawPddText });
   const documentStructure = buildDocumentStructure({ parsedDocument });
@@ -71,27 +68,7 @@ function buildStructuredQueryContext(rawPddText: string) {
 export type StructuredQueryContext = ReturnType<typeof buildStructuredQueryContext>;
 
 export function getStructuredQueryContext(rawPddText: string): StructuredQueryContext {
-  const normalizedRawPddText = rawPddText.trim();
-  if (structuredQueryContextCache?.rawPddText === normalizedRawPddText) {
-    return structuredQueryContextCache.context;
-  }
-
-  const context = buildStructuredQueryContext(normalizedRawPddText);
-  structuredQueryContextCache = {
-    rawPddText: normalizedRawPddText,
-    context,
-  };
-  structuredQueryContextBuildCountForTests += 1;
-  return context;
-}
-
-export function __resetStructuredQueryContextCacheForTests() {
-  structuredQueryContextCache = null;
-  structuredQueryContextBuildCountForTests = 0;
-}
-
-export function __getStructuredQueryContextBuildCountForTests() {
-  return structuredQueryContextBuildCountForTests;
+  return buildStructuredQueryContext(rawPddText.trim());
 }
 
 export function detectRuntimeReviewPath(input: {

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -44,6 +44,9 @@ export {
 } from "@/lib/quickCheck/retrieval/retrieveSections";
 export { evaluateRetrievedReviewQuestion } from "@/lib/quickCheck/evaluation/evaluateEvidence";
 
+let structuredQueryContextCache: { rawPddText: string; context: StructuredQueryContext } | null = null;
+let structuredQueryContextBuildCountForTests = 0;
+
 function buildStructuredQueryContext(rawPddText: string) {
   const parsedDocument = parseDocumentText({ rawText: rawPddText });
   const documentStructure = buildDocumentStructure({ parsedDocument });
@@ -65,25 +68,43 @@ function buildStructuredQueryContext(rawPddText: string) {
   };
 }
 
-function isQuestionStyled(text: string): boolean {
-  const trimmed = text.trim();
-  return trimmed.endsWith("?") || /^(?:does|do|did|is|are|was|were|what|which|who|where|when|why|how|can|could|should|would|will)\b/i.test(trimmed);
+export type StructuredQueryContext = ReturnType<typeof buildStructuredQueryContext>;
+
+export function getStructuredQueryContext(rawPddText: string): StructuredQueryContext {
+  const normalizedRawPddText = rawPddText.trim();
+  if (structuredQueryContextCache?.rawPddText === normalizedRawPddText) {
+    return structuredQueryContextCache.context;
+  }
+
+  const context = buildStructuredQueryContext(normalizedRawPddText);
+  structuredQueryContextCache = {
+    rawPddText: normalizedRawPddText,
+    context,
+  };
+  structuredQueryContextBuildCountForTests += 1;
+  return context;
 }
 
-function isLabelStyleIntentQuery(text: string): boolean {
-  return text.trim().split(/\s+/).filter(Boolean).length <= 5;
+export function __resetStructuredQueryContextCacheForTests() {
+  structuredQueryContextCache = null;
+  structuredQueryContextBuildCountForTests = 0;
+}
+
+export function __getStructuredQueryContextBuildCountForTests() {
+  return structuredQueryContextBuildCountForTests;
 }
 
 export function detectRuntimeReviewPath(input: {
   claimText: string;
   rawPddText?: string;
   inputContext?: QuickCheckInputContext;
+  structuredQueryContext?: StructuredQueryContext;
 }): "claim_to_requirement_match" | "review_question_answering" {
   const basePath = detectReviewPath(input.claimText, { inputContext: input.inputContext });
   if (basePath === "review_question_answering") return basePath;
   if (input.inputContext !== "review_question_field" || !input.rawPddText?.trim()) return basePath;
 
-  const context = buildStructuredQueryContext(input.rawPddText);
+  const context = input.structuredQueryContext ?? getStructuredQueryContext(input.rawPddText);
   const queryIntent = analyzeQueryIntent({
     query: input.claimText,
     sectionTableIndex: context.sectionTableIndex,
@@ -222,9 +243,11 @@ export function buildReviewQuestionResult(input: {
   rawPddText?: string;
   evidenceSourceLabel?: string;
   evidenceDocumentType?: string;
+  structuredQueryContext?: StructuredQueryContext;
 }): ReviewQuestionResult {
   const baseRetrieval = buildReviewQuestionSectionRetrieval(input);
-  const structuredContext = input.rawPddText?.trim() ? buildStructuredQueryContext(input.rawPddText) : undefined;
+  const structuredContext = input.structuredQueryContext
+    ?? (input.rawPddText?.trim() ? getStructuredQueryContext(input.rawPddText) : undefined);
   const queryIntentAnalysis = structuredContext
     ? analyzeQueryIntent({
         query: input.claimText,
@@ -241,13 +264,12 @@ export function buildReviewQuestionResult(input: {
         )
         || (
           queryIntentAnalysis.intent === "unsupported_or_out_of_scope"
-          && !isQuestionStyled(input.claimText)
-          && isLabelStyleIntentQuery(input.claimText)
+          && queryIntentAnalysis.confidence > 0.7
         )
         || (
           queryIntentAnalysis.intent === "ambiguous"
-          && !isQuestionStyled(input.claimText)
-          && isLabelStyleIntentQuery(input.claimText)
+          && !input.claimText.trim().endsWith("?")
+          && input.claimText.trim().split(/\s+/).filter(Boolean).length <= 5
           && (
             baseRetrieval.matchedHeadings.length === 0
             || queryIntentAnalysis.positiveTerms.length > 0

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it } from "@jest/globals";
 import fs from "fs";
 import path from "path";
 import {
+  __getStructuredQueryContextBuildCountForTests,
+  __resetStructuredQueryContextCacheForTests,
   buildReviewQuestionResult,
   buildReviewQuestionSectionRetrieval,
   classifyReviewArea,
@@ -11,6 +13,7 @@ import {
   evaluateRetrievedReviewQuestion,
   extractClaimKeywords,
   findMatchedSectionNumbers,
+  getStructuredQueryContext,
   resolveReviewSections,
   reviewAreaLabel,
   type ReviewArea,
@@ -97,6 +100,17 @@ const ENVIRA_TEXT = fs.readFileSync(
   "utf8",
 );
 
+const REAL_CDM_TEXT = fs.readFileSync(
+  path.join(__dirname, "../fixtures/quick-check/bsp-nepal-activity3-cdm-excerpt.txt"),
+  "utf8",
+);
+
+const REAL_TABLE_HEAVY_APPENDIX_TEXT = (
+  JSON.parse(
+    fs.readFileSync(path.join(__dirname, "../fixtures/projects/ccb1530-appendix1-pages.json"), "utf8"),
+  ) as { pages: Array<{ text?: string }> }
+).pages.map((page) => page.text ?? "").join("\f");
+
 const FACT_AND_METHOD_PDD_TEXT = [
   "Project Title: Coastal Mangrove Restoration Project",
   "Host Country: Kenya",
@@ -116,6 +130,7 @@ const FACT_AND_METHOD_PDD_TEXT = [
 afterEach(() => {
   delete process.env.QUICK_CHECK_PARSER;
   setLiteParseImplementationForTests(null);
+  __resetStructuredQueryContextCacheForTests();
 });
 
 const BOUNDARY_RANKING_PDD = [
@@ -1402,6 +1417,28 @@ describe("PR #657 - article-prefixed baseline question detection", () => {
 });
 
 describe("Phase 4 router integration groundwork", () => {
+  it("reuses the structured query context across runtime path detection and result building in the same flow", () => {
+    const structuredQueryContext = getStructuredQueryContext(REAL_CDM_TEXT);
+
+    expect(detectRuntimeReviewPath({
+      claimText: "What is the project title and host country?",
+      rawPddText: REAL_CDM_TEXT,
+      inputContext: "review_question_field",
+      structuredQueryContext,
+    })).toBe("review_question_answering");
+
+    const result = buildReviewQuestionResult({
+      claimText: "What is the project title and host country?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
+      structuredQueryContext,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("fact_lookup");
+    expect(__getStructuredQueryContextBuildCountForTests()).toBe(1);
+  });
+
   it("routes claim-style fact questions through runtime document q&a when parsed text is available", () => {
     expect(detectRuntimeReviewPath({
       claimText: "What is the project title?",
@@ -1417,66 +1454,56 @@ describe("Phase 4 router integration groundwork", () => {
     })).toBe("review_question_answering");
   });
 
-  it("routes fact lookups to extracted project fact evidence", () => {
+  it("routes real-document project title and host country lookups to fact-backed evidence", () => {
     const result = buildReviewQuestionResult({
-      claimText: "project title",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      claimText: "What is the project title and host country?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("fact_lookup");
-    expect(result.queryIntentAnalysis?.targetFacts).toContain("projectTitle");
-    expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
+    expect(result.queryIntentAnalysis?.targetFacts).toEqual(expect.arrayContaining(["projectTitle", "hostCountry"]));
+    expect(result.documentAnswer.status).toBe("likely_yes");
+    expect(result.documentAnswer.evidence.length).toBeGreaterThanOrEqual(2);
+    expect(result.documentAnswer.evidence[0]?.heading || result.documentAnswer.evidence[0]?.page || result.documentAnswer.evidence[0]?.blockId).toBeTruthy();
     expect(result.documentAnswer.methodologyExplanation).toContain("extracted project facts");
   });
 
-  it("routes section-topic lookups to section-backed evidence", () => {
+  it("routes real-document baseline section-topic lookups to the baseline section", () => {
     const result = buildReviewQuestionResult({
-      claimText: "baseline scenario",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      claimText: "Explain the baseline scenario.",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("section_topic");
-    expect(result.relevantSections.length).toBeGreaterThan(0);
+    expect(result.relevantSections).toContain("B.4");
     expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
   });
 
-  it("routes methodology lookups to methodology evidence", () => {
+  it("routes real-document methodology lookups to provenance-backed methodology evidence", () => {
     const result = buildReviewQuestionResult({
-      claimText: "applied methodology",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      claimText: "What methodology is used for this project?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("methodology_lookup");
     expect(result.queryIntentAnalysis?.targetFacts).toEqual(expect.arrayContaining(["methodologyPrimary", "methodologyModules"]));
     expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
+    expect(result.documentAnswer.evidence[0]?.heading || result.documentAnswer.evidence[0]?.page || result.documentAnswer.evidence[0]?.blockId).toBeTruthy();
     expect(result.documentAnswer.methodologyExplanation).toContain("methodology evidence");
   });
 
-  it("keeps explicit table questions safe when no indexed table evidence exists in the raw-text path", () => {
+  it("keeps real table-heavy queries safe when no deterministic table provenance is available", () => {
     const result = buildReviewQuestionResult({
-      claimText: "table baseline emissions",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
-    });
-
-    expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
-    expect(result.documentAnswer.status).toBe("unclear");
-    expect(result.documentAnswer.evidence).toEqual([]);
-  });
-
-  it("returns unsupported questions as unclear without forcing lexical recovery", () => {
-    const result = buildReviewQuestionResult({
-      claimText: "stock price",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      claimText: "What does the table say about net ghg removals?",
+      methodologyId: "AR-ACM0003",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_TABLE_HEAVY_APPENDIX_TEXT,
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
@@ -1485,12 +1512,26 @@ describe("Phase 4 router integration groundwork", () => {
     expect(result.documentAnswer.evidence).toEqual([]);
   });
 
-  it("returns ambiguous questions as unclear without promoting a single path", () => {
+  it("returns real-document unsupported questions as unclear without forcing lexical recovery", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "What is the stock price of the project developer?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
+    expect(result.documentAnswer.status).toBe("unclear");
+    expect(result.documentAnswer.explanation).toContain("unsupported or out of scope");
+    expect(result.documentAnswer.evidence).toEqual([]);
+  });
+
+  it("returns real-document ambiguous questions as unclear without promoting a single path", () => {
     const result = buildReviewQuestionResult({
       claimText: "baseline methodology",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("ambiguous");

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -2,8 +2,6 @@ import { afterEach, describe, expect, it } from "@jest/globals";
 import fs from "fs";
 import path from "path";
 import {
-  __getStructuredQueryContextBuildCountForTests,
-  __resetStructuredQueryContextCacheForTests,
   buildReviewQuestionResult,
   buildReviewQuestionSectionRetrieval,
   classifyReviewArea,
@@ -130,7 +128,6 @@ const FACT_AND_METHOD_PDD_TEXT = [
 afterEach(() => {
   delete process.env.QUICK_CHECK_PARSER;
   setLiteParseImplementationForTests(null);
-  __resetStructuredQueryContextCacheForTests();
 });
 
 const BOUNDARY_RANKING_PDD = [
@@ -1436,7 +1433,7 @@ describe("Phase 4 router integration groundwork", () => {
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("fact_lookup");
-    expect(__getStructuredQueryContextBuildCountForTests()).toBe(1);
+    expect(result.documentAnswer.methodologyExplanation).toContain("extracted project facts");
   });
 
   it("routes claim-style fact questions through runtime document q&a when parsed text is available", () => {


### PR DESCRIPTION
## What changed
- reuse one structured query context across `detectRuntimeReviewPath` and `buildReviewQuestionResult` in the same Quick Check review-question flow
- remove the module-level structured-context cache in favor of explicit per-flow reuse from `QuickCheckPanel`
- add real-document runtime coverage for fact lookup, methodology lookup, baseline section-topic lookup, table-heavy safety, unsupported queries, and ambiguous queries
- keep `docs/roadmaps/phase-assurance-surface-mvp/phase-status.json` with `RC5` set to `in_progress`
- drop the premium export timestamp edits from this PR so the branch stays focused on Quick Check router/runtime behavior

## Why
PR #735 put query-intent routing on the runtime path, but the same review-question flow could still rebuild parsed document structure and related indexes more than once, and the runtime coverage was mostly synthetic. This follow-up keeps the router work on the Quick Check track, adds real-document confidence, and avoids keeping a module-global cache alive across flows.

## Impact
- avoids duplicate structured-context builds within the same Quick Check review-question execution path
- preserves document-first fallback behavior for weak or generic document questions
- keeps unsupported and ambiguous queries from falling through to lexical evidence when deterministic routing should return `unclear`
- leaves the router phase open; this PR does not mark it done

## Validation
- `npm run pr:gate`
- `npm run quickcheck:eval`
- `npm test -- --runInBand tests/lib/quickCheckReviewQuestion.test.ts`
- `npm test -- --runInBand tests/lib/evidence/export/premiumExport.test.ts`

## Roadmap

### Roadmap-Update
- slug: phase-assurance-surface-mvp
- ack: human
- items:
  - RC5: in_progress

Visible UI changes to look for:
- none; this is runtime behavior and test coverage hardening inside Quick Check review-question flows
