### PR TITLE
fix: make Document Q&A work on real Vichada validation report

### DIFF
--- a/src/lib/chat/quickCheckSectionExtractor.ts
+++ b/src/lib/chat/quickCheckSectionExtractor.ts
@@ -3,13 +3,13 @@ const SECTION_KEY_NORMALIZE_RE = /[^\d.]/g;
 
 const CDM_KEY_RE = /^([A-Z]\.\d+(?:\.\d+)*)$/;
 
-const SECTION_HEADING_RE = /^(?:\s*(?:Section\s+)?(\d+(?:\.\d+)*)\s*[.:]?\s+(.+))\s*$/gm;
-const SECTION_HEADING_DOT_RE = /^(?:\s*(?:Section\s+)?(\d+(?:\.\d+)*)\.\s+(.+))\s*$/gm;
-const SECTION_HEADING_PAREN_RE = /^(?:\s*(?:Section\s+)?(\d+(?:\.\d+)*)\s+\((.+)\))\s*$/gm;
+const SECTION_HEADING_RE = /^(?:[ \t]*(?:Section[ \t]+)?(\d+(?:\.\d+)*)[ \t]*[.:]?[ \t]+(.+))[ \t]*$/gm;
+const SECTION_HEADING_DOT_RE = /^(?:[ \t]*(?:Section[ \t]+)?(\d+(?:\.\d+)*)\.[ \t]+(.+))[ \t]*$/gm;
+const SECTION_HEADING_PAREN_RE = /^(?:[ \t]*(?:Section[ \t]+)?(\d+(?:\.\d+)*)[ \t]+\((.+)\))[ \t]*$/gm;
 
-const SECTION_HEADING_CDM_RE = /^(?:\s*(?:Section\s+)?([A-Z]\.\d+(?:\.\d+)*)\s*[.:]?\s+(.+))\s*$/gm;
-const SECTION_HEADING_CDM_DOT_RE = /^(?:\s*(?:Section\s+)?([A-Z]\.\d+(?:\.\d+)*)\.\s+(.+))\s*$/gm;
-const SECTION_HEADING_CDM_PAREN_RE = /^(?:\s*(?:Section\s+)?([A-Z]\.\d+(?:\.\d+)*)\s+\((.+)\))\s*$/gm;
+const SECTION_HEADING_CDM_RE = /^(?:[ \t]*(?:Section[ \t]+)?([A-Z]\.\d+(?:\.\d+)*)[ \t]*[.:]?[ \t]+(.+))[ \t]*$/gm;
+const SECTION_HEADING_CDM_DOT_RE = /^(?:[ \t]*(?:Section[ \t]+)?([A-Z]\.\d+(?:\.\d+)*)\.[ \t]+(.+))[ \t]*$/gm;
+const SECTION_HEADING_CDM_PAREN_RE = /^(?:[ \t]*(?:Section[ \t]+)?([A-Z]\.\d+(?:\.\d+)*)[ \t]+\((.+)\))[ \t]*$/gm;
 
 export function normalizeSectionKey(key: string): string {
   const cleaned = key.trim();
@@ -954,7 +954,7 @@ export function findRejectedHeadingMatches(
     if (isTocTitle(candidate.title)) reasons.push("line-level TOC markers");
     if (tocBlock && isInsideTocBlock(candidate.start, tocBlock)) reasons.push("inside TOC block");
     if (!hasBodyTextAfter(cleaned, candidate.end, candidate.num)) reasons.push("no body text after heading");
-    if (reasons.length === 0) continue;
+    if (reasons.length === 0) { continue; }
 
     const title = stripTocSuffix(candidate.title);
     const normalizedTitle = normalizeHeadingTitle(title);

--- a/src/lib/quickCheck/documentQa.ts
+++ b/src/lib/quickCheck/documentQa.ts
@@ -23,40 +23,6 @@ export function buildDocumentQuestionAnswer(input: {
   queryIntentAnalysis?: QueryIntentAnalysis;
   routerResult?: DeterministicRouterResult;
 }): DocumentQuestionAnswer {
-  // Unsupported / ambiguous intents: the router correctly defers to
-  // no_evidence / unclear.  The visible answer mirrors that.
-  if (input.queryIntentAnalysis?.intent === "unsupported_or_out_of_scope" && input.queryIntentAnalysis.confidence > 0.7) {
-    return {
-      status: "unclear",
-      methodologyRuleMatched: false,
-      methodologyExplanation: "Quick Check classified this request as outside document-grounded review scope.",
-      explanation: "Quick Check classified this question as unsupported or out of scope for evidence-grounded document review.",
-      evidence: [],
-      diagnostic: {
-        reviewQuestionRoutingFired: true,
-        rawPddTextAvailable: Boolean(input.rawPddText?.trim()),
-        documentEvidenceCount: 0,
-        methodologyRuleMatched: false,
-      },
-    };
-  }
-
-  if (input.queryIntentAnalysis?.intent === "ambiguous" && input.queryIntentAnalysis.confidence > 0.45) {
-    return {
-      status: "unclear",
-      methodologyRuleMatched: false,
-      methodologyExplanation: "Quick Check found multiple plausible intent targets and did not force a retrieval path.",
-      explanation: "Quick Check classified this question as ambiguous and did not promote a single evidence path.",
-      evidence: [],
-      diagnostic: {
-        reviewQuestionRoutingFired: true,
-        rawPddTextAvailable: Boolean(input.rawPddText?.trim()),
-        documentEvidenceCount: 0,
-        methodologyRuleMatched: false,
-      },
-    };
-  }
-
   const router = input.routerResult;
   const rawPddTextAvailable = Boolean(input.rawPddText?.trim());
   const methodologyRuleMatched = Boolean(input.evaluation.reviewAreaReview);

--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -274,6 +274,39 @@ function findLabeledCandidates(
       }
     }
   }
+
+  // Heading-label fallback: when no colon/space-pattern candidates were found,
+  // look for paragraph/field spans whose heading matches a field label.
+  // This handles documents where the label is in the section heading and the
+  // value is the body text (common in validation reports).
+  //
+  // Guard: only accept body text that looks like a real value — at least one
+  // comma or at least two interior capitalised words (proper nouns / locations).
+  // This prevents generic preamble sentences from being mistaken for a value.
+  if (results.length === 0) {
+    const headingMatch = document.spans
+      .filter((s) => s.reliability !== "excluded")
+      .filter((s) => (rule.preferBlockTypes ?? ["field", "paragraph"]).includes(s.blockType))
+      .filter((s) => Boolean(s.heading) && allLabels.some((label) => s.heading!.toLowerCase() === label.toLowerCase()))
+      .sort((a, b) => (a.page ?? Number.MAX_SAFE_INTEGER) - (b.page ?? Number.MAX_SAFE_INTEGER))[0];
+    if (headingMatch) {
+      const rawValue = headingMatch.text.trim().replace(/[.;:,]$/, "").trim();
+      const commaCount = (rawValue.match(/,/g) ?? []).length;
+      const words = rawValue.split(/\s+/).filter(Boolean);
+      const interiorProperNouns = words.slice(1).filter((w) => /^[A-Z][a-z]/.test(w)).length;
+      if (rawValue && (commaCount >= 1 || interiorProperNouns >= 2)) {
+        results.push({
+          value: rawValue,
+          normalizedValue: normalizeValue(rawValue),
+          confidence: "medium",
+          span: headingMatch,
+          extractionRule: `label:${rule.field}`,
+          warnings: [],
+        });
+      }
+    }
+  }
+
   return results;
 }
 

--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -56,7 +56,7 @@ const FIELD_RULES: FieldRule[] = [
   {
     field: "projectLocation",
     labels: ["Project location", "Project site", "Location", "Geographic location", "Geographic reference"],
-    preferBlockTypes: ["field", "table", "paragraph"],
+    preferBlockTypes: ["field", "table", "paragraph", "title", "formula"],
     multiline: true,
     familySpecificLabels: {
       VCS_PD: ["Project location", "Geographic reference of the project activity", "Geographic location"],
@@ -67,13 +67,13 @@ const FIELD_RULES: FieldRule[] = [
   {
     field: "projectProponent",
     labels: ["Project proponent", "Project proponent(s)", "Project participants", "Participants", "Project developer"],
-    preferBlockTypes: ["field", "table", "paragraph"],
+    preferBlockTypes: ["field", "table", "paragraph", "title", "formula"],
     multiline: true,
   },
   {
     field: "methodologyPrimary",
     labels: ["Methodology", "Applied methodology", "Approved methodology"],
-    preferBlockTypes: ["field", "table", "paragraph"],
+    preferBlockTypes: ["field", "table", "paragraph", "title", "formula"],
     multiline: true,
     familySpecificLabels: {
       VCS_PD: ["Title and reference of methodology applied", "Methodology applied"],
@@ -84,19 +84,19 @@ const FIELD_RULES: FieldRule[] = [
   {
     field: "baselineMethodology",
     labels: ["Baseline methodology", "Applied baseline methodology"],
-    preferBlockTypes: ["field", "table", "paragraph"],
+    preferBlockTypes: ["field", "table", "paragraph", "title", "formula"],
     multiline: true,
   },
   {
     field: "monitoringMethodology",
     labels: ["Monitoring methodology", "Monitoring approach"],
-    preferBlockTypes: ["field", "table", "paragraph"],
+    preferBlockTypes: ["field", "table", "paragraph", "title", "formula"],
     multiline: true,
   },
   {
     field: "creditingPeriod",
-    labels: ["Crediting period", "Project crediting period", "Crediting period of the project activity"],
-    preferBlockTypes: ["field", "paragraph"],
+    labels: ["Crediting period", "Project crediting period", "Crediting period of the project activity", "Project Lifetime", "GHG Accounting Period", "Accounting Period"],
+    preferBlockTypes: ["field", "paragraph", "title"],
     multiline: true,
     familySpecificLabels: {
       VCS_PD: ["Project crediting period", "Crediting period", "Project lifetime"],
@@ -257,8 +257,23 @@ function findLabeledCandidates(
     const spaceMatch = span.text.match(spacePattern);
     if (spaceMatch?.[1]) {
       const rawValue = rule.multiline ? spaceMatch[1] : spaceMatch[1].split(/\s{2,}|\n/)[0];
-      const value = rawValue.trim().replace(/[.;:,]$/, "").trim();
-      if (value && value.split(/\s+/).length <= 8) {
+      // Trim trailing punctuation and drop annotations after ";" or "("
+      let value = rawValue.trim().replace(/[.;:,]$/, "").trim();
+      if (value) {
+        const semicolonIndex = value.indexOf(";");
+        const parenIndex = value.indexOf("(");
+        const cutIndex = Math.min(
+          semicolonIndex > 0 ? semicolonIndex : Infinity,
+          parenIndex > 0 ? parenIndex : Infinity,
+        );
+        if (cutIndex !== Infinity) {
+          value = value.slice(0, cutIndex).trim();
+        }
+      }
+      // Cover-table entries for multiline fields can be longer (date ranges
+      // etc).  Monoline fields keep the stricter 8-word guard.
+      const maxWords = rule.multiline ? 20 : 8;
+      if (value && value.split(/\s+/).length <= maxWords) {
         const dedupeKey = normalizeValue(value);
         if (!seenValues.has(dedupeKey)) {
           seenValues.add(dedupeKey);

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -306,11 +306,17 @@ function buildSectionCandidate(input: DeterministicRouterInput): RouterCandidate
 
   if (candidates.length === 0) return null;
 
+  // Prefer body-text spans (paragraph, field, formula) for the visible
+  // answer over heading-only spans.  Heading text ("STAKEHOLDER COMMENTS")
+  // is kept in sectionPaths / quote validation but the answer to the user
+  // should show substantive body content.
+  const bodyBlockTypes = new Set(["paragraph", "field", "formula"]);
+  const bestBody = candidates.find((c) => bodyBlockTypes.has(c.blockType)) ?? candidates[0];
   const best = candidates[0];
   const node = input.sectionTableIndex.sectionTree.nodesById[targetSections[0]];
 
   return {
-    answerText: node ? `${sectionDisplay(node)}: ${best.text}` : best.text,
+    answerText: node ? `${sectionDisplay(node)}: ${bestBody.text}` : bestBody.text,
     route: "section_index",
     confidence: clampConfidence(Math.min(
       input.queryIntentAnalysis.confidence,

--- a/tests/evals/quickCheckDocumentSmoke.test.ts
+++ b/tests/evals/quickCheckDocumentSmoke.test.ts
@@ -318,3 +318,105 @@ describe("Quick Check — Vichada validation report regression", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// PLUM / a.pdf cover-table regression
+// ---------------------------------------------------------------------------
+const PLUM_A_DOC_TEXT = fs.readFileSync(
+  path.join(FIXTURE_DIR, "a-pdf-extracted.txt"),
+  "utf-8",
+);
+
+describe("Quick Check — a.pdf / PLUM cover-table regression", () => {
+  it("project location: Indonesia, Central Kalimantan", () => {
+    const r = buildReviewQuestionResult({
+      claimText: "What is the project location?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: PLUM_A_DOC_TEXT,
+    });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.answerText).toContain("Indonesia");
+    expect(r.routerResult.answerText).toContain("Central Kalimantan");
+    expect(r.routerResult.quotes.length).toBeGreaterThan(0);
+    expect(r.routerResult.pages).toContain(1);
+    expect(r.documentAnswer.status).toBe("likely_yes");
+  });
+
+  it("crediting period: 01 August 2022 – 31 July 2082", () => {
+    const r = buildReviewQuestionResult({
+      claimText: "What is the crediting period?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: PLUM_A_DOC_TEXT,
+    });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.answerText).toContain("01 August 2022");
+    expect(r.routerResult.answerText).toContain("31 July 2082");
+    expect(r.routerResult.pages).toContain(1);
+    expect(r.documentAnswer.status).toBe("likely_yes");
+  });
+
+  it("marine biodiversity offsets: no_evidence", () => {
+    const r = buildReviewQuestionResult({
+      claimText: "What does the document say about marine biodiversity offsets?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: PLUM_A_DOC_TEXT,
+    });
+    expect(r.routerResult.status).toBe("no_evidence");
+    expect(r.routerResult.quotes).toEqual([]);
+    expect(r.documentAnswer.status).not.toBe("likely_yes");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PD_REDD_v1_130 regression
+// ---------------------------------------------------------------------------
+const PD_REDD_DOC_TEXT = fs.readFileSync(
+  path.join(FIXTURE_DIR, "pd-redd-v130-extracted.txt"),
+  "utf-8",
+);
+
+describe("Quick Check — PD_REDD_v1_130 regression", () => {
+  it("project location includes Cacheu and Cantanhez, not just the section heading", () => {
+    const r = buildReviewQuestionResult({
+      claimText: "What is the project location?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: PD_REDD_DOC_TEXT,
+    });
+    expect(r.routerResult.status).toBe("answered");
+    expect(r.routerResult.answerText).toContain("Cacheu");
+    expect(r.routerResult.answerText).toContain("Cantanhez");
+    // Must not be just the section heading: "Project Location"
+    expect(r.routerResult.answerText).not.toMatch(/^Project location: Project Location/);
+    expect(r.documentAnswer.status).toBe("likely_yes");
+  });
+
+  it("stakeholder consultation includes substantive text, not just STAKEHOLDER COMMENTS", () => {
+    const r = buildReviewQuestionResult({
+      claimText: "What does the document say about stakeholder consultation?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: PD_REDD_DOC_TEXT,
+    });
+    expect(r.routerResult.status).toBe("answered");
+    // Answer text should contain body content, not just the heading
+    expect(r.routerResult.answerText).toContain("participatory process");
+    expect(r.routerResult.answerText).not.toMatch(/^6 STAKEHOLDER COMMENTS: STAKEHOLDER COMMENTS/);
+    expect(r.documentAnswer.status).toBe("likely_yes");
+  });
+
+  it("marine biodiversity offsets: no_evidence", () => {
+    const r = buildReviewQuestionResult({
+      claimText: "What does the document say about marine biodiversity offsets?",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+      rawPddText: PD_REDD_DOC_TEXT,
+    });
+    expect(r.routerResult.status).toBe("no_evidence");
+    expect(r.routerResult.quotes).toEqual([]);
+    expect(r.documentAnswer.status).not.toBe("likely_yes");
+  });
+});

--- a/tests/evals/quickCheckDocumentSmoke.test.ts
+++ b/tests/evals/quickCheckDocumentSmoke.test.ts
@@ -181,3 +181,140 @@ describe("Quick Check raw document text smoke test", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Vichada validation report (VALID_REP_1530_31MAY2016) regression
+// ---------------------------------------------------------------------------
+const VICHADA_DOC_TEXT = fs.readFileSync(
+  path.join(FIXTURE_DIR, "vichada-validation-report-extracted.txt"),
+  "utf-8",
+);
+
+const VICHADA_METHODOLOGY = { id: "AR-ACM0003", version: "2.0" };
+
+describe("Quick Check — Vichada validation report regression", () => {
+  describe("fact questions return answered with provenance", () => {
+    it("project location: answered, evidenceSpanIds, quote, page, section provenance", () => {
+      const r = buildReviewQuestionResult({
+        claimText: "What is the project location?",
+        methodologyId: VICHADA_METHODOLOGY.id,
+        methodologyVersion: VICHADA_METHODOLOGY.version,
+        rawPddText: VICHADA_DOC_TEXT,
+      });
+      expect(r.routerResult.status).toBe("answered");
+      expect(r.routerResult.route).toBe("project_fact_contract");
+      expect(r.routerResult.quotes.length).toBeGreaterThan(0);
+      expect(r.routerResult.pages.length).toBeGreaterThan(0);
+      expect(r.routerResult.sectionPaths.length).toBeGreaterThan(0);
+      expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+      expect(r.routerResult.warnings).toEqual([]);
+      // Document Q&A derives from RouterResult
+      expect(r.documentAnswer.status).toBe("likely_yes");
+      expect(r.documentAnswer.evidence.length).toBeGreaterThan(0);
+    });
+
+    it("methodology: answered, evidenceSpanIds, quote, page, section provenance", () => {
+      const r = buildReviewQuestionResult({
+        claimText: "What methodology is used?",
+        methodologyId: VICHADA_METHODOLOGY.id,
+        methodologyVersion: VICHADA_METHODOLOGY.version,
+        rawPddText: VICHADA_DOC_TEXT,
+      });
+      expect(r.routerResult.status).toBe("answered");
+      expect(r.routerResult.route).toBe("project_fact_contract");
+      expect(r.routerResult.quotes.length).toBeGreaterThan(0);
+      expect(r.routerResult.pages.length).toBeGreaterThan(0);
+      expect(r.routerResult.sectionPaths.length).toBeGreaterThan(0);
+      expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+      expect(r.routerResult.warnings).toEqual([]);
+      expect(r.documentAnswer.status).toBe("likely_yes");
+      expect(r.documentAnswer.evidence.length).toBeGreaterThan(0);
+    });
+
+    it("crediting period: answered, evidenceSpanIds, quote, page, section provenance", () => {
+      const r = buildReviewQuestionResult({
+        claimText: "What is the crediting period?",
+        methodologyId: VICHADA_METHODOLOGY.id,
+        methodologyVersion: VICHADA_METHODOLOGY.version,
+        rawPddText: VICHADA_DOC_TEXT,
+      });
+      expect(r.routerResult.status).toBe("answered");
+      expect(r.routerResult.route).toBe("project_fact_contract");
+      expect(r.routerResult.quotes.length).toBeGreaterThan(0);
+      expect(r.routerResult.pages.length).toBeGreaterThan(0);
+      expect(r.routerResult.sectionPaths.length).toBeGreaterThan(0);
+      expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+      expect(r.routerResult.warnings).toEqual([]);
+      expect(r.documentAnswer.status).toBe("likely_yes");
+      expect(r.documentAnswer.evidence.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("section-topic questions", () => {
+    it("stakeholder consultation: answered or unclear-with-evidence, not no_evidence", () => {
+      const r = buildReviewQuestionResult({
+        claimText: "What does the document say about stakeholder consultation?",
+        methodologyId: VICHADA_METHODOLOGY.id,
+        methodologyVersion: VICHADA_METHODOLOGY.version,
+        rawPddText: VICHADA_DOC_TEXT,
+      });
+      expect(r.routerResult.status).not.toBe("no_evidence");
+      expect(["answered", "unclear"]).toContain(r.routerResult.status);
+      expect(r.routerResult.quotes.length).toBeGreaterThan(0);
+      expect(r.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+      expect(r.documentAnswer.status).not.toBe("likely_no");
+    });
+  });
+
+  describe("unsupported question refusal", () => {
+    it("marine biodiversity offsets: no_evidence, zero quotes, zero evidenceSpanIds", () => {
+      const r = buildReviewQuestionResult({
+        claimText: "What does the document say about marine biodiversity offsets?",
+        methodologyId: VICHADA_METHODOLOGY.id,
+        methodologyVersion: VICHADA_METHODOLOGY.version,
+        rawPddText: VICHADA_DOC_TEXT,
+      });
+      expect(r.routerResult.status).toBe("no_evidence");
+      expect(r.routerResult.quotes).toEqual([]);
+      expect(r.routerResult.evidenceSpanIds).toEqual([]);
+      expect(r.documentAnswer.status).not.toBe("likely_yes");
+    });
+  });
+
+  describe("Document Q&A / router agreement contract", () => {
+    it("visible status derives from RouterResult — no independent decision", () => {
+      const questions = [
+        "What is the project location?",
+        "What methodology is used?",
+        "What is the crediting period?",
+        "What does the document say about stakeholder consultation?",
+        "What does the document say about marine biodiversity offsets?",
+      ];
+      for (const q of questions) {
+        const r = buildReviewQuestionResult({
+          claimText: q,
+          methodologyId: VICHADA_METHODOLOGY.id,
+          methodologyVersion: VICHADA_METHODOLOGY.version,
+          rawPddText: VICHADA_DOC_TEXT,
+        });
+        const router = r.routerResult;
+        const da = r.documentAnswer;
+
+        // answered → likely_yes
+        if (router.status === "answered") {
+          expect(da.status).toBe("likely_yes");
+        }
+        // no_evidence → unclear
+        if (router.status === "no_evidence") {
+          expect(da.status).toBe("unclear");
+        }
+        // unclear → unclear
+        if (router.status === "unclear") {
+          expect(da.status).toBe("unclear");
+        }
+        // never likely_no (dead code — should never be produced)
+        expect(da.status).not.toBe("likely_no");
+      }
+    });
+  });
+});

--- a/tests/fixtures/quick-check/a-pdf-extracted.txt
+++ b/tests/fixtures/quick-check/a-pdf-extracted.txt
@@ -1,0 +1,983 @@
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 1
+PLUM PROJECT
+Document Prepared By PT Pagatan Usaha Makmur
+Project Title PLUM Peat and Mangrove Conservation and Restoration Project (PLUM
+Project)
+Version 1.0
+Date of Issue 23-February-2024
+Project Location Indonesia, Central Kalimantan
+Project Proponent(s)
+PT Pagatan Usaha Makmur
+Contact: Mr. Handoko Limaho
+Email: info@plumproject.id
+Telephone: +62-21-39502295
+Prepared By PT Pagatan Usaha Makmur
+Validation Body
+Earthood Services Private Limited
+Contact: Mr. Kaviraj Sinh
+Email: info@earthood.in
+Telephone: +91-124-4204599
+Project Lifetime 01 August 2022 – 31 July 2082; 60-year lifetime
+GHG Accounting
+Period 01 August 2022 – 31 July 2082; 60-year total period
+History of CCB
+Status Combined validation with VCS
+Gold Level Criteria
+Gold Level for Climate Change Adaptation Benefits (GL1), Exceptional
+Benefits for Community (GL2) and Biodiversity (GL3)
+GL1: The project will implement activities that increase the resilience of
+local communities and biodiversity to climate change, including activities
+for livelihood diversification and habitat conservation and restoration.
+GL2: A total of 13 villages adjacent to the project area are included as the
+target beneficiaries of this project, including six villages classified as
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 3
+Table of Contents
+1 Summary of Project Benefits .......................................................................................................... 11
+1.1 Unique Project Benefits .............................................................................................................. 11
+1.2 Standardized Benefit Metrics ...................................................................................................... 12
+2 General .............................................................................................................................................. 16
+2.1 Project Goals, Design and Long-Term Viability .......................................................................... 16
+2.2 Without-project Land Use Scenario and Additionality................................................................. 54
+2.3 Stakeholder Engagement ........................................................................................................... 57
+2.4 Management Capacity ................................................................................................................ 67
+2.5 Legal Status and Property Rights ............................................................................................... 74
+3 Climate ............................................................................................................................................... 81
+3.1 Application of Methodology......................................................................................................... 81
+3.2 Quantification of GHG Emission Reductions and Removals .................................................... 104
+3.3 Monitoring ................................................................................................................................. 174
+3.4 Optional Criterion: Climate Change Adaptation Benefits .......................................................... 185
+4 Community ...................................................................................................................................... 202
+4.1 Without-Project Community Scenario ....................................................................................... 202
+4.2 Net Positive Community Impacts .............................................................................................. 214
+4.3 Other Stakeholder Impacts ....................................................................................................... 222
+4.4 Community Impact Monitoring .................................................................................................. 223
+4.5 Optional Criterion: Exceptional Community Benefits ................................................................ 223
+5 Biodiversity ..................................................................................................................................... 228
+5.1 Without-Project Biodiversity Scenario....................................................................................... 228
+5.2 Net Positive Biodiversity Impacts.............................................................................................. 245
+5.3 Offsite Biodiversity Impacts ...................................................................................................... 248
+5.4 Biodiversity Impact Monitoring .................................................................................................. 248
+5.5 Optional Criterion: Exceptional Biodiversity Benefits ................................................................ 250
+6 Appendices ..................................................................................................................................... 254
+Appendix 1: Remote Sensing Approach and Land Cover Classification Reports ................................ 254
+Appendix 2: Biomass Report ................................................................................................................ 254
+Appendix 3: Proxy Deforestation Report .............................................................................................. 254
+Appendix 4: NPV Calculation ............................................................................................................... 254
+Appendix 5: FPIC Consultation Report................................................................................................. 254
+Appendix 6: SOC Tidal Wetland Calculation ........................................................................................ 254
+Appendix 7: AFOLU Non-permanence Risk Report ............................................................................. 254
+Appendix 8: Baseline Emissions Calculation........................................................................................ 254
+Appendix 9: Project Emissions Calculation .......................................................................................... 254
+Appendix 10: Net VCU Calculation....................................................................................................... 254
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 11
+1 SUMMARY OF PROJECT BENEFITS
+The PLUM Peat and Mangrove Conservation and Restoration Project (PLUM Project) is a conservation
+and restoration project of peat and mangrove forests located in Central Kalimantan Province, Indonesia.
+The project is implemented on a forest concession with Forest Utilization Business License held by PT
+Pagatan Usaha Makmur (PT PUM) for 60 years, covering a total area of 23,665 hectares. Prior to PT PUM
+receiving its principal PBPH license in 20221, the project area was planned to be developed as an oil palm
+plantation along with two other companies adjacent to the area.
+The project is expected to have a range of climate, community and biodiversity benefits by preserving and
+restoring the integrity of the Peat Swamp and Mangrove Forest landscape and the rich biodiversity in the
+area while improving the well-being of local communities. In terms of climate benefits, it is estimated the
+PLUM Project will result in net emissions reductions and removals of 69,999,940 tCO2e over 60 years of
+crediting period. This will be achieved through activities covered by the VM0007 REDD+ Methodology
+Framework including (1) Avoiding Planned Deforestation (APD), (2) Afforestation, Reforestation and
+Revegetation (ARR), (3) Restoration of Wetlands Ecosystems (RWE) on Peatland and Tidal Wetlands, and
+(4) Avoiding Planned Wetland Degradation (APWD) on Peatland and Tidal Wetlands. Additionally, the
+project will deliver Climate Change Adaptation Benefits by increasing the resilience of local communities
+and biodiversity to climate change.
+The project meets the CCB criteria for Exceptional Community Benefits. There are 13 villages within the
+project zone and over 50% of villagers are below the national poverty line of IDR 2,120,371/month per
+household. Furthermore, six of the 13 villages in the project zone are underdeveloped villages. These six
+villages are the main target of the project’s community development programs. The project activities will
+target the most vulnerable communities within the project zone, improve access to health services and
+provide fair and just employment opportunities. The project activities will provide a positive impact on
+communities’ livelihoods and well-being.
+The project also meets the CCB criteria for Exceptional Biodiversity Benefits. PT PUM’s ecosystems are
+home to 31 globally threatened species with three Critically Endangered (CR) species (i.e., Bornean
+orangutan), eight Endangered (EN) species (i.e., Proboscis monkey, Bornean white-bearded gibbon), and
+20 Vulnerable (VU) species. Furthermore, the project area is home to restricted range species that can only
+be seen on Kalimantan Island including four endemic mammals and one endemic bird. The project activities
+will contribute to the conservation of these species and their habitat, and restore the degraded peatland
+and mangroves to improve the habitat quality and reduce the threats to biodiversity.
+1.1 Unique Project Benefits
+Outcome or Impact Estimated by the End of Project Lifetime Section
+Reference
+1) A total of 21,010 ha peatland will be conserved and restored through peat rewetting
+(e.g., canal blocking) and fire prevention and management activities. This effort will allow
+degraded areas to recover and hence provide suitable habitats for key species. In
+addition, negative health impacts from fire smoke and haze to local communities will be
+reduced.
+2.1.11,
+3.2.2
+1 Principal license granted to PT PUM by the Ministry of Investment since 1 August 2022 (Decision of the Head of
+Investment Coordination No.01082211116206001), followed by the definitive license on November 27th, 2023.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 16
+2 GENERAL
+2.1 Project Goals, Design and Long-Term Viability
+2.1.1 Summary Description of the Project (G1.2)
+The PLUM Peat and Mangrove Conservation and Restoration Project (PLUM Project) is a conservation
+and restoration project of peat and mangrove forests located in Central Kalimantan Province, Indonesia.
+The project is implemented on a 23,665-hectare forest concession with Forest Utilization Business License,
+held by PT Pagatan Usaha Makmur (PT PUM) for 60 years. The project will implement activities to conserve
+and restore the peat and mangrove forests in the project area while delivering positive impact on the
+community and biodiversity. Among others, the project will implement forest patrols, fire prevention, and
+biodiversity monitoring activities to prevent forest loss and protect biodiversity. Peat ecosystems will be
+restored by blocking canals and rewetting the area to avoid further peat drainage. Approximately 15,088
+ha of degraded land will be restored through reforestation and Assisted Natural Regeneration (ANR).
+The eastern part of the project is a peatland forest area located in Katingan Regency, Katingan Kuala Sub-
+district, adjacent to the Sebangau National Park. The western part of the concession is located in East
+Kotawaringin Regency, Pulau Hanaut Sub-district, and mostly consists of mangrove forests (Map 2-1).
+Based on the conducted biodiversity assessment, the concession provides important habitat for 31
+threatened species, including the Bornean orangutan, the Proboscis monkey, and the Bornean white-
+bearded gibbon. The area is also important for at least 17 migratory bird species from three families.
+The project will provide tangible benefits to local communities living in the surrounding area by working to
+improve local livelihoods, health, education, and well-being. For example, the project will assist local coffee
+farmers and honey producers to improve harvesting, processing, and market access. The project will
+support the establishment of women’s groups in the target villages to promote economic opportunities for
+women; and implement interventions that improve health and sanitation in the 13 target villages.
+Prior to PT PUM receiving its principal PBPH license in 2022, the project area was planned to be developed
+as an oil palm plantation along with two other companies adjacent to the area. All three companies were
+owned by a company group named PT Agro Inti Semesta (PT AIS). Additionally, in 2022, an approval to
+convert forest land into oil palm plantation was given to another oil palm company located along the western
+boundary of PT PUM. Without the PLUM Project, it is highly likely that PT PUM’s area would have been
+developed into an oil palm plantation by PT AIS.
+The project will generate GHG emission reductions or removals by implementing activities covered by the
+VM0007 REDD+ Methodology Framework including (1) Avoiding Planned Deforestation (APD), (2)
+Afforestation, Reforestation and Revegetation (ARR), (3) Restoration of Wetlands Ecosystems (RWE) on
+Peatland and Tidal Wetlands, and (4) Avoiding Planned Wetland Degradation (APWD) on Peatland and
+Tidal Wetlands. It is estimated that the project will generate a total net Verified Carbon Unit (VCU) volume
+of 69,999,940 tCO2e over 60 years of crediting period or 1,166,666 tCO2e per annum (Table 3-44).
+The project’s goal is to conserve the remaining forest, restore ecosystem function, protect biodiversity, and
+improve the well-being of communities to become resilient to climate change. In conclusion, it is expected
+that the PLUM Project will contribute to preserving the integrity of the Peat Swamp and Mangrove Forest
+landscape and biodiversity in the area while improving the well-being of local communities.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 30
+ha of rice areas that were excluded from the project area in consultation with local stakeholders27. This
+project area (23,153.75 ha) is where the project activities aim to generate net climate benefits. The project
+zone is defined as the project area plus the surrounding area where the project activities directly affect land
+and associated resources, including activities related to the provision of livelihood improvement and
+community development. This project zone covers 75,280.54 ha of land (Map 2-7). The project zone
+boundary was determined based on village administrative boundaries (13 villages) and exclusion of
+conservation/protection areas (e.g., national park, protection forest, other ecosystem restoration
+concession).
+Map 2-7. Project area (red polygon) and project zone (purple polygon) of the PLUM Project
+27 The final license document refers to 23,665 ha. However, conservatively the area of 23,631.51 ha is used which
+refers to the approved coordinates for the principal license. The project area is 23,153.75 ha excluding 467.68 ha of
+SIMURP rice area and approximately 10 ha of rice area in the western part of the project.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 35
+Stakeholder Description Role in the Project
+Katingan Hulu Unit
+XVII
+forest areas or is dominated by production forest
+areas.
+Bogor Agricultural
+University (IPB)
+State-owned agricultural university based in
+Bogor, Indonesia
+Support – as academic
+institution
+Palangkaraya
+University
+State-owned university located in Palangkaraya,
+Central Kalimantan
+Support – as academic
+institution
+Borneo Nature
+Foundation
+Not-for-profit wildlife and biodiversity
+conservation and research organization that
+protects and safeguards tropical rainforests and
+the environment in Borneo.
+Support – as non-profit
+conservation organization
+Dompet Dhuafa Health focused NGO Support – as non-profit
+organization
+PT Best Agro Oil palm company Business
+PT Katingan Mujur
+Sejahtera
+Oil palm company Business
+PT Katingan Sawit
+Bersama
+Oil palm company Business
+PT Persada Era
+Agro Kencana
+Oil palm company Business
+PT Pulang Pisau
+Antang Perkasa
+Oil palm company Business
+PT Trubus Bumi
+Sejahtera
+Oil palm company Business
+2.1.10 Sectoral Scope and Project Type
+This project belongs to Sectoral Scope 14 for ‘Agriculture, Forestry, and Other Land-Use (AFOLU)’. The
+project comprises REDD (APD) and ARR activities on peatland and tidal wetland as defined in VM0007
+(Version 1.6). PLUM Project activities covered by the VM0007 include (1) Avoiding Planned Deforestation
+(APD), (2) Afforestation, Reforestation and Revegetation (ARR), (3) Restoration of Wetlands Ecosystems
+(RWE) on Peatland and Tidal Wetlands, and (4) Avoiding Planned Wetland Degradation (APWD) on
+Peatland and Tidal Wetlands.
+The project is not a grouped project.
+2.1.11 Project Activities and Theory of Change (G1.8)
+The project aims to reduce emissions from planned deforestation and forest degradation while providing
+tangible climate, community, and biodiversity benefits. The area is directly threatened by the potential
+conversion to commercial oil palm plantation, which was successfully halted by the project. A portion of the
+project area is in a degraded condition due to historical logging, peatland drainage, and forest fires. Low
+community welfare surrounding the project area due to various causes, such as limited livelihood
+opportunities and low land productivity, have also indirectly threatened the integrity of the area through
+community agriculture expansion and illegal logging.
+In the baseline scenario, the existence of commercial oil palm plantation in the area may provide some
+livelihood opportunities for the communities. However, it will not address the other issues currently faced
+by the communities, such as the limited access to health care services and education, limited livelihood
+opportunities and marketing of agricultural products, climate change, land degradation, and low water
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 81
+3 CLIMATE
+3.1 Application of Methodology
+3.1.1 Title and Reference of Methodology
+The methodology title and reference are the approved VCS Methodology VM0007 REDD+ Methodology
+Framework (REDD+ MF), v.1.6, 8 September 2020.
+The tools applied by the project are: 1) the VT0001 Tool for the Demonstration and Assessment of
+Additionality in AFOLU Project Activities, v.3.0, 1 February 2012 (T-ADD); 2) the Agriculture, Forestry, and
+Other Land Use (AFOLU) Non-Permanence Risk Tool (NPRT), v.4.2, 12 October 2023 (T-BAR); 3) Tool
+for testing significance of GHG emissions in A/R CDM project activities (T-SIG) v.0.1.
+3.1.2 Applicability of Methodology
+The project applies the latest version of VCS Methodology VM0007 (Version 1.6 dated 08 September 2020)
+also called ‘REDD+ MF’ together with applicable pre-framed modules and tools. The modules were selected
+based on the PLUM Project activities covered by the VM0007 including (1) Avoiding Planned Deforestation
+(APD), (2) Afforestation, Reforestation and Revegetation (ARR), (3) Restoration of Wetlands Ecosystems
+(RWE) on Peatland and Tidal Wetlands, and (4) Avoiding Planned Wetland Degradation (APWD) on
+Peatland and Tidal Wetlands. All applicability conditions of the VM0007 (REDD+ MF) and its associated
+modules/tools are met by the project.
+Table 3-1. Analysis of applicability conditions for the VM0007 methodology.
+No Module Applicability Condition Comment
+1 REDD+ MF
+Version 1.6,
+Section 4.2,
+All Project
+Activities
+All land areas registered under the
+CDM or under any other GHG
+program (both voluntary and
+compliance oriented) must be
+transparently reported and excluded
+from the project area. The exclusion
+of land in the project area from any
+other GHG program must be
+monitored over time and reported in
+the monitoring reports.
+Condition met, no part of the project
+area is under any CDM or any other
+GHG program (either voluntary or
+compliance
+oriented).
+2 REDD+ MF
+Version 1.6,
+Section 4.3.1,
+All REDD
+Activity Types
+Land in the project area has qualified
+as forest (following the definition used
+by VCS) for at least the 10 years prior
+to the project start date.
+Condition met. Land use records
+indicate that all land subject to REDD
+project activities in the project area is
+covered by tropical forest on peatland
+and has qualified as such under the
+applicable definition for at least 10
+years.
+3 REDD+ MF
+Version 1.6,
+Section 4.3.1,
+All REDD
+Activity Types
+If land within the project area is
+peatland or tidal wetlands and
+emissions from the SOC pool is
+deemed significant, the relevant WRC
+modules (see Table 3) must be
+applied alongside other relevant
+modules.
+Condition met. All relevant WRC
+modules have been applied to
+estimate emissions from peat
+soils.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 82
+No Module Applicability Condition Comment
+4 REDD+ MF
+Version 1.6,
+Section 4.3.1,
+All REDD
+Activity Types
+Baseline deforestation and forest
+degradation in the project area fall
+within one or more of the following
+categories: Unplanned deforestation
+(VCS category AUDD), Planned
+Deforestation/ degradation (VCS
+category APD), Degradation through
+extraction of wood for fuel (fuelwood
+and charcoal production) (VCS
+category AUDD)
+Condition met. Baseline deforestation
+falls in the category of APD. The
+project area does not include any
+significant unplanned deforestation or
+forest degradation and is not modelled
+in either the baseline of the project
+scenario.
+5 REDD+ MF
+Version 1.6,
+Section 4.3.1,
+All REDD
+Activity Types
+Leakage avoidance activities must not
+include: Agricultural lands that are
+flooded to increase production (e.g.,
+rice paddy) Intensifying livestock
+production through use of feed lots 10
+and/or manure lagoons.
+Condition met. The project does not
+promote either establishment of
+agriculture on flooded land or
+intensification of livestock production.
+6 REDD+ MF
+Version 1.6,
+Section 4.3.3,
+Avoiding
+Planned
+Deforestation/
+Degradation
+Avoiding planned
+deforestation/degradation activities
+are applicable under the following
+condition: Where conversion of forest
+lands to a deforested condition must
+be legally permitted.
+Condition met. See baseline scenario
+7 REDD+ MF
+Version 1.6,
+Section 4.4,
+ARR
+The project area is non-forest land or
+land with degraded forest.
+Condition met. See baseline scenario
+8 REDD+ MF
+Version,
+Section 4.4,
+ARR
+In strata with drained organic soil,
+ARR activities must be combined with
+rewetting.
+Condition met. The project scenario
+includes rewetting activities.
+9 REDD+ MF
+Version 1.6,
+Section 4.4,
+ARR
+ARR activities are not eligible if the
+project scenario involves the
+application of nitrogen fertilizers.
+Condition met. The project does not
+involve the application of any
+fertilizers.
+10 REDD+ MF
+Version 1.6,
+Section 4.4,
+ARR
+Where project activities on wetlands
+are excluded by the applicability
+conditions of applied modules or
+tools, these can be disregarded for
+the purpose of their use within this
+methodology, as quantification
+procedures for the peat soil are
+provided in modules BL-PEAT and M-
+PEAT.
+Condition met. The project applies
+modules BL-PEAT and M-PEAT
+alongside all modules related to ARR.
+11 REDD+ MF
+Version 1.6,
+Section 4.5.1,
+All WRC
+Activity Types
+WRC activities are not eligible under
+the
+following conditions:
+> Project activities lower the water
+table, unless the project converts
+open water to tidal wetlands, or
+improves the hydrological connection
+to impounded waters.
+> Changes in hydrology do not result
+in the accumulation or maintenance of
+Condition met. The project activities do
+not lower the water table, hydrological
+connection of the peatland does not
+lead to increase of emissions outside
+of the project area and do not include
+burning of organic soil, and does not
+include the use of fertilizers.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 83
+No Module Applicability Condition Comment
+SOC stock, noting that a) this pertains
+to projects that intend to sequester
+carbon through sedimentation and/or
+vegetation development and b) this
+does not pertain to projects that
+increase salinity to reduce CH4
+emissions.
+> Projects that aim to decrease CH4
+emissions through increased salinity
+must account for any changes in SOC
+stocks.
+> Hydrological connectivity of the
+project area with adjacent areas leads
+to a significant increase in GHG
+emissions outside the project area.
+> Project activities include the burning
+of organic soil. Nitrogen fertilizer(s),
+such as chemical fertilizer or manure,
+are applied in the project area during
+the project crediting period.
+12 REDD+ MF
+Version 1.6,
+Section 4.5.2,
+RWE Project
+Activities
+General
+For RWE project activities, prior to the
+project start date, the project area
+must meet the following conditions:
+The area is free of any land use that
+could be displaced outside the project
+area, as demonstrated by at least one
+of the following, where relevant:
+• The project area has been
+abandoned for two or more years
+prior to the project start date; or
+• Use of the project area for
+commercial purposes (i.e., trade) is
+not profitable as a result of salinity
+intrusion, market forces, or other
+factors. In addition, timber harvesting
+in the baseline scenario within the
+project area does not occur; or
+• Degradation of additional wetlands
+for new agricultural/aquacultural sites
+within the country will not occur or is
+prohibited by enforced law.
+OR
+b) The area is under a land use that
+could be displaced outside the project
+area, although in such case, baseline
+emissions from this land use must not
+be accounted for, and where
+degradation of additional wetlands for
+new agricultural/aquacultural sites
+within the country will not occur or is
+prohibited by enforced law.
+OR
+Condition met. The project will
+continue at a similar or greater level of
+service or production during the project
+crediting period as the concession is
+under a Forest Utilization Business
+License (PBPH). The license is valid
+until the end of the project crediting
+period. In line with the granted license,
+the project will develop a long-term
+and annual management plan
+(RKU/RKT) which will include
+restoration of wetland ecosystem in the
+project area.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 174
+3.3 Monitoring
+3.3.1 Data and Parameters Available at Validation
+Data / Parameter ∆CBSL,planned
+Data unit t CO2e
+Description Net greenhouse gas emissions in the baseline from planned
+deforestation
+Equation 3, 14
+Source of data Module BL-PL
+Value applied N/A
+Justification of choice of
+data or description of
+measurement methods
+and procedures applied
+See Module BL-PL, among others the module is applicable for
+estimating the baseline emissions on forest lands (usually privately
+or government owned) that are legally authorized and documented
+to be converted to non-forest land.
+Purpose of data Calculation of baseline emissions
+Comments N/A
+Data / Parameter ∆CBSL-ARR
+Data unit t CO2e
+Description Net GHG removals in the ARR baseline scenario up to year t*
+Equation 5
+Source of data Module BL-ARR
+Value applied N/A
+Justification of choice of
+data or description of
+measurement methods
+and procedures applied
+See Module BL-ARR, among others the project scenarios
+involving the harvesting of trees are excluded from this module.
+Purpose of data Calculation of baseline emissions
+Comments N/A
+Data / Parameter GHGBSL-PEAT
+Data unit t CO2e
+Description Net GHG emissions in the WRC baseline scenario up to year t*
+Equation 6, 7
+Source of data Module BL-PEAT
+Value applied N/A
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 175
+Justification of choice of
+data or description of
+measurement methods
+and procedures applied
+See Module BL-PEAT, among others this module applies to the
+baseline scenario of WRC project activities on peatlands that are
+expected to be or remain (partly) drained in the absence of the
+project activity.
+Purpose of data Calculation of baseline emissions
+Comments N/A
+Data / Parameter GHGBSL-TW
+Data unit t CO2e
+Description Net GHG emissions in the WRC baseline scenario up to year t*
+Equation 6, 7
+Source of data Module BL-TW
+Value applied N/A
+Justification of choice of
+data or description of
+measurement methods
+and procedures applied
+See Module BL-TW, among others this module applies to the
+baseline scenario of WRC project activities on tidal wetlands that
+are expected to be or remain (partly) drained in the absence of the
+project activity.
+Purpose of data Calculation of baseline emissions
+Comments N/A
+3.3.2 Data and Parameters Monitored
+Data/Parameter ∆CWPS-REDD
+Data Unit t CO2e
+Description Net GHG emissions in the REDD project scenario up to year t*
+Equation 2
+Source of data Module M-REDD
+Description of
+measurement methods
+and procedures to be
+applied
+Applicable to monitoring ex-post emissions and removals of GHGs
+due to avoiding planned deforestation and forest degradation, and
+carbon stock enhancement that has been induced as a result of
+REDD project implementation within the project area and leakage
+belt and as a result of natural disturbances
+Frequency of
+monitoring/recording
+See Module M-REDD (Every 10 years (when the project baseline
+must be revisited) or every five years where conditions trigger
+more frequent baseline renewal)
+Value applied N/A
+Monitoring equipment Tool T-SIG
+QA/QC procedures to be
+applied See Module M-REDD
+Purpose of Data Calculation of project emissions
+Calculation method See Module M-REDD
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 176
+Comments N/A
+Data/Parameter ∆CWPS-ARR
+Data Unit t CO2e
+Description Net GHG emissions in the ARR project scenario up to year t*
+Equation 5
+Source of data Module M-ARR
+Description of
+measurement methods
+and procedures to be
+applied
+See Module M-ARR
+Frequency of
+monitoring/recording
+See Module M-ARR
+Value applied N/A
+Monitoring equipment See Module M-ARR
+QA/QC procedures to be
+applied
+See Module M-ARR
+Purpose of Data Calculation of project emissions
+Calculation method See Module M-ARR
+Comments N/A
+Data/Parameter GHGWPS-PEAT
+Data Unit t CO2e
+Description Net GHG emissions in the WRC project scenario up to year t*
+Equation 6
+Source of data Module M-PEAT
+Description of
+measurement methods
+and procedures to be
+applied
+See Module M-PEAT
+Frequency of
+monitoring/recording
+See Module M-PEAT
+Value applied N/A
+Monitoring equipment See Module M-PEAT
+QA/QC procedures to be
+applied
+See Module M-PEAT
+Purpose of Data Calculation of project emissions
+Calculation method See Module M-PEAT
+Comments N/A
+Data/Parameter GHGWPS-TW
+Data Unit t CO2e
+Description Net GHG emissions in the WRC project scenario up to year t*
+Equation 6
+Source of data Module M-TW
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 177
+Description of
+measurement methods
+and procedures to be
+applied
+See Module M-TW
+Frequency of
+monitoring/recording
+See Module M-TW
+Value applied N/A
+Monitoring equipment See Module M-TW
+QA/QC procedures to be
+applied
+See Module M-TW
+Purpose of Data Calculation of project emissions
+Calculation method See Module M-TW
+Comments N/A
+Data/Parameter Frequency of patrol activities
+Data Unit Number of activities per year
+Description Record of the number of patrol activities carried out in the project
+area and leakage belt during the monitoring period.
+Equation N/A
+Source of data Patrol reports
+Description of
+measurement methods
+and procedures to be
+applied
+To be established
+Frequency of
+monitoring/recording
+To be established
+Value applied N/A
+Monitoring equipment N/A
+QA/QC procedures to be
+applied
+N/A
+Calculation method N/A
+Comments N/A
+Data/Parameter Monitoring of forest cover by high-resolution satellite imagery
+Data Unit Number of activities per year
+Description Presentation of monitoring reports on land cover and land cover
+changes through high resolution satellite images.
+Equation N/A
+Source of data Forest cover monitoring reports
+Description of
+measurement methods
+and procedures to be
+applied
+High-resolution satellite data obtained through reliable and valid
+data sources, will be analyzed in order to examine the forest
+coverage monitoring data in the project area and leakage belt. To
+identify changes in land use in the monitored area, the data from
+the examined periods will be automatically categorized and
+visually interpreted.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 178
+Frequency of
+monitoring/recording
+To be established
+Value applied N/A
+Monitoring equipment Geographical Information System (GIS) and Remote Sensing
+(RS) including the variety of tools, will be selected to support
+monitoring processes
+QA/QC procedures to be
+applied
+Precision target of >90% confidence interval at +/-10% of mean.
+>90% [Overall Classification Accuracy = ‘Number of Pixels
+Classified Correctly’ divided by ‘Total Number of Classified
+Pixels’].
+Resolution (satellite imagery): <= 30 meter (m). Selection of
+Remote sensing instruments are, amongst others: Landsat,
+Resourcesat-1, Sentinel-1, Sentinel-2, JERS-1, ALOS/PALSAR,
+SPOT, Rapid Eye, PlanetLab.
+Cloud cover <10% during 12-month period.
+Calculation method N/A
+Comments N/A
+3.3.3 Monitoring Plan
+Climate impacts will be monitored in accordance with Appendix 13: Monitoring Plan, which includes land
+cover change monitoring, fire monitoring (e.g., hotspots, burnt areas), peat water table and subsidence
+monitoring following the requirements under VCS VM0007 methodology. The project will use both remote
+sensing approach and field data measurement for monitoring climate impacts. The monitoring plan outlines
+the indicators to be monitored, monitoring frequency, and data collection method.
+3.3.3.1 Remote Sensing
+Remote sensing approach will be used to monitor land cover change and burnt areas (if any fire incidences
+occur within the project area) and will be conducted annually. Satellite imageries with resolution of ≤ 30
+meters (e.g., PlanetLab, Sentinel-1, Sentinel-2, ALOS/PALSAR, etc.) with cloud cover <10% will be used.
+Land cover change analysis will follow the procedures set out in Appendix 1: Remote Sensing Approach
+and Land Cover Classification Reports. Any deforested areas within the project area and project zone will
+be groundtruthed by the field team by directly visiting the location and/or using drones if the location is
+inaccessible. Overall classification accuracy is targeted at >90%.
+Leakage monitoring in this project is undertaken to address the risk that deforestation activities are
+displaced elsewhere. By focusing on a specific identified actor, namely PT AIS, the project applies a
+targeted approach that draws on historical information and present circumstances and practices to
+demonstrate low potential for project-induced leakage.
+Additionally, a robust and diversified monitoring strategy is implemented by the project as a commitment to
+transparency and environmental integrity, as follows:
+• Remote Sensing: Satellite imagery tracking land cover changes across the project area and project
+zone to provide a general view of possible changes in land use patterns indicative of leakage.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 179
+• GLAD Alerts: The incorporation of the Global Land Analysis & Discovery system to provide near-
+real-time deforestation alert data, a tool that helps in rapid identification of unexpected changes to
+forest cover and enables prompt investigation and response.
+• Ground Truthing: Regular field visits shall be undertaken to verify remote sensing and alert data to
+ensure accuracy for detection and attribution of leakage to actual activities or developments.
+These sources of information are gathered and analyzed each time a new verification event occurs, with a
+special focus on the production, changes in the water table, and new oil palm developments. This integrated
+approach not only meets the specifications of the VMD0009 LK-ASP module but also serves to further build
+the project’s capacity in monitoring any potential leakage and responding appropriately, hence delivering
+on its commitment to reducing deforestation and the related climate impact.
+The project’s approach to monitoring tidal wetlands adopts a comprehensive strategy to effectively curb
+GHG emissions. By combining direct measurements of GHG flux through both chamber methods with water
+quality evaluations for nutrients and dissolved carbon, this method offers a robust analysis of environmental
+health. The use of remote sensing technology, such as satellite imagery and drone surveys, provides
+detailed insights into the dynamics of the wetland, including changes in vegetation and shoreline changes.
+Ground evaluations further contribute by assessing the vegetation and soil’s carbon storage potential.
+Monitoring the hydrological aspects, such as water table levels and the impact of tides, is fundamental for
+understanding how water movements influence emission trends. This integrated system ensures that the
+project can enhance the wetland’s capacity for carbon capture while keeping GHG releases to a minimum.
+3.3.3.2 Field Data Measurement
+3.3.3.2.1 AGB C Stock
+To monitor the C stock within the project area, the project will establish 20 permanent vegetation/biomass
+plots in the same locations that were used for the baseline assessment. The plots will be monitored annually
+for tree growth (DBH). To estimate the C stock from DBH, we will use the same allometric equations that
+were used when determining the baseline AGB C stock74.
+For ARR activities, the project will establish new plots that will represent the areas of ARR (including ANR)
+activities for both mangrove and peat ARR. DBH will be the main parameter measured in the field and
+species specific allometric equations will be used to estimate the C stock (in accordance with the species
+that will be planted). Field measurement will be conducted annually. In addition, the project will create a
+logbook that records the number of seedlings planted by species, survival rate, DBH, and height for active
+planting activities.
+74 PT PUM’s Biomass Carbon Stock Assessment Report.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 180
+Map 3-10. Planned location of permanent vegetation plots
+3.3.3.2.2 Fire Hotspots and Burnt Areas
+The project will develop a Fire Danger Rating System (FDRS) to serve as an early warning system of fire
+risk in the project area. Automatic Weather Stations (AWS) will be installed on the ground to collect climate
+data that correlate with fire risk (e.g., temperature, precipitation, soil moisture, and peat water level) and
+these data will be supplied into the FDRS to calculate the Peat Fire Vulnerability Index (PFVI). The FDRS
+will then provide a 7-day forecast of fire risk in the project area. The FDRS will categorize the fire risk based
+on PFVI’s value as Safe / Alert / Dangerous / Extreme.
+In the field, the project will monitor fire hotspots through daily monitoring from fire watch tower and fire
+prevention patrols during the dry season when the FDRS rates the fire risk as Alert / Dangerous / Extreme.
+In addition, the project also monitors fire hotspots from NASA’s Fire Information for Resource Management
+System (FIRMS). FIRMS provides near real-time active fire data within three hours of satellite observation
+from the MODIS and VIIRS instruments. The fire patrol team will verify fire hotspots on the ground by
+directly visiting the location and/or using drone if the location is inaccessible.
+Burnt areas within the project area will be mapped and calculated using remote sensing approach with
+high-resolution satellite imagery within one month of fire incidences with detailed procedure listed in the
+Standard Operational Procedure document for Prevention and Management of Forest and Land Fire
+(please refer to Appendix 12: List of SOPs). Areas with repeated burning will be analyzed using historical
+burning records. GHG emissions from biomass and peat burning will be calculated annually following the
+E-BPB module.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 181
+3.3.3.2.3 Peat Water Table and Subsidence
+The project plans to install 352 dipwells and 13 subsidence poles along the planned canal blocks in the
+project area to monitor peat water level and peat subsidence. However, the numbers of monitoring stations
+may be adjusted depending on field conditions. Peat water level will be measured automatically (daily) or
+manually (weekly), while peat subsidence will be monitored manually every three months.
+The project implements a detailed approach to monitor peat water levels and subsidence, crucial for
+evaluating its impact on peatland conservation and carbon sequestration. Through both automatic (daily)
+and manual (weekly) measurements of water levels, as well as quarterly manual checks of peat subsidence,
+it captures essential data on hydrology and land stability. This is followed by data analysis on peat water
+levels and subsidence to provide further understanding of this influential factor on greenhouse gas (GHG)
+emissions. Water-level fluctuations in peat, in fact, determine the rate of decomposition. Generally, low
+water levels imply more decomposition, hence higher emissions of GHGs. Equally, peat subsidence data
+provide information on the long-term stability in the peat and also the storage of carbon in peatland.
+Summed with other data points, the project can then very accurately infer GHG emissions from peat
+decomposition in tropical peatlands.
+3.3.3.2.4 GHG Emissions
+The project is exploring future installation of greenhouse gas (GHG) monitoring equipment aimed at
+providing long-term data on atmospheric GHG flux in peatlands, including carbon dioxide (CO2), methane
+(CH4), among others. Atmospheric monitoring of GHG flux enhances the understanding on the
+sequestration of carbon from the atmosphere by vegetation and its subsequent integration into the soils.
+The project may leverage atmospheric-based monitoring, potentially employing GHG flux towers, in
+collaboration with Hyphen Global AG to further these objectives.75
+75 Hyphen Global AG is a Switzerland-based climate tech company pioneering science driven digital MRV by way of
+precision emissions validation through real-time atmospheric greenhouse gas (GHG) monitoring. Atmospheric-based
+methodologies for monitoring these processes receive international endorsement from authoritative bodies such as the
+Intergovernmental Panel on Climate Change (IPCC), the United Nations Framework Convention on Climate Change
+(UNFCCC), and the World Meteorological Organization (WMO). These endorsements underscore the peer-reviewed
+accuracy of measured sequestration data obtained through atmospheric monitoring.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 182
+Map 3-11. Planned location of canal blocks, dip-wells and subsidence poles
+Table 3-45 Monitoring Indicators
+No Monitoring Indicator Remote Sensing Field Data Monitoring Frequency
+1 Land Cover Change ● ● Annually
+2 Shoreline Change ● ● Annually
+3 AGB C Stock ● Annually
+4 Fire Hotspots and Burnt
+Areas
+● ● Daily during the dry season,
+burnt areas analysis within one
+month of incidence
+5 Peat Water Table ● Daily (automatic)/ weekly
+(manual)
+6 Peat Subsidence ● Every three months
+3.3.3.3 Data Management
+The procedures for data management, internal auditing and QA/QC are described in Figure 3-7 below.
+Please also refer to Section 2.3.8 and Figure 2-4 on the project’s adaptive management.
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 183
+Figure 3-7. Data management process
+The project will also adopt the Spatial Monitoring and Reporting Tool (SMART) Patrol System76 to digitize
+the process of field data collection (including data for Community and Biodiversity) and therefore minimizing
+the risk of human error in manual data entry. The SMART Patrol Mobile application will be installed on
+tablets or smartphones that will be used by the field staff for data collection. The SMART Patrol Desktop
+application will serve as the main database of all field data.
+To avoid non-conformances with the monitoring plan, the project has developed and will develop SOPs at
+each level (e.g., field data collection, data management, data analysis, etc.). A list of available SOPs and
+planned SOPs that will be developed is available in Appendix 12: List of SOPs. A copy of SOPs can be
+provided to the validator upon request. All project staff will be trained to follow procedures in accordance
+with the SOPs and will continuously be supervised. The project will also implement multiple QA/QC at
+various levels. All of the data collected, entered, uploaded, and analyzed are subject to review and approval
+by the Coordinator or Manager or Expert or Director (depending on the level) to ensure that the SOPs are
+correctly followed (Figure 3-7). In addition, the project also adopts adaptive management principle (please
+refer to Section 2.3.8) and will regularly evaluate the implementation of monitoring procedures and make
+improvements when required.
+The following table provides the list of monitoring team members, responsibilities, and competencies.
+76 https://smartconservationtools.org/
+
+CCB & VCS PROJECT DESCRIPTION:
+CCB Version 3, VCS Version 3
+CCB v3.0, VCS v3.3 184
+Table 3-46. Monitoring team members
+No Name / Position Responsibilities Competencies
+1 TBD / Technical Director Oversee and provide technical
+advice on all processes, final
+QA/QC of technical analysis and
+emissions calculation
+Please refer to Section 2.1.4
+2 TBD / GIS-Remote
+Sensing Manager
+Supervise SOPs development,
+remote sensing and GIS analyses
+QA/QC
+Please refer to Section 2.1.4
+3 Imanuddin Utoro / RSO
+Manager
+Supervise SOPs development,
+field data analysis QA/QC
+Please refer to Section 2.4.3
+4 TBD / Carbon Expert Develop carbon models, calculate
+emissions from monitoring data
+analyses results
+Please refer to Section 2.1.4
+5 Vanny Milenia / GIS-
+Remote Sensing Analyst
+Development of SOPs, spatial
+field data QA/QC, perform remote
+sensing and GIS analyses
+Please refer to Section 2.4.3
+6 Larissa D Salaki / Senior
+RSO Officer
+Development of SOPs, field data
+QA/QC, field data analysis,
+progress tracking
+Please refer to Section 2.4.3
+7 Andreina Triyantari / RSO
+Officer
+Development of SOPs, field data
+QA/QC, field data analysis,
+progress tracking
+Please refer to Section 2.4.3
+8 Siti Nadia / RSO Officer Development of SOPs, field data
+QA/QC, field data analysis,
+progress tracking
+Please refer to Section 2.4.3
+9 Soni Budiawan / Site
+Manager
+Field data QA/QC Please refer to Section 2.4.3
+10 Pandji A. Fauzan /
+Biodiversity & Forest
+Protection Coordinator
+Assist and supervise field staff on
+field data collection and entry,
+field data QA/QC, field data
+upload
+Please refer to Section 2.4.3
+11 Field Staff Field data collection, field data
+entry
+Various, please refer to
+Section 2.4.1
+RSO = Restoration and Sustainability
+3.3.4 Dissemination of Monitoring Plan and Results (CL4.2)
+There are three types of stakeholders involved in the project, namely government, local communities, and
+business entities. For all stakeholders, the summary of project documents, including monitoring plan and
+results, will be shared and given access to through regular coordination, printed documents at the project
+offices and village information boards, and online resources through Verra and the project website
+(www.plumproject.id).
+Specifically for communities, the project documents will be shared through village meetings and village
+information boards. Regular communication will occur during the project lifetime, as the project will closely
+involve the community in the project activities and monitoring. Formally, at least two village meetings will
+be conducted annually to disseminate project activities updates and reports.

--- a/tests/fixtures/quick-check/pd-redd-v130-extracted.txt
+++ b/tests/fixtures/quick-check/pd-redd-v130-extracted.txt
@@ -1,0 +1,8930 @@
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 1
+COMMUNITY BASED AVOIDED
+DEFORESTATION PROJECT IN
+GUINEA-BISSAU
+Project Title Community Based Avoided Deforestation Project in Guinea-Bissau
+Version 01.13
+Date of Issue 13-October-2020
+Prepared By Henrique de A. Pereira
+Joana de Melo
+Tanya Yudelman-Bloch
+Contact hpereira@waycarbon.com - +55 31 9188 1400
+joana.lx.bm@gmail.com - +351 911 217 283
+tyudelmanbloch@worldbank.org - +1 202 352 8842
+Acknowledgements:
+The project team would like to thank the teams of Winrock International (Dr. Tim Person and Felipe
+Casarim) and IICT (Dr. Maria Vasconcelos and Dr. João Carreiras) for their technical support.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 2
+Table of Contents
+1 Project Details .................................................................................................................................. 4
+1.1 Summary Description of the Project ....................................................................................... 4
+1.2 Sectoral Scope and Project Type ........................................................................................... 5
+1.3 Project Proponent ................................................................................................................... 5
+1.4 Other Entities Involved in the Project ...................................................................................... 5
+1.5 Project Start Date .................................................................................................................... 6
+1.6 Project Crediting Period .......................................................................................................... 6
+1.7 Project Scale and Estimated GHG Emission Reductions or Removals ................................. 6
+1.8 Description of the Project Activity ........................................................................................... 7
+1.9 Project Location ...................................................................................................................... 8
+1.10 Conditions Prior to Project Initiation ...................................................................................... 10
+1.11 Compliance with Laws, Statutes and Other Regulatory Frameworks .................................. 17
+1.12 Ownership and Other Programs ........................................................................................... 20
+1.12.1 Right of Use .................................................................................................................. 20
+1.12.2 Emissions Trading Programs and Other Binding Limits .............................................. 21
+1.12.3 Other Forms of Environmental Credit .......................................................................... 21
+1.12.4 Participation under Other GHG Programs ................................................................... 22
+1.12.5 Projects Rejected by Other GHG Programs ................................................................ 22
+1.13 Additional Information Relevant to the Project ...................................................................... 22
+2 Application of Methodology ........................................................................................................... 24
+2.1 Title and Reference of Methodology ..................................................................................... 24
+2.2 Applicability of Methodology ................................................................................................. 25
+2.3 Project Boundary................................................................................................................... 27
+2.4 Baseline Scenario ................................................................................................................. 32
+2.5 Additionality ........................................................................................................................... 34
+2.6 Methodology Deviations ........................................................................................................ 39
+3 Quantification of GHG Emission Reductions and Removals......................................................... 46
+3.1 Baseline Emissions ............................................................................................................... 46
+3.1.1 Collection of Appropriate Data Sources ....................................................................... 46
+3.1.2 Mapping of Historical Land-Use and Land-Cover change ........................................... 48
+3.1.3 Map accuracy assessment ........................................................................................... 53
+3.1.4 Estimation of the annual areas of unplanned baseline deforestation .......................... 54
+3.1.5 Estimation of carbon stocks and carbon stock changes .............................................. 57
+3.2 Project Emissions.................................................................................................................. 67
+3.3 Leakage ................................................................................................................................ 77
+3.4 Net GHG Emission Reductions and Removals .................................................................... 85
+3.4.1 Estimation of VCS buffer .............................................................................................. 87
+3.4.2 Uncertainty analysis ..................................................................................................... 90
+4 Monitoring ...................................................................................................................................... 90
+4.1 Data and Parameters Available at Validation ....................................................................... 91
+4.2 Data and Parameters Monitored ........................................................................................... 94
+4.3 Monitoring Plan ................................................................................................................... 125
+4.3.1 Revision of the Baseline ............................................................................................. 128
+4.3.2 Monitoring of Actual Carbon Stock Changes and GHG Emissions ........................... 132
+4.3.3 Monitoring of Leakage Carbon Stock Changes ......................................................... 137
+4.3.4 Updating forest carbon stock estimated ..................................................................... 139
+5 Environmental Impact .................................................................................................................. 145
+6 Stakeholder Comments ............................................................................................................... 146
+APPENDIX 1: Non-permanence Risk report ........................................................................................ 150
+1 Internal Risk ................................................................................................................................. 150
+2 External Risks .............................................................................................................................. 153
+3 Natural Risks ............................................................................................................................... 156
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 3
+4 Overall Non-Permanence Risk Rating and Buffer Determination ............................................... 157
+4.1 Overall Risk Rating ............................................................................................................. 157
+4.2 Calculation of Total VCUs ................................................................................................... 157
+APPENDIX 2: Wood density Information ............................................................................................. 158
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 4
+1 PROJECT DETAILS
+1.1 Summary Description of the Project
+The objective of the project is to avoid deforestation of the forest areas situated within two
+National Parks in the Republic of Guinea Bissau (GB), thus reducing carbon emissions and
+contributing to the protection of these globally important biodiversity sites. Cacheu Mangrove
+Forest National Park is located in the administrative region of Cacheu, São Domingos and
+Cacheu sectors, encompasses 28.052 inhabitants in 23 villages/tabancas (INEC, 2007) and
+comprises a total area of 74,700 hectares. It was created with the objective of protecting the
+most relevant patches of mangrove in the northern part of GB, which are located around the
+Cacheu River estuary. The other predominant vegetation cover types in this region are open
+forest and palm groves. Cantanhez Forest National Park, with an area of 106,500 hectares, is
+located in the administrative region of Tombali, covering the Bedanda sector and
+encompasses 22.505 inhabitants in 111 villages/tabancas (INEC, 2007). Cantanhez forests
+represent the last remaining patches of primary sub-humid forest, which form part of a larger
+area that extends to the south, into neighboring Guinea Conakry. Terrestrial vegetation in the
+Cantanhez Park consists of patches of dense mature forest in a mosaic of patches of
+secondary forests, as the result of the cultivation and fallow stages of shifting agricultural
+practices. Mangroves cover a large proportion of the area of the park, particularly to the south
+and western regions, on the margins of the Cumbijã River.
+Underlying causes of deforestation in the project area include mainly unsustainable land use
+practices related to agricultural extensification by the local community. From 2005-2011, the
+World Bank, Global Environment Facility (GEF), and European Commission (EC) provided
+support to the Government of Guinea Bissau to protect large areas of coastal mangrove and
+forests through the Coastal and Biodiversity Management Project (CBMP). The CBMP efforts
+led to the creation of the Institute for Biodiversity and Protected Areas of Guinea-Bissau
+(IBAP) and the establishment of a financial instrument called the Fund for Local Environmental
+Initiatives (FIAL). The CBMP also assisted in the establishment of a protected area network,
+including Cacheu and Cantanhez National Parks, which are managed by IBAP.
+However, the CBMP, which provided the bulk of the funding for both the investment and
+operating costs for these parks, closed on March 2011. Two follow-on projects financed by the
+GEF and the World Bank over two and four years, respectively, are providing US$2.95 million
+in short term, stopgap financing for the basic operating costs of the protected area network
+while more sustainable financing is identified. Given the country’s extreme poverty, the
+Government will not be able to finance the ongoing management of these parks from the
+national budget. There is a real risk, therefore, that IBAP will not have the necessary financing
+to continue to protect these areas.
+The proposed REDD project, seeks to enable Guinea Bissau to support the work of IBAP and
+to provide additional tangible financial benefits to the participating communities. Without the
+carbon financing, the parks will not be able to guarantee the protection of the forests they
+contain and the rate of deforestation will accelerate. The project is expected to reduce an
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 5
+annual average of 90,330 tCO2e totaling 1,806,617 tCO2e in the first crediting period (20
+years).
+1.2 Sectoral Scope and Project Type
+Scope 14. AFOLU: Reduced Emissions from Deforestation and Degradation (REDD)
+Project Category: Activities that reduce emissions from unplanned deforestation (AUDD)
+1.3 Project Proponent
+Organization name Instituto da Biodiversidade e das Áreas Protegidas da República da
+Guiné-Bissau – IBAP
+Contact person Alfredo Simão da Silva
+Title General Director
+Address Av. Dom Settimio Arturro Ferrazzetta C.P. 70
+Bissau, República da Guiné Bissau
+Telephone +245 20 71 06/7
+Email alfredo.simao.dasilva@iucn.org
+1.4 Other Entities Involved in the Project
+Organization name The World Bank
+Role in the project Project preparation support
+Contact person Liba Feldblyum
+Title Task Team Leader, AFTN3
+Address 1818 H Street, NW
+Washington, DC 20433
+Telephone +1 202 458-4391
+Email Lfeldblyum@worldbank.org
+Organization name BioGuinea Foundation
+Role in the project Project implementation partner
+Contact person Paul R. Siegel
+Title Founding Board Member
+Address 2-6 Cannon Street
+London, England
+EC4M 6YH
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 6
+Telephone
+Email psiegel42@gmail.com
+1.5 Project Start Date
+31/March/2011
+This date corresponds to the closure of the CBMP.
+1.6 Project Crediting Period
+The Project Crediting Period is 20 years and can be renewed at most four times.
+Start Date: 31/March/2011 – End Date: 30/March/2031
+Baseline must be revised every 10 years. Next baseline revision to be carried on 31st of
+December 2021.
+1.7 Project Scale and Estimated GHG Emission Reductions or Removals
+Project x
+Large project
+Years Estimated GHG emission
+reductions or removals (tCO2e)
+2013 75,290
+2014 153,923
+2015 235,897
+2016 321,215
+2017 409,874
+2018 501,876
+2019 597,221
+2020 695,908
+2012 797,937
+2022 903,308
+2023 978,599
+2024 1,057,231
+2025 1,139,206
+2026 1,224,523
+2027 1,313,183
+2028 1,405,185
+2029 1,500,529
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 7
+2030 1,599,216
+2031 1,701,245
+2032 1,806,617
+Total estimated ERs 1,806,617
+Total number of crediting years 20
+Average annual ERs 90,330
+1.8 Description of the Project Activity
+The REDD project activity will support the long term conservation of the mangrove and
+terrestrial forests of two National Parks of high biodiversity relevance that would otherwise be
+unable to be financed. The project is not located within a jurisdiction covered by a
+jurisdicational REDD+ program. The REDD Project, through the sale of carbon credits, will
+provide sustainable and stable flow of funds to IBAP and, through FIAL, to the participating
+communities for the continued operation of Cacheu and Cantanhez National Parks.
+IBAP is the project proponent and the institution in charge of operating and managing this
+REDD initiative. Amongst other responsibilities, IBAP will run all on-the-ground activities,
+provide technical support for communities, operate the micro-finance mechanism (FIAL),
+organize the park committee meetings and monitor the REDD project.
+The protected area sustainability strategy rests on securing sustainable financing streams for
+the long term. The country is in the process of establishing the BioGuinea Foundation, a
+private, non-profit institution with public utility to help secure this objective. It is envisioned that
+this Foundation will, over time, gradually build up an endowment fund sufficient to provide
+sustainable financing for managing the country’s parks and biodiversity in perpetuity.
+According to the World Bank, operating a modestly staffed and equipped system for IBAP and
+the existing 5 National Parks in Guinea-Bissau would cost an estimated USD 1.0 million p.a,
+implying an optimal endowment fund for the Foundation of some USD 20.0 million 1. This
+REDD activity is a key element of that strategy. Therefore, the BioGuinea Foundation role is to
+guarantee transparency in the financial management of the project and reduce dependency on
+donor money. All revenues from carbon sales will be received by the Foundation and will be
+sent to IBAP in accordance with the project budget plan and work schedule. It is also expected
+that the Foundation will provide a better access to market, facilitating the transaction of VERs
+with buyers in Europe.
+On the ground, the project will halt deforestation through the application of a community based
+management approach in conjunction with an innovative micro-finance mechanism, the FIAL.
+In addition to traditional park management efforts, like surveillance, enforcement and fire
+control, IBAP operates a participatory management model, strongly linked with the local
+communities. Participatory surveillance involves the community in the task of preventing
+deforestation activities, reducing the demand for park guards and expanding monitoring
+coverage in the Project Area. The community is also directly involved in the management of
+the area. The Park Management Committee meets bi-annually with 50 percent community
+participation, establishing a collaborative ethic supporting sustainable development in the
+1 Considering a 5% investment return
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 8
+Project Area. The active participation of the community is paramount to project success. So
+far, community support and engagement have been high, as they understand the relevance of
+the parks and the forest it contain.
+Organized communities residing in and around (2 km buffer) the Project Areas will have
+access, via FIAL, to small scale, socio-economic investments with conservation goals. The
+project activity will support community development activities in and around Cantanhez Park
+and Cacheu Park through this micro-finance mechanism which facilitates adoption of simple,
+innovative technologies designed to increase incomes and improve social infrastructure while
+curbing deforestation, improving drainage, conserving water and protecting water sources,
+preserving mangrove zones and building local ownership of the principles and practices
+supporting sustainable fisheries and coastal management.
+The project was developed with financial and technical assistance from the World Bank. All
+fieldwork to the establishment of the baseline, the PD development and the validation of this
+REDD project activity was supported by the World Bank and its partners. The REDD project
+activity will strengthen the community-based management of these areas clearly
+demonstrating tangible financial benefits from forest protection through carbon finance.
+More specifically, the project will provide:
+• Sustainable and stable flows of funds to Cantanhez and Cacheu Parks;
+• Continued and additional support to IBAP to operationalize the management of
+Cacheu and Cantanhez Parks to protect the forests they contain; and
+• Additional financing through the FIAL mechanism to ensure that the communities in
+and around the parks realize direct and tangible benefits from forest protection.
+1.9 Project Location
+The project comprises two distinct areas in the Republic of Guinea-Bissau totaling 181,200
+hectares of which 145,698 hectares are considered the Project Area. Cacheu Mangrove
+Forest National Park (Cacheu Park) has 74,700 hectares, of which 55,247 comprises the
+Project Area, and was legally established by Decree 12/20002 to protect the most relevant
+patches of mangroves around the Cacheu River estuary in the northern part of Guinea-Bissau.
+Cantanhez Forest National Park (Cantanhez Park) has 106,500 hectares, of which 90,451
+comprises the Project Area, and was legally established by Decree 14/2011 to protect the
+remaining patches of primary sub-humid forest that form part of a larger area that extends to
+the south into Guinea Conakry. Figure 1 depicts the geographic position of Guinea-Bissau.
+2 http://faolex.fao.org/docs/pdf/gbs46131.pdf
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 9
+Figure 1. Geographic location of Guinea-Bissau
+Both areas are inhabited since, in line with Guinea-Bissau’s protected area law, no physical
+resettlement was required of communities already living within the boundaries of the protected
+area at the time of its establishment. Cacheu Park has a population density of 38 inhabitants
+per km2, with an estimated growth rate of 1.26%. Cantanhez Park has a population density of
+21 inhabitants per km2, with an estimated growth rate of 1.56%3. The project area is available
+for farming4, mostly shifting agriculture, swamp rice fields and fruit plantation.
+Cacheu Park is located at Latitude 12°18'38.37"N and Longitude 16°11'25.19"W, 111 km from
+Bissau. Cantanhez Park is located at Latitude 11°16'29.85"N and Longitude 14°59'8.00"W,
+275 km from Bissau. Both parks are accessible by car from Bissau. Figure 2 shows the
+geographic location of Cacheu Park, in green, and Cantanhez Park, in blue, in Guinea-Bissau.
+3 Estimated population for both parks (inhabitants/km2) based on population figures from the 2007
+census (INEC, 2007). Available at: http://www.stat-guinebissau.com/
+4 Temudo (2009), Quitino (1971)
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 10
+Figure 2. Geographic map of Guinea-Bissau (1:500,000 scale) overlaid with Cacheu and
+Cantanhez Parks limits and the administrative sectors of GB (Source: Junta de Investigações
+do Ultramar, Portugal, 1962; Administrative regions from Global Administrative Areas, GADM,
+2010).
+1.10 Conditions Prior to Project Initiation
+Guinea-Bissau is one of the poorest countries in the world, ranking 164 out of 169 countries on
+the United Nations Human Development Index 2010. It has a population of roughly 1.6 million,
+and its economy is based primarily on farming and fishing activities, which represent some 55
+percent of gross domestic product (GDP). Agriculture generates 80 percent of employment
+and 90 percent of exports (primarily through cashew nuts, the main export), while fisheries
+represent some 7 to 10 percent of GDP and up to 25-40 percent of public revenues. The
+country has poor infrastructure and weak social indicators; life expectancy is 48 years, more
+than two out of every three people live below the poverty line (US$2/day), and one out of every
+five lives in extreme poverty.
+Prior to REDD project initiation, Cacheu and Cantanhez Parks were operational and financed
+by international donors. In spite of international assistance, since the wind down of the CBMP,
+IBAP has been forced to operate with a budget deficit.5. As a result IBAP had to decrease the
+scope of its protected area management efforts in line with funding limitations. Two short term,
+follow-on GEF and World Bank projects have been approved to help keep basic operations
+running through 2013 and 2015, respectively, while more sustainable financing streams are
+identified. This assistance totals US$ 2.95 million. Support for park operations includes
+payment of IBAP salaries, the bi-annual Park Management Committee Meetings and
+regular/participatory monitoring and surveillance activities. These are complemented by some
+smaller contributions by other donors. Unfortunately, the execution of new FIAL financed
+community projects is currently on hold due to the closure of the CBMP and the associated
+5 According to IBAP data in 2010 (EUR 177,525) and in 2011 (EUR 54,992).
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 11
+cessation of project-based micro-project funding. Consequently, emissions are expected to
+accelerate due to the reduction in resources available to keep the parks running. As can be
+demonstrated, the project has not been implemented to generate GHG emissions for the
+purpose of their subsequent reduction since, in spite of IBAP efforts, baseline historical
+deforestation remain relevant. This condition is further described in the Baseline Scenario
+section (Section 2.4). The present and prior environmental conditions of the area are
+described below.
+Climate
+The Guinea-Bissau Climatologic Profile Report (Dias et al., 2007), states that the territory of
+Guinea-Bissau is inserted in the Inter-Tropical Front (ITF) field of action, characterized by the
+existence of a terrestrial mass, 5° North on the West African bulge, and an insular part in the
+Atlantic Ocean. The country weather is mainly conditioned by the position of the territory in
+relation to the ITF and by the subsidiary actions of semi-permanent cells of high pressure,
+known as Azores Anticyclone, in the North Atlantic, the Anticyclone of Santa Helena, in the
+South Atlantic, and the low summer heat that settles over the Sahara.
+The country is divided into two distinct climatic regions: the tropical humid sub-Guinean,
+coincident with the coastal zone, and the tropical Sudanese Region that influences the eastern
+half of the country. Cacheu and Cantanhez are located in the tropical humid region that is
+characterized by heavy rainfall (between 1,500 and 2,500 mm per year), average temperature
+ranges (26,3 ºC) and strong air humidity throughout the year (CNSMC, 2004).
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 12
+Figure 3. (i) Annual Precipitation, (ii) Potential Evapotranspiration, (iii) Mean annual
+temperature (ºC) and (iv) Annual Temperature Range (ºC). Source: GAEZ / FAO
+The country’s climatic profile study (Dias et al, 2007), divides Guinea-Bissau into three rainfall
+zones: the Southern zone, where Cantanhez is located, (Regions of Tombali, Quinara and
+Bolama-Bijagos), with an annual average of more than 2,000 mm, the Northwest area, where
+Cacheu is located (Regions of Bissau, Biombo, Cacheu and Oio), with an annual rainfall
+average between 1,400 and 1,800 mm and the Eastern Zone (Regions of Bafata and Gabu),
+whose average annual precipitation ranges from 1,300 mm to 1.500 mm. The maximum
+rainfall is reached in August, with the monthly average of more than 300 mm. Rainfall is highly
+seasonal and there is 7-month dry period from December to April.
+Hydrology
+The Republic of Guinea-Bissau is heavily marked by the presence of estuaries and mangrove
+areas. Both Cacheu and Cantanhez are located in the coastal area, thus influenced by these
+characteristics. A dense network of drowned valleys demarcates this area. Almost all of
+Guinea-Bissau is low-lying and bathed daily by tidal water that reach as far as 100 km inland.
+Tidal penetration into the interior, facilitated by the country’s flat coastal topography, carries
+some agricultural advantages: the surge of brackish water can be used to irrigate the
+extensive drowned rice paddies.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 13
+Figure 4. Main rivers of Guinea-Bissau.
+The coastal zone extends over an area of approximately 180 km and is covered by a network
+consisting of important water courses. In the first place, the Geba and Corubal Rivers and
+lochs of the sea in the forms of Cacheu, Mansoa, Rio Grande de Buba, Cumbijã and Cacine
+Rivers. The Corubal and Geba Rivers are the only freshwater rivers serving as the most
+important resources of the country’s surface water, while Cufada Lagoon is the largest reserve
+in the country.
+Interactions between semi-diurnal tidal currents, littoral drifts and the effects of estuaries
+greatly influence the degree of the kinematics of the area, resulting in the accumulation of
+sediments promptly intercepted by arrows sand. The project area is covered by a hydrographic
+network that consists of the flowing streams: the Cacheu, the Cumbijã and the Cacine Rivers
+branches and estuaries. The Cacheu River, the most relevant of the three, has total length of
+about 257 km. One of its major tributaries is the Canjambari River. Cacheu River is navigable
+to large (2,000 ton) ships for about 97km in, and to smaller vessels much further.
+Topography and Soils
+The morphology of the territory of Guinea-Bissau is basically plains, with most of the country
+being below the elevation of 50 meters. Coastal zones, North and South, are mostly lowlands.
+Thus with the high tidal ranges that occur, reaching 6 meters, large areas of coastal areas are
+exposed to its effects. The plains cover a large part of the territory in the Central and Northeast
+Regions of the country. The inner Southeast zone is the most rugged part of Guinea-Bissau,
+other than the hills of Boé, the highest part of the territory, which does not exceed 298 meters
+in altitude (Mota, 1954).
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 14
+In Guinea-Bissau the following types of soil can be identified: Ferralsoils, Plintosoils,
+Sandysoils, Hydromorphicsoils and other types of substrate (bouali, mud and sands). In the
+table below, the area occupied and percentage occupancy for each soil type is shown.
+Table 1. Soil Type in Guinea Bissau
+Soil Type Area (ha) % Occupacy
+1. Ferralsoils 1,960,000 62
+2. Plinthosoils 550,00 17
+3. Sandysoils 20,00 1
+4. Hidromírtic Soils
+4.1 Gleisoils
+4.2 Reverine
+650,00
+150,00
+500,00
+20
+5
+15
+The soil groups most representative in Guinea-Bissau are Ferralsoils, Plintosoils, Gleysoils,
+and Fluvisoil (Teixeira, 1962). Ferralsoils, which in Teixeira’s nomenclature correspond to
+ferralitic and fersialitic soils, cover most of the northern and southern regions of Guinea-
+Bissau. They are among the deepest soils in the country, but are relatively poor in organic
+matter and in mineral nutrients. The natural vegetation of Guinea-Bissau Ferralsoils is mainly
+open forest, though, when weather conditions allow, can develop dense sub-humid forest. This
+is the case of Cantanhez, with more than 2,000 mm of annual rainfall and deep soils create
+the ecological conditions that favor the establishment of the sub-humid forest. In the coastline
+and lower river areas there is occurrence of Fluvisoils. These soils are fine texture of fluvial
+origin, often affected by salt or brackish water and, therefore, high in sodium. According to
+Teixeira (1962), they correspond to hydromorphic soils derived from marine alluvium. The
+natural vegetation on these soils consists of mangroves. These are fertile soils and used for
+growing rice in salty water rice fields.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 15
+Figure 5. Soil Map of Guinea-Bissau. Source: Teixeira, 1962.
+In Cacheu National Park, 75% of soils are Fluvisols/Gleysols and 25% Ferrasols. In
+Cantanhez National Park, 41% are Fluvisols/Gleysols, 58% Ferrasols and 2% Arenasols.
+Vegetation and Ecosystems
+Guinea-Bissau is rich in flora and fauna resources, thanks to its extremely varied vegetation
+cover (dense and open forests, savannas, palm groves and mangroves). It has an important
+Protected Areas Network of 470,000 ha, equivalent to about 13% of the total area of the
+country. Dense forests cover the coastal lowlands; mostly swamp forests, while the interior is
+savanna covered, with gallery forests along streams.
+The coastal area, subjected to high tidal ranges, has a dual importance: environmental and
+socio-economic. Its ecological importance is justified by the fact that it encompasses diverse
+ecosystems rich in terms of biodiversity resources such as forest, mangrove, freshwater,
+intertidal and marine ecosystems. The rare and endemic species, as well as the ones that
+migrate from Europe, Asia, and from the Sub-Region choose this area for shelter, feeding and
+reproduction. Its economic potential and social importance derives from that ecological
+richness, given that the exploitation of such biodiversity resources contributes greatly to the
+economy of the country, notably through forest exploitation, fisheries, agriculture and tourism,
+among other activities. This explains why about 70% of the population is concentrated in
+coastal areas, depending almost entirely on the resources of its ecosystem.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 16
+Cantanhez holds the latest patches of dense mature sub-humid forest, which form part of a
+larger area that extends to the south, into Guinea Conakry. Cacheu holds the most relevant
+patches of mangroves in the northern part of GB, which is located around the Cacheu River
+estuary. The other predominant vegetation covers are open forest, savannahs and palm
+groves.
+Flora diversity in the country is relatively high, with occurrence of around 1,500 species and
+subspecies (Catarino et al. 2006, 2008). In the regions with higher rainfall, in the south of the
+territory, in particular the Cacheu region, the sub-humid forest can reach 30 meters (Catarino
+et al. 2012) with Anisophyllea laurina, Dialium guineense, Hunteria umbellata and Strombosia
+pustulata being to most characteristic species. Open forests can be found all round the
+territory, with forest cover between 40% and 60%. Most common species are Afzelia africana,
+Daniellia oliveri, Detarium senegalense, Khaya senegalensis, Parkia biglobosa and
+Pterocarpus erinaceus (Dinz, 2012). Palm groves develop in deep soils around wet valleys,
+with dominance of Elaeis guineensis. Wooded Savannahs can be found all over the country,
+but are more relevant in the Northern and Eastern parts of Guinea-Bissau. Forest cover is
+around 10% to 40%. Amongst the most common species there are Borassus aethiopum in
+deep soils, Erythrina senegalensis, Guiera senegalenses, Piliostigma thonningii, Strychnos
+spinosa and Terminalia macroptera. Mangroves can be found on the coastline and on river
+estuaries. In Cacheu, the species found are of global relevance being the largest contiguous
+mangrove forest in West Africa. Most common species are Avicennia germinans and
+Rhizophora mangle (Diniz, 2012).
+The Guinean marine and coastal zones are represented by a variety of ecosystems (marine,
+transitional and terrestrial) high productivity and rich in biodiversity resources. Considering the
+high concentration of nutrients due to a huge potential of mangrove and other favorable
+environmental conditions such as temperature gradients and variable salinity and also the
+exceptional conditions of shelter support reproduction and initial feeding of most species
+inhabiting oceans and coastal environments became a major focus of attention. Most of the
+shoreline and numerous estuaries in Guinea-Bissau serve as spawning and development for
+some pelagic fish. Most of these pelagic species migrates along the West African Coast, and it
+is therefore very difficult to specify the potential annual production for Guinea-Bissau alone.
+This area, in addition to their national strategic importance, also has an international ecological
+function of great importance, serving as habitat for reproduction, growth, feeding and refuge
+for several species of cultural, symbolic and economic interests like those classified as rare or
+endangered at the world level. Species most noted in this zone include: the manatee
+(Trichechus senegalensis); Hippos (Hippopotamus amphibius); Nile crocodiles (Crocodylus
+niloticus); Leatherback sea turtle (Dermochelys coriacea); Olive Ridley sea turtle
+(Lepidochelys olivacea); Hawksbill sea turtle (Eretmochelys imbricate); Green sea turtle
+(Chelonia mydas) and Loggerhead turtle (Caretta caretta); different species of mammals,
+particularly primates: Bijagó Monkey (Cercopithecus petaurista); Western Red Colobus
+Monkey (Poliocolobus badius); Nobel Monkey polykomos Colobus; Chimpanzee (Pan
+troglodytes versus); and other mammals such as: elephant(Loxodonta Africana); African
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 17
+Buffalo (Syncerus sp); White Boca antelope (Sable equinus koba) and Defassa waterbuck
+(Kobus ellipsiprymnus defassa).
+During particular seasons, the coastal region also serves as a breeding area and migration
+route for a large number of migratory birds from Europe, Asia and the sub region, Guinea-
+Bissau, in general and in particular the Bijagós Archipelago, is after Banc d'Arguin in
+Mauritania, the second most important place in West Africa, receiving up to 700 thousand
+Palearctic migratory birds of various species annually. Birds that can be encountered breeding
+include: African Darter or Snakebird (Anhinga rufa); White Heron or Great Egret (Egretta alba);
+Little Heron (Egretta garzetta); African Sacred-ibis (Threskiornis aethiopicus); African spoonbill
+(Platalea alba); gray pelican (Pelecanus rufescens); Grey-headed Gull (cirrocephalus);
+Slender-billed Gull (Larus genei); Large Tern (Sterna Caspian); Royal Tern (Sterna maxima);
+Gull-billed tern (Sterna nilotica) and the gray parrot (Psittacus timneh). A large part of the
+coastal zone and their habitats are thus included in the network of Important Areas for the
+Birds - IBA (T. Dodman and Mr SA 2005).
+Relevant Historic Conditions
+After independence the country enjoyed only a brief period of stable constitutional rule (1974-
+1980). In late 1980, the first government was overthrown in a relatively bloodless coup led by
+Prime Minister and former armed forces commander João Bernardo “Nino” Vieira, who would
+rule this country for 19 years from 1980 to 1999. In the period between 2000 and 2013,
+Guinea-Bissau experienced considerable political and military upheaval with elections being
+undertaken successfully in June 2014. Decades of week institutional capacity lead to total
+absence of rules over natural resources in the country. International donors allowed the
+country to establish, in 2004, an independent body to managed and protect the forests and the
+biodiversity the country contain. IBAP, the Institute for Biodiversity and Protected Areas,
+successfully created the National System of Protect Area (SNAP) and, although with great
+struggle, has been able to establish infrastructure and train human resources to support its
+mission. This REDD project is part of a broader strategy put in place by IBAP to reduce the
+country’s dependency on foreign resources to manage its protected areas.
+1.11 Compliance with Laws, Statutes and Other Regulatory Frameworks
+The project responds and complies with all relevant national and local laws and regulations,
+most importantly: the Constitution of the Republic of Guinea-Bissau, the Forestry Law, the
+Land Law, the laws related to national parks and protected areas including the Protected
+Areas Law and the laws that established Cacheu National Park, Cantanhez National Parks
+and IBAP. At local level, the Internal Regulations of Cacheu and Cantanhez are also relevant
+and are included in the analysis. Finally, in concern of worker rights, the national labor law (Lei
+Geral do Trabalho) is also included.
+• Constituição
+The constitution of the Republic of Guinea Bissau, clearly establishes the rights over
+the territory and the rule of the government over natural resources, including forests.
+More specifically, on Article 8º, §2 “The Republic of Guinea Bissau is sovereign over
+all natural resources in its territory”, and on Article 10º “executing exclusive rights in
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 18
+maters of conservation and exploitation of natural resources. Finally, Article 12º, §2
+states that “Are State property the soil, the subsoil, the water, the mineral resources,
+the main energy sources, the forestry richness and the social infra-structures. The
+proposed REDD project is proposed by IBAP with specific power granted by the State
+according to the Decree 02/2005 (IBAP Establishment Decree) to manage the
+protected areas and safeguards the national biodiversity.
+• Lei Florestal (05/2011)
+The Forestry Law was published in 2011 with three objectives, (i) promote the
+sustainable management of the resources that composes the forestry resources, (ii)
+optimize the contribution of the natural forests to the socio-economic and cultural
+development and the environmental protection and (iii) to improve the livelihood of the
+population. The law defines on its Article 14º that “all cut of tree in the forestry domains
+of Guinea Bissau for agricultural purposes, is subjected to approval and site visit by
+the Forestry Department (DGFF). The project will support the Forestry Law by
+monitoring, on the ground, any deforestation in the project area and supporting
+forestry protection enforcement through its parks guards and patrolling activities.
+• Lei Quadro das Áreas Protegidas (3/1997) and its revision (5-A/20116):
+The Protected Areas Law establishes the general objectives of the Protected Areas in
+Guinea-Bissau. The law defines inter alia the role of IBAP; the governance structure
+for the parks (IBAP, Park´s Director and the Management Committee) and the
+development and update of the Parks Management Plans every 10 years. On its
+Article 2º, the law lists its objectives. As discussed in the baseline section, Guinea
+Bissau cannot enforce this legislation given its budgetary constraints and the necessity
+to invest in other priority areas like infrastructure and health. The project will assist
+IBAP in reaching the objectives of the Protected Areas Law, more specifically in
+safeguarding habitats, animal and vegetal species under threat, in conserving and
+restoring habitats of the migratory fauna and its corridors (in special in the coastal
+area), to defend, conserve and value the traditional way of life that does not harm the
+ecological patrimony and to promote and support the sustainable use of natural
+resources by the communities. The project is also in compliance once its activities are
+integrated within the broader IBAP plans and activities. In fact, this project is a pilot to
+IBAP evaluate how REDD can assist Guinea Bissau in protecting its relevant natural
+resources.
+• Lei da Terra (05/1998)
+The land law, from April 23rd of 1998, nationalizes the soil in all national territory, giving
+to the State the property over all land in the country. The law, on its Article 2º,
+established that land is property of the State but accessible to all people in the country.
+More important, the law recognizes the customary law of communities stating the
+relevance of the traditional land use, the culture and practices carried from generation
+to generation that established reciprocal rights and obligation in the communities. The
+REDD project was designed based on community management practices already
+6 Approved by the Ministry Council in March 1st 2011. Issued on the Boletim Oficial number 9, 2011.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 19
+recognizing this complex context. Whilst IBAP is, by law, the ruler of the Protected
+Areas, a much complex social relationship exists in the communities with traditional
+leadership and a long established participatory arrangement governing daily practices.
+Both the Protected Areas Law and each park establishment decree recognize the park
+committee as the body able to take decisions and the local level. Therefore, Internal
+Regulations are decided and voted at this sphere avoiding future conflicts and granting
+agreement and participation of the community. The REDD Project, aware of this social
+structure, was designed to follow community decisions, in special, the benefit sharing
+mechanism (FIAL) uses a participatory approach to decide who will receive money
+and where this money will be invested. Communities can prioritize investments and
+make collective decision. The REDD project recognizes that its success depends on
+community engagement and on ways to support behavioral change, in special related
+to traditional extensive agricultural practices that have been deforesting both outside
+and inside the parks.
+• Cacheu Park Establishment Decree (12/20007)
+Creates Cacheu National Park, sets its boundaries and zones, establishes the
+management structure of the park, legal activities and penalties. The project was
+design to follow the park’s boundaries in order to support IBAP in managing and
+conserving Cacheu National Park. The proposed REDD activity was though to assist
+Cacheu in reaching its long-term objective (Article 2º).
+• Cacheu Internal Regulation
+An Internal Regulation is a legal instrument established by the Protected Areas Law
+and by each national park decree to clarify and enforce local rules that must follow
+both the ecological aspects of the area and the social aspects of the communities that
+live on the same area. The Internal Regulation is collectively agreed at the Park
+Management Committee made of representatives of the Government, IBAP, Park
+Director and other relevant staff and the local community. Cacheu Internal Regulation
+sets the objectives of the park, in line with Decree 12/2000 but is more specific as it
+forbids, inter alia, tree cut in all park, fire use during the dry season and mangrove cut.
+As with other laws previously presented, the project goes hand and hand with the
+Internal Regulation objectives and, in fact, strengthens IBAP’s enforcement capacity
+reducing deforestation inside the park borders.
+• IBAP Establishment Decree (02/20058)
+Establishes the Institute of Biodiversity and Protected Areas (IBAP). In particular it
+defines as one of IBAP´s competencies: Manage the Protected Areas and safeguard
+the endangered species through implementation of the strategy and action plan for the
+7 Approved by the Ministry Council in November 30th 2000. Issued on the Boletim Oficial number 49,
+2000.
+8 Approved by the Ministry Council in March 9th 2005. Issued on the Boletim Oficial number 11, 2005.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 20
+conservation of biodiversity9. The project is compliant with the law once the project
+proponent, IBAP, is the institution with legal mandate to manage the project area. As
+established by the decree, is IBAP’s responsibility to “implement strategies and action
+plans for the conservation of biodiversity”. This REDD project is a relevant part of IBAP
+strategy to guarantee sustainable and stable flow of funds to financially support its
+activities in Cacheu and Cantanhez National Parks.
+• Cantanhez Park Establishment Decree (14/201110)
+Creates Cantanhez National Park, sets its boundaries and zones, establishes the
+management structure of the park, legal activities and penalties. The project was
+design to follow the park’s boundaries in order to support IBAP in managing and
+conserving Cantanhez National Park. The proposed REDD activity was though to
+assist Cantanhez in reaching its long-term objective (Article 2º).
+• Cantanhez Internal Regulation
+An Internal Regulation is a legal instrument established by the Protected Areas Law
+and by each national park decree to clarify and enforce local rules that must follow
+both the ecological aspects of the area and the social aspects of the communities that
+live on the same area. The Internal Regulation is collectively agreed at the Park
+Management Committee made of representatives of the Government, IBAP, Park
+Director and other relevant staff and the local community. Cantanhez Internal
+Regulation sets the objectives of the park, in line with Decree 14/2011 but is more
+specific as it forbids, inter alia, tree cut in all park, fire use during the dry season and
+mangrove cut. As with other laws previously presented, the project goes hand and
+hand with the Internal Regulation objectives and, in fact, strengthens IBAP’s
+enforcement capacity reducing deforestation inside the park borders.
+• Lei Geral do Trabalho (02/1986)
+The labor law was approved on April 5th 1986. It governs all work relationships and
+also established that other relationships not governed by law must be derived from
+Work Contracts. IBAP operates in accordance with such law, keeping registries and
+following its legal obligations in relation to workload, payment of social contributions
+and taxes. Any future worker, hired by IBAP to support the REDD initiative; will also
+follow the labor law. So far, no local worker had been hired by the project as the
+project activities had not started.
+1.12 Ownership and Other Programs
+1.12.1 Right of Use
+The Project Area is under the institutional control of the Institute for Biodiversity and Protected
+Areas of Guinea Bissau (Instituto da Biodiversidade e das Áreas Protegidas – IBAP). IBAP
+9 Art. 4º, (b) “Gerir as áreas protegidas e as espécias ameaçadas através da estratégia e do pano de
+acção para a conservação da biodiversidade”.
+10 Approved by the Ministry Council in February 22nd 2011. Issued on the Boletim Oficial number 8,
+2011.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 21
+was founded in December 2004, under Decree no 2/2005, Chapter II, Article 3o: This Decree
+defines IBAP’s mandate11 to include the following:
+a. Recommend, coordinate and execute the policies and actions related to biodiversity and
+protected areas in all national territory;
+b. Promote and protect the ecosystems, biodiversity and protected areas and, to promote by
+all human and technical available means, the socially and economically sustainable use of
+the natural resources within the national territory, including the continental waters and the
+sea.
+IBAP has legal rights over National Parks and its resources. Communities hold traditional land
+use rights but, in Guinea-Bissau, private ownership of land is not allowed by law. Therefore,
+rights of use in Cacheu and Cantanhez are controlled by IBAP, which coordinates park
+committee meetings for collaborative decision-making (following Parks Internal Regulation),
+enforce land use regulations and apply penalties when necessary. These rights are
+established by law (Decree nº 5/2011 – Protected Area Law) as follows:
+• Chapter IV – Management of Protected Areas: grant IBAP the power over new
+buildings establishment (Article 21º), Economic Activity Control (Article 22º),
+Exploitation Titles (Article 23º) and Coastal and Riverine Protection (Article 24º). All
+mentioned articles establish that IBAP has rights to permit or request environmental
+impact assessment prior to the execution of such activities.
+• Chapter VII – Monitoring of Protected Areas: grant IBAP staff legal power to enforce
+use rights.
+In addition, the Internal Regulations of each park (Cacheu and Cantanhez) reiterate that IBAP
+has rights to control use and regulate economic activities in National Park areas (Article 19º in
+Cantanhez Internal Regulation and Article 24º in Cacheu Internal Regulation).
+1.12.2 Emissions Trading Programs and Other Binding Limits
+The project is being developed in a Least Developed Country (LDC) where no legally binding
+limits on GHG emissions exist. The project is voluntary and will not be used for compliance
+with an emissions trading program.
+1.12.3 Other Forms of Environmental Credit
+No other environmental credit has or intends to be generated by the project. The project is
+eligible to participate in the following programs to create another form of GHG-related
+environmental credit:
+• Plan Vivo
+• ISO 14.064 Part 2
+11 http://guinebissau.adbissau.org/inormacoes/Relatorio.pdf
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 22
+• American Carbon Registry (ACR) Standard
+The project may seek co-benefits assurance by a third party validator in the Climate,
+Community and Biodiversity (CCBA) or the SocialCarbon Standard in the future. CCBA and
+SocialCarbon do not issue credits, they are a combined certification to be used jointly with the
+VCS Standard to certify further sustainability impacts due to the implementation of the project
+activity.
+1.12.4 Participation under Other GHG Programs
+The project is not registered or seeking registration under any other GHG Program.
+1.12.5 Projects Rejected by Other GHG Programs
+The project did not try registration under any other GHG Program, and hence, had not been
+rejected by any other GHG Program.
+1.13 Additional Information Relevant to the Project
+Eligibility Criteria
+The project activity comprises two areas 12 – Cacheu Mangrove Forest National Park and
+Cantanhez Forest National Park – both with similar legal frameworks and baseline cases. The
+table below indicates the most plausible VCS-eligible activity for the project activity.
+Step 0. Identification of the most plausible VCS-eligible activity
+Is the forest land expected to be converted to non-forest land in the baseline case?
+YES NO
+Is the land legally authorized and documented
+to be converted to non-forest?
+Is the forest expected to degrade by fuel
+wood extraction or charcoal production, in the
+baseline case?
+YES NO YES NO
+Avoided planned
+deforestation
+Avoided unplanned
+deforestation
+Avoided forest
+degradation
+Proposed project is
+not a VCS REDD
+activity currently
+covered by the
+module framework
+12 World Database on Protected Area (WDPA). Available at:
+http://www.protectedplanet.net/sites/Cantanhez_Forest_National_Park and
+http://www.protectedplanet.net/sites/Rio_Cacheu_Mangroves_Natural_Park
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 23
+Forestland is expected to be converted to non-forest land in the baseline case as will be
+demonstrated in the Baseline Scenario section (2.4) of this VCS PD. The project activity will
+avoid unplanned deforestation, an eligible VCS activity.
+Leakage Management
+FIAL is expected to be a strong leakage management tool capable of maintaining or
+increasing local population livelihoods through the introduction of new technological practices
+and alternative activities. In the event of residual leakage, emissions will be captured through
+the project’s MRV system. Leakage management and the justification as to why Project
+Proponent expects Leakage to be minor are described below:
+The nature of deforestation is subsistence agriculture and hence not prone to much
+displacement (not much mobility). In both parks, subsistence agricultural activities are the main
+drivers of deforestation. In Cacheu, the most representative ethnic groups are Manjacos,
+Cobianas and Felupes. These two groups use agricultural practices with shifting cultivation
+and plantation of rice, collection of oil and other products from palm groves and conversion of
+forest into savannah-orchards. The main agricultural product is rice, and during the last
+decades, plantation of fruit trees has increased (in particular cashew13). In Cantanhez, the
+local population consists of the Balanta, Nalu, Tandas, Djacancas and Fula ethnic groups. As
+in Cacheu, rice is the main agricultural product. In this area, the development of fruit
+plantations is also observed (particularly bananas).
+The project design is targeted to neutralize the drivers in a way that avoids leakage. While
+there is a risk that leakage could arise from the displacement of the subsistence agricultural
+activities, it is anticipated that project funds, flowing via the FIAL micro-project financing
+mechanism, can provide the necessary means to improve agricultural practices, create
+additional income from fruit processing and other extractive activities, thus ensuring that the
+deforestation activities will not be transferred to other areas.
+So far, FIAL has demonstrated excellent performance. Micro-projects used simple, innovative
+technologies designed to increase incomes and improve social infrastructure while curbing
+deforestation, improving drainage, conserving water and protecting water sources, preserving
+mangrove zones and building local ownership of the principles and practices supporting
+sustainable fisheries and coastal management. Not all investments had or were intended to
+have direct conservation impacts, e.g., schools, but FIAL conveyed a strong message through
+project-financed communications campaigns about the link between the environment and
+sustainable livelihoods, the meaning of conservation per se, and the need for organized,
+community-based approaches. Improved educational opportunities and literacy were seen as
+longer-term investments in sustainability. Priority was given to activities that also help reduce
+poverty and empower poorer communities.
+During its implementation stage, FIAL’s goal was that at least 75% of the micro-projects
+funded would satisfactorily achieve their objectives (based upon an independent evaluation).
+13 INEC (2007), during the 2007 census, 48% of the respondents listed cashew nuts as an agricultural
+product at the household.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 24
+According to a series of evaluations14, FIAL’s success rate reached 81,3% of the projects; a
+total disbursement of 1,47 million USD was made across 129 projects. An important example
+of institutional/stakeholder collaboration for conservation and sustainable development ends
+was the rapid and effective FIAL-financed pilot effort to restore seawater–flooded lowland rice
+paddies threatening the subsistence and livelihoods of 3,000 people as well as the forested
+upland areas vulnerable to invasion and deforestation by these same groups if the paddies
+were not reclaimed.
+The project boundaries are drawn according to methodological requirements so it captures
+any displacement to the Leakage Belt. Although not expected to be significant, the project
+boundaries, more specifically the Project Area and Leakage Belt, have been designed to allow
+detection of potential leakage, ensuring that any residual leakage is captured through the
+project’s MRV system.
+Commercially Sensitive Information
+No commercially sensitive information has been provided.
+Further Information
+Not applicable
+2 APPLICATION OF METHODOLOGY
+2.1 Title and Reference of Methodology
+VM0007 – REDD Methodology Framework (REDD-MF). Version 1.4
+The following Modules and Tools are also applied:
+Module ID Version Choice
+REDD Methodology Framework REDD-MF
+(VM0007) Version 1.4 Always Mandatory
+Methods for monitoring of greenhouse gas
+emissions and removals.
+M-MON
+(VMD0015) Version 2.1 Always Mandatory
+Tool for Demonstration and Assessment of
+Additionality in VCS AFOLU Project Activities.
+T-ADD
+(VT0001) Version 3.0 Always Mandatory
+Tool for AFOLU non-permanence risk analysis
+and buffer determination. T-BAR Version 3.2 Always Mandatory
+Estimation of uncertainty for REDD project
+activities
+X-UNC
+(VMD0017) Version 2.0 Always Mandatory
+Methods for stratification of the project area. X-STR
+(VMD0016) Version 1.0 Always Mandatory
+Estimation of baseline carbon stock changes
+and greenhouse gas emissions from
+unplanned deforestation.
+BL-UP
+(VMD0007) Version 3.2 Mandatory for Unplanned
+Deforestation
+14 The World Bank (2011) Final Evaluation Report of CBMP, Vaz, d´Alva and Badji (2008, 2009)
+Evaluation of FIAL Micro-Projects, and d´Alva (2011) Final Evaluation of FIAL Micro-Projects
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 25
+Estimation of emissions from activity shifting
+for avoided unplanned deforestation.
+LK-ASU
+(VMD0010) Version 1.0 Mandatory for Unplanned
+Deforestation
+Estimation of carbon stocks in the above and
+belowground biomass in live tree and non-tree
+pools.
+CP-AB
+(VMD0001) Version 1.1 Always Mandatory
+Estimation of greenhouse gas emissions from
+biomass burning
+E-BB
+(VMD0013) Version 1.0 Always Mandatory
+CDM “Tool for testing significance of GHG
+emissions in A/R CDM Project Activities”. T-SIG Version 1.0
+Applied to justify selection
+of carbon pools and
+emission sources
+2.2 Applicability of Methodology
+The project is compliant to the following applicability conditions:
+REDD-MF
+• Land in the project area has qualified as forest at least 10 years before the project start
+date as can be seen in the baseline (2000-2010) maps.
+• The project area includes forested wetlands (Mangrove Forest) and terrestrial forest.
+Based on Teixeira (1962) soils map, it was estimated the proportion of the soil types in
+Cacheu: Fluvisols/Gleysols (75%) and Ferralsols (25%), and Cantanhez:
+Fluvisols/Gleysols (41%), Ferralsols (58%) and Arenasols (2%). Mangrove areas are
+mainly composed of Fluvisols/Gleysols whist the terrestrial forest is found at Ferralsols
+area. Therefore, forested wetlands in the project area do not grow on peat (Histosol).
+• IBAP has control over Cacheu Mangrove Forest National Parka and Cantanhez Forest
+National Park and ownership of the carbon rights for the project area as discussed in the
+legal background (1.11) and right of use (1.12.1) sections. Control can also be
+demonstrated by the constant presence of IBAP personnel in the Project Area.
+• Baseline deforestation in the project area fall within the category unplanned deforestation
+(VCS category AUDD). Deforestation in Cacheu and Cantanhez is not allowed as
+demonstrated in the Legal Section (1.11) of this PD;
+• The Community Based Avoided Deforestation Project in GB will renew its baseline every
+10 years after the start of the project.
+• Areas within the project boundary are not registered or seeking registration under the
+CDM or other carbon-trading scheme.
+• Post-deforestation land use is described by Temudo (1998). After deforestation land is
+converted to agricultural use and enters a shifting cultivation cycle composed of 2 years
+cropland and 5 to 6 year fallow period.
+• Areas where post-deforestation land use constitutes reforestation (e.g. Cashew
+Plantation) were excluded from the baseline analysis (Winrock/IICT, 2012)
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 26
+• Leakage avoidance activities do not include agricultural lands that are flooded to increase
+production or Intensification of livestock production through use of “feed-lots” and/or
+manure lagoons. Section 1.13 discusses the Leakage Management clearly demonstrating
+the leakage avoidance measures to be put into practice.
+BL-UP
+• Baseline agents of deforestation are the local population living within the Project Area and
+clear the land for crop production (Subsistence Agriculture) according to traditional land
+use practices not amounting to large-scale industrial agriculture activities (Winrock/IICT,
+2012);
+• Areas where post-deforestation land use constitutes reforestation (e.g. Cashew
+Plantation) were excluded from the baseline analysis (Winrock/IICT, 2012)
+• Fuelwood collection is small scale and related to the energetic demand of the local
+households. Casarim et al. (2010) using data published by the FAO showed no increase
+in threat to forest carbon stocks through either production or consumption of fuelwood in
+the country. Statements from the Cacheu Park Management Plan 2008-2018 (IBAP,
+2008) and the Coastal and Biodiversity Management Project Appraisal Document
+(PGBZC, 2004) supported the decision of not including the analysis of BL-DFW
+(VMD0008) and LK-DFW (VMD0012) in this assessment. According to these two
+documents, for domestic consumption (cooking) around 90% of households use firewood
+mainly from down dead wood, there is little use of charcoal (approximately 11%) (PGBZC,
+2004) and all extraction for commercial purposes is officially forbidden under the park’s
+regulation (IBAP, 2008).
+LK-ASU
+• Applies as far as BL-UP is used.
+CP-AB
+• Applicable to all forest types and age classes;
+• Aboveground and Belowground tree biomass pools has been accounted by the field
+inventories;
+• Non-tree aboveground biomass is excluded since stocks are expected to be higher in the
+project scenario.
+E-BB
+• Since fire may occur ex-post the module is applied in the monitoring plan to account GHG
+emissions.
+M-MON
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 27
+• The module is always mandatory. The ex-ante stratification is fixed for this baseline and
+will not be changed.
+X-STR
+• Stratification of pre-deforestation forest classes used CARBOVEG-GB maps as ancillary
+data and as proxy for potential biomass classes and area estimation.
+X-UNC
+• A precision target of 95% confidence interval equal or less than 15% of the recorded
+values has been used to determinate the number of plots (Winrock/IICT 2012);
+• Total net GHG emission reductions are adjusted according to the estimated total
+uncertainty in baseline scenario. Uncertainty in the baseline in Cacheu totalled 16% and
+in Cantanhez 11%.
+2.3 Project Boundary
+Step 1. Definition of the project boundaries
+a. Geographical boundaries
+Following the module BL-UP, the spatial delineation of each feature (Reference Region,
+Project Area and Leakage Belt) is presented for the two parks that constitute the Project
+Activity (Figure 3 and Figure 4). The definition of the Reference Region and the Leakage Belt
+was performed based on detailed analysis of the factors to be characterized (such as agents
+of deforestation) or quantified (such as proportion of forest types). The main drivers of land
+cover change in GB are tied to subsistence agriculture activities, and vary geographically with
+ecological, socio-economic and ethnical/cultural characteristics.
+The RRD (Reference Region for Projecting Rate of Deforestation) was the only Reference
+Region defined since the configuration of deforestation in the Project Area is transition and the
+BL-UP requirement is achieved15. The RRD does not need to be contiguous with, and shall not
+encompass the Project Area or the Leakage Belt, and its total area must be forested at the
+start of the historical reference period. The area around Cacheu Park has the same ecological
+characteristic of those present within the Park, including the proportion of forest types
+observed in ancillary maps. The RRD includes forestlands spread along the administrative
+sectors of Cacheu, Caio and Cachungo. Wetlands of the region of Oio, along the margins of
+the rivers Cacheu and Mansoa, were also included to guarantee a similar proportion of
+mangrove and soil type. The area around Cantanhez includes most of the south western part
+of GB, which is the region with the most similar ecological and socio-economic conditions to
+those present in the Park. It includes the forests of the sectors of Buba, Empada and Catio
+15 Location analysis is not required where it can be shown that ≥ 25% of the project geographic
+boundary is within 50m of land that has been anthropogenically deforested within the 10 years prior to
+the project start date
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 28
+and also those in the south of the administrative sector of Cacine. Additionally, the wetlands in
+the northern region of Quinara, along the margins of the Geba River, were also included in the
+RRD to ensure a similar proportion of mangroves.
+In Cacheu, the Leakage Belt was established with some relaxation given that the proportion of
+mangrove is inevitable higher in the Project Area. The Leakage Belt boundary was adjusted to
+consider the remaining mangroves in the surrounding areas, and upstream on the Cacheu
+River16. In Cantanhez, the minimum area criterion was achieved. The Leakage Belt boundary
+was influenced by the distribution of closed forests in the region and the methodological
+requisite of similar proportion of the same forest type.
+Finally, as described on section 1.9, the Project Area is constituted of Cacheu Mangrove
+Forest National Park and Cantanhez Forest National Park. The parks boundaries are
+presented by the solid polygons on Figure 6 and Figure 7.
+Figure 6. Cacheu Project Area (PA), Leakage Belt (LK) and Reference Region for projecting
+rate of Deforestation (RRD) boundaries
+16 As anticipated in the BL-UP: “The minimum leakage belt area shall be equal to at least 90% of the
+area of the project. However, if identification of a forested area of this size (meeting criteria a to g) is
+impossible then the following guidelines shall be followed: Available forest area meeting criteria a – g >
+75% Project Area (with similarity requirements in d and e relaxed to ±50%)”
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 29
+Figure 7. Cantanhez Project Area (PA), Leakage Belt (LK) and Reference Region for
+projecting rate of Deforestation (RRD) boundaries
+b. Temporal Boundaries
+The historical reference period is the temporal domain from which information on historical
+deforestation is extracted, analyzed and projected into the future. The historical reference
+period was established in compliance with VMD0007 methodological requirements of three
+points in time of no less than 3 years apart covering no more than 12 years. Three spatial data
+points were selected: 2002, 2007 and 2010.
+c. Carbon pools
+The carbon stock assessment was designed in accordance with the protocol established in the
+module VMD0007 (BL-UP) and VMD0001 (CP-AB). Sampling was designed to accurately
+account for the total biomass carbon stocks in the selected carbon pools and stratified using
+ancillary data provided from satellite imagery and following VMD0016 (X-STR). The
+assessment relied on both data collected in the CARBOVEG-GB Project and new data
+sampled in 2010 and 2012 by Winrock International and the Portuguese Tropical Research
+Institute (IICT).
+Aboveground and belowground tree biomass carbon was estimated for the following strata:
+• Closed Forests
+• Open Forests
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 30
+• Mangroves
+• Savannah
+The remaining carbon pools were conservatively excluded following T-SIG17. VMD0017 (X-
+UNC) was applied to evaluate precision and define the number of plots to reach the desired
+target of 15% (CI 95%). A total of 261 plots were considered in the carbon stock analysis
+based on data from the fieldwork developed by Winrock and IICT in 2010 and 2012 and the
+CARBOVEG-GB in 2007, 2008 and 2009.
+Carbon Pools Included? Justification/Explanation
+Aboveground Included Significant carbon pool. Carbon stock change in this
+pool is relevant.
+Belowground Included Significant carbon pool.
+Dead wood Excluded Conservatively excluded
+Harvested wood
+products Excluded Conservatively excluded. No long term wood product
+activities observed in the project area.
+Litter Excluded Conservatively excluded
+Soil organic
+carbon Excluded
+Conservatively excluded. In the event of conversion
+of mangrove systems into wetland rice cultivation, the
+soil carbon stocks will likely not decrease because
+the flooding regime will be maintained and the
+wetland area is enclosed
+d. Sources of greenhouse gases
+Potential sources of GHG emissions in REDD projects could arise from the use of fertilizers,
+biomass burning and use of fossil fuels in vehicles and stationary equipment. Non-CO2 gases
+that can be emitted from woody biomass burning are included in the project emissions in case
+if fire occurs. Other project emissions are not considered since those sources are not relevant
+to the proposed REDD project.
+17 Tool for testing significance of GHG emissions
+http://cdm.unfccc.int/methodologies/ARmethodologies/tools/ar-am-tool-04-v1.pdf
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 31
+Source Gas Included? Justification/Explanation
+Baseline
+Agriculture
+CO2 Included
+CO2 emissions are fully accounted in the carbon
+stock changes in the aboveground and
+belowground tree biomass pools.
+CH4 Excluded Non-CO2 emissions from agriculture are
+conservatively omitted, because such emissions
+are expected to be greater in the baseline than in
+the project scenario, as deforestation followed by
+agricultural practices is expected to decrease.
+N2O Excluded
+Project
+Biomass
+Burning
+CO2 Excluded
+CO2 emissions are fully accounted in the carbon
+stock changes in the aboveground and
+belowground tree biomass pools.
+CH4 Included Non-CO2 gases emitted from woody biomass
+burning are included in the project in case if fire
+occurs.
+N2O Included
+Combustion
+of Fossil
+Fuels
+CO2 Excluded
+IBAP currently manages the two parks and will
+continue to do so in the project scenario. Therefore,
+fossil fuel consumption is expected to be very
+similar in the baseline and project scenario.
+CH4 Excluded Potential emissions are negligibly small
+N2O Excluded Potential emissions are negligibly small
+Use of
+Fertilizer
+CO2 Excluded Conservatively omitted from both the baseline and
+project scenarios.
+CH4 Excluded Conservatively omitted from both the baseline and
+project scenarios.
+N2O Excluded
+In Guinea-Bissau the traditional agricultural method
+does not utilize fertilizers. In the project scenario,
+fertilization application is also not expected.
+e. Sources of leakage
+Leakage is expected to be minor as discussed in the Leakage Management section.
+Furthermore, the Government never contemplated ring fencing the project area and removing
+populations, thus there will be no direct dislocation of people due to the project activity. The
+evaluation of the potential displacement of activities from the Project Area to the Leakage Belt
+follows VMD0010 (LK-ASU).
+Resident population density is low inside the project areas. The 2007 census18 is the most
+recent socio-economic study in the Project Area. Cacheu National Park has 28,052 inhabitants
+with a population density of 38 hab/km2 and Cantanhez National Park has 23,992 inhabitants
+with a population density of 21 hab/km2. A PRA also demonstrate that immigrants comprises
+9.3% of the population. The FIAL19 works with this population to promote conservation goals
+18 INEP/INEC: Recenseamento, Estudo Socio-económico e Ambiental das Áreas Protegidas – 2007
+19 Instituto da Biodiversidade e das Área Protegidas (IBAP). 2007. Estratégia Nacional para as Áreas
+Protegidas e a Conservação da Biodiversidade na Guiné- Bissau 2007 – 2011. Bissau, 78
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 32
+by: (i) financing small-scale investments in basic socio-economic infrastructure and productive
+activities, and (ii) linking the planning processes and approved micro-project to the REDD
+Project objectives, using a classic community-driven demand methodology. Approval of micro-
+projects is explicitly linked to the Cacheu Park and Cantanhez Park objectives by the Park
+Management Committee. FIAL typically provides matching grants of up to US$10,000 per
+community in support of specific, community-based micro-projects that can be linked to
+conservation objectives. FIAL activities are concentrated on communities located in or around
+protected areas.
+Park Management Committees (with 50% community participation) and the Participatory Park
+Patrols have established a collaborative ethic supporting sustainable development in each
+Park; and organized communities residing in and around the Protected Areas are eligible for
+access to FIAL. The socio-economic survey and census done as part of FIAL preparation
+established an eligible target population of 70,000 people already within the PAs and the 2 km
+outside radius (buffer zone) of each PA to remove the incentive for people to move into the
+PAs to benefit from FIAL.
+Source Gas Included? Justification/Explanation
+Leakage
+Local
+Deforestation
+Agents
+CO2 Included
+FIAL independent evaluation has shown a success
+rate above 80% of the Community Micro-Project.
+Leakage considers a 20% failure rate of FIAL
+CH4 Excluded Potential emissions are negligibly small
+N2O Excluded
+Immigrant
+Deforestation
+Agents
+CO2 Included According to the PRA done in the project area 9.3%
+of the population is immigrant
+CH4 Excluded Potential emissions are negligibly small
+N2O Excluded
+2.4 Baseline Scenario
+The baseline scenario describes the most plausible scenario in the absence of the Project
+Activity. Land use in Guinea-Bissau is characterized by traditional agricultural practices
+performed by the local communities that have customary land use rights. Slash-and-burn is
+the common agricultural practice with consequent loss in forest cover20. According to Temudo
+(1998), after the land is cleared the agricultural activities typically comprise 8-year shifting
+rotation: 2-year cropland and 6-year fallow.
+In an attempt to promote the conservation and sustainable use of natural resources, including
+the reduction of deforestation, the Government of Guinea-Bissau launched a concerted effort
+to conserve the country´s biodiversity in the late 1990s and early 2000s. These efforts
+resulted in the creation of IBAP in 2004 and the establishment of a national network comprised
+pag. República da Guiné-Bissau
+20 National deforestation rate between 2002 and 2010 was 37,782 ha per year
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 33
+of five national and one community protected areas. IBAP has the mandate of issuing policies
+and rules related to biodiversity conservation and the management of the network of national
+protected areas.
+To date the Government, and more specifically, IBAP’s efforts have been exclusively financed
+by external sources, namely international donor and NGO projects. Government funding for
+IBAP and the protected areas has not been forthcoming due to the urgency of competing
+development priorities (health, education, basic infrastructure, among others) and chronic
+budget shortages21. This heavy dependence on external ad hoc, project-based financing puts
+the sustainability of the achievements at risk, and finding a way to secure regular, stable
+sources of financing able to sustain the conservation activities over the long term is one of the
+key challenges facing the country.
+Hence, while the CBMP has been successful in establishing IBAP, building the management
+capacity for the protected areas network in Guinea-Bissau, and securing community
+involvement and commitment to the conservation goals through the FIAL, unless funding is
+secured over the long term, there is a serious risk that the achievements to date will be
+eroded. Although some limited transitional financing has been secured through 2013 and
+2015 through the follow-on GEF and IDA financed projects, respectively, this financing in turn
+will end, which once again confirms the importance of securing sustainable long term financing
+for these activities. Even with this transitional support, while enabling IBAP to maintain a
+minimum presence on the ground, the scope of management activities is significantly
+constrained. Furthermore, funds are currently not available to support implementation of any
+new FIAL initiatives.
+The Government is requesting additional financing from the GEF to help capitalize the
+Foundation, but the available envelope for Guinea-Bissau is small (maximum of US$ 4.6
+million under the current Resource Allocation Framework - RAF 5) and would still leave a
+financing gap22. Additional World Bank IDA financing is unlikely, given the high priorities of the
+country on infrastructure and budget support and the limited three year IDA envelope available
+(approximately US$ 25 million). Similarly, funding from other donors is likely to remain low,
+particularly in the context of the ongoing global economic crisis.
+Given this context, the Government of Guinea-Bissau is likely not to be able to finance the on-
+going management of Cacheu and Cantanhez. Without financing, IBAP and FIAL will be
+unable to sustain the on-going dialog with the community nor be able to provide the technical
+and financial assistance necessary to enable the communities to identify and implement
+alternatives that reduce pressure over the forest. Under these circumstances, the most
+21 Around the globe, funding for PAs depends on budget allocation of central governments, however,
+according to IBAP’s Annual Activity Report- 2011: “in Guinea-Bissau the environmental management
+sector does not have the privilege of public funding, because other sectors like health, education and
+infrastructure are priority and have immediate urgency”.
+22 The GEF Biodiversity Conservation Trust Fund project, seeks to secure $3-5m as initial seed capital
+to the FBG, with a view in the first instance to financing the core recurrent costs of two marine
+protected areas: Joao Vieira e Poilao National Park and Orango National Park.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 34
+plausible scenario in the absence of the project activity is the dominance of traditional land use
+practices with a consequent acceleration in deforestation rates.
+2.5 Additionality
+As per VT0001 (Tool for Demonstration and Assessment of Additionality in VCS AFOLU
+Project Activities), version 3.0, project proponent(s) shall apply the following four steps:
+STEP 1. Identification of alternative land use scenarios to the AFOLU project activity;
+This step serves to identify alternative land use scenarios to the proposed VCS REDD project
+activity that could be the baseline scenario, through the following sub-steps:
+Sub-step 1a. Identify credible alternative land use scenarios to the proposed VCS REDD
+project activity:
+Two realistic and credible land-use scenarios are identified and could occur on the land within
+the project boundary in the absence of the REDD project activity under the VCS. The
+scenarios are feasible based on relevant national policies and circumstances, such as
+historical land uses, practices and economic trends. The alternative land use scenarios are:
+Alternative I.
+Under this scenario, funding for IBAP would be drastically reduced and deforestation rates
+would accelerate. Observed historical deforestation rates would continue similar to pre-
+project trends. Currently, FIAL already lacks the resources to support micro-projects in
+Cacheu and Cantanhez.
+Alternative II.
+Under this scenario, the Government of Guinea Bissau has both successfully secured
+sufficient financial means and has the political will to dedicate these resources to sustaining
+and supporting the conservation efforts in Cacheu Mangrove Forest National Park and in
+Cantanhez Forest National Park over the long term.
+Sub-step 1b. Consistency of credible land use scenarios with enforced mandatory applicable
+laws and regulations.
+All land use scenarios are compliant with mandatory applicable laws and regulations.
+Customary land use right are respected; therefore, traditional land use practices would
+continue to be performed by the population living in Cantanhez and Cacheu National Parks.
+Sub-step 1c. Selection of the baseline scenario
+The most plausible baseline scenario is Alternative Scenario I as defined in Step 3 (Barrier
+Analysis).
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 35
+STEP 2. Investment Analysis to determine that the proposed project activity is not the most
+economically or financially attractive of the identified land use scenarios
+Not Applicable.
+STEP 3. Barriers Analysis
+Sub-step 3a. Identify barriers that would prevent the implementation of the type of proposed
+project activity
+This step will demonstrate that Alternative II is neither a credible nor a realistic scenario due to
+three main barriers:
+A Financial Barrier exists because IBAP is not able to secure the necessary long-term
+financing commitments. The government has historically suffered from chronic public budget
+shortages and donor funding is both unpredictable and of limited duration.
+An Institutional Barrier exists due to the history of political and institutional instability affecting
+the country. Tensions between the civilian government and the military lead to regular
+changes in government and ministers, undermining the implementation of national policies and
+strategies.
+The proposed REDD project is the First of Its Kind in the country.
+Consequently, the most likely scenario in the absence of the proposed REDD project is
+Alternative I, namely that deforestation rates would accelerate. The barriers are further
+discussed and substantiated below.
+I. Financial Barrier:
+Guinea-Bissau, with a population of 1.6 million, is one of the world‘s poorest countries. The
+country has ranked invariably in the bottom rung on the last decade‘s annual UNDP Human
+Development Indices, being the 164th out of 169 countries in the 2010 report for example.
+Income per capita in 2010 was estimated at about US$500. Chronic poverty is deep and
+entrenched, with an estimated 70 percent of the population living under the $2 dollar-a-day
+poverty line in 2010, a worsening since the 2002 estimate of 65 percent. Economic growth in
+the decade following the 1998-99 internal conflict has barely exceeded population growth. Low
+growth has also translated into low state revenues. The Government cannot generate
+sufficient revenues to finance the country’s expenses and is characterized by a frequent
+inability to pay public suppliers and employees, and a general inability to fund development
+spending. Guinea-Bissau’s developmental challenges are considerable and the competition
+between sectors for scarce public and donor resources is high. Despite Highly Indebted Poor
+Country (HIPC) debt relief in 2010, as demonstrated in Table 1 below, the country continues to
+struggle with significant budget deficits and remains entirely dependent on donors.
+Table 2. Guinea Bissau Revenues and Expenditures 2009 - 2011
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 36
+Δ GDP Revenues (million
+FCFA)
+Expenses
+(million FCFA)
+Budget Deficit
+(million FCFA)
+2009 2,9% 29,900.00 146,083.00 -116,183.00
+2010 3,0% 44,994.00 121,114.00 -76,120.00
+2011 5,3% 47,691.00 101,998.00 -54,307.00
+2012 4,5% 61,783.00 116,063.00 -54,280.00
+Source: Orçamento Geral do Estado, 2009, 2010, 2011 and 2012.
+In this context, the Government has not been able to finance IBAP from the national budget
+and, in the face of very real and urgent competing development demands across all sectors,
+including but not limited to health, education and infrastructure, it is unlikely that this situation
+will change in the foreseeable future23.
+The absence of public financing means that management of GB’s protected areas has and will
+continue to depend exclusively on external financing sources, more specifically, projects
+financed by international donors and NGOs. While, over the past decade, project-based
+financing has enabled the country to establish the legal and institutional framework and
+develop capacity to manage these valuable resources, this type of financing is not well suited
+to ensuring the ongoing management of the protected areas over time. Long term protected
+area management is a continual process, requiring steady and predictable financing streams
+able to sustain the core management activities (park staff, surveillance, stakeholder dialogue,
+monitoring, etc.) consistently over time. In contrast, as exemplified in Guinea Bissau, project-
+based donor financing is unpredictable and, even when secured, is typically characterized by:
+(i) short time frames (generally not more than a 4-5 year commitment); (ii) a preference to
+finance investment costs (equipment, consultancies, studies, etc.) over recurrent operating
+expenditures (staff, fuel, maintenance, etc.); and (iii) a focus on current donor financing
+priorities, which may not include or be well aligned with the country’s protected area
+management concerns, thus leaving portions of their program needs unfunded. Furthermore,
+the constant need for fund raising, as well as the time required to meet the diverse donor
+reporting requirements, distracts IBAP’s staff from focusing on their real mandate, which is to
+implement the protected areas management program of activities. The issues highlighted
+above clearly impact IBAP’s operations, forcing IBAP to negotiate emergency funding with
+donors on an annual basis to cover its core operational financing gap: To illustrate this
+situation, in 2012, the salary gap alone was € 90,000, representing 42 percent of its salaries.
+In addition, the global financial crisis has negatively affected donor aid budgets. This, together
+with the political and economic uncertainties facing the country, means that neither the
+government nor international donors can provide the necessary financial stability proposed
+under Alternative II to ensure the management of Protected Areas over the long term.
+23 According to IBAP (2011) “in Guinea-Bissau the environmental management sector does not have
+the privilege of public funding, because other sectors like health, education and infrastructure are
+priority and have immediate urgency”.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 37
+II. Institutional Barriers
+Guinea-Bissau is a fragile state which, since the internal conflict of 1998-1999, has been
+characterized by political instability, often marked by the intrusion of the military or paramilitary
+on the political scene. Between 2004 and 2009, the average term of the successive
+governments did not exceed 6 months, and although the government was relatively stable
+between 2009 and early 2012, the April 2012 coup indicates that the country still has a long
+path to achieve a reasonable governance level. This situation has undermined law and order
+and weakened successive government’s ability to provide essential public services and
+infrastructure and to run a broadly stable macroeconomic course. This instability has also
+undermined already weak institutions, impeding the consistent and persistent implementation
+of medium term strategies in virtually all areas of public policy, and contributed to high turnover
+in senior positions and to the exodus of qualified public personnel. An evaluation of The World
+Bank Governance Index 24 (WGI) for the last five years highlights the country’s weak
+institutional context in Guinea-Bissau. The average grade between the six indicators that
+composes the index is -1.02 in the period 2007 and 2011.
+Table 3. WGI of Guinea-Bissau (GNB) between 2007 - 2011
+GNB
+Indicator 2007 2008 2009 2010 2011 Average
+Voice and Accountability -0.77 -0.77 -0.80 -0.88 -0.97 -0.84
+Political Stability -0.45 -0.69 -0.65 -0.66 -0.70 -0.63
+Government Effectiveness -1.12 -1.06 -1.04 -1.04 -1.04 -1.06
+Regulatory Quality -1.08 -1.2 -1.19 -1.14 -1.12 -1.15
+Rule of Law -1.34 -1.42 -1.36 -1.35 -1.31 -1.36
+Control of Corruption -1.14 -1.09 -1.11 -1.07 -1.06 -1.09
+Given this, and the historical roots underpinning this situation, as well as the inter dependence
+of economic and political developments, it is unrealistic to expect that the country will in the
+near future have a sufficiently stable political environment and strong enough institutions to
+achieve Alternative II.
+III. First of Its Kind Barrier
+Finally, the third barrier relates to the common practice for financing Protected Areas in
+Guinea-Bissau. This REDD Project is the first of its kind in the country and represents a
+breakthrough. This can be demonstrated through a research in the VCS Project Database
+(www.vcsprojectdatabase.org). Sectoral Scope 14 (AFOLU) currently holds 42 projects. None
+is hosted by Guinea-Bissau.
+Sub-step 3b. Show that the identified barriers would not prevent the implementation of at least
+one of the alternative land use scenarios
+24 Scores range from -2.5 to 2.5
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 38
+The remaining alternative scenario is Scenario I. None of the above listed barriers prevent the
+occurrence of the Alternative Scenario I. In fact, the listed barriers corroborate and strengthen
+the feasibility of Scenario I as the most likely baseline scenario in the absence of the proposed
+REDD Project Activity.
+STEP 4. Common Practice Analysis.
+To date, the network of protected areas of Guinea Bissau includes five National Parks that are
+legally established. All of them suffer from the same weak institutional and financial capacity
+hindering the proper management of the parks areas. The objective of the proposed REDD
+project activity is to provide intensive monitoring and effective enforcement into the project
+area seeking the full conservation of the forests Cacheu and Cantanhez hold and to establish
+an benefit sharing mechanism to demonstrate tangible returns to the communities due to
+forest conservation. Thus, although the network of protected areas exist none of the parks can
+be considered similar to the proposed project activity as no other area can provide the same
+level of monitoring and enforcement to pursue full conservation of forests. The project can be
+considered unique as no other similar activities exist in Guinea-Bissau.
+The principle aspects that differentiate the project from other previous and on-going
+conservation initiatives in the country’s National Parks are threefold:
+(1) the source and sustainability of financing - it is the first REDD initiative in Guinea-
+Bissau. To date, all conservation projects have been forced to rely on short-term
+donor grant financing (1-5 yrs), which inhibits the planning and attainment of long term
+park conservation objectives. This project will, for the first time, tap into a long-term
+market based initiative thus allowing for long term planning and execution.
+Furthermore, the project design linking the REDD initiative with the BioGuine
+Foundation will allow a portion of the carbon revenues accrued during the 20 year
+crediting period to be converted into a sustainable flow of financing able to support
+forest conservation in the project areas in perpetuity;
+(2) currently the effectiveness of park management activities is monitored based on
+proxy data, the project will produce for the first time actual field data for tracking and
+evaluating the impact of forest management activities. This will greatly strengthen the
+on the ground capacity to conserve these resources; and, additionally,
+(3) to date evaluation of community micro scale projects has been done on a case-by-
+case basis, project ecosystem level monitoring will enable a broader park level impact
+assessment to be executed. The predictability of long term financing together with
+actual field monitoring of ecosystem health trends will thus transform the ability to
+manage and preserve this forest resources.
+To corroborate these distinct differences that makes the REDD project activity not a common
+practice in the country, the Secretary of State of Environment and Tourism, Sr. Agostinho da
+Costa, declared that the “Community Based Avoided Deforestation Project in Guinea Bissau
+will promote, for the first time, systematic forest monitoring activities, continuous dialog and
+support to local communities and provide technical assistance allowing the development of
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 39
+alternative subsistence activities and income generation through sustainable agricultural
+production” (GAB_SEC_EST.pdf). Further, the secretary reinforces that the project will allow
+that financial barriers be overcome, supporting the protected areas and the communities in
+Cacheu and Cantanhez in the long run. Similarly, the Union Internationale pour la
+Conservation de la Nature (IUCN) provided documental evidence (IUCN_STATEMENT.pdf) to
+support the differences between the project activity and other protected areas in the country.
+The NGO is present in Guinea-Bissau since 1988 and is fully aware of the country´s
+challenges and efforts in the conservation of its terrestrial and coastal forests. According to
+IUCN “the activities that are being proposed go beyond the current efforts undertaken by IBAP
+and its partners and cannot be considered common practice in the country”.
+2.6 Methodology Deviations
+Six deviations had been approved in the course of the project validation. All of them relates
+only to the criteria and procedures for monitoring and measurement, and does not relate to
+any other part of the methodology, and will not negatively impact the conservativeness of the
+quantification of GHG emissions reductions or removals.
+1. Use of Delaney et al. (1999) equation to calculate palm biomass: after extensive literature
+research (8 equations) it was concluded that no palm equation specific to Guinea-Bissau
+or to West Africa, or even species-specific for mature stands of naturally grown Elaeis
+guineenses is available in the literature. All equations miss one of the methodology´s
+applicability conditions: either not based on at least 30 sampled individuals, or not having
+r2 > 0.8. The project requested a deviation to apply an equation for palms with similar
+physiognomy listed by the IPCC (2003) in the GPG-LULUCF that comply with the
+methodological requirements. The deviation delivers conservative results. The graph
+below demonstrates the conservativeness of the Delaney et al. (1999) equation in
+comparison to the limited measurement approach.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 40
+Further, the deviation was approved once it relates only to the criteria and procedures for
+monitoring and measurement, in special the validation of the allometric equation to
+estimate carbon stocks in aboveground live biomass for Palms, not affecting other parts of
+the methodology. This can be demonstrated referencing back to the methodology modules
+and where the resulting parameter (CAB_tree, Palm) is applied. The resulting data
+(Aboveground carbon stock in Palm trees) is used exclusively for two aspects, monitoring
+and measurement. Measurement is the process for obtaining information about data that
+feeds in the quantification of GHG emission reduction. Therefore, the parameter provides
+the carbon stocks of a tree type (Palm trees) according to module CP-AB. Monitoring
+consists of continuous or periodic assessment of GHG emissions reductions or removals.
+In the project case, the parameter is used to calculate carbon stock changes in the
+leakage belt and the project area and used to assess GHG emissions reductions or
+removals on modules BL-UP, LK-ASU and M-MON. The file “Corrective Action Plan Palms
+– Finding 2012.30 – revised20130625.docx” detail the equation applicability, its testing
+and the conservative results.
+2. Validation of the allometric equation for Mangrove after the validation but prior to the
+verification of the project: In light of the fact that the Chave equation is anticipated to be
+conservative, and will undervalue the actual AGB for the mangroves within the project
+area, a methodological deviation was approved such that the validation of the mangrove
+equation be completed after project validation, but prior to project verification. After
+researching the available literature the Chave equation is anticipated to be conservative
+for both mangrove species in Guinea-Bissau in comparison to the other equation that
+could be applied (Komiyama et al. 2005) as demonstrated in the graphs.
+Elaeis guineensis AGB estimation
+0 2 4 6 8 10 12 14 16 18 20
+height (m)
+0
+50
+100
+150
+200
+250
+300
+350
+400
+AGB (kg)
+6.666 + 12.826 x H0.5 x Ln(H)
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 41
+Rhizophora sp.
+Chave et al. (2005) = 0.168*1*(X**2.47)
+Komiyama et al. (2005) = 0.251*1*(X**2.46)
+0 5 10 15 20 25 30 35 40
+DBH (cm)
+0
+200
+400
+600
+800
+1000
+1200
+1400
+1600
+1800
+2000
+AGB (kg)
+Komiyama et al. (2005)
+(Chave et al., 2005)
+Avicennia germinans
+Chave et al. (2005) = 0.168*0.756*(X**2.47)
+Komiyama et al. (2005) = 0.251*0.756*(X**2.46)
+0 10 20 30 40 50
+DBH (cm)
+0
+200
+400
+600
+800
+1000
+1200
+1400
+1600
+1800
+2000
+AGB (kg)
+Chave et al. (2005)
+Komiyama et al. (2005)
+Additional fieldwork is required for validation of Chave et al. (2005) equation following the
+“Limited Measurement” approach. 16 individuals of Rhizophora sp. and 14 of Avicennia
+sp. will be measured to guarantee that species representation is in proportion to relative
+basal area encountered in the fieldwork. The detailed data collection procedure was
+presented and validated, the file “Corrective Action Plan Mangrove – Finding 2012.28-29 –
+revised20130625.docx” detail procedures and demonstrate that Chave et al. (2005) is
+conservative and can be use for the ex ante emission reduction quantification and be later
+validated prior to verification. The requested deviation only relates to the criteria and
+procedures for monitoring and measurement, in specific the validation of the allometric
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 42
+equation to estimate carbon stocks in aboveground live biomass for Mangroves, and does
+not relate to any other part o the methodology. This can be demonstrated referencing back
+to the methodology modules and where the resulting parameter (CAB_tree, Mangrove) is
+applied. The resulting data (Aboveground carbon stock in Mangrove trees) is used
+exclusively for two aspects, monitoring and measurement. Measurement is the process for
+obtaining information about data that feeds in the quantification of GHG emission
+reduction. Therefore, the parameter provides the carbon stocks of a tree type (Mangrove
+trees) according to module CP-AB. Monitoring consists of continuous or periodic
+assessment of GHG emissions reductions or removals. In the project case, the parameter
+is used to calculate carbon stock changes in the leakage belt and the project area and
+used to assess GHG emissions reductions or removals on modules BL-UP, LK-ASU and
+M-MON.
+3. Validation of the allometric equation for terrestrial forest after the validation but prior to the
+verification of the project: the project requested a deviation since sampling conducted
+during the fieldwork was not sufficient to validate the allometric equation for terrestrial
+forest. Therefore, validation of the allometric equation for terrestrial forest will be carried
+after validation but prior to the verification of the project. The approved deviation relates
+only to the criteria and procedures for monitoring or measurement in specific the validation
+of the allometric equation to estimate carbon stocks in aboveground live biomass for
+terrestrial forest, and does not relate to any other part o the methodology. This can be
+demonstrated referencing back to the methodology modules and where the resulting
+parameter (CAB_tree, Terrestrial_Forest) is applied. The resulting data (Aboveground carbon stock
+in terrestrial forests) is used exclusively for two aspects, monitoring and measurement.
+Measurement is the process for obtaining information about data that feeds in the
+quantification of GHG emission reduction. Therefore, the parameter provides the carbon
+stocks of a tree type (terrestrial forests) according to module CP-AB. Monitoring consists
+of continuous or periodic assessment of GHG emissions reductions or removals. In the
+project case, the parameter is used to calculate carbon stock changes in the leakage belt
+and the project area and used to assess GHG emissions reductions or removals on
+modules BL-UP, LK-ASU and M-MON. Additional fieldwork will be required to validate
+Chave et al. (2005) equation, as almost all trees in the dataset fork to low in the trunk, and
+thus are likely to produce over conservative estimates. The same Limited Measurements
+approach will be followed when collecting new data but the measurements will be made
+until a diameter of 10 cm instead of only until the first trunk fork. With this adjustment it will
+be possible to work on a dataset that better represents the forest trees in the project area
+and validate the use of the Chave et al. (2005) allometric equation. As demonstrated in the
+file “Finding 2012.27 – Validation of Chave allometric equation v3_20140912.docx” the
+equation can be considered conservative. Using the 40 trees sampled, two applicable
+equations from Chave et al. (2005) for dry forest and the single equation presented at
+Chave et al. (2014) were compared so the most conservative one could be applied for ex-
+ante estimation thus not negatively impacting the conservativeness of quantification of
+GHG. Results are presented below.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 43
+The use of Chave et al. (2005) is more conservative and, consequently, used for ex ante
+estimation.
+4. Establishment of two distinct RRDs: given the characteristics of each Protected Area (PA)
+the project decided to establish two distinct RRDs to better reflect baseline emissions on
+each PA. Similarly, two distinct Leakage Belt had been establish to reflect the local reality
+of each PA. The project understand that such approach results in more accurate
+estimation of baseline emissions by ensuring that the estimated baseline for each of the
+Cacheu and Cantanhez National Parks are fully reflective of historical deforestation in the
+immediate vicinity of said PA. A detailed baseline study prepared by Winrock International
+and IICT presents step-by-step procedures for the determination of each RRD
+(WB_revisionupdate_Final_Report_v6.pdf). The applied approach constitutes a deviation
+only to the criteria and procedures for monitoring or measurement of the Leakage Belt,
+one for Cantanhez and one for Cacheu, and the RRD, one for Cantanhez and one for
+Cacheu, and does not relate to any other part of the methodology. More specifically, the
+deviation impacts the correspondent areas (ARRD and ALK in ha) of the RRD and the
+Leakage Belt. The areas of the RDD and the Leakage Belt are used as a data that feeds
+in the quantification of GHG emissions for the baseline scenario (BL-UP module) both in
+the RRD and the Leakage Belt, therefore as criteria for measurement. The areas are also
+used for the subsequente continuous or periodic assessment of GHG emission reduction
+according to module M-MON, therefore as criteria for monitoring net carbon stock
+changes. As detailed on the PD, the individual baseline emissions and leakage emissions
+are simply summed to present more accurante aggregate project values.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 44
+5. Ex-ante Leakage Calculation: strict application of Equation 6 of LK-ASU would result in
+negative value in the outcome and, thus, erroneous quantification of GHG emission
+reductions. Thus, the project had reversed the order of the subtraction of the changes in
+the baseline scenario from the changes in carbon stocks in the project scenario for ex-ante
+quantification purposes, not negatively impacting the conservativeness of the
+quantification of GHG emissions reductions. If the reversion in the order of the subtraction
+is not performed, leakage emissions are negative and, consequently, emission reduction
+estimated ex-ante is higher. The conservativeness of the applied approach can be
+demonstrated since the current application of the deviation result in a lower emission
+reduction estimated ex-ante in comparison to the emission reduction estimated with the
+strict application of Equation 6 of LK-ASU. This deviation only relates to criteria and
+procedures for measurement of ex ante leakage emissions and does not relate to any
+other part of the methodology. Equation 6 is used in the process of obtaining information
+about data that feeds in the quantification of GHG emission reduction, in this case the
+measurement of unplanned deforestation displaced from the project area to outside the
+Leakage Belt (Step 4). The detailed quantification of ex-ante Leakage Emissions is
+presented in the workbook GB-REDD_ER_v5.xlsx.
+6. PRA sample design: a Participatory Rural Appraisal (PRA) was conducted to evaluate the
+project area degradation potential and to quantify the immigration population (PROPIMM)
+living within the Project Area. Degradation was found to be irrelevant since fuelwood
+collection is mainly undertaken from deadwood, and therefore, degradation emissions are
+considered zero in the ex-ante emissions quantification. The immigration population was
+used to calculated leakage emissions inside and outside the leakage belt. A deviation was
+requested because the PRA sample design is not fully compliant with methodology
+requirements. The deviation only related to the criteria and procedures for measurement
+and does not related to any other part of the methodology. More specifically, sample
+design was undertaken considering an area of 2km outside the Project Area boundary
+while methodology requires that sampling take place in an area of 2 km from the Leakage
+Belt. The deviation does not negatively impact the conservativeness of the quantification
+of the GHG emissions reductions or removals as demonstrated on the file
+2012.46_PRA_DEVIATON.docx. The sample design had to be adjusted given the lack of
+reliable information. The government, or any other public agency, does not have
+information on villages locations (i.e coordinates) so a local census undertaken under the
+CBPM project was used. For CBMP, conservation and poverty alleviation measures are
+undertaken inside the project area and in a 2 km belt. Therefore, the project is applying the
+most reliable information available. Spacial evaluation identified that 36.5% of the villages
+sample fully comply with the requirement of 2 km from the Leakage Belt. The map below
+shows the areas of the 2 km from the project area, 2 km from the leaka belt and the
+intersection of the two areas.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 45
+Criteria for the selection of the reference region (RRD) and leakage belt (LK): the BL-UP
+module establishes the criteria for the selection of the RRD and LK. For the RRD, section
+1.1.1.1 lists 6 aspects to be considered when defining the RRD boundary. The module
+also allows for a relaxation of ±20% on some of these criteria. In the same way, for the LK
+section 1.1.3 lists 7 aspects to be considered when defining the LK boundary, also
+allowing for a relaxation of ±20% on some of these criteria. A deviation was approved
+because non-material variations, between 1% and 3%, were identified when the final
+boundaries of the RRD and LK were defined. The deviation does not negatively impact the
+conservativeness of the quantification of the GHG emissions reductions or removals
+because conservative assumptions, values and procedures were used to ensure that net
+GHG emission reductions are not overestimated. The file
+Justification_PA_RRD_LK_Cacheu_Cantanhez.xlsx evidences why the deviation is
+conservative. In total, 3 criteria are not compliant with BL-UP: (1) the proportion of the
+terrestrial forests class in the RRD, in comparison to the PA, is 3% above the upper limit.
+This is so because Guinea-Bissau is a small country and there is no sufficient forest cover
+to comply with the methodology. (2) One soil class in the RRD was not identified in the PA
+resulting in 1% of the soil classes in the RRD not identified in the PA and (3) the ferralsols
+in the LK is 1% above the upper limit. It is not expected that imaterial differences in soil
+proportions will affect the quantification of GHG emission reductions. All other criteria are
+compliant with the module. Further, the applied approach constitutes a deviation only to
+the criteria and procedures for monitoring or measurement of the Leakage Belt and the
+RRD, and does not relate to any other part of the methodology. More specifically, the
+deviation impacts the correspondent areas (ARRD and ALK in ha) of the RRD and the
+Leakage Belt. The areas of the RDD and the Leakage Belt are used as a data that feeds
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 46
+in the quantification of GHG emissions for the baseline scenario (BL-UP module) both in
+the RRD and the Leakage Belt, therefore as criteria for measurement. The areas are also
+used for the subsequente continuous or periodic assessment of GHG emission reduction
+according to module M-MON, therefore as criteria for monitoring net carbon stock
+changes.
+3 QUANTIFICATION OF GHG EMISSION REDUCTIONS AND REMOVALS
+3.1 Baseline Emissions
+Following BL-UP, the boundaries for the project were established and historical deforestation
+evaluated during the historical reference period within the RRD and the Leakage Belt as
+demonstrated in section 2.3 of this VCS PD. The Simple historic Baseline rate approach was
+followed for projecting the rate of deforestation.
+3.1.1 Collection of Appropriate Data Sources
+Under the CARBOVEG-GB project the Tropical Research Institute (IICT) produced Landsat
+image mosaics for the entire country for the years 2002 and 2007. These mosaics were used
+along with new images from 2010. The original Landsat scenes, path/rows and acquisition
+dates of the images covering the relevant areas are shown in
+Table 4 for 2002 and 2007 and in Table 5 for 2010.
+Table 4. Landsat imagery from 2002 and 2007 used in CARBOVEG-GB
+Satellite Sensor Resolution Coverage Acquisition date Scene or point
+identifier
+Spatial
+(m)
+Spectral
+(μm) (km2) (DD-MM-YYYY) Path Row
+Landsat TM 28.5 0.45-2.35 32,000 02-04-2002 205 51
+Landsat TM 28.5 0.45-2.35 32,000 07-02-2007 205 51
+Landsat ETM+ 28.5 0.45-2.35 32,000 11-04-2002 204 51
+Landsat TM 28.5 0.45-2.35 32,000 28-02-2007 204 51
+Landsat TM 28.5 0.45-2.35 32,000 11-04-2002 204 52
+Landsat TM 28.5 0.45-2.35 32,000 28-02-2007 204 52
+Landsat TM 28.5 0.45-2.35 32,000 04-04-2002 203 52
+Landsat TM 28.5 0.45-2.35 32,000 09-03-2007 203 52
+Table 5. Landsat imagery from 2010 (available at: http://glovis.usgs.gov/). Primary scenes and
+fill scenes for 2010.
+Satellite Sensor Resolution Coverage Acquisition date Scene or point
+identifier
+Spatial
+(m)
+Spectral
+(μm) (km2) (DD-MM-YYYY) Path Row
+Landsat ETM+ 30 0.45-2.35 32 000 02-01-2010 205 51
+Landsat ETM+ 30 0.45-2.35 32 000 18-01-2010 205 51
+Landsat ETM+ 30 0.45-2.35 32 000 19-02-2010 205 51
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 47
+Landsat ETM+ 30 0.45-2.35 32 000 07-03-2010 205 51
+Landsat ETM+ 30 0.45-2.35 32 000 23-03-2010 205 51
+Landsat ETM+ 30 0.45-2.35 32 000 27-01-2010 204 51
+Landsat ETM+ 30 0.45-2.35 32 000 12-02-2010 204 51
+Landsat ETM+ 30 0.45-2.35 32 000 28-02-2010 204 51
+Landsat ETM+ 30 0.45-2.35 32 000 16-03-2010 204 51
+Landsat ETM+ 30 0.45-2.35 32 000 01-04-2010 204 51
+Landsat ETM+ 30 0.45-2.35 32 000 27-01-2010 204 52
+Landsat ETM+ 30 0.45-2.35 32 000 12-02-2010 204 52
+Landsat ETM+ 30 0.45-2.35 32 000 28-02-2010 204 52
+Landsat ETM+ 30 0.45-2.35 32 000 16-03-2010 204 52
+Landsat ETM+ 30 0.45-2.35 32 000 01-04-2010 204 52
+Landsat ETM+ 30 0.45-2.35 32 000 20-01-2010 203 52
+Landsat ETM+ 30 0.45-2.35 32 000 09-03-2010 203 52
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 48
+3.1.2 Mapping of Historical Land-Use and Land-Cover change
+The pre-processed images listed above were used in a mapping operation that followed a
+three-step approach: preprocessing, classification, and validation. The preprocessing included
+geometric corrections, radiomatric calibration, and gap fill for the 2010 images. The gap fill
+methodology by Scaramuzza et al. (2004) was applied to the 2010 images affected by the
+malfunctioning of the Scan-line corrector mechanism and the relative radiometric calibration
+procedure by Phua et al. (2008) was applied prior to building the mosaic layers for the years
+analyzed. The need for this procedure explains the high number of images used to compose a
+complete mosaic for the dry season of 2010.
+The forest class was divided into two sub-classes - terrestrial forest and mangrove - and used
+to produce maps for 2002, 2007, and 2010. A further subdivision of the "terrestrial forest" class
+was assessed (Closed-Forest, Open-Forest, and Savanna) to be consistent with the
+stratification presented by the country in it 2nd National Communication. However, as this
+subdivision of the "terrestrial forest" class failed to comply with the accuracy requirements,
+only the two sub-classes (terrestrial forest and mangrove) were used to assess the changes of
+forest areas, derive the deforested areas, and the deforestation rates. Deforestation Maps
+showing areas of deforestation with paired data were produced for the RRD for the time
+periods between each historic image, i.e. 2002-2007 and 2007-2010.
+Figure 8. Deforestation Map for Cacheu RRD – 2002-2007
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 49
+Figure 9. Deforestation Map for Cacheu RRD – 2007-2010
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 50
+Figure 10. Deforestation Map for Cantanhez RRD – 2002-2007
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 51
+Figure 11. Deforestation Map for Cantanhez RRD – 2007-2010
+To estimate the historical deforestation, a conservative approach was followed. Only areas that were
+permanently deforested were accounted as deforestation, i.e. where post-deforestation land use
+constitutes reforestation this area is not included in the deforestation estimates. Thus, any areas in the
+baseline where forest is converted to any other reforestation activity (e.g. cashew, natural regrowth)
+are not eligible, and were excluded from the baseline deforestation. Gross deforestation is defined as
+the loss in forest area over a given time period caused by conversion of forest to non-forested land
+(GOFC-GOLD, 201225). The "eligible deforestation" mentioned throuought this document is equivalent
+to the "net deforestation", estimated as the difference in forest area between two points in time, taking
+into account both losses from deforestation and gains from forest regeneration and/or tree plantations,
+divided by the number of years between the two time periods (FAO, 201026, 200027). It is called
+"eligible" because it complies with the VMD0007 requirement "post-deforestation land use shall not
+25 GOFC-GOLD, “A sourcebook of methods and procedures for monitoring and reporting
+anthropogenic greenhouse gas emissions and removals associated with deforestation, gains and
+losses of carbon stocks in forests remaining forests, and forestation” (GOFC-GOLD report version
+COP18-1, GOFC-GOLD Land Cover Project Office, Wageningen University, Netherlands, 2012)
+26 FAO-FRA, “Global forest resources assessment 2010” (FAO forestry paper 163, FAO, Rome, 2010);
+www.fao.org/forestry/fra/fra2010/en.
+27 FAO-FRA, “On defi nitions of forest and forest change” (Working paper 33, FAO, Rome, 2000).
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 52
+constitute reforestation" and excludes the areas in the baseline where forest is converted to any other
+reforestation activity (e.g. cashew, natural regrowth).
+To estimate the eligible deforestation, the three land cover maps (2002, 2007, 2010) were combined to
+produce a single map with all possible transitions among the three land cover classes (i.e., terrestrial
+forest, mangrove, non-forest) and a single transition matrix was derived from the map for calculation of
+the total deforestation from each forest class (terrestrial forest and mangrove) during the reference
+period 2002-2010 (ARRD,unplanned,hrp, see section 3.1.4 below). The tables showing the transition matrices
+obtained through map algebra operations with the landscape state at an initial time and the state of the
+same pixel at a later time are shown in Table 06 and Table 07.
+Table 6. RRD Cacheu. Land cover transitions between the three selected historical dates
+(2002, 2007, 2010), using a 3-class legend of terrestrial forest (TF), mangrove (M) and non-
+forest (NF).
+Dates Area (ha) % Total
+2002 2007 2010
+TF TF TF 67,621 38.94
+TF TF M 792 0.46
+TF TF NF 2,149 1.24
+TF M TF 1,603 0.92
+TF M M 560 0.32
+TF M NF 93 0.05
+TF NF TF 5,921 3.41
+TF NF M 239 0.14
+TF NF NF 2,299 1.32
+M TF TF 894 0.51
+M TF M 2,734 1.57
+M TF NF 215 0.12
+M M TF 1,407 0.81
+M M M 76,197 43.88
+M M NF 1,745 1.01
+M NF TF 596 0.34
+M NF M 6,681 3.85
+M NF NF 1,889 1.09
+173,634 100.00
+Table 7. RRD Cantanhez. Land cover transitions between the three selected historical dates
+(2002, 2007, 2010), using a 3-class legend of terrestrial forest (F), mangrove (M) and non-
+forest (NF).
+Dates Area (ha) % Total
+2002 2007 2010
+TF TF TF 121,840 63.32
+TF TF M 2,496 1.30
+TF TF NF 8,099 4.21
+TF M TF 1,799 0.94
+TF M M 1,700 0.88
+TF M NF 466 0.24
+TF NF TF 2,067 1.07
+TF NF M 610 0.32
+TF NF NF 4,069 2.11
+M TF TF 809 0.42
+M TF M 1,674 0.87
+M TF NF 598 0.31
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 53
+M M TF 1,139 0.59
+M M M 39,773 20.67
+M M NF 1,664 0.86
+M NF TF 134 0.07
+M NF M 1,421 0.74
+M NF NF 2,075 1.08
+192,432 100.00
+3.1.3 Map accuracy assessment
+Map accuracy assessment was performed using an independent dataset, i.e. through in situ
+observations, with field data collected in 2007, 2008, 2009 and 2010 (Forest class), and
+analysis of very high resolution data (Non-Forest class). Overall accuracy of the 2010
+Forest/Non-Forest maps is 95.9% (AAu=95,5%). With an overall accuracy (AAu) of 93.9%, the
+three-class map (Terrestrial-Forest/Mangrove/Non-Forest) was also compliant with the
+methodological requirement. The confusion matrices used for the calculation of the accuracy
+parameters (overall accuracy, Kappa coefficient, commission error, and omission error)
+through simple cross tabulation between the classes of the classified map and the reference
+data are shown in Tables 8 and 9.
+Table 8. Confusion matrix of the 2-class map of Forest/Non-Forest for 2010.
+Predicted (# pixels)
+Forest Non-
+forest Total Omission
+error (%)
+Producer’s
+accuracy (%)
+Observed
+(# pixels)
+Forest 385 13 398 3.3 96.7
+Non-forest 7 86 93 7.5 92.5
+Total 392 99 491
+Commission error (%) 1.8 13.1
+User’s accuracy 98.2 86.9
+Overall accuracy (%) 95.9
+Kappa coefficient 0.87
+Table 9. Confusion matrix of the 3-class map of Terrestrial Forest/Mangrove/Non-Forest for
+2010.
+Predicted (# pixels)
+Terrestri
+al forest Mangrove Non-forest Total Omission
+error (%)
+Producer’s
+accuracy (%)
+Observed (# pixels)
+Terrestrial
+forest 325 3 12 340 4.4 95.6
+Mangrove 7 50 1 58 13.8 86.2
+Non-forest 6 1 86 93 7.5 92.5
+Total 338 54 99 491 −
+Commission
+error (%) 3.8 7.4 13.1 − − −
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 54
+User’s
+accuracy 96.2 92.6 86.9 − − −
+Overall accuracy (%) 93.9
+Kappa coefficient 0.87
+3.1.4 Estimation of the annual areas of unplanned baseline deforestation
+As mentioned above, the simple historic default approach for estimation of annual areas of
+unplanned deforestation was followed. As in this assessment there are only two deforestation
+time points, the mean area deforested, hectares per year, across the historical reference
+period was used to calculate the projected area of annual unplanned baseline deforestation in
+the RRD as:
+ABSL,RRD,unplanned,t = ARRD,unplanned,𝒽rp/T𝒽rp
+Where:
+ABSL,RRD,unplanned,t Projected area of unplanned baseline deforestation in the RRD in year
+t; ha
+ARRD,unplanned,𝒽rp Total area deforested during the historical reference period in the
+RRD; ha
+T𝒽rp Duration of the historical reference period in years; yr
+t 1, 2, 3, ...t years elapsed since the projected start of the REDD project
+activity
+Net deforestation rate in the RRD was 0.62 for Cacheu PA and 1.15 for Cantanhez PA for the
+entire reference period. The modeled annual area of deforestation in the RRD
+(ABSL,RRD,unplanned,t) of each Project Area was calculated across the historical reference period.
+The next table (Table 10) shows the values of area of unplanned baseline deforestation in the
+RRD in year t (ha) (ABSL,RRD,unplanned,t) for Cacheu and Cantanhez, both on a gross and eligible
+(net) deforestation basis.
+Table 10. Annual Area of Deforestation in the RRD (ha) in Cacheu and Cantanhez
+RRD − TF M
+Cacheu Eligible (ha) 568 481
+Gross (ha) 1,338 1,391
+Cantanhez Eligible (ha) 1,579 542
+Gross (ha) 1,914 736
+* TF – Terrestrial Forest, M – Mangrove
+In the case of a transition configuration, location analysis is not required as long as it can be
+shown that ≥ 25% of the project geographic boundary is within 50 m of land that has been
+anthropogenically deforested within the 10 years prior to the project start date. Since the >25%
+criterion is met for both Project Areas, location analysis is not required and thus will not be
+elected. The projected unplanned baseline deforestation in the project area was estimated as
+follows:
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 55
+ABSL,PA,unplanned,t = ABSL,RRD,unplanned,t ∗ PPA
+Where:
+ABSL,PA,unplanned,t Projected area of unplanned baseline deforestation in the project area
+in year t; ha
+ABSL,RRD,unplanned,t Projected area of unplanned baseline deforestation in the RRD in year
+t; ha
+PPA Ratio of the project area to the total area of RRD; dimensionless
+t 1, 2, 3, ...t years elapsed since the projected start of the REDD project
+activity
+Similarly, the annual area of unplanned baseline deforestation in the leakage belt (Table 5)
+was estimated as follows:
+ABSL,LK,unplanned,t = ABSL,RRD,unplanned,t ∗ PLK
+Where:
+ABSL,LK,unplanned,t Projected area of unplanned baseline deforestation in the leakage belt
+in year t; ha
+ABSL,RRD,unplanned,t Projected area of unplanned baseline deforestation in the RRD in year
+t; ha
+PLK Ratio of the area of the leakage belt to the total area of RRD;
+dimensionless
+t 1, 2, 3, ...t years elapsed since the projected start of the REDD project
+activity
+Table 11. Annual Area of Deforestation in the Project Area (ha) and Leakage Belt (ha)
+Project Area Leakage Belt
+TF M TF M
+Cacheu
+2012 Eligible (ha) 181 153 102 86
+Gross (ha) 426 442 240 250
+2013 Eligible (ha) 181 153 102 86
+Gross (ha) 426 442 240 250
+2014 Eligible (ha) 181 153 102 86
+Gross (ha) 426 442 240 250
+2015 Eligible (ha) 181 153 102 86
+Gross (ha) 426 442 240 250
+2016 Eligible (ha) 181 153 102 86
+Gross (ha) 426 442 240 250
+2017 Eligible (ha) 181 153 102 86
+Gross (ha) 426 442 240 250
+2018 Eligible (ha) 181 153 102 86
+Gross (ha) 426 442 240 250
+2019 Eligible (ha) 181 153 102 86
+Gross (ha) 426 442 240 250
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 56
+2020 Eligible (ha) 181 153 102 86
+Gross (ha) 426 442 240 250
+2021 Eligible (ha) 181 153 102 86
+Gross (ha) 426 442 240 250
+Cantanhez
+2012 Eligible (ha) 742 255 819 281
+Gross (ha) 900 346 992 382
+2013 Eligible (ha) 742 255 819 281
+Gross (ha) 900 346 992 382
+2014 Eligible (ha) 742 255 819 281
+Gross (ha) 900 346 992 382
+2015 Eligible (ha) 742 255 819 281
+Gross (ha) 900 346 992 382
+2016 Eligible (ha) 742 255 819 281
+Gross (ha) 900 346 992 382
+2017 Eligible (ha) 742 255 819 281
+Gross (ha) 900 346 992 382
+2018 Eligible (ha) 742 255 819 281
+Gross (ha) 900 346 992 382
+2019 Eligible (ha) 742 255 819 281
+Gross (ha) 900 346 992 382
+2020 Eligible (ha) 742 255 819 281
+Gross (ha) 900 346 992 382
+2021 Eligible (ha) 742 255 819 281
+Gross (ha) 900 346 992 382
+* TF – Terrestrial Forest, M – Mangrove
+The total area of unplanned baseline deforestation in the Project Area and Leakage Belt were
+estimated as follows:
+ABSL,PA,unplanned = ∑ ABSL,PA,unplanned
+t
+t=1
+ABSL,LK,unplanned = ∑ ABSL,LK,unplanned
+t
+t=1
+Where:
+ABSL,PA,unplanned Total area of unplanned baseline deforestation in the project area; ha
+ABSL,LK,unplanned Projected area of unplanned baseline deforestation in the leakage belt;
+ha
+ABSL,PA,unplanned,t Projected area of unplanned baseline deforestation in the project area
+in year t; ha
+ABSL,LK,unplanned,t Projected area of unplanned baseline deforestation in the leakage belt
+in year t; ha
+t 1, 2, 3, ...t years elapsed since the projected start of the REDD project
+activity
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 57
+3.1.5 Estimation of carbon stocks and carbon stock changes
+Estimation of carbon stock changes and GHG emissions followed BL-UP, CP-AB, X-STR and
+X-UNC. The maps in the following pages display the final delineation of strata in Cacheu and
+Cantanhez in 2010 as requested by Module X-STR.
+Figure 12. Land Cover Map – all strata – Cacheu 2010
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 58
+Figure 13. Land Cover Map – all strata – Cantanhez 2010
+The method chosen for sampling and estimation of carbon stocks in aboveground tree
+biomass is described in VMD0001 as "Part 1, Option 1. Fixed Area Plots with Allometric
+Equation method".
+A total of 259 plots were sampled for the carbon stock analysis based on data from the field
+missions developed under the World Bank (2010 and 2012) and the CARBOVEG-GB (2007,
+2008, and 2009) projects. Of the 259 plots, 124 were measured in the Cacheu Protected Area,
+and 135 in the Cantanhez Protected Area. Field measurements for the carbon stock
+assessment closely followed the requirements stated in the VM0007 VCS framework and the
+carbon stock measurement protocols established in Pearson in et al. (2005). Data analyses
+were also conducted according to the VMD0007 (BL-UP) module. All trees with DBH of ≥5 cm
+and a minimum height (H) of 1.3 m were measurement in the instaled nested plots. To be
+representative of all sizes of tree present in sampled parks in GB, measured tree dimensions
+varied between different forest types.
+After running some tests for data verification prior to data processing, on the GB collected data
+and different models (in more detail below), the project team concluded that the best fit for
+estimating above-ground biomass (AGB) of trees was the pantropical allometric equation
+formulated by Chave et al. (2005). Separate equations as a function of climate and primarily
+the mean monthly evapotranspiration and rainfall were developed by Chave et al. (2005), with
+these being for wet, moist, and dry forests. Given that forests in GB can be considered dry
+(Carreiras et al., 2012), the predictive model for dry forests in Chave et al. (2005) was used to
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 59
+estimate the AGB of each live forest tree in all strata (closed forest, open forest, and savanna).
+When known, species specific wood density was applied. When species was not known or
+wood density values were not published/available, an average wood density calculated from all
+other trees was applied. As for mangroves, Chave et al. (2005) common allometric equation
+for mangroves requiring only two parameters (DBH and wood density) was used. Finally, the
+conservativea allometric equation listed in both IPCC (2003) and Pearson et al. (2005) was
+used to estimate the biomass of palm trees. Together with the carbon fraction (CFj) used, i.e.
+the standard conversion factor of 0.47 (IPCC, 2006), these equations (fj(X, Y … ), in equation
+below) were used to estimate the carbon stock in aboveground biomass for each individual
+tree with the equation:
+CABtree,sp,i = ∑ ∑ fj(X, Y … ) × CFj
+Nj,sp,i
+l=1
+S
+j
+Where
+CABtree,sp,i Carbon stock in aboveground biomass of trees in plot sp in stratum i; t
+C
+CFj Carbon fraction of biomass for species group j; t C t-1 d.m; i.e. 0.47
+(IPCC, 2006)
+fj(X, Y … ) Aboveground biomass of trees based on the above mentioned
+allometric equation for species group j based on measured tree
+variable(s); t. d.m. tree-1
+i 1, 2, 3, …M strata
+j 1, 2, 3 … S tree species
+l 1, 2, 3, … Nj,sp,i sequence number of individual trees of species
+group j in sample plot sp in stratum i
+Subsequently, the mean carbon stock in aboveground biomass is calculated for each stratum
+and converted to carbon dioxide equivalents, using the equation:
+CABtree,i = ∑ CAB_tree,sp,i
+Asp,i
+× 44
+12
+Pi
+sp=1
+Where:
+CAB_tree,i Mean aboveground biomass carbon stock in stratum i; t CO2-e ha-1
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 60
+CABtree,sp,i,t Aboveground biomass carbon stock of trees in sample plot sp of
+stratum i , t C
+Aspi Area of sample plot sp in stratum i; ha
+sp 1, 2, 3, … Pi sample plots in stratum i
+i 1, 2, 3, …M strata
+44/12 Ratio of molecular weight of CO2 to carbon, t CO2-e t C-1
+One should note that dividing the aboveground biomass carbon stock of trees in each sample
+plot (CABtree,sp,i,t ) by the area of that plot (Aspi) to extrapolate the estimate to the area of a full
+hectare is equivalent to multiplying the aboveground biomass carbon stock of trees in each
+sample plot ( CABtree,sp,i,t ) by a scaling factor, i.e. calculating the proportion of an hectare
+(10,000 m2) that is occupied by a given plot (or nest in this case) using a scaling factor. The
+scaling factor is calculated as follows:
+( )
+2
+2
+_
+000	,	10
+_ m	plot	Area
+m
+factor	Scaling =
+The mean carbon stock in belowground tree biomass per unit area was estimated based on
+field measurements of aboveground parameters in sample plots. Root to shoot ratios were
+coupled with the allometric equations method used for estimation of aboveground biomass to
+calculate belowground from aboveground biomass. Option 1 from VMD0001(Fixed area plots
+with root to shoot ratio) was followed.
+For forest trees the below-ground biomass (was estimated using a linear relationship between
+root biomass and shoot biomass reported by Mokany et al. (2006). The authors developed a
+root to shoot ratio (RSR) for many different types of vegetation and the relationship reported
+for tropical dry forest was chosen based on IPCC (1996). The relationship establishes that :
+• if AGB < 20 t ha-1, BGB (t ha-1) = 0.56*AGB; or
+• if AGB > 20 t ha-1, BGB (t ha-1) = 0.28*AGB
+Below-ground biomass is of particular importance in mangroves because mangrove trees
+accumulate significant portion of its biomass in the roots (Komiyama et al., 2008). However, no
+root-to-shoot ratios for African mangrove forests were found in the literature. To estimate BGB
+in mangroves, AGB and BGB data reported by Komiyama et al. (2008) (including data for
+Indonesia, Australia, Thailand, Panama, and Puerto Rico) was compiled and an average RSR
+of 0.61 was calculated across all available values. Conservatively the half-width of the 95%
+confidence interval of the data compiled was used to estimate BGB of mangroves, i.e., the
+mean AGB:BGB ratio minus the confidence interval value (0.46).
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 61
+as for palm trees, since there is no dataset available or published that relate above- to below-
+ground biomass for palm trees, conservatively, belowground carbon stocks of palm trees were
+omitted.
+To estimate the belowground tree biomass carbon stock for each plot the following equation
+was used:
+CBBtree,sp,i = R × CABtree,sp,i
+Where:
+CBBtree,sp,i Belowground tree biomass carbon stock of trees in plot sp, in stratum
+i; t C
+CABtree,sp,i,t Aboveground biomass carbon stock of trees in sample plot sp of
+stratum i , t C (as listed in the text above)
+R Root to shoot ratio; t root d.m. t-1 shoot d.m.
+i 1, 2, 3, …M strata
+Subsequently, the mean belowground tree biomass carbon stock for each stratum was
+calculated and converted to carbon dioxide equivalents with the following equation:
+CBBtree,i = ∑ CBB_tree,sp,i
+Asp,i
+× 44
+12
+Pi
+sp=1
+Where:
+CBB_tree,i Mean belowground tree biomass carbon stock in stratum i; t CO2-e ha-
+1
+CBBtree,sp,i,t Mean belowground tree biomass carbon stock of trees in sample plot
+sp of stratum i , t C
+Aspi Area of sample plot sp in stratum i; ha
+sp 1, 2, 3, … Pi sample plots in stratum i
+i 1, 2, 3, …M strata
+44/12 Ratio of molecular weight of CO2 to carbon, t CO2-e t C-1
+Similarly to what was described above for the expansion of the estimated aboveground
+biomass in a plot to the area of a full hectare, for belowground biomass the same method of
+using an expansion factor applies.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 62
+For the baseline, only aboveground (CAB_tree, i, tCO2-e ha-1) and belowground (CBB_tree, i, tCO2-e
+ha-1) biomass tree pools were quantified following the equations below:
+∆CABtree,i = CABtreebsl,i − CABtreepost,i
+∆CBBtreebsl,i = CBBtreeBSL,i − CBBtreepost,i
+Where:
+∆CABtree,i Baseline carbon stock change in aboveground tree biomass in stratum
+i; t CO2-e ha-1
+CABtree,BSL,i Forest carbon stock in aboveground tree biomass in stratum i; t CO2-e
+ha-1
+CABtree,post,i Post-deforestation carbon stock in aboveground tree biomass in
+stratum i; t CO2-e ha-1
+∆CBBtree,i Baseline carbon stock change in belowground tree biomass in stratum
+i; t CO2-e ha-1
+CBBtree,bsl,i Forest carbon stock in belowground tree biomass in stratum i; t CO2-e
+ha-1
+CABtree,post,i Post-deforestation carbon stock in belowground tree biomass in
+stratum i; t CO2-e ha-1
+As previously mentioned, the main agents of deforestation in GB are the local population, who
+clear land for subsistence agriculture. The main agricultural product is rice, which is planted in
+two different systems: dry land rice and wetland rice. Therefore, subsistence agriculture from
+both dry land and wetland is the only post-deforestation land-use mapped. IPCC default values
+were applied to the post deforestation carbon stock.
+Post-deforestation carbon stock was calculated by independently carrying out the Silva et al.
+(2011) equation. Through this method, post-deforestaion carbon stock is assumed to be the
+long-term average stocks on the land following deforestation. For the reasons and
+deforestation drivers mentioned above, it was assumed that all the land following deforestation
+enters a shifting cultivation cycle composed of a 2-year cropland period and a 5- to 6-year
+fallow period (Temudo, 1998). To produce conservative estimates, we used an 8-year shifting
+cultivation cycle, composed of a 2-year cropland period and a 6-year fallow period. Therefore,
+and on a spatial basis, we assumed that 2/8 of any post-deforestation area was occupied by
+cropland and 6/8 by fallow land of different ages (1 to 6 years) in equal proportion. The
+average post-deforestation C stock in a shifting cultivation cycle with these characteristics is:
+
+
+
+
+
+
++	
+
+
+
+
+
+= fallow	crop	i	post	AB C	C	C *
+8
+6
+*
+8
+2
+,	_
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 63
+Where:
+CAB_post, i Long-term average C stock of post deforestation land use i (tC ha-1)
+Ccrop Average C stock of cropland per year (tC ha-1 yr-1)
+Cfallow Average C stock per year of fallow land (tC ha-1 yr-1)
+Only one cropland class was defined under this study: rice production. Since no local study on
+rice carbon stocks is available, the 5.0 tCha-1 post-deforestation carbon stock from the IPCC
+(2006) was used as the default biomass carbon stocks present on land converted to cropland
+in the year following conversion (Table 5.9, chapter 5, Vol. 4 AFOLU, IPCC, 2006).
+As for fallow land, an equation initially developed by Zarin et al. (2001) and modified by Silva
+et al. (2011) was applied to estimate above-ground biomass accumulation following
+disturbance caused by shifting cultivation practices. The equation estimates above-ground
+biomass as a function of fallow period and climate data. Different equations were developed
+according to soil texture (sandy vs. non-sandy), but all the land supporting shifting cultivation in
+GB were in sandy soils (Silva et al., 2011). Therefore, the following equation was used:
+
+
+
+
+
+ 		+	−	= 365
+ln	8542	.	23	8011	.	65 L
+T	FP	AGBS
+where:
+AGBs Aboveground biomass accumulation in sandy soils (tha-1)
+FP Fallow period (years)
+T Growing season temperature (°C)
+L Duration of the growing season (days), and L/365 is the duration of the
+growing season as a fraction of the year)
+Both T and L were estimated from climate data, as described in Silva et al. (2011). The
+analysis and results described in Silva et al. (2011) were produced at the country scale. For
+Guinea-Bissau the product 𝑇𝑥 𝐿
+365 (named growing season degree years, GSDY) was
+estimated as 11.5. To obtain this value maps of T (growing season average surface
+temperature), and L (duration of the growing season, days) were combined (weighted by area)
+to obtain a unique value of GSDY per country, as described in Silva et al (2011). The previous
+equation was used to individually estimate the AGB for fallow periods of 1, 2, 3, 4, 5, and 6
+years. Subsequently, the average value was computed for those six years as 18.6 tha-1. Using
+a standard conversion factor of 0.47 (IPCC, 2006), the average C stock is 8.7 tCha-1.
+Finally, the time-weighted average C stock in post-deforested lands in an 8-year shifting
+cultivation cycle was calculated as:
+8	.	7	7	.	8
+8
+6
+0	.	5
+8
+2
+,	_ =		+		=	i	post	AB	C
+tC ha-1 or 28.6 tCO2-e ha-1
+In total, 125 forest plots were measured in Cacheu and 136 in Cantanhez. Applying the overall
+average forest stock per hectare to all strata would result in inaccurate estimates (GOFC-
+GOLD, 2011). Therefore, dividing forest into homogeneous sub-classes (i.e., stratifying by
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 64
+forest type) may improve accuracy of carbon stock and carbon stock change estimates.
+Although the maps produced only stratify forest into terrestrial forest and mangrove, an
+additional stratification exercise was anticipated in the field work plan that preceded the
+collection of field data in all field campaigns (2007, 2008, 2009, 2010, and 2012). Following
+VMD0016, CARBOVEG-GB maps were used as ancillary data and as a proxy for potential
+biomass classes and area estimation. The pre-stratification of the project area into the
+following forest sub-classes contributed to avoiding post measurement stratification:
+• Closed Forest
+• Open Forest
+• Savanna Woodland
+• Mangrove
+VMD0017 uses the target precision of 15% (for a confidence interval of 95%). An estimate of
+the additional number of plots required to reduce uncertainty of carbon stocks and achieve the
+VMD0017 module precision target was performed prior to the fieldwork. Table 12 presents the
+average carbon stock per stratum in Cacheu and Cantanhez Project areas.
+Table 12. Average carbon stocks per stratum in the Project Area
+Project
+Area Stratum Area
+(ha)
+# of
+Plots
+AGB carbon stock
+(CAB_tree, i, tCO2-eha-1)
+BGB carbon stock
+(CBB_tree, i, tCO2-eha-1)
+Cacheu
+Open Forest 14,509 69 132.9 35.2
+Savanna 4,438 18 97.7 26.5
+Mangrove 33,596 37 72.9 33.4
+Cantanhez
+Closed Forest 6,915 45 306.11 84.2
+Open Forest 45,659 46 127.0 33.8
+Savanna 14,195 18 101.4 28.2
+Mangrove 22,144 26 100.45 46.0
+The sum of the baseline carbon stock changes was calculated under the business as usual at
+the end of the 10-year period by applying the estimated deforestation per year to the stratum
+with the lowest carbon stock for each project area and leakage belt using the equations below:
+∆CTOT = ∑ ∑ ∆CBSL,i,t
+M
+i=1
+t
+t=1
+∆CBSL,i,t = Aunplanned,i,t × ∆CABtree,i + ∑ Aunplanned,i,t
+t
+t−10
+× ∆CBBtree,i × 1
+10
+Where:
+∆CTOT Sum of the baseline carbon stock change in all pools up to time t; t
+CO2-e (calculated separately for the project area and the leakage belt;
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 65
+∆CBSL,i,t Sum of the baseline carbon stock change in all pools in stratum i at
+time t, t CO2-e
+Aunplanned,i,t Area of unplanned deforestation in forest stratum i at time t; ha
+∆CABtree,i Baseline carbon stock change in aboveground tree biomass in stratum
+i; t CO2-e ha-1
+∆CABtree,i Baseline carbon stock change in aboveground tree biomass in stratum
+i; t CO2-e ha-1
+∆CBBtree,i Baseline carbon stock change in belowground tree biomass in stratum
+i; t CO2-e ha-1
+i 1, 2, 3, … M strata
+t 1, 2, 3, ...t years elapsed since the projected start of the REDD project
+activity
+As no location analysis has been conducted, annual deforestation area is given directly by
+ABSL,PA, unplanned,t for the Project Area and ABSL,LK, unplanned, t for the Leakage Belt. The cumulative
+carbon stock change under the business as usual in each Project Area is shown below
+Table 13. Cumulative Carbon Stock Changes in the BAU in the Project Area(tCO2e)
+ΔCBSL,i (tCO2-e)
+PA Stratum 2012 2013 2014 2015 2016 2017 2018 2019 2020 2021
+Cacheu
+
+Terrestrial
+Forest 12,949 26,377 40,282 54,667 69,529 84,870 100,690 116,987 133,763 151,018
+Mangrove 7,283 15,078 23,383 32,200 41,527 51,366 61,715 72,576 83,948 95,831
+ΔCTOT (tCO2e) 20,232 41,454 63,666 86,866 111,056 136,236 162,405 189,563 217,711 246,849
+Cantanhez
+Terrestrial
+Forest 56,119 114,329 174,632 237,026 301,513 368,091 436,761 507,523 580,377 655,323
+Mangrove 19,468 40,108 61,920 84,905 109,063 134,392 160,894 188,569 217,416 247,435
+ΔCTOT (tCO2e) 75,586 154,437 236,552 321,932 410,575 502,483 597,655 696,092 797,793 902,758
+The cumulative carbon stock change under the business as usual in each Leakage Belt is
+shown below.
+Table 14. Cumulative Carbon Stock Changes in the BAU in the Leakage Belt (tCO2e)
+ΔCBSL,i (tCO2-e)
+LK Stratum 2012 2013 2014 2015 2016 2017 2018 2019 2020 2021
+Cacheu
+Terrestrial Forest 7,310 14,890 22,740 30,860 39,251 47,911 56,841 66,042 75,512 85,252
+Mangrove 4,112 8,512 13,200 18,177 23,443 28,997 34,840 40,971 47,390 54,098
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 66
+ΔCTOT (tCO2e) 11,422 23,402 35,940 49,038 62,693 76,908 91,681 107,012 122,902 139,351
+Cantanhez
+
+Terrestrial Forest 61,911 126,130 192,657 261,491 332,634 406,084 481,842 559,908 640,281 722,963
+Mangrove 21,477 44,248 68,312 93,669 120,320 148,264 177,501 208,032 239,857 272,974
+ΔCTOT (tCO2e) 83,388 170,378 260,968 355,160 452,953 554,348 659,343 767,940 880,138 995,937
+The sum of the baseline carbon stock change (ΔCTOT) in each project area and leakage belt is
+the difference between the total forest carbon stock and the total post-deforestation carbon
+stock change under business as usual. The sum of the baseline carbon stock change in all
+pools up to the 10th year of the current baseline scenario are shown below. The wood products
+pool (CWP) was excluded since this pool is only mandatory where the process of deforestation
+involves timber harvesting for commercial markets, which is not applicable to the project.
+Table 15. Total Carbon Stock Change (tCO2e)
+ΔCTOT (tCO2-e)
+Cacheu PA 246,849
+LB 139,351
+Cantanhez PA 902,758
+LB 995,937
+*PA – Project Area, LB – Leakage Belt
+The GHG emissions were accounted as zero in the calculation of net emissions (Table 10) and
+therefore, the net GHG emissions in the baseline was calculated as follows:
+∆CBSL,unplanned = ∆CBSL,PA,unplanned + 0
+∆CBSL,PA,unplanned = ∆CTOT,PA
+Where:
+∆CBSL,unplanned Net greenhouse gas emissions in the baseline from unplanned
+deforestation; t CO2-e
+∆CBSL,PA,unplanned Net CO2 emissions in the baseline from unplanned deforestation in the
+project area; t CO2-e
+∆CTOT,PA Sum of the baseline carbon stock change in all pools up to time t in the
+project area; t CO2-e
+Table 16. Net emissions reductions from avoiding unplanned deforestation in the baseline
+scenario.
+ΔCBSL,PA,unplanned
+(tCO2e)
+GHGBLS,E
+(tCO2e)
+ΔCBSL,unplanned
+(tCO2e)
+Cacheu 246,849 0 246,849
+Cantanhez 902,758 0 902,758
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 67
+The next table shows the net emissions in the baseline from unplanned deforestation
+estimated as the sum at the end of the 10-year period.
+Table 17. Net emissions in the Baseline Scenario (tCO2e)
+ΔCBSL,unplanned (tCO2e)
+2012 2013 2014 2015 2016
+Cacheu
+ΔCBSL,PA,unplanned (tCO2e) 20,232 41,454 63,666 86,866 111,056
+ΔCBSL,unplanned (tCO2e) 20,232 41,454 63,666 86,866 111,056
+Cantanhez
+ΔCBSL,PA,unplanned (tCO2e) 75,586 154,437 236,552 321,932 410,575
+ΔCBSL,unplanned (tCO2e) 75,586 154,437 236,552 321,932 410,575
+ΔCBSL,unplanned (tCO2e)
+2017 2018 2019 2020 2021
+Cacheu
+ΔCBSL,PA,unplanned (tCO2e) 136,236 162,405 189,563 217,711 246,849
+ΔCBSL,unplanned (tCO2e) 136,236 162,405 189,563 217,711 246,849
+Cantanhez
+ΔCBSL,PA,unplanned (tCO2e) 502,483 597,655 696,092 797,793 902,758
+ΔCBSL,unplanned (tCO2e) 502,483 597,655 696,092 797,793 902,758
+3.2 Project Emissions
+This section describes the procedure for ex-post quantification of project emissions in
+accordance with VMD0007 due to deforestation within the project area and leakage belt, forest
+degradation through extraction of trees for illegal timber and fuelwood and charcoal, and as
+result of natural disturbance, including fire. This section also provides explanation and
+justifications for developing the ex-ante estimate of the respective output parameters. Net
+greenhouse gas emissions within the project area under the project scenario (∆CP) within the
+project area and the leakage belt are calculated according to M-MON (v2.1) module. In the
+case of the proposed project activity three emissions sources are anticipated, potential net
+carbon stock changes as a result of (i) deforestation in the project area (∆CP,DefPA,i,t) and the
+leakage belt (∆CP,DefLB,i,t) in the project case. If the PRA indicates forest (ii) degradation is
+taking place in the project area, such emissions must be calculated (∆CP,DegW,i,t). Finally,
+although emissions due to (iii) natural disturbances are not expected, this section also
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 68
+presents relevant equations and justification of methodological choices for the calculation of
+ex-post net carbon stocks changes as a result of natural disturbance28 (ACP,DistPA,i,t).
+Carbon stocks changes from forest degradation (∆CP,DegW,i,t) are accounted as zero for the ex-
+ante estimate. As demonstrated in the PRA, carbon stock changes from wood extraction in the
+project area are considered insignificant. The PRA must be updated every two years and if the
+results suggest that there is a potential for degradation activities, then limited field sampling
+must be undertaken to delineate the areas that are potentially subjected to degradation. Net
+carbon stock changes as a result of degradation shall be estimated according to the equations
+below:
+Where the PRA or limited sampling indicate no degradation is occurring:
+∆CP,DegW,i,t = 0
+Where the PRA and the limited sampling indicate degradation is occurring:
+∆CP,DegW,i,t = ADegW,i ∗ CDegW,I,t
+APi
+Where:
+∆CP,DegW,i,t Net Carbon stock changes as a result of degradation in stratum I in
+project area at time t; tCO2e
+ADegW,i Area potentially impacted by degradation processes in stratum i; ha
+CDegW,I,t Biomass carbon of trees cut and removed through degradation
+process from plots measured in stratum I at time t; tCO2e
+APi Total area of degradation sample plots in stratum i; ha
+i 1,2,3…M strata
+t 1,2,3… t* years elapsed since the start of the REDD project activity
+Carbon Dioxide (CO2) emissions are fully accounted in the net carbon stock change. Other
+GHG gases like methane (CH4) and nitrous oxide (N2O) are not expected to be relevant
+because: IBAP activities do not include fire use ( EBiomassBurn,i,t ) or nitrogen fertilization
+(N2Odirect−N,i,t). Patrolling is done by the local communities on foot, therefore fossil fuel use is
+also not relevant (EFC,i,t).
+For the project area the net greenhouse gas emissions in the project case is equal to the sum
+of stock changes due to deforestation, degradation and natural disturbance:
+28 According to the M-MON module such disturbances include tectonic activities, extreme weather,
+pest, drought or fire that result in a degradation of forest carbon stocks.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 69
+∆CP = ∑ ∑(∆CP,DefPA,i,t + ∆CP,Deg,i,t + ∆CP,DistPA,i,t)
+M
+i=1
+t∗
+t=1
+Where:
+∆CP Net greenhouse has emissions within the project area under the
+project scenario; tCO2e
+∆CP,DefPA,i,t Net carbon stock change as a result of deforestation in the project
+area in the project case in stratum i at time t, tCO2e
+ACP,Deg,i,t Net carbon stock changes as a result of degradation in the project
+area in the project case in stratum i at time t, tCO2e
+ACP,DistPA,i,t Net carbon stock changes as a result of the natural disturbance in the
+project area in the project case in stratum i at time t, tCO2e
+i 1,2,3...M strata (Closed Forest, Open Forest, Savanna, Mangrove)
+t 1,2,3... t* years elapsed since the start of the REDD project activity
+For the leakage belt the net greenhouse gas emissions in the project case is equal to the sum
+of stock changes due to deforestation in the leakage belt:
+∆CP,LB = ∑ ∑ ∆CP,DefLB,i,t
+M
+i=1
+t∗
+t=1
+Where:
+∆CP,LB Net greenhouse has emissions within the leakage belt under the
+project scenario; tCO2e
+∆CP,DefLB,i,t Net carbon stock change as a result of deforestation in the leakage
+belt in the project case in stratum i at time t, tCO2e
+i 1,2,3...M strata (Closed Forest, Open Forest, Savanna, Mangrove)
+t 1,2,3... t* years elapsed since the start of the REDD project activity
+Land-use and land-cover (LU/LC) change data must be collected for each monitoring period.
+Medium resolution remotely sensed spatial data should be used (e.g. Landsat). Data to
+identify and quantify (ha) the area deforested (ADef,PA,u,i,t) and burned (Aburn,i,t) in the project
+area and the area deforested (ADef,LB,u,i,t) in the leakage belt must cover the entire project area
+and leakage belt. Data shall be available for the year in which monitoring and verification is
+occurring. The area of each category change will be calculated within the project area and,
+where required, the leakage belt at the end of each monitoring period.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 70
+Net carbon changes due to deforestation
+Net carbon stock changes as a result of deforestation is equal to the area deforested
+multiplied by the emission per unit area. The calculation is performed according to Equations 3
+and 4 of M-MON.
+∆CP,DefPA,i,t = ∑(ADefPA,u,i,t ∗ ∆Cpools,P,Def,u,i,t
+U
+u=1
+)
+∆CP,DefLB,i,t = ∑(ADefLB,u,i,t ∗ ∆Cpools,P,Def,u,i,t
+U
+u=1
+)
+Where:
+∆CP,DefPA,i,t Net carbon stock changes as a result of deforestation in the project
+case in the project area in stratum i at time t; tCO2e
+∆CP,DefLB,i,t Net carbon stock change as a result of deforestation in the project
+case in the leakage belt in stratum i at time t, tCO2e
+ADefPA,u,i,t Area of recorded deforestation in the project area stratum i converted
+to land use u ate time t; ha
+ADefLB,u,i,t Area of recorded deforestation in the leakage belt stratum i converted
+to land use u ate time t; ha
+∆Cpools,P,Def,u,i,t Net carbon stock change in all pools in the project case in land use u
+in stratum i at time t; tCO2e
+u 1,2,3...U post-deforestation land uses (Temudo, 1998; Silva et al.,
+2011: 8 year shifting cultivation cycle)
+i 1,2,3...M strata (Closed Forest, Open Forest, Savanna, Mangrove)
+t 1,2,3... t* years elapsed since the start of the REDD project activity
+The emission per unit area is equal to the difference between the stocks before and after
+deforestation minus any wood products created from timber extraction in the process of
+deforestation as shown in the next equation (Equation 5 of M-MON). It is conservative in the
+project case to assume no wood products are produced.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 71
+∆Cpools,Def,u,i,t = CBSL,i − CP,post,u,i − CWP,i
+Where:
+∆Cpools,Def,u,i,t Net carbon stock change in all pools as a result of deforestion in the
+project case in land use u in stratum i at time t; tCO2e
+CBSL,i Carbon stock in all pools in the baseline case in stratum i, tCO2e
+CP,post,u,i Carbon stock in all pools in post-deforestation land use u in stratum i,
+tCO2e
+CWP,i Carbon stock sequestrered in wood products from harvests in stratum
+i, tCO2e
+u 1,2,3...U post-deforestation land uses (Temudo, 1998; Silva et al.,
+2011: 8 year shifting cultivation cycle)
+i 1,2,3...M strata (Closed Forest, Open Forest, Savanna, Mangrove)
+t 1,2,3... t* years elapsed since the start of the REDD project activity
+Therefore, ∆Cpools,P,Def,u,i,t is equal to the carbon stock in the baseline case in the project area
+and leakage belt (see Section 3.1) minus the post deforestation carbon stock. Instead of
+tracking annual emissions through burning and/or decomposition, the project employs the
+simplifying assumption that all carbon stocks are emitted in the year deforested.
+For each post-deforestation land use (u) the project shall estimate the long-term carbon stock.
+Carbon stocks in the selected pools are the same used for the project baseline quantification,
+measured and estimated using the methods in the module CP-AB (CABtree,i and CBBtree,i). The
+calculation of carbon stocks in all pools in post-deforestation land use is performed according
+to Equations 6 of M-MON.
+Cpost,u,i = CABtree,i + CBBtree,i
+Where:
+Cpost,u,i Carbon stock in all pools in post-deforestation land use u in stratum i,
+tCO2e ha-1
+CABtree,i Carbon stock in aboveground tree biomass in stratum i, tCO2e ha-1
+CBBtree,i Carbon stock in belowground tree biomass in stratum i, tCO2e ha-1
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 72
+In the project case, post-deforestation land use only considers an 8-year shifting cultivation
+cycle (2-year cropland period and 6-year fallow period) described by Temudo (1998) and Silva
+et al. (2011). As calculated in the spreadsheet WB2 – C assessment and emissions baseline
+v2.3.xlsx, CAB_tree,i is equal 28.6 tCO2e.ha-1.
+Net carbon changes in areas undergoing natural disturbances
+Apart from monitoring emissions from deforestation, the project will also monitor net carbon
+changes in areas undergoing natural disturbances. Therefore, project emissions consider net
+carbon stock changes as a result of natural disturbances in the project area, including non-
+CO2 emissions (CH4 and N2O) in case of fire. Emissions due to fire are calculated according to
+the module E-BB (v1.0). Carbon dioxide emissions are not included as project emission from
+natural disturbance since it is fully accounted through stock changes. The module M-MON
+(v2.1) provides the procedures to the monitoring of data and parameters used for verification,
+in the project area, in case natural disturbances happen. For fire (ABurn,i,t), the module makes
+specific reference to the E-BB module to calculate the parameter EBiomassBurn,i,t. Finally, carbon
+stocks in aboveground biomass in trees on each stratum (CABtree,i,t) is calculated according to
+CP-AB (v1.1) module.
+Where natural disturbance occurs ex-post in the project area the area disturbed shall be
+delineated and the resulting emissions estimated. Emissions resulting from natural
+disturbances may be omitted if they are deemed de minimis through the use of the module T-
+SIG. Net carbon stock changes as a result of natural disturbance in the project case in the
+project area shall be determined as:
+∆CP,DistPA,i,t = ∑(ADisPA,q,i,t ∗ ∆CP,Dist,q,i,t)
+Q
+q=1
+Where:
+∆CP,DistPA,i,t Net carbon stock change as a result of natural disturbance in the
+project case in the project area in stratum i at time t; tCO2e
+ADisPA,q,i,t Area impacted by natural disturbance in post-natural disturbance
+stratum q in stratum i, at time t; ha
+∆CP,Dist,q,i,t Net carbon stock changes in pools as a result of natural disturbance
+in post-natural disturbance stratum q in stratum I at time t; tCO2e
+q 1,2,3...Q post-natural disturbance strata
+i 1,2,3...M strata (Closed Forest, Open Forest, Savanna, Mangrove)
+t 1,2,3... t* years elapsed since the start of the REDD project activity
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 73
+Where natural disturbance in post-natural disturbance stratum q included fire, the area burned
+shall be assumed to be equal to the area impacted by natural disturbance in post-natural
+disturbance stratum q. Therefore:
+ABurn,i,t = ∑ ABurn,q,i,t
+Q
+q=1
+ABurn,q,i,t = ADisPA,q,i,t for stratum where the natural disturbance included fire
+Where:
+ADisPA,q,i,t Area impacted by natural disturbance in post-natural disturbance
+stratum q in stratum i, at time t; ha
+ABurn,q,i,t Area burnt in post-natural disturbance stratum q in stratum i, at time t;
+ha
+q 1,2,3...Q post-natural disturbance strata where the natural disturbance
+included fire
+i 1,2,3...M strata (Closed Forest, Open Forest, Savanna, Mangrove)
+t 1,2,3... t* years elapsed since the start of the REDD project activity
+Non-CO2 emissions from woody biomass burning, in case fire occurs in the project area, are
+estimated based on IPCC 2006 Inventory Guidelines, as detailed in E-BB module, and shall be
+determined as:
+EBiomassBurn,i,t = ∑ (((ABurn,i,t ∗ Bi,t ∗ COMFi ∗ Gg,i) ∗ 10−3) ∗ GWPg)
+G
+g=1
+Where:
+EBiomassBurn,i,t Greenhouse emissions due to biomass burning as part of
+deforestation activities in stratum i in year t; tCO2-e of each GHG (CH4
+and N2O)
+ABurn,i,t Area burnt in stratum i in year t; ha
+Bi,t Average aboveground biomass stock before burning stratum i in year
+t; tonnes d.m.ha-1
+COMFi Combustion factor for stratum i in year t; dimensionless (default IPCC
+value according to Annex 1 of E-BB)
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 74
+Gg,i Emission factor for stratum i for gas g; kg.t-1 dry matter burnt (default
+IPCC value according to Annex 2 of E-BB)
+GWPg Global Warming Potential for gas g; tCO2/t gas g (default IPCC SAR)
+g Greenhouse gas included in project emissions due to burning (CH4
+and N2O)
+i 1,2,3...M strata (Closed Forest, Open Forest, Savanna, Mangrove)
+t 1,2,3... t* years elapsed since the start of the REDD project activity
+The table below presents the default values to be applied.
+Parameter Value Source
+COMFClosed Forest 0.32 E-BB, v1.0 Annex 1. Primary Tropical Forest.
+COMFOpen Forest 0.45 E-BB, v1.0 Annex 1. Primary Open Tropical Forest.
+COMFSavanna 0.72 E-BB, v1.0 Annex 1. Savanna Woodland (mid/late dry season
+burns)
+COMFMangrove 0.36 E-BB, v1.0 Annex 1. All Primary Tropical Forest.
+GCH4,Closed Forest 6.80 E-BB, v1.0 Annex 2. Tropical Forest
+GN2O,Closed Forest 0.20 E-BB, v1.0 Annex 2. Tropical Forest
+GCH4,Open Forest 6.80 E-BB, v1.0 Annex 2. Tropical Forest
+GN2O,Open Forest 0.20 E-BB, v1.0 Annex 2. Tropical Forest
+GCH4,Savanna 2.30 E-BB, v1.0 Annex 2. Savanna and grassland
+GN2O,Savanna 0.21 E-BB, v1.0 Annex 2. Savanna and grassland
+GCH4,Mangrove 4.70 E-BB, v1.0 Annex 2. Extra tropical forest (all other forest type)
+GN2O,Mangrove 0.26 E-BB, v1.0 Annex 2. Extra tropical forest (all other forest type)
+GWPCH4 21 IPCC SAR
+GWPN2O 310 IPCC SAR
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 75
+The sources of all default values are presented on the table and the rationale for the
+application of each value to a particular stratum is based on IPCC (2006) stratification factors
+that consider, amongst other aspects, climate and ecological zones. For closed forest, open
+forest and savanna Annexes 1 and 2 of E-BB present specific values considering a general
+vegetation type and specific subcategories, therefore, values for each stratum could be
+identified. In the case of mangroves, the mentioned annexes do not present specific values for
+this vegetation type. Therefore, considering climate and ecological zones of the Project Area
+the best fits are the combustion factor for “All primary tropical forests” on Annex 1 and the
+emission factor for “Extra Tropical Forest” which considers all other forest types not listed on
+the table.
+The monitoring of the area burned for each stratum at any given period (ABurn,i,t) is performed
+according to M-MON module (v2.1). The net carbon stock change as a result of fire is equal to
+the area burn multiplied by the emission per unit area as defined in E-BB. Land-use and land-
+cover (LU/LC) change data must be collected for each monitoring period. Medium resolution
+remotely sensed spatial data should be used (e.g. Landsat). Data to identify and quantify (ha)
+the area burned must cover the entire project area. Data shall be available for the year in
+which monitoring and verification is occurring.
+The average aboveground biomass stock before burning for a particular stratum is estimated
+as follows:
+Bi,t = (CABtree,i,t) ∗ 12 44	⁄ ∗ 1 CF	⁄
+Where
+Bi,t Average aboveground biomass stock before burning for stratum i,
+time t, tonnes of d.m.ha-1
+CABtree,i,t Mean aboveground biomass carbon stock in stratum i at time t, tCO2e
+ha-1 (estimated using CP-AB)
+12 44	⁄ Inverse ratio of molecular weight of CO2 to carbon, tCO2e tC-1
+CF Carbon fraction of biomass, tC t-1 d.m
+i 1,2,3...M strata (Closed Forest, Open Forest, Savanna, Mangrove)
+t 1,2,3... t* years elapsed since the start of the REDD project activity
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 76
+Parameter Value Source
+CABtree,Closed Forest,Cantanhez,t=0 306.11 WB2 – C assessment and emissions baseline v2.3.
+Value for Closed Forest in Cantanhez.
+CABtree,Open Forest,Cantanhez,t=0 127.01 WB2 – C assessment and emissions baseline v2.3.
+Value for Open Forest in Cantanhez.
+CABtree,Savanna,Cantanhez,t=0 101.43 WB2 – C assessment and emissions baseline v2.3.
+Value for Savanna in Cantanhez.
+CABtree,Mangrove,Cantanhez,t=0 100.45 WB2 – C assessment and emissions baseline v2.3.
+Value for Mangrove in Cantanhez.
+CABtree,Open Forest,Cacheu,t=0 132.88 WB2 – C assessment and emissions baseline v2.3.
+Value for Open Forest in Cacheu.
+CABtree,Savanna,Cacheu,t=0 97.70 WB2 – C assessment and emissions baseline v2.3.
+Value for Savanna in Cacheu.
+CABtree,Mangrove,Cacheu,t=0 72.89 WB2 – C assessment and emissions baseline v2.3.
+Value for Mangrove in Cacheu.
+CF 0.47 IPCC 2006, Chapter 4, Table 4.3
+The emission per unit area is equal to the difference between the stocks before and the stocks
+after natural disturbance, as follows:
+∆CP,Dist,q,i,t = CBSL,i − CP,Dist,q,i
+Where:
+∆CP,Dist,q,i,t Net carbon stock changes in pools as a result of natural disturbance in
+the project case in post-natural disturbance stratum q in stratum i at
+time t; tCO2e ha-1
+CBSL,i Carbon stock in all pools in the baseline case in stratum i: tCO2e ha-1
+CP,Dist,q,i Carbon stock in pools in post-natural disturbance strata q in stratum i;
+tCO2e ha-1
+Instead of tracking annual emissions through burning and/or decomposition, the methodology
+employs the simplifying assumption that all carbon stocks are emitted in the year the natural
+disturbance occurs. For each post-natural disturbance stratum (q) estimate the carbon stock
+following the natural disturbance. Carbon stocks must be estimated using the module CP-AB
+and measurement uncertainty assessed using X-UNC. It is conservative to assume that post-
+natural disturbance ABG pool is equal to zero.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 77
+CP.Dist,q,i = CABtree,i + CBBtree,i
+Where:
+CP,Dist,q,i Carbon stock in all pools in post-natural disturbance q in baseline
+stratum i; tCO2e ha-1
+CAB_tree,i Carbon stock in aboveground tree biomass in stratum i: tCO2e ha-1
+CBB_tree,i Carbon stock in belowground tree biomass in stratum i; tCO2e ha-1
+q 1,2,3…Q post-natural disturbance strata
+i 1,2,3...M strata (Closed Forest, Open Forest, Savanna, Mangrove)
+For ex-ante emission calculation purpose, project emissions are considered to be zero for
+three reasons: (1) the project areas do not have a history of natural disturbance, (2) the PRA
+does not indicate fire is relevant in the project area, following methodological requirements the
+PRA will be updated every two years, and (3) deforestation in the project area is not expected
+since IBAP holds permanent presence in Cacheu and Cantanhez. Park guards are monitoring
+the area and communities approved the internal regulations and agreed to protect the forests
+inside the project. Therefore, ADefPA,u,i,t = 0. Similarly, since natural disturbance is not
+expected in the project area, ADistPA,q,i,t was also considered zero for ex-ante quantification
+purpose. Finally, since the PRA did not indicated degradation is occurring ADegW,i = 0.
+3.3 Leakage
+Leakage emissions accounted for are entirely from displacement of unplanned deforestation
+and were estimated applying the LK-ASU (v1.0) module. Leakage due to market effects is
+considered zero because the project is not anticipated to impact any commercial harvesting
+activity.
+The initial PRA indicated that the agents of deforestation comprise in majority the local
+population (PROPRES=90.7%) performing agriculture activities, leakage emissions
+(∆CLK−AS,unplanned) comprise potential emissions from displacement of this activity. As
+discussed previously, the proposed REDD project includes strong leakage prevention
+measures through FIAL. Both the micro scale and the participatory model aim at increasing
+the effectiveness of FIAL. FIAL has two windows, one for community development and one for
+mitigation measures necessitated by the collective determination of restrictions on access to
+resources. Community development measures are those that are validated by the entire
+community, benefiting either the community at large and/or a chosen subgroup e.g., wells,
+boats, schools, clinics, and alternative technology and/or income generating activities such as
+new agricultural processing technologies, bee keeping, horticulture and other initiatives that
+are available to everyone in the community. Mitigation measures, by contrast, are initiatives
+that benefit only those people who lost access, in whole or in part, to a specific resource.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 78
+For the ex-ante leakage estimation it is considered a 20% leakage factor based on the failure
+rate of FIAL according to independent evaluations of the 129 projects historically financed by
+the mechanism. PROPIMM is equal to 9.3% following the results of the PRA. Leakage is
+calculated as the difference between project and baseline emissions in the leakage belt. Ex-
+ante estimates of the net CO2 emissions due to unplanned deforestation displaced from the
+project area to the leakage belt is calculated for each year in the baseline period following
+Equation 1 from LK-ASU Module. Moreover, no emission is expected as a result of leakage
+avoidance measures.
+∆CLK−ASU−LB = ∆CP,LB − ∆CBSL,LK,unplanned
+Where:
+∆CLK−ASU−LB Net CO2 emissions due to unplanned deforestation displaced from the
+project area to the leakage belt; tCO2e
+∆CP,LB Net GHG emissions within the leakage belt in the project case; tCO2e.
+Ex-ante estimate calculated based on a 20% emissions displacement
+factor from the project area to the leakage belt. This result is added to
+the estimated baseline for the leakage belt.
+∆CBSL,LK,unplanned Net CO2 emissions in the baseline form unplanned deforestation in
+the leakage belt; tCO2e
+Table 18. Estimated net CO2 emissions due to unplanned deforestation caused by local agents
+displaced from the project area to the Leakage Belt
+Year ∆𝐶𝐵𝑆𝐿,𝑢𝑛𝑝𝑙𝑎𝑛𝑛𝑒𝑑
+Leakage
+Factor (20%) ∆CP,LB ∆CBSL,LK,unplanned ∆CLK−ASU−LB
+2013 95,819 19,164 113,974 94,810 19,164
+2014 195,891 39,178 232,958 193,779 39,178
+2015 300,218 60,044 356,952 296,909 60,044
+2016 408,798 81,760 485,957 404,198 81,760
+2017 521,632 104,326 619,973 515,647 104,326
+2018 638,719 127,744 758,999 631,255 127,744
+2019 760,061 152,012 903,036 751,024 152,012
+2020 885,656 177,131 1,052,083 874,952 177,131
+2021 1,015,504 203,101 1,206,141 1,003,040 203,101
+2022 1,149,607 229,921 1,365,210 1,135,288 229,921
+2023 1,245,426 249,085 1,479,183 1,230,098 249,085
+2024 1,345,498 269,100 1,598,167 1,329,068 269,100
+2025 1,449,825 289,965 1,722,162 1,432,197 289,965
+2026 1,558,405 311,681 1,851,167 1,539,486 311,681
+2027 1,671,239 334,248 1,985,183 1,650,935 334,248
+2028 1,788,326 357,665 2,124,209 1,766,544 357,665
+2029 1,909,667 381,933 2,268,246 1,886,312 381,933
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 79
+2030 2,035,262 407,052 2,417,293 2,010,241 407,052
+2031 2,165,111 433,022 2,571,351 2,138,329 433,022
+2032 2,299,214 459,843 2,730,419 2,270,576 459,843
+Total 2,299,214 459,843 2,730,419 2,270,576 459,843
+The estimation of unplanned deforestation displaced from the project area to outside the
+Leakage Belt considers immigrants prevented from migrating into and deforesting the project
+area. The available national forest area (TOTFOR) is calculated according to the equation 2 of
+LK-ASU Module. TOTFOR is derived from the national forest cover provided officially in the
+Second National Communication on Climate Change in Guinea-Bissau (UNFCCC, 201129).
+The value applied is 2,683,290 ha. Conservatively, PROTFOR and MANFOR are considered
+zero, therefore, all national forest areas are considered available for deforestation displaced
+from the project area to outside the leakage belt.
+Table 19. Forest area, per stratum, Guinea Bissau (2007) according to the Second National
+Communication on Climate Change (UNFCCC, 2011)
+Forest Type 2007 (ha) Source
+Terrestrial Forest
+Closed Forest 147,865 Second
+National
+Communication
+on Climate
+Change in
+Guinea-Bissau
+(UNFCCC
+2011)
+Open Forest 638,350
+Savanna 1,582,289
+Wetlands Mangrove 314,786
+TOTAL 2,683,290
+𝐴𝑉𝐹𝑂𝑅 = 𝑇𝑂𝑇𝐹𝑂𝑅 − 𝑃𝑅𝑂𝑇𝐹𝑂𝑅 − 𝑀𝐴𝑁𝐹𝑂𝑅
+Where:
+𝐴𝑉𝐹𝑂𝑅 Total available national forest area for unplanned deforestation; ha
+𝑇𝑂𝑇𝐹𝑂𝑅 Total available national forest area; ha
+𝑃𝑅𝑂𝑇𝐹𝑂𝑅 Total are of fully protected forest nationally; ha
+𝑀𝐴𝑁𝐹𝑂𝑅 Total area of forest under active management nationally; ha
+𝐴𝑉𝐹𝑂𝑅 = 2,683,290
+29 http://unfccc.int/resource/docs/natc/gnbnc2e.pdf
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 80
+Next, the ratio of the forested area in the Leakage Belt ( 𝑃𝑅𝑂𝑃𝐿𝐵 ) was calculated as a
+proportion of the total available national forest area.
+𝑃𝑅𝑂𝑃𝐿𝐵 = 𝐿𝐵𝐹𝑂𝑅 𝐴𝑉𝐹𝑂𝑅	⁄
+Where:
+𝑃𝑅𝑂𝑃𝐿𝐵 Area of forest available in the Leakage Belt for unplanned deforestation as a
+proportion of the total national forest area available for unplanned
+deforestation; proportion
+𝐿𝐵𝐹𝑂𝑅 Total available forest area for unplanned deforestation in the Leakage Belt; ha
+(BL-UP: Leakage Belt Forest Cover Map)
+𝐴𝑉𝐹𝑂𝑅 Total available national forest area for unplanned deforestation; ha
+Table 20. LBFOR value and source
+Variable Value Source
+𝐿𝐵𝐹𝑂𝑅 130,975 LK area based on WB2 - C assessment
+and emission baseline v2.3.xlsx
+𝑃𝑅𝑂𝑃𝐿𝐵= 0.049
+To stratify 𝐴𝑉𝐹𝑂𝑅, forest carbon stocks across the country and forest cover areas from the
+Second National Communication of Guinea-Bissau to UNFCCC (2011) were used. The
+document is the official communication of the Government of Guinea-Bissau to the United
+National Framework Convention on Climate Change regarding national GHG emissions,
+including those arising for land use and land cover change. The document is publically
+available at http://unfccc.int/resource/docs/natc/gnbnc2e.pdf. The mean aboveground live tree
+carbon stock outside the leakage belt (𝐶𝑂𝐿𝐵) was calculated based on official governmental
+data submitted to UNFCCC. Area weighted average AGB for open forest, closed forest,
+savannah and mangroves were used and 𝐶𝑂𝐿𝐵 calculated according to the table below.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 81
+Table 21. Parameters used for COLB calculation and source
+Forest Type Average
+AGB (t/ha)
+Carbon
+Fraction tC/ha Area (ha) tCO2/ha Source
+Terrestrial
+Forest
+Closed
+Forest 186.26 0.47 88 147,865 321 Second
+National
+Communication
+on Climate
+Change in
+Guinea-Bissau
+(UNFCCC
+2011)
+Open
+Forest 120.64 0.47 57 638,350 208
+Savanna 27.68 0.47 13 1,582,289 48
+Wetlands Mangrove 23.82 0.47 11 314,786 41
+Total Forest 2,683,290 100.09
+𝐶𝑂𝐿𝐵 = 100.09
+The mean aboveground live tree carbon stock inside the leakage belt (𝐶𝐿𝐵) was calculated
+based on field data, using area weighted average AGB for open forest, closed forest,
+savannah and mangroves. In doing so, the AGB value applied for closed forest (306.1129
+tCO2/ha) is the one quantified for Cantanhez since this is the only data available, as this
+stratum was not identified in Cacheu. For all remaining stratum the average AGB were
+weighted considering the relative areas of each stratum in Cacheu and Cantanhez. Each value
+is calculated considering ((LB Area Stratum(i, Cacheu)* AGB tCO2/ha(i, Cacheu)+ (LB Area
+Stratum(i, Cantanhez)* AGB tCO2/ha(i, Cantanhez))/ ((LB Area Stratum(i, Cacheu)+(LB Area
+Stratum(i, Cantanhez)). All data is sourced from field data presented on the spreadsheet WB2
+– C assessment and emissions baseline v2.3.xlsx and the resulting values are presented on
+the table below.
+Table 22. Parameters used for CLB calculation and source
+Forest Type Area (ha) tCO2/ha Source
+Terrestrial Forest
+Closed Forest 8,425 306.11 WB2 - C assessment and
+emission baseline
+v2.3.xlsxOpen Forest 62,247 128.07
+Savanna 21,970 100.77
+Wetlands Mangrove 35,927 89.55
+Total Forest 128,569 124.31
+𝐶𝐿𝐵 = 124.31
+The proportional difference in carbon stocks between areas of forest available for unplanned
+deforestation both inside and outside de leakage belt (PROPCS).
+𝑃𝑅𝑂𝑃𝐶𝑆 = 𝐶𝑂𝐿𝐵
+𝐶𝐿𝐵
+⁄
+Where:
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 82
+𝑃𝑅𝑂𝑃𝐶𝑆 The proportional difference in carbon stocks between areas of forest available
+for unplanned deforestation both inside and outside the leakage belt;
+proportion
+𝐶𝑂𝐿𝐵 Area weighted average aboveground tree carbon stock for forest available for
+unplanned deforestation outside the leakage belt; tCO2e.ha-1
+𝐶𝐿𝐵 Area weighted average aboveground tree carbon stock for forest available for
+unplanned deforestation inside the leakage belt; tCO2e.ha-1
+𝑃𝑅𝑂𝑃𝐶𝑆 = 0.805
+The proportional leakage for areas with immigrating populations are equal to the immigrating
+proportion multiplied by the proportion of available national forest area outside de Leakage
+Belt multiplied by the proportional difference in stocks between forests inside and outside the
+Leakage Belt and was calculated according to equation 5 of LK-ASU Module.
+LKPROP = PROPIMM ∗ (1 − PROPLB) ∗ PROPCS
+Where:
+LKPROP Proportional leakage for areas with immigrating population; proportion
+PROPIMM Estimated proportion of baseline deforestation caused by immigrating
+population; proportion
+PROPLB Area of forest available in the Leakage Belt for unplanned deforestation as a
+proportion of the total national forest area available for unplanned
+deforestation; proportion
+PROPCS The proportional difference in carbon stocks between areas of forest available
+for unplanned deforestation both inside and outside the leakage belt;
+proportion
+LKPROP= 0.071
+The net leakage outside the Leakage Belt (ΔCLK-AS,OLB) is calculated below:
+∆CLK−ASU,OLB = (∆CBSL,LK,unplanned − ∆CP,LB) ∗ LKPROP
+Where:
+∆CLK−ASU,OLB Net CO2 emissions due to unplanned deforestation displaced outside
+the leakage belt; tCO2e
+∆CBSL,LK,unplanned Net CO2 emissions in the baseline form unplanned deforestation in
+the leakage belt; tCO2e
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 83
+∆CP,LB Net GHG emissions within the leakage belt in the project case; tCO2e.
+Ex-ante estimate calculated based on a 20% emissions displacement
+factor from the project area to the leakage belt. This result is added to
+the estimated baseline for the leakage belt.
+LKPROP Proportional leakage for areas with immigrating population; proportion
+Table 23. Ex ante estimation of net CO2 emissions due to unplanned deforestation displaced
+outside the Leakage Belt
+Years ∆CBSL,LK,unplanned ∆CP,LB LKPROP ∆CLK−ASU,OLB
+2013 94,810 113,974 0.071 1,365
+2014 193,779 232,958 0.071 2,791
+2015 296,909 356,952 0.071 4,277
+2016 404,198 485,957 0.071 5,824
+2017 515,647 619,973 0.071 7,431
+2018 631,255 758,999 0.071 9,099
+2019 751,024 903,036 0.071 10,828
+2020 874,952 1,052,083 0.071 12,617
+2021 1,003,040 1,206,141 0.071 14,467
+2022 1,135,288 1,365,210 0.071 16,377
+2023 1,230,098 1,479,183 0.071 17,742
+2024 1,329,068 1,598,167 0.071 19,168
+2025 1,432,197 1,722,162 0.071 20,654
+2026 1,539,486 1,851,167 0.071 22,201
+2027 1,650,935 1,985,183 0.071 23,808
+2028 1,766,544 2,124,209 0.071 25,476
+2029 1,886,312 2,268,246 0.071 27,205
+2030 2,010,241 2,417,293 0.071 28,994
+2031 2,138,329 2,571,351 0.071 30,844
+2032 2,270,576 2,730,419 0.071 32,754
+Total 2,270,576 2,730,419 32,754
+Total leakage due to displacement of unplanned deforestation is presented below applying
+equation 13 from LK-ASU Module. As previously discussed, it is not anticipated any emissions
+arising from leakage prevention activities.
+∆CLK−AS,unplanned = ∆CLK−ASU−LB + ∆CLK−ASU,OLB + GHGLK,E
+Where:
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 84
+∆CLK−AS,unplanned Net greenhouse gas emissions due to activity shifting leakage for
+projects preventing unplanned deforestation net CO2 emissions;
+tCO2e
+∆CLK−ASU−LB Net CO2 emissions due to unplanned deforestation displaced from the
+project area to the leakage belt; tCO2e
+∆CLK−ASU,OLB Net CO2 emissions due to unplanned deforestation displaced outside
+the leakage belt; tCO2e
+GHGLK,E Greenhouse gas emissions as a result of leakage of avoided
+deforestation activities; tCO2e
+Table 24. Calculation of the total leakage due to the displacement of unplanned deforestation
+Years ∆CLK−ASU−LB ∆CLK−ASU,OLB GHGLK,E ∆CLK−AS,unplanned
+2013 19,164 1,365 0 20,529
+2014 39,178 2,791 0 41,969
+2015 60,044 4,277 0 64,320
+2016 81,760 5,824 0 87,583
+2017 104,326 7,431 0 111,757
+2018 127,744 9,099 0 136,843
+2019 152,012 10,828 0 162,840
+2020 177,131 12,617 0 189,748
+2021 203,101 14,467 0 217,568
+2022 229,921 16,377 0 246,298
+2023 249,085 17,742 0 266,827
+2024 269,100 19,168 0 288,267
+2025 289,965 20,654 0 310,619
+2026 311,681 22,201 0 333,882
+2027 334,248 23,808 0 358,056
+2028 357,665 25,476 0 383,141
+2029 381,933 27,205 0 409,138
+2030 407,052 28,994 0 436,046
+2031 433,022 30,844 0 463,866
+2032 459,843 32,754 0 492,597
+Total 459,843 32,754 0 492,597
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 85
+3.4 Net GHG Emission Reductions and Removals
+The total net greenhouse gas emissions reductions of the REDD project activity are calculated
+as follows (Equation 1 of REDD-MF):
+CREDD,t = ∆CBSL − ∆CP − ∆CLK
+Where:
+CREDD,t Total net greenhouse emission reduction at time t; tCO2e
+∆CBSL Net greenhouse gas emission under the baseline scenario; tCO2e
+∆CP Net greenhouse gas emission within the project area under the project
+scenario; tCO2e (Section 3.2)
+∆CLK Net greenhouse gas emission due to leakage; tCO2e
+The net greenhouse gas emissions under the baseline scenario (∆CBSL) are the emissions in
+the baseline from unplanned deforestation (∆CBSL,unplanned) demonstrated in Section 3.1 and
+derived from module BL-UP. The annual baseline emissions for the first 20 years crediting
+period are presented in the tables below. Since the project calculated baseline emissions
+separately for each Project Area (i.e. Cacheu and Cantanhez) the values are presented
+individually. For the net GHG emissions reductions and removal calculation the values are
+aggregated and each values combined summing up baseline emission in Cacheu and
+Cantanhez. Table 25 depicts the sum of the net GHG baseline emissions on Cacheu and
+Cantanhez, for example, in 2013 the value 95,819 is the round up of the sum of 20,232.41
+(Cacheu) and 75,586.43 (Cantanhez).
+2013 2014 2015 2016 2017
+Cacheu
+ΔCBSL,PA,unplanned (tCO2-e) 20,232 41,454 63,666 86,866 111,056
+ΔCBSL,unplanned (tCO2-e) 20,232 41,454 63,666 86,866 111,056
+Cantanhez
+ΔCBSL,PA,unplanned (tCO2-e) 75,586 154,437 236,552 321,932 410,575
+ΔCBSL,unplanned (tCO2-e) 75,586 154,437 236,552 321,932 410,575
+2018 2019 2020 2021 2022
+Cacheu
+ΔCBSL,PA,unplanned (tCO2-e) 136,236 162,405 189,563 217,711 246,849
+ΔCBSL,unplanned (tCO2-e) 136,236 162,405 189,563 217,711 246,849
+Cantanhez
+ΔCBSL,PA,unplanned (tCO2-e) 502,483 597,655 696,092 797,793 902,758
+ΔCBSL,unplanned (tCO2-e) 502,483 597,655 696,092 797,793 902,758
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 86
+2023 2024 2025 2026 2027
+Cacheu
+ΔCBSL,PA,unplanned (tCO2-e) 267,081 288,303 310,514 333,715 357,905
+ΔCBSL,unplanned (tCO2-e) 267,081 288,303 310,514 333,715 357,905
+Cantanhez
+ΔCBSL,PA,unplanned (tCO2-e) 978,345 1,057,195 1,139,310 1,224,690 1,313,333
+ΔCBSL,unplanned (tCO2-e) 978,345 1,057,195 1,139,310 1,224,690 1,313,333
+2028 2029 2030 2031 2032
+Cacheu
+ΔCBSL,PA,unplanned (tCO2-e) 383,085 409,254 436,412 464,560 493,697
+ΔCBSL,unplanned (tCO2-e) 383,085 409,254 436,412 464,560 493,697
+Cantanhez
+ΔCBSL,PA,unplanned (tCO2-e) 1,405,241 1,500,414 1,598,850 1,700,551 1,805,516
+ΔCBSL,unplanned (tCO2-e) 1,405,241 1,500,414 1,598,850 1,700,551 1,805,516
+The same calculation is performed for every year for the first crediting period, between 2013
+and 2032. As discussed on Section 3.2, net greenhouse gas emissions within the project area
+under the project scenario (∆CP) is considered zero for ex-ante quantification purpose.
+Net greenhouse gas emissions due to leakage (∆CLK) were calculated for each year in the first
+crediting period and detailed on Section 3.3 (see Table 24). Therefore, for every year, the
+Baseline Emissions was calculated summing the baseline emissions for Cacheu and
+Cantanhez (as shown above). From this value project emissions and leakage emissions were
+subtracted. Since estimated project emission for ex-ante calculations is considered zero only
+leakage emissions are subtracted. Table 25 presents the estimated net GHG emissions
+reduction and removals due to the project activity between 2013 and 2032. For 2013, for
+example:
+CREDD,2013 = ∆CBSL,2013 − ∆CP,2013 − ∆CLK,2013
+CREDD,2013 = 95,819 − 0 − 20,529
+CREDD,2013 = 75,290 tCO2e
+The expected net GHG emissions reduction or removals in the first crediting period totals
+1,806,617 tCO2e.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 87
+Table 25. Estimated net GHG emissions reduction or removals (tCO2e)
+Years
+Estimated
+baseline
+emissions or
+removals (tCO2e)
+Estimated project
+emissions or
+removals (tCO2e)
+Estimated leakage
+emissions (tCO2e)
+Estimated net
+GHG emission
+reductions or
+removals (tCO2e)
+2013 95,819 0 20,529 75,290
+2014 195,891 0 41,969 153,923
+2015 300,218 0 64,320 235,897
+2016 408,798 0 87,583 321,215
+2017 521,632 0 111,757 409,874
+2018 638,719 0 136,843 501,876
+2019 760,061 0 162,840 597,221
+2020 885,656 0 189,748 695,908
+2021 1,015,504 0 217,568 797,937
+2022 1,149,607 0 246,298 903,308
+2023 1,245,426 0 266,827 978,599
+2024 1,345,498 0 288,267 1,057,231
+2025 1,449,825 0 310,619 1,139,206
+2026 1,558,405 0 333,882 1,224,523
+2027 1,671,239 0 358,056 1,313,183
+2028 1,788,326 0 383,141 1,405,185
+2029 1,909,667 0 409,138 1,500,529
+2030 2,035,262 0 436,046 1,599,216
+2031 2,165,111 0 463,866 1,701,245
+2032 2,299,214 0 492,597 1,806,617
+Total 2,299,214 0 492,597 1,806,617
+3.4.1 Estimation of VCS buffer
+In AFOLU projects there is a stock permanence risk. In other words, a GHG reduction in a
+given year can be turned into an emission in case, for example, of fire or in the events of
+natural disturbance. To mitigate such risks, the VCS established that a crediting buffer must be
+established and a percentage of the VCU withhold considering an specific project risk. The
+number of credits to be held in the permanence risk buffer is determined as a percentage of
+the total carbon stock benefits. The percentage is calculated following the module T-BAR. The
+detailed risk report is presented on Appendix I of this PD.
+The VCS Buffer is equal to the net emissions in the baseline minus project emissions derived
+from fossil fuels use and fertilizers use multiplied by the risk factor resulting from T-BAR (see
+Appendix I). Leakage emissions do not factor into the buffer calculations. As discussed, the
+project does not expect emissions from fossil fuel use or fertilizer application; hence, the buffer
+equation was simplified as follows (Equation 5 of REDD-MF):
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 88
+Bufferunplanned = (∆CBSL,unplanned − ∆CP) ∗ Buffer%
+Where:
+Bufferunplanned Buffer withholding for unplanned deforestation project areas; tCO2e
+∆CBSL,unplanned Net greenhouse gas emissions in the baseline from unplanned
+deforestation; tCO2e
+∆CP Net greenhouse gas emissions within the project area under the
+project scenario; tCO2e
+Buffer% Buffer withholding percentage; %. Calculated according to T-BAR, for
+details see Appendix I of the PD. (0.10)
+According to the Risk Report, the project totals 6 points in the non-permanence risk analysis.
+Since the minimum risk scoring allowed is 10, a value of 10 was applied to the project (10% or
+0.10). The next table details the calculation. It is important to notice, as said, that the buffer
+account does not consider leakage emissions, therefore, the 10% risk buffer is derived only
+from the estimated baseline emissions presented on Table 25. Using the same example as
+before for year 2013, the sum of the baseline emissions in Cacheu and Cantanhez in 2013
+totaled 95,819. Hence, the 10% buffer value is 9,582 as shown below:
+Bufferunplanned,2013 = (∆CBSL,unplanned,2013 − ∆CP,2013) ∗ Buffer%
+Bufferunplanned,2013 = (95,819 − 0) ∗ 0.10
+Bufferunplanned,2013 = 95,819 ∗ 0.10
+Bufferunplanned,2013 = 9,582
+Uncertainty analysis was conducted to provide conservative estimates of the total net GHG
+emission reduction according to module X-UNC version 2.0. Total uncertainty in the baseline
+scenario summed 13% for Cacheu and 9% for Cantanhez at the 95% confidence interval.
+According to the module, the allowable uncertainty under the REDD-MF methodology is +/-
+15% of CREDD,t at the 95% confidence interval. Since the uncertainty level is attained no
+deduction is performed. The estimate number of Verified Carbon Units (VCUs) for the
+monitoring period T=t2-t1 is performed according to Equation 8 of REDD-MF.
+VCUt = (Adjusted_CREDD,t2 − Adjusted_CREDD,t1) − BufferTOTAL
+Where:
+VCUt Number of Verified Carbon Units at time t=t2-t1; VCU
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 89
+Adjusted_CREDD,t2 Cumulative total net GHG emissions reductions at time t2 adjusted to
+account for uncertainty; tCO2e
+Adjusted_CREDD,t1 Cumulative total net GHG emissions reductions at time t1 adjusted to
+account for uncertainty; tCO2e
+BufferTOTAL Total permanence risk buffer withholding; tCO2e
+An example calculation is presented for the year 2014:
+VCU2014 = (Adjusted_CREDD,2014 − Adjusted_CREDD,2013) − BufferTOTAL,2014
+VCU2014 = 153,923 − 19,589
+VCU2014 = 134,333
+The table below present the calculation performed for each year in the first crediting period.
+Years
+Estimated net GHG
+emission reductions or
+removals (tCO2e)
+Risk buffer
+Deductions for
+AFOLU pooled
+buffer account
+Net Total
+(tCO2e)
+2013 75,290 10% 9,582 65,708
+2014 153,923 10% 19,589 134,333
+2015 235,897 10% 30,022 205,876
+2016 321,215 10% 40,880 280,335
+2017 409,874 10% 52,163 357,711
+2018 501,876 10% 63,872 438,004
+2019 597,221 10% 76,006 521,215
+2020 695,908 10% 88,566 607,342
+2021 797,937 10% 101,550 696,386
+2022 903,308 10% 114,961 788,348
+2023 978,599 10% 124,543 854,056
+2024 1,057,231 10% 134,550 922,681
+2025 1,139,206 10% 144,982 994,223
+2026 1,224,523 10% 155,840 1,068,683
+2027 1,313,183 10% 167,124 1,146,059
+2028 1,405,185 10% 178,833 1,226,352
+2029 1,500,529 10% 190,967 1,309,563
+2030 1,599,216 10% 203,526 1,395,690
+2031 1,701,245 10% 216,511 1,484,734
+2032 1,806,617 10% 229,921 1,576,696
+Total 1,806,617 10% 229,921 1,576,696
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 90
+3.4.2 Uncertainty analysis
+As discussed, total uncertainty was calculated according to (X-UNC) for the aboveground and
+belowground biomass tree pools. Both in Cantanhez and Cacheu the variation was within the
+15% (CI 95%) confidence level and no adjustment had to be made.
+4 MONITORING
+This section presents the monitoring methodology for changes in the forest cover and carbon
+stock changes. All relevant parameters of the monitoring plan, according to M-MON, are
+included and detailed in this section. The monitoring plan includes the periodic revision of: (i)
+the baseline, (ii) the changes in actual carbon stock and associated GHG emissions, (iii) the
+eventual leakage and associated GHG emissions and (iv) the ex-post net carbon stock
+changes and GHG emissions.
+Revision of the baseline
+The baseline shall be revised every 10 years from the project start date because agents,
+drivers and underlying causes of deforestation change dynamically. The methodological
+procedure used to update the baseline shall be the same as used in the definition of the
+baseline according to this PD. The objective of the revision of the baseline is to evaluate any
+significant changes in the deforestation trends in the Reference Region
+The technical description of the monitoring task is presented in Section 4.3. Section 4.2
+presents all data to be collected, including procedures, quality control and quality assurance
+(QC/QA) and data archiving.
+Monitoring of actual carbon stock changes and greenhouse gas emissions
+The monitoring of actual carbon stock changes and GHG emissions is necessary to evaluate
+the actual efficiency of the project in reducing deforestation. Monitoring of the forest cover and
+the carbon stocks in the project area will be performed and associated GHG emissions
+calculated.
+The technical description of the monitoring task is presented in Section 4.3. Section 4.2
+presents all data to be collected, including procedures, quality control and quality assurance
+(QC/QA) and data archiving
+Monitoring of leakage carbon stock changes and greenhouse gas emissions
+The monitoring of leakage emissions will be performed through the evaluation of forest cover
+changes due to the displacement of deforestation activities from the project area to the
+leakage belt. Monitoring of Leakage Belt will be performed and associated GHG emissions
+calculated.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 91
+The technical description of the monitoring task is presented in Section 4.3. Section 4.2
+presents all data to be collected, including procedures, quality control and quality assurance
+(QC/QA) and data archiving
+Estimation of ex-post net carbon stock changes and greenhouse gas emissions.
+The monitoring of the actual carbon stock changes and the leakage emissions will allow the
+estimation of the ex-post net carbon stock changes and associated GHG emission reduction.
+The technical description of the monitoring task is presented in Section 4.3. Section 4.2
+presents all data to be collected, including procedures, quality control and quality assurance
+(QC/QA) and data archiving
+Organization and responsibilities of the parties involved in all the above.
+The Institute for Biodiversity and Protected Areas (IBAP) of Guinea-Bissau is the organization
+responsible for the monitoring of the project.
+4.1 Data and Parameters Available at Validation
+Data / Parameter CF
+Data unit tC t-1 d.m.
+Description Carbon fraction of dry matter
+Source of data IPCC 2006 Ch.4 Table 4.3
+Value applied: Default value 0.47 t C t-1 d.m.
+Justification of choice of
+data or description of
+measurement methods
+and procedures applied
+IPCC is a peer-reviewed source widely used for GHG
+quantification.
+Purpose of Data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Comments Default values shall be updated whenever new guidelines are
+produced by the IPCC.
+Data / Parameter COMFi
+Data unit Dimensionless
+Description Combustion factor for stratum i (vegetation type)
+Source of data Default values IPCC 2006 Ch.2 Table 2.6
+Value applied: Closed Forest - 0.32
+Open Forest - 0.45
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 92
+Savanna - 0.72
+Mangrove - 0.36
+Justification of choice of
+data or description of
+measurement methods
+and procedures applied
+IPCC is a peer-reviewed source widely used for GHG
+quantification. The choice of values applied to each stratum
+considers climatic and ecological classifications defined by IPCC.
+Table 2.6 presents values for Closed Forest, Open Forest and
+Savanna. For mangrove the classification of “all primary tropical
+forests” is used since no specific value is presented.
+Purpose of Data • Calculation of project emissions
+Comments The combustion factor is a measure of the proportion of the fuel
+that is actually combusted, which varies as a function of the size
+and architecture of the fuel load, the moisture content of the fuel
+and the type of fire.
+Default values shall be updated whenever new guidelines are
+produced by the IPCC.
+Data / Parameter Ggi
+Data unit g kg-1 dry matter burnt
+Description Emission factor for stratum i for gas g
+Source of data Default values IPCC 2006 Ch.2 Table 2.5
+Value applied: Closed Forest: CH4 – 6.8 and N2O – 0.20
+Open Forest: CH4 – 6.80 and N2O – 0.20
+Savanna: CH4 – 2.30 and N2O – 0.21
+Mangrove: CH4 – 4.7 and N2O – 0.26
+Justification of choice of
+data or description of
+measurement methods
+and procedures applied
+IPCC is a peer-reviewed source widely used for GHG
+quantification. The choice of values applied to each stratum
+considers climatic and ecological classifications defined by IPCC.
+Table 2.5 presents values for Tropical Forest, used for Closed
+Forest and Open Forest, and Savanna. For mangrove the
+classification of “extra tropical forests” is used since no specific
+value is presented and the table recommends this category be
+used for all other forest type.
+Purpose of Data • Calculation of project emissions
+Comments Default values shall be updated whenever new guidelines are
+produced by the IPCC
+Data / Parameter Dj
+Data unit t d.m. m3
+Description Basic wood density in t d.m m3 for species j
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 93
+Source of data Data is source from a combination of literature ranging from (a)
+national species-specific or group of species-specific, from
+CARBOVEG-GB, (b) species-specific or groups of species from
+neighboring countries with similar conditions, from Brown (1997),
+Nygard & Elfying (2000) and Reyes et al. (1992), and (c) global
+species-specific or group of species-specific, from IPCC (2006)
+and the Global Wood Density Database.
+When known, species-specific wood density was applied. When
+the species was not known or wood density values were not
+published/available, an average wood density was calculated from
+the data collected under CARBOVEG-GB and applied (0.731 g
+cm3)
+Value applied: See Appendix 2 – Wood Density Information
+Justification of choice of
+data or description of
+measurement methods
+and procedures applied
+Data sources comply with the requirements of M-MON and all
+values are referenced on Appendix 2 – Wood Density Information.
+When reference is made to CARBOVEG-GB, measurements were
+undertaken by IICT on three different periods: 2007, 2009 and
+2012. The methods and procedures applied are the same
+described on section 4.3.4 and follow the protocols and
+requirements established by the modules CP-AB and X-STR.
+Purpose of Data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Comments Not applicable
+Data / Parameter fpalm (X,Y)
+Data unit t d.m. tree-1
+Description Allometric equation for palm species linking measured tree
+variable(s) to aboveground biomass of living trees.
+Source of data Delaney, S. and Powell, M. (1999) 1999 Carbon-Offset Report for
+the Noel Kempff Climate Action Project, Bolivia. Reporto to the
+Nature Conservancy. Winrock International, Arlington, VA, USA.
+The reference is listed both in IPCC GPG-LULUCF (2003) and
+Pearson et al. (2005)
+Value applied: AGBpalm = 6.666 + 12.826 * H0.5 * ln H
+Justification of choice of
+data or description of
+measurement methods
+and procedures applied
+Delaney et al. (1999) complies with M-MON requirements being
+built on a sample of n=30 and a deviation was approved since r2 =
+0.75 but conservativeness was demonstrating by comparing
+Delaney et al. (1999) equation with other equations available in
+the literature. The equation is a allometric equation for mangroves
+requiring only one parameter (height). The equation is a (e) pan-
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 94
+tropical forest type-specific.
+Purpose of Data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Comments The deviation was approved and the equation validated based on
+a sample of 30 palms (Elaeis guineensis) in Guinea Bissau
+measured in February 2013.
+Data / Parameter R
+Data unit t root d.m. t-1 shoot d.m.
+Description Root to shoot ratio appropriate to species or forest type / biome
+applied as belowground biomass per unit area
+Source of data Mokany et al. (2006) for tropical dry forest (IPCC 2006 Ch.4 Table
+4.4)
+Komyiama et al. (2008) for mangrove
+Value applied: For tropical dry forest:
+• if AGB < 20 t.ha-1 R=0.56;
+• if AGB > 20 t.ha-1 R=0.28
+For mangrove forest R=0.46
+Justification of choice of
+data or description of
+measurement methods
+and procedures applied
+The data applied for terrestrial forests are (b) globally forest type-
+specific or eco-region-specific sourced from IPCC 2006. IPCC is a
+peer-reviewed source widely used for GHG quantification.
+For mangroves, data reported in Komyiama et al. (2006) were
+averaged and resulted in a RSR value of 0.61. Conservatively, the
+half-width of the 95% confidence interval of these data was used
+to estimate the applied RSR (0.46).
+Purpose of Data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Comments Not applicable
+4.2 Data and Parameters Monitored
+Data / Parameter COLB
+Data unit tCO2e ha-1
+Description Area weighted average aboveground tree carbon stock for forests
+available for unplanned deforestation outside the Leakage Belt
+Source of data Second National Communication on Climate Change in Guinea-
+Bissau (UNFCCC, 2011)
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 95
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: Data from (i) aboveground tree
+carbon stock of forests outside the leakage belt and (ii)
+forest cover areas must be weight averaged (tCO2e ha-1).
+Detailed calculation methods of carbon stocks are
+presented on Section 4.3.4.
+• Entity responsible for the measurement: IBAP
+• Accuracy: for the delineation of forest area (ha) the
+minimum map accuracy must be 90% for the classification
+of the forest/non-forest in the remote sensing imagery. For
+carbon stocks see Section 4.3.4.
+If peer-reviwed data is applied, calculation methods and
+procedures are not applicable. Accuracy will be depedent on
+quality of available data.
+Frequency of
+monitoring/recording
+The area-weighted average must be recalculated at least every 5
+years.
+Value applied: 100.09
+Monitoring equipment If field measurement is performed, data collection must be in
+accordance with module CP-AB. The following monitoring
+equipments shall be used:
+• Diametric tape;
+• Hypsometer;
+• GPS;
+• Digital Camera;
+• Remote sensing data;
+• Computer, GIS software and spreadsheets.
+If peer-reviwed data is applied, monitoring equipments are not
+applicable.
+QA/QC procedures to be
+applied
+If field measurement is performed, standard QA/QC assurance
+procedures for forest inventory, including field data collection and
+data management shall be applied. All data registry must be
+backed up and stored in diferent sources (physical and digital) and
+midias (HDs, serves, internet cloud). See the Monitoring Plan for
+detailed QA/QC procedures (Section 4.3)
+Purpose of data • Calculation of leakage
+Calculation method Either:
+• Calculate directly from field measurement; OR
+• Use numbers derived from peer-reviewed literature that
+are nationally or at least regionally appropriate.
+Comments For ex-ante GHG emissions reduction quantification, data from
+forest area and stratum carbon content is derived from the official
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 96
+governmental communication on Climate Change in Guinea-
+Bissau to the United National Framework Convention on Climate
+Change (UNFCCC).
+Data / Parameter CLB
+Data unit tCO2e ha-1
+Description Area weighted average aboveground tree carbon stock for forests
+available for unplanned deforestation inside the Leakage Belt
+Source of data Derived from field work measurement (Carbon Stock) performed
+for the baseline establishment (Winrock/IICT 2012) and on remote
+sensing using Landsat imagery (Stratum Area) in combination with
+GPS data collected during ground truthing (Winrock/IICT 2012)
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: calculated from field
+measurement using modules CP-AB, BL-UP and X-STR.
+On each monitoring period forest cover changes must be
+quantified using map algebra and a new area weighted
+average aboveground carbon stock for forest inside the
+leakage belt recalculated. Detailed calculation methods of
+carbon stocks are presented on Section 4.3.4.
+• Entity responsible for the measurement: IBAP
+• Accuracy: for the delineation of forest area (ha) the
+minimum map accuracy must be 90% for the classification
+of the forest/non-forest in the remote sensing imagery. For
+carbon stocks see Section 4.3.4.
+Frequency of
+monitoring/recording
+Must be recalculated at each monitoring period.
+Value applied: 124.31
+Monitoring equipment The following monitoring equipments shall be used:
+• Diametric tape;
+• Hypsometer;
+• GPS;
+• Digital Camera;
+• Remote sensing data;
+• Computer, GIS software and spreadsheets.
+QA/QC procedures to be
+applied
+Standard QA/QC assurance procedures for forest inventory,
+including field data collection and data management shall be
+applied. All data registry must be backed up and stored in diferent
+sources (physical and digital) and midias (HDs, serves, internet
+cloud). See the Monitoring Plan for detailed QA/QC procedures
+(Section 4.3).
+If map classification accuracy is less than 90% then the map is not
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 97
+acceptable for further analysis. More remote sensing data and
+ground truthing data will be needed to produce a product that
+reaches the 90% minimum mapping accuracy.
+Purpose of data • Calculation of leakage
+Calculation method Calculate directly from field measurement and map algebra.
+Comments As forests in the leakage belt are deforested, the area-weighted
+average must be recalculated at each monitoring period.
+Data / Parameter MANFOR
+Data unit ha
+Description Total area of forest under active management nationally
+Source of data Official data, peer reviewed publication and other verifiable
+sources
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: identify available data on the total
+area of forest under active management from official data
+or peer-reviewed publication.
+• Entity responsible for the measurement: IBAP
+• Accuracy: subject to the quality of the data available, for
+example, protected area boundaries provided by the
+government
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs in
+a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: 0
+Monitoring equipment Not applicable
+QA/QC procedures to be
+applied
+Broader evaluation must be carried out so the most up-to-date
+information is used.
+Purpose of data • Calculation of leakage
+Calculation method Sourced from literature
+Comments For ex-ante quantification MANFOR was considered
+conservatively as zero.
+Data / Parameter PROPIMM
+Data unit Proportion
+Description Estimated proportion of baseline deforestation caused by
+immigrating population
+Source of data PRA, peer-reviewed literature or official governmental data
+Description of • Methods and procedures: identify and collect available data
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 98
+measurement methods
+and procedures to be
+applied
+on the proportion of immigrants
+• Entity responsible for the measurement: IBAP
+• Accuracy: subject to the quality of the data available. When
+using a PRA, sampling must be carried on and around the
+project area and within 2 km from the leakage belt
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs in
+a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: 0.093
+Monitoring equipment The following monitoring equipments shall be used to perform the
+PRA:
+• Notebooks, field sheets, tablets;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+When the proportion of immigrants is calculated using a PRA all
+data must be documented and stored. The field team interviewing
+the communities must be properly trained.
+Purpose of data • Calculation of leakage
+Calculation method Semi structured research applied to communities living inside and
+around the Project Area
+Comments Not applicable
+Data / Parameter PROPRES
+Data unit Proportion
+Description Estimated proportion o baseline deforestation caused by
+population that has been resident for more than 5 years
+Source of data PRA, peer-reviewed literature or official governmental data
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: identify and collect available data
+on the proportion of immigrants
+• Entity responsible for the measurement: IBAP
+• Accuracy: subject to the quality of the data available. When
+using a PRA, sampling must be carried on and around the
+project area and within 2 km from the leakage belt
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs in
+a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: 0.907
+Monitoring equipment The following monitoring equipments shall be used to perform the
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 99
+PRA:
+• Notebooks, field sheets, tablets;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+When the proportion of residents is calculated using a PRA all
+data must be documented and stored. The field team interviewing
+the communities must be properly trained.
+Purpose of data • Calculation of leakage
+Calculation method Semi structured research applied to communities living inside and
+around the Project Area
+Comments Not applicable
+Data / Parameter PROTFOR
+Data unit ha
+Description Total area of fully protected forest nationally
+Source of data Official data, peer reviewed publication and other verifiable
+sources
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: identify available data on the total
+area of forest under active management from official data
+or peer-reviewed publication. In Guinea-Bissau the total
+area of forest under protection is equal to the area of the
+National System of Protected Areas (SNAP).
+• Entity responsible for the measurement: IBAP
+• Accuracy: subject to the quality of the data available, for
+example, protected area boundaries provided by the
+government
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs in
+a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: 0
+Monitoring equipment Not applicable
+QA/QC procedures to be
+applied
+Broader evaluation must be carried so the must up-to-date
+information is used. A good cross check is the official information
+provided by the legal decrees that established each protected
+area
+Purpose of data • Calculation of leakage
+Calculation method Sourced from literature or from legal documents (i.e decrees that
+establish national parks)
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 100
+Comments For ex-ante quantification MANFOR was considered
+conservatively as zero.
+Data / Parameter TOTFOR
+Data unit ha
+Description Total available national forest area
+Source of data Official data, peer reviewed publications, remotely sensed imagery
+or cadastral maps and other verifiable sources
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: identify and collect available data
+on the total available national forest area
+• Entity responsible for the measurement: IBAP
+• Accuracy: subject to the quality of the data available.
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs in
+a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: 2,683,290
+Monitoring equipment If remotely sensed imagery, the following monitoring equipments
+shall be used:
+• Remote sensing data;
+• Computer, GIS software and spreadsheets.
+QA/QC procedures to be
+applied
+Broader evaluation must be carried so the must up-to-date
+information is used. If maps are produced and map accuracy is
+less than 90% then the map is not acceptable for further analysis.
+More remote sensing data and ground truthing data will be
+needed to produce a product that reaches the 90% minimum
+mapping accuracy.
+Purpose of data • Calculation of leakage
+Calculation method Sourced from literature or classification of remotely sensed
+imagery.
+Comments For ex-ante quantification degradation is considered zero
+Data / Parameter fterrestrial_forest (X,Y)
+Data unit t d.m. tree-1
+Description Allometric equation for terrestrial forest species linking measured
+tree variable(s) to aboveground biomass of living trees. This
+equation is used to estimate biomass of all forest tree species
+excluding palm trees and mangrove trees.
+Source of data Chave et al. (2005). Tree allometry and improved estimation of
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 101
+carbon stocks and balance in tropical forests. Oecologia 145, 87-
+89
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: For terrestrial forest three
+measured variables are applied: DBH, wood density and
+Height. For detailed methods and procedures on carbon
+stock quantification using the proposed allometric
+equation, including the measurement of DBH and Height,
+see Section 4.3.4. Wood density is sourced from peer-
+reviewed literature.
+• Entity responsible for the measurement: IBAP
+• Accuracy: should be validade according to CP-AB. Accuracy
+also subjected to the implied error in the allometric
+equation applied. Chave et al. (2005) complies with M-
+MON requirements being built on a sample of n=316 and
+r2 = 0.99.
+Frequency of
+monitoring/recording
+Must be re-validated whenever biomass stocks are re-measured
+(at least every 10 years).
+Value applied: AGBterrestrial_forest = 0.112* (ρ* DBH2 * H)0.916
+Monitoring equipment Not applicable
+QA/QC procedures to be
+applied
+Should be validated according to module CP-AB. If the equation is
+not validated new data should be collected to validate the
+equation or a new equation should be selected. Detailed
+procedures are available at Pearson, T. et al. (2005) Sourcebook
+for Land Use, Land-Use Change and Forestry Project. Winrock
+International and the World Bank Biocarbon Fund.
+Purpose of data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Calculation method The equation is a common allometric equation for dry forest
+requiring three parameters (DBH, wood density and height). The
+equation is a (e) pan-tropical forest type-specific. For detailed
+calculation methods see Section 4.3.4.
+Comments A deviation was approved allowing the allometric equation to be
+validated after the project validation but prior to verification. A
+Corrective Action Plan (CAP) was prepared detailing the methods
+and procedures for the field data collection and demonstrating that
+the equation is conservative for ex-ante quantification.
+Data / Parameter fmangrove (X,Y)
+Data unit t d.m. tree-1
+Description Allometric equation for mangrove species linking measured tree
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 102
+variable(s) to aboveground biomass of living trees.
+Source of data Chave et al. (2005). Tree allometry and improved estimation of
+carbon stocks and balance in tropical forests. Oecologia 145, 87-
+89
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: For mangrove forest two
+measured variables are applied: DBH and wood density.
+For detailed methods and procedures on carbon stock
+quantification using the proposed allometric equation,
+including the measurement of DBH, see Section 4.3.4.
+Wood density is sourced from peer-reviewed literature.
+• Entity responsible for the measurement: IBAP
+• Accuracy: should be validade according to CP-AB. Accuracy
+also subjected to the implied error in the allometric
+equation applied. Chave et al. (2005) complies with M-
+MON requirements being built on a sample of n=84 and r2
+= 0.99.
+Frequency of
+monitoring/recording
+Must be re-validated whenever biomass stocks are re-measured
+(at least every 10 years).
+Value applied: AGBmongrove = 0.168 * ρ* DBH2.47
+Monitoring equipment Not applicable
+QA/QC procedures to be
+applied
+Should be validated according to module CP-AB. If the equation is
+not validated new data should be collected to validate the
+equation or a new equation should be selected. Detailed
+procedures are available at Pearson, T. et al. (2005) Sourcebook
+for Land Use, Land-Use Change and Forestry Project. Winrock
+International and the World Bank Biocarbon Fund.
+Purpose of data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Calculation method The equation is a common allometric equation for mangroves
+requiring only two parameters (DBH and wood density). The
+equation is a (e) pan-tropical forest type-specific. For detailed
+calculation methods see Section 4.3.4.
+Comments A deviation was approved allowing the allometric equation to be
+validated after the project validation but prior to verification. A
+Corrective Action Plan (CAP) was prepared detailing the methods
+and procedures for the field data collection and demonstrating that
+the equation is conservative for ex-ante quantification.
+Data / Parameter ARRD,unplanned,hrp
+Data unit ha
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 103
+Description Total area deforested during the historical reference period in the
+RRD
+Source of data Remote sensing using Landsat imagery from 2002, 2007 and
+2010 in combination with GPS data collected during ground
+truthing
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: mid-resolution satellite imagery,
+like Landsat, is the most commonly data source used for
+land cover classification and land cover change analysis
+in large areas. Pre-processed Landsat images are used in
+a mapping operation that follows a three-step approach:
+preprocessing, classification, and validation. The
+preprocessing included geometric corrections, radiometric
+calibration, and gap fill for the 2010 images. The gap fill
+methodology by Scaramuzza et al. (2004) was applied to
+the 2010 images affected by the malfunctioning of the
+Scan-line corrector mechanism and the relative
+radiometric calibration procedure by Phua et al. (2008)
+was applied prior to building the mosaic layers for the
+years analyzed. The classification and mapping followed
+the protocols established by the module BL-UP and X-
+STR. For detailed procedures see Sections 3.1, 4.3.1 and
+4.3.2.
+• Entity responsible for the measurement: IBAP
+• Accuracy: The minimum map accuracy must be 90% for the
+classification of forest/non-forest in the remote sensing
+imagery.
+Frequency of
+monitoring/recording
+Must be updated upon baseline revision, at least every ten years.
+Value applied: • Cacheu (2002-2010): 10,487
+• Cantanhez (2002-2010): 21,213
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+If the classification accuracy is less than 90% then the maps is not
+acceptable for further analysis. More remote sensing data and
+ground truthing data will be needed to produce a product that
+reaches the 90% minimum mapping accuracy.
+Purpose of data • Determination of baseline scenario
+Calculation method For the current baseline, Landsat images date from 2002, 2007
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 104
+and 2010 in periods between January and April were collected.
+Fieldwork for ground truthing took place on the dry season of 2010
+and 2012, totaling 261 validation coordinates (125 in Cacheu and
+136 and Cantanhez). The calculation method is based on map
+algebra using gis software. All land cover transition is identified
+and the related transition areas calculated. A transition matrix is
+build to sum up all the conversion of forest areas (in ha) to non-
+forest areas (in ha). Detailed calculation methos are presented on
+Sections 3.1, 4.3.1 and 4.3.2.
+Comments Monitored for the purpose of baseline revision
+Data / Parameter Ai
+Data unit ha
+Description Area of stratum i
+Source of data Remote sensing imagery in combination with GPS data collected
+during ground truthing
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: mid-resolution satellite imagery,
+like Landsat, is the most commonly data source used for
+land cover classification and land cover change analysis
+in large areas. Pre-processed Landsat images are used in
+a mapping operation that follows a three-step approach:
+preprocessing, classification, and validation. The
+preprocessing included geometric corrections, radiometric
+calibration, and gap fill for the 2010 images. The gap fill
+methodology by Scaramuzza et al. (2004) was applied to
+the 2010 images affected by the malfunctioning of the
+Scan-line corrector mechanism and the relative
+radiometric calibration procedure by Phua et al. (2008)
+was applied prior to building the mosaic layers for the
+years analyzed. The classification and mapping followed
+the protocols established by the module BL-UP and X-
+STR. For detailed procedures see Sections 3.1, 4.3.1 and
+4.3.2.
+• Entity responsible for the measurement: IBAP
+• Accuracy: The minimum map accuracy must be 90% for the
+classification of forest/non-forest in the remote sensing
+imagery.
+Frequency of
+monitoring/recording
+Must be updated upon baseline revision, at least every ten years.
+Value applied: The adjusted values correcting misclassification bias in satellite-
+based areal cover type estimates (Walsh and Burk, 1993) are:
+• Closed Forest: 6,915
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 105
+• Open Forest: 60,168
+• Savanna: 18,633
+• Mangrove: 55,740
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+If the classification accuracy is less than 90% then the maps is not
+acceptable for further analysis. More remote sensing data and
+ground trothing data will be needed to produce a product that
+reaches the 90% minimum mapping accuracy.
+Purpose of data • Calculation of project emissions
+Calculation method For the current baseline, Landsat images dated from 2002, 2007
+and 2010 in periods between January and April were collected.
+Fieldwork for ground truthing took place on the dry season of 2010
+and 2012, totaling 261 validation coordinates (125 in Cacheu and
+136 and Cantanhez). The calculation method is based on well-
+known GIS technics. Satelite imagery is classified using
+classification software (commercial or open source) and the
+classification is validated using ground thruthing data (GPS
+coordinates and observed land cover type) to comply with
+methodology accuracy requirements. Detailed calculation methos
+are presented on Sections 3.1, 4.3.1 and 4.3.2.
+Comments Ex-ante it shall be assumed that strata area will remain constant
+for the baseline period.
+Data / Parameter Regional Forest Cover / Non-Forest Cover Benchmark Map
+Data unit Dimensionless
+Description Map showing the location of forest land within the RRD at the
+beginning of each project crediting period
+Source of data Remote sensing data in combination with GPS data collected
+during ground truthing
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: Landsat, or similar mid-resolution,
+images used in the mapping operation must follow a
+three-step approach: preprocessing, classification, and
+validation. The preprocessing includes geometric
+corrections and radiometric calibration. The classification
+and mapping must follow the protocols established by the
+module BL-UP and X-STR. The benchmark RRD Forest
+Cover map will be used as the baseline to the
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 106
+quantification of deforestation rates in the Reference
+Region.
+• Entity responsible for the measurement: IBAP
+• Accuracy: the minimum map accuracy must be 90% for the
+classification of the forest/non-forest in the remote sensing
+imagery.
+Frequency of
+monitoring/recording
+Update frequency at a minimum three times over the ten years
+leading up to baseline renewal (every 10 years).
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+If map classification accuracy is less than 90% then the map is not
+acceptable for further analysis. More remote sensing data and
+ground truthing data will be needed to produce a product that
+reaches the 90% minimum mapping accuracy.
+Purpose of data • Determination of baseline scenario
+• Calculation of baseline emissions
+Calculation method The classification and mapping must follow the protocols
+established by the module BL-UP and X-STR. For the current
+baseline, landsat images date from January 2010 until April 2010
+were collected. Fieldwork for ground truthing took place on the dry
+season of 2010 and 2012, totaling 261 validation coordinates (125
+in Cacheu and 136 and Cantanhez). The calculation method is
+based on well-known GIS technics. Satelite imagery is classified
+using classification software (commercial or open source) and the
+classification is validated using ground thruthing data (GPS
+coordinates and observed land cover type) to comply with
+methodology accuracy requirements.
+Comments Where forestland contains more than one forest class, the map
+must be stratified into forest classes using module X-STR
+Data / Parameter Project Forest Cover Benchmark Map
+Data unit Dimensionless
+Description Map showing the location of forestland within the Project Area at
+the beginning of each project crediting period.
+Source of data Remote sensing data in combination with GPS data collected
+during ground truthing
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 107
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: Landsat, or similar mid-resolution,
+images used in the mapping operation must follow a
+three-step approach: preprocessing, classification, and
+validation. The preprocessing includes geometric
+corrections and radiometric calibration. The classification
+and mapping must follow the protocols established by the
+module BL-UP and X-STR. The benchmark Project Area
+Forest Cover map will be used as the baseline for forest
+cover changes in the Project Area.
+• Entity responsible for the measurement: IBAP
+• Accuracy: the minimum map accuracy must be 90% for the
+classification of the forest/non-forest in the remote sensing
+imagery.
+Frequency of
+monitoring/recording
+Update frequency at a minimum three times over the ten years
+leading up to baseline renewal (every 10 years).
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+If map classification accuracy is less than 90% then the map is not
+acceptable for further analysis. More remote sensing data and
+ground truthing data will be needed to produce a product that
+reaches the 90% minimum mapping accuracy.
+Purpose of data • Determination of baseline scenario
+• Calculation of baseline emissions
+Calculation method The classification and mapping must follow the protocols
+established by the module BL-UP and X-STR. For the current
+baseline, landsat images date from January 2010 until April 2010
+were collected. Fieldwork for ground truthing took place on the dry
+season of 2010 and 2012, totaling 261 validation coordinates (125
+in Cacheu and 136 and Cantanhez). The calculation method is
+based on well-known GIS technics. Satelite imagery is classified
+using classification software (commercial or open source) and the
+classification is validated using ground thruthing data (GPS
+coordinates and observed land cover type) to comply with
+methodology accuracy requirements.
+Comments Where forestland contains more than one forest class, the map
+must be stratified into forest classes using module X-STR.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 108
+Data / Parameter Leakage Belt Forest Cover Benchmark Map
+Data unit Dimensionless
+Description Map showing the location of forestland within the Leakage Belt at
+the beginning of each project crediting period.
+Source of data Remote sensing data in combination with GPS data collected
+during ground truthing
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: Landsat, or similar mid-resolution,
+images used in the mapping operation must follow a
+three-step approach: preprocessing, classification, and
+validation. The preprocessing includes geometric
+corrections and radiometric calibration. The classification
+and mapping must follow the protocols established by the
+module BL-UP and X-STR. The benchmark Leakage Belt
+Forest Cover map will be used as the baseline for forest
+cover changes in the Leakage Belt.
+• Entity responsible for the measurement: IBAP
+• Accuracy: the minimum map accuracy must be 90% for the
+classification of the forest/non-forest in the remote sensing
+imagery.
+Frequency of
+monitoring/recording
+Update frequency at a minimum three times over the ten years
+leading up to baseline renewal (every 10 years).
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+If map classification accuracy is less than 90% then the map is not
+acceptable for further analysis. More remote sensing data and
+ground truthing data will be needed to produce a product that
+reaches the 90% minimum mapping accuracy.
+Purpose of data • Determination of baseline scenario
+• Calculation of baseline emissions
+Calculation method The classification and mapping must follow the protocols
+established by the module BL-UP and X-STR. For the current
+baseline, landsat images date from January 2010 until April 2010
+were collected. Fieldwork for ground truthing took place on the dry
+season of 2010 and 2012, totaling 261 validation coordinates (125
+in Cacheu and 136 and Cantanhez). The calculation method is
+based on well-known GIS technics. Satelite imagery is classified
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 109
+using classification software (commercial or open source) and the
+classification is validated using ground thruthing data (GPS
+coordinates and observed land cover type) to comply with
+methodology accuracy requirements.
+Comments Where forestland contains more than one forest class, the map
+must be stratified into forest classes using module X-STR
+Data / Parameter Project Forest Cover Monitoring Map
+Data unit Dimensionless
+Description Map showing the location of forestland within the project area at
+the beginning of each monitoring period. If, within the Project
+Area, some forestland is cleared the map must show the
+deforested areas at each monitoring event.
+Source of data Remote sensing data in combination with GPS data collected
+during ground truthing
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: Landsat, or similar mid-resolution,
+images used in the mapping operation must follow a
+three-step approach: preprocessing, classification, and
+validation. The preprocessing includes geometric
+corrections and radiometric calibration. The classification
+and mapping must follow the protocols established by the
+module BL-UP and X-STR. The monitoring project area
+forest cover map will be compared to the benchmark
+project area forest cover map and land cover transitions
+areas from forest to non-forest in the project area
+quantified using map algebra
+• Entity responsible for the measurement: IBAP
+• Accuracy: the minimum map accuracy must be 90% for the
+classification of the forest/non-forest in the remote sensing
+imagery.
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs
+on a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+If map classification accuracy is less than 90% then the map is not
+acceptable for further analysis. More remote sensing data and
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 110
+ground truthing data will be needed to produce a product that
+reaches the 90% minimum mapping accuracy.
+Purpose of data • Calculation of project emissions
+Calculation method Map algebra will be used to calculate forest to non-forest
+transitions.
+Comments Where forest land contains more than one forest class, the map
+must be stratified into forest classes using module X-STR
+Data / Parameter Leakage Belt Forest Cover Monitoring Map
+Data unit Dimensionless
+Description Map showing the location of forestland within the Leakage Belt
+area at the beginning of each monitoring period.
+Source of data Remote sensing using in combination with GPS data collected
+during ground truthing
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: Landsat, or similar mid-resolution,
+images used in the mapping operation must follow a
+three-step approach: preprocessing, classification, and
+validation. The preprocessing includes geometric
+corrections and radiometric calibration. The classification
+and mapping must follow the protocols established by the
+module BL-UP and X-STR. The monitoring leakage belt
+cover map will be compared to the benchmark leakage
+belt cover map and land cover transitions areas from
+forest to non-forest in the leakage belt quantified using
+map algebra
+• Entity responsible for the measurement: IBAP
+• Accuracy: the minimum map accuracy must be 90% for the
+classification of the forest/non-forest in the remote sensing
+imagery.
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs
+on a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+If map classification accuracy is less than 90% then the map is not
+acceptable for further analysis. More remote sensing data and
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 111
+ground truthing data will be needed to produce a product that
+reaches the 90% minimum mapping accuracy.
+Purpose of data • Calculation of leakage
+Calculation method Map algebra will be used to calculate forest to non-forest
+transitions.
+Comments Where forest land contains more than one forest class, the map
+must be stratified into forest classes using module X-STR
+Data / Parameter Degradation PRA Results
+Data unit Dimensionless
+Description Degradation potential identified through the Participatory Rural
+Appraisal (PRA) determining if there is the potential for illegal
+extraction of trees to occur
+Source of data Interviews with the communities inside and surrounding the
+project area
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: the PRA consists of semi-
+structured interviews / questionnaires. The PRA shall
+evaluate whether the following activities may be occurring
+in the project area: (i) harvesting of fuel wood, (ii)
+harvesting of wood for charcoal production and (iii) timber
+harvest. If ≥ 10% of those interviewed/surveyed suggest
+that degradation may be occurring within the project
+boundary then the limited on the ground degradation
+survey shall be triggered. An additional output of the PRA
+shall be a depth of penetration of degradation pressure. A
+maximum distance shall be recorded for penetration into
+the forest from access points (such as roads, rivers,
+already cleared areas) for the purpose of harvesting fuel
+wood, charcoal and/or timber. It is likely that differing
+distances shall exist for each degradation pressure. If
+multiple pressures exist in the same stratum the deepest
+depth of penetration shall be used to define Adeg,i
+• Entity responsible for the measurement: IBAP
+• Accuracy: communities need to be sampled inside and on
+the surroundings of the project area and within 2 km of the
+boundaries of the Leakage Belt to avoid bias. Sampling
+must be randomly designed and at least 10% of
+communities shall be sampled. If 10% of communities are
+less than 10 communities then the sample size shall be
+set as 10 or 100% of the communities. If 10% is more
+than 10 communities then the sample size shall be set as
+30.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 112
+Frequency of
+monitoring/recording
+The PRA must be updated every two years
+Value applied: 0 (no potential for degradation)
+Monitoring equipment • GPS;
+• Field interview forms;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+Communities locations shall be structured in a geo referenced
+database. If communities no longer exist or new settlements are
+established the database must be updated. All information
+collected on the field (i.e. questionnaires, spreadsheets) must be
+digitalized. Information must be recorded and backed-up digitally
+and physical copies stored at IBAP headquarters.
+Prior to PRA update the field team must be trained both on the
+interview method and on the questionnaire template.
+Purpose of data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Calculation method Semi-structured intervews with the communities to identify forest
+degradation potential
+Comments The PRA developed indicated no significant risk of degradation,
+therefore for ex-ante quantification emissions from degradation is
+considered zero.
+Data / Parameter Result of Limited Degradation Survey
+Data unit Dimensionless
+Description Rapid assessment to evaluate potential for degradation allowing
+the delineation of the areas that are potentially subjected to
+degradation.
+Source of data Field sampling
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: The area subjected to
+degradation shall be delineated based on an access
+buffer from all access points, such as roads and rivers or
+previously cleared areas, to the project area, with a width
+equal to the distance of degradation penetration. The area
+shall be sampled by surveying several transects of known
+length and width across the access-buffer area (equal in
+area to at least 1% of ADeg,i) to check whether new tree
+stumps are evident or not. If there is little to no evidence
+that trees are being harvested then degradation can be
+assumed to be zero and no monitoring is needed. If
+degradation indications exist, systematic sampling must
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 113
+be conducted.
+• Entity responsible for the measurement: IBAP
+• Accuracy: T-SIG shall be used to establish significance.
+Frequency of
+monitoring/recording
+Must be repeated each time the PRA indicates a potential for
+degradation
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• GPS;
+• Digital Camera;
+• Diametric tape;
+• Field sampling spreadsheets;
+• Computer, GIS software.
+QA/QC procedures to be
+applied
+All information collected on the field (i.e. questionnaires,
+spreadsheets, tree stump data) must be digitalized. Information
+must be recorded and backed-up digitally and physical copies
+stored at IBAP headquarters.
+Prior to PRA update the field team must be trained following a
+specific SOP detailing field and data collection methods. All maps
+produced delineating degradation areas must comply with the
+same error limit as established for other mapping activities in the
+monitoring plan (limit of 90%).
+Purpose of data • Calculation of project emissions
+Calculation method The sampling plan must be designed using plots systematically
+placed over the buffer zone so that they sample at least 3% of the
+area of the buffer zone. The diameter of all tree stumps will be
+measured and conservatively assumed to be the same as the
+DBH.
+Comments The PRA developed indicated no significant risk of degradation,
+therefore for ex-ante quantification emissions from degradation is
+considered zero.
+Data / Parameter ADefPA, i, u, t
+Data unit ha
+Description Area of recorded deforestation in the project area in stratum i
+converted to land use u at time t
+Source of data Remote sensing imagery
+Description of
+measurement methods
+and procedures to be
+• Methods and procedures: Landsat, or similar mid-resolution,
+images used in the mapping operation must follow a
+three-step approach: preprocessing, classification, and
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 114
+applied validation. The preprocessing includes geometric
+corrections and radiometric calibration. The classification
+and mapping must follow the protocols established by the
+module BL-UP and X-STR. The monitoring forest cover
+map will be compared to the benchmark forest cover map
+and land cover transitions areas from forest to non-forest
+in the project area quantified using map algebra
+• Entity responsible for the measurement: IBAP
+• Accuracy: the minimum map accuracy must be 90% for the
+classification of the forest/non-forest in the remote sensing
+imagery.
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs
+on a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+All data sources and analytical procedures will be documented
+and archived. Accuracy of the classification must be assessed by
+comparing the classification with ground truthing samples.
+Purpose of data • Calculation of project emissions
+Calculation method Map algebra will be used to calculate forest to non-forest
+transitions.
+Comments Ex-ante quantification considers deforestation in the Project Area
+equal to zero since IBAP keep permanence presence on both
+Cacheu and Cantanhez with clear infrastructure, patroling and
+policies are in place to prevent deforestation.
+Data / Parameter ADefLB, i, u, t
+Data unit ha
+Description Area of recorded deforestation in the leakage belt in stratum i
+converted to land use u at time t
+Source of data Remote sensing imagery
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: Landsat, or similar mid-resolution,
+images used in the mapping operation must follow a
+three-step approach: preprocessing, classification, and
+validation. The preprocessing includes geometric
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 115
+corrections and radiometric calibration. The classification
+and mapping must follow the protocols established by the
+module BL-UP and X-STR. The monitoring forest cover
+map will be compared to the benchmark forest cover map
+and land cover transitions areas from forest to non-forest
+in the leakage belt quantified using map algebra
+• Entity responsible for the measurement: IBAP
+• Accuracy: the minimum map accuracy must be 90% for the
+classification of the forest/non-forest in the remote sensing
+imagery.
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs
+on a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+All data sources and analytical procedures will be documented
+and archived. Accuracy of the classification must be assessed by
+comparing the classification with ground truthing samples.
+Purpose of data • Calculation of leakage
+Calculation method Map algebra will be used to calculate forest to non-forest
+transitions.
+Comments Ex-ante quantification of deforestation in the leakage belt is
+performed applying the module LK-ASU
+Data / Parameter ADegW, i
+Data unit ha
+Description Area potentially impacted by degradation processes in stratum i
+Source of data GIS delineation and ground truthing
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: the parameter is composed of a
+buffer from all access points, such as roads and rivers or
+previously cleared areas. The width of the buffer shall be
+determined by the depth of degradation penetration as
+defined as a PRA output. The sampling plan must be
+designed using plots systematically placed over the buffer
+zone so that they sample at least 3% of the area of the
+buffer zone. The diameter of all tree stumps will be
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 116
+measured and conservatively assumed to be the same as
+the DBH.
+• Entity responsible for the measurement: IBAP
+• Accuracy: degradation area delineation must be validated
+using ground truthing data according to the sampling plan
+Frequency of
+monitoring/recording
+Must be repeated each time the PRA indicates a potential for
+degradation.
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+All data collected and analytical procedures will be documented
+and archived. Areas under degradation must be validated using
+ground truthing. The field team will be trained according to an
+appropriate SOP to identify and measure tree stumps.
+Purpose of data • Calculation of project emissions
+Calculation method Map algebra will be used to calculate forest loss due to
+degradation.
+Comments Not applicable
+Data / Parameter ADistPA, q, i, t
+Data unit ha
+Description Area impacted by natural disturbances in the project stratum i
+converted to natural disturbance stratum q at time t
+Source of data Remote Sensing imagery combined with ground verification or
+GPS coordinates
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: where natural disturbance occur
+ex-post in the project area such as tectonic activity,
+extreme weather, pest, drought or fire that result in a
+degradation of forest carbon stock, the area disturbed
+shall be delineated. Using map algebra, the area impacted
+by natural disturbance is equal to the area that overlap
+between the delineated area of disturbance and the area
+of unplanned deforestation in the project area.
+• Entity responsible for the measurement: IBAP
+• Accuracy: degradation area delineation must be validated
+using ground truthing data of GPS coordinates. Emissions
+resulting from natural disturbances may be omitted if they
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 117
+are deemed de minimis through the use of the module T-
+SIG
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs
+on a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+All data sources and analytical procedures will be documented
+and archived. Accuracy of the classification must be assessed by
+comparing the classification with ground truthing or GPS samples.
+Purpose of data • Calculation of project emissions
+Calculation method Map algebra to overlap the areas undergoing natural disturbance
+and the project area.
+Comments Not applicable
+Data / Parameter APi
+Data unit ha
+Description Total area of degradation sample plots in stratum i
+Source of data Ground measurement
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: calculated by summing the area
+(slope corrected) of sample plots measures in the sample
+of ADeg,W, i, t.
+• Entity responsible for the measurement: IBAP
+• Accuracy: total area must be slope corrected
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs
+on a frequency of less than every five years examination occur
+prior to any verification event.
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be Incident areas of potential degradation are confirmed and
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 118
+applied delineated in the field using GPS, sample plot dimensions are
+measured in the field on plot establishment.
+Purpose of data • Calculation of project emissions
+Calculation method Calculated by summing the area (slope corrected) of sample plots
+measures in the sample of ADeg,W, i, t.
+Comments For ex-ante quantification degradation is considered zero
+Data / Parameter CDegW, i, t
+Data unit t CO2e
+Description Biomass carbon of trees cut and removed through illegal logging
+and fuelwood and charcoal extraction degradation process from
+plots measured in stratum i at time t
+Source of data Field measurement
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: temporary circular sample plots
+will be allocated and measured in the area of potential
+logging. Diameter at cut height of stumps will be
+measured. Significance of GHG emissions shall be
+assessed using T-SIG. If emissions from degradation is
+deemed significant, biomass of trees cut and removed will
+be estimated from measured diameter (conservatively
+assuming that diameter at stump cut are equivalent to
+DBH) applying allometric equations from Chave et al.
+(2005) and Delayne (1999)
+• Entity responsible for the measurement: IBAP
+• Accuracy: the proposed approach to consider diameter at
+cut height equivalent to DBH assures the
+conservativeness of the parameter
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs in
+a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: Not applicable
+Monitoring equipment • Diametric Tape;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+All data sources and analytical procedures will be documented
+and archived.
+Purpose of data • Calculation of project emissions
+Calculation method Estimated from diameter measurements of cut stumps in the
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 119
+sample plots
+Comments For ex-ante quantification degradation is considered zero
+Data / Parameter CAB,tree,i
+Data unit tCO2e ha-1
+Description Carbon Stock in aboveground biomass in trees in Cantanhez and
+Cacheu in stratum i
+Source of data Field Measurement (Winrock/IICT 2012) applied with allometric
+equation published in Chave et al. (2005) and Delaney (1999)
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: see Section 4.3.4
+• Entity responsible for the measurement: IBAP
+• Accuracy: see Section 4.3.4
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs in
+a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: Cacheu
+• Open Forest: 132.88
+• Savanna: 97.70
+• Mangrove: 72.89
+Cantanhez
+• Closed Forest: 306.11
+• Open Forest: 127.01
+• Savanna: 101.43
+• Mangrove: 100.45
+Monitoring equipment • Diametric Tape;
+• Hypsometer;
+• Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+Independent 3rd party audit of field data and procedures.
+Purpose of data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Calculation method See Section 4.3.4
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 120
+Comments Not applicable
+Data / Parameter DBHtree, i
+Data unit cm
+Description Diameter at breast height of a tree
+Source of data Field measurement
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: typically measured at 1.3
+aboveground. Detail on methods and procedures are
+presented on Section 4.3.4
+• Entity responsible for the measurement: IBAP
+• Accuracy: procedures for accuracy assurance for forest
+inventory are detailed on section 4.3.4.
+Frequency of
+monitoring/recording
+Monitoring must occur at least every ten years from baseline
+renewal.
+Value applied: Not applicable
+Monitoring equipment • GPS;
+• Diametric tape;
+• Hypsometer.
+QA/QC procedures to be
+applied
+Independent 3rd party audit of field data and procedures. Field
+observation sheets will include DBH of each measured tree for
+evaluation of reasonableness of measurement based on feasible
+growth rate.
+Purpose of data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Calculation method See Section 4.3.4
+Comments Not applicable
+Data / Parameter H
+Data unit m
+Description Total height of tree
+Source of data Field measurement
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: height measure undertook using a
+hypsometer. Detail on methods and procedures are
+presented on Section 4.3.4
+• Entity responsible for the measurement: IBAP
+• Accuracy: procedures for accuracy assurance for forest
+inventory are detailed on section 4.3.4.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 121
+Frequency of
+monitoring/recording
+Monitoring must occur at least every ten years from baseline
+renewal.
+Value applied: Not applicable
+Monitoring equipment • GPS;
+• Hypsometer.
+QA/QC procedures to be
+applied
+Independent 3rd party audit of field data and procedures. Field
+observation sheets will include H of each measured tree for
+evaluation of reasonableness of measurement based on feasible
+growth rate.
+Purpose of data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Calculation method See Section 4.3.4
+Comments Not applicable
+Data / Parameter CBB,tree,i
+Data unit tCO2e ha-1
+Description Carbon Stock in belowground biomass in trees in Cantanhez and
+Cacheu in stratum i
+Source of data Field Measurement (Winrock/IICT 2012) applied with root-to-shoot
+rations
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: see Section 4.3.4
+• Entity responsible for the measurement: IBAP
+• Accuracy: see Section 4.3.4
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs in
+a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: Cacheu
+• Open Forest: 35.23
+• Savanna: 26.49
+• Mangrove: 33.39
+Cantanhez
+• Closed Forest: 84.15
+• Open Forest: 33.77
+• Savanna: 28.18
+• Mangrove: 46.01
+Monitoring equipment Not applicable
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 122
+QA/QC procedures to be
+applied
+Independent 3rd party audit of field data and procedures.
+Purpose of data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Calculation method See Section 4.3.4
+Comments Not applicable
+Data / Parameter CAB,tree,post,i
+Data unit tCO2e ha-1
+Description Post-deforestation carbon stock in aboveground biomass in trees
+in Cantanhez and Cacheu in stratum i
+Source of data Field Measurement or literature data
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: see Section 3.1.5
+• Entity responsible for the measurement: IBAP
+• Accuracy: see Section 3.1.5
+Frequency of
+monitoring/recording
+At least every 10 years upon baseline revision
+Value applied: 7.8
+Monitoring equipment If field measurement is undertaken the following equipments shall
+be applied:
+• Diametric Tape;
+• Hypsometer;
+• Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+In case literature data is applied, monitoring equipments are not
+applicable.
+QA/QC procedures to be
+applied
+Independent 3rd party audit of field data and procedures.
+Purpose of data • Calculation of baseline emissions
+• Calculation of project emissions
+• Calculation of leakage
+Calculation method See Section 3.1.5
+Comments For the current baseline, default carbon stock values extracted
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 123
+from IPCC are applied to the land uses described in Temudo
+(1998) and Silva et al. (2011) to calculate the carbon stocks in the
+post deforestation scenario.
+Data / Parameter Aburn, i, t
+Data unit ha
+Description Area burnt at time t (if any occurs)
+Source of data Remote sensing imagery
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: using GIS and Landsat imagery
+delineate area burnt at time t
+• Entity responsible for the measurement: IBAP
+• Accuracy: map accuracy must comply with methodology
+requirements (90% minimum)
+Frequency of
+monitoring/recording
+Must be monitored at least every 5 years or if verification occurs in
+a frequency of less than every 5 years examination must occur
+prior to any verification event
+Value applied: Not applicable
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+Incident areas of fire are confirmed and delineated in the field
+using GPS.
+Purpose of data • Calculation of project emissions
+Calculation method Total burnt area is quantified using map algebra
+Comments For ex-ante quantification degradation is considered zero
+Data / Parameter Asp
+Data unit ha
+Description Area of sample plots in ha
+Source of data Recording and archiving of number and size of sample plots
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: the project applies circular nested
+plots. The outter circle has 20 mts and the area is sloped
+adjusted in the field using a hypsometer. For details see
+Section 4.3.4
+• Entity responsible for the measurement: IBAP
+• Accuracy: the hypsometer shall be calibrated according to
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 124
+factory procedures before field campaigns.
+Frequency of
+monitoring/recording
+Monitoring must occur at least every ten years for baseline
+renewal.
+Value applied: 0,13 ha (radius of 20 mts)
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• Hypsometer;
+• GPS;
+• Digital Camera;
+• Spreadsheets.
+QA/QC procedures to be
+applied
+Personel must be trained in the operation of hypsometers and
+how to correct for slope in the terrain. All data must be recorded
+and backuped in multiple locations including physical copies and
+digital copies (HDs, servers, cloud)
+Purpose of data • Calculation of baseline emissions
+Calculation method Plots are circular. Three circles are nested, the bigger with 20 mts,
+the intermediary with 14 mts and the internal with 4 mts. For
+detailes on calculation methods see Section 4.3.4
+Comments Not applicable
+Data / Parameter N
+Data unit Dimensionless
+Description Number of sample points
+Source of data Recording and archiving of number of sample points
+Description of
+measurement methods
+and procedures to be
+applied
+• Methods and procedures: Plots are randomly selected over
+a 250x250 grid of points. For details see Section 4.3.4
+• Entity responsible for the measurement: IBAP
+• Accuracy: when overlaying the grid of points standard
+mapping procedures shall be observed to avoid distortion
+os misplacement of points.
+Frequency of
+monitoring/recording
+Monitoring must occur at least every ten years for baseline
+renewal.
+Value applied: 259 plots
+Monitoring equipment • Remote sensing data;
+• Computer, GIS software;
+• GPS;
+QA/QC procedures to be Personel must be trained in GIS and digital mapping operations.
+All data must be recorded and backuped in multiple locations
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 125
+applied including physical copies and digital copies (HDs, servers, cloud)
+Purpose of data • Calculation of baseline emissions
+Calculation method A 250 x 250 meter systematic grid of points with a random origin
+shall be created. The number of plots to be sampled in each
+stratum are determined based on three considerations: (1) the
+variability of biomass within a stratum (evaluated using previously
+collected data); (2), the estimated area covered by each stratum;
+and (3) the target precision level (set at 15%, 95% CI). Sample
+plots are then randomly selected for each stratum that were
+deforested and need to be revised over the grid. Selected plot
+coordinates shall be loaded into GPS equipment and later used in
+the field to reach the center of each plot. For detailes on
+calculation methods see Section 4.3.4
+Comments Not applicable
+4.3 Monitoring Plan
+The project monitoring and reporting process is IBAP's Monitoring Unit responsibility. IBAP is
+responsible for the conservation and management of forest-related biodiversity in Guinea-
+Bissau, and in the past ten years has recruited qualified staff and has grown into a fully
+functioning institution, coordinating the day-to-day management of more than 450,000 ha of
+critical natural habitats. Figure 14 presents an overview of the monitoring process and defines
+the structure of IBAP's Monitoring Unit to be implemented for the monitoring of this project.
+Figure 14. Overview of the monitoring process and structure.
+IBAP
+Advisory Board
+Director and
+program coordinator
+Head of
+Monitoring
+Monitoring Unit
+VCS
+Verification
+Monitoring
+Field Team
+Cacheu Cantanhez
+Local
+Communities
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 126
+The monitor reports will be developed by the head of monitoring and discussed amongst all
+parts of the monitoring unit. Specific groups of the monitoring team will be responsible for
+forest monitoring map production, others for ground observations, data compilation, and
+carbon stock assessments, and others for working mostly with the communities and apply
+PRA techniques to assess forest degradation risks. The monitoring team reports in each of
+these components directly to the head of monitoring, receiving feedback from the head of
+monitoring in order to improve the quality of the data and ensure that the standard operating
+procedures (SOPs) and QC/QA procedures are followed. The head of monitoring will be
+responsible for the final compilation of all data, ensure data achieving, and for reporting. He is
+also responsible for setting up corrective or preventing actions to avoid non-conformances with
+the validated monitoring plan. The forest monitoring is developed in a process of continuous
+improvement, which means that all the activities to be monitored by the monitoring team are
+subject to a report to be revised by the head of monitoring. This process of internal audit shall
+be used namely to identify deviations or non-conformances, that if occurring shall be
+recorded/computized and a report shall be developed justifying the conservativeness of the
+monitoring approach. If deemed necessary, correction action plans (CAPs) are developed and
+SOPs adjusted in the Monitoring Plan, including if a non-conformance is identified and the
+justification report fails to prove the conservativeness of the new method, equipment or
+strategy. SOPs are developed and updated with the assistance of external carbon experts or
+advisory board and are provided by the head of monitoring to the monitoring field team. The
+monitoring unit will have the support and guidance of an advisory board in all stages. This
+advisory board includes carbon and remote sensing experts that will assist with data entry,
+compilation of inventory results, and remote sensing work. The importance of these experts
+will gradually diminish and become occasional as IBAP gains technical independence in all
+monitoring activities. Table 15 synthesizes the responsibilities of each group of the monitoring
+unit.
+Table 26. Overview of the responsabilities of the monitoring team.
+Group/Staff Responsibility
+Director / Program
+Coordinator
+Managing the VCS verification process
+Revise monitoring reports from the head of monitoring and
+provide feedback
+Reporting
+Ensure engagement and support of external consultants and
+other members of the advisory board
+Head of Monitoring Compile data
+Data archiving
+Ensure consistency between the monitoring field team collecting
+data in the two parks
+Prepare monitoring reports
+Drafting SOPs
+Prepare CAPs when needed
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 127
+Selection of qualified staff for each specific activity to be
+performed by the monitoring field team (in collaboration with the
+Parks' Director)
+Identify training requirements
+Main liaison with the advisory board
+Liaison between the monitoring field team and the director and
+program coordinator
+Ensure that the quality control procedures are being implemented
+Plan and coordinate the Monitoring Field Team activities
+Monitoring Field
+Team
+Field data collection
+Data entry
+Data archiving
+Equipment maintenance and calibration
+Forest monitoring map production
+Prepare reports to the head of monitoring
+Advisory Board Provide technical and scientific support when needed and as
+required by the head of monitoring and IBAP's Director / Program
+coordinator
+Technical review or pre-verification of the data
+Technical review of monitoring reports and consistency with the
+monitoring plan
+All data collected as part of the monitoring program will be archived in both electronic and
+paper forms (when possible). To safeguard its security, copies of the data should be stored at
+IBAP's headquarters under the responsibility of the head of monitoring and at the offices of
+each Park (Cacheu and Cantanhez) under the supervision of the parks' directors. The
+archiving of the data will be under the responsibility of the head of monitoring with the
+supervision of IBAP's director / program coordinator. The QA/QC protocol will also be
+supervised by the head of monitoring and includes:
+• Collect data to validate the information produced with remote sensing
+• Ensure that the field team is trained - with biannual workshops, and discussion of
+SOPs
+• Register all field members and their specific responsibilities, and archive that
+information together with the data collected (metadata)
+• Routine checks of the data sheets to ensure data integrity and correct labelling.
+• Cross-check of the input data for transcription errors conducted by personnel not
+directly involved in inventory and data compilation steps.
+• Total transparency of the worksheet to enable reproduction of the emission and
+uncertainty estimates
+• Revisit a sample of the measured plots to ensure the quality of the plot location (i.e. of
+the coordinates)
+• Compare data from the GPS equipment with the coordinates in the field datasheet and
+in the excel workbook to identify and correct eventual transcription errors.
+• Technical review or pre-verification of the data, and monitoring report will be
+conducted by the advisory board and IBAP's Director / Program coordinator
+The ex-post monitoring has two key aspects: (i) monitoring according to the Monitoring Plan
+and (ii) revising the baseline every 10 years. Carbon stocks shall be revisited every 10 years
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 128
+together with the baseline deforestation update in the reference region because agents,
+drivers and underlying causes of deforestation change dynamically.
+The Community Based Avoided Deforestation Project in Guinea Bissau must monitor land
+cover changes and degradation activities before verifications in order to assess ex-post
+emission reduction. The main goal of this Monitoring Plan is to present a protocol to the
+collection of the data that will allow the verification of the deforestation and degradation within
+the Project Area and its Leakage Belt throughout time, regularly updating the emissions
+estimation as well as the generation of sufficient and timely information to evaluate the impact
+of the on the ground community measures to reduce pressure over the forest and make the
+necessary adjustments.
+This Monitoring Plan covers the parameters described in section 4.2 and monitors the area of
+forest land converted to non-forest land and associates changes in carbon stocks, the area of
+forest land undergoing loss in carbon from degradation activities and associated changes in
+carbon stocks, the area of forest land undergoing loss in carbon stocks resulting from natural
+disturbances and associated changes in carbon stocks and the greenhouse gas emissions
+associated with project implementation.
+4.3.1 Revision of the Baseline
+The baseline, as outlined in this PD, is valid for 10 years, through 31st of March 2011 until 30th
+of March 2021. The baseline will be updated every 10 years from the project start date
+because agents, drivers and underlying causes of deforestation change dynamically. The
+methodological procedure used to update the baseline shall be the same used in the definition
+of the baseline according to the PD and are further described in the following sections.
+a. Technical Description of the monitoring task
+The methodological procedure used to update the baseline shall be the same used in the first
+estimation (WB_revisionupdate_FINAL_Report_v6.pdf). The following parameters shall be
+estimated: net greenhouse gas emissions in the baseline from unplanned deforestation
+(ΔCBSL,unplanned), net greenhouse gas emissions due to activity shifting for projects preventing
+unplanned deforestation (ΔCLK-AS,unplanned), and the net greenhouse gas emissions within the
+project area under the project scenario (ΔCP). Carbon stocks shall be re-estimated from new
+field measurement after 10 years of the current baseline. Standard methods of remote sensing
+used for the establishment of the baseline will be used for the updated of the following
+parameters when the baseline is revised: LB (Leakage Belt Area, in ha), PA (Unplanned
+Deforestation Project Area, in ha), PLK (LK/RRD, dimensionless), PPA (PA/RRD,
+dimensionless), RRD (Reference Area for the Projection of Deforestation, in ha) and Thrp
+(Duration of the historical reference period, in years).
+The procedures and data to be collected for the update of LB, PA and RRD are detailed on
+section (b) below. PLK and PPA are ratios that will be updated at least once every 10 years
+(when the baseline is revisited) using the parameters LB, PA and RRD. The parameter Thrp
+depends on data availability at the moment of the baseline update. This parameter will be
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 129
+updated at least once every 10 years (when the baseline is revised) and must cover a
+historical reference period between 10 and 15 years.
+b. Data to be collected
+The update of the spatial boundaries LB, PA and RRD must follow the criteria established by
+the BL-UP Module. PA is the area inside Cantanhez and Cacheu National Parks covered by
+forestland in the end of the baseline historical period. The boundaries of the National Parks
+are fixed and established by law. The shapefiles are provided by IBAP. Mid resolution imagery
+(e.g. Landsat) or, if available, imagery with higher resolution sources (e.g. Sentinel) will be
+collected for three time periods from a historical reference period between 10 and 15 years
+(Thrp). Image classification will be used to produce maps and calculate total area of forest
+cover in the National Parks to define the PA in hectare.
+The Leakage Belt (LB) is the area suitable for activity shifting from the PA. LB must be
+updated following the criteria established by BL-UP that includes minimum area in relation to
+the PA, landscape factors (% forest type, % soil type, % slope proportion) and transport
+factors (river density, road density and population density). The same procedure used to
+establish the current baseline must be followed. Mid resolution imagery (e.g. Landsat) or, if
+available, imagery with higher resolution sources (e.g. Sentinel) will be collected for three time
+periods from a historical reference period between 10 and 15 years (Thrp). Image classification
+will be used to produce maps of forest cover and, together with the previously listed criteria,
+update LB. If the minimal required area is not reached justification must be provided in
+accordance with BL-UP requirements.
+The RRD is the reference area for projecting deforestation rate and must not encompass the
+PA and the LB. The update of RRD must follow the criteria established in the BL-UP module
+that includes deforestation agents, landscape factors and transportation network and
+infrastructure. Mid resolution imagery (e.g. Landsat) or, if available, imagery with higher
+resolution sources (e.g. Sentinel) will be collected for three time periods from a historical
+reference period between 10 and 15 years (Thrp). Image classification will be used to produce
+maps of forest cover and, together with the previously listed criteria, update RRD. If the
+minimal required area is not reached to equal MREF, then MREF shall be made equal to the
+area that meets the listed criteria in accordance with BL-UP requirements.
+For the reassessment of the carbon stocks of each stratum, new plots shall be established and
+measured. The field measurements used for the carbon stock assessment must be re-
+established at least once every 10 years (when the baseline is revisited).
+c. Overview of data collection procedures
+Similarly to the approach followed in the baseline presented in this PD, land cover change will
+be assessed based on maps obtained by processing satellite data. The type of satellite
+imagery, the scenes dates, and the processing methodology, must align with the requirements
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 130
+of VM0007 VCS REDD methodology and follow all the good practice guidelines for remote
+sensing analysis.
+The remotely sensed data collected must be prepared for analysis. Minimum pre-processing
+involves geometric correction and geo-referencing and cloud and shadow detection and
+removal. All information on image pre-processing, classification procedures and map validation
+is presented below.
+Pre-processing:
+• Geometric Corrections - To remove distortions or degradations from the images,
+geometric corrections shall be made. This operation shall be performed using an ortho-
+rectified image. The process will involve Ground Control Points (GPC) distributed across
+the study area for all the images and years, and shall yield an acceptable overall accuracy
+expressed as an average root mean square error (RMSE). It is important to ensure that
+the RMSE is not greater than one pixel, in order to co-register images from different
+dates. Using the nearest neighbor resampling technique (which preserves the maximum
+raw spectral information) the images shall be resampled into the Universal Transverse
+Mercator projection (UTM, Zone 28 North, WGS84) with a 25m grid.
+• Radiometric calibration - Each acquired image has its own atmospheric and phase angle
+effects. Therefore, a multi-date image normalization correction using regression must be
+applied to each pair of images (Jensen, 2005). All the images shall be radiometrically
+calibrated using a band-to-band linear regression (Phua et al., 2008; Lillesand & Kiefer,
+1987). This approach normalizes the differences between the images from different dates,
+allowing data comparison, and facilitates the production of a homogeneous mosaic of
+scenes for all the years. This correction consists on selecting a base image and
+transforming the spectral characteristics of all other images obtained on different dates to
+have approximately the same radiometric scale as the base image (Jensen, 2005). To do
+that, pseudo-invariant features are selected in pixels that should change very little through
+time, e.g., deep-water bodies and bare soil. The relation of this pseudo-invariant features
+from the base image to the other images is done using regression equations, which will
+assume that the pixels sampled at time t+1 and t-1 are linearly related to the pixels for the
+same location on the base image (Jensen, 2005). Once these regressions equations are
+applied, the variations between images are removed and they can be used in the
+classification step.
+• Fill gaps methodology in case of images with existing clouds or gaps - This operation is
+based on the SLC Gap-Filled Products Methodology and shall only be applied if needed.
+The process starts with the choice of the SLC- off scenes with gaps to fill (named primary
+scenes) and the scenes to fill the gaps (fill scenes).
+Image classification:
+The classification of each image shall be carried out with a maximum likelihood classifier
+(Lillesand & Kiefer, 1987). This approach uses the signatures that characterize each of the
+land cover classes extracted from training sites to calculate statistics, which are used to
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 131
+evaluate the probability of each unknown pixel belonging to a given class. The class with the
+highest likelihood is attributed to the pixel.
+To train the classifier training data shall be extracted using a color composite (RGB). The
+bands middle infrared (MIR), near infrared (NIR) and red are considered to be the most
+relevant for visual discrimination of land cover information. The data for the training sets shall
+be extracted by visual on-screen interpretation assisted by ancillary data and expert
+knowledge from previous field campaigns.
+Assuming that the training area samples capture the variability and characteristics of the
+population, in order to improve consistency between the different dates, areas used for
+extracting training data shall be the same on different dates, except in those areas where land
+cover/use has changed between dates. A statistical analysis shall be made for each training
+class dataset and checked for class separability through the use of the Jeffries-Matusita (JM)
+distance (Matusita, 1966). The JM distance is a saturating transformation of the Bhattacharya
+distance (Jensen, 1996) with values between 0 (not separable) and 2 (classes perfectly
+separable). All the statistics shall be calculated only for land pixels, excluding water, due to
+tide differences among the different years. Some problems could occur due to localized
+geometric differences between the years. The algorithm used for classifying the imagery was
+developed under CARBOVEG-GB and the results of its application were verified by field
+observations across the country in all strata that are considered by the Project Activity.
+After the first classification, the land cover maps shall be reclassified into a Forest vs Non-
+Forest map (two-class) with a minimum mapping unit of one hectare.
+Validation
+An accuracy assessment procedure shall be applied to access the accuracy and validate the
+land cover maps produced. The overall classification accuracy of the maps produced must be
+90% or more.
+Mapping land cover change
+To assess the changes of forest areas, derive the deforested areas, and the new deforestation
+rates, Deforestation Maps showing areas of deforestation with paired data shall be produced
+for the RRD for the time periods between each new historic image. The areas of all possible
+transitions must be spatially identified and the transition matrices obtained through map
+algebra operations are used to estimate the new historical deforestation rates.
+For the reassessment of the carbon stocks of each stratum, new plots shall be established and
+measured. The existing 250 x 250 meter systematic grid covering the entire country shall be
+stratified according to the most recent land cover map produced and used to determine the
+plots location. The number of plots to be measured shall meet the desired statistical precision
+of the methodology - i.e., 95% confidence interval is within 15% of the mean. A detailed
+description of the data collection is presented in section 4.3.4.
+d. Quality control and quality assurance procedure
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 132
+The accuracy assessment shall be performed over the latest Forest/Non-Forest and latest
+Terrestrial Forest/Non-Forest/Mangrove map using an independent dataset. For the accuracy
+assessment, a sampling strategy based on a 250x250 meter systematic grid of points with a
+random origin, created over the entire Guinea-Bissau territory and used as a basis for plot
+location in the carbon stock assessment activity shall be used. In addition, Non-Forest data
+shall be collected over very high-resolution data like Google Earth and used to confirm the
+validation. The confusion matrices provide the basis on which to both describe classification
+accuracy and characterize errors (Foody, 2002).
+All data sources and analytical procedures described above to produce the data for the
+baseline renewal will be archived and documented, and all the procedures and data produced
+shall be checked or audited by the advisory board and IBAP's Director / Program coordinator.
+e. Data archiving
+Data will be archived and maintained electronically by IBAP at its headquarter in Bissau. All
+data sources and processing, classification and change detection will be documented and
+stored. Data to be archive must include raw imagery, ancillary cartographic data used, data
+used for training the classification, software version applied, classified images, data used for
+ground thruthing and final accuracy assessment matrix.
+To safeguard its security, copies of the data should be stored at IBAP's headquarters under
+the responsibility of the head of monitoring and at the offices of each Park (Cacheu and
+Cantanhez) under the supervision of the parks' directors. The archiving of the data will be
+under the responsibility of the head of monitoring with the supervision of IBAP's director /
+program coordinator.
+f. Organization and Responsibilities
+The responsibility for each task of the baseline renewal shall be assigned based on the
+flowchart and table presented above.
+The baseline renewal report will be developed by the head of monitoring with the supervision
+and revision of IBAP's director or the program coordinator.
+4.3.2 Monitoring of Actual Carbon Stock Changes and GHG Emissions
+Monitoring of actual emissions in the project area focuses on emissions due to deforestation
+and natural disturbance, illegal degradation and biomass burning.
+Emissions due to deforestation and natural disturbances
+a. Technical Description of the monitoring task
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 133
+Forest cover change due to deforestation and natural disturbances is monitored through
+periodic assessment of classified satellite imagery covering the project area and ancillary data
+from direct or indirect monitoring that shall be used to identify and distinguish deforestation
+from natural disturbances. Natural disturbances may include wildfires, insect and disease
+infestations, and/or extreme weather events, beyond the control of, and not materially
+influenced by human activity, Although the immediate cause of wildfires may be difficult to
+determine, in Guinea-Bissau the use of fire is closely linked to cultural factors, Catastrophic
+events are also not expected in the Project Area or Leakage Belt. Nevertheless, if by any
+chance a catastrophic event or a wildfire (break out during a dry season, or due to lightning)
+presents during the Project’s lifetime, such events will be reported if significant using a hybrid
+approach.
+The objective of this monitoring task is to establish ADef, PA,i,t and ADist, PA,i,t (Area Deforested and
+Impacted by Natural Disturbance in the Project Area in time t) and multiply these factors by the
+average forest carbon stock per unit area. The project boundary, as set in the PD, will serve as
+the initial forest cover benchmark map against which changes in forest cover will be assessed
+over the interval of the first monitoring period; the entire project area has been demonstrated
+to meet the forest definition at the beginning of the crediting period. Stocks estimates from the
+initial field inventory are valid for the initial baseline period (10 years) and will not have to be
+monitored during the baseline period. Upon baseline update forest carbon stock estimates will
+also be updated for any strata where deforestation or natural disturbance is detected.
+b. Data to be collected
+Mid resolution imagery (e.g. Landsat) or, if available, imagery with higher resolution sources
+(e.g. Sentinel) will be collected to produce maps that support the analysis of deforestation and
+natural disturbance during the monitoring period within the project area. Deforestation and
+natural disturbance will be distinguished using an hybrid approach of remote sensing with
+ground data, and a local community alert system with ground observations/measurements to
+identify and delineate disturbances due to natural events. In case an event is reported by the
+communities, monitoring procedures are triggered and direct ground measurements (using a
+GPS) are undertaken. Ground measurements will also be collected randomly over the areas
+mapped as deforested to identify possible disturbances due to natural events misclassified as
+anthropogenic deforestation.
+c. Overview of data collection procedures
+All procedures for image pre-processing (e.g. geometric corrections, radiometric calibration),
+image classification and map validation shall follow the procedures described for the baseline
+renewal (section 4.3.1 c). The deforestation maps produced will need to be analyzed to
+identify and exclude disturbed areas due to natural events.
+Ancillary data which may include but is not limited to routine ground-based surveys to local
+communities, direct communications from local communities to the Park guards and
+authorities, information from local land manager, and direct ground
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 134
+observations/measurements to assess if, when, and to what extent extreme weather events or
+insect pests have occurred causing a disturbance in the forest constitute the local community
+alert system. When a natural event is reported through the system the direct monitoring
+procedures are triggered. A team of park guards will conduct ground surveys to gather
+evidence, including the georeferenced location of the occurrence, year and types of
+disturbances, and gather ground data to determine the extent to what the forests were affected
+by the reported disturbance. Although a statistical sampling scheme do not provide delineation
+of disturbed areas directly, this complementary ancillary method shall be used to assess if a
+deforested area identified using remote sensing techniques to map deforestation (MMU of 1
+ha) was instead a change triggered by the occurrence of natural disturbance. To depict natural
+disturbances, techniques based on repetitive measurements of spectral, spatial and temporal
+indicators and/or increased spatial or spectral resolution of satellite observations shall be
+explored (e.g., Verbesselt et al., 201230). A 250x250 meters grid of points shall be used for the
+validation of the deforestation maps (depicting two different types of disturbance: natural and
+anthropogenic), and 10% of the points over the deforested area shall be visited. In each
+selected point location the required information to determine if that area was subject to a
+natural event is registered.
+d. Quality control and quality assurance procedure
+The map accuracy assessment shall be performed over the latest Forest/Non-Forest and
+latest Terrestrial Forest/Non-Forest/Mangrove maps using an independent dataset and shall
+be performed for each future monitoring. For the accuracy assessment, a sampling strategy
+based on a 250x250 meter systematic grid of points with a random origin, created over the
+entire Guinea-Bissau territory shall be applied. This grid shall be stratified using land cove
+maps produces at each monitoring phase into four forest classes (Closed forest, Open forest,
+Savanna Woodland and Mangrove) which will be grouped to validate the Forest/non-Forest
+and Forest/Non-Forest/Mangrove map. In addition, Non-Forest data shall be collected over
+very high-resolution data like Google Earth and used to confirm the validation. The confusion
+matrices provide the basis on which to both describe classification accuracy and characterize
+errors (Foody, 2002).
+All data sources and analytical procedures applied to produce the monitoring data will be
+archived and documented, and all the procedures and data produced shall be checked or
+audited by the advisory board and IBAP's Director / Program coordinator..
+e. Data archiving
+Data will be archived and maintained electronically by IBAP at its headquarter in Bissau. All
+data sources and processing, classification and change detection will be documented and
+stored. Data to be archive must include raw imagery, ancillary cartographic data used, data
+used for training the classification, software version applied, classified images, data used for
+30 Verbesselt J, Zeileis A, Herold M (2012). Near real-time disturbance detection using satellite image
+time series. Remote Sensing Of Environment, 123, 98–108. http://dx.doi.org/10.1016/j.rse.2012.02.022
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 135
+ground thruthing and final accuracy assessment matrix. If existing, the natural disturbances
+reports, including the collected ground information registered in a field sheet, shall also be
+archived in IBAP's headquarters in Bissau under the responsibility of the head of monitoring,
+and a copy shall be kept by each parks' station (Cacheu and Cantanhez) under the
+supervision of the parks' directors.
+f. Organization and Responsibilities
+The responsibility for each monitoring task shall be assigned based on the flowchart and table
+presented above. The monitoring report will be developed by the head of monitoring in close
+coordination between the Parks Directors and with the supervision and revision of IBAP's
+director or the Program Coordinator. The advisory board is responsible for data inspection, for
+providing assistance as required by the head of monitoring and for the technical revision of the
+monitoring report.
+Under the supervision of the Parks' Directors, the guards comprising the monitoring field team
+shall be responsible for conducting and managing the local community alert system to assess
+the occurrence of natural disturbances, and to communicate and interact with local
+communities, including applying PRA techniques when necessary. They will interact with the
+Park Director to identify risks and difficulties which will in turn communicate the issues to the
+head of monitoring and trigger the development of a corrective action plan (CAP), if required.
+These CAPs inform of any necessary revision of the field standard operating procedures
+(SOPs), or additional training requirements, thereby enabling the continuous improvement of
+the procedures.
+Emissions due to Illegal Degradation
+Degradation may take place in the project area due to illegal extraction of trees for timber or
+for fuel and charcoal. As remote methods for monitoring degradation are not available ground-
+based methods must be used. For the baseline, a Participatory Rural Appraisal (PRA) was
+conducted demonstrating that emissions from degradation are not occurring in the project area
+and in the buffer zone (2 km).
+a. Technical Description of the monitoring task
+Emissions due to illegal degradation will be tracked by conducting a PRA every 2 years. The
+first step in addressing forest degradation is to complete a participatory rural appraisal (PRA)
+of the communities inside and surrounding the project area (2 km) to determine if there is the
+potential for illegal extraction of trees to occur. If this assessment finds no potential pressure
+for these activities then degradation (ΔCP,DegW,i,t) can be assumed to be zero and no monitoring
+is needed.
+b. Data to be collected
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 136
+If the results of the PRA suggest that there is a potential for degradation activities, then limited
+field sampling must be undertaken. First, the area that is potentially subject to degradation
+needs to be delineated (ADeg,i). An output of the PRA shall be a distance of degradation
+penetration from all access points (access buffer), such as roads and rivers or previously
+cleared areas, to the project area. The distance of degradation penetration will vary by form of
+degradation with a deeper penetration likely for illegal logging than for fuelwood and charcoal.
+The area subject to degradation shall be delineated (ADegW,i) based on an access buffer from
+all access points, such as roads and rivers or previously cleared areas, to the project area,
+with a width equal to the distance of degradation penetration. The area shall be sampled by
+surveying several transects of known length and width across the access-buffer area (equal in
+area to at least 1% of ADegW,i) to check whether new tree stumps are evident or not. If there is
+little to no evidence that trees are being harvested then degradation can be assumed to be
+zero and no monitoring is needed. This limited sampling must to be repeated each time the
+PRA indicates a potential for degradation.
+If the limited sampling does provide evidence that trees are being removed in the buffer area,
+then a more systematic sampling must be implemented. The sampling plan must be designed
+using plots systematically placed over the buffer zone so that they sample at least 3% of the
+area of the buffer zone (ADegW,i). The diameter of all tree stumps will be measured and
+conservatively assumed to be the same as the DBH. If the stump is a large buttress, identify
+several individuals of the same species nearby and determine a ratio of the diameter at DBH
+to the diameter of buttress at the same height above ground as the measured stumps. This
+ratio will be applied to the measured stumps to estimate the likely DBH of the cut tree. The
+above and belowground carbon stock of each harvested tree must be estimated using the
+same allometric regression equation and root to shoot ratio used in the baseline scenario. The
+mean above and below ground carbon stock of the harvested trees is conservatively estimated
+to be the total emissions and to all enter the atmosphere.
+c. Overview of data collection procedures
+Data collection should follow best practices in PRA methodologies for assessing the land use
+practices of the communities within and surrounding the project area, as well as linkages with
+local forest resources. The fieldwork must characterize activities and practices causing
+emissions by extraction of wood for fuel, production of charcoal and timber production. The
+target population includes communities living within the project area (Cacheu and Cantanhez
+National Parks) and in a 2 km buffer zone. The questionnaires shall be applied on randomly
+selected households to identify potential for degradation activities related to energetic use for
+cooking (fuelwood and charcoal) and timber extraction.
+If degradation practices are identified, fieldwork will be carried to collect data on new tree
+stumps and to estimate the likely DBH of the cut tree. The carbon stock quantification shall
+follow the same procedure used for the baseline definition according to CP-AB module.
+Park guards (from the monitoring field team) will carry routine patrols; if illegal wood harvest
+activities are identified immediate action will be taken according to the law and internal park
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 137
+regulations. The activity shall be registered to ease the data collection to the monitoring of
+degradation.
+d. Quality control and quality assurance procedure
+The team conducting the PRA shall be properly trained and the sample randomly designed to
+avoid any bias. If degradation is detected, the same quality assurance and quality control
+procedures as detailed in the section for the updating estimates of forest carbon stocks will be
+adhered to in the field surveys of potential degradation areas.
+e. Data archiving
+Data will be archived permanently and maintained electronically by IBAP at its headquarter in
+Bissau. All originals field reports from the PRA shall be archived and the digital files kept. To
+safeguard its security, copies of the data should be stored at IBAP's headquarters under the
+responsibility of the head of monitoring and at the offices of each Park (Cacheu and
+Cantanhez) under the supervision of the parks' directors. The archiving of the data will be
+under the responsibility of the head of monitoring with the supervision of IBAP's director /
+program coordinator.
+f. Organization and Responsibilities
+The responsibility for each task of the illegal degradation monitoring shall be assigned based
+on the flowchart and table presented at the beginning of the monitoring section. The forest
+degradation monitoring report will be developed by the head of monitoring with the supervision
+and revision of IBAP's director or the Program Coordinator. The monitoring team that collects
+the data is responsible for data entry and compilation. The methods to collect the data and the
+databases will be verified by the advisory board before being submitted to the head of
+monitoring for compilation, data analysis and reporting.
+4.3.3 Monitoring of Leakage Carbon Stock Changes
+a. Technical Description of the monitoring task
+Activities that deforestation agents would implement inside the project area in the absence of
+the REDD project activity that can be displaced outside the project boundary as a
+consequence of the implementation of the REDD project activity must be monitored. Where
+this displacement of activities increases the rate of deforestation, the related carbon stock
+changes and non-CO2 emissions must be estimated and counted as leakage.
+Activity-shifting leakage in the leakage belt will be monitored by tracking forest cover change in
+the leakage belt (ADef,LK,u,i,t) using classified satellite imagery produced following the same
+procedures outlined in Section 4.3.2 referencing the forest cover benchmark map for the
+leakage belt.
+b. Data to be collected
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 138
+Using a Participatory Rural Appraisal (PRA) approach, randomly sample communities living
+within 2 km of the boundaries of the Leakage Belt and Project Area to estimate the proportion
+of the area deforested by immigrants (PROPIMM and PROPRES) and local deforestation agents
+using the same approach as done for the definition of the baseline. This assessment must be
+repeated at least every 5 years and the estimated proportions will be assumed to be
+representative for up to five future years.
+Leakage emissions from unplanned deforestation in the Leakage Belt is estimated by
+subtracting the emissions in the baseline from unplanned deforestation in the leakage belt
+(ΔCBSL, LK, unplanned) from the net GHG emission within the leakage belt in the project case in
+year t (ΔCP, LB). Parameters for forest carbon stock and carbon stocks in post deforestation
+land use in all pools are the same used in the baseline case, and shall be revised and updated
+with the baseline revision every ten years. The value of parameter, PROPIMM, 9.3%, will be
+employed for the first five years of the project. Subsequently, the parameter, PROPIMM, will be
+derived from the results of surveys conducted among neighbouring communities every < 5
+years. Immigrants are defined as someone who has lived in the area less than 5 years and
+came from an area outside the leakage belt.
+Activity shifting leakage outside the leakage belt will be tracked by monitoring deforestation in
+the project area (ADefPA,i,t) and leakage belt (ADefLB,i,t) using mid resolution imagery (e.g.
+Landsat TM and Enhanced TM+ (ETM+) collected to produce maps that support the leakage
+analysis.
+c. Overview of data collection procedures
+Mapping and Land Use Transition analysis should follow the procedures established in section
+4.3.1, including pre-processing, classification and map validation. Every 5 years, the proportion
+of immigrants and local population living in the project area, leakage belt and within a 2 km
+buffer shall be collected following best practices in PRA methodologies for assessing the land
+use practices of the communities.
+d. Quality control and quality assurance procedure
+The map accuracy assessment shall be performed over the latest Forest/Non-Forest and
+latest Terrestrial Forest/Non-Forest/Mangrove map using an independent dataset and shall be
+performed each future monitoring. For the accuracy assessment, a sampling strategy based
+on a 250x250 meter systematic grid of points with a random origin, created over the entire
+Guinea-Bissau territory. This grid shall be used as a basis for plot location for the four forest
+classes, (Closed forest, Open forest, Savanna Woodland and Mangrove) which will be
+grouped to validate the Forest/non- Forest and Forest/Non-Forest/Mangrove map. In addition,
+Non-Forest data shall be collected over very high-resolution data like Google Earth and used
+to confirm the validation. The confusion matrices provide the basis on which to both describe
+classification accuracy and characterize errors (Foody, 2002).
+The PRA should be designed randomly avoiding bias in the community sampling. The
+minimum sample size is 10% of communities living within 2 km of the boundaries of the
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 139
+leakage belt and project area. If 10% is less than 10 communities then the sample size shall
+be set as 10 or 100% of the communities. If 10% is more than 30 communities then the
+sample size shall be set as 30.
+The team conducting the PRA shall be properly trained. SOPs must be presented and
+discussed between the monitoring field team and the head of monitoring, with the support of
+the advisory board. Technical review or pre-verification of the data, check-list to assess that
+SOPs were followed, and revision of the monitoring report will be conducted by the advisory
+board and the head of monitoring.
+e. Data archiving
+Data will be archived and maintained electronically by IBAP at its headquarter in Bissau under
+the responsibility of the head of monitoring and at the offices of each Park (Cacheu and
+Cantanhez) under the supervision of the parks' directors. All data sources and processing,
+classification and change detection will be documented and stored. PRA field reports must
+also be maintained in the original hard copies and electronically (digitalized). Data to be
+archive must include raw imagery, ancillary cartographic data used, data used for training the
+classification, software version applied, classified images, data used for ground thruthing, final
+accuracy assessment matrix, PRA sample design and field reports.
+f. Organization and Responsibilities
+The responsibility for the leakage carbon stock changes monitoring shall be assigned based
+on the flowchart and table presented at the beginning of the monitoring plan. Leakage
+emissions report will be developed by the head of monitoring with the supervision and revision
+of IBAP's director or the program coordinator.
+4.3.4 Updating forest carbon stock estimated
+Forest carbon stock used to calculate emissions will use estimates derived from field
+measurements less than or equal to 10 years old. In the event that any deforestation is
+reported, forest carbon stock estimates older than 10 years will be updated for any strata
+where deforestation is detected (including deforestation resulting from natural disturbances).
+The same stratification used for the initial baseline (compatible official/government
+publications) will be used unless significant difference in carbon stock or impacts of natural
+disturbances are detected. In that case, a given stratum may be further stratified based on
+post-natural disturbance carbon stocks. Initial above and belowground biomass stock
+estimates from the 2011 inventory are valid and treated as constant through 2021, after which
+they will be re-estimated from new field measurements.
+a. Technical Description of the monitoring task
+This section presents the methodology applied for the carbon stocks estimation for above- and
+below-ground biomass. This shall be replicated in every baseline update. Sampling shall be
+designed to accurately account for the total biomass carbon stocks in the selected carbon
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 140
+pools and stratified using ancillary data provided from satellite imagery and following
+VMD0016 (X-STR). The carbon pools assessed for the baseline were defined based on
+VM0007 and on factors described in further detail below.
+b. Data to be collected
+The carbon pools estimated in this project are: live vegetation above- and below-ground tree
+biomass. The above- and below-ground tree biomass carbon was estimated for the existing
+vegetation at “time zero” in the following strata:
+• Closed Forests
+• Open Forests
+• Mangroves
+• Savannah
+c. Overview of data collection procedures
+To re-assess forest carbon stock, a minimum sample size will be defined to comply with the
+desired statistical precision according to the CP-AB module (i.e. 95% confidence interval is
+within 15% of the mean) and the maximum uncertainty according to X-UNC. The sample
+design can benefit from known variability of biomass data of previous projects and the baseline
+study to comply with the target error level of 15% (CI 95%).
+A 250 x 250 meter systematic grid of points with a random origin shall be created. The number
+of plots to be sampled in each stratum are determined based on three considerations: (1) the
+variability of biomass within a stratum (evaluated using previously collected data); (2), the
+estimated area covered by each stratum; and (3) the target precision level (set at 15%, 95%
+CI). Sample plots are then randomly selected for each stratum that were deforested and need
+to be revised over the grid. Selected plot coordinates shall be loaded into GPS equipment and
+later used in the field to reach the center of each plot.
+At the plot level, the following data shall be recorded: geographic coordinates (with GPS),
+physiographic location, dominant aspect, and slope. At the stand level, data to be recorded
+include the classification of the forest type, tree crown cover, forest degradation factors (soil
+erosion, illegal logging and burning practices, etc.). At tree level, species shall be identified;
+tree vitality classified, and diameter at breast height (DBH, as shown in the figure below), total
+height, top and basal diameter of dead trees and stem height of palm-trees (H) shall be
+measured.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 141
+Figure 15. Schematic representation of location on tree where DBH was measured. Pearson et
+al. (2005)
+All trees with DBH of ≥5 cm and a minimum height (H) of 1.3 m are considered for
+measurement in the nested plots. To be representative of all sizes of tree present in sampled
+parks in GB, measured tree dimensions varied between different forest types. Dimensions of
+Open Forest and Savanna plots and diameter classes measured in each nest are shown in the
+schematic diagram below.
+Figure 16. Schematic diagram representing an Open Forest and Savanna circular nested plot
+Dimensions of mangrove nested plots followed the format of the schematic diagram presented
+in Figure 15.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 142
+Figure 17. Schematic diagram representing a Mangrove circular nested plot
+Parameters relevant for C stock estimation measured for each vegetation formation are
+summarized in Table 15 below.
+Table 27. Parameters measured in different vegetative formation for the baseline analysis
+Data collected in the field and analysed at the nested plot level shall be converted to carbon
+and extrapolated to the area of a full hectare to produce carbon stock estimates. Extrapolation
+occurs by calculating the proportion of a hectare (10,000 m2) that is occupied by a given plot
+(or nest in this case) using a scaling factor.
+Aboveground biomass (AGB) in terrestrial forest and mangroves will be estimated applying the
+allometric equation of Chave et al 2005 and maintain consistency with analytical procedures
+applied in the original inventory. AGB in palm forest will be estimated applying the allometric
+equation of Delaney et al 1999 and maintain consistency with the analytical procedures
+applied in the original inventory.
+The below-ground biomass (BGB) of trees was estimated using a linear relationship between
+root biomass and shoot biomass reported by Mokany et al. (2006). The authors developed a
+root to shoot ratio (RSR) for many different types of vegetation and the relationship reported
+for tropical dry forest was chosen based on IPCC (1996). The relationship establishes that:
+• if AGB < 20 t ha-1, BGB (t ha-1) = 0.56 * AGB; or
+• if AGB > 20 t ha-1, BGB (t ha-1) = 0.28 * AGB
+For Palm Trees, to the Project Proponent knowledge there is no dataset available or published
+that relate above- to below- ground biomass for palm trees. Therefore, conservatively,
+belowground carbon stocks of palm trees are omitted.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 143
+BGB is of particular importance in mangroves because mangrove trees accumulate significant
+portion of its biomass in the roots (Komiyama et al., 2008). However, no root-to-shoot ratios for
+African mangrove forests were found in the literature. To estimate BGB in mangroves, we
+compiled AGB and BGB data reported by Komiyama et al. (2008) (including data for
+Indonesia, Australia, Thailand, Panama, and Puerto Rico) and an average RSR of 0.61 was
+calculated across all available values. Table 13 depicts the compilation of the data based on
+AGB and BGB reported by Komiyama et al. (2008).
+Table 28. Global mangrove AGB and BGB for estimation of RSR for mangrove forests in
+Guinea-Bissau
+d. Quality control and quality assurance procedure
+The following steps will be taken to control for errors in field sampling and measurements and
+data analysis:
+1. Field crews with prior training in forest inventory will carry out all field data collection and
+adhere to field measurement protocols. Pilot sample plots shall be measured before the
+initiation of formal measurements to train and appraise field crews and identify and correct
+any errors in field measurements. The head of monitoring will be responsible for ensuring
+that field protocols are followed by the monitoring field team to ensure accurate and
+consistent measurement and for identifying training requirements.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 144
+2. To ensure accurate measurements, the height of diameter at breast height (1.3 m) will be
+periodically re-assessed by personnel during the course of the inventory. Field crews will
+have fine scale forest strata maps for use in the field to precisely interpret strata/forest
+boundaries and identify potential areas of plot overlap.
+3. Calibration of hypsometers will be confirmed prior to formal field measurements daily
+before the team leaving for the field. All borderline trees will be measured and assessed
+against hypsometer plot radius factor (accounting for slope) according to the field
+measurement protocol.
+4. Field measurement data will be recorded on standard field data sheets, digitalized for
+records and transferred to electronic media following each return from the field.
+5. Checks will be run for unusual (high or low) values to identify and correct any errors in
+recorded field data or transcription. Personnel involved in data analysis will consult with
+personnel involved in measurement to clarify any ambiguities in recorded field data.
+6. If wood density analysis is necessary, all balances for measuring dry weights will be
+calibrated against known weights prior to use. All calibration results will be documented
+and archived along with sample analysis results.
+7. Register all field members and their specific responsibilities in each field sheet
+8. Compare data from the GPS equipment with the coordinates in the field datasheet and in
+the excel workbook to identify and correct eventual data entry errors.
+9. Technical review or pre-verification of the data will be conducted by the head of monitoring
+and the advisory board
+e. Data archiving
+Original data sheets will be permanently archived at IBAP office and the electronic database of
+all field measurements will be housed in the dedicated long-term electronic archive maintained
+on IBAP office (external HD). The electronic database will also archive GIS coverage, detailing
+forest and strata boundaries and plot locations. To safeguard its security, copies of the data
+should be stored at IBAP's headquarters under the responsibility of the head of monitoring and
+at the offices of each Park (Cacheu and Cantanhez) under the supervision of the parks'
+directors. The archiving of the data will be under the responsibility of the head of monitoring
+with the supervision of IBAP's director / program coordinator.
+f. Organization and Responsibilities
+The responsibility for each task of carbon stock update shall be assigned based on the
+flowchart and table presented at the beginning of the monitoring plan. The carbon stock
+update report will be developed by the head of monitoring with the supervision and revision of
+IBAP's director or the program coordinator.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 145
+5 ENVIRONMENTAL IMPACT
+The Project anticipates positive environmental impacts on the forest and biodiversity. Both
+Cantanhez and Cacheu Parks represent globally significant habitats that will be effectively
+protected. Cacheu National Park is the fifth largest contiguous mangrove ecosystem in Africa.
+The area plays an important role both in the conservation of maritime biodiversity and
+terrestrial biodiversity receiving numerous species of migratory birds during the winter. The
+complex of estuarine mangroves, swamp and marshland are of great importance to
+Palaearctic waders, waterfowls and birds of prey. Cantanhez Forest National Park holds one
+of the few remaining stands of primary sub-humid Guinea forest and is home to the
+endangered chimpanzee, Colobus, Manatees and Marine Turtles.
+The Project also relies on a participatory management structure safeguarding the local
+community livelihoods and preserving access to the valuable natural resources whilst
+providing funding through FIAL to the establishment of long-term sustainability practices in
+agriculture and extraction activities. As part of the establishment of CBMP an Environmental
+and Social Impact Analysis was conducted assuring stakeholders awareness and support for
+the project. Such analysis has been publicly disclosed in Guinea-Bissau and is available
+through the World Bank and IUCN. In general the Project will contribute to:
+• long term financing of globally significant habitats under effective protection;
+• improved conservation of globally significant fauna and flora species and assemblages
+within and outside the Project Area;
+• strengthened protection for globally and regionally significant species, including marine
+turtles, African manatees, chimpanzees, sharks, sea-going hippopotami, migratory birds
+and colobus monkeys;
+• improved sustainability of regionally important fisheries through the better management of
+critical breeding grounds and nurseries;
+• decreased loss and degradation of critical coastal habitats and ecosystems, with
+associated benefits for conservation of endangered and threatened species and for the
+productivity of regionally significant fisheries;
+• development of practical models for guiding participatory biodiversity management
+elsewhere in the region;
+• demonstrate that carbon finance can provide tangible financial benefits for forest
+conservation.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 146
+6 STAKEHOLDER COMMENTS
+The REDD project builds upon the participatory process launched under the CBMP. As such it
+is based on a long tradition of stakeholder consultation and participation, beginning with the
+highly participatory identification and design of the CBMP, and continuing throughout its
+implementation phase and that of the follow on initiatives. In addition to the broad
+consultations, and in line with World Bank safeguard policies, a team of social and
+environmental specialists specifically visited the parks and met with target populations, as well
+as other key stakeholders (local authorities, NGOs, etc.). This led to the preparation of an
+Environmental and Social Assessment of the proposed projects’ activities, an Environmental
+and Social Management Framework designed to guide any future activities, especially those
+under the FIAL; a Process Framework, designed to guide consultations on activities which
+might give rise to restrictions of access to resources. As a precautionary measure the
+government also prepared a Resettlement Process Framework, providing guidance on how to
+address involuntary resettlement situations. (This last has not been an issue since Guinea
+Bissau law permits people to reside within protected areas, and relocation has never been
+considered.) Each of these CBMP documents were discussed publicly by a cadre of experts,
+and amended thereafter, and the target population in the project zone was informed via
+community and regional radio stations about the project and possible environmental and social
+impacts.
+Further, key stakeholders, especially local communities, public authorities and NGOs have
+been heavily involved in protected area management. There is also ongoing consultation and
+discussion with communities and other stakeholders through the bi-annual Park Management
+Committees, of which they form 50 percent, and through which management decisions are
+taken and enforced. These Committees are also key to the FIAL process, prioritizing
+community roll out, and reviewing and ensuring microprojects fit with the resource
+conservation objectives.
+Consultations specific to the REDD financing have also been conducted, with the objective to
+help stakeholders understand the REDD concept and get feedback on the design of this
+initiative.
+The consultations mainly relied on workshops, seminars, a radio broadcast and meetings with
+governmental personnel, including the State Secretary of Environment and Sustainable
+Development. The workshops and seminars included IBAP, the local community and NGOs
+and were held in Cantanhez and Cacheu. The main meetings are presented below.
+List of all meetings and workshops planned (9-29 February, 2012)
+09/02/2012 IBAP, Bissau – meeting
+11/02/2012 São Domingos, PNTC – workshop theoretical component
+11-13/02/2012 São Domingos, PNTC – workshop practical component
+14/02/2012 IBAP, Bissau – REDD seminar with major stakeholders
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 147
+14/02/2012 AD, Bissau – meeting with Carlos Schwarz da Silva (NGO AD)
+15/02/2012 Iemberém, Cantanhez – interview broadcast in Radio Lamparam
+16-23/02/2012 Cantanhez – workshop practical component
+23-27/02/2012 Cacheu – meeting with Fernando Biag and workshop (practical component)
+28/02/2012 SEAD, Bissau – meeting with the State Secretary Mário Dias Sami
+29/02/2012 IBAP, Bissau – Final meeting
+09/02/2012 IBAP, Bissau
+Participants: Mr. Alfredo Simão da Silva (Director of IBAP) Ms. Tanya Yudelman Bloch
+(World Bank) Ms. Maria Vasconcelos (IICT) Mr. Luis Catarino (IICT) Ms. Joana Melo
+(RSET)
+Field campaign preparatory meeting between IICT/RSET technical team, the representative of
+the funding agency (World Bank), and IBAP’s Director. Discussion of the REDD Project
+Activities in an informal setting. Organization of the seminar, including setting the day for the
+project presentation (February 14th) and selection of major stakeholders to be invited.
+11-13/02/2012 São Domingos, PNTC
+This workshop was structured into a theoretical and practical component. The theoretical
+component took place on February 11th at IBAP’s facilities in São Domingos (PNTC) and was
+on the basis of the whole training program to IBAP staff working in the carbon stock field work
+that would extend until the end of the month. The instructors from IICT/RSET had the support
+of Viriato Cassamá (SEADD) who made the translation to Creole. The theoretical class
+allowed the participants to have a general understanding of the REDD mechanism and how
+the quality of the fieldwork is fundamental for the project success. After the main session and
+before division of the participants into two teams – the mangrove and the terrestrial forest
+teams – the maps were presented and the equipment introduced. The members of the two
+teams installed and measured the first three plots together to ensure that all participants were
+familiar with the field protocol and equipment.
+Instructors: Ms. Maria Vasconcelos (IICT) Mr. Luís Catarino (IICT) Ms. Joana Melo (RSET)
+Participants: Mr. Viriato Cassamá (SEADD) Mr. Antão da Costa (SEADD) Mr. Sadjo
+Danfa (IBAP) Mr. António da Silva (IBAP) Mr. Nélson Justino Gomes (SEADD) Mr.
+Fernando Indami (SEADD) Mr. Joãozinho Mané (IBAP) Mr. Santos Mendes (IBAP – PNTC
+Park guard)
+14/02/2012 IBAP, Bissau – REDD seminar with major stakeholders
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 148
+The meeting was cancelled. Unfortunately and unexpectedly the seminar had to be cancelled.
+The main stakeholders invited to this session included: SEADD - Ministerio da Agricultura
+(Direcção Geral das Florestas e Caça, DG da Agricultura) - Ministério da Economia e Plano
+(Direcção Geral do Plano) - IBAP - UICN - Gabinete de Planificação Costeira - ONGs
+(AD and Tininguena) - Direcção Geral das Alfandegas (Guardas Fiscais) - CAIA
+Although the conference had to be canceled, the presentation was made available to the
+stakeholders invited.
+14/02/2012 AD, Bissau
+Meeting with Carlos Schwarz da Silva, Executive Director of the NGO Acção para o
+Desenvolvimento (AD) at the AD headquarters in Bissau.
+Participants: Mr. Carlos Schwarz da Silva Mr. Viriato Cassamá (SEADD) Ms. Maria
+Vasconcelos (IICT) Mr. Luís Catarino (IICT) Ms. Joana Melo (RSET)
+15/02/2012 Iemberém, Cantanhez
+After the arrival at the IBAP facilities at the Cantanhez Park a reporter from the local radio
+station (Radio Lamparam) interviewed Luís Catarino and Viriato Cassama (who spoke in
+Creoule) to explain to the local population the work that the field crew would be doing there
+during the next few days. The benefits for the local populations from a future REDD project in
+the park were also highlighted. This broadcast was very useful for the terrestrial forest team.
+As the population in each tabanca was already informed of the work in progress they were
+very cooperative and helpful when needed.
+16-23/02/2012 Cantanhez
+Revision of the theoretical concepts (including the sampling methodology), and equipment
+functioning. Re-adjustment of the field teams.
+Instructors: Ms. Maria Vasconcelos (IICT) Mr. Luís Catarino (IICT) Ms. Joana Melo (RSET)
+Participants: Mr. Viriato Cassamá (SEADD) Mr. Nélson Justino Gomes (SEADD) Mr.
+Fernando Indami (SEADD) Mr. Joãozinho Mané (IBAP) Mr. António Pansau Ndafá
+(SEADD) Mr. Mutaru Cumpó (Cantanhez park guard) Mr. Tchutchu Indami (Cantanhez park
+guard)
+23-27/02/2012 Cacheu
+Meeting with Fernando Biag (PNTC Director) for exchanging of ideas about the park and
+presentation of the project. Fernando Biag was very enthusiastic about the future prospects of
+the project and joined the field work teams.
+Instructors: Ms. Maria Vasconcelos (IICT) Mr. Luís Catarino (IICT) Ms. Joana Melo (RSET)
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 149
+Participants: Mr. Fernando Biag (IBAP) Mr. Nélson Justino Gomes (SEADD) Mr. Fernando
+Indami (SEADD) Mr. António Pansau Ndafá (SEADD) Mr. Luís Gomes (IBAP)
+28/02/2012 SEAD, Bissau
+Meeting with the State Secretary Mário Dias Sami to present the project, its activities,
+background and future prospects of the REDD mechanism.
+Participants: Mr. Mário Dias Sami (SEADD) Mr. Viriato Cassamá (SEADD) Ms. Maria
+Vasconcelos (IICT) Ms. Joana Melo (RSET)
+29/02/2012 IBAP, Bissau
+Wrap-up meeting at IBAP’s headquarters, Bissau. The objective of this meeting was to
+somehow substitute the canceled seminar. The project team had the chance to meet and
+discuss the ongoing project with part of IBAP’s staff and give an overview of its background in
+an international setting (i.e., the REDD mechanism). This meeting also promoted some share
+of information and the linkage between the parks management during the past years and the
+forest dynamics observed in the maps produced using time-series of remote sensing imagery.
+Participants:- Mr. Alfredo Simão da Silva (IBAP) - Ms. Aissa Regala (IBAP) - Mr. António da
+Silva (IBAP) - Mr. Maurício Insumbu (IBAP) - Mr. Sadjo Danfa (IBAP) - Mr. Viriato Cassamá
+(SEADD) - Ms. Maria Vasconcelos (IICT) - Mr. Luís Catarino (IICT) - Ms. Joana Melo (RSET)
+All comments received were duly evaluated and discussed at the meetings, workshops and
+seminars. The continued communication of the REDD project activity will be carried by IBAP at
+the bi-annual Park Management Committee meetings.
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 150
+APPENDIX 1: NON-PERMANENCE RISK REPORT
+1 INTERNAL RISK
+Project Management
+Risk
+Factor
+Risk Factor and/or Mitigation Description Risk
+Rating
+a) Species planted (where applicable) associated with more than 25% of the stocks on
+which GHG credits have previously been issued are not native or proven to be
+adapted to the same or similar agro-ecological zone(s) in which the project is
+located. (Not applicable)
+0
+b) On going enforcement to prevent encroachment by outside actors is required to
+protect more than 50% of stock Risk on which GHG credits have previously been
+issued. (Not applicable)
+0
+c) Management team does not include individuals with significant experience in all skills
+necessary to successfully undertake all project activities (i.e., any area of required
+experience is not covered by at least one individual with at least 5 years experience
+in the area).
+The project managed team holds two professionals with 10+ years of experience in
+conservation, park management, community engagement and agriculture. The CVs,
+in French, of Dr. Justino Biai and Alfredo Simão clearly demonstrate the necessary
+experience to successfully manage the project.
+0
+d) Management team does not maintain a presence in the country or is located more
+than a day of travel from the project site, considering all parcels or polygons in the
+project area.
+IBAP maintains and operates one office on each park included in the project activity
+(Cacheu and Cantanhez). On each office, there is a local team composed of, inter
+alia, a Park Director, Specialists and Park Guards. The presence is also supported
+by the continued engagement with the community and the participation of the local
+population on the park management committee.
+0
+e) Mitigation: Management team includes individuals with significant experience in
+AFOLU project design and implementation, carbon accounting and reporting (e.g.,
+individuals who have successfully managed projects through validation, verification
+and issuance of GHG credits) under the VCS Program or other approved GHG
+programs. (Not applicable)
+0
+f) Mitigation: Adaptive management plan in place. (Not applicable) 0
+Total Project Management (PM) [as applicable, (a + b + c + d + e + f)]
+Total may be less than zero. 0
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 151
+Financial Viability
+Risk
+Factor
+Risk Factor and/or Mitigation Description Risk
+Rating
+a) Project cash flow breakeven point is greater than 10 years from the current risk
+assessment (Not applicable) 0
+b) Project cash flow breakeven point is between 7 and up to less than 10 years from
+the current risk assessment (Not applicable) 0
+c) Project cash flow breakeven point between 4 and up to less than 7 years from the
+current risk assessment (Not applicable) 0
+d) Project cash flow breakeven point is less than 4 years from the current risk
+assessment
+As demonstrated in the file RISK_REDD_20140622.xlsx (worksheet
+Cashflow_REDD) the project has a positive return on year 02, therefore breakeven
+point is less than 4 years. Park management costs are derived from Vreugdenhil
+(2007) the article is being provided to SCS (Vreugdenhil_2007_COST_IBAP.pdf).
+Other costs related to the VCS process, including validation, verification, levy and
+registries are based on public available information and on the current VVB contract
+with the project proponent. Revenues are calculated based on Ecosystem
+Marketplace (2012) on the state and trends of the voluntary carbon market. Finally,
+the cash flow arbitrarily establishes that 30% of the REDD revenues are channelled
+direct to the communities through the benefit sharing mechanism (FIAL).
+0
+e) Project has secured less than 15% of funding needed to cover the total cash out
+before the project reaches breakeven (Not applicable) 0
+f) Project has secured 15% to less than 40% of funding needed to cover the total cash
+out required before the project reaches breakeven (Not applicable) 0
+g) Project has secured 40% to less than 80% of funding needed to cover the total cash
+out required before the project reaches breakeven (Not applicable) 0
+h) Project has secured 80% or more of funding needed to cover the total cash out
+before the project reaches breakeven
+IBAP is receiving support from the World Bank and the GEF. The VCS costs are
+being fully covered by this international support. For park management costs, GEF 5
+is supporting IBAP with USD 2.95 million in a four-year grant to support the network
+of protected areas (SNAP). Further detail on the GEF 5 disbursement to the country
+can be found at http://qa-gef-wb.reisys.com/new-country-profile?countryCode=GW
+demonstrating that, in total, Guinea Bissau will receive USD 4,6 million, from which
+USD 1,5 million are focused on biodiversity and USD 2,0 million on Climate Change.
+0
+i) Mitigation: Project has available as callable financial resources at least 50% of total 0
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 152
+cash out before project reaches breakeven. (Not applicable)
+Total Financial Viability (FV) [as applicable, ((a, b, c or d) + (e, f, g or h) + i)]
+Total may not be less than zero. 0
+Opportunity Cost
+Risk
+Factor
+Risk Factor and/or Mitigation Description Risk Rating
+a) NPV from the most profitable alternative land use activity is expected to be at
+least 100% more than that associated with project activities; or where baseline
+activities are subsistence-driven, net positive community impacts are not
+demonstrated. (Not applicable)
+0
+b) NPV from the most profitable alternative land use activity is expected to be
+between 50% and up to100% more than from project activities (Not applicable) 0
+c) NPV from the most profitable alternative land use activity is expected to be
+between 20% and up to 50% more than from project activities (Not applicable) 0
+d) NPV from the most profitable alternative land use activity is expected to be
+between 20% more than and up to 20% less than from project activities; or
+where baseline activities are subsistence-driven, net positive community
+impacts are demonstrated.
+As demonstrated in the baseline assessment, the main deforestation driver is
+the small scale, subsistence-driven, traditional agricultural practices. In addition,
+the project provides net positive community impacts.
+0
+e) NPV from project activities is expected to be between 20% and up to 50% more
+profitable than the most profitable alternative land use activity (Not applicable) 0
+f) NPV from project activities is expected to be at least 50% more profitable than
+the most profitable alternative land use activity (Not applicable) 0
+g) Mitigation: Project proponent is a non-profit organization (Not applicable) 0
+h) Mitigation: Project is protected by legally binding commitment to continue
+management practices that protect the credited carbon stocks over the length
+of the project crediting period (see project longevity) (Not applicable)
+0
+i) Mitigation: Project is protected by legally binding commitment to continue
+management practices that protect the credited carbon stocks over at least 100
+years (see project longevity)
+The parks are protected areas, legally established (Decrees 12/2000 and
+14/2001). Further, both have Internal Regulations formally approved by the
+parks management committee. Both the laws and internal regulations had been
+provided to SCS.
+-8
+Total Opportunity Cost (OC) [as applicable, (a, b, c, d, e or f) + (g or h)]
+Total may not be less than 0. 0
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 153
+Project Longevity
+a) Without legal agreement or requirement to continue the management
+practice (Not applicable) 0
+b) With legal agreement or requirement to continue the management
+practice
+The parks are protected areas, legally established (Decrees 12/2000 and
+14/2001). Further, both have Internal Regulations formally approved by
+the parks management committee. Both the laws and internal regulations
+had been provided to SCS.
+-20
+Total Project Longevity (PL)
+May not be less than zero 0
+Internal Risk
+Total Internal Risk (PM + FV + OC + PL)
+Total may not be less than zero. 0
+2 EXTERNAL RISKS
+Land and resource tenure
+Risk
+Factor
+Risk Factor and/or Mitigation Description Risk Rating
+a) Ownership and resource access/use rights are held by same entity(s) (Not
+applicable) 0
+b)
+Ownership and resource access/use rights are held by different entity(s) (eg,
+land is government owned and the project proponent holds a lease or
+concession)
+The parks are public property; no private land rights exist in Guinea Bissau.
+Land belongs to the government and is managed by IBAP. Communities, by
+tradition, have rights over resources access and use. At community level, the
+elder defines resources share and access to standing forests. The Land Law
+clearly defines that ownership is not allowed but recognizes the consuetudinary
+rights of communities over land use and resource access. The land law and the
+protected area law demonstrating this situation had been provided to SCS.
+2
+c)
+In more than 5% of the project area, there exist disputes over land tenure or
+ownership
+(Not applicable)
+0
+d) There exist disputes over access/use rights (or overlapping rights) 0
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 154
+Traditional culture establishes, for example, how land is passed in a family over
+the years, the role of male and female in the community and how sacred
+location are defined and protect. No disputes over access or overlapping rights
+exist.
+e)
+WRC projects unable to demonstrate that potential upstream and sea impacts
+that could undermine issued credits in the next 10 years are irrelevant or
+expected to be insignificant, or that there is a plan in place for effectively
+mitigating such impacts (Not applicable)
+0
+f)
+Mitigation: Project area is protected by legally binding commitment (eg, a
+conservation easement or protected area) to continue management practices
+that protect carbon stocks over the length of the project crediting period
+The parks are protected areas, legally established (Decrees 12/2000 and
+14/2001). Further, both have Internal Regulations formally approved by the
+parks management committee. Both the laws and internal regulations had been
+provided to SCS.
+-2
+g)
+Mitigation: Where disputes over land tenure, ownership or access/use rights
+exist, documented evidence is provided that projects have implemented
+activities to resolve the disputes or clarify overlapping claims (Not applicable)
+0
+Total Land Tenure (LT) [as applicable, ((a or b) + c + d + e+ f)]
+Total may not be less than zero. 0
+Community Engagement
+Risk
+Factor
+Risk Factor and/or Mitigation Description Risk Rating
+a) Less than 50 percent of households living within the project area who are reliant
+on the project area, have been consulted 0
+b) Less than 20 percent of households living within 20 km of the project boundary
+outside the project area, and who are reliant on the project area, have been
+consulted
+For the establishment of the CBMP, IBAP performed a census that included
+households outside the Parks (Project Area) that could be impacted by the
+project. After understanding the potential impacts of protecting Cacheu and
+Cantanhez, FIAL, which was the micro project financial support instrument part
+of the CBMP, was extended to communities living outside Cacheu and
+Cantanhez. However, the project proponent cannot quantify the percentage of
+households consulted, therefore the most conservative value was selected.
+5
+c) Mitigation: The project generates net positive impacts on the social and
+economic wellbeing of the local communities who derive livelihoods from the
+project area -5
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 155
+The main project component to reduce deforestation relies on community
+engagement and support. The project will protect the standing forest by
+generating net positive impacts on the social and economic wellbeing of the
+local communities through technical support and training, efficiency gains in
+agricultural production, support to alternative income generation activities, and
+so forth. Moreover, the benefit sharing mechanism, similar to FIAL, will
+guarantee that micro projects relevant to communities are financed.
+Total Community Engagement (CE) [where applicable, (a+b+c)]
+Total may be less than zero. 0
+Political Risk
+Risk
+Factor
+Risk Factor and/or Mitigation Description Risk Rating
+a) Governance score of less than -0.79
+The Worldwide Governance Indicator (WGI) was used to calculate the
+aggregate governance score. GB totaled a negative score of -1.02. The file
+RISK_REDD_20140622.xlsx presents (worksheet WGI_GB) the detailed
+calculation of the index.
+6
+b) Governance score of -0.79 to less than -0.32 (Not applicable) 0
+c) Governance score of -0.32 to less than 0.19 (Not applicable) 0
+d) Governance score of 0.19 to less than 0.82 (Not applicable) 0
+e) Governance score of 0.82 or higher (Not applicable) 0
+f) Mitigation: Country implementing REDD+ Readiness or other activities such
+as:
+a) The country is receiving REDD+ Readiness funding from the FCPF, UN-
+REDD or other bilateral or multilateral donors
+b) The country is participating in the CCBA/CARE REDD+ Social and
+Environmental Standards Initiative
+c) The jurisdiction in which the project is located is participating in the
+Governors' Climate and Forest Taskforce
+d) The country has an established national FSC or PEFC standards body
+e) The country has an established DNA under the CDM and has at least one
+registered CDM A/R project
+(Not applicable)
+0
+Total Political (PC) [as applicable ((a, b, c, d or e) + f)]
+Total may not be less than zero. 6
+External Risk
+Total External Risk (LT + CE + PC)
+Total may not be less than zero. 6
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 156
+3 NATURAL RISKS
+Natural Risk – Fire
+Significance Insignificant
+Likelihood Unlikely – natural fire does not occur in the project area. No registration could
+be found on such natural risk event
+Score (LS) 0 (Not applicable)
+Mitigation Not applicable
+Natural Risk – Pest and Disease outbreaks
+Significance Insignificant
+Likelihood Unlikely – the project proponent could not find registration of pest and diseases
+outbreaks in the project area.
+Score (LS) 0 (Not applicable)
+Mitigation Not applicable
+Natural Risk – Extreme Weather
+Significance Insignificant
+Likelihood Unlikely – there are no records of extreme weather events in the project area
+Score (LS) 0 (Not applicable)
+Mitigation Not applicable
+Natural Risk – Geological Risks
+Significance Insignificant – Guinea Bissau is not subject to geological events like
+earthquakes.
+Likelihood Unlikely – Guinea Bissau is not subject to geological events like earthquakes.
+Score (LS) 0 (Not applicable)
+Mitigation Not applicable
+Natural Risk – Other natural risk
+Significance Not applicable
+Likelihood Not applicable
+Score (LS) Not applicable
+Mitigation Not applicable
+Score for each natural risk applicable to the project
+(Determined by (LS × M)
+Fire (F) (Not applicable) 0
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 157
+Pest and Disease Outbreaks (PD) (Not applicable) 0
+Extreme Weather (W) (Not applicable) 0
+Geological Risk (G) (Not applicable) 0
+Other natural risk (ON) (Not applicable) 0
+Total Natural Risk (as applicable, F + PD + W + G + ON) 0
+Total Natural Risk (F + PD + W + G + ON) 0.00
+Note: Total may not be less than zero
+If the Total Natural Risk is above 35 then the project fails the entire risk analysis
+4 OVERALL NON-PERMANENCE RISK RATING AND BUFFER DETERMINATION
+4.1 Overall Risk Rating
+Risk Category Rating
+a) Internal Risk 0
+b) External Risk 6
+c) Natural Risk 0
+Overall Risk Rating (a + b + c) 10
+Note: Overall risk rating shall be rounded up to the nearest whole
+percentage
+The minimum risk rating shall be 10, regardless of the risk rating
+calculated
+If the overall risk rating is over 60 then the project fails the entire risk
+analysis
+Since the risk score cannot be lower than 10 the project assigns a total score of 10 for the Non-
+Permanence Risk Rating.
+4.2 Calculation of Total VCUs
+Years Estimated net GHG emission
+reductions or removals (tCO2e) Risk buffer
+Deductions for
+AFOLU pooled
+buffer account
+Net Total (tCO2e)
+2013 75,290 10% 9,582 65,708
+2014 153,923 10% 19,589 134,333
+2015 235,897 10% 30,022 205,876
+2016 321,215 10% 40,880 280,335
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 158
+2017 409,874 10% 52,163 357,711
+2018 501,876 10% 63,872 438,004
+2019 597,221 10% 76,006 521,215
+2020 695,908 10% 88,566 607,342
+2021 797,937 10% 101,550 696,386
+2022 903,308 10% 114,961 788,348
+2023 978,599 10% 124,543 854,056
+2024 1,057,231 10% 134,550 922,681
+2025 1,139,206 10% 144,982 994,223
+2026 1,224,523 10% 155,840 1,068,683
+2027 1,313,183 10% 167,124 1,146,059
+2028 1,405,185 10% 178,833 1,226,352
+2029 1,500,529 10% 190,967 1,309,563
+2030 1,599,216 10% 203,526 1,395,690
+2031 1,701,245 10% 216,511 1,484,734
+2032 1,806,617 10% 229,921 1,576,696
+Total 1,806,617 10% 229,921 1,576,696
+APPENDIX 2: WOOD DENSITY INFORMATION
+SPECIES
+CODE SPECIES COMMON
+NAMES COMMON NAMES FAMILY WOOD
+DENSITY SOURCE
+Aca_mac
+Acacia
+macrosta
+chya
+Rchb. ex
+DC.
+pau-de-
+ferida, pau-
+ferida
+gáudè, tanda-sara
+(ff); bula-bali, bule,
+búrlé, quide, tchide
+(fu).
+Legumin
+osae/
+Mimosoi
+deae
+0.759 Nygard &
+Elfving 2000
+Ada_dig
+Adansoni
+a digitata
+L.
+Calabacera
+látè (ba); uáto (bj);
+cabaceira,
+cabacera; baobab,
+pain de singe (o
+fruto) (fr); bóè (fu);
+bedom-hal,
+burungule-
+burúnque (mc); citô
+(md); bebáque,
+bedom-hal, brungal
+(mj); m'béke (nl);
+burungule (pp);
+Bombac
+aceae 0.32
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 159
+cabaceira,
+calabaceira (pt); kiri
+(ss).
+Afz_afr
+Afzelia
+africana
+Sm. ex
+Pers.
+pau-conta,
+pó-de-
+conta
+biiguê, pega (ba);
+aru, oru (cs);
+lengue, lénguei (ff);
+lengueje, leoncó,
+luengue (fu);
+bignáni (mc);
+lencom-ô, linqué
+(md); becancha,
+becancla, congô,
+gongô (mj); butáua,
+butone (pp).
+Legumin
+osae 0.655 EFGP
+Alb_adi
+Albizia
+adianthifol
+ia
+(Schumac
+h.)
+W.Wight
+faróba-de-
+lala,
+farroba-de-
+lala
+cobaga-ê,
+conecam,
+empantanca,
+unchámpô (bj);
+untchaintchain (cb);
+caroubier (fr);
+catchena (fs);
+marnei, nétèmàe,
+néto-máiô (fu);
+netô-farô (md);
+bianque (mj);
+masamp-thai (nl);
+alfarroba (pt); uasa-
+fiké (ss).
+Legumin
+osae/
+Mimosoi
+deae
+0.595605
+6 CARBOVEG
+Alb_alt
+Albizia
+altissima
+Hook.f.
+nétéchango (fu).
+Legumin
+osae/
+Mimosoi
+deae
+0.52
+Albizia spp.
+Brown97 /
+América
+Alb_din
+Albizia
+dinklagei
+(Harms)
+Harms
+farroba-de-
+mato
+nasce-fôrè (ba);
+correré (bj);
+bansabúle (bm);
+gaúde (ff);
+bubricaramba (fs);
+netechaguhol,
+sindjadjálê,
+sindjalale (fu);
+masamp, masamp-
+tchill, masang-na
+(nl); ussúmbulo
+(pp); safatá,
+uasafore, (ss).
+Legumin
+osae/
+Mimosoi
+deae
+0.52
+Albizia spp.
+Brown97 /
+Africa
+Alb_fer
+Albizia
+ferruginea
+(Guill. &
+Perr.)
+Benth.
+faróba-de-
+lala,
+farroba-de-
+lala
+untchampo (bj);
+furbirõ (cs); marnei,
+nete-maio (fu);
+farranetó (md).
+Legumin
+osae/
+Mimosoi
+deae
+0.47 Brown97 /
+Africa
+Alb_gla
+Albizia
+glaberrim
+a
+(Schumac
+uarmáma (fu);
+tangalamara (md).
+Legumin
+osae/
+Mimosoi
+deae
+0.52
+Albizia spp.
+Brown97 /
+Africa
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 160
+h. &
+Thonn.)
+Benth.
+var.
+glaberrim
+a
+Alb_rho
+Albizia
+rhombifoli
+a Benth.
+djêgo, nétè-cula
+(fu); d'jagu (md);
+quéquê-camacama
+(ss).
+Legumin
+osae/
+Mimosoi
+deae
+0.52
+Albizia spp.
+Brown97 /
+Africa
+Alb_zyg
+Albizia
+zygia
+(DC.)
+J.F.Macbr
+.
+pó-de-raio
+biaioga, buiaioga
+(bf); cobaga-ê (bj);
+bunike (fs);
+mabodadi,
+marroné, tali, taliba,
+uarmáua (fu);
+tangalamára (md);
+masamp, msamp-
+m'boko (nl);
+tombonka're (ss).
+Legumin
+osae/
+Mimosoi
+deae
+0.46 Brown97 /
+Africa
+Alc_cor Alchornea
+cordifolia
+0.731101
+955
+Dens. Média
+CARBOVEG
+All_afr Allophylus
+africanus 0.45 Brown97 /
+Africa
+Als_boo
+Alstonia
+boonei De
+Wild.
+tacára,
+tagara,
+tagarra
+biangue, bianque,
+psoque,(ba);
+polõfuru (cs);
+banta-forodjé,
+bantera-fôrô,
+batanforo (fu);
+batacar (mc);
+iangué, ianké,
+ianque (nl)
+Apocyn
+aceae 0.33
+A. congensis
+Brown97 /
+Africa
+Als_con
+Alstonia
+congensis
+Engl.
+tacára,
+tagara,
+tagarra
+djambé (ba);
+cudjésse, quessum
+(bj); léguerè (ff);
+bantam-foro (fu);
+betácarre (mc);
+bantam-forô (md);
+bidjésse (mj);
+batáguar (pp);
+iangué, ianké,
+ianque (nl).
+Apocyn
+aceae 0.33 Brown97 /
+Africa
+Ana_occ
+Anacardiu
+m
+occidental
+e L.
+Cadju Ncadju (mj) Anacard
+iaceae 0.431
+GlobalWoodD
+ensityDatabas
+e
+Ani_lau
+Anisophyll
+ea laurina
+R.Br. ex
+Sabine
+miséria,
+pau-
+miséria, pó-
+de-miséria
+mafel, máfèlè (ba);
+budjagálá (planta),
+mandjagálá (fruto)
+(bf); edoconhe (bj);
+kanse (fu); n'sunp,
+sénhè, unsununtu
+(nl); cantingui (ss);
+Rhizoph
+oraceae
+0.730875
+2 CARBOVEG
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 161
+angueidja (td).
+Ant_dja
+Anthoclei
+sta
+djalonensi
+s A.Chev.
+tagare (fu); bintié
+(mj).
+Logania
+ceae 0.5
+A. keniensis
+Brown97 /
+Africa
+Ant_mac
+Anthonoth
+a
+marcophil
+a
+0.78 Brown97 /
+Africa
+Ant_mem
+Antidesm
+a
+membran
+aceum
+0.731101
+955
+Dens. Média
+CARBOVEG
+Ant_pro
+Anthoclei
+sta
+procera
+Lepr. ex
+Bureau
+caboupa-
+matcho
+kufá, cúfè (ba);
+(ba); cadjangue,
+cadjanuè (bj);
+beidomodjô, tagare
+(fu); bintié (mj);
+papae-um-eme
+(pp); dissauri (ss).
+Logania
+ceae 0.5
+A. keniensis
+Brown97 /
+Africa
+Ant_sen
+Anthoste
+ma
+senegale
+nse
+A.Juss.
+binhal, pó-
+de-binhal,
+pó-de-lete
+p’tone (ba); cabate,
+cabete (bj);
+bulucune (fs);
+bufena, m´burô,
+umburo (fu); mante
+(nl); minhále, tagi
+(pp).
+Euphorb
+iaceae
+0.554625
+2 CARBOVEG
+Ant_tox
+Antiaris
+toxicaria
+subsp.
+welwitschi
+i var.
+africana
+(Engl.) A.
+Chev.
+língua-di-
+baca, pau-
+bicho, pau-
+de-bicho-
+amarelo,
+pó-de-
+bicho-
+branco, po-
+de-bitche,
+pó-de-lete
+noii (bj); djauláe,
+nhenhe,
+tambatchilam,
+tchime (fu);
+tumbuiru (md);
+binam-ne, cóngoró,
+cóngôrô, (mj);
+bucanhe (pp);
+n'nhonhinhe (ss).
+Morace
+ae 0.37 Brown97 /
+Africa
+Ant_ven
+Antidesm
+a
+venosum
+E.Mey. ex
+Tul.
+Euphorb
+iaceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Ant_vog
+Anthoclei
+sta vogelii
+Planch.
+acuapôpo,
+caboupa-
+matcho
+cadjanué (bj);
+ugumba, undango
+(cb).
+Logania
+ceae 0.5
+A. keniensis
+Brown97 /
+Africa
+Aph_sen
+Aphania
+senegale
+nsis
+(A.Juss.
+ex Poir.)
+Radlk.
+cerença,
+cerija,
+serinça
+m'bôtcherê (ba);
+buiema (dj); bulebo
+(fl); culneldacu,
+mantchampôdje
+(fu); simbode-ô,
+simbondô (md);
+bute, n'pórlô, obalei
+(pp).
+Sapinda
+ceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Arv_desc Árvore 0.731101 Dens. Média
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 162
+viva
+desconhe
+cida
+955 CARBOVEG
+Arv_mort
+Arvore
+morta em
+pé
+0.328
+Dens. Mínima
+das árvores
+vivas
+CARBOVEG
+Avi_ger
+Avicennia
+germinan
+s (L.) L.
+tarafe,
+tarrafé,
+tarrafe
+béthá, ió, petá,
+péthsá (ba);
+bufendê (planta),
+m’pendê
+(população de
+plantas) (bf);
+cobaca, cudjuno
+(bj); behelm, ùle
+(cb); cabêço,
+camangacú (fl); úle
+(mc); djibicum,
+tarafô, (md);
+pebadje, púle (mj);
+iófo, n'kim (nl); búle
+(pp); uofiri (ss).
+Avicenni
+aceae 0.756 CARBOVEG
+Bli_sap
+Blighia
+sapida
+K.D.Koeni
+g
+m'butchiri (ba); otau
+(bj); cuiema (dj);
+féso (fu).
+Sapinda
+ceae 0.74
+B. welwitschii
+Brown97
+Africa
+Bli_uni
+Blighia
+unijugata
+Baker
+osso-de-
+dari
+bissabe (bf);
+democôri, sátágá-
+preto (fu); firifora
+(md); m'but-balé,
+n'timlake (nl);
+beleque-súlè (ss).
+Sapinda
+ceae 0.74
+B. welwitschii
+Brown97
+Africa
+Boi_mam Boila
+mamba
+0.731101
+955
+Dens. Média
+CARBOVEG
+Bom_cos
+Bombax
+costatum
+Pellegr. &
+Vuillet
+Polóm-
+fidalgo,
+polóm-fôro,
+sumauma
+bumbum, buúforè
+(ba); brêgue (bf);;
+djóia, djóè (ff);
+djóia, djóè, luncum
+(fu); belofa (mc);
+buncum-ô (md);
+djóia, belofa (mj);
+ulófo (pp).
+Bombac
+aceae
+0.493105
+9 CARBOVEG
+Bor_aet
+Borassus
+aethiopu
+m Mart.
+cibe
+bace (ba); buár (bf);
+eudá (bj); dúbè,
+palmier-rônier,
+rônier (fc); dúbè (ff);
+cibedje (fu); cibô
+(md); n'bene,
+umbena (mj);
+buane, opane (pp).
+Palmae 0.885 EFGP
+Bri_mic
+Bridelia
+micrantha
+(Hochst.)
+Baill.
+bissáca
+tagate (ba); bissai,
+bussácá (bf);
+endure, n' tongue,
+untágué, untongue
+Euphorb
+iaceae 0.47 Brown97 /
+Africa
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 163
+(bj); utchak (cb);
+fudetchir (fs);
+bissoia, gúgri (fu);
+bissaiô, bissoia
+(md); m'bonhé,
+n'taque (nl);
+bissaque (pp);
+tolingué, tolingi
+(ss).
+Byr_bro
+Byrsanthu
+s brownii
+Guill.
+Euphorb
+iaceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Car_pro
+Carapa
+procera
+DC.
+cola-
+amargoso,
+cola-
+malegossa
+caranhane (bj);
+punhe (bm); kola-
+malgos, pada-di-
+kola, siti-malgos
+(cs); bunhogone
+(dj); boculamape
+(fl); boncom-hadje,
+gobi, mambodadje
+(fu); maló, boncom-
+ô (md); bépale,
+buaque, cóque
+(mj); bóco (pp).
+Meliace
+ae 0.59 Brown97 /
+Africa
+Cas_sie
+Cassia
+sieberian
+a DC.
+canafistra,
+canafístula,
+sambassin
+hague
+p’fonante (ba);
+bissindje, bussindja
+(bf); caquecequece
+(bj); sama-sidjam,
+samba-sindjandje
+samba-sinhangho,
+sambasinhanha,
+sambassinhamé,
+sandjoné, sanjoué
+(fu); sindjam-ô
+(md); bentape,
+n'tame, untame
+(mj); betame (pp).
+Legumin
+osa/Cae
+salp.
+0.72 Nygard &
+Elfving 2000
+Cei_pen
+Ceiba
+pentandra
+(L.)
+Gaertn.
+Poilão,
+poilon,
+polóm
+psáhè, pthaé,
+rumbum (ba),
+brêgue (bf); cob-bê,
+fromager (bj);
+bantanhe (ff, fu);
+pentene (mc);
+bantam-ó (md);
+péntia (mj); m'bath
+(nl); metchene,
+n´tene, untene (pp).
+Bombac
+aceae 0.26 Brown97 /
+Africa
+Cit_sin Citrus
+sinensis Larandja Plele (mj) 0.731101
+955
+Dens. Média
+CARBOVEG
+Col_cor
+Cola
+cordifolia
+(Cav.)
+R.Br.
+mandjanja,
+manjandja
+m’bué (ba);
+budjanhi (bf);
+utuludjene (dj); tábá
+(fu); tabô (md).
+Sterculi
+aceae 0.458 EFGP
+Col_nit Cola 0.7 Cola sp. /
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 164
+nitida Brown97 /
+Africa
+Com_ade
+Combretu
+m
+adenogon
+ium
+Steud. ex
+A.Rich.
+Jambacatá
+djambacatã (bf);
+djambacatam-ô (ff);
+bané, djambacatam
+(fu); djambacatam-
+quéo (md).
+Combret
+aceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Com_c_g
+Combretu
+m
+collinum
+subsp.
+geitonoph
+yllum
+(Diels)
+Okafor
+bierrequêtê (bf);
+djambacatá
+(fêmea) (fu);
+hiremoussôlo,
+madifô, (md).
+Combret
+aceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Com_c_h
+Combretu
+m
+collinum
+subsp.
+hypopilinu
+m (Diels)
+Okafor
+Combret
+aceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Com_mic
+Combretu
+m
+micranthu
+m
+Combret
+aceae 0.736 Nygard &
+Elfving 2000
+Com_nig
+Combretu
+m
+nigricans
+var. elliotii
+(Engl. &
+Diels)
+Aubrév.
+pau-de-
+pilão
+betne (ba); betne,
+bunro (bf); buidé,
+dodje-górè, úidè
+(fu); djambacatam-
+ô (md); atchelogon,
+tchelogom (td).
+Combret
+aceae 0.957348 CARBOVEG
+Com_sp Combretu
+m sp
+0.731101
+955
+Dens. Média
+CARBOVEG
+Cor_pin
+Cordyla
+pinnata
+(Lepr. ex
+A.Rich.)
+Milne-
+Redh.
+psila (ba); dirqué,
+dóki, duco, dúki,
+dúquei, (fu); doto,
+dúnta, dutos,
+ulacomô-dutô (md).
+Legumin
+osae/
+Mimosoi
+deae
+0.719 EFGP
+Cra_lau
+Craterisp
+ermum
+laurinum
+0.731101
+955
+Dens. Média
+CARBOVEG
+Cro_feb
+Crossopte
+ryx
+febrifuga
+(Afzel. ex
+G.Don)
+Benth.
+baradagamarama
+(bf); belim,
+colidjâncuma, (fu).
+Rubiace
+ae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Dal_boe
+Dalbergia
+boehmii
+Taub.
+bierequété (bf);
+godjoli (fu);
+n'pessa, umpessa
+Legumin
+osae/
+Mimosoi
+0.731101
+955
+Dens. Média
+CARBOVEG
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 165
+(mj); n'ticambague
+(nl); simoili (ss);
+ambrecome (td).
+deae
+Dan_oli
+Daniellia
+oliveri
+(Rolfe)
+Hutch. &
+Dalziel
+pau-
+incenso,
+pó-de-
+incenso
+bóbe (ba); ucumbo
+(bj); si-bink (cs);
+santan, tchébè,
+tchéne (fr); tchénè
+(fu); santam-ô,
+santam-um,
+santangô (md);
+becúncaro, biécar
+(mj); boto, m'bétá
+(nl); rúngulo,
+untande (pp);
+kaméuri (ss).
+Legumin
+osae 0.536 EFGP
+Dat_mic
+Detarium
+microcarp
+um Guill.
+& Perr.
+mamboli
+códóde (bj); bôto,
+compondôgô,
+pompôdôgô (fu);
+sárôco, sara-ôncô
+(md); m'betá,
+m'petch (nl); amule
+(td).
+Legumin
+osae 0.565 Nygard &
+Elfving 2000
+Dat_sen
+Detarium
+senegale
+nse
+J.F.Gmel.
+mambode
+bobode (bf);
+cudoce (bj); boto,
+pó-pondogo,
+querenduta (fu);
+mabodô, sarôco
+(md); bumbuar (mj);
+bórrè (pp).
+Legumin
+osae 0.547 EFGP
+Det_sp Detarium
+sp
+0.731101
+955
+Dens. Média
+CARBOVEG
+Dia_gui
+Dialium
+guineens
+e Willd.
+beludo,
+pau-veludo,
+pó-de-
+veludo,
+veludo
+m'boié, n´boi,
+umboi (ba); bufarô
+(bf); epádum (bj);
+uparan (fs); boiè-
+maio, cossiráe,
+mèco, moquê (fu);
+citó, cossitô, moquê
+(md); bebúi, bubúi
+(mj); m'bim,
+m'bimbe (nl);
+moquê (ss);
+atenguengelere
+(td).
+Legumin
+osae 0.698 EFGP
+Dic_cin
+Dichrosta
+chys
+cinerea
+subsp.
+platycarp
+a (Welw.
+ex W.Bull)
+Brenan &
+Brummitt
+var.
+fedida-
+branco,
+ferida-
+preto; fididi-
+preta, pau-
+ferida, pó-
+de-fidida-
+preto
+biohé-mone, duê
+(ba); emudu (bj);
+sipiñan (cs);
+bulabêlê, bula-bétè,
+bulé, bule-baledje,
+bulu-caledje, búrlè,
+burlei, búrlè-lubode,
+burlé-lubodje, búrli
+(fu); n'gami-coió,
+n'gari-coió (md).
+Legumin
+osae/
+Mimosoi
+deae
+0.919601
+4 CARBOVEG
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 166
+platycarp
+a
+Dio_ell
+Diospyros
+elliotii
+(Hiern)
+F.White
+Ebenac
+eae 1.03
+Diospyrus sp.
+Reyes et al.
+1992
+Dio_fer
+Diospyros
+ferrea
+(Willd.)
+Bakh.
+Ebenac
+eae 1.03
+Diospyrus sp.
+Reyes et al.
+1992
+Dio_heu
+Diospyros
+heudelotii
+Hiern
+ebangleba (bj);
+silabono (fu);
+cussito, malefu
+(md); jagôrtá,
+n’jangugurta,
+tchamburtá (nl);
+iatété, malefú,
+malevu (ss); culum
+(td).
+Ebenac
+eae
+0.938400
+3 CARBOVEG
+Eke_cap Ekebergia
+capensis
+0.731101
+955
+Dens. Média
+CARBOVEG
+Ela_gui
+Elaeis
+guineensi
+s Jacq.
+palmera
+quem, ribe (ba);
+benintchi, bunintchi
+(bf); eárra, lara (bj);
+palmier-à-huile (fc);
+tuguêih (ff); tem-
+em-eih (fu); tem-ô
+(md); mintchame
+(mj); n'quemê (pp);
+palmeira de azeite,
+palmeira de óleo,
+palmeira déndém
+(pt).
+Palmae
+Ery_afr
+Erythrophl
+eum
+africanum
+(Welw. ex
+Benth.)
+Harms
+corombel,
+gerombéle, pele,
+péli, querenduta
+(fu); cursonsum-ô,
+cussonsom (md).
+Legumin
+osae 1.02
+Média de E.
+africanum em
+Brown97
+Ery_sen
+Erythrina
+senegale
+nsis DC.
+bissaca,
+pó-de-osso,
+pó-di-osso,
+pó-di-conta
+m'zisse (ba);
+burale, sélélé (bf);
+cusserê (bj); pó-di-
+budogo (cs); arbre-
+corail, erythrine du
+Sénégal (fr);
+bondja,
+botchotchadje,
+bothola, mochôla,
+m'zisse (fu); dlim-
+ôdolim-ô (md);
+n'chaka-refat,
+n'tchakarfat (nl);
+bissansce (pp).
+Legumin
+osae/
+Mimosoi
+deae
+0.31
+Média de
+Erythrina sp.
+em Brown97
+Ery_sig Erythrina dolim-bá, dolimba Legumin 0.31 Média de
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 167
+sigmoidea
+Hua
+(md). osae/
+Mimosoi
+deae
+Erythrina sp.
+em Brown97
+Ery_sua
+Erythrophl
+eum
+suaveolen
+s (Guill. &
+Perr.)
+Brenan
+mancone,
+manconi
+betomo, otone (ba);
+budatchai (fs);
+talidje, téli (fu);
+mãnçone (cs);
+buirame (fl);
+betitche (mc); tálô
+(md); baier
+(=amarga), bentabe
+(mj); betitche (pp).
+Legumin
+osae 0.824 EFGP
+EspDesc
+Espécie
+viva
+desconhe
+cida
+0.731101
+955
+Dens. Média
+CARBOVEG
+Euc_lon Euclinia
+longiflora
+0.731101
+955
+Dens. Média
+CARBOVEG
+Fai_alb
+Faidherbi
+a albida
+(Delile) A.
+Chev.
+ferida-
+branco,
+pau-ferida,
+pó-de-
+ferida-
+branco
+bioépi, djúè (ba);
+camude, camudé,
+camudo (bj);
+biongômo (bm);
+sipiñã, sipiña-brabu
+(cs); busseu-uliba
+(fl); cad (fr);
+bubirique (fs);
+borassanhe,
+buladanêlhe, bulé,
+búrlè-danédjo,
+marroné, (fu);
+betampale (mc);
+borassam,
+borassam-ô (md);
+butchampele (mj)
+Legumin
+osae/
+Mimosoi
+deae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Fic_dic
+Ficus
+dicranosty
+la Mildbr.
+sur (ba); d’jambô,
+djambo-surei
+suredje, surei (fu);
+anak (td).
+Morace
+ae 0.465
+Média de
+Ficus sp. em
+Brown97
+Fic_exa
+Ficus
+exasperat
+a Vahl
+acarta-lixo,
+língua-di-
+baca, po-di-
+lixa,(cr)
+noii (bj); uiássiáss
+(cb); karda (cs);
+nhinha (fu);
+bungadjé, n'cungre
+(uncungre) (mj);
+cuncre, cungre,
+n'cuncre, uncuncre
+(pp).
+Morace
+ae 0.465
+Média de
+Ficus sp. em
+Brown97
+Fic_glu
+Ficus
+glumosa
+Delile
+pau-de-leite
+ságuê (ba);
+quequeiè (fu); sótô
+(md).
+Morace
+ae 0.465
+Média de
+Ficus sp. em
+Brown97
+Fic_ova Ficus
+ovata
+Morace
+ae 0.465
+Média de
+Ficus sp. em
+Brown97
+Fic_sp Ficus sp 0.465 Média de
+Ficus sp. em
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 168
+Brown98
+Fic_sur Ficus sur
+Forssk.
+blata, tumbli (ba);
+canhamá,
+catchocodo (bj);
+défay (cs); bucune
+(fs); tcheque,
+tchequedje (fu);
+buncuncul (mc);
+turô (md); cuncre,
+cungre, n´cungre,
+uncungre (mj);
+tonkin-iá, tonquinha
+(nl); uncúngne (pp);
+anaque (td).
+Morace
+ae 0.465
+Média de
+Ficus sp. em
+Brown97
+Fic_syc
+Ficus
+sycomoru
+s subsp.
+gnaphalo
+carpa
+(Miq.)
+C.C.Berg
+chéque, tcheque
+(pl. tchequedje)
+(fu); cungre,
+n’cungre, uncungre
+(mj).
+Morace
+ae 0.465
+Média de
+Ficus sp. em
+Brown97
+Fun_afr
+Funtumia
+africana
+(Benth.)
+Stapf
+ripetche (ba);
+budiquédo (fu).
+Apocyn
+aceae 0.4 Reyes et al.
+1992
+Gar_imp
+Gardenia
+imperialis
+K.Schum.
+tári-sútò (fu). Rubiace
+ae 0.76 Gardenia sp.
+em Brown 97
+Gar_ter_S
+Gardenia
+ternifolia
+subsp.
+jovis-
+tonantis
+var.
+goetzei
+(Stapf &
+Hutch.)
+Verdc.
+brintintchi (ba);
+undágál (cb);
+bosseléole, djugale
+(fu); bireu (mc);
+n'dô (nl).
+Rubiace
+ae 0.655 Nygard &
+Elfving 2000
+Gar_ter_
+W
+Gardenia
+ternifolia
+subsp.
+jovis-
+tonantis
+(Welw.)
+Verdc.
+var. jovis-
+tonantis
+djugale (fu); n'dué
+(nl).
+Rubiace
+ae 0.655 Nygard &
+Elfving 2000
+Han_und
+Hannoa
+undulata
+(Guill. &
+Perr.)
+Planch.
+psône, psunn, tibdé
+(ba); tchuco (bj);
+colanzu, colonzo,
+quécui, quécui-
+djom, tibedé (fu);
+bren (mc); kéo-fôro
+(md).
+Simarou
+baceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 169
+Har_mad
+Harungan
+a
+madagas
+cariensis
+Lam.
+canho, pó-
+di-faia
+mintchéle, umpátè
+(ba); canho,
+uómnhé (bj); utéhia
+(cb); súngala (ff);
+chungalá, sungala
+(fu); sumbalá, uliéli,
+ulielò (md);
+binhanhaque (mj);
+acanjongra (td).
+Euphorb
+iaceae 0.45 Reyes et al.
+1992
+Hei_par Heisteria
+parvifolia
+0.731101
+955
+Dens. Média
+CARBOVEG
+Hex_cri
+Hexalobu
+s
+crispifloru
+s A.Rich.
+Annona
+ceae 0.48 Reyes et al.
+1992
+Hex_mon
+Hexalobu
+s
+monopeta
+lus
+(A.Rich.)
+Engl. &
+Diels
+mambumba bacuré, boile, boili,
+canjé, tapircó (fu)
+Annona
+ceae 0.827473 CARBOVEG
+Hol_flo
+Holarrhen
+a
+floribunda
+(G.Don)
+T. Durand
+& Schinz
+bribait,
+bripatche
+rubitchi (ba); ete-éri
+(bj); machalô (fs);
+charra-quidjé,
+endama, rubitchi,
+tcharaquidje,
+tchoráqui (fu);
+bedufe, bedufi,
+bidufe (mc);
+tcharico (md);
+metchel (nl);
+kamaitê (ss).
+Apocyn
+aceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Hun_umb
+Hunteria
+umbellata
+(K.Schum
+.) Hallier f.
+pó-di-pinti
+báuri (fu); belace,
+belaha (mj);
+n'tchintchamp (nl);
+balé (ss).
+Apocyn
+aceae 0.926 CARBOVEG
+Hym_aci
+Hymenoc
+ardia
+acida Tul.
+var. acida
+Coroncond
+e,
+coronconto
+beninebahan,
+betenam (ba);
+coroncondô (bf);
+corocondé, oábi
+(bj); pilitoró (ff);
+bodi, caraconde,
+corocondé (fu);
+corocondô,
+cureucóndô (md);
+matikzé, n'tisé (nl);
+curencúnde,
+simóilé, simóieli
+(ss).
+Euphorb
+iaceae 0.702
+GlobalWoodD
+ensityDatabas
+e
+Hym_heu
+Hymenoc
+ardia
+heudelotii
+Planch.
+Euphorb
+iaceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 170
+ex
+Müll.Arg.
+Hym_lyr
+Hymenoc
+ardia
+lyrata Tul.
+odinaco (bj). Euphorb
+iaceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Kee_sp Keetia sp 0.731101
+955
+Dens. Média
+CARBOVEG
+Kha_sen
+Khaya
+senegale
+nsis
+(Desr.)
+A.Juss.
+bissilão,
+bissilon
+famé, iacume,
+tagmi, táminii (ba);
+bussilô (bf);
+unchómrô,
+unchonro (bj);
+betenhète (dj); cáe
+(ff); acajou-du-
+Sénégal, caïcédrat
+(fr); cáe (fu);
+biaiérre (mc); djaló
+(md); béntia,
+bentiene, betone
+(mj); embale, utime
+(pp).
+Meliace
+ae 0.608 EFGP
+Lad_heu
+Landolphi
+a
+heudeloii
+0.731101
+955
+Dens. Média
+CARBOVEG
+Lag_rac
+Laguncul
+aria
+racemosa
+0.731101
+955
+Dens. Média
+CARBOVEG
+Lan_aci
+Lannea
+acida
+A.Rich.
+mantede
+dôto (ba); ututene
+(fs); bembedja,
+bembem-hei,
+tchingole (fu);
+bémbô (md);
+betôlôdje (pp).
+Anacard
+. 0.465 Nygard &
+Elfving 2000
+Lan_nig
+Lannea
+nigritana
+(Scott-
+Elliot)
+Keay
+mantede
+bembedje,
+bembem-hei,
+tchingole (fu);
+bêmbô (md);
+betôlôdje (pp)
+Anacard
+. 0.611 L. velutina
+CARBOVEG
+Lan_sp Lanea sp 0.731101
+955
+Dens. Média
+CARBOVEG
+Lan_vel
+Lannea
+velutina
+A.Rich.
+bembei,
+dembei,
+mantede
+dôtô (ba);
+bembedje, bembei,
+bembem-hei,
+tchingole (fu);
+bémbô (md);
+betôlôdje (pp)
+Anacard
+. 0.611 CARBOVEG
+Lec_cup
+Lecaniodi
+scus
+cupanioid
+es
+Planch.
+ex Benth.
+sátaga (fu) Sapinda
+ceae
+0.855673
+9 CARBOVEG
+Lop_lan Lophira
+lanceolata mené p’fancha (ba);
+udoma (bj);
+Ochnac
+eae 0.706 EFGP
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 171
+Tiegh. ex
+Keay
+malanga,
+marnenáe,
+p'bancar (ff);
+ledalbodeel,
+malanga,
+marnenáe,
+p'bancar (fu); mufó
+(pp); mené (ss).
+Mal_aln
+Malacant
+ha
+alnifolia
+(Baker)
+Pierre
+ukíssig (cb); lixa
+(cr); cafore (dj);
+nhada-haco,
+nhénhéò (fu);
+mafaléu (nl); lakó,
+lalaúri (ss).
+Sapotac
+eae
+0.699939
+4 CARBOVEG
+Man_ind Mangifera
+indica mango
+pamango (mj);
+manga, mangueira
+(pt)
+Anacard
+iaceae 0.552
+GlobalWoodD
+ensityDatabas
+e
+Mar_tom
+Markhami
+a
+tomentos
+a (Benth.)
+K.Schum.
+ex Engl.
+boloitche (ba); n'álè
+(um-hálè) (fu).
+Bignoni
+aceae 0.473
+GlobalWoodD
+ensityDatabas
+e
+Mil_reg Milicia
+regia 0.439 EFGP
+Mor_gem
+Morinda
+geminata
+DC.
+boloncodjib
+á-macho,
+bolongodjib
+a, bulungu-
+djubá
+gunhe,
+n'dunquinhe,
+n'gume, ungume
+(ba); bulongodjibá
+(bf); obonodje (bj);
+bubalden (dj);
+n´garba, ungarba
+(ff);
+biloncontchebáe,
+bolonco-tchibá,
+dacuré, lhiamba,
+n'garba, uanda,
+wáda (fu);
+biloncondjebá,
+boloncom,
+boloncondjibá ,
+goloneogita,
+simbom-ô, u
+Rubiace
+ae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Mor_luc
+Morinda
+lucida
+Benth.
+Rubiace
+ae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Mor_sen
+Morelia
+senegale
+nsis
+A.Rich.
+Rubiace
+ae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Neo_mac
+Neocarya
+macrophy
+lla
+(Sabine)
+Mampatace
+-grande,
+tamankumb
+a,
+n'bute (umbatú),
+n'djapô, téhè (ba);
+bufângha (bf);
+nórònóròdó,
+Chiryso
+balanac
+eae
+0.731101
+955
+Dens. Média
+CARBOVEG
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 172
+Prance ex
+F.White
+tambacumb
+a
+nororodo, orodjô
+(bj); cura-bussuma
+(ff); bio, quió (fruto)
+(fl); batè (fs);
+curanaco, nando,
+náudo (fu); menau,
+bénôbénô, bitiague
+(mc); tambacumba
+(md); bénôbénô,
+bitiague, menau
+(mj); mavé
+New_lae
+Newbould
+ia laevis
+(P.Beauv.
+) Seem.
+Manduco-
+de-feticero
+bugampal (bf);
+canhom,
+cassinconco (bj);
+mãnduk-difuti-siru
+(cs); sucúndè (ff);
+fugumpa (fs);
+canhómburi (fu);
+becuape (mj);
+n´simkété, singèle
+(nl); angade-tcharre
+(td).
+Bignoni
+aceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Oxy_aby
+Oxytenant
+hera
+abyssinic
+a
+0.731101
+955
+Dens. Média
+CARBOVEG
+Par_big
+Parkia
+biglobosa
+(Jacq.)
+R.Br. ex
+G.Don
+faroba,
+farôba,
+farroba,
+farrobe
+gante, mehanté
+(ba); biáie, buiái
+(bf); canhando (o
+fruto), em-bando,
+nándo, n'andu,
+unhando (árvore)
+(bj); poroba (cs);
+caroubier-africain,
+mimosa-poupre (fr);
+néré, netch, nétè
+(fu); olélè, ulélè
+(mc); nétè (md); ií
+(nl); olélè, ulélè
+(pp); néri (ss); a
+Legumin
+osae/
+Mimosoi
+deae
+0.533 EFGP
+Par_exc
+Parinari
+excelsa
+Sabine
+meile, n'djano, pilé,
+undiano (ba);
+bussol, mantchoul
+(fruto) (bf);
+kankenom (fruto),
+nhêg-cuneme,
+uguene, ukenom
+(bj); mampatace,
+mampatás,
+mampataz (cr);
+cura (ff); bionai (fs);
+cura, curanaco (fu);
+minquela (mc);
+mampatá (md);
+Chiryso
+balanac
+eae
+0.604 EFGP
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 173
+bitchalam,
+n'tchalame (mj
+Per_lax
+Pericopsi
+s laxiflora
+(Benth. ex
+Baker)
+Meeuwen
+cúlèculè, culi-culi;
+culu-cula (fu); baba,
+buba (mj).
+Legumin
+osae/
+Mimosoi
+deae
+0.94 Pericopsis sp.
+em Brown 97
+Pho_rec
+Phoenix
+reclinata
+Jacq.
+sarábá, sérquê
+(ba); buadiá (bf);
+mandjaca (bj);
+bêlem (fu); bam-ò,
+corossedjambo,
+córóssó (md);
+bedjaca, m'jacai
+(mj); medjaca (pp).
+Palmae
+Pil_ret
+Piliostigm
+a
+reticulatu
+m (DC.)
+Hochst.
+pouúnquè (ba);
+canná, epamámbo
+(bj); bárquè (fu);
+fará (md); n'toncre,
+untoncre (pp).
+Legumin
+osae 0.641 Nygard &
+Elfving 2000
+Pil_tho
+Piliostigm
+a
+thonningii
+(Schumac
+h. &
+Thonn.)
+Milne-
+Redh.
+fará, panu-
+di-kankora
+boã, mansonca,
+mansanca,
+pouúnquè (ba);
+fará, bufárá (bf);
+canna, epamámbo,
+epandando (bj);
+budandepe,
+bupande (fs);
+baiqué, bárquè,
+barquedje,
+barqueiê, bongué,
+fará (fu); fará (md);
+impukui, m'bukui
+mukui (nl); n'tangré,
+n'toncre, untoncre
+(pp).
+Legumin
+osae
+0.765215
+5 CARBOVEG
+Pre_his Premma
+hispida 0.86 Premna sp.
+em Brown 97
+Pro_afr
+Prosopis
+africana
+(Guill. &
+Perr.)
+Taub.
+pau-carvão,
+pó-carvão,
+pó-de-
+carbom,
+po-di-
+carvom
+tentera (ba);
+buiengué,
+bussagan (bf);
+karbon, késeg-
+késeg (cs); tchelem
+(ff); tchalem-ai,
+tchela,
+tchelangadje,
+tchelem (fu); bal-
+tencali, culengô,
+culim-ô, djandjam-
+ô, quéssem-
+quéssem (md);
+djeiha, ogea (pp).
+Legumin
+osae/
+Mimosoi
+deae
+0.847 EFGP
+Pte_eri Pterocarp
+us
+pau-
+sangue, pó-
+psilá, sila (ba);
+buana (bf); bane,
+Legumin
+osae/ 0.616 EFGP
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 174
+erinaceus
+Lam. ex
+Poir.
+di-sangue báni, djêgo (fu);
+beléle (mc); kenê,
+quénò (md); beléle,
+beliadje, betéi,olei
+(mj); n'sila (nl);
+beliadje, betéi, ulei
+(pp).
+Mimosoi
+deae
+Pte_san
+Pterocarp
+us
+santalinoi
+des L'Hér.
+ex DC.
+mangantem
+dêssa, dessáha,
+déxa (ba); antante,
+benganta (bf);
+ebontonton (bj);
+djégo (ff);
+djecudjecumádje,
+d'jega, d'jego,
+mangantum,(fu);
+nitichiba, n'tisebá,
+sibá (nl).
+Legumin
+osae/
+Mimosoi
+deae
+0.44
+Pterocarpus
+sp. em Brown
+97
+Pyc_ang
+Pycnanth
+us
+angolensi
+s
+0.409
+Dens. Média
+GlobalWoodD
+ensityDatabas
+e
+Rap_pal
+Raphia
+palma-
+pinus
+(Gaertn.)
+Hutch.
+tara, tarra
+darré (ba); ápél
+(singular), befén
+(plural) (cb);
+mãmbãmpa-tara
+(cs).
+Palmae
+Rhi_har
+Rhizophor
+a
+harrisonii
+Leechm.
+Rhizoph
+oraceae 1 R. mangle em
+Brown 97
+Rhi_man
+Rhizophor
+a mangle
+L.
+tarafe,
+tarrafe
+senhea, sóle (ba);
+bufendê (planta),
+m’pendê
+(população de
+plantas) (bf); sem-
+ah (bm); irangá,
+ubá (bj); fussossá
+(dj); cassolaco (fl);
+palétuvier-rouge
+(fr); mancô (md);
+pidjeu (mj);
+bugáha,ugáha (pp).
+Rhizoph
+oraceae 1 Brown 97
+Rhi_rac
+Rhizophor
+a
+racemosa
+G.Mey.
+tarafe,
+tarrafe
+cóbácá, codega,
+iranga, uba (bj);
+Rhizoph
+oraceae 1 R. mangle em
+Brown 97
+Ric_heu
+Ricinoden
+dron
+heudelotii
+(Baill.)
+Pierre ex
+Heckel
+subsp.
+heudelotii
+bidjabarrana (bf); n'
+tonte (nl); tonta
+(ss).
+Euphorb
+iaceae
+0.364979
+7 CARBOVEG
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 175
+San_sen
+Sansevier
+ais
+senegam
+bica
+0.731101
+955
+Dens. Média
+CARBOVEG
+Sar_lat
+Sarcocep
+halus
+latifolius
+tambacumb
+a-di-
+santcho
+0.731101
+955
+Dens. Média
+CARBOVEG
+Sch_arb
+Schreber
+a arborea
+A.Chev.
+pau-goiaba,
+po-de-
+goiaba
+bugóiaba (planta),
+goiaba (fruto) (bf);
+maharra (bj); batirô
+(md).
+Oleacea
+e 0.607 EFGP
+Sor_jug
+Sorindeia
+juglandifol
+ia
+(A.Rich.)
+Planch.
+ex Oliv.
+m'riuol (ba);
+aionque (bj);
+balêbári (fruto),
+undêbári (planta)
+(cb); coxolourô,
+cupote-cuxolourô
+(fs); sandji- bombro
+(fu); lagari (mj);
+n'taluass,
+n'tchalúas,
+untchalbinass (nl);
+n'tata, untata (pp);
+ambilire (td).
+Anacard
+.
+0.731101
+955
+Dens. Média
+CARBOVEG
+Spo_mom
+Spondias
+mombin
+L.
+mandiple
+p’sale, sale, samé
+(ba); budjábual (bf);
+negae, ogáe, ugai
+(bj); báfôssé (fruto),
+upôssé (planta)
+(cb); mandipul (cs);
+bujendendem (fs);
+prunes-mombin (fr);
+tchálè (fu); n'pela,
+umpela (mc);
+nincom-ô (md);
+pilme (mj); n'pilo,
+umpilo (pp)
+Anacard
+.
+0.558804
+4 CARBOVEG
+Ste_tra
+Sterculia
+tragacant
+ha Lindl.
+nassino,
+pau-corda,
+pó-de-
+cabaço
+búè, umbufúrè (ba);
+ereitô, éritú, freitô
+(bj); dácud, úcud
+(cb); barquelei,
+tabáe, tchapelêguê,
+tehapeleque (fu);
+bamé (mc);
+d´jubitabô, tabá,
+tabô (md);
+ibulbbecana,
+n'bama, umbana
+(mj); bamba (pp);
+mangéboré (ss);
+atakssulé (td).
+Sterculi
+aceae 0.625
+Média de
+Sterculia para
+África em
+Brown 97
+Str_inn
+Strychnos
+innocua
+Delile
+Logania
+ceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 176
+Str_pus
+Strombosi
+a
+pustulata
+Oliv.
+osso-de-
+dari tinlake (nl). Olacace
+ae
+0.907940
+8 CARBOVEG
+Syz_gui
+Syzygium
+guineens
+e (Willd.)
+DC.
+subsp.
+guineens
+e
+pó-branco
+n'ocasso, nopêdê
+(bj); sotõno,
+trafidin-tera (cs);
+butote (dj); cadjô
+(ff); culelam-ô (md).
+Myrtace
+ae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Ter_alb
+Terminali
+a albida
+Scott-
+Elliot
+cabuto (bj); furanfã
+(fs); sirafitom (md);
+n'tangunha (nl).
+Combret
+aceae
+0.925114
+5 CARBOVEG
+Ter_avi
+Terminali
+a
+avicennioi
+des Guill.
+& Perr.
+culume (fu); sirá-
+fitom, sirafitom
+(md).
+Combret
+aceae 0.638 Nygard &
+Elfving 2000
+Ter_lax
+Terminali
+a laxiflora
+Engl. &
+Diels
+Combret
+aceae 0.916
+média de T.
+albida e T.
+macroptera
+CARBOVEG
+Ter_mac
+Terminali
+a
+macropter
+a Guill. &
+Perr.
+karkone,
+macete,
+macite
+fadi (ba); bulofôr
+(bf); djamba-catam
+(ff); bóde, bói (fu);
+bolóbô (mc); hólô-
+fôro (md); betáli,
+betcháli, betèlèdje,
+braqui, têlêjê (mj);
+n'kone (nl); n'túlam,
+untulam (pp).
+Combret
+aceae
+0.906501
+9 CARBOVEG
+Tre_afr
+Treculia
+africana
+Decne. ex
+Trécul
+subsp.
+africana
+var.
+africana
+bala, busaka,
+sobsob (cs);
+guilinte (ff);
+guibinte,
+mantchampudje
+(fu); mantchambô
+(md); becuáe (mj);
+bulóio (pp).
+Morace
+ae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Tre_ori
+Trema
+orientalis
+(L.)
+Blume
+buanhônhô (bf);
+nonha (bj); quere
+(fu).
+Ulmace
+ae
+0.327834
+4 CARBOVEG
+Tri_eme
+Trichilia
+emetica
+subsp.
+suberosa
+J.J.de
+Wilde
+pó-cetona búme, quécujon
+(fu); quécô (md)
+Meliace
+ae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Tri_mon
+Trichilia
+monadelp
+ha
+nequeno (bj). Meliace
+ae
+0.731101
+955
+Dens. Média
+CARBOVEG
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 177
+(Thonn.)
+J.J. de
+Wilde
+Tri_pri
+Trichilia
+prieuriana
+A.Juss.
+subsp.
+prieuriana
+cudaco, nequeno
+(bj); fulubudjone
+(dj); cudaco (fl);
+djambadjilom,
+quibiricarre (fu);
+benkar (nl);
+bugondjôle (pp).
+Meliace
+ae 0.63 Brown 1997
+Unknown Unknown 0.731101
+955
+Dens. Média
+CARBOVEG
+Vit_don
+Vitex
+doniana
+Sweet
+cetona,
+cetona-
+pequeno,
+cetona-
+preta
+múni, múri (ba);
+bugúa (planta),
+mangúa (fruto) (bf);
+n'bumbo, ubumbo,
+ubunvo (bj); bujinke
+(dj); prunier-noir
+(fr); búmé (fu);
+cutóbulo, cutubulô
+(md); bessápale,
+munsopane (mj);
+gúa (pp).
+Labiatae 0.4 Brown 1997
+Vit_fer
+Vitex
+ferruginea
+Schumac
+h. &
+Thonn.
+Labiatae 0.731101
+955
+Dens. Média
+CARBOVEG
+Vit_mad
+Vitex
+madiensis
+Oliv.
+subsp.
+madiensis
+azeitona,
+azeitona-
+pequeno,
+cetona,
+cetona-
+pequena
+muni (ba); bugúa
+(planta), mangúa
+(fruto) (bf); bumé,
+bume-ainacobe
+(fu); intompinha,
+n'ssogorro (nl);
+kukukunkuri (ss);
+anhongore (td).
+Labiatae 0.731101
+955
+Dens. Média
+CARBOVEG
+Voa_afr
+Voacanga
+africana
+Stapf ex
+Scott-
+Elliot
+blacahai (ba);
+epopoquê (bj); pau-
+de-borracha (cr);
+m'pumbu (nl).
+Apocyn
+aceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Voa_tho
+Voacanga
+thouarsii
+Roem. &
+Schult.
+Apocyn
+aceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Xer_stu
+Xeroderri
+s
+stuhlman
+nii (Taub.)
+Mendonç
+a &
+E.C.Sous
+a
+pó-de-
+sangue-
+branco
+bandanei, bani-
+dánè, bani-dani,
+bani-dárè (fu);
+n'bóbó (nl).
+Legumin
+osae/
+Mimosoi
+deae
+0.565 Nygard &
+Elfving 2000
+Xim_ame Ximenia limon-do- agara (bj); udôngul, Olacace 0.646 Nygard &
+
+PROJECT DESCRIPTION: VCS
+Version 3
+v3.2 178
+american
+a L.
+mato,
+limon-di-
+sancho
+undemna-aguidig
+(cb); citronier-de-
+mer, prunier-de-
+mer (fr); tcheme,
+tjeme (fu); tufissa
+(md); mampã (nl);
+tufissa,
+tumbecrinhaque
+(ss).
+ae Elfving 2000
+Xyl_acu
+Xylopia
+acutiflora
+(Dunal)
+A.Rich.
+guilibete-bade (fu) Annona
+ceae
+0.731101
+955
+Dens. Média
+CARBOVEG
+Xyl_aet
+Xylopia
+aethiopica
+(Dunal)
+A.Rich.
+malagueta-
+da-guiné,
+malagueta-
+preta,
+malagueta-
+preto-de-
+guiné,
+malagueta-
+di-mato
+sem-unte-pulhe,
+sentê (ba); eda,
+equêche, ocanhebo
+(bj); erauci (fs);
+guilé-balei, guilè-
+bétè (fu); idóié-
+iginal (mc); canafiô,
+janafim-ô (md);
+brôbleque, irú (mj);
+séla (nl); djodjô,
+djó-gófe, iobogôfo
+(pp); calantú, calatù
+(ss)
+Annona
+ceae 0.5 Brown 1997
+Africa
+Zan_lep
+Zanthoxyl
+um
+leprieurii
+Guill. &
+Perr.
+mádjá, mantcha,
+mantchu (ba);
+eranha (bj);
+barquelem (fu).
+Rutacea
+e
+0.731101
+955
+Dens. Média
+CARBOVEG

--- a/tests/fixtures/quick-check/vichada-validation-report-extracted.txt
+++ b/tests/fixtures/quick-check/vichada-validation-report-extracted.txt
@@ -1,0 +1,1833 @@
+VALIDATION REPORT: VCS Version 3
+v3.3
+1
+VALIDATION REPORT
+GROUPED PROJECT FOR COMMERCIAL FOREST PLANTATIONS
+INITIATIVES IN THE DEPARTMENT OF VICHADA
+Colombian Institute for Technical Standards and Certification – ICONTEC
+Project Title Grouped project for commercial forest plantations initiatives in the department of
+Vichada
+Version Version 1.1 – 31/05/2016
+Report ID VCSVA-15-003
+Report Title Validation Report “Grouped project for commercial forest plantations initiatives in
+the department of Vichada”
+Client Fundación Natura
+Pages 31
+Date of Issue 31-May-2016
+Prepared By Colombian Institute for Technical Standards and Certification – ICONTEC
+Contact Julio Alejandro Giraldo B.
+Phone: (571) 607 88 88 Ext.: 1381
+E-Mail: jgiraldo@icontec.org
+Address: Carrera 37 # 52 – 95 Bogotá – Colombia
+www.icontec.org
+Approved By Monica Vivas
+Work Carried
+Out By
+Angela Duque – Lead Auditor/Sectorial Specialist
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+2
+Summary:
+The Grouped Project for Commercial Forest Plantations Initiatives in the Department of Vichada aims
+to promote investments new commercial forest plantations in Puerto Carreño Municipality. The land
+within the project boundary is degraded grassland for all cases of the grouped instances, as they all
+occur in the same baseline conditions. For the first instance, it is expected to reforest around 12,172 ha
+with commercial plantations, using the species Acacia mangium, Eucalyptus tereticornis, Eucalyptus
+pellita, Hevea brasiliensis, Pinus caribaea, Gmelina arborea and other 18 native species. However, the
+potential total area is 25,000 ha.
+ICONTEC was contracted by Fundación Natura Colombia to conduct the project validation. The validation
+process was intended to assess the conformance of the project with the VCS rules and the
+methodology applied to the project. The validation audit was performed through a combination of
+document review, interviews with relevant personnel and on-site inspections. The project complies with
+all of the validation criteria, and the assessment team has no restrictions or uncertainties with respect
+to the compliance of the project with the validation criteria.
+The Project Description contains complete information about the project activities, project start date,
+project crediting period, project scale, project location, project boundary, baseline scenario,
+additionality and monitoring. The Project Description was designed to conform to the VCS Standard
+v.3.5, specifically as an ARR project under the AFOLU project types (AFOLU Requirements VCS v.3).
+The project applied the approved CDM Afforestation and Reforestation methodology: AR-ACM0003
+A/R Large-scale Consolidated Methodology “Afforestation and Reforestation of lands except wetlands”
+- Version 2.0.
+The purpose and scope of validation involve documental review, on-site visit, interviews and
+consultation of secondary information sources, findings statements, feedback with the project owner
+and elaboration of the final report. In order to carry out the validation, Verified Carbon Standard
+Program Guide v3.5, dated 8 October 2013 were taken into account and following the guidance
+provided in the VCS Validation and Verification Manual (8 October 2013, v3.1).
+During the validation, the ICONTEC team identified 30 findings (18 Clarification Requests and 12
+Corrective Action Request) that were addressed satisfactorily by the project proponent during the
+validation process to ensure that the Project Description fulfills the VCS program requirements. No
+CARs that could lead to a material discrepancy between the project and the project description were
+identified.
+Documentation review, interviews and on-site visit allowed ICONTEC to collect enough evidences to
+completely assess the validation criteria and determinate that the project is implemented according to
+the Project Description (Version 2.1, May 16, 2016). Removals were correctly calculated, based on the
+applied methodology.
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+3
+Table of Contents
+1 INTRODUCTION ..................................................................................................................... 4
+1.1 OBJECTIVE ......................................................................................................................................... 4
+1.2 SCOPE AND CRITERIA ......................................................................................................................... 4
+1.3 LEVEL OF ASSURANCE ........................................................................................................................ 4
+1.4 SUMMARY DESCRIPTION OF THE PROJECT ........................................................................................... 5
+2 VALIDATION PROCESS ........................................................................................................ 5
+2.1 METHOD AND CRITERIA ...................................................................................................................... 5
+2.2 DOCUMENT REVIEW ........................................................................................................................... 8
+2.3 INTERVIEWS ....................................................................................................................................... 9
+2.4 SITE INSPECTIONS .............................................................................................................................. 9
+2.5 RESOLUTION OF FINDINGS ................................................................................................................ 12
+2.6 FORWARD ACTION REQUESTS .......................................................................................................... 12
+3 VALIDATION FINDINGS ...................................................................................................... 12
+3.1 PROJECT DETAILS ............................................................................................................................ 12
+3.1.1 Project scope, type, technologies and measures implemented, and eligibility of the project12
+3.1.2 Project proponent .................................................................................................................. 13
+3.1.3 Project start date ................................................................................................................... 13
+3.1.4 Project crediting period .......................................................................................................... 13
+3.1.5 Project scale and estimated GHG emission reductions or removals .................................... 13
+3.1.6 Project location ...................................................................................................................... 14
+3.1.7 Conditions prior to project initiation ....................................................................................... 14
+3.1.8 Project compliance with applicable laws, statutes and other regulatory frameworks ........... 14
+3.1.9 Ownership and other programs ............................................................................................. 15
+3.1.10 Additional information relevant to the project, including: ....................................................... 15
+Eligibility criteria for grouped projects ............................................................................................................... 15
+Leakage management for AFOLU projects ...................................................................................................... 15
+3.2 APPLICATION OF METHODOLOGY ....................................................................................................... 15
+3.2.1 Title and Reference ............................................................................................................... 15
+3.2.2 Applicability ............................................................................................................................ 16
+3.2.3 Project Boundary ................................................................................................................... 16
+3.2.4 Baseline Scenario ................................................................................................................. 16
+3.2.5 Additionality ........................................................................................................................... 17
+3.2.6 Quantification of GHG Emission Reductions and Removals ................................................ 17
+Quantification of baseline emissions ................................................................................................................ 17
+Quantification of project emissions ................................................................................................................... 18
+Quantification of leakage .................................................................................................................................. 18
+3.2.7 Methodology Deviations ........................................................................................................ 18
+3.2.8 Monitoring Plan...................................................................................................................... 18
+3.3 NON-PERMANENCE RISK ANALYSIS ................................................................................................... 19
+3.4 ENVIRONMENTAL IMPACT .................................................................................................................. 19
+3.5 COMMENTS BY STAKEHOLDERS ........................................................................................................ 20
+4 VALIDATION CONCLUSION ............................................................................................... 20
+5 APPENDIX A: VALIDATION PROTOCOL ........................................................................... 21
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+4
+1 INTRODUCTION
+1.1 Objective
+According to VCS rules (VCS Standard v.3.5) the validation involves the assessment of the
+project description, regarding the project conformance to VCS rules and the applied methodology,
+including the procedure for the demonstration of additionality specified in the methodology.
+Additionally, to confirm that methods and procedures set out in the project description will
+generate verifiable GHG data and information when implemented.
+In this sense, the purpose of the validation audit activity was conduct an independent assessment
+of the project to determine whether the project complies with the validation criteria, as set out in
+the guidance documents listed in Section 1.2 of this report.
+1.2 Scope and Criteria
+The validation scope includes the independent and objective revision to determine that the project
+design meets the following criteria: VCS program (relevance, completeness, consistency,
+accuracy, transparency, and conservativeness), as well as the requirements described in the
+selected methodology (AR-ACM0003 “Afforestation and Reforestation of lands except wetlands” -
+Version 02.0.).
+In accordance with Section 4.3.4 of ISO 14064-3:2006, the scope was defined as follows:
+• The project and its baseline scenarios;
+• The physical infrastructure, activities, technologies and processes of the project;
+• The GHG sources, sinks and/or reservoirs applicable to the project;
+In accordance with Section 5.3.1 of the VCS Standard, the criterion for validation was the VCS
+Version 3, including the following documents:
+• VCS Program Guide
+• VCS Standard
+• VCS AFOLU Requirements
+• VCS AFOLU Non-Permanence Risk Tool
+ICONTEC, based on its ethics code and internal procedures for carrying out validation,
+verification and certification audits of VCS project activities (which, in turn, are based on the
+Voluntary Carbon Standard) focused on the identification of significant risks for credits
+generation, and verification of the mitigation.
+1.3 Level of Assurance
+Besides the above mentioned, during the verification ICONTEC ensured to fulfill the requirements
+additional to ISO 14064-3:2006 and ISO 14065:2007, set in VCS standard 2015, which are as
+follows:
+ The level of assurance is reasonable for validation;
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+5
+ The criteria is VCS 2013 or other GHG Program as approved under the VCS Program;
+ The objective is in conformance with the VCS 2013 requirements and VCS program
+methodologies as applicable to the specific project; and
+ The project is classified like a Project (Less than or equal to 300,000 tons of CO2e per year).
+In consequence, the materiality with respect to the aggregate of errors, omissions and
+misrepresentations relative to the total reported GHG removals, is five per cent.
+1.4 Summary Description of the Project
+Project Proponent(s): Fundación Natura Colombia
+Title of project activity: Grouped Project for Commercial Forest Plantations
+Initiatives in the Department of Vichada
+Baseline and monitoring
+methodology:
+AR-ACM0003 “Afforestation and reforestation of lands
+except wetlands” – Version 2.0.
+Sectoral scope(s): 14. Land-use, land-use change and forestry
+Location of the project activity: The grouped project is located in Puerto Carreño
+Municipality (Vichada, Colombia). The project area for
+the first instance corresponds to the planted areas
+inside the properties of La Pedregoza, El Toro,
+Canapro, El Diamante and Horizonte Verde, located at
+the veredas Caño Negro, Aceitico, La Esperanza and
+Campo Alegre, in the municipality of Puerto Carreño.
+Project crediting period: The total length of the grouped project-crediting period
+is 30 years.
+Crediting period start date: The start date of the crediting period is June 15, 2011.
+Crediting period end date: The end date is June 14, 2041.
+2 VALIDATION PROCESS
+2.1 Method and Criteria
+The validation consisted of the following four phases: i) a desk review and investigation on
+secondary sources of information, ii) on-site assessment iii) the resolution of findings and iv)
+issuance of the final validation report with the conclusion, as follows:
+06/03/2016
+to
+12/03/2016
+Desk Review
+Developing the Planning of the validation activities.
+14/03/2016
+Opening Meeting
+ Introduction of auditor
+ Audit objective
+ Schedule discussion/remarks
+ Preparation of sample plot visits
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+6
+ Questions
+Project Description, Sectoral scope and project type
+Project location and project boundary (GIS and Project sites)
+Methodology applicability
+Assessment of the baseline scenario – selected alternatives.
+Project additionality – Tools and assessment results.
+Ex-ante Quantification of Emission Reductions – estimation of the net
+anthropogenic removals by sinks (methodology equations) evidence for input
+data and parameter to the VER calculations, leakage (Uncertainty and
+conservativeness)
+Monitoring Plan
+Description and explanations about environmental / social impacts and
+stakeholder’s consultation.
+Non-Permanence Risk Tool and the Non-Permanence Risk Report.
+The application of tool and the number of credits that the project proponent
+deposits into the reserve of non-tradable credits, the AFOLU pooled buffer
+account.
+Field visit
+Project location and project boundary - Confirmation of Project sites and
+project boundaries
+Management activities and baseline scenario
+Stratification on field
+Planting Plan and monitoring plan implementation
+18/03/2016 Partial Closing meeting with PP.
+16/05/2016
+Project owners submits relevant documentation to addressing (Corrective
+Actions Requests
+(CARs)/Clarification Requests (CLs) in one submission to DOE/AIE
+21/05/2016
+to
+22/05/2016
+Review by the VCS Validation team of documentation submitted by the Client
+in order to close all CARs/ CLAs / FARs
+23/05/2016 Writing of the draft report after closure of all CARs/ CLs
+25/05/2016
+to Internal Technical Review
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+7
+28/06/2016
+31/05/2016
+to
+01/06/2016
+Adjustments to the final validation report and relative documents to
+submission, according to the findings spotted by the technical reviewer team
+02/05/2016 Project Submission to Project Participant of Final Validation Report
+The criteria allow the validation/verification guidance provided by VCS Standard and the rules
+related to AR-CDM methodology applied. In consequence, the following documents were used to
+assess this project:
+• VCS Standard, 25 March 2015, Version 3.5,
+• VCS Guidance Validation and Verification Manual, 8 October 2013, v3.1
+• VCS Project Description: VCS Version 3.2
+• VCS Agriculture, Forestry and Other Land Use (AFOLU) Requirements, 8 October 2013,
+v3.4
+• VCS Guidance. AFOLU Guidance: Additional guidance for VCS Afforestation,
+Reforestation and Revegetation projects using CDM Afforestation/Reforestation Methodologies, 8
+March 2011
+• VCS Non-Permanence Risk Report Template, v3.1 (4 October 2012)
+• VCS Monitoring Report Template, Version 3
+• AR-ACM0003. A/R Large-scale Consolidated Methodology, Afforestation and
+reforestation of lands except wetlands, Version 02.0 (4 October 2013)
+• A/R Methodological tool “Combined tool to identify the baseline scenario and
+demonstrate additionality in A/R CDM project activities” (Version 01)
+• A/R Methodological tool. Estimation of carbon stocks and change in carbon stocks of
+trees and shrubs in A/R CDM project activities (Version 04.1)
+• A/R Methodological Tool. Estimation of non-CO2 GHG emissions resulting from burning
+of biomass attributable to an A/R CDM project activity” (Version 04.0.0)
+• A/R Methodological Tool. Estimation of carbon stocks and change in carbon stocks in
+dead wood and litter in A/R CDM project activities (Version 3.0)
+• A/R Methodological Tool. Estimation of the increase in GHG emissions attributable to
+displacement of pre-project agricultural activities in A/R CDM project activity (Version 02.0)
+• A/R Methodological Tool. Calculation of the number of sample plots for measurements
+within A/R CDM project activities (Version 02.1.0)
+• A/R Methodological Tool. Demonstrating appropriateness of allometric equations for
+estimation of aboveground tree biomass in A/R CDM project activities (Version 01.0.0)
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+8
+• A/R Methodological Tool. Demonstrating appropriateness of volume equations for
+estimation of aboveground tree biomass in A/R CDM project activities” (Version 01.0.1)
+Documentation review, interviews and on-site visit allowed ICONTEC to collect enough evidences
+to completely assess the validation criteria and determinate that the PD (Version 2.0, May 11,
+2016) is in conformance with the rules and VCS criteria. Removals were correctly calculated,
+based on the applied methodology. ICONTEC can confirm that the GHG removals are calculated
+without material misstatements. The validation protocol resulting from the assessment of the
+project is enclosed in Appendix A of this report.
+The validation team consists of the personnel described in Table 1.
+Table 1: Validation Team
+Role/Qualification Last
+Name
+First
+Name Country
+Type of involvement
+Desk
+review
+Site
+visit/Interviews Reporting
+Lead Auditor /
+Sectoral Expert Duque Angela Colombia X X X
+The Validation Team is qualified in accordance with ICONTEC qualification scheme for VCS
+validation and verification.
+2.2 Document Review
+The documentary review was performed in March 06-12, 2016, based on the information
+provided by the Project Proponent before the on-site visit. This documentation was compared
+with: Voluntary Carbon Standard 2015 and Voluntary Carbon Standard AFOLU Guidance 2013.
+This information crosschecking allowed identifying several findings that were declared in
+Appendix A - Validation Protocol. In addition, the following documents, among others were
+checked:
+The Project Description VCS - v. 01, 18/02/2016 (PD_ARVichada_160218_V01) and v.2.1,
+16/05/2016 (PD_ARVichada_ 160516_V02.1).
+The applicable approved methodology AR-ACM0003 “Afforestation and Reforestation of lands
+except wetlands” (version 02.0) and related Tools.
+Project Area (SIG, supporting maps and shapes) and Eligibility Analysis (Consolidado de
+areas_160516, Núcleos elegibilidad, Bosque no bosque 2001-2011)
+Agreement and Commitment landowners (Commitment letters, CL_Canapro, CL_El Diamante,
+CL_El Toro, CL_Horizonte Verde, CL_La Pedregoza, and signed “Otrosi” 01/02)
+The estimated GHG removals (CANAPRO_160505, ElDiamante_160505, ElToro_160505,
+HorizonteVerde_160505, LaPedregoza_160505, PlantingPlan_160505 and Summary)
+VCS Non-Permanence Risk (Folders Non permanence risk: Canapro, El Diamate, El Toro, HV,
+La Pedregoza)
+Forestry Management Plans (Folders titled PMFS El Diamante, Horizonte Verde, Canapro, LA
+Pedregoza and El Toro)
+Land Tenure and related information with each property included in the grouped project (Proof of
+Title)
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+9
+Sources of Equations & default values (Torres y Del Valle, 2007; Vega y González, 2003; IPCC
+GPG-LULUCF, 2003 among others)
+Stakeholder consultation (Stakeholder Consultation Report GFV, Assistance registry, received
+comments and photographic evidence)
+The whole documentation was reviewed and a validation audit plan was completely carried out
+during the validation activities.
+2.3 Interviews
+Between 14/03/2016 to 18/03/2016 a site visit to the project was undertaken. Interviews were
+conducted with Beatriz Zapata (Forestry Project Developer Carbono & Bosques) and Andrea
+Vera (Forestry Project Developer, South Pole Group - SPG).
+Interviews were carried out to assess understanding of program requirements and to determine if
+the Project Description is in accordance with the applied methodology. In consequence, on the
+interviews with the project developer (Research Center Carbono & Bosques and South Pole
+Group) and the Project Participants, ICONTEC audited in particular the procedures to
+determinate project boundary and baseline scenarios, carbon calculation, land eligibility as well
+as proof of land tenure/ownership, including leakage. In addition, the relevant issues related with
+the Monitoring Plan. During the on-site visit the following people were interviewed (Table 2).
+Table 2: Interviews
+Project Participant Name Position
+Canapro Nubia Flórez Administrative Coordinator
+Canapro Adiela Henao Secretary
+Canapro Eduardo Ulloa Administrator
+Canapro Jhon Jairo Jiménez Supervisor
+Canapro Jorge Corcho Coordinator
+La Pedregoza Dexter Dombro Project Manager Amazonia El Vita
+La Pedregoza Cristian Espinel Forest Nursery Technical
+El Diamante Héctor Urrea In charge of the farm
+Horizonte Verde Diego Solano Administrator
+Horizonte Verde Jhoana Bermúdez Supervisor
+Horizonte Verde Juan Carlos Gaviria Genetic Improvement Technical
+Horizonte Verde Elkin Salazar Management Assistant
+El Toro Edilberto Castillo In charge of the farm
+The Desk Review and the On-site visit resulted in the validation protocol included in Appendix A.
+The use of this protocol ensures a complete validation process and allows obtaining the
+information needed to confirm the consistence of the PD whit the program requirements.
+2.4 Site Inspections
+The objectives of the on-site inspections performed were to:
+ Ensure that the geographic area of the project, as reported in the PD and the accompanying
+Shape file, is in conformance with the program and methodology requirements;
+ Perform a risk-based review of the project area to ensure that the project is in conformance
+the eligibility requirements of the VCS rules and the applicability conditions of the
+methodology; and
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+10
+ Perform a risk-based review of the project area to ensure that the project conforms to all
+other requirements of the VCS rules and the applied methodology.
+ In fulfillment of the above objectives, the audit team performed an on-site inspection of the
+project area on March 14-18, 2016.
+ During field reconnaissance, GPS waypoints were collected at boundaries and other
+significant features including locations where photos were taken.
+The eligible areas in the first instance include a total of 12,172 hectares with planted areas
+distributed in 42 sites on the eight strata. The shape file and maps of all eligible areas was
+available.
+The project area and the site inspections were completed to confirm the project boundaries, verify
+baseline and check species, age and density of plantings. Site inspections were also conducted
+to evaluate the consistency of the designed stratification. The project site and plot location were
+confirmed with GPS.
+The project boundary was visited, regarding the baseline conditions and the project stratification.
+ICONTEC defined a sample size for the sites visited. Those sites were selected randomly, by
+strata, in the list of plots and identified in field by using a GPS with and accuracy of <10m.
+According to that, a total of 14 sites were checked, including representative samples for the
+identified strata. The sites visited during the validation are provided in Table 3.
+Table 3: Sites visited
+Species/Planting year Strata POINT_X POINT_Y
+Acacia 2013 3 -68.1495270 5.8196520
+Acacia 2013 3 -68.1482040 5.8275920
+Acacia 2013 3 -68.1514460 5.8306150
+Acacia 2013 3 -68.1568920 5.8293080
+Acacia 2013 3 -68.1560840 5.8257800
+Acacia 2013 3 -68.1645840 5.8214170
+Acacia 2013 3 -68.1550100 5.8219290
+Acacia 2011 1 -68.1537460 5.8141980
+E pellita 2011 4 -68.3952520 5.6412140
+E tereticornis 2013 6 -68.3799680 5.5702460
+E tereticornis 2012 5 -68.3819600 5.5733120
+Acacia 2011 1 -68.3815290 5.5740500
+Acacia 2011 1 -68.3827960 5.5798430
+E tereticornis 2013 6 -68.3872120 5.5744200
+E tereticornis 2013 6 -68.3927130 5.5756850
+Acacia 2011 1 -68.3929920 5.5709780
+Acacia 2011 1 -68.3925230 5.5706210
+E tereticornis 2013 6 -68.3898120 5.5755950
+E tereticornis 2012 5 -68.3836030 5.5473160
+E tereticornis 2012 5 -68.3693420 5.5618520
+E tereticornis 2012 5 -68.3620810 5.5609040
+E tereticornis 2012 5 -68.3573270 5.5601910
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+11
+Species/Planting year Strata POINT_X POINT_Y
+E tereticornis 2012 5 -68.3570230 5.5538280
+Acacia 2011 1 -68.3580570 5.5450680
+Acacia 2011 1 -68.3597610 5.5410380
+Acacia 2011 1 -68.3623760 5.5468420
+E tereticornis 2013 6 -68.3497450 5.5642360
+E tereticornis 2013 6 -68.3488410 5.5619880
+Acacia 2011 1 -68.3421030 5.5414490
+Acacia 2011 1 -68.3394810 5.5394290
+Acacia 2011 1 -68.3392640 5.5379640
+Acacia 2011 1 -68.3453370 5.5337940
+E tereticornis 2012 5 -68.3347350 5.5495190
+E tereticornis 2012 5 -68.3371780 5.5618250
+E tereticornis 2012 5 -68.3376130 5.5660980
+Acacia 2011 1 -68.3952560 5.6414000
+Acacia 2011 1 -68.3959810 5.6502800
+Acacia 2011 1 -68.3995110 5.6493560
+Acacia 2012 2 -68.3946000 5.6536760
+Acacia 2011 1 -68.3967500 5.6589930
+Acacia 2011 1 -68.3988850 5.6644100
+Acacia 2011 1 -68.3988860 5.6644070
+Acacia 2011 1 -68.3922770 5.6670310
+Acacia 2011 1 -68.3859550 5.6698640
+Acacia 2011 1 -68.3930310 5.6622090
+E pellita 2015 7 -68.3598510 5.6776320
+E pellita 2015 7 -68.3563010 5.6766190
+E pellita 2015 7 -68.3509570 5.6770460
+E pellita 2015 7 -68.3452680 5.6753310
+E pellita 2015 7 -68.3504100 5.6768660
+E tereticornis 2013 6 -68.3429580 5.6699830
+E tereticornis 2013 6 -68.3425500 5.6640270
+E tereticornis 2013 6 -68.3435470 5.6536910
+E tereticornis 2013 6 -68.3411050 5.6481130
+Acacia 2013 3 -68.2796260 6.1303460
+Acacia 2013 3 -68.2776150 6.1334050
+Acacia 2013 3 -68.2759260 6.1403530
+Acacia 2013 3 -68.2760590 6.1425170
+Acacia 2012 2 -68.2764220 6.1444300
+Acacia 2012 2 -68.2772120 6.1469980
+Acacia 2012 2 -68.2794130 6.1446430
+Acacia 2013 3 -68.2813200 6.1407710
+Acacia 2013 3 -68.2784300 6.1352850
+Acacia 2012 2 -67.7834820 5.9221620
+Acacia 2012 2 -67.7795410 5.9295550
+Acacia 2012 2 -67.7956420 5.8897960
+Acacia 2011 1 -67.7290240 6.0608430
+Nativas 2014 8 -67.7358390 6.0508300
+E pellita 2012 5 -67.7420850 6.0602610
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+12
+2.5 Resolution of Findings
+Findings established during the validation can be seen as a non-fulfillment of validation criteria, or
+an identified risk to the fulfillment of the project objectives. The findings could take the form of a
+Corrective Action Request (CAR), Forward action Request (FAR) or a Clarification Request (CL).
+A Corrective Action Request (CAR) shall be raised if one of the following situations occurs:
+(a) Non-compliance with the monitoring plan or methodology are found in monitoring and
+reporting and has not been sufficiently documented by the project participants, or if the
+evidence provided to prove conformity is insufficient;
+(b) Modifications to the implementation, operation and monitoring of the registered project
+activity has not been sufficiently documented by the project participants;
+(c) Mistakes have been made in applying assumptions, data or calculations of emission
+reductions which will impact the quantity of emission reductions;
+(d) Issues identified in a FAR during validation to be verified during verification have not been
+resolved by the project participants.
+A Clarification Request (CL) shall be raised if information is insufficient or not clear enough to
+determine whether the applicable VCS requirements have been met.
+A Forward Action Request (FAR) is issued for actions if the monitoring and reporting require
+attention and/or adjustment for the next verification period.
+This report includes all CARs and CLs raised in this validation. The findings of the validation are
+stated in the following sections. The validation criteria (requirements), the means of validation and
+the results from verifying the identified criteria are documented in more detail in the validation
+protocol in Appendix A.
+As a result of this assessment there were found twelve (12) CARs, Eighteen (18) CLs and zero (0)
+FARs. CAR and CLs were closed based upon adequate responses from the project proponent
+which meet the applicable requirements; findings were reassessed before their formal acceptance
+and closure. All finding, included the issues raised, the responses provided by the project
+proponent and the final conclusions are contained in the Appendix A. All required changes are
+observable on PD Version 02.1 (16/05/2016).
+2.6 Forward Action Requests
+There are not Forward Action Requests.
+3 VALIDATION FINDINGS
+3.1 Project Details
+3.1.1 Project scope, type, technologies and measures implemented, and eligibility of the project
+The project is an AFOLU A/R, under sectoral scope 14 (AFOLU). As described in Section 4.2 of
+the VCS AFOLU Requirements, the project falls under the category of Afforestation,
+Reforestation and Revegetation.
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+13
+The Grouped Project aims to promote investments new commercial forest plantations in Puerto
+Carreño Municipality. The project is based on changing the use of land from extensive cattle
+ranching (of low productivity and which use prescribed burns to encourage the regrowth of
+degraded grassland) to sustainable forest production systems, based on good forestry practices,
+which will increase the forest cover in the project region and promote remnant natural forest
+restoration, thus generating a landscape of biological and productive corridors that produce
+financial, social and environmental services for the region. These impacts include the mitigation
+of climate change, regulation of water flows, expansion of habitat and conservation of the flora
+and fauna in the zone and the Orinoco region.
+3.1.2 Project proponent
+The project proponent is Fundación Natura.
+Fundación Natura is a non-profit and non-governmental organization (NGO) whose mission is to
+promote the conservation of biodiversity and the sustainable use of natural resources. Through
+the Agreement No. 02 of 2015, Fundación Natura established an alliance with the landowners
+and project owners, in order to co-finance and collaborate with the development of the project
+design for carbon markets and eventually with other related activities.
+3.1.3 Project start date
+The project start date, according to the PD (section 1.5), is June 15, 2011.
+The Annual Planting Report (2011), signals the date which started the reforestation activities in
+the nucleus La Pedregoza. The starting date was confirmed by ICONTEC according the
+requirements of VVM. The starting date is clearly defined and the evidence is sufficient to prove
+it. Accordingly, ICONTEC verified that the start date of the project activity is 15/06/2011, which
+corresponds to the date of the first registry of planting activities (32.6 hectares with 10 native
+species). Besides, the shape file and maps, including planted areas was reviewed. In this sense,
+the VVB completed a site inspection to confirm the planted sites and the date of plantation of
+each of those in the respective reports and formats used by the PP.
+The VVB also checked in person such information and discuss about it with the project owner. All
+files were checked and evaluated properly according to the standard requirements.
+3.1.4 Project crediting period
+The total length of the grouped project-crediting period is 30 years. The start date of the crediting
+period is June 15, 2011; the end date is June 14, 2041. There is no difference between the
+project start date and the project crediting period start date.
+3.1.5 Project scale and estimated GHG emission reductions or removals
+The project is considered a “project” according to the requirements of Section 3.9.1 of the VCS
+Standard.
+The project is estimated to result in GHG emission reductions and removals equivalent to
+39,506.38 tCO2e per year, over the project crediting period, for the first instance.
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+14
+3.1.6 Project location
+The project area for the first instance corresponds to the planted areas inside the properties of La
+Pedregoza, El Toro, Canapro, El Diamante and Horizonte Verde, located at the veredas Caño
+Negro, Aceitico, La Esperanza and Campo Alegre, in the municipality of Puerto Carreño. The
+Project description includes the geodetic coordinates of the central point, within the farms (Table
+4).
+Table 4: Project location – First Instance
+Nucleus Farm Coordinate X Coordinate Y
+Canapro Bita 1,040,338.61 1,172,503.33
+Caño Negro 1,033,726.78 1,145,425.19
+El Toro
+La Esperanza 1,004,503.46 1,150,573.95
+Las Maravillas 1,003,557.44 1,154,285.04
+El Toro 978,189.56 1,171,384.59
+La
+Pedregoza
+La Pedregoza (conformed by the
+properties La Pedregoza, El Sol and
+El Encierro)
+1,038,893.26 1,163,248.50
+El Diamante El Diamante 992,586.52 1,134,837.61
+Horizonte
+Verde
+El Sinaí 970,745.19 1,105,251.76
+El Reflejo 968,276.26 1,106,465.08
+La Fenicia 965,269.87 1,107,016.73
+San José 972,230.04 1,114,629.04
+El Silencio 977,677.24 1,116,001.90
+Pozo Azul 974,690.02 1,115,035.41
+La Estaca 969,996.24 1,115,742.06
+El Triunfo 983,664.04 1,114,753.83
+La Payara 987,784.69 1,149,968.49
+La concordia 986,765.04 1,115,441.17
+Los Eucaliptos 965,479.28 1,116,924.84
+El Pretesto 985,038.06 1,123,535.53
+La Diversión 984,102.26 1,120,523.56
+The project proponent provided KML files depicting the property boundaries, in conformance with
+the VCS Standard. Comparison of GPS waypoints taken during the on-site visit with the
+boundaries represented by the Shape files found no discrepancies.
+3.1.7 Conditions prior to project initiation
+The PD includes the description of the present environmental conditions of the area planned to
+the proposed A/R project activity, including a concise description of ecological and climate
+information (Temperature, precipitation, relative humidity, soils, geomorphology, hydrography,
+land use and biodiversity conditions), in conformance with the VCS Standard.
+3.1.8 Project compliance with applicable laws, statutes and other regulatory frameworks
+According PD, project complies with the national statutes and other regulatory frameworks.
+Domestic law does not require any special licenses or permits to plant a forest. The company
+complies with the Act 1377 of 2010 that regulates the activity for commercial reforestation and
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+15
+Regulatory Decree No. 2803 of 2010, by which is regulated the Ac 1377 of 2010 about
+registration of forest crops and agroforestry systems for commercial purposes, protective-
+productive plantations and the mobilization of primary processing products, among others.
+In addition, the project proponent presents adequately the information related with the other local
+regulation for the grouped project.
+3.1.9 Ownership and other programs
+ICONTEC confirmed that the Grouped project for commercial forest plantations initiatives in the
+department of Vichada is clear with respect to the form of participation of individuals or entities
+interested in the project, at the level of demonstrating the legal land tenure, the ownership rights
+of the resources and services obtained.
+Through the Agreement No. 02 of 2015, Fundación Natura established an alliance with the
+landowners and project owners, in order to co-finance and collaborate with the development of
+the project design for carbon markets and eventually with other related activities. The owners and
+legal representatives of the first instance agreed that Fundación Natura could act as project
+proponent, as they move towards the establishment of a formal figure that represents them.
+The project has not been registered under any other GHG program and is not seeking a second
+registration in the future. The current VCS project is completely independent from any other
+carbon project scheme being developed in Colombia such as REDD projects. The project is not
+seeking participation into any other GHG program.
+3.1.10 Additional information relevant to the project, including:
+Eligibility criteria for grouped projects
+In section 1.13 of the PD (Additional Information Relevant to the Project), PP provides a list of the
+eligibility criteria that project instances need to meet for the inclusion of any new eligible areas as
+instances willing to participate within the proposed grouped project, regarding the areas under
+control of the PP and the conditions about eligibility, baseline scenario and additionality
+conditions for the specified project activity and geographic area.
+ICONTEC confirms that definition of eligibility criteria complies with paragraph 3.4.9 of the VCS
+Standard version 3.5 (25 March, 2015).
+Leakage management for AFOLU projects
+The project is not required to manage leakage. See discussion under section 3.2.6 of this report.
+In summary, ICONTEC considers that the description, documentation and information related to
+the project description is accurate, complete and provides an understanding of the nature of the
+project.
+3.2 Application of Methodology
+3.2.1 Title and Reference
+The methodology applied to the project (hereafter termed “the methodology”) is a CDM A/R
+approved methodology AR-ACM0003: A/R Large-scale Consolidated Methodology Afforestation
+and reforestation of lands except wetlands – Version 2.0. The methodology can be found at
+https://cdm.unfccc.int/methodologies/DB/C9QS5G3CS8FW04MYYXDFOQDPXWM4OE.
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+16
+Tools referenced, and adequately applied by the project, are the following:
+- “Combined tool to identify the baseline scenario and demonstrate additionality in A/R CDM
+project activities”;
+- “Estimation of carbon stocks and change in carbon stocks of trees and shrubs in A/R CDM
+project activities”;
+- “Estimation of carbon stocks and change in carbon stocks in dead wood and litter in A/R CDM
+project activities”;
+- “Tool for estimation of change in soil organic carbon stocks due to the implementation of A/R
+CDM project activities”;
+- “Estimation of non-CO2 greenhouse gas (GHG) emissions resulting from burning of biomass
+attributable to an A/R CDM project activity”;
+- “Estimation of the increase in GHG emissions attributable to displacement of pre-project
+agricultural activities in A/R CDM project activity”.
+3.2.2 Applicability
+The applicability conditions for the methodology are:
+a) The A/R CDM project activity is implemented on degraded lands, which are expected to
+remain degraded or to continue to degrade in the absence of the project, hence the land
+cannot be expected to revert to a non-degraded state without human intervention;
+b) If at least a party of the project activity is implemented on organic soils, drainage of these
+soils is not allowed and not more than 10% of their area may be disturbed as result of soil
+preparation for planting;
+c) The land does not fall into wetland I category.
+The Project Proponent addresses each of these applicability conditions, correctly and including
+the consistency between the requirements and the project activity, in section 2.2 of the Project
+Description Version 02.1, 16.05.2016.
+By all-inclusive review and cross-checking, ICONTEC corroborated that the selected
+methodology applies to the project activity and was correctly applied with respect to the following:
+project boundary, baseline identification, formulae to determine emission reductions, additionality
+and monitoring methodology.
+3.2.3 Project Boundary
+The relevant GHG sources, sinks and reservoirs for the project and baseline scenarios are
+presenting in Table 16 on PD. GHG pools for the project include above-ground biomass, below-
+ground biomass, dead wood, litter and soil organic carbon. Emission of non-CO2 GHGs resulting
+from the loss of aboveground tree biomass due to fire (in the event that occur) is considered and
+calculated using the above ground biomass in trees of relevant strata.
+By reviewed information and the field visit, ICONTEC could conclude that the project boundary
+and selected sources, sinks and reservoirs are adequately justified for the project.
+3.2.4 Baseline Scenario
+The baseline scenario has been justified applying the A/R CDM Methodological tool “Combined
+tool to identify the baseline scenario and demonstrate additionality in A/R CDM project activities”.
+The land within the project boundary is defined as degraded grassland for all cases of the
+grouped instances.
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+17
+The project proponent follows the procedures outlined in the mentioned tool. The credible
+alternative land use scenarios that would have occurred on the land within the project boundary
+correspond to:
+• Continuation of the pre-project land use: Degraded pasture
+• Project activity on the land within the project boundary performed without being
+registered as the VCS AFOLU project
+Based on those alternative land uses identified, the project proponent identifies barriers to project
+implementation related to investment, technological and infrastructure (routes of transportation)
+and social aspects.
+In this sense, applying the decision tree presented in the “Combined tool to identify the baseline
+scenario and demonstrate additionality in A/R CDM project V.1.0 in the outcome of sub-step 3b is
+concluded that: Degraded pasture by extensive livestock and burning grassland is the land use
+alternative that does not face any of the identified barriers. Forest plantations with or without
+native species, without carbon revenues face all the identified barriers. Therefore, degraded
+pasture by extensive livestock and burning grassland is the baseline scenario.
+The audit team examined the documentation that provide evidence and justify the exactitude of
+the information and descriptions in PD.
+In accordance with the requirements of the baseline and additionality tool, a common practice
+analysis has been. Pertinent section on PD includes a discussion about. ICONTEC confirmed
+that the project initiative is different of the common practices in the region project.
+In concurs with observations made during the site visit and information provided by project
+proponent, in addition with the review of documentation related to the forestry sector and the
+dynamic of the land use in the project area, considering the evidence and application of the CDM
+tool, as required by the methodology, the audit team finds that the historical uses and the
+economic determinants of land use would most probably result in a continuation of degraded
+pasture are the most plausible baseline scenario and that the project activity is additional.
+3.2.5 Additionality
+See the discussion under section 3.2.4. Note that under the VCS Standard section 3.14,
+additionality is to be demonstrated and assessed in accordance with the requirements set out in
+the methodology.
+3.2.6 Quantification of GHG Emission Reductions and Removals
+Quantification of baseline emissions
+Baseline carbon stock changes are assumed to be zero. The PP applied the methodology (AR-
+TOOL14, Estimation of carbon stocks and change in carbon stocks of trees and shrubs in A/R
+CDM project activities Version 04.1, section 5), considering that the carbon stock in trees in the
+baseline can be accounted as zero, regarding the conditions of the tool indicated. The
+compliance of those conditions is guaranteed and the information reviewed determines that the
+indicators related with conditions under which carbon stock and change in carbon stock may be
+estimated as zero in the AR methodological tool has been considered and changes in carbon
+stocks in trees and shrubs in the baseline have been accounted as zero.
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+18
+ICONTEC verified the information available and the process implemented by PP during the
+documentary review and confirmed this information by observations on the first instance during
+the site visit.
+Quantification of project emissions
+The procedures and equations identified in the PD for calculating net GHG emissions follow the
+procedures and equations laid out in the methodology, including reference to specified CDM tools
+for individual pools.
+Quantification of leakage
+According the applied methodology, the emissions due to the displacement of agricultural
+activities should be account by leakages. As described in section 3.3 of PD, the project activity
+attributable to displacement is grazing. However, at the time of the project’s implementation, the
+properties were not being used for cattle or it was not significant (it was between 0.02 and 0.09
+animals / hectare, while the carrying capacity for cattle in this region is between 0.1 and 0.2
+animals / hectare). The few animals in the project boundary were moved to other existing grazing
+lands inside the farms. Accordingly, leakage emission attributable to the displacement of grazing
+activities is considered insignificant and hence accounted as zero.
+The audit team concludes that the Project Proponent’s assertion that leakage can be considered
+insignificant is justified and conforms to the VCS requirements.
+In regard to procedures in the correspondent requirement of VCS Standard, ICONTEC confirms
+the following statements:
+a) All relevant assumptions and data are listed in the project description, including their
+references and sources.
+b) All data and parameter values used in the project description are considered reasonable in
+the context of the project.
+c) All estimates of the baseline emissions can be replicated using the data and parameter
+values provided in the project description.
+According the information and evidence presented, the grazing activity is the only agricultural pre-
+project activity. Based on this analysis, leakage emissions for this project are considered
+negligible, and have been accounted as Zero. ICONTEC has been confirmed through visual
+inspection that grazing activities displacements are adequately referred in the PD. Also, the
+information collected during the interviews with the landowners confirmed the presented
+information. Finally, the audit team concludes that the methodology and any referenced tools
+have been applied correctly to calculate baseline emissions, project emissions, leakage and net
+GHG emission reductions and removals.
+3.2.7 Methodology Deviations
+The PD identifies no methodology deviations and none were found by the audit team.
+3.2.8 Monitoring Plan
+ICONTEC verified that a Monitoring Plan was included in the PD. The monitoring plan is intended
+to facilitate monitoring, recording, reporting, and verification activities necessary for assessment
+of the project performance and determination of the achieved emissions reductions in compliance
+with the approved methodology AR-ACM0003. This MP monitors the carbon stock changes in the
+A/R project activity.
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+19
+The assessment team has checked all the parameters presented in the monitoring plan against
+the requirements of the methodology. In this sense, the Monitoring Plan contains all necessary
+parameters, with adequate descriptions as to: Source of data, measurements procedures,
+monitoring frequency and QA/QC procedures to be applied.
+The Monitoring Plan is further described all the issues of the MP are included. The following
+components are addressed in the monitoring plan (MP) for quantifying the carbon sequestered
+under the proposed A/R Project: Data storage, information data management system, monitoring
+periods and frequency, monitoring and operational procedures, measurement and estimation of
+carbon content changes, stratification, plot size, quality assurance and quality control (QA/QC).
+Also, includes the operational and management structure to monitor actual GHG removals by
+sinks and any leakage generated by the proposed A/R project activity.
+The MP complies with the requirement of AR-ACM0003, Version 02.0 (Section 6). The audit team
+checked the parameters, source of data, measurements procedures, monitoring frequency and
+QA/QC procedures. The requirements for the monitoring of carbon stock changes were correctly
+applied. The boundary and the forest management were defined following the methodology and
+specifically for the project conditions. The selected monitoring frequency of the parameters is
+consistent with the requirements of methodology.
+Based on these descriptions and on documental verifications, the DOE deems that the technical
+and organizational design proposed in the Monitoring Plan is adequate to ensure that removals
+resulting from the project can be reported ex post and verified. The monitoring plan presented
+complies with the requirement of the methodology AR-ACM0003, Version 02.0.
+3.3 Non-Permanence Risk Analysis
+The project proponent has been determined the risk factors through a qualitative analysis,
+following the guidance of the VCS AFOLU Non Permanence Risk Tool and providing enough
+evidence and documentation. ICONTEC evaluated the risk assessment undertaken by the project
+proponent and assessed all data, rationales, assumptions, justifications and documentation
+provided by the project proponent to support the non-permanence risk rating.
+The result of the AFOLU non-permanence risk was 20%, in accordance with the supporting
+documents (VCS Non-Permanence Risk report for project sites: CANAPRO, El Diamante, El
+Toro, Horizonte Verde and La Pedregoza). Therefore, this percentage of the net GHG emission
+reductions or removals (178,308), have to be deposit into the AFOLU pooled buffer account.
+ICONTEC considers that the data provided to support the result is adequate and the risk score is
+appropriate.
+3.4 Environmental Impact
+As described on PD, the project proponent has been developed an environmental impact
+assessments with respect to the project. The project is developed as a system of well-managed
+commercial plantations, which seeks to minimize the impact of plantations on natural ecosystems
+and promote the maintenance of the different ecosystem services in the high plains, using criteria
+of environmental sustainability.
+The description about environmental impact is in way to the characteristics of project and project
+area. Additionally, the reforestation project does not need an impact assessment in Colombia.
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+20
+3.5 Comments by Stakeholders
+The project proponent explains correctly the stakeholder’s participation and present adequately
+the summary of the mechanisms for on-going communication and comments received (see
+Section 6 on PD).
+4 VALIDATION CONCLUSION
+ICONTEC performed the validation process of the project: “Grouped project for commercial
+forest plantations initiatives in the department of Vichada”. The validation was performed on
+the basis of the VCS Agriculture, Forestry and Other Land Use (AFOLU) Requirements, 8
+October 2013, v3.4 and VCS Standard, 25 March 2015, Version 3.5.
+The review of the Project Description and the subsequent follow up interviews has provided
+ICONTEC with sufficient evidence to determine the fulfillment of the stated criteria. The project
+correctly applies the following CDM methodology: AR-ACM0003 - “Afforestation and
+Reforestation of lands except wetlands” - Version 02.0.
+The grouped project is based on changing the use of land from extensive cattle ranching to
+sustainable forest production systems, based on good forestry practices, which will increase the
+forest cover in the project region and promote remnant natural forest restoration, thus generating
+a landscape of biological and productive corridors that produce financial, social and
+environmental services for the region. The objective of the first instance is to establish forest
+plantations with commercial species. The most used species for the project are the Acacia
+mangium, E. tereticornis which occupy more than 80% of the area intervened by the project.
+The project activity started in June 15, 2011. The total emission reductions from the project are
+estimated to be on the average of 39,506.38 tCO2e per year over the project crediting period. The
+Estimated net GHG emission reductions or removals (tCO2e) are 1,185,191.26. The emission
+reduction forecast has been checked and it is deemed likely that the stated amount is achieved
+because the underlying assumptions do not change.
+In summary, it is ICONTEC’s opinion that the project “Grouped project for commercial forest
+plantations initiatives in the department of Vichada”, as described in the Project Description
+(version 02.1), meets all relevant AFOLU VCS requirements. ICONTEC thus requests the
+registration of the project as a VCS project activity.
+Bogotá, 02/06/2016
+Mónica Vivas
+Director of conformity assessment
+ICONTEC
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+21
+5 APPENDIX A: VALIDATION PROTOCOL
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+Clarification Request CL1
+In the summary description of the project,
+the PP signals that the project include
+“restoring natural forest cover and
+creating a landscape of biological and
+productive corridors”; however, in the
+project activities there are not description
+about those aspects.
+Project Description
+Template v3.2
+11 – 05- 2016
+In the summary description of
+the project, the sentence…
+“restoring natural forest cover
+and creating a landscape of
+biological and productive
+corridors”… was modified in
+order to explain that natural
+forest cover restoration is not a
+project activity, but an expected
+impact of the project.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL2
+On section 1.4 (Other entities involved in
+the project) there are some missing
+information.
+Project Description
+Template v.3.2
+Section 1
+Project Details
+11 – 05- 2016
+On section 1.4, the missing
+information related to project
+owners, was added.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL3
+The project start date is not presented,
+specifying the day, month and year.
+AFOLU Requirements
+VCS v.3.4
+Section 3.2
+Project Description
+Template v.3.2
+Section 1.5
+Project Start Date
+11 – 05- 2016
+As indicated in the section 1.5 of
+the PDD, the project star date is
+June 15th, 2011 corresponding
+to the reforestation activity in La
+Pedregoza.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL4
+The reference about the species planted
+is not consistent. There is not included
+Simarouba amara in the Table 1.
+Moreover, there is not presented the
+description of the some species in the
+section.
+Project Description
+Template v.3.2
+Section 1.8
+Description of the
+Project Activity
+11 – 05- 2016
+The list of used tree species was
+revised, corrected and
+supplemented. Besides,
+description of the species was
+added.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+22
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+Clarification Request CL5
+The reference to the Table 2 is missing in
+the text.
+Project Description
+Template v.3.2
+Section 1.8
+Description of the
+Project
+11 – 05- 2016
+The reference to the Table 2
+was added in the text.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL6
+On section related to silvicultural
+activities, there are some texts incorrect,
+e.g. in the Table 4 is included Gmelina
+arborea, and the section related to project
+activities does not consider this species.
+Project Description
+Template v.3.2
+Section 1.8
+Description of the
+Project
+11 – 05- 2016
+In 2011 and 2012, 2.35 ha of
+Gmelina arborea were planted in
+La Pedregoza. This specie was
+included in the section 1.8.1. and
+Table 1.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL7
+Is not clear if the current land use
+presented in the section 1.10.1
+(Description of the grouped project
+location) corresponds to the project area.
+Besides, the last idea included in the list
+of activities, does not an activity, it is a
+consequence.
+Project Description
+Template v.3.2
+Section 1.10
+Conditions prior to
+project location
+11 – 05- 2016
+The current land use presented
+in the section 1.10.1,
+corresponds to the area in which
+the group project is expected to
+extend the project area. This
+clarification was incorporated in
+the PD.
+Adjustments to the paragraphs
+corresponding to current land
+use were also made.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL8
+On section 1.10.2, the description about
+La Pedregoza is not consistent with the
+documentation. The farm is conformed by
+three properties. On the other hand, the
+data related to farm area is incorrect:
+“..an area of 2.652 ha, which include
+7.187 ha eligible for project activities”.
+AFOLU Requirements
+VCS v.3.4
+Section 4.3
+Project Boundary
+AR-ACM0003 ver02.0
+Section 3
+A/R Methodological tool
+11 – 05- 2016
+On section 1.10.2, the
+description about La Pedregoza
+was corrected. Overall, La
+Pedregoza nuclei comprises
+three properties (La Pedregoza,
+El Encierro and El Sol) for a total
+area of 2,684 hectare, which
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+23
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+“Combined tool to
+identify the baseline
+scenario and
+demonstrate
+additionality in A/R
+CDM project activities”
+(Version 01)
+include 1,826 ha eligible for
+project activities.
+Clarification Request CL9
+The description about the land use in the
+farm El Diamante is not clear. The text
+indicates that “the lands of the farm are
+dedicated to the development of
+reforestation activities”; however, in the
+table there are other land uses.
+AFOLU Requirements
+VCS v.3.4
+Section 3.4
+Project Description
+Template v.3.2
+Section 1.10
+Conditions prior to
+project location
+11 – 05- 2016
+Modified. New information taken
+from the Management Forest
+Plan.
+Land use of El Diamante is
+Gallery Forest, flooded forest
+and Savanna.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL10
+The section 1.11 is not adequate. The PP
+enlists the regulatory frameworks, the
+national legislation, departmental
+legislation and municipal legislation.
+Nevertheless, is missing the
+demonstration of the compliance of the
+project with all and any relevant local,
+regional and national lows, statutes and
+regulatory frameworks.
+A/R Methodological tool
+“Combined tool to
+identify the baseline
+scenario and
+demonstrate
+additionality in A/R
+CDM project activities”
+(Version 01)
+Project Description
+Template v.3.2
+Section 1.11
+Compliance with laws,
+statues and other
+regulatory frameworks
+11 – 05- 2016
+The information regarding the
+compliance with any relevant
+local, regional and national laws,
+statutes and regulatory
+frameworks, was added in the
+section 1.11.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL11
+The right of use described on section
+1.12.1 is not appropriate. The PP
+explains the right of use related to the
+land in the project. On this section should
+be explained, and evidenced, the right of
+AFOLU Requirements
+VCS v.3.4
+Section 3.4
+Project Description
+Template v.3.2
+11 – 05- 2016
+The five nucleus will form an
+official entity that manage the
+carbon credits.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+24
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+use with respect to the GHG removals. Section 1.9
+Project Location
+Closed
+Clarification Request CL12
+The sentence: “Greater than one has
+continuous areas. Forest” (Section 1.13)
+is not clear. It is confusing.
+Project Description
+Template v.3.2
+Section 1.13
+Eligibility Criteria
+VCS Standard v.3.5(0)
+Section 3.4.1
+Grouped Projects
+11 – 05- 2016
+This sentence was corrected.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL13
+There is not an adequate explanation
+about the organic soils in the project
+boundary. In the Table 15, the PP have
+been included a text about the soils in the
+Colombian high plains, and references
+the PMES El Diamante, but the areas in
+the project are conformed by multiple
+properties.
+Project Description
+Template v.3.2
+Section 2.2
+Applicability of
+Methodology
+VCS Standard v.3.5(0)
+Section 4.3
+Applicability Conditions
+AR-ACM0003 ver02.0
+Section 2.2
+11 – 05- 2016
+The explanation about the soils
+in the project boundary was
+corrected in order to clarify that
+the project activities do not take
+place on organic soils. This
+explanation was also extended
+to include all the project
+properties.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL14
+About the applicability conditions of the
+ARAM-tool-15-v2.0 (Estimation of the
+increase in GHG emissions attributable to
+displacement of pre-project agricultural
+activities in A/R CDM project activity); the
+applicability condition included in the
+Table 16 is not appropriate. In this sense,
+the text in the column “Compliance” is not
+consistent with the condition described.
+Moreover, PP inscribes that “the
+implementation of project do not cause
+displacement of agricultural activities”;
+Besides in onsite visit was observed
+grazing activities in the project boundary.
+Project Description
+Template v.3.2
+Section 2.2
+Applicability of
+Methodology
+VCS Standard v.3.5(0)
+Section 4.3
+Applicability Conditions
+AR Tool 15 v 02.0
+11 – 05- 2016
+The text related to the
+compliance with the ARAM-tool-
+15-v2.0 was corrected according
+to the project conditions.
+The information about grazing
+activities inside the project farms
+was included in a new table on
+section 3.3.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+25
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+Therefore, it should be applied the Tool,
+and provide the correct evidence about
+the grazing activities.
+Clarification Request CL15
+On monitoring section (4.1. Data and
+parameters available at validation), about
+the factor Root-Shoot-Radio, the PP
+explain that parameters for the project
+sites and the region were not available at
+the time of validation , the project
+participant use for all tree species, the
+equation suggested by the ARAM Tool
+14; However, in page 75 the text is: “For
+all cases (except H. brasiliensis)….”.
+VCS Standard v.3.5(0)
+Section 4.8
+Monitoring
+AFOLU Requirements
+v3.4
+Section 4.0
+Monitoring
+Project Description
+Template v.3.2
+Section 4.1
+11 – 05- 2016
+On section 4.1., it was explained
+that the equation suggested by
+the ARAM Tool 14 was used to
+calculate the Root-Shoot-Ratio
+for all cases except H.
+brasiliensis.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL16
+Some data and parameters presented in
+section 4.2 should be contained also in
+section 4.1, available at validation.
+VCS Standard v.3.5(0)
+Section 4.8
+Monitoring
+AFOLU Requirements
+v3.4
+Section 4.0
+Monitoring
+Project Description
+Template v.3.2
+Section 4.1
+11 – 05- 2016
+The parameters A, Ai, VTREE, j,p,i,t
+and F(D,H) used to calculate ex
+ante project emissions, was
+included in the section 4.1
+(parameters available at
+validation).
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Clarification Request CL17
+On section 5.1 (Environmental Impact
+Assessment), the PP states: “The forest
+cover generated by the plantations,
+increase the connectivity of natural
+ecosystems, which favors the protection
+of gallery forests, wetlands and
+morichales. Additionally, the recovery of
+ecological niches for endemic, vulnerable
+or threatened species is favored”.
+Project Description
+Template v.3.2
+Section 5
+11 – 05- 2016
+Additional information added
+based on scientific papers.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+26
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+Moreover, “the project is also considered
+an activity of landscape restoration that
+incorporates objectives of conservation of
+biodiversity”. Those are theoretical
+sentences. It is necessary to explain and
+justify the relation to the project activities
+with that.
+Clarification Request CL18
+The PP does not include the complete
+references to sources of information in
+the some parts of PD (document or study
+used, author, date and if applicable the
+web site where it is available). Also, there
+are some mistakes in the sources
+identified.
+VCS Standard v.3.5(0)
+AR-ACM0003 ver02.0
+Project Description
+Template v.3.2
+11 – 05- 2016
+Complete references added.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Corrective Action Request CAR1
+The specie Anacardium occidentale not
+presents compliance with the forest
+definition; this specie should not be
+included in the carbon calculation.
+AR-ACM0003 ver02.0
+Section 3
+A/R Methodological tool
+“Combined tool to
+identify the baseline
+scenario and
+demonstrate
+additionality in A/R
+CDM project activities”
+(Version 01)
+11 – 05- 2016
+This specie was excluded from
+the ex-ante emission
+calculations.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Corrective Action Request CAR2
+The project location is presented in the
+Table 12. The farms contained in this
+table are not coherent with the properties
+included in the documentation; e.g. the
+farm La Pedregoza consists of three
+properties.
+AFOLU Requirements
+VCS v.3.4
+Section 4.3
+Project Boundary
+AR-ACM0003 ver02.0
+Section 3
+A/R Methodological tool
+“Combined tool to
+identify the baseline
+11 – 05- 2016
+La Pedregoza consists of three
+properties: La Pedregoza, El Sol
+and El Encierro (these were the
+previous names before being
+purchased by Amazonia El Vita).
+However, the cartographic
+information is entirely merged
+into a single polygon, with a total
+area of 2,684 ha. The geodetic
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+27
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+scenario and
+demonstrate
+additionality in A/R
+CDM project activities”
+(Version 01)
+Project Description
+Template v.3.2
+Section 1.9
+Project Location
+coordinates presented in the
+section 1.9, correspond to the
+entire polygon.
+This clarification was also
+included in the PD.
+Corrective Action Request CAR3
+According section 1.10, “the conditions
+existing prior to the project initiation is
+livestock under conventional conditions of
+low productivity”. In the same way, on
+page 37 is explained: “The predominant
+land use correspond mostly to extensive
+livestock activities”. However, in section
+3.3 (Leakage), the PP signals that “the
+properties were not being used for cattle
+or it was not significant”.
+Additionally, in the common practice
+analysis, the first scenario described is
+cattle farming. This is not clear for the
+conditions existing prior the project
+initiation, baseline scenario and the
+aspects related to additionality.
+VCS Standard v.3.5(0)
+Section 3.1
+AR-ACM0003 ver02.0
+Section 3
+A/R Methodological tool
+“Combined tool to
+identify the baseline
+scenario and
+demonstrate
+additionality in A/R
+CDM project
+activities”(Version 01)
+11 – 05- 2016
+The baseline scenario of the
+project activity corresponds to
+the degraded pasture lands,
+mostly by extensive cattle
+ranching and regular
+antropogenic burning of grasses.
+Additionality section modified.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Corrective Action Request CAR4
+The description presented about the farm
+El Toro is not consistent with the
+information included about the properties.
+The text signals: “is conformed by the
+farms La Esperanza, Las Maravillas, El
+Toro1 and El Toro Sur”, but the
+documentation submitted includes 2
+properties.
+AFOLU Requirements
+VCS v.3.4
+Section 4.3
+Project Boundary
+AR-ACM0003 ver02.0
+Section 3
+A/R Methodological tool
+“Combined tool to
+11 – 05- 2016
+El Toro consists of three
+properties: El Toro, Las
+Maravillas and La Esperanza.
+The documents related to the
+three properties were updated
+and added into the folder: Proof
+of Title.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+28
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+identify the baseline
+scenario and
+demonstrate
+additionality in A/R
+CDM project activities”
+(Version 01)
+Corrective Action Request CAR5
+On section 2.1, the PP indicates that the
+project “aims to reforest degraded lands,
+which are expected to remain degraded
+or to continue degraded in the absence of
+the project”. And, in Table 24
+(Parameters used for the estimation of
+the soil organic carbon), the management
+factor used corresponds to lands are
+identified as degraded lands. However,
+there is not enough evidence, in the
+document, that the lands in the project
+are degraded lands.
+AR-ACM0003 ver02.0
+Section 3
+A/R Methodological tool
+“Combined tool to
+identify the baseline
+scenario and
+demonstrate
+additionality in A/R
+CDM project activities”
+(Version 01)
+11 – 05- 2016
+The evidence that the lands in
+the project are degraded lands
+was added in the sections 2.4
+(Baseline scenario) and 2.5
+(Additionality).
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Corrective Action Request CAR6
+The analysis about the credible
+alternative land use scenarios to the
+proposed project activity does not include
+the reference related to another carbon
+project in the Vichada department.
+VCS Standard v.3.5(0)
+Section 3.14
+Additionality
+AR-ACM0003 ver02.0
+Section 3
+A/R Methodological tool
+“Combined tool to
+identify the baseline
+scenario and
+demonstrate
+additionality in A/R
+CDM project activities”
+(Version 01)
+11 – 05- 2016
+This reference was added in the
+PD
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Corrective Action Request CAR7
+The barrier analysis is not enough. Some
+discussions are not clear, and the
+VCS Standard v.3.5(0)
+Section 3.14
+Additionality
+11 – 05- 2016
+Due to forest plantations are
+22-05-2016
+The project proponent response
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+29
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+presented evidence is not sufficient. The
+PP have been include an explanation
+about the incentives and taxes that
+support the commercial reforestation; the
+idea is not consistent with the investment
+barrier (“About 90% of commercial
+reforestations are supported by incentives
+and tax benefits given by the
+government”).
+AR-ACM0003 ver02.0
+Section 3
+A/R Methodological tool
+“Combined tool to
+identify the baseline
+scenario and
+demonstrate
+additionality in A/R
+CDM project activities”
+(Version 01)
+supported by the CIF, this
+incentive is limited by the annual
+budget availability.
+adequately addresses the
+finding.
+Closed
+Corrective Action Request CAR8
+The PP should to improve the
+assessment about common practice
+analysis, including explanation and
+justification regarding the description
+presented.
+VCS Standard v.3.5(0)
+Section 3.14
+Additionality
+AR-ACM0003 ver02.0
+Section 3
+A/R Methodological tool
+“Combined tool to
+identify the baseline
+scenario and
+demonstrate
+additionality in A/R
+CDM project activities”
+(Version 01)
+11 – 05- 2016
+Common practice analysis
+modified.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Corrective Action Request CAR9
+It is not clear the statement, on page 114
+(PDD): “Leave some potential planting
+area as natural ecosystem, including
+savannahs”. We can assume that the
+areas on the project boundary are a
+natural ecosystem (savannas). In this
+sense, according VCS Standard,
+activities that convert native ecosystems
+to generate GHG credits are not eligible
+AFOLU Requirements,
+v3.4
+Section 3.1.6
+11 – 05- 2016
+The cover vegetation in the
+project boundary are degraded
+savannahs, which have been
+historically intervened for cattle
+ranching purposes. The
+dominant food and main source
+of dietary energy for livestock
+are pastures with high level of
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+30
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+under the VCS Program. lignification, therefore
+widespread slash-and-burn
+techniques and prescribed burns
+are used to encourage the
+regrowth of these pastures.
+These practices have generated
+fundamental changes in this
+ecosystem, including
+degradation and loss of
+biodiversity. It means that these
+are not natural but disturbed
+ecosystems that have been most
+significantly altered by
+anthropogenic pressure.
+Some changes were made in the
+PD in order to clarify this issue.
+Corrective Action Request CAR10
+The AFOLU Non-Permanence Risk Tool
+was adequately applied; however a
+complete source and justification of the
+information that confirms the assumptions
+and calculus is not presented in the
+pertinent report.
+Additionally, there are some aspects that
+were not appropriately considered in the
+analysis for the parameter M, in the tool
+(0.25). The presence of fires in the project
+area is high. In consequence, is
+necessary an adjustment, related to
+project in the Natural Risk Management,
+and the inclusion of the pertinent
+evidence.
+VCS Standard v.3.5(0)
+Section 3.2.2
+AFOLU Requirements
+VCS v.3.4
+Section 2.1/Section 3.7
+11 – 05- 2016
+The AFOLU Non-Permanence
+Risk Report was modified and
+supporting information is now
+complete.
+Besides, the presence of fires in
+the project area is considered
+high in the tool:
+Likelihood: Less than every 10
+years (the highest)
+Significance: Minor (5% to less
+than 25% loss carbon stocks).
+According to the information
+provided for the project owners,
+during the worst events 20% of
+the areas had been affected by
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+
+VALIDATION REPORT: VCS Version 3
+v3.3
+31
+Clarifications and corrective action
+requests Reference Summary of project proponent
+response Validation Team conclusion
+the fires, and the impact has
+been greater on younger
+plantations (i.e. on stands with
+lower carbon stocks).
+Finally, the score applied for M is
+0.5 (instead of 0.5).
+Corrective Action Request CAR11
+There are some planted areas before
+2011 (identified as the project start date),
+included in the project boundary. Those
+areas should be excluded; a cause of the
+compliance of the forest definition.
+VCS Standard v.3.5(0)
+Section 3.14
+Additionality
+AR-ACM0003 ver02.0
+Section 3
+A/R Methodological tool
+“Combined tool to
+identify the baseline
+scenario and
+demonstrate
+additionality in A/R
+CDM project activities”
+(Version 01)
+11 – 05- 2016
+These areas were excluded from
+the project boundary, and the
+information was updated in the
+PD and project boundary
+documentation.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed
+Corrective Action Request CAR12
+There is a property included in another
+carbon project, currently without
+registration. However, according VCS
+Standard, “where projects are eligible to
+participate under one or more programs
+to create another form of GHG-related
+environmental credit, but are not currently
+doing so, a list of such programs shall be
+provided to the validation/verification
+body”.
+VCS Standard, v3.5(0)
+Section 3.11.5
+11 – 05- 2016
+Currently the nucleus La
+Pedregoza is involved in another
+carbon project, using a local
+standard. The name of this
+program was added in the PD.
+22-05-2016
+The project proponent response
+adequately addresses the
+finding.
+Closed

--- a/tests/lib/quickCheckReviewQuestion.test.ts
+++ b/tests/lib/quickCheckReviewQuestion.test.ts
@@ -1501,8 +1501,8 @@ describe("Phase 4 router integration groundwork", () => {
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
+    expect(result.routerResult.status).toBe("no_evidence");
     expect(result.documentAnswer.status).toBe("unclear");
-    expect(result.documentAnswer.explanation).toContain("unsupported or out of scope");
     expect(result.documentAnswer.evidence).toEqual([]);
   });
 
@@ -1515,8 +1515,8 @@ describe("Phase 4 router integration groundwork", () => {
     });
 
     expect(result.queryIntentAnalysis?.intent).toBe("unsupported_or_out_of_scope");
+    expect(result.routerResult.status).toBe("no_evidence");
     expect(result.documentAnswer.status).toBe("unclear");
-    expect(result.documentAnswer.explanation).toContain("unsupported or out of scope");
     expect(result.documentAnswer.evidence).toEqual([]);
   });
 


### PR DESCRIPTION
## What

Fixes Document Q&A to work correctly on real validation reports and cover-table PDDs. Two main issues fixed:

1. **Document Q&A independently deciding status** — removed early-exit paths that bypassed the router
2. **Cover-table fact extraction** — added `title`/`formula` block types + new label aliases
3. **Heading-only answer suppression** — visible answer now prefers body text over heading text

## Changes

### 1. Document Q&A: remove independent status decisions (`documentQa.ts`)
- Removed early-exit blocks for unsupported/ambiguous intents
- Visible status always derives from `DeterministicRouterResult.status`

### 2. Heading regex: prevent multi-line matching (`quickCheckSectionExtractor.ts`)
- Changed `\s` to `[ \t]` in all `SECTION_HEADING_*` regexes
- Prevents page numbers from consuming real headings across newline boundaries

### 3. Cover-table fact extraction (`buildProjectFactContract.ts`)
- Added `"title"` and `"formula"` to `preferBlockTypes` for cover table fields
- Added `"Project Lifetime"`, `"GHG Accounting Period"`, `"Accounting Period"` as `creditingPeriod` label aliases
- Relaxed space-pattern word-count guard to 20 words for multiline fields
- Truncate annotations after `;` or `(` in space-pattern values
- Heading-label fallback with guard heuristic (≥1 comma or ≥2 interior capitalised words)

### 4. Heading-only answer suppression (`deterministicRouter.ts`)
- `buildSectionCandidate` now prefers body-text spans (paragraph, field, formula) over heading-only spans for the visible answer text

### 5. Regression fixtures and tests
- Added extracted text from VALID_REP_1530_31MAY2016, a.pdf (PLUM), PD_REDD_v1_130
- Smoke tests cover project location, methodology, crediting period, stakeholder consultation, marine biodiversity offsets for all three documents
- Visible-answer/router agreement contract test

## Verification

- `npx tsc --noEmit`: clean
- `npm run lint`: clean (0 warnings)
- `npm test` (relevant suites): 333 tests pass
- `npm run quickcheck:eval:corpus -- --strict`: 0 regressions, all thresholds met

### Per-document acceptance

**Vichada validation report:**
| Question | Result |
|----------|--------|
| Project location | answered, evidenceSpanIds, quote, page, section provenance |
| Methodology | answered |
| Crediting period | answered |
| Stakeholder consultation | answered, not no_evidence |
| Marine biodiversity offsets | no_evidence |

**a.pdf / PLUM cover table:**
| Question | Result |
|----------|--------|
| Project location | answered → Indonesia, Central Kalimantan |
| Crediting period | answered → 01 August 2022 – 31 July 2082 |
| Marine biodiversity offsets | no_evidence |

**PD_REDD_v1_130:**
| Question | Result |
|----------|--------|
| Project location | answered → includes Cacheu and Cantanhez |
| Stakeholder consultation | answered → body text (not just heading) |
| Marine biodiversity offsets | no_evidence |

## What this is NOT
- No LLM calls
- No OCR
- No vector search
- No UI changes
- No weakened eval thresholds