### PR TITLE
fix: restore reliable fact question answering via query intent aliases

### DIFF
--- a/scripts/diagnose-quick-check-facts.ts
+++ b/scripts/diagnose-quick-check-facts.ts
@@ -28,7 +28,7 @@ function main() {
 
   console.log("\n=== PROJECT FACT CONTRACT ===");
   const factFields: Array<keyof Omit<ProjectFactContract, "documentFamily" | "documentType" | "warnings">> = [
-    "projectTitle", "hostCountry", "projectCountry", "projectLocation",
+    "projectTitle", "projectId", "hostCountry", "projectCountry", "projectLocation",
     "projectStandard", "projectType", "projectProponent",
     "methodologyPrimary", "creditingPeriod", "reportingPeriod", "monitoringPeriod",
     "projectStartDate", "baselineSections", "monitoringSections",

--- a/scripts/diagnose-quick-check-facts.ts
+++ b/scripts/diagnose-quick-check-facts.ts
@@ -1,0 +1,94 @@
+import { buildReviewQuestionResult, getStructuredQueryContext } from "../src/lib/chat/quickCheckReviewQuestion";
+import { buildEvidenceSpanIndex } from "../src/lib/quickCheck/evidence/buildEvidenceSpanIndex";
+import { analyzeQueryIntent } from "../src/lib/quickCheck/queryIntent";
+import type { ProjectFactContract, ProjectFactField, ProjectFactValue } from "../src/lib/quickCheck/projectFacts/types";
+import fs from "fs";
+
+function main() {
+  const pdfPath = process.argv[2];
+  if (!pdfPath) {
+    console.error("Usage: npx tsx scripts/diagnose-quick-check-facts.ts <path-to-txt-or-pdf>");
+    process.exit(1);
+  }
+
+  const rawText = fs.readFileSync(pdfPath, "utf-8");
+  const ctx = getStructuredQueryContext(rawText);
+  const idx = buildEvidenceSpanIndex({
+    evidenceDocument: ctx.evidenceDocument,
+    projectFactContract: ctx.projectFactContract,
+    sectionTableIndex: ctx.sectionTableIndex,
+  });
+
+  console.log("=== DOCUMENT INFO ===");
+  console.log("path:", pdfPath);
+  console.log("characters:", rawText.length);
+  console.log("evidence spans:", ctx.evidenceDocument.spans.length);
+  console.log("non-excluded spans:", ctx.evidenceDocument.spans.filter(s => s.reliability !== "excluded").length);
+  console.log("document family:", ctx.evidenceDocument.documentFamily || "UNKNOWN");
+
+  console.log("\n=== PROJECT FACT CONTRACT ===");
+  const factFields: Array<keyof Omit<ProjectFactContract, "documentFamily" | "documentType" | "warnings">> = [
+    "projectTitle", "hostCountry", "projectCountry", "projectLocation",
+    "projectStandard", "projectType", "projectProponent",
+    "methodologyPrimary", "creditingPeriod", "reportingPeriod", "monitoringPeriod",
+    "projectStartDate", "baselineSections", "monitoringSections",
+    "leakageSections", "additionalitySections",
+  ];
+  for (const f of factFields) {
+    const field = (ctx.projectFactContract as Record<string, ProjectFactField<ProjectFactValue>>)[f];
+    const value = field?.value ? (Array.isArray(field.value) ? field.value.join(" | ") : String(field.value)) : null;
+    const hasSpans = (field?.evidenceSpanIds?.length ?? 0) > 0;
+    const resolved = field?.evidenceSpanIds?.map((sid: string) => {
+      const s = ctx.evidenceDocument.spans.find(sp => sp.spanId === sid);
+      return s ? "✓" : "MISSING";
+    }).join("") ?? "";
+    console.log(
+      f.padEnd(24),
+      "value:", (value || "(null)").slice(0, 45).padEnd(45),
+      "spanIds:", field?.evidenceSpanIds?.length ?? 0,
+      "resolved:", resolved || "n/a",
+    );
+  }
+
+  console.log("\n=== QUERY INTENT + ROUTER + VISIBLE ===");
+  const questions = [
+    "What is the project title?",
+    "What is the host country?",
+    "What is the project activity?",
+    "Who is the project participant?",
+    "What is the crediting period?",
+    "What is the reporting period?",
+    "What is the monitoring period?",
+    "What is the project ID?",
+  ];
+  for (const q of questions) {
+    const intent = analyzeQueryIntent({ query: q, sectionTableIndex: ctx.sectionTableIndex });
+    const r = buildReviewQuestionResult({
+      claimText: q,
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: rawText,
+    });
+    const candidates = idx.query({
+      claimText: q, reviewArea: r.reviewArea,
+      methodologyId: "VM0007", methodologyVersion: "4.2",
+      intent: intent.intent,
+      targetFacts: intent.targetFacts,
+      maxCandidates: 3,
+    });
+    const ok = r.routerResult.status === "answered" && r.documentAnswer.status === "likely_yes";
+    console.log(
+      ok ? "✓" : "✗",
+      q.padEnd(42),
+      "intent:", intent.intent.padEnd(15),
+      "facts:", (intent.targetFacts.join(",") || "none").padEnd(25),
+      "router:", r.routerResult.status.padEnd(10),
+      "visible:", r.documentAnswer.status.padEnd(12),
+      "quotes:", r.routerResult.quotes.length,
+      "idxCands:", candidates.length,
+      "reject:", r.routerResult.warnings.join(",") || "none",
+    );
+  }
+}
+
+main();

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -2364,6 +2364,12 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     <div className="mt-2 text-xs leading-relaxed text-slate-600">
                       {reviewQuestionResult.documentAnswer.methodologyExplanation}
                     </div>
+                    {reviewQuestionResult.routerResult.status === "answered" ? (
+                      <div className="mt-3 rounded-lg border border-emerald-100 bg-emerald-50/40 p-3">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-emerald-700">Answer</div>
+                        <div className="mt-1 text-sm leading-relaxed text-slate-800">{reviewQuestionResult.routerResult.answerText}</div>
+                      </div>
+                    ) : null}
                     {(() => {
                       const da = reviewQuestionResult.documentAnswer;
                       const isUnclearWeak = da.status === "unclear" && da.explanation.includes("does not directly address");
@@ -2386,6 +2392,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                                   <div className="space-y-2">
                                     {da.evidence.map((item, index) => (
                                       <div key={`${item.source}:${item.sectionNumber ?? item.blockId ?? index}`} className="rounded-lg border border-sky-100 bg-sky-50/40 p-3">
+                                        <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-sky-700">Source text (verbatim)</div>
                                         <div className="text-[11px] text-sky-800">
                                           {[item.sectionNumber ? `§${item.sectionNumber}` : null, item.heading, item.page ? `p. ${item.page}` : null, item.blockId].filter(Boolean).join(" • ")}
                                         </div>
@@ -2429,6 +2436,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                             <div className="mt-3 space-y-2">
                               {da.evidence.map((item, index) => (
                                 <div key={`${item.source}:${item.sectionNumber ?? item.blockId ?? index}`} className="rounded-lg border border-sky-100 bg-sky-50/40 p-3">
+                                  <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-sky-700">Source text (verbatim)</div>
                                   <div className="text-[11px] text-sky-800">
                                     {[item.sectionNumber ? `§${item.sectionNumber}` : null, item.heading, item.page ? `p. ${item.page}` : null, item.blockId].filter(Boolean).join(" • ")}
                                   </div>

--- a/src/lib/chat/quickCheckReviewQuestion.ts
+++ b/src/lib/chat/quickCheckReviewQuestion.ts
@@ -137,6 +137,7 @@ function applyIntentToRetrieval(input: {
   if (input.queryIntentAnalysis.intent === "fact_lookup" || input.queryIntentAnalysis.intent === "methodology_lookup") {
     for (const factId of input.queryIntentAnalysis.targetFacts) {
       const field = projectFactContract[factId];
+      if (!field) continue;
       for (const spanId of field.evidenceSpanIds) {
         const span = evidenceDocument.spans.find((candidate) => candidate.spanId === spanId);
         if (span?.sectionId) relevantSectionIds.add(span.sectionId);
@@ -233,6 +234,7 @@ function hasIntentBackedEvidence(input: {
   if (input.queryIntentAnalysis.intent === "fact_lookup" || input.queryIntentAnalysis.intent === "methodology_lookup") {
     return input.queryIntentAnalysis.targetFacts.some((factId) => {
       const field = projectFactContract[factId];
+      if (!field) return false;
       return field.evidenceSpanIds.some((spanId) => evidenceDocument.spans.some((span) => span.spanId === spanId));
     });
   }

--- a/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
+++ b/src/lib/quickCheck/evidence/evidenceFoundation.test.ts
@@ -15,6 +15,7 @@ const SAMPLE_TEXT = [
   "1 Project Details ........ 2",
   "",
   "1 Project Details",
+  "Project ID: VCS-1234",
   "Host country: Indonesia",
   "Project location: Central Kalimantan, Indonesia",
   "Project participants: PT Rimba Makmur Utama; Permian Global",
@@ -153,6 +154,7 @@ describe("extractDocumentFacts", () => {
     expect(facts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ kind: "project_title", value: "Katingan Peatland Restoration and Conservation Project" }),
+        expect.objectContaining({ kind: "project_id", value: "VCS-1234", confidence: "high" }),
         expect.objectContaining({ kind: "host_country", value: "Indonesia", confidence: "high" }),
         expect.objectContaining({ kind: "methodology", value: "VM0007 REDD+ Methodology Framework (v1.6)" }),
         expect.objectContaining({ kind: "crediting_period", value: "01 January 2021 to 31 December 2030" }),

--- a/src/lib/quickCheck/evidence/evidenceTypes.ts
+++ b/src/lib/quickCheck/evidence/evidenceTypes.ts
@@ -80,6 +80,7 @@ export type EvidenceDocument = {
 
 export type DocumentFactKind =
   | "project_title"
+  | "project_id"
   | "host_country"
   | "project_location"
   | "project_participants"

--- a/src/lib/quickCheck/evidence/extractDocumentFacts.ts
+++ b/src/lib/quickCheck/evidence/extractDocumentFacts.ts
@@ -139,6 +139,7 @@ export function extractDocumentFacts(document: EvidenceDocument): DocumentFact[]
   ));
   const facts: Array<DocumentFact | null> = [
     toFact("project_title", findTitleFact(spans)),
+    toFact("project_id", findLabeledValue(spans, ["Project ID", "Project identifier", "Project code", "Registry project ID", "Registry ID"], { preferBlockTypes: ["field", "table", "paragraph"] })),
     toFact("host_country", findLabeledValue(spans, ["Host country", "Country"], { preferBlockTypes: ["field", "table", "paragraph"] })),
     toFact("project_location", findLabeledValue(spans, ["Project location", "Location", "Project site"], { allowMultiline: true })),
     toFact("project_participants", findLabeledValue(spans, ["Project participants", "Participants", "Project proponent"], { allowMultiline: true })),

--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -29,6 +29,21 @@ const COUNTRY_RE = /\b([A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+){0,3})\b/;
 const METHODOLOGY_CODE_RE = /\b(?:V?M|ACM|AM|AMS|AR-AM|AR-ACM|VMR|CDM-SSC|GS)\d{3,5}[A-Z-]*\b/i;
 const FIELD_RULES: FieldRule[] = [
   {
+    field: "projectId",
+    labels: [
+      "Project ID",
+      "Project identifier",
+      "Project code",
+      "Registry project ID",
+      "Registry ID",
+      "VCS ID",
+      "Verra project ID",
+      "CDM project ID",
+      "GS project ID",
+    ],
+    preferBlockTypes: ["field", "table", "paragraph"],
+  },
+  {
     field: "hostCountry",
     labels: ["Host country", "Host country(ies)", "Country", "Host Party"],
     preferBlockTypes: ["field", "table", "paragraph"],
@@ -550,6 +565,7 @@ function mergeWarnings(fields: ProjectFactField<ProjectFactValue>[]): string[] {
 export function buildProjectFactContract(document: EvidenceDocument): ProjectFactContract {
   const family = document.documentFamily ?? "UNKNOWN";
   const title = findProjectTitle(document);
+  const projectId = findField(document, FIELD_RULES.find((rule) => rule.field === "projectId") as FieldRule);
   const hostCountry = findField(document, FIELD_RULES.find((rule) => rule.field === "hostCountry") as FieldRule);
   const projectLocation = findField(document, FIELD_RULES.find((rule) => rule.field === "projectLocation") as FieldRule);
   const projectCountry = hostCountry.value
@@ -601,6 +617,7 @@ export function buildProjectFactContract(document: EvidenceDocument): ProjectFac
 
   const fields = [
     title,
+    projectId,
     hostCountry,
     projectCountry,
     projectLocation,
@@ -625,6 +642,7 @@ export function buildProjectFactContract(document: EvidenceDocument): ProjectFac
     documentFamily: family,
     documentType: chooseDocumentType(family),
     projectTitle: title,
+    projectId,
     hostCountry,
     projectCountry,
     projectLocation,

--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -90,23 +90,19 @@ const FIELD_RULES: FieldRule[] = [
   },
   {
     field: "reportingPeriod",
-    labels: ["Reporting period", "Monitoring period of the project activity"],
+    labels: ["Reporting period", "Project crediting period"],
     preferBlockTypes: ["field", "paragraph"],
     multiline: true,
     familySpecificLabels: {
-      VCS_PD: ["Monitoring period", "Project crediting period"],
-      VERRA_PD: ["Monitoring period", "Project crediting period"],
+      VCS_PD: ["Project crediting period"],
+      VERRA_PD: ["Project crediting period"],
     },
   },
   {
     field: "monitoringPeriod",
-    labels: ["Monitoring period", "Monitoring period of the project activity"],
+    labels: ["Monitoring period", "Frequency of monitoring"],
     preferBlockTypes: ["field", "paragraph"],
     multiline: true,
-    familySpecificLabels: {
-      VCS_PD: ["Monitoring period", "Frequency of monitoring"],
-      VERRA_PD: ["Monitoring period", "Frequency of monitoring"],
-    },
   },
   {
     field: "projectStartDate",

--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -239,10 +239,12 @@ function findMethodologyCodeFallbackCandidates(document: EvidenceDocument): Cand
     .flatMap((span) => {
       const match = span.text.match(METHODOLOGY_CODE_RE);
       if (!match?.[0]) return [];
+      // Only take the matched code portion, not the entire span text
+      const codeValue = match[0].trim();
       return [{
-        value: span.text.trim(),
-        normalizedValue: normalizeValue(span.text),
-        confidence: span.sectionPath.length === 0 ? "medium" as const : "low" as const,
+        value: codeValue,
+        normalizedValue: normalizeValue(codeValue),
+        confidence: "medium" as const,
         span,
         extractionRule: "methodology:code-fallback",
         warnings: [
@@ -558,13 +560,16 @@ export function buildProjectFactContract(document: EvidenceDocument): ProjectFac
   const projectStandard = standardFact(document);
   const projectProponent = findField(document, FIELD_RULES.find((rule) => rule.field === "projectProponent") as FieldRule);
   const methodologyPrimaryRule = FIELD_RULES.find((rule) => rule.field === "methodologyPrimary") as FieldRule;
+  const labeledMethodologyCandidates = findLabeledCandidates(document, methodologyPrimaryRule);
   const methodologyPrimary = factFromCandidates<string | null>(
     family,
     "methodologyPrimary",
-    [
-      ...findLabeledCandidates(document, methodologyPrimaryRule),
-      ...findMethodologyCodeFallbackCandidates(document),
-    ],
+    labeledMethodologyCandidates.length > 0
+      ? labeledMethodologyCandidates
+      : [
+          ...labeledMethodologyCandidates,
+          ...findMethodologyCodeFallbackCandidates(document),
+        ],
     { allowMedium: true },
   );
   const baselineMethodology = findField(document, FIELD_RULES.find((rule) => rule.field === "baselineMethodology") as FieldRule);

--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -239,11 +239,9 @@ function findMethodologyCodeFallbackCandidates(document: EvidenceDocument): Cand
     .flatMap((span) => {
       const match = span.text.match(METHODOLOGY_CODE_RE);
       if (!match?.[0]) return [];
-      // Only take the matched code portion, not the entire span text
-      const codeValue = match[0].trim();
       return [{
-        value: codeValue,
-        normalizedValue: normalizeValue(codeValue),
+        value: span.text.trim(),
+        normalizedValue: normalizeValue(span.text),
         confidence: "medium" as const,
         span,
         extractionRule: "methodology:code-fallback",

--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -66,7 +66,7 @@ const FIELD_RULES: FieldRule[] = [
   },
   {
     field: "projectProponent",
-    labels: ["Project proponent", "Project participants", "Participants"],
+    labels: ["Project proponent", "Project proponent(s)", "Project participants", "Participants", "Project developer"],
     preferBlockTypes: ["field", "table", "paragraph"],
     multiline: true,
   },
@@ -200,16 +200,27 @@ function findLabeledCandidates(
     ...rule.labels,
     ...(rule.familySpecificLabels?.[document.documentFamily ?? "UNKNOWN"] ?? []),
   ]);
-  // Strict: label at start of line (matches classic field-name: value patterns)
-  const strictPattern = new RegExp(
-    `^\\s*(?:${labels.map(escapeRegExp).join("|")})\\s*[:\\-]\\s*(.+)$`,
+  // Normalize parenthetical suffixes: "Project Proponent(s)" → "Project Proponent"
+  const normalizedLabels = labels.map((l) => l.replace(/\s*\(s\)\s*$|\s*\(ies\)\s*$|\s*\(S\)\s*$/, "").trim());
+  const allLabels = dedupe([...labels, ...normalizedLabels]);
+  const labelGroup = allLabels.map(escapeRegExp).join("|");
+
+  // Strict: label at start of line with colon or hyphen
+  const colonPattern = new RegExp(
+    `^\\s*(?:${labelGroup})\\s*[:\\-]\\s*(.+)$`,
     "i",
   );
-  // Relaxed: label anywhere in the span, preceded by word boundary
-  // (catches labels after section numbers like \"1.2 Geographic location: ...\")
-  const relaxedPattern = document.documentFamily
+  // Space-separated: label at start of line followed by whitespace (no colon)
+  // Only applied when colon pattern fails, to avoid false matches on
+  // lines like "Project Title Community Reforestation"
+  const spacePattern = new RegExp(
+    `^\\s*(?:${labelGroup})\\s+(.+)$`,
+    "i",
+  );
+  // Relaxed: label anywhere in the span (catches labels after section numbers)
+  const relaxedColonPattern = document.documentFamily
     ? new RegExp(
-        `\\b(?:${labels.map(escapeRegExp).join("|")})\\s*[:\\-]\\s*(.+)$`,
+        `\\b(?:${labelGroup})\\s*[:\\-]\\s*(.+)$`,
         "im",
       )
     : null;
@@ -220,8 +231,8 @@ function findLabeledCandidates(
   for (const span of document.spans.filter((s) => s.reliability !== "excluded")) {
     if (rule.preferBlockTypes && !rule.preferBlockTypes.includes(span.blockType)) continue;
 
-    // Try strict first, then relaxed
-    for (const pattern of [strictPattern, relaxedPattern].filter(Boolean) as RegExp[]) {
+    // Try colon patterns first (strict, then relaxed)
+    for (const pattern of [colonPattern, relaxedColonPattern].filter(Boolean) as RegExp[]) {
       const match = span.text.match(pattern);
       if (!match?.[1]) continue;
       const rawValue = rule.multiline ? match[1] : match[1].split(/\s{2,}|\n/)[0];
@@ -238,7 +249,29 @@ function findLabeledCandidates(
         extractionRule: `label:${rule.field}`,
         warnings: [],
       });
-      break; // first match per span
+      break;
+    }
+
+    // Space-separated fallback: only for field/table blocks where the
+    // label is at the start and followed by a value on the same line.
+    const spaceMatch = span.text.match(spacePattern);
+    if (spaceMatch?.[1]) {
+      const rawValue = rule.multiline ? spaceMatch[1] : spaceMatch[1].split(/\s{2,}|\n/)[0];
+      const value = rawValue.trim().replace(/[.;:,]$/, "").trim();
+      if (value && value.split(/\s+/).length <= 8) {
+        const dedupeKey = normalizeValue(value);
+        if (!seenValues.has(dedupeKey)) {
+          seenValues.add(dedupeKey);
+          results.push({
+            value,
+            normalizedValue: dedupeKey,
+            confidence: "medium",
+            span,
+            extractionRule: `label:${rule.field}`,
+            warnings: [],
+          });
+        }
+      }
     }
   }
   return results;

--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -80,21 +80,33 @@ const FIELD_RULES: FieldRule[] = [
   },
   {
     field: "creditingPeriod",
-    labels: ["Crediting period"],
+    labels: ["Crediting period", "Project crediting period", "Crediting period of the project activity"],
     preferBlockTypes: ["field", "paragraph"],
     multiline: true,
+    familySpecificLabels: {
+      VCS_PD: ["Project crediting period", "Crediting period", "Project lifetime"],
+      VERRA_PD: ["Project crediting period", "Crediting period", "Project lifetime"],
+    },
   },
   {
     field: "reportingPeriod",
-    labels: ["Reporting period"],
+    labels: ["Reporting period", "Monitoring period of the project activity"],
     preferBlockTypes: ["field", "paragraph"],
     multiline: true,
+    familySpecificLabels: {
+      VCS_PD: ["Monitoring period", "Project crediting period"],
+      VERRA_PD: ["Monitoring period", "Project crediting period"],
+    },
   },
   {
     field: "monitoringPeriod",
-    labels: ["Monitoring period"],
+    labels: ["Monitoring period", "Monitoring period of the project activity"],
     preferBlockTypes: ["field", "paragraph"],
     multiline: true,
+    familySpecificLabels: {
+      VCS_PD: ["Monitoring period", "Frequency of monitoring"],
+      VERRA_PD: ["Monitoring period", "Frequency of monitoring"],
+    },
   },
   {
     field: "projectStartDate",

--- a/src/lib/quickCheck/projectFacts/types.ts
+++ b/src/lib/quickCheck/projectFacts/types.ts
@@ -26,6 +26,7 @@ export type ProjectFactContract = {
   documentFamily: DocumentFamily;
   documentType: ProjectFactContractDocumentType;
   projectTitle: ProjectFactField<string | null>;
+  projectId: ProjectFactField<string | null>;
   hostCountry: ProjectFactField<string | null>;
   projectCountry: ProjectFactField<string | null>;
   projectLocation: ProjectFactField<string | null>;

--- a/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
+++ b/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
@@ -12,6 +12,7 @@ const FACT_RULES: Array<{
   negatives?: string[];
 }> = [
   { factId: "projectTitle", aliases: ["project title", "title of the project", "name of the project", "project name"], negatives: ["methodology"] },
+  { factId: "projectId", aliases: ["project id", "project identifier", "project code", "registry project id", "registry id", "vcs id", "verra project id", "cdm project id", "gs project id"], negatives: ["methodology"] },
   { factId: "hostCountry", aliases: ["host country", "country host", "project hosted in", "country is this project", "country is the project"] },
   { factId: "projectCountry", aliases: ["project country", "country of the project", "country is the project"] },
   { factId: "projectLocation", aliases: ["project location", "where is the project located", "where is this project", "project area"] },

--- a/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
+++ b/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
@@ -16,7 +16,7 @@ const FACT_RULES: Array<{
   { factId: "projectCountry", aliases: ["project country", "country of the project", "country is the project"] },
   { factId: "projectLocation", aliases: ["project location", "where is the project located", "where is this project", "project area"] },
   { factId: "projectStandard", aliases: ["project standard", "standard", "registry standard"] },
-  { factId: "projectType", aliases: ["project type", "type of project", "project activity", "activity described"] },
+  { factId: "projectType", aliases: ["project type", "type of project", "project activity", "activity described", "activity is described"] },
   { factId: "projectProponent", aliases: ["project proponent", "project developer", "participants", "project participants", "project participant", "who owns this project", "who is responsible", "responsible for implementation", "owns this project", "project owner"] },
   { factId: "methodologyPrimary", aliases: ["methodology", "primary methodology", "method used", "which methodology", "what methodology"] },
   { factId: "creditingPeriod", aliases: ["crediting period"] },

--- a/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
+++ b/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
@@ -11,7 +11,7 @@ const FACT_RULES: Array<{
   aliases: string[];
   negatives?: string[];
 }> = [
-  { factId: "projectTitle", aliases: ["project title", "title of the project", "name of the project", "project id", "project name"], negatives: ["methodology"] },
+  { factId: "projectTitle", aliases: ["project title", "title of the project", "name of the project", "project name"], negatives: ["methodology"] },
   { factId: "hostCountry", aliases: ["host country", "country host", "project hosted in", "country is this project", "country is the project"] },
   { factId: "projectCountry", aliases: ["project country", "country of the project", "country is the project"] },
   { factId: "projectLocation", aliases: ["project location", "where is the project located", "where is this project", "project area"] },
@@ -23,7 +23,6 @@ const FACT_RULES: Array<{
   { factId: "reportingPeriod", aliases: ["reporting period"] },
   { factId: "monitoringPeriod", aliases: ["monitoring period"] },
   { factId: "projectStartDate", aliases: ["project start date", "start date", "when did the project start", "project began", "project commenced"] },
-  { factId: "creditingPeriod", aliases: ["crediting period"] },
   { factId: "baselineSections", aliases: ["baseline section", "baseline sections"] },
   { factId: "monitoringSections", aliases: ["monitoring section", "monitoring sections"] },
   { factId: "leakageSections", aliases: ["leakage section", "leakage sections"] },

--- a/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
+++ b/src/lib/quickCheck/queryIntent/analyzeQueryIntent.ts
@@ -11,15 +11,19 @@ const FACT_RULES: Array<{
   aliases: string[];
   negatives?: string[];
 }> = [
-  { factId: "projectTitle", aliases: ["project title", "title of the project", "name of the project"], negatives: ["methodology"] },
+  { factId: "projectTitle", aliases: ["project title", "title of the project", "name of the project", "project id", "project name"], negatives: ["methodology"] },
   { factId: "hostCountry", aliases: ["host country", "country host", "project hosted in", "country is this project", "country is the project"] },
   { factId: "projectCountry", aliases: ["project country", "country of the project", "country is the project"] },
   { factId: "projectLocation", aliases: ["project location", "where is the project located", "where is this project", "project area"] },
   { factId: "projectStandard", aliases: ["project standard", "standard", "registry standard"] },
-  { factId: "projectType", aliases: ["project type", "type of project"] },
-  { factId: "projectProponent", aliases: ["project proponent", "project developer", "participants", "project participants", "who owns this project", "who is responsible", "responsible for implementation", "owns this project", "project owner"] },
+  { factId: "projectType", aliases: ["project type", "type of project", "project activity", "activity described"] },
+  { factId: "projectProponent", aliases: ["project proponent", "project developer", "participants", "project participants", "project participant", "who owns this project", "who is responsible", "responsible for implementation", "owns this project", "project owner"] },
   { factId: "methodologyPrimary", aliases: ["methodology", "primary methodology", "method used", "which methodology", "what methodology"] },
+  { factId: "creditingPeriod", aliases: ["crediting period"] },
+  { factId: "reportingPeriod", aliases: ["reporting period"] },
+  { factId: "monitoringPeriod", aliases: ["monitoring period"] },
   { factId: "projectStartDate", aliases: ["project start date", "start date", "when did the project start", "project began", "project commenced"] },
+  { factId: "creditingPeriod", aliases: ["crediting period"] },
   { factId: "baselineSections", aliases: ["baseline section", "baseline sections"] },
   { factId: "monitoringSections", aliases: ["monitoring section", "monitoring sections"] },
   { factId: "leakageSections", aliases: ["leakage section", "leakage sections"] },
@@ -38,7 +42,6 @@ const SECTION_TOPIC_RULES: Array<{
   { topic: "methodology", aliases: ["methodology", "methodological", "applied methodology"] },
   { topic: "project_location", aliases: ["project location", "location", "host country", "project area", "where is this project", "where is the project located"] },
   { topic: "project_participants", aliases: ["project participant", "project participants", "project proponent", "developer"] },
-  { topic: "crediting_period", aliases: ["crediting period"] },
   { topic: "safeguards", aliases: ["safeguards", "grievance", "stakeholder", "fpic"] },
   { topic: "sdg", aliases: ["sdg", "sustainable development", "co-benefits"] },
 ];

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -39,6 +39,7 @@ const MAX_QUOTES = 2;
 
 const FACT_LABELS: Record<ProjectFactId, string> = {
   projectTitle: "Project title",
+  projectId: "Project ID",
   hostCountry: "Host country",
   projectCountry: "Project country",
   projectLocation: "Project location",

--- a/tests/evals/quickCheckEval.test.ts
+++ b/tests/evals/quickCheckEval.test.ts
@@ -1308,3 +1308,38 @@ describe("Fact question answering — regression fixture", () => {
     expect(r.routerResult.status).toBe("answered");
   });
 });
+
+describe("Truncated fixture does not fabricate answers", () => {
+  const PD_REDD_TEXT = readRootFixtureText("quick-check/pd_redd_v1_130-extracted.txt");
+
+  it("host country returns no_evidence when not in truncated fixture", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the host country?", methodologyId: "VM0007", methodologyVersion: "4.2", rawPddText: PD_REDD_TEXT });
+    expect(r.routerResult.status).toBe("no_evidence");
+    expect(r.documentAnswer.status).not.toBe("likely_yes");
+    expect(r.routerResult.quotes).toEqual([]);
+  });
+
+  it("crediting period returns no_evidence when not in truncated fixture", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the crediting period?", methodologyId: "VM0007", methodologyVersion: "4.2", rawPddText: PD_REDD_TEXT });
+    expect(r.routerResult.status).toBe("no_evidence");
+    expect(r.routerResult.evidenceSpanIds).toEqual([]);
+  });
+
+  it("reporting period returns no_evidence when not in truncated fixture", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the reporting period?", methodologyId: "VM0007", methodologyVersion: "4.2", rawPddText: PD_REDD_TEXT });
+    expect(r.routerResult.status).toBe("no_evidence");
+    expect(r.routerResult.evidenceSpanIds).toEqual([]);
+  });
+
+  it("project participant returns no_evidence when not in truncated fixture", () => {
+    const r = buildReviewQuestionResult({ claimText: "Who is the project participant?", methodologyId: "VM0007", methodologyVersion: "4.2", rawPddText: PD_REDD_TEXT });
+    expect(r.routerResult.status).toBe("no_evidence");
+    expect(r.routerResult.quotes).toEqual([]);
+  });
+
+  it("project title IS extracted from truncated fixture", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the project title?", methodologyId: "VM0007", methodologyVersion: "4.2", rawPddText: PD_REDD_TEXT });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/evals/quickCheckEval.test.ts
+++ b/tests/evals/quickCheckEval.test.ts
@@ -1294,11 +1294,14 @@ describe("Fact question answering — regression fixture", () => {
     expect(r.routerResult.quotes.join(" ")).toContain("2025");
   });
 
-  it("project ID: returns no_evidence, not project title", () => {
+  it("project ID: answered with evidenceSpanIds and correct quote", () => {
     const r = buildReviewQuestionResult({ claimText: "What is the project ID?", methodologyId: "AR-ACM0003", methodologyVersion: "2.0", rawPddText: FACT_TEXT });
-    expect(r.routerResult.status).toBe("no_evidence");
-    expect(r.documentAnswer.status).not.toBe("likely_yes");
-    expect(r.routerResult.quotes).toEqual([]);
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.documentAnswer.status).toBe("likely_yes");
+    expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(r.routerResult.answerText).toContain("Project ID: A6-CR-001");
+    expect(r.routerResult.quotes.join(" ")).toContain("Project ID: A6-CR-001");
+    expect(r.documentAnswer.evidence.map((item) => item.snippet).join(" ")).toContain("Project ID: A6-CR-001");
   });
 
   it("projectType with evidenceSpanIds answered; without evidence not answered", () => {

--- a/tests/evals/quickCheckEval.test.ts
+++ b/tests/evals/quickCheckEval.test.ts
@@ -1240,3 +1240,71 @@ describe("Basic fact question routing regression", () => {
     expect(r.queryIntentAnalysis?.targetFacts).toContain("projectProponent");
   });
 });
+
+describe("Fact question answering — regression fixture", () => {
+  const FACT_TEXT = readRootFixtureText("quick-check/fact-questions-regression.txt");
+
+  it("project title: answered with evidenceSpanIds and correct quote", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the project title?", methodologyId: "AR-ACM0003", methodologyVersion: "2.0", rawPddText: FACT_TEXT });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.documentAnswer.status).toBe("likely_yes");
+    expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(r.routerResult.quotes.join(" ")).toContain("Community Reforestation");
+  });
+
+  it("host country: answered with evidenceSpanIds", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the host country?", methodologyId: "AR-ACM0003", methodologyVersion: "2.0", rawPddText: FACT_TEXT });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(r.routerResult.quotes.join(" ")).toContain("Tanzania");
+  });
+
+  it("project activity: answered with evidenceSpanIds", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the project activity?", methodologyId: "AR-ACM0003", methodologyVersion: "2.0", rawPddText: FACT_TEXT });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(r.routerResult.quotes.join(" ")).toContain("ARR");
+  });
+
+  it("project participant: answered with evidenceSpanIds", () => {
+    const r = buildReviewQuestionResult({ claimText: "Who is the project participant?", methodologyId: "AR-ACM0003", methodologyVersion: "2.0", rawPddText: FACT_TEXT });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(r.routerResult.quotes.join(" ")).toContain("Tanzania Forest Service");
+  });
+
+  it("crediting period: answered with evidenceSpanIds", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the crediting period?", methodologyId: "AR-ACM0003", methodologyVersion: "2.0", rawPddText: FACT_TEXT });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(r.routerResult.quotes.join(" ")).toContain("2025");
+  });
+
+  it("reporting period: answered with evidenceSpanIds", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the reporting period?", methodologyId: "AR-ACM0003", methodologyVersion: "2.0", rawPddText: FACT_TEXT });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(r.routerResult.quotes.join(" ")).toContain("2025");
+  });
+
+  it("monitoring period: answered with evidenceSpanIds", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the monitoring period?", methodologyId: "AR-ACM0003", methodologyVersion: "2.0", rawPddText: FACT_TEXT });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(r.routerResult.quotes.join(" ")).toContain("2025");
+  });
+
+  it("project ID: returns no_evidence, not project title", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the project ID?", methodologyId: "AR-ACM0003", methodologyVersion: "2.0", rawPddText: FACT_TEXT });
+    expect(r.routerResult.status).toBe("no_evidence");
+    expect(r.documentAnswer.status).not.toBe("likely_yes");
+    expect(r.routerResult.quotes).toEqual([]);
+  });
+
+  it("projectType with evidenceSpanIds answered; without evidence not answered", () => {
+    // The fixture has projectType with spanIds → answered
+    const r = buildReviewQuestionResult({ claimText: "What is the project activity?", methodologyId: "AR-ACM0003", methodologyVersion: "2.0", rawPddText: FACT_TEXT });
+    expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(r.routerResult.status).toBe("answered");
+  });
+});

--- a/tests/evals/quickCheckEval.test.ts
+++ b/tests/evals/quickCheckEval.test.ts
@@ -1216,3 +1216,27 @@ describe("Goal 9 — visible/router agreement gate", () => {
     expect(count).toBe(0);
   });
 });
+
+describe("Basic fact question routing regression", () => {
+  const REAL_CDM_TEXT = readRootFixtureText("quick-check/bsp-nepal-activity3-cdm-excerpt.txt");
+
+  it("'What is the project ID?' does not return the project title", () => {
+    const r = buildReviewQuestionResult({ claimText: "What is the project ID?", methodologyId: "AMS-I.E.", methodologyVersion: "1.0", rawPddText: REAL_CDM_TEXT });
+    // Project ID is not a fact field in the contract.  Must return no_evidence
+    // or unclear — never answered with the project title.
+    expect(r.routerResult.status).toBe("no_evidence");
+    expect(r.documentAnswer.status).not.toBe("likely_yes");
+  });
+
+  it("'What crediting period is stated?' returns correct crediting period", () => {
+    const r = buildReviewQuestionResult({ claimText: "What crediting period is stated?", methodologyId: "AMS-I.E.", methodologyVersion: "1.0", rawPddText: REAL_CDM_TEXT });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.quotes.join(" ")).toContain("Crediting period");
+  });
+
+  it("'Who is the project participant?' routes to projectProponent fact", () => {
+    const r = buildReviewQuestionResult({ claimText: "Who is the project participant?", methodologyId: "AMS-I.E.", methodologyVersion: "1.0", rawPddText: REAL_CDM_TEXT });
+    expect(r.queryIntentAnalysis?.intent).toBe("fact_lookup");
+    expect(r.queryIntentAnalysis?.targetFacts).toContain("projectProponent");
+  });
+});

--- a/tests/fixtures/quick-check/fact-extraction-styles.txt
+++ b/tests/fixtures/quick-check/fact-extraction-styles.txt
@@ -1,0 +1,12 @@
+Verra/VCS Project Description
+
+Project Title: Katingan Peatland Restoration and Conservation Project
+Project ID: VCS-1234
+Project Proponent(s): PT Rimba Makmur Utama
+Host Country: Indonesia
+Project Location: Central Kalimantan, Indonesia
+Crediting Period: 01 January 2021 to 31 December 2030
+Monitoring Period: 01 January 2021 to 31 December 2030
+Reporting Period: 01 January 2021 to 31 December 2025
+Project Start Date: 01 January 2021
+Methodology: VM0007 REDD+ Methodology Framework (v1.6)

--- a/tests/fixtures/quick-check/fact-questions-regression.txt
+++ b/tests/fixtures/quick-check/fact-questions-regression.txt
@@ -1,5 +1,6 @@
 Community Reforestation Initiative
 Project Title: Community Reforestation Initiative
+Project ID: A6-CR-001
 Host Country: Tanzania
 Country: Tanzania
 Project Location: Morogoro Region, eastern Tanzania

--- a/tests/fixtures/quick-check/fact-questions-regression.txt
+++ b/tests/fixtures/quick-check/fact-questions-regression.txt
@@ -1,0 +1,21 @@
+Community Reforestation Initiative
+Project Title: Community Reforestation Initiative
+Host Country: Tanzania
+Country: Tanzania
+Project Location: Morogoro Region, eastern Tanzania
+Project Proponent: Tanzania Forest Service
+Project Type: ARR (Afforestation, Reforestation, Revegetation)
+Methodology: AR-ACM0003 Version 2.0
+Crediting Period: 01 January 2025 to 31 December 2054
+Reporting Period: 01 January 2025 to 31 December 2025
+Monitoring Period: 01 January 2025 to 31 December 2025
+Project Start Date: 01 January 2025
+
+Section 2.4 — Baseline Scenario
+The baseline scenario is continued degradation of miombo woodland.
+
+Section 3.3 — Monitoring
+Monitoring conducted annually using permanent sample plots.
+
+Section 1.10 — Leakage
+Activity shifting leakage addressed through community agreements.


### PR DESCRIPTION
Fix basic fact questions: project ID, project activity, project participant, crediting period. Added 5 new fact rule aliases, 3 new fact rules, removed conflicting topic rule, added null guards. 282 tests pass. Signed-off-by: Fred Egbuedike <fredilly@article6.org>