### PR TITLE
[codex] add deterministic Quick Check router result contract

### DIFF
--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -7,7 +7,9 @@ import { compileEvidenceDocumentFromStructure } from "@/lib/quickCheck/evidence/
 import { buildSectionTableIndex } from "@/lib/quickCheck/indexing";
 import { buildProjectFactContract } from "@/lib/quickCheck/projectFacts";
 import { analyzeQueryIntent } from "@/lib/quickCheck/queryIntent";
+import { buildDeterministicRouterResult } from "@/lib/quickCheck/router/deterministicRouter";
 import type {
+  DeterministicRouterResult,
   QuickCheckInputContext,
   ReviewQuestionResult,
   ReviewQuestionRetrievalResult,
@@ -22,6 +24,7 @@ import type { QueryIntentAnalysis } from "@/lib/quickCheck/queryIntent";
 
 export type {
   QuickCheckPath,
+  DeterministicRouterResult,
   ReviewArea,
   ReviewQuestionDiagnostic,
   ReviewQuestionMatchStage,
@@ -262,6 +265,14 @@ export function buildReviewQuestionResult(input: {
     structuredContext,
   });
   const evaluation = evaluateRetrievedReviewQuestion(retrieval);
+  const routerResult: DeterministicRouterResult = buildDeterministicRouterResult({
+    claimText: input.claimText,
+    reviewArea: retrieval.reviewArea,
+    queryIntentAnalysis,
+    evidenceDocument: structuredContext?.evidenceDocument,
+    projectFactContract: structuredContext?.projectFactContract,
+    sectionTableIndex: structuredContext?.sectionTableIndex,
+  });
   const parsedDocument = structuredContext?.parsedDocument ?? (input.rawPddText ? parseDocumentText({ rawText: input.rawPddText }) : undefined);
   const documentAnswer = buildDocumentQuestionAnswer({
     retrieval,
@@ -278,6 +289,7 @@ export function buildReviewQuestionResult(input: {
   return {
     ...retrieval,
     ...evaluation,
+    routerResult,
     queryIntentAnalysis,
     documentAnswer,
     documentDiagnostic: buildReviewQuestionDocumentDiagnostic(documentAnswer),

--- a/src/lib/quickCheck/retrieval/types.ts
+++ b/src/lib/quickCheck/retrieval/types.ts
@@ -92,6 +92,27 @@ export type ReviewRoutingDiagnostic = {
 
 export type DocumentAnswerStatus = "likely_yes" | "likely_no" | "unclear";
 
+export type DeterministicRouterStatus = "answered" | "unclear" | "no_evidence";
+
+export type DeterministicRouterRoute =
+  | "project_fact_contract"
+  | "section_index"
+  | "table_index"
+  | "lexical_retrieval"
+  | "fallback";
+
+export type DeterministicRouterResult = {
+  answerText: string;
+  status: DeterministicRouterStatus;
+  route: DeterministicRouterRoute;
+  confidence: number;
+  evidenceSpanIds: string[];
+  quotes: string[];
+  pages: number[];
+  sectionPaths: string[];
+  warnings: string[];
+};
+
 export type DocumentAnswerEvidence = {
   snippet: string;
   page?: number;
@@ -146,6 +167,7 @@ export type ReviewQuestionResult = {
   reviewArea: ReviewArea;
   status: ReviewQuestionStatus;
   matchStage: ReviewQuestionMatchStage;
+  routerResult: DeterministicRouterResult;
   queryIntentAnalysis?: QueryIntentAnalysis;
   methodologyId: string;
   methodologyVersion: string;
@@ -168,7 +190,14 @@ export type ReviewQuestionResult = {
 
 export type ReviewQuestionRetrievalResult = Omit<
   ReviewQuestionResult,
-  "baselineReview" | "reviewAreaReview" | "documentAnswer" | "documentDiagnostic" | "semanticEvidenceCandidates" | "semanticEvidenceStatus" | "semanticEvidenceWarning"
+  | "baselineReview"
+  | "reviewAreaReview"
+  | "documentAnswer"
+  | "documentDiagnostic"
+  | "semanticEvidenceCandidates"
+  | "semanticEvidenceStatus"
+  | "semanticEvidenceWarning"
+  | "routerResult"
 > & {
   rejectedMatches: RejectedHeadingQueryMatch[];
 };

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -1,0 +1,478 @@
+import type { EvidenceDocument, EvidenceSpan, QuoteValidationInput } from "@/lib/quickCheck/evidence/evidenceTypes";
+import { validateQuotes } from "@/lib/quickCheck/evidence/validateQuotes";
+import type { SectionNode, SectionTableIndex, TableCellReference, IndexedTable } from "@/lib/quickCheck/indexing";
+import type { ProjectFactContract, ProjectFactField, ProjectFactConfidence, ProjectFactValue } from "@/lib/quickCheck/projectFacts/types";
+import type { QueryIntentAnalysis, ProjectFactId } from "@/lib/quickCheck/queryIntent";
+import type {
+  DeterministicRouterResult,
+  DeterministicRouterRoute,
+  ReviewArea,
+} from "@/lib/quickCheck/retrieval/types";
+
+type RouterCandidate = {
+  answerText: string;
+  route: Exclude<DeterministicRouterRoute, "fallback">;
+  confidence: number;
+  evidenceSpanIds: string[];
+  quoteInputs: QuoteValidationInput[];
+  pages: number[];
+  sectionPaths: string[];
+  warnings: string[];
+};
+
+type DeterministicRouterInput = {
+  claimText: string;
+  reviewArea: ReviewArea;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+  evidenceDocument?: EvidenceDocument;
+  projectFactContract?: ProjectFactContract;
+  sectionTableIndex?: SectionTableIndex;
+};
+
+const ANSWER_CONFIDENCE_THRESHOLD = 0.7;
+const LEXICAL_MIN_CONFIDENCE = 0.74;
+const MAX_QUOTES = 2;
+
+const GENERIC_TERMS = new Set([
+  "about",
+  "baseline",
+  "calculate",
+  "calculation",
+  "column",
+  "describe",
+  "document",
+  "does",
+  "evidence",
+  "explain",
+  "for",
+  "from",
+  "how",
+  "is",
+  "methodology",
+  "page",
+  "project",
+  "question",
+  "row",
+  "say",
+  "section",
+  "table",
+  "tell",
+  "the",
+  "this",
+  "what",
+  "which",
+]);
+
+const FACT_LABELS: Record<ProjectFactId, string> = {
+  projectTitle: "Project title",
+  hostCountry: "Host country",
+  projectCountry: "Project country",
+  projectLocation: "Project location",
+  projectStandard: "Project standard",
+  projectType: "Project type",
+  projectProponent: "Project proponent",
+  methodologyPrimary: "Primary methodology",
+  methodologyModules: "Methodology modules",
+  baselineMethodology: "Baseline methodology",
+  monitoringMethodology: "Monitoring methodology",
+  creditingPeriod: "Crediting period",
+  reportingPeriod: "Reporting period",
+  monitoringPeriod: "Monitoring period",
+  projectStartDate: "Project start date",
+  baselineSections: "Baseline sections",
+  monitoringSections: "Monitoring sections",
+  leakageSections: "Leakage sections",
+  additionalitySections: "Additionality sections",
+};
+
+function dedupe<T>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+function clampConfidence(value: number): number {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+}
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function normalizeConfidence(confidence: ProjectFactConfidence): number {
+  switch (confidence) {
+    case "high":
+      return 0.95;
+    case "medium":
+      return 0.8;
+    case "low":
+    default:
+      return 0.62;
+  }
+}
+
+function formatFactValue(value: ProjectFactValue): string | null {
+  if (Array.isArray(value)) {
+    const compact = value.map((entry) => entry.trim()).filter(Boolean);
+    return compact.length > 0 ? compact.join(", ") : null;
+  }
+  if (typeof value === "string") {
+    const compact = value.trim();
+    return compact.length > 0 ? compact : null;
+  }
+  return null;
+}
+
+function formatSectionPath(path: string[]): string {
+  return path.join(" > ");
+}
+
+function getSpanLookup(document: EvidenceDocument): Map<string, EvidenceSpan> {
+  return new Map(document.spans.map((span) => [span.spanId, span]));
+}
+
+function buildFallback(input: {
+  answerText: string;
+  status: DeterministicRouterResult["status"];
+  confidence: number;
+  warnings?: string[];
+}): DeterministicRouterResult {
+  return {
+    answerText: input.answerText,
+    status: input.status,
+    route: "fallback",
+    confidence: clampConfidence(input.confidence),
+    evidenceSpanIds: [],
+    quotes: [],
+    pages: [],
+    sectionPaths: [],
+    warnings: input.warnings ?? [],
+  };
+}
+
+function finalizeCandidate(document: EvidenceDocument, candidate: RouterCandidate): DeterministicRouterResult {
+  const validations = validateQuotes(document, candidate.quoteInputs);
+  const validQuotes = validations
+    .map((validation, index) => ({ validation, quoteInput: candidate.quoteInputs[index] }))
+    .filter((entry): entry is { validation: NonNullable<typeof validations[number]>; quoteInput: QuoteValidationInput } => entry.validation.valid);
+  if (validQuotes.length === 0) {
+    return buildFallback({
+      answerText: "Quick Check found a possible evidence path but could not validate the supporting quotes against source spans.",
+      status: "unclear",
+      confidence: candidate.confidence,
+      warnings: [...candidate.warnings, "quote_validation_failed"],
+    });
+  }
+
+  const matchedSpanIds = dedupe([
+    ...candidate.evidenceSpanIds,
+    ...validQuotes.flatMap(({ validation }) => validation.matchedSpanIds),
+  ]);
+  const spanLookup = getSpanLookup(document);
+  const pages = dedupe([
+    ...candidate.pages,
+    ...matchedSpanIds
+      .map((spanId) => spanLookup.get(spanId)?.page)
+      .filter((page): page is number => typeof page === "number"),
+  ]).sort((left, right) => left - right);
+  const sectionPaths = dedupe([
+    ...candidate.sectionPaths,
+    ...matchedSpanIds
+      .map((spanId) => spanLookup.get(spanId)?.sectionPath ?? [])
+      .filter((path) => path.length > 0)
+      .map((path) => formatSectionPath(path)),
+  ]);
+
+  return {
+    answerText: candidate.answerText,
+    status: candidate.confidence >= ANSWER_CONFIDENCE_THRESHOLD ? "answered" : "unclear",
+    route: candidate.route,
+    confidence: clampConfidence(candidate.confidence),
+    evidenceSpanIds: matchedSpanIds,
+    quotes: dedupe(validQuotes.map(({ quoteInput }) => quoteInput.quote)),
+    pages,
+    sectionPaths,
+    warnings: candidate.confidence >= ANSWER_CONFIDENCE_THRESHOLD
+      ? candidate.warnings
+      : [...candidate.warnings, "low_confidence"],
+  };
+}
+
+function buildFactCandidate(input: DeterministicRouterInput): RouterCandidate | null {
+  if (!input.evidenceDocument || !input.projectFactContract || !input.queryIntentAnalysis) return null;
+  if (!["fact_lookup", "methodology_lookup"].includes(input.queryIntentAnalysis.intent)) return null;
+
+  const resolvedFacts = input.queryIntentAnalysis.targetFacts
+    .map((factId) => ({
+      factId,
+      field: input.projectFactContract?.[factId],
+      value: formatFactValue(input.projectFactContract?.[factId]?.value ?? null),
+    }))
+    .filter((entry): entry is {
+      factId: ProjectFactId;
+      field: ProjectFactField;
+      value: string;
+    } => {
+      const field = entry.field;
+      if (!field || !entry.value) return false;
+      return field.evidenceSpanIds.length > 0;
+    });
+
+  if (resolvedFacts.length === 0) return null;
+
+  const spanLookup = getSpanLookup(input.evidenceDocument);
+  const answerText = resolvedFacts
+    .map(({ factId, value }) => `${FACT_LABELS[factId]}: ${value}.`)
+    .join(" ");
+  const quoteInputs = resolvedFacts
+    .flatMap(({ field }) => field.evidenceSpanIds
+      .map((spanId) => spanLookup.get(spanId))
+      .filter((span): span is EvidenceSpan => Boolean(span))
+      .slice(0, 1)
+      .map((span) => ({
+        quote: span.text,
+        page: span.page,
+        sectionId: span.sectionId,
+        heading: span.heading,
+      })))
+    .slice(0, MAX_QUOTES);
+
+  return {
+    answerText,
+    route: "project_fact_contract",
+    confidence: clampConfidence(Math.min(
+      input.queryIntentAnalysis.confidence,
+      ...resolvedFacts.map(({ field }) => normalizeConfidence(field.confidence)),
+    )),
+    evidenceSpanIds: dedupe(resolvedFacts.flatMap(({ field }) => field.evidenceSpanIds)),
+    quoteInputs,
+    pages: dedupe(resolvedFacts.flatMap(({ field }) => field.pageNumbers)).sort((left, right) => left - right),
+    sectionPaths: dedupe(resolvedFacts.map(({ field }) => formatSectionPath(field.sectionPath)).filter(Boolean)),
+    warnings: dedupe(resolvedFacts.flatMap(({ field }) => field.warnings)),
+  };
+}
+
+function selectContentSpans(document: EvidenceDocument, sectionId?: string): EvidenceSpan[] {
+  return document.spans.filter((span) => (
+    span.sectionId === sectionId
+    && span.reliability !== "excluded"
+    && span.blockType !== "section_heading"
+    && span.blockType !== "toc"
+    && span.blockType !== "footer"
+    && span.blockType !== "header"
+  ));
+}
+
+function sectionDisplay(node: SectionNode): string {
+  return [node.sectionNumber, node.heading].filter(Boolean).join(" ");
+}
+
+function buildSectionCandidate(input: DeterministicRouterInput): RouterCandidate | null {
+  if (!input.evidenceDocument || !input.sectionTableIndex || !input.queryIntentAnalysis) return null;
+  if (input.queryIntentAnalysis.intent !== "section_topic") return null;
+
+  const nodes = input.queryIntentAnalysis.targetSections
+    .map((sectionId) => input.sectionTableIndex?.sectionTree.nodesById[sectionId])
+    .filter((node): node is SectionNode => Boolean(node));
+  if (nodes.length === 0) return null;
+
+  const selectedNode = nodes[0];
+  const sectionSpans = selectContentSpans(input.evidenceDocument, selectedNode.sectionId).slice(0, MAX_QUOTES);
+  if (sectionSpans.length === 0) return null;
+
+  return {
+    answerText: `${sectionDisplay(selectedNode)}: ${sectionSpans[0]?.text ?? selectedNode.heading}`,
+    route: "section_index",
+    confidence: clampConfidence(Math.min(input.queryIntentAnalysis.confidence, selectedNode.confidence)),
+    evidenceSpanIds: dedupe(sectionSpans.map((span) => span.spanId)),
+    quoteInputs: sectionSpans.map((span) => ({
+      quote: span.text,
+      page: span.page,
+      sectionId: span.sectionId,
+      heading: span.heading,
+    })),
+    pages: dedupe(sectionSpans.map((span) => span.page).filter((page): page is number => typeof page === "number")),
+    sectionPaths: dedupe([formatSectionPath(selectedNode.sectionPath)]),
+    warnings: [],
+  };
+}
+
+function hasDeterministicTableProvenance(table: IndexedTable): boolean {
+  return !table.limitedProvenance
+    && table.pageNumbers.length > 0
+    && table.sectionPath.length > 0
+    && table.cells.length > 0;
+}
+
+function describeTableCells(cells: TableCellReference[]): string {
+  return cells
+    .slice(0, 2)
+    .map((cell) => `r${cell.rowIndex + 1}c${cell.columnIndex + 1}=${cell.text}`)
+    .join("; ");
+}
+
+function buildTableCandidate(input: DeterministicRouterInput): RouterCandidate | null {
+  if (!input.sectionTableIndex || !input.queryIntentAnalysis) return null;
+  if (input.queryIntentAnalysis.intent !== "table_lookup") return null;
+  if (input.reviewArea === "baseline" && !input.queryIntentAnalysis.calculationSpecific) {
+    return null;
+  }
+
+  const tables = input.queryIntentAnalysis.targetTables
+    .map((tableKey) => (
+      input.sectionTableIndex?.tableIndex.byTableId[tableKey]
+      ?? input.sectionTableIndex?.tableIndex.byEvidenceSpanId[tableKey]
+    ))
+    .filter((table): table is IndexedTable => Boolean(table))
+    .filter(hasDeterministicTableProvenance);
+
+  if (tables.length === 0) return null;
+
+  const selectedTable = tables[0];
+  const selectedCells = (input.queryIntentAnalysis.targetCells.length > 0
+    ? selectedTable.cells.filter((cell) => input.queryIntentAnalysis?.targetCells.some((target) => (
+      target.rowIndex === cell.rowIndex
+      && target.columnIndex === cell.columnIndex
+      && target.sourceTableId === cell.sourceTableId
+    )))
+    : selectedTable.cells
+  ).slice(0, MAX_QUOTES);
+
+  if (selectedCells.length === 0) return null;
+
+  return {
+    answerText: `${selectedTable.heading ?? "Table evidence"}: ${describeTableCells(selectedCells)}`,
+    route: "table_index",
+    confidence: clampConfidence(Math.min(input.queryIntentAnalysis.confidence, selectedTable.confidence)),
+    evidenceSpanIds: [selectedTable.evidenceSpanId],
+    quoteInputs: selectedCells.map((cell) => ({
+      quote: cell.text,
+      page: cell.pageNumber,
+      sectionId: cell.sectionId,
+      heading: cell.heading,
+    })),
+    pages: selectedTable.pageNumbers,
+    sectionPaths: [formatSectionPath(selectedTable.sectionPath)],
+    warnings: [],
+  };
+}
+
+function extractLexicalTerms(claimText: string, queryIntentAnalysis?: QueryIntentAnalysis): string[] {
+  const claimTerms = normalize(claimText)
+    .split(" ")
+    .map((term) => term.trim())
+    .filter((term) => term.length >= 4)
+    .filter((term) => !GENERIC_TERMS.has(term));
+  return dedupe([
+    ...claimTerms,
+    ...(queryIntentAnalysis?.positiveTerms ?? []),
+  ]).filter((term) => term.length >= 4);
+}
+
+function lexicalScore(span: EvidenceSpan, terms: string[]): number {
+  const searchText = `${span.heading ?? ""} ${span.text}`.toLowerCase();
+  let score = 0;
+  for (const term of terms) {
+    const normalizedTerm = normalize(term);
+    if (!normalizedTerm) continue;
+    if (searchText.includes(normalizedTerm)) {
+      score += span.heading?.toLowerCase().includes(normalizedTerm) ? 2 : 1;
+    }
+  }
+  return score;
+}
+
+function buildLexicalCandidate(input: DeterministicRouterInput): RouterCandidate | null {
+  if (!input.evidenceDocument) return null;
+  if (input.queryIntentAnalysis?.intent === "unsupported_or_out_of_scope" || input.queryIntentAnalysis?.intent === "ambiguous") {
+    return null;
+  }
+  if (input.queryIntentAnalysis && input.queryIntentAnalysis.confidence < LEXICAL_MIN_CONFIDENCE) {
+    return null;
+  }
+
+  const terms = extractLexicalTerms(input.claimText, input.queryIntentAnalysis);
+  if (terms.length === 0) return null;
+
+  const scoredSpans = input.evidenceDocument.spans
+    .filter((span) => span.reliability !== "excluded")
+    .filter((span) => span.blockType !== "footer" && span.blockType !== "header" && span.blockType !== "toc")
+    .filter((span) => span.blockType !== "table" || input.queryIntentAnalysis?.calculationSpecific)
+    .map((span) => ({ span, score: lexicalScore(span, terms) }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => right.score - left.score || right.span.confidence - left.span.confidence)
+    .slice(0, MAX_QUOTES);
+
+  if (scoredSpans.length === 0) return null;
+
+  const topScore = scoredSpans[0]?.score ?? 0;
+  const lexicalConfidence = clampConfidence(Math.min(
+    0.9,
+    0.48 + (topScore * 0.14),
+    input.queryIntentAnalysis?.confidence ?? 0.86,
+  ));
+  if (lexicalConfidence < LEXICAL_MIN_CONFIDENCE) return null;
+
+  const spans = scoredSpans.map((entry) => entry.span);
+  return {
+    answerText: `The document states: ${spans[0]?.text ?? ""}`,
+    route: "lexical_retrieval",
+    confidence: lexicalConfidence,
+    evidenceSpanIds: spans.map((span) => span.spanId),
+    quoteInputs: spans.map((span) => ({
+      quote: span.text,
+      page: span.page,
+      sectionId: span.sectionId,
+      heading: span.heading,
+    })),
+    pages: dedupe(spans.map((span) => span.page).filter((page): page is number => typeof page === "number")),
+    sectionPaths: dedupe(spans.map((span) => formatSectionPath(span.sectionPath)).filter(Boolean)),
+    warnings: [],
+  };
+}
+
+export function buildDeterministicRouterResult(input: DeterministicRouterInput): DeterministicRouterResult {
+  if (!input.evidenceDocument || !input.sectionTableIndex || !input.projectFactContract) {
+    return buildFallback({
+      answerText: "Quick Check could not build the structured evidence context required for deterministic routing.",
+      status: "unclear",
+      confidence: 0,
+      warnings: ["structured_context_unavailable"],
+    });
+  }
+
+  if (input.queryIntentAnalysis?.intent === "unsupported_or_out_of_scope") {
+    return buildFallback({
+      answerText: "Quick Check found no document-grounded evidence path for this unsupported question.",
+      status: "no_evidence",
+      confidence: input.queryIntentAnalysis.confidence,
+      warnings: ["unsupported_or_out_of_scope"],
+    });
+  }
+
+  if (input.queryIntentAnalysis?.intent === "ambiguous") {
+    return buildFallback({
+      answerText: "Quick Check found multiple plausible evidence paths and did not choose one deterministically.",
+      status: "unclear",
+      confidence: input.queryIntentAnalysis.confidence,
+      warnings: ["ambiguous_intent"],
+    });
+  }
+
+  const candidate = buildFactCandidate(input)
+    ?? buildSectionCandidate(input)
+    ?? buildTableCandidate(input)
+    ?? buildLexicalCandidate(input);
+
+  if (!candidate) {
+    const lowConfidence = (input.queryIntentAnalysis?.confidence ?? 0) > 0 && input.queryIntentAnalysis!.confidence < ANSWER_CONFIDENCE_THRESHOLD;
+    return buildFallback({
+      answerText: lowConfidence
+        ? "Quick Check found some routing signal but not enough confidence to answer deterministically."
+        : "Quick Check found no validated evidence path for this question.",
+      status: lowConfidence ? "unclear" : "no_evidence",
+      confidence: input.queryIntentAnalysis?.confidence ?? 0,
+      warnings: lowConfidence ? ["low_confidence"] : ["no_validated_route"],
+    });
+  }
+
+  return finalizeCandidate(input.evidenceDocument, candidate);
+}

--- a/tests/lib/quickCheckDeterministicRouter.test.ts
+++ b/tests/lib/quickCheckDeterministicRouter.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "@jest/globals";
+import type { DocumentStructure } from "@/lib/documentModel";
+import {
+  buildReviewQuestionResult,
+  getStructuredQueryContext,
+} from "@/lib/chat/quickCheckReviewQuestion";
+import { parseDocumentText } from "@/lib/documentParsing";
+import { compileEvidenceDocumentFromStructure } from "@/lib/quickCheck/evidence/compileEvidenceDocument";
+import { validateQuotes } from "@/lib/quickCheck/evidence/validateQuotes";
+import { buildSectionTableIndex } from "@/lib/quickCheck/indexing";
+import { buildProjectFactContract } from "@/lib/quickCheck/projectFacts";
+
+const FACT_PDD_TEXT = [
+  "Project Title: Coastal Mangrove Restoration Project",
+  "Host Country: Kenya",
+  "Project Proponent: Blue Carbon Initiative",
+  "Methodology Applied: VM0007 REDD+ Methodology Framework",
+  "",
+  "2.2 Project Location",
+  "The project is located in Lamu County, Kenya.",
+  "",
+  "2.4 Baseline Scenario",
+  "Without the project activity, mangrove clearing would continue and emissions would increase.",
+].join("\n");
+
+const SECTION_PDD_TEXT = [
+  "1.0 Project Summary",
+  "This project restores degraded forest land.",
+  "",
+  "2.4 Baseline Scenario",
+  "The baseline scenario is continued grazing pressure and fuelwood extraction without the project.",
+  "Remote sensing and field observations support the without-project scenario.",
+  "",
+  "3.1 Monitoring Plan",
+  "Monitoring occurs annually.",
+].join("\n");
+
+const NON_PROVENANCE_TABLE_TEXT = [
+  "1.0 Appendix",
+  "A summary table is mentioned in the appendix narrative.",
+  "The table itself is not extracted with row or column provenance here.",
+].join("\n");
+
+function buildResult(claimText: string, rawPddText: string) {
+  return buildReviewQuestionResult({
+    claimText,
+    methodologyId: "VM0007",
+    methodologyVersion: "4.2",
+    rawPddText,
+  });
+}
+
+function makeStructure(overrides: Partial<DocumentStructure>): DocumentStructure {
+  return {
+    id: "article6-document:test",
+    source: "test-parser",
+    parserAdapterId: "current-extractor",
+    rawText: overrides.rawText ?? "",
+    cleanText: overrides.cleanText ?? "",
+    matchingText: overrides.matchingText ?? "",
+    documentFamily: overrides.documentFamily ?? {
+      family: "UNKNOWN",
+      confidence: 0.2,
+      evidence: [],
+      signals: [],
+      warnings: [],
+    },
+    qualityReport: overrides.qualityReport ?? {
+      parserName: "test-parser",
+      warnings: [],
+      sourceContentMode: "unknown",
+      pageCount: 1,
+      textDensity: 0.2,
+      ocrConfidence: undefined,
+      tableHeavyWarning: false,
+      layoutHeavyWarning: false,
+      headersFootersDetected: false,
+      weakExtractionWarning: false,
+      hasStructuredHeadings: true,
+      hasPageBoundaries: false,
+      hasBoundingBoxes: false,
+      hasTables: true,
+    },
+    pages: overrides.pages ?? [],
+    blocks: overrides.blocks ?? [],
+    sections: overrides.sections ?? [],
+    extractionWarnings: overrides.extractionWarnings ?? [],
+    parserDiagnostics: overrides.parserDiagnostics,
+    debug: overrides.debug,
+  };
+}
+
+function buildTableStructuredContext() {
+  const rawText = [
+    "3.1 Monitoring Plan",
+    "Parameter | Value",
+    "Monitoring frequency | Annual",
+    "Plot revisit cycle | 12 months",
+  ].join("\n");
+  const documentStructure = makeStructure({
+    rawText,
+    cleanText: rawText,
+    matchingText: rawText.toLowerCase(),
+    sections: [{
+      id: "section:3.1",
+      sectionNumber: "3.1",
+      titleRaw: "Monitoring Plan",
+      titleClean: "Monitoring Plan",
+      titleMatchingText: "monitoring plan",
+      bodyRaw: rawText,
+      bodyClean: rawText,
+      bodyMatchingText: rawText.toLowerCase(),
+      displaySnippet: rawText,
+      matchingText: `monitoring plan ${rawText.toLowerCase()}`,
+      parentId: undefined,
+      childIds: [],
+      blockIds: ["heading-1", "table-1"],
+      sourceRefs: [],
+      confidence: 0.96,
+      extractionWarnings: [],
+    }],
+    blocks: [
+      {
+        id: "heading-1",
+        type: "heading",
+        rawText: "3.1 Monitoring Plan",
+        cleanText: "3.1 Monitoring Plan",
+        matchingText: "3.1 monitoring plan",
+        pageNumber: 1,
+        sectionId: "section:3.1",
+        sectionPath: ["section:3", "section:3.1"],
+        sourceRefs: [],
+        confidence: 0.95,
+      },
+      {
+        id: "table-1",
+        type: "table",
+        rawText: "Parameter | Value\nMonitoring frequency | Annual\nPlot revisit cycle | 12 months",
+        cleanText: "Parameter | Value\nMonitoring frequency | Annual\nPlot revisit cycle | 12 months",
+        matchingText: "parameter value monitoring frequency annual plot revisit cycle 12 months",
+        pageNumber: 1,
+        sectionId: "section:3.1",
+        sectionPath: ["section:3", "section:3.1"],
+        table: {
+          id: "table-1",
+          pageNumber: 1,
+          rowCount: 3,
+          columnCount: 2,
+          headerRowCount: 1,
+          cells: [
+            { rowIndex: 0, columnIndex: 0, text: "Parameter" },
+            { rowIndex: 0, columnIndex: 1, text: "Value" },
+            { rowIndex: 1, columnIndex: 0, text: "Monitoring frequency" },
+            { rowIndex: 1, columnIndex: 1, text: "Annual" },
+            { rowIndex: 2, columnIndex: 0, text: "Plot revisit cycle" },
+            { rowIndex: 2, columnIndex: 1, text: "12 months" },
+          ],
+        },
+        sourceRefs: [],
+        confidence: 0.92,
+      },
+    ],
+    pages: [{
+      id: "page:1",
+      pageNumber: 1,
+      rawText,
+      cleanText: rawText,
+      matchingText: rawText.toLowerCase(),
+      blockIds: ["heading-1", "table-1"],
+      sourceRefs: [],
+    }],
+  });
+  const evidenceDocument = compileEvidenceDocumentFromStructure({
+    docId: "router-table-test",
+    documentStructure,
+  });
+  const sectionTableIndex = buildSectionTableIndex({
+    documentStructure,
+    evidenceDocument,
+  });
+  return {
+    parsedDocument: parseDocumentText({ rawText }),
+    documentStructure,
+    evidenceDocument,
+    projectFactContract: buildProjectFactContract(evidenceDocument),
+    sectionTableIndex,
+  };
+}
+
+function expectAnsweredProvenance(rawPddText: string, result: ReturnType<typeof buildResult>) {
+  expect(result.routerResult.status).toBe("answered");
+  expect(result.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+  expect(result.routerResult.quotes.length).toBeGreaterThan(0);
+  expect(result.routerResult.pages.length).toBeGreaterThan(0);
+  expect(result.routerResult.sectionPaths.length).toBeGreaterThan(0);
+  expect(result.routerResult.route).not.toBe("fallback");
+  expect(result.routerResult.confidence).toBeGreaterThanOrEqual(0.7);
+
+  const context = getStructuredQueryContext(rawPddText);
+  const validations = validateQuotes(
+    context.evidenceDocument,
+    result.routerResult.quotes.map((quote) => ({ quote })),
+  );
+  expect(validations.every((validation) => validation.valid)).toBe(true);
+}
+
+describe("deterministic router contract", () => {
+  it("answers fact questions from ProjectFactContract with validated provenance", () => {
+    const result = buildResult("What is the project title and host country?", FACT_PDD_TEXT);
+
+    expect(result.routerResult.route).toBe("project_fact_contract");
+    expect(result.routerResult.answerText).toContain("Project title:");
+    expect(result.routerResult.answerText).toContain("Host country: Kenya.");
+    expectAnsweredProvenance(FACT_PDD_TEXT, result);
+  });
+
+  it("answers section questions from the section index", () => {
+    const result = buildResult("Explain the baseline scenario.", SECTION_PDD_TEXT);
+
+    expect(result.routerResult.route).toBe("section_index");
+    expect(result.routerResult.answerText).toContain("Baseline Scenario");
+    expectAnsweredProvenance(SECTION_PDD_TEXT, result);
+  });
+
+  it("answers table questions only when table-backed provenance exists", () => {
+    const structuredQueryContext = buildTableStructuredContext();
+    const result = buildReviewQuestionResult({
+      claimText: "What does the table say about monitoring frequency?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: structuredQueryContext.documentStructure.rawText,
+      structuredQueryContext,
+    });
+
+    expect(result.routerResult.route).toBe("table_index");
+    expect(result.routerResult.answerText).toContain("Monitoring frequency");
+    expectAnsweredProvenance(structuredQueryContext.documentStructure.rawText, result);
+  });
+
+  it("returns no_evidence for unsupported questions", () => {
+    const result = buildResult("What is the stock price of the project developer?", FACT_PDD_TEXT);
+
+    expect(result.routerResult.status).toBe("no_evidence");
+    expect(result.routerResult.route).toBe("fallback");
+    expect(result.routerResult.evidenceSpanIds).toEqual([]);
+    expect(result.routerResult.quotes).toEqual([]);
+  });
+
+  it("returns unclear for low-confidence or ambiguous questions", () => {
+    const result = buildResult("baseline methodology", FACT_PDD_TEXT);
+
+    expect(result.routerResult.status).toBe("unclear");
+    expect(result.routerResult.route).toBe("fallback");
+    expect(result.routerResult.warnings).toContain("ambiguous_intent");
+  });
+
+  it("keeps baseline questions from answering from tables unless the query is calculation-specific", () => {
+    const result = buildResult("What does the table say about the baseline scenario?", NON_PROVENANCE_TABLE_TEXT);
+
+    expect(result.routerResult.route).toBe("fallback");
+    expect(result.routerResult.status).toBe("no_evidence");
+  });
+});


### PR DESCRIPTION
## Summary
- add the deterministic Quick Check router result contract to review question results
- implement deterministic route ordering across project facts, section index, table index, and lexical fallback
- validate quoted evidence and enforce `no_evidence`, `unclear`, and baseline/table safety behavior
- add focused deterministic router tests covering provenance-backed answers and fallback handling

## Scope
This PR includes only the Phase 5 router work:
- deterministic router result contract
- route ordering
- quote validation
- `no_evidence` handling
- `unclear` handling
- baseline/table safety
- focused router tests

This PR does not include:
- export timestamp changes
- UI polish
- ENOSPC cleanup
- marking Phase 5 done

## Why
This is real Phase 5 implementation work and should be reviewed as a PR before merge.

## Validation
- [x] `npm run pr:gate`
- [x] `npm run quickcheck:eval`
- [x] `npm test -- --runInBand tests/lib/quickCheckReviewQuestion.test.ts`
- [x] `npm test -- --runInBand tests/lib/quickCheckDeterministicRouter.test.ts`

## Roadmap
- Phase: `Phase 5: Grounded Deterministic Router + Validator`
- Status: `in_progress`

Signed-off-by: Fred Egbuedike <fredilly@article6.org>