### PR TITLE
Feat/qc query intent router

### DIFF
--- a/docs/roadmaps/phase-assurance-surface-mvp/phase-status.json
+++ b/docs/roadmaps/phase-assurance-surface-mvp/phase-status.json
@@ -6,7 +6,7 @@
   "PR16": "done",
   "PR17": "done",
   "PR14_1": "done",
-  "RC5": "done",
+  "RC5": "in_progress",
   "pr_evidence": {
     "PR12": [
       326

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -59,6 +59,7 @@ import type { EvidencePin, PddFragment } from "@/lib/proofMap/types";
 import {
   buildReviewQuestionResult,
   detectRuntimeReviewPath,
+  getStructuredQueryContext,
   reviewAreaLabel,
   type ReviewQuestionResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
@@ -1460,10 +1461,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const evidenceAnalysis = await analyzeQuickCheckEvidence(selectedEvidenceSources, { resolvePdfText });
       const reviewFieldText = draft.claimText.trim();
       const claimIntents = classifyQuickCheckClaimIntents(effectiveClaimText);
+      const structuredQueryContext = evidenceAnalysis.rawPddText?.trim()
+        ? getStructuredQueryContext(evidenceAnalysis.rawPddText)
+        : undefined;
       const isReviewQuestion = detectRuntimeReviewPath({
         claimText: reviewFieldText,
         rawPddText: evidenceAnalysis.rawPddText,
         inputContext: "review_question_field",
+        structuredQueryContext,
       }) === "review_question_answering";
       const currentMethodologyResolution = resolveQuickCheckMethodology({
         mentions: methodologyMentionsForDetection({ analysis: evidenceAnalysis, extraction: null }),
@@ -1489,6 +1494,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           rawPddText: evidenceAnalysis.rawPddText,
           evidenceSourceLabel: firstSource?.sourceLabel,
           evidenceDocumentType: evidenceAnalysis.documentTypes[0],
+          structuredQueryContext,
         });
         const runId = reviewQuestionRunRef.current + 1;
         reviewQuestionRunRef.current = runId;

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -58,7 +58,7 @@ import { loadPins, savePins } from "@/lib/proofMap/storage";
 import type { EvidencePin, PddFragment } from "@/lib/proofMap/types";
 import {
   buildReviewQuestionResult,
-  detectReviewPath,
+  detectRuntimeReviewPath,
   reviewAreaLabel,
   type ReviewQuestionResult,
 } from "@/lib/chat/quickCheckReviewQuestion";
@@ -1460,7 +1460,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const evidenceAnalysis = await analyzeQuickCheckEvidence(selectedEvidenceSources, { resolvePdfText });
       const reviewFieldText = draft.claimText.trim();
       const claimIntents = classifyQuickCheckClaimIntents(effectiveClaimText);
-      const isReviewQuestion = detectReviewPath(reviewFieldText, { inputContext: "review_question_field" }) === "review_question_answering";
+      const isReviewQuestion = detectRuntimeReviewPath({
+        claimText: reviewFieldText,
+        rawPddText: evidenceAnalysis.rawPddText,
+        inputContext: "review_question_field",
+      }) === "review_question_answering";
       const currentMethodologyResolution = resolveQuickCheckMethodology({
         mentions: methodologyMentionsForDetection({ analysis: evidenceAnalysis, extraction: null }),
         methods,

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -223,6 +223,7 @@ export function buildReviewQuestionResult(input: {
   evidenceSourceLabel?: string;
   evidenceDocumentType?: string;
 }): ReviewQuestionResult {
+  const baseRetrieval = buildReviewQuestionSectionRetrieval(input);
   const structuredContext = input.rawPddText?.trim() ? buildStructuredQueryContext(input.rawPddText) : undefined;
   const queryIntentAnalysis = structuredContext
     ? analyzeQueryIntent({
@@ -239,15 +240,25 @@ export function buildReviewQuestionResult(input: {
           && hasIntentBackedEvidence({ queryIntentAnalysis, structuredContext })
         )
         || (
-          (queryIntentAnalysis.intent === "unsupported_or_out_of_scope" || queryIntentAnalysis.intent === "ambiguous")
+          queryIntentAnalysis.intent === "unsupported_or_out_of_scope"
           && !isQuestionStyled(input.claimText)
           && isLabelStyleIntentQuery(input.claimText)
+        )
+        || (
+          queryIntentAnalysis.intent === "ambiguous"
+          && !isQuestionStyled(input.claimText)
+          && isLabelStyleIntentQuery(input.claimText)
+          && (
+            baseRetrieval.matchedHeadings.length === 0
+            || queryIntentAnalysis.positiveTerms.length > 0
+            || queryIntentAnalysis.negativeTerms.length > 0
+          )
         )
       )
     : false;
   const appliedQueryIntentAnalysis = shouldApplyIntentRouting ? queryIntentAnalysis : undefined;
   const retrieval = applyIntentToRetrieval({
-    retrieval: buildReviewQuestionSectionRetrieval(input),
+    retrieval: baseRetrieval,
     queryIntentAnalysis: appliedQueryIntentAnalysis,
     structuredContext,
   });

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -44,9 +44,6 @@ export {
 } from "@/lib/quickCheck/retrieval/retrieveSections";
 export { evaluateRetrievedReviewQuestion } from "@/lib/quickCheck/evaluation/evaluateEvidence";
 
-let structuredQueryContextCache: { rawPddText: string; context: StructuredQueryContext } | null = null;
-let structuredQueryContextBuildCountForTests = 0;
-
 function buildStructuredQueryContext(rawPddText: string) {
   const parsedDocument = parseDocumentText({ rawText: rawPddText });
   const documentStructure = buildDocumentStructure({ parsedDocument });
@@ -71,27 +68,7 @@ function buildStructuredQueryContext(rawPddText: string) {
 export type StructuredQueryContext = ReturnType<typeof buildStructuredQueryContext>;
 
 export function getStructuredQueryContext(rawPddText: string): StructuredQueryContext {
-  const normalizedRawPddText = rawPddText.trim();
-  if (structuredQueryContextCache?.rawPddText === normalizedRawPddText) {
-    return structuredQueryContextCache.context;
-  }
-
-  const context = buildStructuredQueryContext(normalizedRawPddText);
-  structuredQueryContextCache = {
-    rawPddText: normalizedRawPddText,
-    context,
-  };
-  structuredQueryContextBuildCountForTests += 1;
-  return context;
-}
-
-export function __resetStructuredQueryContextCacheForTests() {
-  structuredQueryContextCache = null;
-  structuredQueryContextBuildCountForTests = 0;
-}
-
-export function __getStructuredQueryContextBuildCountForTests() {
-  return structuredQueryContextBuildCountForTests;
+  return buildStructuredQueryContext(rawPddText.trim());
 }
 
 export function detectRuntimeReviewPath(input: {

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -44,6 +44,9 @@ export {
 } from "@/lib/quickCheck/retrieval/retrieveSections";
 export { evaluateRetrievedReviewQuestion } from "@/lib/quickCheck/evaluation/evaluateEvidence";
 
+let structuredQueryContextCache: { rawPddText: string; context: StructuredQueryContext } | null = null;
+let structuredQueryContextBuildCountForTests = 0;
+
 function buildStructuredQueryContext(rawPddText: string) {
   const parsedDocument = parseDocumentText({ rawText: rawPddText });
   const documentStructure = buildDocumentStructure({ parsedDocument });
@@ -65,25 +68,43 @@ function buildStructuredQueryContext(rawPddText: string) {
   };
 }
 
-function isQuestionStyled(text: string): boolean {
-  const trimmed = text.trim();
-  return trimmed.endsWith("?") || /^(?:does|do|did|is|are|was|were|what|which|who|where|when|why|how|can|could|should|would|will)\b/i.test(trimmed);
+export type StructuredQueryContext = ReturnType<typeof buildStructuredQueryContext>;
+
+export function getStructuredQueryContext(rawPddText: string): StructuredQueryContext {
+  const normalizedRawPddText = rawPddText.trim();
+  if (structuredQueryContextCache?.rawPddText === normalizedRawPddText) {
+    return structuredQueryContextCache.context;
+  }
+
+  const context = buildStructuredQueryContext(normalizedRawPddText);
+  structuredQueryContextCache = {
+    rawPddText: normalizedRawPddText,
+    context,
+  };
+  structuredQueryContextBuildCountForTests += 1;
+  return context;
 }
 
-function isLabelStyleIntentQuery(text: string): boolean {
-  return text.trim().split(/\s+/).filter(Boolean).length <= 5;
+export function __resetStructuredQueryContextCacheForTests() {
+  structuredQueryContextCache = null;
+  structuredQueryContextBuildCountForTests = 0;
+}
+
+export function __getStructuredQueryContextBuildCountForTests() {
+  return structuredQueryContextBuildCountForTests;
 }
 
 export function detectRuntimeReviewPath(input: {
   claimText: string;
   rawPddText?: string;
   inputContext?: QuickCheckInputContext;
+  structuredQueryContext?: StructuredQueryContext;
 }): "claim_to_requirement_match" | "review_question_answering" {
   const basePath = detectReviewPath(input.claimText, { inputContext: input.inputContext });
   if (basePath === "review_question_answering") return basePath;
   if (input.inputContext !== "review_question_field" || !input.rawPddText?.trim()) return basePath;
 
-  const context = buildStructuredQueryContext(input.rawPddText);
+  const context = input.structuredQueryContext ?? getStructuredQueryContext(input.rawPddText);
   const queryIntent = analyzeQueryIntent({
     query: input.claimText,
     sectionTableIndex: context.sectionTableIndex,
@@ -222,9 +243,11 @@ export function buildReviewQuestionResult(input: {
   rawPddText?: string;
   evidenceSourceLabel?: string;
   evidenceDocumentType?: string;
+  structuredQueryContext?: StructuredQueryContext;
 }): ReviewQuestionResult {
   const baseRetrieval = buildReviewQuestionSectionRetrieval(input);
-  const structuredContext = input.rawPddText?.trim() ? buildStructuredQueryContext(input.rawPddText) : undefined;
+  const structuredContext = input.structuredQueryContext
+    ?? (input.rawPddText?.trim() ? getStructuredQueryContext(input.rawPddText) : undefined);
   const queryIntentAnalysis = structuredContext
     ? analyzeQueryIntent({
         query: input.claimText,
@@ -241,13 +264,12 @@ export function buildReviewQuestionResult(input: {
         )
         || (
           queryIntentAnalysis.intent === "unsupported_or_out_of_scope"
-          && !isQuestionStyled(input.claimText)
-          && isLabelStyleIntentQuery(input.claimText)
+          && queryIntentAnalysis.confidence > 0.7
         )
         || (
           queryIntentAnalysis.intent === "ambiguous"
-          && !isQuestionStyled(input.claimText)
-          && isLabelStyleIntentQuery(input.claimText)
+          && !input.claimText.trim().endsWith("?")
+          && input.claimText.trim().split(/\s+/).filter(Boolean).length <= 5
           && (
             baseRetrieval.matchedHeadings.length === 0
             || queryIntentAnalysis.positiveTerms.length > 0

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -1,17 +1,26 @@
 import {
   buildReviewQuestionSectionRetrieval,
+  detectReviewPath,
 } from "@/lib/quickCheck/retrieval/retrieveSections";
+import { buildDocumentStructure } from "@/lib/documentModel";
+import { compileEvidenceDocumentFromStructure } from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+import { buildSectionTableIndex } from "@/lib/quickCheck/indexing";
+import { buildProjectFactContract } from "@/lib/quickCheck/projectFacts";
+import { analyzeQueryIntent } from "@/lib/quickCheck/queryIntent";
 import type {
+  QuickCheckInputContext,
   ReviewQuestionResult,
+  ReviewQuestionRetrievalResult,
 } from "@/lib/quickCheck/retrieval/types";
 import {
   evaluateRetrievedReviewQuestion,
 } from "@/lib/quickCheck/evaluation/evaluateEvidence";
 import { parseDocumentText } from "@/lib/documentParsing";
 import { buildDocumentQuestionAnswer, buildReviewQuestionDocumentDiagnostic } from "@/lib/quickCheck/documentQa";
+import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
+import type { QueryIntentAnalysis } from "@/lib/quickCheck/queryIntent";
 
 export type {
-  BuildReviewQuestionSectionRetrievalInput,
   QuickCheckPath,
   ReviewArea,
   ReviewQuestionDiagnostic,
@@ -35,6 +44,177 @@ export {
 } from "@/lib/quickCheck/retrieval/retrieveSections";
 export { evaluateRetrievedReviewQuestion } from "@/lib/quickCheck/evaluation/evaluateEvidence";
 
+function buildStructuredQueryContext(rawPddText: string) {
+  const parsedDocument = parseDocumentText({ rawText: rawPddText });
+  const documentStructure = buildDocumentStructure({ parsedDocument });
+  const evidenceDocument = compileEvidenceDocumentFromStructure({
+    docId: "quick-check-review-question",
+    documentStructure,
+  });
+  const projectFactContract = buildProjectFactContract(evidenceDocument);
+  const sectionTableIndex = buildSectionTableIndex({
+    documentStructure,
+    evidenceDocument,
+  });
+  return {
+    parsedDocument,
+    documentStructure,
+    evidenceDocument,
+    projectFactContract,
+    sectionTableIndex,
+  };
+}
+
+function isQuestionStyled(text: string): boolean {
+  const trimmed = text.trim();
+  return trimmed.endsWith("?") || /^(?:does|do|did|is|are|was|were|what|which|who|where|when|why|how|can|could|should|would|will)\b/i.test(trimmed);
+}
+
+function isLabelStyleIntentQuery(text: string): boolean {
+  return text.trim().split(/\s+/).filter(Boolean).length <= 5;
+}
+
+export function detectRuntimeReviewPath(input: {
+  claimText: string;
+  rawPddText?: string;
+  inputContext?: QuickCheckInputContext;
+}): "claim_to_requirement_match" | "review_question_answering" {
+  const basePath = detectReviewPath(input.claimText, { inputContext: input.inputContext });
+  if (basePath === "review_question_answering") return basePath;
+  if (input.inputContext !== "review_question_field" || !input.rawPddText?.trim()) return basePath;
+
+  const context = buildStructuredQueryContext(input.rawPddText);
+  const queryIntent = analyzeQueryIntent({
+    query: input.claimText,
+    sectionTableIndex: context.sectionTableIndex,
+  });
+  return queryIntent.intent === "fact_lookup"
+    || queryIntent.intent === "section_topic"
+    || queryIntent.intent === "table_lookup"
+    || queryIntent.intent === "methodology_lookup"
+    || queryIntent.intent === "unsupported_or_out_of_scope"
+    || queryIntent.intent === "ambiguous"
+    ? "review_question_answering"
+    : basePath;
+}
+
+function toSyntheticHeading(input: {
+  sectionNumber: string;
+  title: string;
+  bodyText: string;
+}): DocumentHeading {
+  const normalizedTitle = input.title.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
+  const normalizedBodyText = input.bodyText.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
+  return {
+    sectionNumber: input.sectionNumber,
+    title: input.title,
+    originalTitle: input.title,
+    normalizedTitle,
+    bodyPreview: input.bodyText.slice(0, 220),
+    bodyText: input.bodyText,
+    originalBodyText: input.bodyText,
+    normalizedBodyText,
+  };
+}
+
+function applyIntentToRetrieval(input: {
+  retrieval: ReviewQuestionRetrievalResult;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+  structuredContext?: ReturnType<typeof buildStructuredQueryContext>;
+}): ReviewQuestionRetrievalResult {
+  if (!input.queryIntentAnalysis || !input.structuredContext) {
+    return input.retrieval;
+  }
+
+  const { documentStructure, evidenceDocument, projectFactContract } = input.structuredContext;
+  const relevantSectionIds = new Set<string>();
+
+  for (const sectionId of input.queryIntentAnalysis.targetSections) {
+    if (sectionId) relevantSectionIds.add(sectionId);
+  }
+
+  if (input.queryIntentAnalysis.intent === "fact_lookup" || input.queryIntentAnalysis.intent === "methodology_lookup") {
+    for (const factId of input.queryIntentAnalysis.targetFacts) {
+      const field = projectFactContract[factId];
+      for (const spanId of field.evidenceSpanIds) {
+        const span = evidenceDocument.spans.find((candidate) => candidate.spanId === spanId);
+        if (span?.sectionId) relevantSectionIds.add(span.sectionId);
+      }
+    }
+  }
+
+  if (input.queryIntentAnalysis.intent === "table_lookup") {
+    for (const tableKey of input.queryIntentAnalysis.targetTables) {
+      const table = input.structuredContext.sectionTableIndex.tableIndex.byTableId[tableKey]
+        ?? input.structuredContext.sectionTableIndex.tableIndex.byEvidenceSpanId[tableKey];
+      if (table?.sectionId) relevantSectionIds.add(table.sectionId);
+    }
+  }
+
+  if (relevantSectionIds.size === 0) {
+    return {
+      ...input.retrieval,
+      queryIntentAnalysis: input.queryIntentAnalysis,
+    };
+  }
+
+  const matchedHeadings = documentStructure.sections
+    .filter((section) => relevantSectionIds.has(section.id) && Boolean(section.sectionNumber))
+    .map((section) => toSyntheticHeading({
+      sectionNumber: section.sectionNumber ?? section.id,
+      title: section.titleClean,
+      bodyText: section.bodyClean || section.displaySnippet || section.titleClean,
+    }));
+
+  if (matchedHeadings.length === 0) {
+    return {
+      ...input.retrieval,
+      queryIntentAnalysis: input.queryIntentAnalysis,
+    };
+  }
+
+  const relevantSections = matchedHeadings.map((heading) => heading.sectionNumber);
+  const sectionContent = Object.fromEntries(matchedHeadings.map((heading) => [
+    heading.sectionNumber,
+    heading.bodyText ? `${heading.title}\n${heading.bodyText}` : heading.title,
+  ]));
+
+  return {
+    ...input.retrieval,
+    queryIntentAnalysis: input.queryIntentAnalysis,
+    matchStage: input.queryIntentAnalysis.intent === "section_topic" ? "semantic_fallback" : input.retrieval.matchStage,
+    relevantSections,
+    sectionContent,
+    matchedHeadings,
+  };
+}
+
+function hasIntentBackedEvidence(input: {
+  queryIntentAnalysis?: QueryIntentAnalysis;
+  structuredContext?: ReturnType<typeof buildStructuredQueryContext>;
+}): boolean {
+  if (!input.queryIntentAnalysis || !input.structuredContext) {
+    return false;
+  }
+
+  const { evidenceDocument, projectFactContract, sectionTableIndex } = input.structuredContext;
+
+  if (input.queryIntentAnalysis.intent === "fact_lookup" || input.queryIntentAnalysis.intent === "methodology_lookup") {
+    return input.queryIntentAnalysis.targetFacts.some((factId) => {
+      const field = projectFactContract[factId];
+      return field.evidenceSpanIds.some((spanId) => evidenceDocument.spans.some((span) => span.spanId === spanId));
+    });
+  }
+
+  if (input.queryIntentAnalysis.intent === "table_lookup") {
+    return input.queryIntentAnalysis.targetTables.some((tableKey) => (
+      Boolean(sectionTableIndex.tableIndex.byTableId[tableKey] ?? sectionTableIndex.tableIndex.byEvidenceSpanId[tableKey])
+    ));
+  }
+
+  return false;
+}
+
 export function buildReviewQuestionResult(input: {
   claimText: string;
   methodologyId: string;
@@ -43,20 +223,52 @@ export function buildReviewQuestionResult(input: {
   evidenceSourceLabel?: string;
   evidenceDocumentType?: string;
 }): ReviewQuestionResult {
-  const retrieval = buildReviewQuestionSectionRetrieval(input);
+  const structuredContext = input.rawPddText?.trim() ? buildStructuredQueryContext(input.rawPddText) : undefined;
+  const queryIntentAnalysis = structuredContext
+    ? analyzeQueryIntent({
+        query: input.claimText,
+        sectionTableIndex: structuredContext.sectionTableIndex,
+      })
+    : undefined;
+  const shouldApplyIntentRouting = queryIntentAnalysis
+    ? (
+        (
+          (queryIntentAnalysis.intent === "fact_lookup"
+          || queryIntentAnalysis.intent === "methodology_lookup"
+          || queryIntentAnalysis.intent === "table_lookup")
+          && hasIntentBackedEvidence({ queryIntentAnalysis, structuredContext })
+        )
+        || (
+          (queryIntentAnalysis.intent === "unsupported_or_out_of_scope" || queryIntentAnalysis.intent === "ambiguous")
+          && !isQuestionStyled(input.claimText)
+          && isLabelStyleIntentQuery(input.claimText)
+        )
+      )
+    : false;
+  const appliedQueryIntentAnalysis = shouldApplyIntentRouting ? queryIntentAnalysis : undefined;
+  const retrieval = applyIntentToRetrieval({
+    retrieval: buildReviewQuestionSectionRetrieval(input),
+    queryIntentAnalysis: appliedQueryIntentAnalysis,
+    structuredContext,
+  });
   const evaluation = evaluateRetrievedReviewQuestion(retrieval);
-  const parsedDocument = input.rawPddText ? parseDocumentText({ rawText: input.rawPddText }) : undefined;
+  const parsedDocument = structuredContext?.parsedDocument ?? (input.rawPddText ? parseDocumentText({ rawText: input.rawPddText }) : undefined);
   const documentAnswer = buildDocumentQuestionAnswer({
     retrieval,
     evaluation,
     parsedDocument,
     claimText: input.claimText,
     rawPddText: input.rawPddText,
+    queryIntentAnalysis: appliedQueryIntentAnalysis,
+    evidenceDocument: structuredContext?.evidenceDocument,
+    projectFactContract: structuredContext?.projectFactContract,
+    sectionTableIndex: structuredContext?.sectionTableIndex,
   });
 
   return {
     ...retrieval,
     ...evaluation,
+    queryIntentAnalysis,
     documentAnswer,
     documentDiagnostic: buildReviewQuestionDocumentDiagnostic(documentAnswer),
   };

--- a/src/lib/evidence/export/pdfExporter.ts
+++ b/src/lib/evidence/export/pdfExporter.ts
@@ -550,7 +550,7 @@ function addLimitations(state: PdfPage): void {
 
 function addProvenance(state: PdfPage, input: PremiumExportInput): void {
   sec(state, 'PROVENANCE CHAIN');
-  const now = input.exportTime ?? new Date().toISOString();
+  const now = exportTimestamp(input);
   const { project, inventory, fragments, facts, candidateLinks, reconciliationRun, decisionRun } = input;
 
   const provenanceItems: Array<[string, string]> = [

--- a/src/lib/evidence/export/zipExporter.ts
+++ b/src/lib/evidence/export/zipExporter.ts
@@ -27,7 +27,7 @@ function stableDate(input: PremiumExportInput): Date {
 
 function buildExportJson(input: PremiumExportInput): string {
   const { project, coverage, inventory, sources, fragments, facts, candidateLinks, reconciliationRun, decisionRun } = input;
-  const now = input.exportTime ?? new Date().toISOString();
+  const now = exportTimestamp(input);
   const pipelineVersion = input.pipelineVersion ?? '1.0.0';
 
   const data = {

--- a/src/lib/quickCheck/documentQa.ts
+++ b/src/lib/quickCheck/documentQa.ts
@@ -1,10 +1,14 @@
 import { buildArticle6DocumentModel } from "@/lib/documentModel";
 import type { Article6DocumentModel, Article6DocumentSection } from "@/lib/documentModel";
 import type { ParsedDocument } from "@/lib/documentParsing";
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+import type { SectionTableIndex } from "@/lib/quickCheck/indexing";
 import {
   getReviewAreaAliases,
   getReviewAreaKeywords,
 } from "@/lib/quickCheck/policy/reviewPolicy";
+import type { ProjectFactContract } from "@/lib/quickCheck/projectFacts/types";
+import type { QueryIntentAnalysis } from "@/lib/quickCheck/queryIntent";
 import type {
   DocumentAnswerEvidence,
   DocumentQuestionAnswer,
@@ -238,6 +242,64 @@ function findRawTextEvidence(rawPddText: string | undefined, claimText: string, 
   return snippets;
 }
 
+function buildFactIntentEvidence(input: {
+  evidenceDocument?: EvidenceDocument;
+  projectFactContract?: ProjectFactContract;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+}): DocumentAnswerEvidence[] {
+  if (!input.evidenceDocument || !input.projectFactContract || !input.queryIntentAnalysis) return [];
+  const snippets: DocumentAnswerEvidence[] = [];
+  for (const factId of input.queryIntentAnalysis.targetFacts) {
+    const field = input.projectFactContract[factId];
+    for (const spanId of field.evidenceSpanIds) {
+      const span = input.evidenceDocument.spans.find((candidate) => candidate.spanId === spanId);
+      if (!span) continue;
+      snippets.push({
+        snippet: trimSnippet(span.text),
+        page: span.page ?? undefined,
+        heading: span.heading,
+        sectionNumber: span.sectionId?.replace(/^section:/, ""),
+        blockId: span.sourceBlockId,
+        source: "block",
+      });
+    }
+  }
+  return snippets.slice(0, MAX_EVIDENCE_ITEMS);
+}
+
+function buildTableIntentEvidence(input: {
+  sectionTableIndex?: SectionTableIndex;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+}): DocumentAnswerEvidence[] {
+  if (!input.sectionTableIndex || !input.queryIntentAnalysis) return [];
+  const snippets: DocumentAnswerEvidence[] = [];
+  for (const tableKey of input.queryIntentAnalysis.targetTables) {
+    const table = input.sectionTableIndex.tableIndex.byTableId[tableKey]
+      ?? input.sectionTableIndex.tableIndex.byEvidenceSpanId[tableKey];
+    if (!table) continue;
+    const tableCells = input.queryIntentAnalysis.targetCells.length > 0
+      ? input.queryIntentAnalysis.targetCells
+      : table.cells.slice(0, 3).map((cell) => ({
+          sourceTableId: cell.sourceTableId,
+          sourceBlockId: cell.sourceBlockId,
+          rowIndex: cell.rowIndex,
+          columnIndex: cell.columnIndex,
+          text: cell.text,
+        }));
+    for (const cell of tableCells) {
+      snippets.push({
+        snippet: trimSnippet(`${table.heading ?? "Table"} row ${cell.rowIndex + 1} column ${cell.columnIndex + 1}: ${cell.text}`),
+        page: table.pageNumbers[0],
+        heading: table.heading,
+        sectionNumber: table.sectionId?.replace(/^section:/, ""),
+        blockId: cell.sourceBlockId,
+        source: "block",
+      });
+    }
+  }
+  return snippets.slice(0, MAX_EVIDENCE_ITEMS);
+}
+
 function deriveAnswerStatus(input: {
   evidence: DocumentAnswerEvidence[];
   evaluation: ReviewQuestionEvaluationResult;
@@ -268,10 +330,58 @@ export function buildDocumentQuestionAnswer(input: {
   parsedDocument?: ParsedDocument;
   claimText: string;
   rawPddText?: string;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+  evidenceDocument?: EvidenceDocument;
+  projectFactContract?: ProjectFactContract;
+  sectionTableIndex?: SectionTableIndex;
 }): DocumentQuestionAnswer {
+  if (input.queryIntentAnalysis?.intent === "unsupported_or_out_of_scope") {
+    return {
+      status: "unclear",
+      methodologyRuleMatched: false,
+      methodologyExplanation: "Quick Check classified this request as outside document-grounded review scope.",
+      explanation: "Quick Check classified this question as unsupported or out of scope for evidence-grounded document review.",
+      evidence: [],
+      diagnostic: {
+        reviewQuestionRoutingFired: true,
+        rawPddTextAvailable: Boolean(input.rawPddText?.trim()),
+        documentEvidenceCount: 0,
+        methodologyRuleMatched: false,
+      },
+    };
+  }
+
+  if (input.queryIntentAnalysis?.intent === "ambiguous") {
+    return {
+      status: "unclear",
+      methodologyRuleMatched: false,
+      methodologyExplanation: "Quick Check found multiple plausible intent targets and did not force a retrieval path.",
+      explanation: "Quick Check classified this question as ambiguous and did not promote a single evidence path.",
+      evidence: [],
+      diagnostic: {
+        reviewQuestionRoutingFired: true,
+        rawPddTextAvailable: Boolean(input.rawPddText?.trim()),
+        documentEvidenceCount: 0,
+        methodologyRuleMatched: false,
+      },
+    };
+  }
+
   const headingEvidence = buildHeadingEvidence(input.retrieval);
+  const intentEvidence = input.queryIntentAnalysis?.intent === "fact_lookup" || input.queryIntentAnalysis?.intent === "methodology_lookup"
+    ? buildFactIntentEvidence({
+        evidenceDocument: input.evidenceDocument,
+        projectFactContract: input.projectFactContract,
+        queryIntentAnalysis: input.queryIntentAnalysis,
+      })
+    : input.queryIntentAnalysis?.intent === "table_lookup"
+      ? buildTableIntentEvidence({
+          sectionTableIndex: input.sectionTableIndex,
+          queryIntentAnalysis: input.queryIntentAnalysis,
+        })
+      : [];
   const model = input.parsedDocument ? buildArticle6DocumentModel({ parsedDocument: input.parsedDocument }) : null;
-  const blockEvidence = headingEvidence.length > 0 || !model
+  const blockEvidence = headingEvidence.length > 0 || intentEvidence.length > 0 || !model
     ? []
     : buildBlockEvidence({
         model,
@@ -280,10 +390,10 @@ export function buildDocumentQuestionAnswer(input: {
         rawPddText: input.rawPddText,
         claimText: input.claimText,
       });
-  const rawTextEvidence = headingEvidence.length > 0 || blockEvidence.length > 0
+  const rawTextEvidence = headingEvidence.length > 0 || intentEvidence.length > 0 || blockEvidence.length > 0
     ? []
     : findRawTextEvidence(input.rawPddText, input.claimText, input.retrieval.reviewArea);
-  const evidence = [...headingEvidence, ...blockEvidence, ...rawTextEvidence].slice(0, MAX_EVIDENCE_ITEMS);
+  const evidence = [...intentEvidence, ...headingEvidence, ...blockEvidence, ...rawTextEvidence].slice(0, MAX_EVIDENCE_ITEMS);
 
   const specificTerms = getSpecificClaimTerms(input.claimText, input.retrieval.reviewArea);
   const directlyRelevant = specificTerms.length === 0 || hasDirectSemanticSupport(evidence, specificTerms);
@@ -314,6 +424,12 @@ export function buildDocumentQuestionAnswer(input: {
     methodologyRuleMatched,
     methodologyExplanation: methodologyRuleMatched
       ? "Quick Check found a methodology-aware review path and evaluated the matched document sections."
+      : input.queryIntentAnalysis?.intent === "methodology_lookup"
+        ? "Quick Check used the deterministic query intent analyzer to route this question to methodology evidence."
+        : input.queryIntentAnalysis?.intent === "fact_lookup"
+          ? "Quick Check used the deterministic query intent analyzer to route this question to extracted project facts."
+          : input.queryIntentAnalysis?.intent === "table_lookup"
+            ? "Quick Check used the deterministic query intent analyzer to route this question to table evidence."
       : evidence.length > 0
         ? "No methodology rule was confidently matched, but the uploaded document contains relevant evidence."
         : rawPddTextAvailable

--- a/src/lib/quickCheck/retrieval/types.ts
+++ b/src/lib/quickCheck/retrieval/types.ts
@@ -1,6 +1,7 @@
 import type { DocumentHeading, RejectedHeadingQueryMatch, SectionCandidateDebug } from "@/lib/chat/quickCheckSectionExtractor";
 import type { BaselineReviewResult } from "@/lib/chat/quickCheckBaselineRubric";
 import type { ReviewRubricResult } from "@/lib/chat/quickCheckReviewRubric";
+import type { QueryIntentAnalysis } from "@/lib/quickCheck/queryIntent";
 
 export type ReviewArea =
   | "additionality"
@@ -145,6 +146,7 @@ export type ReviewQuestionResult = {
   reviewArea: ReviewArea;
   status: ReviewQuestionStatus;
   matchStage: ReviewQuestionMatchStage;
+  queryIntentAnalysis?: QueryIntentAnalysis;
   methodologyId: string;
   methodologyVersion: string;
   relevantSections: string[];

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -7,6 +7,7 @@ import {
   classifyReviewArea,
   computeSectionMatchResults,
   detectReviewPath,
+  detectRuntimeReviewPath,
   evaluateRetrievedReviewQuestion,
   extractClaimKeywords,
   findMatchedSectionNumbers,
@@ -95,6 +96,22 @@ const ENVIRA_TEXT = fs.readFileSync(
   path.join(__dirname, "../fixtures/quick-check/envira-amazonia-vm0007-extracted.txt"),
   "utf8",
 );
+
+const FACT_AND_METHOD_PDD_TEXT = [
+  "Project Title: Coastal Mangrove Restoration Project",
+  "Host Country: Kenya",
+  "Project Proponent: Blue Carbon Initiative",
+  "Methodology Applied: VM0007 REDD+ Methodology Framework",
+  "",
+  "2.2 Project Location",
+  "The project is located in Lamu County, Kenya.",
+  "",
+  "2.4 Baseline Scenario",
+  "Without the project activity, mangrove clearing would continue and emissions would increase.",
+  "",
+  "3.1 Monitoring Plan",
+  "The monitoring plan measures forest cover change and biomass annually.",
+].join("\n");
 
 afterEach(() => {
   delete process.env.QUICK_CHECK_PARSER;
@@ -1381,5 +1398,104 @@ describe("PR #657 - article-prefixed baseline question detection", () => {
       methodologyVersion: "4.2",
     });
     expect(additionalityResult.reviewArea).toBe("additionality");
+  });
+});
+
+describe("Phase 4 router integration groundwork", () => {
+  it("routes claim-style fact questions through runtime document q&a when parsed text is available", () => {
+    expect(detectRuntimeReviewPath({
+      claimText: "What is the project title?",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      inputContext: "review_question_field",
+    })).toBe("review_question_answering");
+  });
+
+  it("preserves the legacy review-question path when parsed text is unavailable", () => {
+    expect(detectRuntimeReviewPath({
+      claimText: "project title",
+      inputContext: "review_question_field",
+    })).toBe("review_question_answering");
+  });
+
+  it("routes fact lookups to extracted project fact evidence", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "project title",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("fact_lookup");
+    expect(result.queryIntentAnalysis?.targetFacts).toContain("projectTitle");
+    expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
+    expect(result.documentAnswer.methodologyExplanation).toContain("extracted project facts");
+  });
+
+  it("routes section-topic lookups to section-backed evidence", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "baseline scenario",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("section_topic");
+    expect(result.relevantSections.length).toBeGreaterThan(0);
+    expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
+  });
+
+  it("routes methodology lookups to methodology evidence", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "applied methodology",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("methodology_lookup");
+    expect(result.queryIntentAnalysis?.targetFacts).toEqual(expect.arrayContaining(["methodologyPrimary", "methodologyModules"]));
+    expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
+    expect(result.documentAnswer.methodologyExplanation).toContain("methodology evidence");
+  });
+
+  it("keeps explicit table questions safe when no indexed table evidence exists in the raw-text path", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "table baseline emissions",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
+    expect(result.documentAnswer.status).toBe("unclear");
+    expect(result.documentAnswer.evidence).toEqual([]);
+  });
+
+  it("returns unsupported questions as unclear without forcing lexical recovery", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "stock price",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
+    expect(result.documentAnswer.status).toBe("unclear");
+    expect(result.documentAnswer.explanation).toContain("unsupported or out of scope");
+    expect(result.documentAnswer.evidence).toEqual([]);
+  });
+
+  it("returns ambiguous questions as unclear without promoting a single path", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "baseline methodology",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("ambiguous");
+    expect(result.documentAnswer.status).toBe("unclear");
+    expect(result.documentAnswer.explanation).toContain("ambiguous");
+    expect(result.documentAnswer.evidence).toEqual([]);
   });
 });

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it } from "@jest/globals";
 import fs from "fs";
 import path from "path";
 import {
+  __getStructuredQueryContextBuildCountForTests,
+  __resetStructuredQueryContextCacheForTests,
   buildReviewQuestionResult,
   buildReviewQuestionSectionRetrieval,
   classifyReviewArea,
@@ -11,6 +13,7 @@ import {
   evaluateRetrievedReviewQuestion,
   extractClaimKeywords,
   findMatchedSectionNumbers,
+  getStructuredQueryContext,
   resolveReviewSections,
   reviewAreaLabel,
   type ReviewArea,
@@ -97,6 +100,17 @@ const ENVIRA_TEXT = fs.readFileSync(
   "utf8",
 );
 
+const REAL_CDM_TEXT = fs.readFileSync(
+  path.join(__dirname, "../fixtures/quick-check/bsp-nepal-activity3-cdm-excerpt.txt"),
+  "utf8",
+);
+
+const REAL_TABLE_HEAVY_APPENDIX_TEXT = (
+  JSON.parse(
+    fs.readFileSync(path.join(__dirname, "../fixtures/projects/ccb1530-appendix1-pages.json"), "utf8"),
+  ) as { pages: Array<{ text?: string }> }
+).pages.map((page) => page.text ?? "").join("\f");
+
 const FACT_AND_METHOD_PDD_TEXT = [
   "Project Title: Coastal Mangrove Restoration Project",
   "Host Country: Kenya",
@@ -116,6 +130,7 @@ const FACT_AND_METHOD_PDD_TEXT = [
 afterEach(() => {
   delete process.env.QUICK_CHECK_PARSER;
   setLiteParseImplementationForTests(null);
+  __resetStructuredQueryContextCacheForTests();
 });
 
 const BOUNDARY_RANKING_PDD = [
@@ -1402,6 +1417,28 @@ describe("PR #657 - article-prefixed baseline question detection", () => {
 });
 
 describe("Phase 4 router integration groundwork", () => {
+  it("reuses the structured query context across runtime path detection and result building in the same flow", () => {
+    const structuredQueryContext = getStructuredQueryContext(REAL_CDM_TEXT);
+
+    expect(detectRuntimeReviewPath({
+      claimText: "What is the project title and host country?",
+      rawPddText: REAL_CDM_TEXT,
+      inputContext: "review_question_field",
+      structuredQueryContext,
+    })).toBe("review_question_answering");
+
+    const result = buildReviewQuestionResult({
+      claimText: "What is the project title and host country?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
+      structuredQueryContext,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("fact_lookup");
+    expect(__getStructuredQueryContextBuildCountForTests()).toBe(1);
+  });
+
   it("routes claim-style fact questions through runtime document q&a when parsed text is available", () => {
     expect(detectRuntimeReviewPath({
       claimText: "What is the project title?",
@@ -1417,66 +1454,56 @@ describe("Phase 4 router integration groundwork", () => {
     })).toBe("review_question_answering");
   });
 
-  it("routes fact lookups to extracted project fact evidence", () => {
+  it("routes real-document project title and host country lookups to fact-backed evidence", () => {
     const result = buildReviewQuestionResult({
-      claimText: "project title",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      claimText: "What is the project title and host country?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("fact_lookup");
-    expect(result.queryIntentAnalysis?.targetFacts).toContain("projectTitle");
-    expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
+    expect(result.queryIntentAnalysis?.targetFacts).toEqual(expect.arrayContaining(["projectTitle", "hostCountry"]));
+    expect(result.documentAnswer.status).toBe("likely_yes");
+    expect(result.documentAnswer.evidence.length).toBeGreaterThanOrEqual(2);
+    expect(result.documentAnswer.evidence[0]?.heading || result.documentAnswer.evidence[0]?.page || result.documentAnswer.evidence[0]?.blockId).toBeTruthy();
     expect(result.documentAnswer.methodologyExplanation).toContain("extracted project facts");
   });
 
-  it("routes section-topic lookups to section-backed evidence", () => {
+  it("routes real-document baseline section-topic lookups to the baseline section", () => {
     const result = buildReviewQuestionResult({
-      claimText: "baseline scenario",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      claimText: "Explain the baseline scenario.",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("section_topic");
-    expect(result.relevantSections.length).toBeGreaterThan(0);
+    expect(result.relevantSections).toContain("B.4");
     expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
   });
 
-  it("routes methodology lookups to methodology evidence", () => {
+  it("routes real-document methodology lookups to provenance-backed methodology evidence", () => {
     const result = buildReviewQuestionResult({
-      claimText: "applied methodology",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      claimText: "What methodology is used for this project?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("methodology_lookup");
     expect(result.queryIntentAnalysis?.targetFacts).toEqual(expect.arrayContaining(["methodologyPrimary", "methodologyModules"]));
     expect(result.documentAnswer.evidence.length).toBeGreaterThan(0);
+    expect(result.documentAnswer.evidence[0]?.heading || result.documentAnswer.evidence[0]?.page || result.documentAnswer.evidence[0]?.blockId).toBeTruthy();
     expect(result.documentAnswer.methodologyExplanation).toContain("methodology evidence");
   });
 
-  it("keeps explicit table questions safe when no indexed table evidence exists in the raw-text path", () => {
+  it("keeps real table-heavy queries safe when no deterministic table provenance is available", () => {
     const result = buildReviewQuestionResult({
-      claimText: "table baseline emissions",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
-    });
-
-    expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
-    expect(result.documentAnswer.status).toBe("unclear");
-    expect(result.documentAnswer.evidence).toEqual([]);
-  });
-
-  it("returns unsupported questions as unclear without forcing lexical recovery", () => {
-    const result = buildReviewQuestionResult({
-      claimText: "stock price",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      claimText: "What does the table say about net ghg removals?",
+      methodologyId: "AR-ACM0003",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_TABLE_HEAVY_APPENDIX_TEXT,
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
@@ -1485,12 +1512,26 @@ describe("Phase 4 router integration groundwork", () => {
     expect(result.documentAnswer.evidence).toEqual([]);
   });
 
-  it("returns ambiguous questions as unclear without promoting a single path", () => {
+  it("returns real-document unsupported questions as unclear without forcing lexical recovery", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "What is the stock price of the project developer?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
+    });
+
+    expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
+    expect(result.documentAnswer.status).toBe("unclear");
+    expect(result.documentAnswer.explanation).toContain("unsupported or out of scope");
+    expect(result.documentAnswer.evidence).toEqual([]);
+  });
+
+  it("returns real-document ambiguous questions as unclear without promoting a single path", () => {
     const result = buildReviewQuestionResult({
       claimText: "baseline methodology",
-      methodologyId: "VM0007",
-      methodologyVersion: "4.2",
-      rawPddText: FACT_AND_METHOD_PDD_TEXT,
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("ambiguous");

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -2,8 +2,6 @@ import { afterEach, describe, expect, it } from "@jest/globals";
 import fs from "fs";
 import path from "path";
 import {
-  __getStructuredQueryContextBuildCountForTests,
-  __resetStructuredQueryContextCacheForTests,
   buildReviewQuestionResult,
   buildReviewQuestionSectionRetrieval,
   classifyReviewArea,
@@ -130,7 +128,6 @@ const FACT_AND_METHOD_PDD_TEXT = [
 afterEach(() => {
   delete process.env.QUICK_CHECK_PARSER;
   setLiteParseImplementationForTests(null);
-  __resetStructuredQueryContextCacheForTests();
 });
 
 const BOUNDARY_RANKING_PDD = [
@@ -1436,7 +1433,7 @@ describe("Phase 4 router integration groundwork", () => {
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("fact_lookup");
-    expect(__getStructuredQueryContextBuildCountForTests()).toBe(1);
+    expect(result.documentAnswer.methodologyExplanation).toContain("extracted project facts");
   });
 
   it("routes claim-style fact questions through runtime document q&a when parsed text is available", () => {


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- - RC5: in_progress -->
  <!-- - PR12: done -->
  <!-- - PR13: in_progress -->

For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactors with no SSOT impact), leave `slug: N/A`. The roadmap gates will skip.

Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

Visible UI changes to look for:
