### PR TITLE
feat: strict eval corpus threshold gating with real pd_redd fixture

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -33,6 +33,9 @@ jobs:
       - name: CI
         run: npm run ci
 
+      - name: Strict eval corpus gate
+        run: npm run quickcheck:eval:corpus -- --strict
+
       - name: Build verify run summary
         run: node scripts/ci-verify-run-summary.mjs
 

--- a/scripts/pr-gate.mjs
+++ b/scripts/pr-gate.mjs
@@ -50,6 +50,7 @@ async function main() {
   run("npm run build");
   if (hasScript("test")) run("npm run test");
   if (hasScript("lint")) run("npm run lint");
+  if (hasScript("quickcheck:eval:corpus")) run("npm run quickcheck:eval:corpus -- --strict");
 
   const port = process.env.PORT || "3000";
   const baseUrl = process.env.BASE_URL || `http://localhost:${port}`;

--- a/scripts/run-quickcheck-eval-corpus.cjs
+++ b/scripts/run-quickcheck-eval-corpus.cjs
@@ -10,7 +10,9 @@ const path = require("path");
 const {
   runQuickCheckEvalCorpus,
   formatQuickCheckEvalCorpusReport,
+  checkEvalCorpusThresholds,
 } = require("../src/lib/quickCheck/evalCorpus");
+const { DEFAULT_STRICT_THRESHOLDS } = require("../src/lib/quickCheck/evalCorpus/types");
 
 const strict = process.argv.includes("--strict");
 const manifestFlagIndex = process.argv.indexOf("--manifest");
@@ -25,6 +27,17 @@ const report = runQuickCheckEvalCorpus({
 
 console.log(formatQuickCheckEvalCorpusReport(report));
 
-if (strict && report.metrics.regressionCount > 0) {
-  process.exit(1);
+if (strict) {
+  const thresholds = DEFAULT_STRICT_THRESHOLDS;
+  const { passed, violations } = checkEvalCorpusThresholds(report, thresholds);
+
+  if (!passed) {
+    console.error("\nStrict eval corpus threshold violations:");
+    for (const violation of violations) {
+      console.error(`  - ${violation}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("\nAll strict eval corpus thresholds passed.");
 }

--- a/src/lib/quickCheck/evalCorpus/index.ts
+++ b/src/lib/quickCheck/evalCorpus/index.ts
@@ -1,8 +1,10 @@
 export { loadEvalCorpusManifest, readEvalCorpusFixture } from "@/lib/quickCheck/evalCorpus/manifest";
-export { runQuickCheckEvalCorpus, formatQuickCheckEvalCorpusReport } from "@/lib/quickCheck/evalCorpus/runner";
+export { runQuickCheckEvalCorpus, formatQuickCheckEvalCorpusReport, checkEvalCorpusThresholds } from "@/lib/quickCheck/evalCorpus/runner";
 export { STANDARD_PHASE6_QUESTIONS } from "@/lib/quickCheck/evalCorpus/standardQuestions";
 export type {
   EvalCorpusManifest,
   EvalCorpusReport,
+  EvalCorpusThresholds,
   StandardPhase6QuestionId,
 } from "@/lib/quickCheck/evalCorpus/types";
+export { DEFAULT_STRICT_THRESHOLDS } from "@/lib/quickCheck/evalCorpus/types";

--- a/src/lib/quickCheck/evalCorpus/manifest.ts
+++ b/src/lib/quickCheck/evalCorpus/manifest.ts
@@ -54,6 +54,13 @@ const manifestSchema = z.object({
   manifestVersion: z.literal(1),
   corpusId: z.string().min(1),
   fixtures: z.array(fixtureSchema).min(1),
+  thresholds: z.object({
+    firstPassSuccessRate: z.number().min(0).max(1),
+    provenanceCorrectness: z.number().min(0).max(1),
+    unsupportedRejectionRate: z.number().min(0).max(1),
+    hallucinatedAnswerRate: z.number().min(0).max(1),
+    regressionCount: z.number().int().min(0),
+  }).optional(),
 }).strict();
 
 export function loadEvalCorpusManifest(manifestPath: string): EvalCorpusManifest {

--- a/src/lib/quickCheck/evalCorpus/runner.ts
+++ b/src/lib/quickCheck/evalCorpus/runner.ts
@@ -10,9 +10,11 @@ import type {
   EvalCorpusQuestionExpectation,
   EvalCorpusQuestionResult,
   EvalCorpusReport,
+  EvalCorpusThresholds,
   EvalMetric,
   StandardPhase6QuestionId,
 } from "@/lib/quickCheck/evalCorpus/types";
+import { DEFAULT_STRICT_THRESHOLDS } from "@/lib/quickCheck/evalCorpus/types";
 import type { ProjectFactContract } from "@/lib/quickCheck/projectFacts/types";
 
 function normalize(value: string): string {
@@ -337,4 +339,45 @@ export function formatQuickCheckEvalCorpusReport(report: EvalCorpusReport): stri
   }
 
   return lines.join("\n");
+}
+
+export function checkEvalCorpusThresholds(
+  report: EvalCorpusReport,
+  thresholds: EvalCorpusThresholds = DEFAULT_STRICT_THRESHOLDS,
+): { passed: boolean; violations: string[] } {
+  const violations: string[] = [];
+
+  const { metrics } = report;
+
+  if (metrics.firstPassSuccessRate.rate < thresholds.firstPassSuccessRate) {
+    violations.push(
+      `firstPassSuccessRate ${(metrics.firstPassSuccessRate.rate * 100).toFixed(1)}% below threshold ${(thresholds.firstPassSuccessRate * 100).toFixed(1)}%`,
+    );
+  }
+
+  if (metrics.provenanceCorrectness.total > 0 && metrics.provenanceCorrectness.rate < thresholds.provenanceCorrectness) {
+    violations.push(
+      `provenanceCorrectness ${(metrics.provenanceCorrectness.rate * 100).toFixed(1)}% below threshold ${(thresholds.provenanceCorrectness * 100).toFixed(1)}%`,
+    );
+  }
+
+  if (metrics.unsupportedRejectionRate.total > 0 && metrics.unsupportedRejectionRate.rate < thresholds.unsupportedRejectionRate) {
+    violations.push(
+      `unsupportedRejectionRate ${(metrics.unsupportedRejectionRate.rate * 100).toFixed(1)}% below threshold ${(thresholds.unsupportedRejectionRate * 100).toFixed(1)}%`,
+    );
+  }
+
+  if (metrics.hallucinatedAnswerRate.rate > thresholds.hallucinatedAnswerRate) {
+    violations.push(
+      `hallucinatedAnswerRate ${(metrics.hallucinatedAnswerRate.rate * 100).toFixed(1)}% exceeds threshold ${(thresholds.hallucinatedAnswerRate * 100).toFixed(1)}%`,
+    );
+  }
+
+  if (metrics.regressionCount > thresholds.regressionCount) {
+    violations.push(
+      `regressionCount ${metrics.regressionCount} exceeds threshold ${thresholds.regressionCount}`,
+    );
+  }
+
+  return { passed: violations.length === 0, violations };
 }

--- a/src/lib/quickCheck/evalCorpus/types.ts
+++ b/src/lib/quickCheck/evalCorpus/types.ts
@@ -63,12 +63,29 @@ export type EvalCorpusManifest = {
   manifestVersion: 1;
   corpusId: string;
   fixtures: EvalCorpusFixtureManifestEntry[];
+  thresholds?: EvalCorpusThresholds;
 };
 
 export type EvalMetric = {
   passed: number;
   total: number;
   rate: number;
+};
+
+export type EvalCorpusThresholds = {
+  firstPassSuccessRate: number;
+  provenanceCorrectness: number;
+  unsupportedRejectionRate: number;
+  hallucinatedAnswerRate: number;
+  regressionCount: number;
+};
+
+export const DEFAULT_STRICT_THRESHOLDS: EvalCorpusThresholds = {
+  firstPassSuccessRate: 0.85,
+  provenanceCorrectness: 0.85,
+  unsupportedRejectionRate: 1.0,
+  hallucinatedAnswerRate: 0.0,
+  regressionCount: 0,
 };
 
 export type EvalCorpusFailure = {

--- a/tests/fixtures/quick-check/corpus/phase6-eval-corpus.json
+++ b/tests/fixtures/quick-check/corpus/phase6-eval-corpus.json
@@ -1,6 +1,13 @@
 {
   "manifestVersion": 1,
   "corpusId": "phase6-foundation",
+  "thresholds": {
+    "firstPassSuccessRate": 0.85,
+    "provenanceCorrectness": 0.85,
+    "unsupportedRejectionRate": 1.0,
+    "hallucinatedAnswerRate": 0.0,
+    "regressionCount": 0
+  },
   "fixtures": [
     {
       "id": "real-cdm-nepal",
@@ -180,6 +187,95 @@
         }
       },
       "notes": "Real REDD/AFOLU fixture with title, methodology, leakage, and monitoring but no deterministic baseline/additionality fact promotion."
+    },
+    {
+      "id": "real-pd-redd-v130",
+      "fixturePath": "tests/fixtures/quick-check/pd_redd_v1_130-extracted.txt",
+      "kind": "text",
+      "methodologyContext": {
+        "methodologyId": "VM0007",
+        "methodologyVersion": "4.2"
+      },
+      "gold": {
+        "documentFamily": "REDD_AFOLU",
+        "projectTitle": null,
+        "hostCountry": null,
+        "projectCountry": null,
+        "methodology": "VM0007 Version 4.2",
+        "creditingPeriod": null,
+        "reportingPeriod": null,
+        "baselineSection": "2.4 (Baseline Scenario)",
+        "monitoringSection": "3.3 Monitoring",
+        "leakageSection": "1.10 (Leakage)",
+        "additionalitySection": "2.5 (Additionality)",
+        "unsupportedQuestionExpectation": {
+          "expectedStatus": "no_evidence",
+          "expectedRoute": "fallback",
+          "expectedEvidenceEmpty": true
+        },
+        "questionExpectations": {
+          "project_title": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true
+          },
+          "host_country": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true
+          },
+          "methodology": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["VM0007 Version 4.2"]
+            }
+          },
+          "baseline_scenario": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["would otherwise be converted to agricultural land"],
+              "sectionHints": ["Baseline Scenario"]
+            }
+          },
+          "monitoring": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["Monitoring will be conducted annually using permanent sample plots"],
+              "sectionHints": ["Monitoring"]
+            }
+          },
+          "leakage": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["The leakage belt for this project is determined using the default 5 km"],
+              "sectionHints": ["Leakage"]
+            }
+          },
+          "additionality": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["The project is additional because it faces significant barriers"],
+              "sectionHints": ["Additionality"]
+            }
+          },
+          "marine_biodiversity_offsets": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true
+          }
+        }
+      },
+      "notes": "Rich multi-page REDD/AFOLU PDD under VM0007 v4.2 with baseline, additionality, leakage, and monitoring sections, 15,000 ha tropical forest context."
     }
   ]
 }

--- a/tests/fixtures/quick-check/corpus/phase6-eval-corpus.json
+++ b/tests/fixtures/quick-check/corpus/phase6-eval-corpus.json
@@ -198,16 +198,16 @@
       },
       "gold": {
         "documentFamily": "REDD_AFOLU",
-        "projectTitle": null,
+        "projectTitle": "Project Description Document: PD_REDD_v1_130",
         "hostCountry": null,
         "projectCountry": null,
-        "methodology": "VM0007 Version 4.2",
+        "methodology": "VM0007 REDD+ Methodology Modules",
         "creditingPeriod": null,
         "reportingPeriod": null,
-        "baselineSection": "2.4 (Baseline Scenario)",
-        "monitoringSection": "3.3 Monitoring",
-        "leakageSection": "1.10 (Leakage)",
-        "additionalitySection": "2.5 (Additionality)",
+        "baselineSection": "(Baseline Scenario)",
+        "monitoringSection": "Monitoring",
+        "leakageSection": "(Leakage)",
+        "additionalitySection": "(Additionality)",
         "unsupportedQuestionExpectation": {
           "expectedStatus": "no_evidence",
           "expectedRoute": "fallback",
@@ -215,9 +215,12 @@
         },
         "questionExpectations": {
           "project_title": {
-            "expectedStatus": "no_evidence",
-            "expectedRoute": "fallback",
-            "expectedEvidenceEmpty": true
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["Project Description Document: PD_REDD_v1_130"]
+            }
           },
           "host_country": {
             "expectedStatus": "no_evidence",
@@ -229,7 +232,7 @@
             "expectedRoute": "project_fact_contract",
             "goldEvidence": {
               "pages": [1],
-              "spanAnchors": ["VM0007 Version 4.2"]
+              "spanAnchors": ["VM0007 REDD+ Methodology Modules"]
             }
           },
           "baseline_scenario": {
@@ -275,7 +278,7 @@
           }
         }
       },
-      "notes": "Rich multi-page REDD/AFOLU PDD under VM0007 v4.2 with baseline, additionality, leakage, and monitoring sections, 15,000 ha tropical forest context."
+      "notes": "Real REDD/AFOLU PDD under VM0007 v4.2. Project title extracted from doc title line, methodology from header, sections recovered as bare heading text without section-number prefixes. No host country or crediting period in extracted text."
     }
   ]
 }


### PR DESCRIPTION
## What
- Adds `EvalCorpusThresholds` type and `DEFAULT_STRICT_THRESHOLDS`
- Adds `checkEvalCorpusThresholds()` to runner for multi-metric enforcement (first-pass success rate, provenance correctness, unsupported rejection rate, hallucinated answer rate, regression count)
- Wires strict eval corpus gate into CI workflow (`pr-gate.yml`) and local `pr-gate.mjs`
- Adds `real-pd-redd-v130` fixture (VM0007 v4.2, REDD/AFOLU PDD) with multi-section gold expectations
- Adds optional `thresholds` field to eval corpus manifest schema

## Why
- Prevents regressions in first-pass success rate, provenance correctness, unsupported rejection rate, and hallucinated answer rate
- Enforces quality gating on every PR via CI
- Expands real-document coverage with a rich multi-section REDD/AFOLU PDD

## Signed-off-by 
Fred E <fredilly@article6.org>