### PR TITLE
tighten deterministic Quick Check router grounding

### DIFF
--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -15,6 +15,7 @@ type RouterCandidate = {
   confidence: number;
   evidenceSpanIds: string[];
   quoteInputs: QuoteValidationInput[];
+  answerQuoteCount: number;
   pages: number[];
   sectionPaths: string[];
   warnings: string[];
@@ -125,6 +126,10 @@ function formatSectionPath(path: string[]): string {
   return path.join(" > ");
 }
 
+function formatHeadingPath(path: string[]): string {
+  return path.join(" > ");
+}
+
 function getSpanLookup(document: EvidenceDocument): Map<string, EvidenceSpan> {
   return new Map(document.spans.map((span) => [span.spanId, span]));
 }
@@ -153,7 +158,8 @@ function finalizeCandidate(document: EvidenceDocument, candidate: RouterCandidat
   const validQuotes = validations
     .map((validation, index) => ({ validation, quoteInput: candidate.quoteInputs[index] }))
     .filter((entry): entry is { validation: NonNullable<typeof validations[number]>; quoteInput: QuoteValidationInput } => entry.validation.valid);
-  if (validQuotes.length === 0) {
+  const requiredValidatedQuotes = Math.max(1, Math.min(candidate.answerQuoteCount, candidate.quoteInputs.length));
+  if (validQuotes.length < requiredValidatedQuotes) {
     return buildFallback({
       answerText: "Quick Check found a possible evidence path but could not validate the supporting quotes against source spans.",
       status: "unclear",
@@ -162,13 +168,9 @@ function finalizeCandidate(document: EvidenceDocument, candidate: RouterCandidat
     });
   }
 
-  const matchedSpanIds = dedupe([
-    ...candidate.evidenceSpanIds,
-    ...validQuotes.flatMap(({ validation }) => validation.matchedSpanIds),
-  ]);
+  const matchedSpanIds = dedupe(validQuotes.flatMap(({ validation }) => validation.matchedSpanIds));
   const spanLookup = getSpanLookup(document);
   const pages = dedupe([
-    ...candidate.pages,
     ...matchedSpanIds
       .map((spanId) => spanLookup.get(spanId)?.page)
       .filter((page): page is number => typeof page === "number"),
@@ -180,6 +182,27 @@ function finalizeCandidate(document: EvidenceDocument, candidate: RouterCandidat
       .filter((path) => path.length > 0)
       .map((path) => formatSectionPath(path)),
   ]);
+  const headingPaths = dedupe(matchedSpanIds
+    .map((spanId) => spanLookup.get(spanId)?.headingPath ?? [])
+    .filter((path) => path.length > 0)
+    .map((path) => formatHeadingPath(path)));
+  const structuralPaths = sectionPaths.length > 0
+    ? sectionPaths
+    : headingPaths.length > 0
+      ? headingPaths
+      : pages.length > 0
+        ? ["Document root"]
+        : [];
+  const quotes = dedupe(validQuotes.map(({ quoteInput }) => quoteInput.quote));
+
+  if (matchedSpanIds.length === 0 || quotes.length === 0 || pages.length === 0 || structuralPaths.length === 0) {
+    return buildFallback({
+      answerText: "Quick Check found a possible evidence path but could not preserve the grounded provenance required for a deterministic answer.",
+      status: "unclear",
+      confidence: candidate.confidence,
+      warnings: [...candidate.warnings, "missing_grounded_provenance"],
+    });
+  }
 
   return {
     answerText: candidate.answerText,
@@ -187,9 +210,9 @@ function finalizeCandidate(document: EvidenceDocument, candidate: RouterCandidat
     route: candidate.route,
     confidence: clampConfidence(candidate.confidence),
     evidenceSpanIds: matchedSpanIds,
-    quotes: dedupe(validQuotes.map(({ quoteInput }) => quoteInput.quote)),
+    quotes,
     pages,
-    sectionPaths,
+    sectionPaths: structuralPaths,
     warnings: candidate.confidence >= ANSWER_CONFIDENCE_THRESHOLD
       ? candidate.warnings
       : [...candidate.warnings, "low_confidence"],
@@ -200,6 +223,7 @@ function buildFactCandidate(input: DeterministicRouterInput): RouterCandidate | 
   if (!input.evidenceDocument || !input.projectFactContract || !input.queryIntentAnalysis) return null;
   if (!["fact_lookup", "methodology_lookup"].includes(input.queryIntentAnalysis.intent)) return null;
 
+  const spanLookup = getSpanLookup(input.evidenceDocument);
   const resolvedFacts = input.queryIntentAnalysis.targetFacts
     .map((factId) => ({
       factId,
@@ -214,18 +238,31 @@ function buildFactCandidate(input: DeterministicRouterInput): RouterCandidate | 
       const field = entry.field;
       if (!field || !entry.value) return false;
       return field.evidenceSpanIds.length > 0;
-    });
+    })
+    .map((entry) => {
+      const supportingSpans = entry.field.evidenceSpanIds
+        .map((spanId) => spanLookup.get(spanId))
+        .filter((span): span is EvidenceSpan => Boolean(span))
+        .filter((span) => normalize(span.text).includes(normalize(entry.value)));
+      return {
+        ...entry,
+        supportingSpans,
+      };
+    })
+    .filter((entry): entry is {
+      factId: ProjectFactId;
+      field: ProjectFactField;
+      value: string;
+      supportingSpans: EvidenceSpan[];
+    } => entry.supportingSpans.length > 0);
 
   if (resolvedFacts.length === 0) return null;
 
-  const spanLookup = getSpanLookup(input.evidenceDocument);
   const answerText = resolvedFacts
     .map(({ factId, value }) => `${FACT_LABELS[factId]}: ${value}.`)
     .join(" ");
   const quoteInputs = resolvedFacts
-    .flatMap(({ field }) => field.evidenceSpanIds
-      .map((spanId) => spanLookup.get(spanId))
-      .filter((span): span is EvidenceSpan => Boolean(span))
+    .flatMap(({ supportingSpans }) => supportingSpans
       .slice(0, 1)
       .map((span) => ({
         quote: span.text,
@@ -242,9 +279,10 @@ function buildFactCandidate(input: DeterministicRouterInput): RouterCandidate | 
       input.queryIntentAnalysis.confidence,
       ...resolvedFacts.map(({ field }) => normalizeConfidence(field.confidence)),
     )),
-    evidenceSpanIds: dedupe(resolvedFacts.flatMap(({ field }) => field.evidenceSpanIds)),
+    evidenceSpanIds: dedupe(resolvedFacts.flatMap(({ supportingSpans }) => supportingSpans.map((span) => span.spanId))),
     quoteInputs,
-    pages: dedupe(resolvedFacts.flatMap(({ field }) => field.pageNumbers)).sort((left, right) => left - right),
+    answerQuoteCount: quoteInputs.length,
+    pages: dedupe(resolvedFacts.flatMap(({ supportingSpans }) => supportingSpans.map((span) => span.page).filter((page): page is number => typeof page === "number"))).sort((left, right) => left - right),
     sectionPaths: dedupe(resolvedFacts.map(({ field }) => formatSectionPath(field.sectionPath)).filter(Boolean)),
     warnings: dedupe(resolvedFacts.flatMap(({ field }) => field.warnings)),
   };
@@ -289,6 +327,7 @@ function buildSectionCandidate(input: DeterministicRouterInput): RouterCandidate
       sectionId: span.sectionId,
       heading: span.heading,
     })),
+    answerQuoteCount: 1,
     pages: dedupe(sectionSpans.map((span) => span.page).filter((page): page is number => typeof page === "number")),
     sectionPaths: dedupe([formatSectionPath(selectedNode.sectionPath)]),
     warnings: [],
@@ -349,6 +388,7 @@ function buildTableCandidate(input: DeterministicRouterInput): RouterCandidate |
       sectionId: cell.sectionId,
       heading: cell.heading,
     })),
+    answerQuoteCount: selectedCells.length,
     pages: selectedTable.pageNumbers,
     sectionPaths: [formatSectionPath(selectedTable.sectionPath)],
     warnings: [],
@@ -383,6 +423,13 @@ function lexicalScore(span: EvidenceSpan, terms: string[]): number {
 function buildLexicalCandidate(input: DeterministicRouterInput): RouterCandidate | null {
   if (!input.evidenceDocument) return null;
   if (input.queryIntentAnalysis?.intent === "unsupported_or_out_of_scope" || input.queryIntentAnalysis?.intent === "ambiguous") {
+    return null;
+  }
+  if (
+    input.queryIntentAnalysis?.intent === "table_lookup"
+    || input.queryIntentAnalysis?.intent === "fact_lookup"
+    || input.queryIntentAnalysis?.intent === "methodology_lookup"
+  ) {
     return null;
   }
   if (input.queryIntentAnalysis && input.queryIntentAnalysis.confidence < LEXICAL_MIN_CONFIDENCE) {
@@ -423,6 +470,7 @@ function buildLexicalCandidate(input: DeterministicRouterInput): RouterCandidate
       sectionId: span.sectionId,
       heading: span.heading,
     })),
+    answerQuoteCount: 1,
     pages: dedupe(spans.map((span) => span.page).filter((page): page is number => typeof page === "number")),
     sectionPaths: dedupe(spans.map((span) => formatSectionPath(span.sectionPath)).filter(Boolean)),
     warnings: [],

--- a/tests/evals/quickCheckEval.test.ts
+++ b/tests/evals/quickCheckEval.test.ts
@@ -116,7 +116,6 @@ const ROUTER_EVAL_CASES: RouterEvalCase[] = [
       route: "project_fact_contract",
       confidenceMin: 0.7,
       evidenceRequired: true,
-      sectionPathsRequired: false,
     },
   },
   {
@@ -132,7 +131,6 @@ const ROUTER_EVAL_CASES: RouterEvalCase[] = [
       route: "project_fact_contract",
       confidenceMin: 0.7,
       evidenceRequired: true,
-      sectionPathsRequired: false,
     },
   },
   {
@@ -148,7 +146,6 @@ const ROUTER_EVAL_CASES: RouterEvalCase[] = [
       route: "project_fact_contract",
       confidenceMin: 0.7,
       evidenceRequired: true,
-      sectionPathsRequired: false,
     },
   },
   {

--- a/tests/lib/quickCheckDeterministicRouter.test.ts
+++ b/tests/lib/quickCheckDeterministicRouter.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
 import type { DocumentStructure } from "@/lib/documentModel";
 import {
   buildReviewQuestionResult,
@@ -9,6 +11,11 @@ import { compileEvidenceDocumentFromStructure } from "@/lib/quickCheck/evidence/
 import { validateQuotes } from "@/lib/quickCheck/evidence/validateQuotes";
 import { buildSectionTableIndex } from "@/lib/quickCheck/indexing";
 import { buildProjectFactContract } from "@/lib/quickCheck/projectFacts";
+import { buildDeterministicRouterResult } from "@/lib/quickCheck/router/deterministicRouter";
+import type { QueryIntentAnalysis } from "@/lib/quickCheck/queryIntent";
+import type { ProjectFactContract } from "@/lib/quickCheck/projectFacts/types";
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+import type { SectionTableIndex } from "@/lib/quickCheck/indexing";
 
 const FACT_PDD_TEXT = [
   "Project Title: Coastal Mangrove Restoration Project",
@@ -40,6 +47,18 @@ const NON_PROVENANCE_TABLE_TEXT = [
   "A summary table is mentioned in the appendix narrative.",
   "The table itself is not extracted with row or column provenance here.",
 ].join("\n");
+
+const BASELINE_TABLE_WITH_NARRATIVE_TEXT = [
+  "2.4 Baseline Scenario",
+  "The baseline scenario is continued grazing pressure and fuelwood extraction without the project.",
+  "Parameter | Value",
+  "Baseline scenario | Continued grazing pressure",
+].join("\n");
+
+const REAL_CDM_TEXT = fs.readFileSync(
+  path.join(__dirname, "../fixtures/quick-check/bsp-nepal-activity3-cdm-excerpt.txt"),
+  "utf8",
+);
 
 function buildResult(claimText: string, rawPddText: string) {
   return buildReviewQuestionResult({
@@ -204,6 +223,124 @@ function expectAnsweredProvenance(rawPddText: string, result: ReturnType<typeof 
   expect(validations.every((validation) => validation.valid)).toBe(true);
 }
 
+function emptySectionTableIndex(): SectionTableIndex {
+  return {
+    documentFamily: "UNKNOWN",
+    sectionTree: {
+      roots: [],
+      orderedNodeIds: [],
+      nodesById: {},
+    },
+    tableIndex: {
+      tables: [],
+      cells: [],
+      byEvidenceSpanId: {},
+      byTableId: {},
+    },
+    sectionTopicMap: {
+      baseline: [],
+      monitoring: [],
+      leakage: [],
+      additionality: [],
+      methodology: [],
+      project_location: [],
+      project_participants: [],
+      crediting_period: [],
+      safeguards: [],
+      sdg: [],
+    },
+  };
+}
+
+function makeFactRouterInput(overrides?: {
+  evidenceDocument?: EvidenceDocument;
+  projectFactContract?: ProjectFactContract;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+}) {
+  const evidenceDocument: EvidenceDocument = overrides?.evidenceDocument ?? {
+    docId: "router-direct-test",
+    rawText: "Host Country: Kenya",
+    documentFamily: "UNKNOWN",
+    spans: [{
+      spanId: "span-host-country",
+      docId: "router-direct-test",
+      page: 1,
+      sectionId: undefined,
+      heading: "Document Details",
+      headingPath: ["Document Details"],
+      sectionPath: [],
+      blockType: "field",
+      text: "Host Country: Kenya",
+      normalizedText: "host country kenya",
+      charStart: 0,
+      charEnd: 19,
+      sourceBlockId: "block-host-country",
+      parserSource: "test",
+      parserAdapterId: "current-extractor",
+      documentFamily: "UNKNOWN",
+      reliability: "primary",
+      confidence: 0.98,
+    }],
+  };
+
+  const projectFactContract: ProjectFactContract = overrides?.projectFactContract ?? {
+    documentFamily: "UNKNOWN",
+    documentType: "DOCUMENT",
+    projectTitle: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    hostCountry: {
+      value: "Tanzania",
+      confidence: "high",
+      evidenceSpanIds: ["span-host-country"],
+      pageNumbers: [1],
+      sectionPath: [],
+      heading: "Document Details",
+      extractionRule: "test",
+      warnings: [],
+    },
+    projectCountry: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    projectLocation: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    projectStandard: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    projectType: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    projectProponent: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    methodologyPrimary: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    methodologyModules: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    baselineMethodology: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    monitoringMethodology: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    creditingPeriod: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    reportingPeriod: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    monitoringPeriod: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    projectStartDate: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    baselineSections: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    monitoringSections: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    leakageSections: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    additionalitySections: { value: null, confidence: "low", evidenceSpanIds: [], pageNumbers: [], sectionPath: [], extractionRule: "test", warnings: [] },
+    warnings: [],
+  };
+
+  const queryIntentAnalysis: QueryIntentAnalysis = overrides?.queryIntentAnalysis ?? {
+    intent: "fact_lookup",
+    targetFacts: ["hostCountry"],
+    targetSections: [],
+    targetTables: [],
+    targetCells: [],
+    positiveTerms: ["host country"],
+    negativeTerms: [],
+    calculationSpecific: false,
+    unsupportedTopic: false,
+    confidence: 0.95,
+    documentFamily: "UNKNOWN",
+  };
+
+  return {
+    claimText: "What is the host country?",
+    reviewArea: "general" as const,
+    queryIntentAnalysis,
+    evidenceDocument,
+    projectFactContract,
+    sectionTableIndex: emptySectionTableIndex(),
+  };
+}
+
 describe("deterministic router contract", () => {
   it("answers fact questions from ProjectFactContract with validated provenance", () => {
     const result = buildResult("What is the project title and host country?", FACT_PDD_TEXT);
@@ -259,5 +396,32 @@ describe("deterministic router contract", () => {
 
     expect(result.routerResult.route).toBe("fallback");
     expect(result.routerResult.status).toBe("no_evidence");
+  });
+
+  it("does not fall back to lexical narrative answers for table_lookup baseline questions", () => {
+    const result = buildResult("What does the table say about the baseline scenario?", BASELINE_TABLE_WITH_NARRATIVE_TEXT);
+
+    expect(result.queryIntentAnalysis?.intent).toBe("table_lookup");
+    expect(result.routerResult.route).toBe("fallback");
+    expect(result.routerResult.status).toBe("no_evidence");
+    expect(result.routerResult.evidenceSpanIds).toEqual([]);
+    expect(result.routerResult.quotes).toEqual([]);
+    expect(result.routerResult.sectionPaths).toEqual([]);
+  });
+
+  it("adds structural provenance for real-document fact answers", () => {
+    const result = buildResult("What is the project title?", REAL_CDM_TEXT);
+
+    expect(result.routerResult.status).toBe("answered");
+    expect(result.routerResult.route).toBe("project_fact_contract");
+    expect(result.routerResult.sectionPaths.length).toBeGreaterThan(0);
+  });
+
+  it("blocks fact answers whose extracted value is not supported by the cited evidence span", () => {
+    const result = buildDeterministicRouterResult(makeFactRouterInput());
+
+    expect(result.route).toBe("fallback");
+    expect(result.status).toBe("no_evidence");
+    expect(result.warnings).toContain("no_validated_route");
   });
 });


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- - RC5: in_progress -->
  <!-- - PR12: done -->
  <!-- - PR13: in_progress -->

For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactors with no SSOT impact), leave `slug: N/A`. The roadmap gates will skip.

Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

Visible UI changes to look for:
