### PR TITLE
Phase 6 eval corpus foundation

### DIFF
--- a/docs/roadmaps/quick-check-document-pipeline/phase-status.json
+++ b/docs/roadmaps/quick-check-document-pipeline/phase-status.json
@@ -47,7 +47,7 @@
     "phase_3_retrieval_evaluation_split": [669, 670, 671],
     "phase_4_declarative_review_policy": [676, 677],
     "phase_5_eval_harness": [679, 680],
-    "phase_6_secondary_parser_adapter": [745]
+    "phase_6_eval_corpus_foundation": [745]
   },
   "notes": {
     "phase_6_eval_corpus_foundation": "PR #745 lays the Phase 6 eval corpus foundation with a manifest-backed runner and standard question set. This is foundation-only: strict CI enforcement and broader fixture coverage are not yet in place. Phase 6 remains active, not complete."

--- a/docs/roadmaps/quick-check-document-pipeline/phase-status.json
+++ b/docs/roadmaps/quick-check-document-pipeline/phase-status.json
@@ -46,6 +46,10 @@
     "phase_2_article6_document_model": [667],
     "phase_3_retrieval_evaluation_split": [669, 670, 671],
     "phase_4_declarative_review_policy": [676, 677],
-    "phase_5_eval_harness": [679, 680]
+    "phase_5_eval_harness": [679, 680],
+    "phase_6_secondary_parser_adapter": [745]
+  },
+  "notes": {
+    "phase_6_eval_corpus_foundation": "PR #745 lays the Phase 6 eval corpus foundation with a manifest-backed runner and standard question set. This is foundation-only: strict CI enforcement and broader fixture coverage are not yet in place. Phase 6 remains active, not complete."
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "node --require ./scripts/node-version-shim.js ./node_modules/next/dist/bin/next lint --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "quickcheck:eval": "jest tests/evals/quickCheckEval.test.ts --runInBand",
+    "quickcheck:eval:corpus": "node scripts/run-quickcheck-eval-corpus.cjs",
     "ci": "npm run guard:methodology-boundary && npm run lint && npm run typecheck && npm run check:docs-layout && npm run roadmap:validate-evidence && npm run quickcheck:eval && npm test && npm run build && npm run check:quick-check-pdf-trace && npm run roadmap:check",
     "test": "jest --passWithNoTests",
     "test:e2e": "playwright test",

--- a/scripts/run-quickcheck-eval-corpus.cjs
+++ b/scripts/run-quickcheck-eval-corpus.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: "commonjs",
+  moduleResolution: "node",
+});
+require("ts-node/register");
+require("tsconfig-paths/register");
+
+const path = require("path");
+const {
+  runQuickCheckEvalCorpus,
+  formatQuickCheckEvalCorpusReport,
+} = require("../src/lib/quickCheck/evalCorpus");
+
+const strict = process.argv.includes("--strict");
+const manifestFlagIndex = process.argv.indexOf("--manifest");
+const manifestPath = manifestFlagIndex >= 0 && process.argv[manifestFlagIndex + 1]
+  ? path.resolve(process.argv[manifestFlagIndex + 1])
+  : path.resolve(process.cwd(), "tests/fixtures/quick-check/corpus/phase6-eval-corpus.json");
+
+const report = runQuickCheckEvalCorpus({
+  manifestPath,
+  repoRoot: process.cwd(),
+});
+
+console.log(formatQuickCheckEvalCorpusReport(report));
+
+if (strict && report.metrics.regressionCount > 0) {
+  process.exit(1);
+}

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -190,6 +190,36 @@ function applyIntentToRetrieval(input: {
   };
 }
 
+function enrichProjectFactContractWithStructuredInput(
+  contract: ReturnType<typeof buildStructuredQueryContext>["projectFactContract"],
+  methodologyId: string,
+  methodologyVersion: string,
+): typeof contract {
+  if (!methodologyId.trim()) return contract;
+  const existing = contract.methodologyPrimary;
+  if (existing.value && existing.evidenceSpanIds.length > 0) return contract;
+
+  const methodologyLabel = methodologyVersion.trim()
+    ? `${methodologyId.trim()} \u00b7 ${methodologyVersion.trim()}`
+    : methodologyId.trim();
+
+  return {
+    ...contract,
+    methodologyPrimary: {
+      value: methodologyLabel,
+      confidence: "high",
+      evidenceSpanIds: [],
+      pageNumbers: [],
+      sectionPath: [],
+      heading: undefined,
+      extractionRule: "structured-input",
+      sourceParser: undefined,
+      family: contract.documentFamily,
+      warnings: [],
+    },
+  };
+}
+
 function hasIntentBackedEvidence(input: {
   queryIntentAnalysis?: QueryIntentAnalysis;
   structuredContext?: ReturnType<typeof buildStructuredQueryContext>;
@@ -265,12 +295,20 @@ export function buildReviewQuestionResult(input: {
     structuredContext,
   });
   const evaluation = evaluateRetrievedReviewQuestion(retrieval);
+  const enrichedProjectFactContract = structuredContext
+    ? enrichProjectFactContractWithStructuredInput(
+        structuredContext.projectFactContract,
+        input.methodologyId,
+        input.methodologyVersion,
+      )
+    : undefined;
+
   const routerResult: DeterministicRouterResult = buildDeterministicRouterResult({
     claimText: input.claimText,
     reviewArea: retrieval.reviewArea,
     queryIntentAnalysis,
     evidenceDocument: structuredContext?.evidenceDocument,
-    projectFactContract: structuredContext?.projectFactContract,
+    projectFactContract: enrichedProjectFactContract ?? structuredContext?.projectFactContract,
     sectionTableIndex: structuredContext?.sectionTableIndex,
   });
   const parsedDocument = structuredContext?.parsedDocument ?? (input.rawPddText ? parseDocumentText({ rawText: input.rawPddText }) : undefined);
@@ -282,7 +320,7 @@ export function buildReviewQuestionResult(input: {
     rawPddText: input.rawPddText,
     queryIntentAnalysis: appliedQueryIntentAnalysis,
     evidenceDocument: structuredContext?.evidenceDocument,
-    projectFactContract: structuredContext?.projectFactContract,
+    projectFactContract: enrichedProjectFactContract ?? structuredContext?.projectFactContract,
     sectionTableIndex: structuredContext?.sectionTableIndex,
   });
 

--- a/src/lib/quickCheck/evalCorpus/index.ts
+++ b/src/lib/quickCheck/evalCorpus/index.ts
@@ -1,0 +1,8 @@
+export { loadEvalCorpusManifest, readEvalCorpusFixture } from "@/lib/quickCheck/evalCorpus/manifest";
+export { runQuickCheckEvalCorpus, formatQuickCheckEvalCorpusReport } from "@/lib/quickCheck/evalCorpus/runner";
+export { STANDARD_PHASE6_QUESTIONS } from "@/lib/quickCheck/evalCorpus/standardQuestions";
+export type {
+  EvalCorpusManifest,
+  EvalCorpusReport,
+  StandardPhase6QuestionId,
+} from "@/lib/quickCheck/evalCorpus/types";

--- a/src/lib/quickCheck/evalCorpus/manifest.ts
+++ b/src/lib/quickCheck/evalCorpus/manifest.ts
@@ -1,0 +1,77 @@
+import fs from "fs";
+import path from "path";
+import { z } from "zod";
+import type { EvalCorpusManifest } from "@/lib/quickCheck/evalCorpus/types";
+import { STANDARD_PHASE6_QUESTION_IDS } from "@/lib/quickCheck/evalCorpus/types";
+
+const goldEvidenceSchema = z.object({
+  pages: z.array(z.number().int().positive()).optional(),
+  spanAnchors: z.array(z.string().min(1)).optional(),
+  sectionHints: z.array(z.string().min(1)).optional(),
+}).strict();
+
+const questionExpectationSchema = z.object({
+  expectedStatus: z.enum(["answered", "unclear", "no_evidence"]),
+  expectedRoute: z.enum(["project_fact_contract", "section_index", "table_index", "lexical_retrieval", "fallback"]).optional(),
+  expectedEvidenceEmpty: z.boolean().optional(),
+  goldEvidence: goldEvidenceSchema.optional(),
+}).strict();
+
+const questionExpectationsSchema = z.object(
+  Object.fromEntries(STANDARD_PHASE6_QUESTION_IDS.map((questionId) => [questionId, questionExpectationSchema])) as Record<
+    (typeof STANDARD_PHASE6_QUESTION_IDS)[number],
+    typeof questionExpectationSchema
+  >,
+).strict();
+
+const fixtureSchema = z.object({
+  id: z.string().min(1),
+  fixturePath: z.string().min(1),
+  kind: z.enum(["text", "json-pages"]),
+  methodologyContext: z.object({
+    methodologyId: z.string().min(1),
+    methodologyVersion: z.string().min(1),
+  }).strict(),
+  gold: z.object({
+    documentFamily: z.string().min(1),
+    projectTitle: z.string().nullable().optional(),
+    hostCountry: z.string().nullable().optional(),
+    projectCountry: z.string().nullable().optional(),
+    methodology: z.string().nullable().optional(),
+    creditingPeriod: z.string().nullable().optional(),
+    reportingPeriod: z.string().nullable().optional(),
+    baselineSection: z.string().nullable().optional(),
+    monitoringSection: z.string().nullable().optional(),
+    leakageSection: z.string().nullable().optional(),
+    additionalitySection: z.string().nullable().optional(),
+    unsupportedQuestionExpectation: questionExpectationSchema,
+    questionExpectations: questionExpectationsSchema,
+  }).strict(),
+  notes: z.string().optional(),
+}).strict();
+
+const manifestSchema = z.object({
+  manifestVersion: z.literal(1),
+  corpusId: z.string().min(1),
+  fixtures: z.array(fixtureSchema).min(1),
+}).strict();
+
+export function loadEvalCorpusManifest(manifestPath: string): EvalCorpusManifest {
+  const absolutePath = path.resolve(manifestPath);
+  const raw = fs.readFileSync(absolutePath, "utf-8");
+  return manifestSchema.parse(JSON.parse(raw)) as EvalCorpusManifest;
+}
+
+export function readEvalCorpusFixture(repoRoot: string, fixturePath: string, kind: "text" | "json-pages"): string {
+  const absolutePath = path.resolve(repoRoot, fixturePath);
+  if (kind === "json-pages") {
+    const parsed = JSON.parse(fs.readFileSync(absolutePath, "utf-8")) as {
+      pages?: Array<{ text?: string; rawText?: string }>;
+    };
+    return (parsed.pages ?? [])
+      .map((page) => page.text ?? page.rawText ?? "")
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  return fs.readFileSync(absolutePath, "utf-8");
+}

--- a/src/lib/quickCheck/evalCorpus/runner.ts
+++ b/src/lib/quickCheck/evalCorpus/runner.ts
@@ -1,0 +1,340 @@
+import path from "path";
+import { buildReviewQuestionResult, getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import { STANDARD_PHASE6_QUESTIONS } from "@/lib/quickCheck/evalCorpus/standardQuestions";
+import { loadEvalCorpusManifest, readEvalCorpusFixture } from "@/lib/quickCheck/evalCorpus/manifest";
+import type {
+  EvalCorpusFailure,
+  EvalCorpusFixtureGold,
+  EvalCorpusFixtureManifestEntry,
+  EvalCorpusFixtureResult,
+  EvalCorpusQuestionExpectation,
+  EvalCorpusQuestionResult,
+  EvalCorpusReport,
+  EvalMetric,
+  StandardPhase6QuestionId,
+} from "@/lib/quickCheck/evalCorpus/types";
+import type { ProjectFactContract } from "@/lib/quickCheck/projectFacts/types";
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function includesNormalized(haystack: string, needle: string): boolean {
+  return normalize(haystack).includes(normalize(needle));
+}
+
+function makeMetric(passed: number, total: number): EvalMetric {
+  return {
+    passed,
+    total,
+    rate: total > 0 ? passed / total : 0,
+  };
+}
+
+function compareFactValue(actual: string | string[] | null, expected: string | null | undefined): boolean {
+  if (expected === undefined) return true;
+  if (expected === null) return actual == null;
+  if (Array.isArray(actual)) return actual.some((value) => includesNormalized(value, expected));
+  return actual != null && includesNormalized(actual, expected);
+}
+
+function actualSectionSignals(result: ReturnType<typeof buildReviewQuestionResult>): string[] {
+  return Array.from(new Set([
+    ...result.routerResult.sectionPaths,
+    ...result.matchedHeadings.map((heading) => heading.title),
+    result.routerResult.answerText,
+  ].filter(Boolean)));
+}
+
+function compareFactContract(gold: EvalCorpusFixtureGold, contract: ProjectFactContract): string[] {
+  const failures: string[] = [];
+  const factChecks: Array<{ label: string; actual: string | string[] | null; expected: string | null | undefined }> = [
+    { label: "documentFamily", actual: contract.documentFamily, expected: gold.documentFamily },
+    { label: "projectTitle", actual: contract.projectTitle.value, expected: gold.projectTitle },
+    { label: "hostCountry", actual: contract.hostCountry.value, expected: gold.hostCountry },
+    { label: "projectCountry", actual: contract.projectCountry.value, expected: gold.projectCountry },
+    { label: "methodology", actual: contract.methodologyPrimary.value, expected: gold.methodology },
+    { label: "creditingPeriod", actual: contract.creditingPeriod.value, expected: gold.creditingPeriod },
+    { label: "reportingPeriod", actual: contract.reportingPeriod.value, expected: gold.reportingPeriod },
+    { label: "baselineSection", actual: contract.baselineSections.value, expected: gold.baselineSection },
+    { label: "monitoringSection", actual: contract.monitoringSections.value, expected: gold.monitoringSection },
+    { label: "leakageSection", actual: contract.leakageSections.value, expected: gold.leakageSection },
+    { label: "additionalitySection", actual: contract.additionalitySections.value, expected: gold.additionalitySection },
+  ];
+
+  for (const check of factChecks) {
+    if (!compareFactValue(check.actual, check.expected)) {
+      failures.push(`${check.label} mismatch`);
+    }
+  }
+  return failures;
+}
+
+function evaluateQuestion(input: {
+  fixture: EvalCorpusFixtureManifestEntry;
+  questionId: StandardPhase6QuestionId;
+  expectation: EvalCorpusQuestionExpectation;
+  rawPddText: string;
+}): {
+  result: EvalCorpusQuestionResult;
+  provenancePassed: number;
+  provenanceTotal: number;
+  sectionPrecisionPassed: number;
+  sectionPrecisionTotal: number;
+  sectionRecallPassed: number;
+  sectionRecallTotal: number;
+  unsupportedPassed: number;
+  unsupportedTotal: number;
+  noEvidenceFalseNegativeFailures: number;
+  noEvidenceFalseNegativeTotal: number;
+  hallucinatedAnswered: number;
+  answeredTotal: number;
+} {
+  const reviewResult = buildReviewQuestionResult({
+    claimText: STANDARD_PHASE6_QUESTIONS[input.questionId],
+    methodologyId: input.fixture.methodologyContext.methodologyId,
+    methodologyVersion: input.fixture.methodologyContext.methodologyVersion,
+    rawPddText: input.rawPddText,
+  });
+  const failures: string[] = [];
+  const expectation = input.expectation;
+
+  if (reviewResult.routerResult.status !== expectation.expectedStatus) {
+    failures.push(`status expected ${expectation.expectedStatus} but got ${reviewResult.routerResult.status}`);
+  }
+  if (expectation.expectedRoute && reviewResult.routerResult.route !== expectation.expectedRoute) {
+    failures.push(`route expected ${expectation.expectedRoute} but got ${reviewResult.routerResult.route}`);
+  }
+  if (expectation.expectedEvidenceEmpty) {
+    if (
+      reviewResult.routerResult.evidenceSpanIds.length !== 0
+      || reviewResult.routerResult.quotes.length !== 0
+      || reviewResult.routerResult.pages.length !== 0
+    ) {
+      failures.push("expected empty evidence for unsupported/no-evidence case");
+    }
+  }
+
+  let provenancePassed = 0;
+  let provenanceTotal = 0;
+  let sectionPrecisionPassed = 0;
+  let sectionPrecisionTotal = 0;
+  let sectionRecallPassed = 0;
+  let sectionRecallTotal = 0;
+
+  if (expectation.goldEvidence?.pages?.length) {
+    provenanceTotal += 1;
+    const pagesMatch = expectation.goldEvidence.pages.every((page) => reviewResult.routerResult.pages.includes(page));
+    if (pagesMatch) provenancePassed += 1;
+    else failures.push(`expected evidence pages ${expectation.goldEvidence.pages.join(", ")} not found`);
+  }
+
+  if (expectation.goldEvidence?.spanAnchors?.length) {
+    provenanceTotal += 1;
+    const quotes = reviewResult.routerResult.quotes.join("\n");
+    const anchorMatch = expectation.goldEvidence.spanAnchors.every((anchor) => includesNormalized(quotes, anchor));
+    if (anchorMatch) provenancePassed += 1;
+    else failures.push("expected quote anchors were not all present");
+  }
+
+  const expectedSectionHints = expectation.goldEvidence?.sectionHints ?? [];
+  if (expectedSectionHints.length > 0) {
+    const signals = actualSectionSignals(reviewResult);
+    const matchedSection = expectedSectionHints.some((hint) => signals.some((signal) => includesNormalized(signal, hint)));
+    sectionRecallTotal += 1;
+    if (signals.length > 0) sectionPrecisionTotal += 1;
+    if (matchedSection) {
+      sectionRecallPassed += 1;
+      if (signals.length > 0) sectionPrecisionPassed += 1;
+    } else {
+      failures.push(`expected section hint not recovered: ${expectedSectionHints.join(" | ")}`);
+    }
+  }
+
+  const unsupportedTotal = input.questionId === "marine_biodiversity_offsets" ? 1 : 0;
+  const unsupportedPassed = unsupportedTotal === 1 && reviewResult.routerResult.status === "no_evidence" ? 1 : 0;
+  const noEvidenceFalseNegativeTotal = expectation.expectedStatus === "no_evidence" ? 1 : 0;
+  const noEvidenceFalseNegativeFailures = noEvidenceFalseNegativeTotal === 1 && reviewResult.routerResult.status !== "no_evidence" ? 1 : 0;
+
+  const answeredTotal = reviewResult.routerResult.status === "answered" ? 1 : 0;
+  const answeredWithoutProvenance = answeredTotal === 1 && (
+    (expectation.goldEvidence?.pages?.length ? !expectation.goldEvidence.pages.every((page) => reviewResult.routerResult.pages.includes(page)) : false)
+    || (expectation.goldEvidence?.spanAnchors?.length ? !expectation.goldEvidence.spanAnchors.every((anchor) => includesNormalized(reviewResult.routerResult.quotes.join("\n"), anchor)) : false)
+    || reviewResult.routerResult.quotes.length === 0
+    || reviewResult.routerResult.pages.length === 0
+  ) ? 1 : 0;
+
+  return {
+    result: {
+      questionId: input.questionId,
+      passed: failures.length === 0,
+      actualStatus: reviewResult.routerResult.status,
+      actualRoute: reviewResult.routerResult.route,
+      failures,
+    },
+    provenancePassed,
+    provenanceTotal,
+    sectionPrecisionPassed,
+    sectionPrecisionTotal,
+    sectionRecallPassed,
+    sectionRecallTotal,
+    unsupportedPassed,
+    unsupportedTotal,
+    noEvidenceFalseNegativeFailures,
+    noEvidenceFalseNegativeTotal,
+    hallucinatedAnswered: answeredWithoutProvenance,
+    answeredTotal,
+  };
+}
+
+export function runQuickCheckEvalCorpus(options?: {
+  manifestPath?: string;
+  repoRoot?: string;
+}): EvalCorpusReport {
+  const repoRoot = options?.repoRoot ?? path.resolve(process.cwd());
+  const manifestPath = options?.manifestPath ?? path.join(repoRoot, "tests/fixtures/quick-check/corpus/phase6-eval-corpus.json");
+  const manifest = loadEvalCorpusManifest(manifestPath);
+  const failures: EvalCorpusFailure[] = [];
+  const fixtureResults: EvalCorpusFixtureResult[] = [];
+
+  let factPassed = 0;
+  let factTotal = 0;
+  let provenancePassed = 0;
+  let provenanceTotal = 0;
+  let sectionPrecisionPassed = 0;
+  let sectionPrecisionTotal = 0;
+  let sectionRecallPassed = 0;
+  let sectionRecallTotal = 0;
+  let unsupportedPassed = 0;
+  let unsupportedTotal = 0;
+  let noEvidenceFalseNegativeFailures = 0;
+  let noEvidenceFalseNegativeTotal = 0;
+  let hallucinatedAnswered = 0;
+  let answeredTotal = 0;
+  let fixturesPassed = 0;
+
+  for (const fixture of manifest.fixtures) {
+    const rawPddText = readEvalCorpusFixture(repoRoot, fixture.fixturePath, fixture.kind);
+    const structuredContext = getStructuredQueryContext(rawPddText);
+    const factFailures = compareFactContract(fixture.gold, structuredContext.projectFactContract);
+    const questionResults: EvalCorpusQuestionResult[] = [];
+
+    const factChecksTotal = 11;
+    factTotal += factChecksTotal;
+    factPassed += factChecksTotal - factFailures.length;
+    for (const factFailure of factFailures) {
+      failures.push({
+        fixtureId: fixture.id,
+        category: "fact_contract",
+        questionId: "fact_contract",
+        message: factFailure,
+      });
+    }
+
+    for (const [questionId, expectation] of Object.entries(fixture.gold.questionExpectations) as Array<
+      [StandardPhase6QuestionId, EvalCorpusQuestionExpectation]
+    >) {
+      const evaluated = evaluateQuestion({
+        fixture,
+        questionId,
+        expectation,
+        rawPddText,
+      });
+      questionResults.push(evaluated.result);
+      provenancePassed += evaluated.provenancePassed;
+      provenanceTotal += evaluated.provenanceTotal;
+      sectionPrecisionPassed += evaluated.sectionPrecisionPassed;
+      sectionPrecisionTotal += evaluated.sectionPrecisionTotal;
+      sectionRecallPassed += evaluated.sectionRecallPassed;
+      sectionRecallTotal += evaluated.sectionRecallTotal;
+      unsupportedPassed += evaluated.unsupportedPassed;
+      unsupportedTotal += evaluated.unsupportedTotal;
+      noEvidenceFalseNegativeFailures += evaluated.noEvidenceFalseNegativeFailures;
+      noEvidenceFalseNegativeTotal += evaluated.noEvidenceFalseNegativeTotal;
+      hallucinatedAnswered += evaluated.hallucinatedAnswered;
+      answeredTotal += evaluated.answeredTotal;
+
+      for (const failure of evaluated.result.failures) {
+        failures.push({
+          fixtureId: fixture.id,
+          category: "question",
+          questionId,
+          message: failure,
+        });
+      }
+    }
+
+    const fixturePassed = factFailures.length === 0 && questionResults.every((question) => question.passed);
+    if (fixturePassed) fixturesPassed += 1;
+    fixtureResults.push({
+      fixtureId: fixture.id,
+      passed: fixturePassed,
+      factFailures,
+      questionResults,
+    });
+  }
+
+  return {
+    corpusId: manifest.corpusId,
+    fixtureCount: manifest.fixtures.length,
+    fixtureResults,
+    failures,
+    metrics: {
+      factExtractionAccuracy: makeMetric(factPassed, factTotal),
+      provenanceCorrectness: makeMetric(provenancePassed, provenanceTotal),
+      sectionRetrievalPrecision: makeMetric(sectionPrecisionPassed, sectionPrecisionTotal),
+      sectionRetrievalRecall: makeMetric(sectionRecallPassed, sectionRecallTotal),
+      unsupportedRejectionRate: makeMetric(unsupportedPassed, unsupportedTotal),
+      noEvidenceFalseNegativeRate: makeMetric(noEvidenceFalseNegativeFailures, noEvidenceFalseNegativeTotal),
+      hallucinatedAnswerRate: makeMetric(hallucinatedAnswered, answeredTotal),
+      firstPassSuccessRate: makeMetric(fixturesPassed, manifest.fixtures.length),
+      regressionCount: failures.length,
+    },
+  };
+}
+
+function pct(metric: EvalMetric): string {
+  return `${(metric.rate * 100).toFixed(1)}% (${metric.passed}/${metric.total})`;
+}
+
+export function formatQuickCheckEvalCorpusReport(report: EvalCorpusReport): string {
+  const lines = [
+    `Quick Check Eval Corpus: ${report.corpusId}`,
+    `Fixtures: ${report.fixtureCount}`,
+    "",
+    "Metrics",
+    `- Fact extraction accuracy: ${pct(report.metrics.factExtractionAccuracy)}`,
+    `- Provenance correctness: ${pct(report.metrics.provenanceCorrectness)}`,
+    `- Section retrieval precision: ${pct(report.metrics.sectionRetrievalPrecision)}`,
+    `- Section retrieval recall: ${pct(report.metrics.sectionRetrievalRecall)}`,
+    `- Unsupported rejection rate: ${pct(report.metrics.unsupportedRejectionRate)}`,
+    `- No-evidence false negative rate: ${pct(report.metrics.noEvidenceFalseNegativeRate)}`,
+    `- Hallucinated answer rate: ${pct(report.metrics.hallucinatedAnswerRate)}`,
+    `- First-pass success rate: ${pct(report.metrics.firstPassSuccessRate)}`,
+    `- Regression count: ${report.metrics.regressionCount}`,
+    "",
+    "Fixtures",
+  ];
+
+  for (const fixture of report.fixtureResults) {
+    lines.push(`- ${fixture.fixtureId}: ${fixture.passed ? "PASS" : "FAIL"}`);
+    if (fixture.factFailures.length > 0) {
+      lines.push(`  fact failures: ${fixture.factFailures.join("; ")}`);
+    }
+    const failedQuestions = fixture.questionResults.filter((question) => !question.passed);
+    if (failedQuestions.length > 0) {
+      for (const failedQuestion of failedQuestions) {
+        lines.push(`  ${failedQuestion.questionId}: ${failedQuestion.failures.join("; ")}`);
+      }
+    }
+  }
+
+  if (report.failures.length > 0) {
+    lines.push("", "Failures");
+    for (const failure of report.failures.slice(0, 20)) {
+      lines.push(`- ${failure.fixtureId}${failure.questionId ? `/${failure.questionId}` : ""}: ${failure.message}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/lib/quickCheck/evalCorpus/standardQuestions.ts
+++ b/src/lib/quickCheck/evalCorpus/standardQuestions.ts
@@ -1,0 +1,12 @@
+import type { StandardPhase6QuestionId } from "@/lib/quickCheck/evalCorpus/types";
+
+export const STANDARD_PHASE6_QUESTIONS: Record<StandardPhase6QuestionId, string> = {
+  project_title: "What is the project title?",
+  host_country: "What is the host country?",
+  methodology: "What methodology is used?",
+  baseline_scenario: "What is the baseline scenario?",
+  monitoring: "What does the document say about monitoring?",
+  leakage: "What does the document say about leakage?",
+  additionality: "What does the document say about additionality?",
+  marine_biodiversity_offsets: "What does the document say about marine biodiversity offsets?",
+};

--- a/src/lib/quickCheck/evalCorpus/types.ts
+++ b/src/lib/quickCheck/evalCorpus/types.ts
@@ -1,0 +1,112 @@
+import type { DeterministicRouterRoute, DeterministicRouterStatus } from "@/lib/quickCheck/retrieval/types";
+import type { DocumentFamily } from "@/lib/documentParsing";
+
+export const STANDARD_PHASE6_QUESTION_IDS = [
+  "project_title",
+  "host_country",
+  "methodology",
+  "baseline_scenario",
+  "monitoring",
+  "leakage",
+  "additionality",
+  "marine_biodiversity_offsets",
+] as const;
+
+export type StandardPhase6QuestionId = (typeof STANDARD_PHASE6_QUESTION_IDS)[number];
+
+export type EvalCorpusFixtureKind = "text" | "json-pages";
+
+export type EvalCorpusMethodologyContext = {
+  methodologyId: string;
+  methodologyVersion: string;
+};
+
+export type EvalCorpusGoldEvidence = {
+  pages?: number[];
+  spanAnchors?: string[];
+  sectionHints?: string[];
+};
+
+export type EvalCorpusQuestionExpectation = {
+  expectedStatus: DeterministicRouterStatus;
+  expectedRoute?: DeterministicRouterRoute;
+  expectedEvidenceEmpty?: boolean;
+  goldEvidence?: EvalCorpusGoldEvidence;
+};
+
+export type EvalCorpusFixtureGold = {
+  documentFamily: DocumentFamily;
+  projectTitle?: string | null;
+  hostCountry?: string | null;
+  projectCountry?: string | null;
+  methodology?: string | null;
+  creditingPeriod?: string | null;
+  reportingPeriod?: string | null;
+  baselineSection?: string | null;
+  monitoringSection?: string | null;
+  leakageSection?: string | null;
+  additionalitySection?: string | null;
+  unsupportedQuestionExpectation: EvalCorpusQuestionExpectation;
+  questionExpectations: Record<StandardPhase6QuestionId, EvalCorpusQuestionExpectation>;
+};
+
+export type EvalCorpusFixtureManifestEntry = {
+  id: string;
+  fixturePath: string;
+  kind: EvalCorpusFixtureKind;
+  methodologyContext: EvalCorpusMethodologyContext;
+  gold: EvalCorpusFixtureGold;
+  notes?: string;
+};
+
+export type EvalCorpusManifest = {
+  manifestVersion: 1;
+  corpusId: string;
+  fixtures: EvalCorpusFixtureManifestEntry[];
+};
+
+export type EvalMetric = {
+  passed: number;
+  total: number;
+  rate: number;
+};
+
+export type EvalCorpusFailure = {
+  fixtureId: string;
+  category: string;
+  questionId?: StandardPhase6QuestionId | "fact_contract";
+  message: string;
+};
+
+export type EvalCorpusQuestionResult = {
+  questionId: StandardPhase6QuestionId;
+  passed: boolean;
+  actualStatus: DeterministicRouterStatus;
+  actualRoute: DeterministicRouterRoute;
+  failures: string[];
+};
+
+export type EvalCorpusFixtureResult = {
+  fixtureId: string;
+  passed: boolean;
+  factFailures: string[];
+  questionResults: EvalCorpusQuestionResult[];
+};
+
+export type EvalCorpusReport = {
+  corpusId: string;
+  fixtureCount: number;
+  fixtureResults: EvalCorpusFixtureResult[];
+  failures: EvalCorpusFailure[];
+  metrics: {
+    factExtractionAccuracy: EvalMetric;
+    provenanceCorrectness: EvalMetric;
+    sectionRetrievalPrecision: EvalMetric;
+    sectionRetrievalRecall: EvalMetric;
+    unsupportedRejectionRate: EvalMetric;
+    noEvidenceFalseNegativeRate: EvalMetric;
+    hallucinatedAnswerRate: EvalMetric;
+    firstPassSuccessRate: EvalMetric;
+    regressionCount: number;
+  };
+};

--- a/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
+++ b/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
@@ -209,6 +209,35 @@ export function analyzeQueryIntent(input: QueryIntentAnalyzerInput): QueryIntent
   ].sort((a, b) => b.score - a.score);
 
   if (
+    wantsMethodology
+    && !wantsTable
+    && !topicMatches.some((match) => match.topic === "baseline" && match.score > 0)
+    && factMatches.some((match) => match.factId === "methodologyPrimary" && match.score > 0)
+  ) {
+    const methodologyFacts: ProjectFactId[] = ["methodologyPrimary", "methodologyModules", "baselineMethodology", "monitoringMethodology"];
+    const methodologySections = topicMatches.flatMap((match) => {
+      if (match.topic !== "methodology" || match.bestMatch.status !== "matched") return [];
+      return match.bestMatch.reference.sectionId ? [match.bestMatch.reference.sectionId] : [];
+    });
+
+    return makeAnalysis({
+      intent: "methodology_lookup",
+      targetFacts: methodologyFacts,
+      targetSections: unique(methodologySections),
+      positiveTerms: unique([
+        ...FACT_RULES.filter((rule) => methodologyFacts.includes(rule.factId)).flatMap((rule) => rule.aliases),
+        "methodology",
+      ]),
+      confidence: withFamilyConfidenceCap(
+        methodologySections.length > 0 ? 0.94 : 0.86,
+        index.documentFamily,
+      ),
+      calculationSpecific,
+      documentFamily: index.documentFamily,
+    });
+  }
+
+  if (
     !factQuestionFrame
     && topScores[0].score > 0
     && topScores[1].score > 0

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -19,6 +19,7 @@ type RouterCandidate = {
   pages: number[];
   sectionPaths: string[];
   warnings: string[];
+  isStructuredInput: boolean;
 };
 
 type DeterministicRouterInput = {
@@ -237,9 +238,16 @@ function buildFactCandidate(input: DeterministicRouterInput): RouterCandidate | 
     } => {
       const field = entry.field;
       if (!field || !entry.value) return false;
-      return field.evidenceSpanIds.length > 0;
+      return field.evidenceSpanIds.length > 0 || field.extractionRule === "structured-input";
     })
     .map((entry) => {
+      if (entry.field.extractionRule === "structured-input") {
+        return {
+          ...entry,
+          supportingSpans: [] as EvidenceSpan[],
+          isStructuredInput: true as const,
+        };
+      }
       const supportingSpans = entry.field.evidenceSpanIds
         .map((spanId) => spanLookup.get(spanId))
         .filter((span): span is EvidenceSpan => Boolean(span))
@@ -247,6 +255,7 @@ function buildFactCandidate(input: DeterministicRouterInput): RouterCandidate | 
       return {
         ...entry,
         supportingSpans,
+        isStructuredInput: false as const,
       };
     })
     .filter((entry): entry is {
@@ -254,14 +263,19 @@ function buildFactCandidate(input: DeterministicRouterInput): RouterCandidate | 
       field: ProjectFactField;
       value: string;
       supportingSpans: EvidenceSpan[];
-    } => entry.supportingSpans.length > 0);
+      isStructuredInput: boolean;
+    } => entry.isStructuredInput || entry.supportingSpans.length > 0);
 
   if (resolvedFacts.length === 0) return null;
 
   const answerText = resolvedFacts
-    .map(({ factId, value }) => `${FACT_LABELS[factId]}: ${value}.`)
+    .map(({ factId, value, isStructuredInput }) =>
+      isStructuredInput
+        ? `${FACT_LABELS[factId]}: ${value} (from structured input).`
+        : `${FACT_LABELS[factId]}: ${value}.`)
     .join(" ");
-  const quoteInputs = resolvedFacts
+  const documentFacts = resolvedFacts.filter((f) => !f.isStructuredInput);
+  const quoteInputs = documentFacts
     .flatMap(({ supportingSpans }) => supportingSpans
       .slice(0, 1)
       .map((span) => ({
@@ -279,12 +293,13 @@ function buildFactCandidate(input: DeterministicRouterInput): RouterCandidate | 
       input.queryIntentAnalysis.confidence,
       ...resolvedFacts.map(({ field }) => normalizeConfidence(field.confidence)),
     )),
-    evidenceSpanIds: dedupe(resolvedFacts.flatMap(({ supportingSpans }) => supportingSpans.map((span) => span.spanId))),
+    evidenceSpanIds: dedupe(documentFacts.flatMap(({ supportingSpans }) => supportingSpans.map((span) => span.spanId))),
     quoteInputs,
     answerQuoteCount: quoteInputs.length,
-    pages: dedupe(resolvedFacts.flatMap(({ supportingSpans }) => supportingSpans.map((span) => span.page).filter((page): page is number => typeof page === "number"))).sort((left, right) => left - right),
+    pages: dedupe(documentFacts.flatMap(({ supportingSpans }) => supportingSpans.map((span) => span.page).filter((page): page is number => typeof page === "number"))).sort((left, right) => left - right),
     sectionPaths: dedupe(resolvedFacts.map(({ field }) => formatSectionPath(field.sectionPath)).filter(Boolean)),
     warnings: dedupe(resolvedFacts.flatMap(({ field }) => field.warnings)),
+    isStructuredInput: documentFacts.length === 0 && resolvedFacts.length > 0,
   };
 }
 
@@ -331,6 +346,7 @@ function buildSectionCandidate(input: DeterministicRouterInput): RouterCandidate
     pages: dedupe(sectionSpans.map((span) => span.page).filter((page): page is number => typeof page === "number")),
     sectionPaths: dedupe([formatSectionPath(selectedNode.sectionPath)]),
     warnings: [],
+    isStructuredInput: false,
   };
 }
 
@@ -392,6 +408,7 @@ function buildTableCandidate(input: DeterministicRouterInput): RouterCandidate |
     pages: selectedTable.pageNumbers,
     sectionPaths: [formatSectionPath(selectedTable.sectionPath)],
     warnings: [],
+    isStructuredInput: false,
   };
 }
 
@@ -474,6 +491,7 @@ function buildLexicalCandidate(input: DeterministicRouterInput): RouterCandidate
     pages: dedupe(spans.map((span) => span.page).filter((page): page is number => typeof page === "number")),
     sectionPaths: dedupe(spans.map((span) => formatSectionPath(span.sectionPath)).filter(Boolean)),
     warnings: [],
+    isStructuredInput: false,
   };
 }
 
@@ -520,6 +538,22 @@ export function buildDeterministicRouterResult(input: DeterministicRouterInput):
       confidence: input.queryIntentAnalysis?.confidence ?? 0,
       warnings: lowConfidence ? ["low_confidence"] : ["no_validated_route"],
     });
+  }
+
+  if (candidate.isStructuredInput) {
+    return {
+      answerText: candidate.answerText,
+      status: candidate.confidence >= ANSWER_CONFIDENCE_THRESHOLD ? "answered" : "unclear",
+      route: candidate.route,
+      confidence: clampConfidence(candidate.confidence),
+      evidenceSpanIds: candidate.evidenceSpanIds,
+      quotes: [],
+      pages: candidate.pages,
+      sectionPaths: candidate.sectionPaths,
+      warnings: candidate.confidence >= ANSWER_CONFIDENCE_THRESHOLD
+        ? [...candidate.warnings, "structured_input_provenance"]
+        : [...candidate.warnings, "low_confidence", "structured_input_provenance"],
+    };
   }
 
   return finalizeCandidate(input.evidenceDocument, candidate);

--- a/tests/evals/quickCheckEval.test.ts
+++ b/tests/evals/quickCheckEval.test.ts
@@ -101,6 +101,7 @@ function readRootFixtureText(fixturePath: string): string {
 const REAL_CDM_TEXT = readRootFixtureText("quick-check/bsp-nepal-activity3-cdm-excerpt.txt");
 const REAL_ENVIRA_TEXT = readRootFixtureText("quick-check/envira-amazonia-vm0007-extracted.txt");
 const REAL_TABLE_HEAVY_APPENDIX_TEXT = readRootFixtureText("projects/ccb1530-appendix1-pages.json");
+const WEAK_UNKNOWN_FALLBACK_TEXT = readRootFixtureText("quick-check/weak-unknown-fallback.txt");
 
 const ROUTER_EVAL_CASES: RouterEvalCase[] = [
   {
@@ -229,6 +230,54 @@ const ROUTER_EVAL_CASES: RouterEvalCase[] = [
       evidenceRequired: false,
       emptyEvidenceExpected: true,
       warningsInclude: ["ambiguous_intent"],
+    },
+  },
+  {
+    id: "real_document_envira_project_title_router_contract",
+    rawPddText: REAL_ENVIRA_TEXT,
+    input: {
+      claimText: "What is the project title?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+    },
+    expected: {
+      status: "answered",
+      route: "project_fact_contract",
+      confidenceMin: 0.7,
+      evidenceRequired: true,
+    },
+  },
+  {
+    id: "real_document_envira_host_country_no_evidence",
+    rawPddText: REAL_ENVIRA_TEXT,
+    input: {
+      claimText: "What is the host country?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+    },
+    expected: {
+      status: "no_evidence",
+      route: "fallback",
+      confidenceMin: 0,
+      evidenceRequired: false,
+      emptyEvidenceExpected: true,
+    },
+  },
+  {
+    id: "structured_input_methodology_fallback_warns_provenance",
+    rawPddText: WEAK_UNKNOWN_FALLBACK_TEXT,
+    input: {
+      claimText: "What methodology is used?",
+      methodologyId: "AMS-III.AV.",
+      methodologyVersion: "4.0",
+    },
+    expected: {
+      status: "answered",
+      route: "project_fact_contract",
+      confidenceMin: 0.7,
+      evidenceRequired: false,
+      emptyEvidenceExpected: true,
+      warningsInclude: ["structured_input_provenance"],
     },
   },
 ];

--- a/tests/fixtures/quick-check/corpus/phase6-eval-corpus.json
+++ b/tests/fixtures/quick-check/corpus/phase6-eval-corpus.json
@@ -1,0 +1,185 @@
+{
+  "manifestVersion": 1,
+  "corpusId": "phase6-foundation",
+  "fixtures": [
+    {
+      "id": "real-cdm-nepal",
+      "fixturePath": "tests/fixtures/quick-check/bsp-nepal-activity3-cdm-excerpt.txt",
+      "kind": "text",
+      "methodologyContext": {
+        "methodologyId": "AMS-I.E.",
+        "methodologyVersion": "1.0"
+      },
+      "gold": {
+        "documentFamily": "CDM_PDD",
+        "projectTitle": "Biogas Support Program - Nepal Activity-3",
+        "hostCountry": "Nepal",
+        "projectCountry": "Nepal",
+        "methodology": "AMS-I.E. Switch from non-renewable biomass for thermal applications by the user",
+        "creditingPeriod": "13 Dec 2011 - 12 Dec 2018",
+        "reportingPeriod": null,
+        "baselineSection": "Baseline scenario",
+        "monitoringSection": "Monitoring methodology and plan",
+        "leakageSection": "Leakage",
+        "additionalitySection": "Demonstration of additionality",
+        "unsupportedQuestionExpectation": {
+          "expectedStatus": "no_evidence",
+          "expectedRoute": "fallback",
+          "expectedEvidenceEmpty": true
+        },
+        "questionExpectations": {
+          "project_title": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["Biogas Support Program - Nepal Activity-3"]
+            }
+          },
+          "host_country": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["Host country: Nepal"]
+            }
+          },
+          "methodology": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["Applied baseline methodology: AMS-I.E."]
+            }
+          },
+          "baseline_scenario": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["Without the project activity, rural households would continue to use non-renewable biomass"],
+              "sectionHints": ["Baseline scenario"]
+            }
+          },
+          "monitoring": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["Monitoring includes digester operation checks"],
+              "sectionHints": ["Monitoring methodology and plan"]
+            }
+          },
+          "leakage": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["Leakage emissions are expected to be negligible"],
+              "sectionHints": ["Leakage"]
+            }
+          },
+          "additionality": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["The project is additional because upfront household investment barriers"],
+              "sectionHints": ["Demonstration of additionality"]
+            }
+          },
+          "marine_biodiversity_offsets": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true
+          }
+        }
+      },
+      "notes": "Compact CDM excerpt with deterministic fact fields and named baseline/monitoring/leakage/additionality sections."
+    },
+    {
+      "id": "real-envira-amazonia",
+      "fixturePath": "tests/fixtures/quick-check/envira-amazonia-vm0007-extracted.txt",
+      "kind": "text",
+      "methodologyContext": {
+        "methodologyId": "VM0007",
+        "methodologyVersion": "4.2"
+      },
+      "gold": {
+        "documentFamily": "REDD_AFOLU",
+        "projectTitle": "Envira Amazonia REDD+ Project",
+        "hostCountry": null,
+        "projectCountry": null,
+        "methodology": "VM0007 Version 4.2",
+        "creditingPeriod": null,
+        "reportingPeriod": null,
+        "baselineSection": null,
+        "monitoringSection": "Monitoring Plan",
+        "leakageSection": "Leakage",
+        "additionalitySection": null,
+        "unsupportedQuestionExpectation": {
+          "expectedStatus": "no_evidence",
+          "expectedRoute": "fallback",
+          "expectedEvidenceEmpty": true
+        },
+        "questionExpectations": {
+          "project_title": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["Envira Amazonia REDD+ Project"]
+            }
+          },
+          "host_country": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true
+          },
+          "methodology": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["VM0007 Version 4.2"]
+            }
+          },
+          "baseline_scenario": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true
+          },
+          "monitoring": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["The monitoring plan defines the sampling design"],
+              "sectionHints": ["Monitoring Plan"]
+            }
+          },
+          "leakage": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["Activity shifting leakage is addressed through community agreements"],
+              "sectionHints": ["Leakage"]
+            }
+          },
+          "additionality": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true
+          },
+          "marine_biodiversity_offsets": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true
+          }
+        }
+      },
+      "notes": "Real REDD/AFOLU fixture with title, methodology, leakage, and monitoring but no deterministic baseline/additionality fact promotion."
+    }
+  ]
+}

--- a/tests/lib/quickCheckDeterministicRouter.test.ts
+++ b/tests/lib/quickCheckDeterministicRouter.test.ts
@@ -424,4 +424,43 @@ describe("deterministic router contract", () => {
     expect(result.status).toBe("no_evidence");
     expect(result.warnings).toContain("no_validated_route");
   });
+
+  it("answers methodology from structured input when document has no methodology text", () => {
+    const DOC_WITHOUT_METHODOLOGY = [
+      "Project Title: Community Reforestation Project",
+      "Host Country: Tanzania",
+      "",
+      "2.4 Baseline Scenario",
+      "The baseline scenario is continued grazing pressure.",
+    ].join("\n");
+
+    const result = buildResult("What methodology is used?", DOC_WITHOUT_METHODOLOGY);
+
+    expect(result.routerResult.route).toBe("project_fact_contract");
+    expect(result.routerResult.status).toBe("answered");
+    expect(result.routerResult.answerText).toContain("Primary methodology: VM0007");
+    expect(result.routerResult.answerText).toContain("4.2");
+    expect(result.routerResult.answerText).toContain("from structured input");
+    expect(result.routerResult.warnings).toContain("structured_input_provenance");
+    expect(result.routerResult.quotes).toEqual([]);
+  });
+
+  it("prefers document-extracted methodology over structured input when both are available", () => {
+    const DOC_WITH_METHODOLOGY = [
+      "Project Title: Community Reforestation Project",
+      "Methodology: AMS-III.AV Low greenhouse gas emitting safe drinking water production systems",
+      "",
+      "2.4 Baseline Scenario",
+      "The baseline scenario is continued grazing pressure.",
+    ].join("\n");
+
+    const result = buildResult("What methodology is used?", DOC_WITH_METHODOLOGY);
+
+    expect(result.routerResult.route).toBe("project_fact_contract");
+    expect(result.routerResult.status).toBe("answered");
+    expect(result.routerResult.answerText).toContain("AMS-III.AV");
+    expect(result.routerResult.answerText).not.toContain("from structured input");
+    expect(result.routerResult.answerText).not.toContain("VM0007");
+    expect(result.routerResult.quotes.length).toBeGreaterThan(0);
+  });
 });

--- a/tests/lib/quickCheckEvalCorpus.test.ts
+++ b/tests/lib/quickCheckEvalCorpus.test.ts
@@ -1,0 +1,39 @@
+import path from "path";
+import { describe, expect, it } from "@jest/globals";
+import {
+  STANDARD_PHASE6_QUESTIONS,
+  formatQuickCheckEvalCorpusReport,
+  loadEvalCorpusManifest,
+  runQuickCheckEvalCorpus,
+} from "@/lib/quickCheck/evalCorpus";
+
+const MANIFEST_PATH = path.join(process.cwd(), "tests/fixtures/quick-check/corpus/phase6-eval-corpus.json");
+
+describe("quick check eval corpus foundation", () => {
+  it("loads the phase 6 manifest with the standard question set represented per fixture", () => {
+    const manifest = loadEvalCorpusManifest(MANIFEST_PATH);
+
+    expect(manifest.manifestVersion).toBe(1);
+    expect(manifest.fixtures.length).toBeGreaterThan(0);
+    for (const fixture of manifest.fixtures) {
+      expect(Object.keys(fixture.gold.questionExpectations).sort()).toEqual(Object.keys(STANDARD_PHASE6_QUESTIONS).sort());
+    }
+  });
+
+  it("computes scaffold metrics and prints a readable report", () => {
+    const report = runQuickCheckEvalCorpus({
+      manifestPath: MANIFEST_PATH,
+      repoRoot: process.cwd(),
+    });
+    const rendered = formatQuickCheckEvalCorpusReport(report);
+
+    expect(report.fixtureCount).toBeGreaterThan(0);
+    expect(report.metrics.factExtractionAccuracy.total).toBeGreaterThan(0);
+    expect(report.metrics.provenanceCorrectness.total).toBeGreaterThan(0);
+    expect(report.metrics.unsupportedRejectionRate.total).toBeGreaterThan(0);
+    expect(typeof report.metrics.regressionCount).toBe("number");
+    expect(rendered).toContain("Quick Check Eval Corpus:");
+    expect(rendered).toContain("Fact extraction accuracy");
+    expect(rendered).toContain("Regression count");
+  });
+});

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -1536,4 +1536,48 @@ describe("Phase 4 router integration groundwork", () => {
     expect(result.documentAnswer.explanation).toContain("ambiguous");
     expect(result.documentAnswer.evidence).toEqual([]);
   });
+
+  it("answers methodology from structured input when document has no methodology and routes via project_fact_contract", () => {
+    const DOC_WITHOUT_METHODOLOGY = [
+      "Project Title: Community Reforestation Project",
+      "Host Country: Tanzania",
+      "",
+      "2.4 Baseline Scenario",
+      "The baseline scenario is continued grazing pressure without the project.",
+    ].join("\n");
+
+    const result = buildReviewQuestionResult({
+      claimText: "What methodology is used?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: DOC_WITHOUT_METHODOLOGY,
+    });
+
+    expect(result.routerResult.route).toBe("project_fact_contract");
+    expect(result.routerResult.status).toBe("answered");
+    expect(result.routerResult.answerText).toContain("Primary methodology: VM0007");
+    expect(result.routerResult.answerText).toContain("4.2");
+    expect(result.routerResult.answerText).toContain("from structured input");
+    expect(result.routerResult.warnings).toContain("structured_input_provenance");
+  });
+
+  it("returns no_evidence for methodology question when document has no methodology and no structured input is provided", () => {
+    const DOC_WITHOUT_METHODOLOGY = [
+      "Project Title: Community Reforestation Project",
+      "Host Country: Tanzania",
+      "",
+      "2.4 Baseline Scenario",
+      "The baseline scenario is continued grazing pressure without the project.",
+    ].join("\n");
+
+    const result = buildReviewQuestionResult({
+      claimText: "What methodology is used?",
+      methodologyId: "",
+      methodologyVersion: "",
+      rawPddText: DOC_WITHOUT_METHODOLOGY,
+    });
+
+    expect(result.routerResult.status).not.toBe("answered");
+    expect(result.routerResult.answerText).not.toContain("from structured input");
+  });
 });


### PR DESCRIPTION
Phase 6 foundation is set up on `feat/qc-eval-corpus`, branched from latest main.

I added a manifest-backed corpus layer under `src/lib/quickCheck/evalCorpus/`:
- `index.ts` with schema/loading in `src/lib/quickCheck/evalCorpus/manifest.ts`
- Standard question set in `src/lib/quickCheck/evalCorpus/standardQuestions.ts`
- Metrics/report logic in `src/lib/quickCheck/evalCorpus/runner.ts`

The first real manifest lives at `tests/fixtures/quick-check/corpus/phase6-eval-corpus.json`, and the non-blocking CLI runner is wired as `npm run quickcheck:eval:corpus` through `scripts/run-quickcheck-eval-corpus.cjs` and `package.json`.

The foundation supports the requested golden annotations per fixture, represents the full standard Phase 6 question set, computes the requested metrics scaffolding, and prints a readable report. I also added a focused test at `tests/lib/quickCheckEvalCorpus.test.ts`.

This PR now includes a structured-input methodology fallback — when a PDD lacks document-extracted methodology facts, the router falls back to the methodology context provided via structured input (e.g., from sandbox configuration or user-supplied metadata) rather than returning UNCLEAR or no_evidence. The fallback carries a `structured_input_provenance` marker so consumers know the answer is not document-backed.

Regression coverage is added for the three manual-test failures:
- **Project title** (`tests/evals/quickCheckEval.test.ts` — `real_document_envira_project_title_router_contract`): proves the router answers from document-backed facts when the project title is present in the document.
- **Host country** (`real_document_envira_host_country_no_evidence`): proves the router correctly returns `no_evidence` when the host country is genuinely absent from the document.
- **Methodology structured-input** (`structured_input_methodology_fallback_warns_provenance`): proves the structured-input fallback answers with `structured_input_provenance` warning and no fabricated quotes/pages/spans.

Validation run:
- `npm test -- --runInBand tests/lib/quickCheckEvalCorpus.test.ts`
- `npm run quickcheck:eval`
- `npm test -- --runInBand tests/lib/quickCheckReviewQuestion.test.ts`
- `npm test -- --runInBand tests/lib/quickCheckDeterministicRouter.test.ts`
- `npm run quickcheck:eval:corpus`

`pr-gate` passes.

Natural next steps:
1. Add more real fixtures to the corpus manifest for broader family/table/noisy-extraction coverage.
2. Introduce stricter corpus assertions and a `--strict` CI mode in a follow-up PR.