### PR TITLE
feat: build in-memory EvidenceSpanIndex implementation

### DIFF
--- a/src/lib/quickCheck/evidence/buildEvidenceSpanIndex.ts
+++ b/src/lib/quickCheck/evidence/buildEvidenceSpanIndex.ts
@@ -1,0 +1,190 @@
+/**
+ * First in-memory implementation of EvidenceSpanIndex.
+ *
+ * Wraps existing EvidenceDocument spans with fact-contract and
+ * section-table-index metadata to provide a unified, ranked
+ * evidence-candidate search.
+ */
+
+import type { EvidenceDocument, EvidenceSpan } from "@/lib/quickCheck/evidence/evidenceTypes";
+import type { ProjectFactContract, ProjectFactField, ProjectFactValue } from "@/lib/quickCheck/projectFacts/types";
+import type { SectionTableIndex } from "@/lib/quickCheck/indexing";
+import type {
+  EvidenceSpanCandidate,
+  EvidenceSpanIndex,
+  EvidenceSpanQuery,
+} from "@/lib/quickCheck/evidence/evidenceSpanIndex";
+
+const DEFAULT_MAX_CANDIDATES = 5;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalize(text: string): string {
+  return text.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function lexicalScore(span: EvidenceSpan, terms: string[]): number {
+  const searchText = normalize(`${span.heading ?? ""} ${span.text}`);
+  let score = 0;
+  for (const term of terms) {
+    const nt = normalize(term);
+    if (!nt) continue;
+    if (searchText.includes(nt)) {
+      score += (span.heading && normalize(span.heading).includes(nt)) ? 2 : 1;
+    }
+  }
+  return score;
+}
+
+function claimTerms(claimText: string): string[] {
+  const stopWords = new Set([
+    "does", "this", "that", "with", "from", "what", "when", "where", "which",
+    "document", "project", "describe", "explain", "check", "review", "assess",
+    "support", "include", "provide", "demonstrate", "define", "disclose",
+    "address", "discuss", "mention", "outline", "summarize", "present",
+    "about", "prove", "proved", "proven", "proving",
+    "the", "and", "for", "are", "was", "has", "its",
+  ]);
+  return normalize(claimText)
+    .split(/\s+/)
+    .filter((t) => t.length >= 3 && !stopWords.has(t));
+}
+
+function toCandidate(
+  span: EvidenceSpan,
+  score: number,
+  matchReason: EvidenceSpanCandidate["matchReason"],
+  topicTags: string[] = [],
+): EvidenceSpanCandidate {
+  return {
+    evidenceSpanId: span.spanId,
+    text: span.text,
+    pageNumbers: span.page != null ? [span.page] : [],
+    sectionPath: span.sectionPath,
+    heading: span.heading,
+    blockType: span.blockType,
+    topicTags,
+    score,
+    matchReason,
+  };
+}
+
+// ── Fact lookup ─────────────────────────────────────────────────────────────
+
+function factCandidates(
+  contract: ProjectFactContract,
+  evidenceDoc: EvidenceDocument,
+  targetFacts: string[],
+): EvidenceSpanCandidate[] {
+  const results: EvidenceSpanCandidate[] = [];
+  for (const factId of targetFacts) {
+    const field = (contract as unknown as Record<string, ProjectFactField<ProjectFactValue>>)[factId];
+    if (!field || !field.value) continue;
+    for (const spanId of field.evidenceSpanIds) {
+      const span = evidenceDoc.spans.find((s) => s.spanId === spanId);
+      if (!span) continue;
+      results.push(toCandidate(span, field.confidence === "high" ? 0.95 : field.confidence === "medium" ? 0.8 : 0.6, "fact"));
+    }
+  }
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, DEFAULT_MAX_CANDIDATES);
+}
+
+// ── Section lookup ──────────────────────────────────────────────────────────
+
+function sectionCandidates(
+  sectionTableIndex: SectionTableIndex,
+  evidenceDoc: EvidenceDocument,
+  targetSections: string[],
+): EvidenceSpanCandidate[] {
+  const results: EvidenceSpanCandidate[] = [];
+  const targetSet = new Set(targetSections);
+  for (const span of evidenceDoc.spans) {
+    if (span.reliability === "excluded") continue;
+    if (!span.sectionId) continue;
+    // Check if any section in the span's path matches a target
+    const matches = span.sectionPath.some((s) => targetSet.has(s)) || targetSet.has(span.sectionId);
+    if (!matches) continue;
+    const node = sectionTableIndex.sectionTree.nodesById[span.sectionId];
+    const topicTags = node ? [node.heading] : [];
+    results.push(toCandidate(span, 0.85, "section", topicTags));
+  }
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, DEFAULT_MAX_CANDIDATES);
+}
+
+// ── Table lookup ────────────────────────────────────────────────────────────
+
+function tableCandidates(
+  sectionTableIndex: SectionTableIndex,
+  evidenceDoc: EvidenceDocument,
+  targetTables: string[],
+): EvidenceSpanCandidate[] {
+  const results: EvidenceSpanCandidate[] = [];
+  const tableIds = new Set(targetTables);
+  for (const span of evidenceDoc.spans) {
+    if (span.reliability === "excluded") continue;
+    if (span.blockType !== "table") continue;
+    if (!span.sectionId) continue;
+    const tableEntry = sectionTableIndex.tableIndex.byEvidenceSpanId[span.spanId]
+      ?? sectionTableIndex.tableIndex.byTableId[span.sectionId];
+    if (!tableEntry || !tableIds.has(tableEntry.tableId ?? span.sectionId)) continue;
+    results.push(toCandidate(span, 0.8, "table"));
+  }
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, DEFAULT_MAX_CANDIDATES);
+}
+
+// ── Lexical lookup ──────────────────────────────────────────────────────────
+
+function lexicalCandidates(
+  evidenceDoc: EvidenceDocument,
+  query: EvidenceSpanQuery,
+): EvidenceSpanCandidate[] {
+  const terms = claimTerms(query.claimText);
+  if (terms.length === 0) return [];
+
+  const scored = evidenceDoc.spans
+    .filter((s) => s.reliability !== "excluded")
+    .filter((s) => s.blockType !== "footer" && s.blockType !== "header" && s.blockType !== "toc")
+    .map((span) => ({ span, score: lexicalScore(span, terms) }))
+    .filter((e) => e.score > 0)
+    .sort((a, b) => b.score - a.score || b.span.confidence - a.span.confidence);
+
+  const results = scored.map((e) => toCandidate(e.span, Math.min(0.7, 0.3 + e.score * 0.1), "lexical"));
+  return results.slice(0, DEFAULT_MAX_CANDIDATES);
+}
+
+// ── Build ───────────────────────────────────────────────────────────────────
+
+export function buildEvidenceSpanIndex(input: {
+  evidenceDocument: EvidenceDocument;
+  projectFactContract: ProjectFactContract;
+  sectionTableIndex: SectionTableIndex;
+}): EvidenceSpanIndex {
+  const { evidenceDocument, projectFactContract, sectionTableIndex } = input;
+
+  return {
+    query(query: EvidenceSpanQuery): EvidenceSpanCandidate[] {
+      const max = query.maxCandidates ?? DEFAULT_MAX_CANDIDATES;
+
+      // 1. Fact lookup (highest priority)
+      if (query.targetFacts && query.targetFacts.length > 0) {
+        return factCandidates(projectFactContract, evidenceDocument, query.targetFacts).slice(0, max);
+      }
+
+      // 2. Section topic lookup
+      if (query.targetSections && query.targetSections.length > 0) {
+        return sectionCandidates(sectionTableIndex, evidenceDocument, query.targetSections).slice(0, max);
+      }
+
+      // 3. Table lookup
+      if (query.targetTables && query.targetTables.length > 0) {
+        return tableCandidates(sectionTableIndex, evidenceDocument, query.targetTables).slice(0, max);
+      }
+
+      // 4. Lexical fallback
+      return lexicalCandidates(evidenceDocument, query).slice(0, max);
+    },
+  };
+}

--- a/tests/lib/quickCheck/evidenceSpanIndex.test.ts
+++ b/tests/lib/quickCheck/evidenceSpanIndex.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import { buildEvidenceSpanIndex } from "@/lib/quickCheck/evidence/buildEvidenceSpanIndex";
+import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import type { EvidenceSpanQuery } from "@/lib/quickCheck/evidence/evidenceSpanIndex";
+
+function readFixture(name: string): string {
+  return fs.readFileSync(
+    path.join(process.cwd(), "tests/fixtures/quick-check", name),
+    "utf-8",
+  );
+}
+
+describe("EvidenceSpanIndex — in-memory implementation", () => {
+  const CDM_TEXT = readFixture("bsp-nepal-activity3-cdm-excerpt.txt");
+  const ctx = getStructuredQueryContext(CDM_TEXT);
+  const index = buildEvidenceSpanIndex({
+    evidenceDocument: ctx.evidenceDocument,
+    projectFactContract: ctx.projectFactContract,
+    sectionTableIndex: ctx.sectionTableIndex,
+  });
+
+  describe("fact lookup", () => {
+    it("returns candidates for a known hostCountry fact", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "What is the host country?",
+        reviewArea: "general",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+        intent: "fact_lookup",
+        targetFacts: ["hostCountry"],
+      };
+      const results = index.query(q);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].matchReason).toBe("fact");
+      expect(results[0].text).toContain("Nepal");
+      expect(results[0].pageNumbers.length).toBeGreaterThan(0);
+    });
+
+    it("preserves provenance (page numbers, section path)", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "What is the project title?",
+        reviewArea: "general",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+        intent: "fact_lookup",
+        targetFacts: ["projectTitle"],
+      };
+      const results = index.query(q);
+      expect(results.length).toBeGreaterThan(0);
+      const c = results[0];
+      expect(c.evidenceSpanId).toBeTruthy();
+      expect(c.pageNumbers).toBeInstanceOf(Array);
+      expect(c.sectionPath).toBeInstanceOf(Array);
+      expect(c.blockType).toBeTruthy();
+      expect(c.text).toContain("Biogas");
+    });
+
+    it("returns empty for an unsupported fact", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "What is the stock price?",
+        reviewArea: "general",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+        intent: "fact_lookup",
+        targetFacts: ["projectStartDate"],
+      };
+      const results = index.query(q);
+      // CDM fixture has no projectStartDate evidence
+      expect(results.length).toBe(0);
+    });
+
+    it("sorts candidates by confidence (high > medium > low)", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "What methodology is used?",
+        reviewArea: "general",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+        intent: "fact_lookup",
+        targetFacts: ["methodologyPrimary"],
+        maxCandidates: 3,
+      };
+      const results = index.query(q);
+      // deterministic: higher score first
+      for (let i = 1; i < results.length; i++) {
+        expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+      }
+    });
+  });
+
+  describe("section lookup", () => {
+    it("returns candidates for a known section", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "What does the document say about monitoring?",
+        reviewArea: "monitoring",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+        intent: "section_topic",
+        targetSections: ["section:D.1"],
+      };
+      const results = index.query(q);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].matchReason).toBe("section");
+    });
+
+    it("preserves heading and topic tags from section", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "Explain the baseline scenario.",
+        reviewArea: "baseline",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+        intent: "section_topic",
+        targetSections: ["section:B.4"],
+      };
+      const results = index.query(q);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].topicTags.length).toBeGreaterThan(0);
+    });
+
+    it("returns empty for a non-existent section", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "test",
+        reviewArea: "general",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+        intent: "section_topic",
+        targetSections: ["section:nonexistent"],
+      };
+      expect(index.query(q)).toEqual([]);
+    });
+  });
+
+  describe("lexical lookup", () => {
+    it("finds spans containing claim keywords", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "Explain the monitoring plan.",
+        reviewArea: "monitoring",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+      };
+      const results = index.query(q);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].matchReason).toBe("lexical");
+      expect(results[0].score).toBeGreaterThan(0);
+    });
+
+    it("filters out footer, header, and toc block types", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "Explain the monitoring plan.",
+        reviewArea: "monitoring",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+      };
+      const results = index.query(q);
+      for (const c of results) {
+        expect(c.blockType).not.toBe("footer");
+        expect(c.blockType).not.toBe("header");
+        expect(c.blockType).not.toBe("toc");
+      }
+    });
+  });
+
+  describe("deterministic ordering", () => {
+    it("same query produces same results in the same order", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "What does the document say about leakage?",
+        reviewArea: "leakage",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+      };
+      const a = index.query(q);
+      const b = index.query(q);
+      expect(a).toEqual(b);
+    });
+
+    it("lexical results sort by score descending", () => {
+      const q: EvidenceSpanQuery = {
+        claimText: "monitoring",
+        reviewArea: "monitoring",
+        methodologyId: "AMS-I.E.",
+        methodologyVersion: "1.0",
+        maxCandidates: 10,
+      };
+      const results = index.query(q);
+      for (let i = 1; i < results.length; i++) {
+        expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## WHAT

First in-memory implementation of the EvidenceSpanIndex contract.

Wraps existing EvidenceDocument, ProjectFactContract, and
SectionTableIndex to provide a unified ranked evidence-candidate
search. Returns candidates only — no answer status decisions.

Supports four query modes in priority order:
1. **fact lookup** — ProjectFactContract evidence spans
2. **section lookup** — spans in target section paths
3. **table lookup** — table-type spans by table ID
4. **lexical lookup** — claim-keyword search over spans

## Tests

11 tests: fact lookup, section lookup, lexical lookup, deterministic
ordering, provenance preservation. All pass.

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>