### PR TITLE
feat: route section questions through EvidenceSpanIndex

### DIFF
--- a/src/lib/quickCheck/evidence/buildEvidenceSpanIndex.ts
+++ b/src/lib/quickCheck/evidence/buildEvidenceSpanIndex.ts
@@ -61,6 +61,7 @@ function toCandidate(
     text: span.text,
     pageNumbers: span.page != null ? [span.page] : [],
     sectionPath: span.sectionPath,
+    sectionId: span.sectionId,
     heading: span.heading,
     blockType: span.blockType,
     topicTags,

--- a/src/lib/quickCheck/evidence/evidenceSpanIndex.ts
+++ b/src/lib/quickCheck/evidence/evidenceSpanIndex.ts
@@ -22,6 +22,9 @@ export type EvidenceSpanCandidate = {
   /** Ordered section path from root to this span's section. */
   sectionPath: string[];
 
+  /** The section ID of the span (matches EvidenceSpan.sectionId). */
+  sectionId?: string;
+
   /** The heading / title of the section containing this span, if any. */
   heading?: string;
 

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -1,5 +1,6 @@
 import type { EvidenceDocument, EvidenceSpan, QuoteValidationInput } from "@/lib/quickCheck/evidence/evidenceTypes";
 import { validateQuotes } from "@/lib/quickCheck/evidence/validateQuotes";
+import { buildEvidenceSpanIndex } from "@/lib/quickCheck/evidence/buildEvidenceSpanIndex";
 import type { SectionNode, SectionTableIndex, TableCellReference, IndexedTable } from "@/lib/quickCheck/indexing";
 import type { ProjectFactContract, ProjectFactField, ProjectFactConfidence, ProjectFactValue } from "@/lib/quickCheck/projectFacts/types";
 import type { QueryIntentAnalysis, ProjectFactId } from "@/lib/quickCheck/queryIntent";
@@ -303,48 +304,56 @@ function buildFactCandidate(input: DeterministicRouterInput): RouterCandidate | 
   };
 }
 
-function selectContentSpans(document: EvidenceDocument, sectionId?: string): EvidenceSpan[] {
-  return document.spans.filter((span) => (
-    span.sectionId === sectionId
-    && span.reliability !== "excluded"
-    && span.blockType !== "section_heading"
-    && span.blockType !== "toc"
-    && span.blockType !== "footer"
-    && span.blockType !== "header"
-  ));
-}
-
 function sectionDisplay(node: SectionNode): string {
   return [node.sectionNumber, node.heading].filter(Boolean).join(" ");
 }
 
 function buildSectionCandidate(input: DeterministicRouterInput): RouterCandidate | null {
   if (!input.evidenceDocument || !input.sectionTableIndex || !input.queryIntentAnalysis) return null;
+  if (!input.projectFactContract) return null;
   if (input.queryIntentAnalysis.intent !== "section_topic") return null;
 
-  const nodes = input.queryIntentAnalysis.targetSections
-    .map((sectionId) => input.sectionTableIndex?.sectionTree.nodesById[sectionId])
-    .filter((node): node is SectionNode => Boolean(node));
-  if (nodes.length === 0) return null;
+  const targetSections = input.queryIntentAnalysis.targetSections;
+  if (!targetSections || targetSections.length === 0) return null;
 
-  const selectedNode = nodes[0];
-  const sectionSpans = selectContentSpans(input.evidenceDocument, selectedNode.sectionId).slice(0, MAX_QUOTES);
-  if (sectionSpans.length === 0) return null;
+  const index = buildEvidenceSpanIndex({
+    evidenceDocument: input.evidenceDocument,
+    projectFactContract: input.projectFactContract,
+    sectionTableIndex: input.sectionTableIndex,
+  });
+
+  const candidates = index.query({
+    claimText: input.claimText,
+    reviewArea: input.reviewArea,
+    methodologyId: "",
+    methodologyVersion: "",
+    intent: "section_topic",
+    targetSections,
+    maxCandidates: MAX_QUOTES,
+  });
+
+  if (candidates.length === 0) return null;
+
+  const best = candidates[0];
+  const node = input.sectionTableIndex.sectionTree.nodesById[targetSections[0]];
 
   return {
-    answerText: `${sectionDisplay(selectedNode)}: ${sectionSpans[0]?.text ?? selectedNode.heading}`,
+    answerText: node ? `${sectionDisplay(node)}: ${best.text}` : best.text,
     route: "section_index",
-    confidence: clampConfidence(Math.min(input.queryIntentAnalysis.confidence, selectedNode.confidence)),
-    evidenceSpanIds: dedupe(sectionSpans.map((span) => span.spanId)),
-    quoteInputs: sectionSpans.map((span) => ({
-      quote: span.text,
-      page: span.page,
-      sectionId: span.sectionId,
-      heading: span.heading,
+    confidence: clampConfidence(Math.min(
+      input.queryIntentAnalysis.confidence,
+      node?.confidence ?? best.score,
+    )),
+    evidenceSpanIds: candidates.map((c) => c.evidenceSpanId),
+    quoteInputs: candidates.map((c) => ({
+      quote: c.text,
+      page: c.pageNumbers[0],
+      sectionId: targetSections[0],
+      heading: c.heading ?? node?.heading,
     })),
     answerQuoteCount: 1,
-    pages: dedupe(sectionSpans.map((span) => span.page).filter((page): page is number => typeof page === "number")),
-    sectionPaths: dedupe([formatSectionPath(selectedNode.sectionPath)]),
+    pages: dedupe(candidates.flatMap((c) => c.pageNumbers)),
+    sectionPaths: node ? dedupe([formatSectionPath(node.sectionPath)]) : [],
     warnings: [],
     isStructuredInput: false,
   };

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -348,7 +348,7 @@ function buildSectionCandidate(input: DeterministicRouterInput): RouterCandidate
     quoteInputs: candidates.map((c) => ({
       quote: c.text,
       page: c.pageNumbers[0],
-      sectionId: c.sectionPath.length > 0 ? c.sectionPath[c.sectionPath.length - 1] : (node?.sectionId ?? targetSections[0]),
+      sectionId: c.sectionId ?? node?.sectionId ?? targetSections[0],
       heading: c.heading ?? node?.heading,
     })),
     answerQuoteCount: 1,

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -348,12 +348,15 @@ function buildSectionCandidate(input: DeterministicRouterInput): RouterCandidate
     quoteInputs: candidates.map((c) => ({
       quote: c.text,
       page: c.pageNumbers[0],
-      sectionId: targetSections[0],
+      sectionId: c.sectionPath.length > 0 ? c.sectionPath[c.sectionPath.length - 1] : (node?.sectionId ?? targetSections[0]),
       heading: c.heading ?? node?.heading,
     })),
     answerQuoteCount: 1,
     pages: dedupe(candidates.flatMap((c) => c.pageNumbers)),
-    sectionPaths: node ? dedupe([formatSectionPath(node.sectionPath)]) : [],
+    sectionPaths: dedupe([
+      ...candidates.flatMap((c) => c.sectionPath),
+      node ? formatSectionPath(node.sectionPath) : "",
+    ].filter(Boolean)),
     warnings: [],
     isStructuredInput: false,
   };

--- a/tests/evals/quickCheckEval.test.ts
+++ b/tests/evals/quickCheckEval.test.ts
@@ -777,6 +777,53 @@ describe("Phase 6 — Verra-family country and location fact routing", () => {
   });
 });
 
+describe("EvidenceSpanIndex — section routing provenance", () => {
+  const REAL_CDM_TEXT = readRootFixtureText("quick-check/bsp-nepal-activity3-cdm-excerpt.txt");
+
+  it("section_index route carries actual evidence span provenance, not just parent section ID", () => {
+    const result = buildReviewQuestionResult({
+      claimText: "What does the document say about monitoring?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
+    });
+
+    expect(result.routerResult.route).toBe("section_index");
+    expect(result.routerResult.status).toBe("answered");
+
+    // Evidence must have span IDs
+    expect(result.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+
+    // Pages must come from actual spans, not be empty
+    expect(result.routerResult.pages.length).toBeGreaterThan(0);
+
+    // Section paths must be present
+    expect(result.routerResult.sectionPaths.length).toBeGreaterThan(0);
+
+    // Quote validation must pass (no quote_validation_failed warning)
+    expect(result.routerResult.warnings).not.toContain("quote_validation_failed");
+  });
+
+  it("descendant section candidate validates correctly with its own provenance", () => {
+    // Baseline scenario (B.4) has content spans. Target the parent section
+    // and verify that the returned evidence carries the actual span's
+    // provenance, not just the parent's section ID.
+    const result = buildReviewQuestionResult({
+      claimText: "What is the baseline scenario?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
+    });
+
+    expect(result.routerResult.route).toBe("section_index");
+    expect(result.routerResult.status).toBe("answered");
+    expect(result.routerResult.quotes.length).toBeGreaterThan(0);
+
+    // No quote validation failures
+    expect(result.routerResult.warnings.filter((w) => w.includes("quote_validation"))).toEqual([]);
+  });
+});
+
 describe("Phase 6 visible-answer eval — eval corpus runner returns visible answer metrics", () => {
   it("report includes visibleAnswerGoldMatch and visibleAnswerAgreementRate", () => {
     const report = runQuickCheckEvalCorpus();

--- a/tests/evals/quickCheckEval.test.ts
+++ b/tests/evals/quickCheckEval.test.ts
@@ -4,8 +4,10 @@ import path from "path";
 import {
   buildReviewQuestionResult,
   buildReviewQuestionSectionRetrieval,
+  getStructuredQueryContext,
 } from "@/lib/chat/quickCheckReviewQuestion";
 import { getDocumentQaUiConfig } from "@/lib/quickCheck/documentQa";
+import { buildEvidenceSpanIndex } from "@/lib/quickCheck/evidence/buildEvidenceSpanIndex";
 import {
   runQuickCheckEvalCorpus,
   checkEvalCorpusThresholds,
@@ -821,6 +823,51 @@ describe("EvidenceSpanIndex — section routing provenance", () => {
 
     // No quote validation failures
     expect(result.routerResult.warnings.filter((w) => w.includes("quote_validation"))).toEqual([]);
+  });
+
+  it("candidate sectionId is passed into quote validation, not inferred from sectionPath", () => {
+    // Build the EvidenceSpanIndex directly and verify sectionId is set on candidates
+    const ctx = getStructuredQueryContext(REAL_CDM_TEXT);
+    const index = buildEvidenceSpanIndex({
+      evidenceDocument: ctx.evidenceDocument,
+      projectFactContract: ctx.projectFactContract,
+      sectionTableIndex: ctx.sectionTableIndex,
+    });
+
+    const candidates = index.query({
+      claimText: "What is the baseline scenario?",
+      reviewArea: "baseline",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      intent: "section_topic",
+      targetSections: ["section:B.4"],
+      maxCandidates: 2,
+    });
+
+    expect(candidates.length).toBeGreaterThan(0);
+    for (const c of candidates) {
+      // sectionId must be explicitly carried, not reconstructed
+      expect(c.sectionId).toBeDefined();
+      expect(typeof c.sectionId).toBe("string");
+      expect(c.sectionId!.length).toBeGreaterThan(0);
+    }
+
+    // Verify the full pipeline produces validated quotes with correct provenance
+    const result = buildReviewQuestionResult({
+      claimText: "What is the baseline scenario?",
+      methodologyId: "AMS-I.E.",
+      methodologyVersion: "1.0",
+      rawPddText: REAL_CDM_TEXT,
+    });
+
+    expect(result.routerResult.status).toBe("answered");
+    expect(result.routerResult.route).toBe("section_index");
+
+    // Evidence span IDs exist and map to actual document spans
+    for (const spanId of result.routerResult.evidenceSpanIds) {
+      const span = ctx.evidenceDocument.spans.find((s) => s.spanId === spanId);
+      expect(span).toBeDefined();
+    }
   });
 });
 


### PR DESCRIPTION
## WHAT

Route section-topic questions through EvidenceSpanIndex instead of
direct section-node content-span lookup.

Replaced `selectContentSpans` with `EvidenceSpanIndex.query()`.

## Change

- `buildSectionCandidate` now builds an EvidenceSpanIndex and
  queries it with `targetSections` from the query intent
- Removed `selectContentSpans` helper (dead code)
- Candidates preserve provenance: evidenceSpanIds, pageNumbers,
  sectionPaths, headings
- Router still validates evidence and decides final status
- Document Q&A remains presentation-only

## Tests

246 eval + 161 review question + 149 npm suites pass.
Strict eval gate passes all thresholds.

Signed-off-by: Fred Egbuedike <fredilly@article6.org>