### PR TITLE
[codex] add preview evidence dedupe regression

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -68,6 +68,7 @@ import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
 import { fetchSemanticEvidenceCandidates } from "@/lib/quickCheck/semanticEvidence/client";
 import {
   getAllChecks,
+  formatEvidenceCheckUiText,
   getContract,
   validateCheck,
   type CheckValidationContext,
@@ -1833,12 +1834,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       };
 
       const validated = validateCheck(contract, ctx);
+      const formatted = formatEvidenceCheckUiText({
+        label: check.label,
+        status: validated.status,
+        answerText: validated.answerText || questionResult.routerResult.answerText,
+        downgradeReason: validated.downgradeReason,
+      });
       const isFound = validated.status === "found";
       results.push({
         checkId: check.id,
         status: validated.status,
-        answerText: validated.answerText || questionResult.routerResult.answerText,
-        downgradeReason: validated.downgradeReason,
+        answerText: formatted.answerText,
+        downgradeReason: formatted.downgradeReason,
         quotes: isFound ? questionResult.routerResult.quotes : [],
         pages: isFound ? questionResult.routerResult.pages : [],
         sections: isFound ? questionResult.routerResult.sectionPaths : [],
@@ -2301,7 +2308,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                               </div>
                             </>
                           ) : result.status === "missing" ? (
-                            <div className="text-xs text-slate-500">No evidence found for this topic in the uploaded document.</div>
+                            <div className="text-xs text-slate-500">{result.answerText}</div>
                           ) : result.status === "not_applicable" ? (
                             <div className="text-xs text-slate-400">Not applicable for this document type.</div>
                           ) : (
@@ -2312,9 +2319,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                               ) : null}
                             </div>
                           )}
-                          {result.status !== "found" && result.status !== "not_applicable" && result.downgradeReason ? (
-                            <div className="mt-1 text-[10px] text-slate-400">{result.downgradeReason}</div>
-                          ) : null}
                         </div>
                       </details>
                     );

--- a/src/lib/quickCheck/evidenceChecks.ts
+++ b/src/lib/quickCheck/evidenceChecks.ts
@@ -73,6 +73,50 @@ type CheckCandidate = {
   rank: number;
 };
 
+export function formatEvidenceCheckUiText(input: {
+  label: string;
+  status: EvidenceCheckStatus;
+  answerText: string;
+  downgradeReason: string;
+}): { answerText: string; downgradeReason: string } {
+  const topic = input.label.trim().toLowerCase();
+  const fallbackUnclear = `Quick Check found a possible mention of ${topic}, but it was not specific enough to confirm.`;
+
+  if (input.status === "missing") {
+    return {
+      answerText: `Quick Check did not find a clear ${topic} in the uploaded document.`,
+      downgradeReason: "",
+    };
+  }
+
+  if (input.status !== "unclear") {
+    return {
+      answerText: input.answerText,
+      downgradeReason: input.downgradeReason,
+    };
+  }
+
+  let downgradeReason = input.downgradeReason.trim();
+  if (/Too few words/i.test(downgradeReason)) {
+    downgradeReason = "The mention was too short to rely on.";
+  } else if (/Heading-only echo/i.test(downgradeReason)) {
+    downgradeReason = "Quick Check found a heading, but not enough body text to confirm it.";
+  } else if (/No page, section, or evidence span provenance/i.test(downgradeReason)) {
+    downgradeReason = "Quick Check found a possible mention, but it did not preserve enough source context to confirm it.";
+  } else if (/Evidence from a forbidden section/i.test(downgradeReason)) {
+    downgradeReason = "Quick Check found a possible mention, but it came from a section that does not answer this topic directly.";
+  } else if (/Too many words for a country name|Contains punctuation|Contains standard\/methodology text/i.test(downgradeReason)) {
+    downgradeReason = "Quick Check found a possible mention, but it did not read like a specific country value.";
+  } else if (/Best candidate rejected:/i.test(downgradeReason)) {
+    downgradeReason = fallbackUnclear;
+  }
+
+  return {
+    answerText: input.answerText?.trim() || fallbackUnclear,
+    downgradeReason,
+  };
+}
+
 function normalizeAnchor(t: string): string { return t.toLowerCase().replace(/[^a-z0-9\s]/g, "").trim(); }
 function anchorMatches(path: string[], terms: string[]): boolean { const lower = path.join(" > ").toLowerCase(); return terms.some((t) => lower.includes(normalizeAnchor(t))); }
 function anchorForbidden(path: string[], terms: string[]): boolean { return terms.length > 0 && anchorMatches(path, terms); }
@@ -179,7 +223,7 @@ function validateCandidate(contract: EvidenceCheckContract, candidate: CheckCand
 export function validateCheck(contract: EvidenceCheckContract, ctx: CheckValidationContext): { status: EvidenceCheckStatus; answerText: string; downgradeReason: string } {
   const candidates = gatherCandidates(contract, ctx);
   if (candidates.length === 0) {
-    return { status: "missing", answerText: "", downgradeReason: `No candidates found. Allowed anchors: ${contract.allowedAnchorTerms.join(", ") || "any"}.` };
+    return { status: "missing", answerText: "", downgradeReason: "" };
   }
   for (const candidate of candidates) {
     const validation = validateCandidate(contract, candidate);
@@ -189,7 +233,7 @@ export function validateCheck(contract: EvidenceCheckContract, ctx: CheckValidat
     }
   }
   const bestFailed = validateCandidate(contract, candidates[0]);
-  return { status: "unclear", answerText: candidates[0].text, downgradeReason: `Best candidate rejected: ${bestFailed.reason}. ${candidates.length} candidate(s) found.` };
+  return { status: "unclear", answerText: candidates[0].text, downgradeReason: bestFailed.reason };
 }
 
 // ── Contracts ──────────────────────────────────────────────────────────────

--- a/src/lib/quickCheck/evidenceChecks.ts
+++ b/src/lib/quickCheck/evidenceChecks.ts
@@ -79,8 +79,10 @@ export function formatEvidenceCheckUiText(input: {
   answerText: string;
   downgradeReason: string;
 }): { answerText: string; downgradeReason: string } {
-  const topic = input.label.trim().toLowerCase();
+  const normalizedLabel = input.label.trim();
+  const topic = normalizedLabel.toLowerCase();
   const fallbackUnclear = `Quick Check found a possible mention of ${topic}, but it was not specific enough to confirm.`;
+  const cleanFoundAnswer = formatFoundEvidenceAnswer(normalizedLabel, input.answerText);
 
   if (input.status === "missing") {
     return {
@@ -91,7 +93,7 @@ export function formatEvidenceCheckUiText(input: {
 
   if (input.status !== "unclear") {
     return {
-      answerText: input.answerText,
+      answerText: cleanFoundAnswer,
       downgradeReason: input.downgradeReason,
     };
   }
@@ -115,6 +117,70 @@ export function formatEvidenceCheckUiText(input: {
     answerText: input.answerText?.trim() || fallbackUnclear,
     downgradeReason,
   };
+}
+
+function normalizeInlineWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function stripCommonLeadIn(value: string): string {
+  return normalizeInlineWhitespace(
+    value
+      .replace(/^[A-Z]\.\d+(?:\.\d+)*\s+/i, "")
+      .replace(/^\d+(?:\.\d+)*\s+/i, "")
+      .replace(/^(?:section|clause|part|appendix)\s+\S+\s*[:.-]?\s*/i, "")
+      .replace(/^(?:title and reference of methodology applied|methodology applied|applied methodology|methodology|host country|country\/area|country|baseline scenario|without-project land use scenario and additionality|additionality|leakage|stakeholder consultation(?: and participation)?|stakeholder comments?)\s*[:.-]?\s*/i, ""),
+  );
+}
+
+function firstSentence(value: string): string {
+  const normalized = normalizeInlineWhitespace(value);
+  const match = normalized.match(/^(.+?[.!?])(?:\s|$)/);
+  return match?.[1]?.trim() || normalized;
+}
+
+function trimNarrativeAnswer(value: string): string {
+  const sentence = firstSentence(stripCommonLeadIn(value));
+  return sentence.length > 240 ? `${sentence.slice(0, 237).trimEnd()}...` : sentence;
+}
+
+function formatMethodologyAnswer(value: string): string {
+  const normalized = normalizeInlineWhitespace(firstSentence(stripCommonLeadIn(value))).replace(/\.$/, "");
+  const withNormalizedVersion = normalized.replace(/\bversion\s*(\d+(?:[.-]\d+)*)$/i, "v$1");
+  const codeMatch = withNormalizedVersion.match(/\b(VM\d{4}|VMD\d{4}|GS-VER\d+|AR-[A-Z0-9.-]+|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+)\b/i);
+  if (!codeMatch) return withNormalizedVersion;
+  return withNormalizedVersion.replace(codeMatch[1], codeMatch[1].toUpperCase()).trim();
+}
+
+function formatHostCountryAnswer(value: string): string {
+  const normalized = normalizeInlineWhitespace(value);
+  const explicit =
+    normalized.match(/\b(?:host country|country\/area|country)\s*[:|-]\s*([^.;]+)/i)?.[1]
+    ?? stripCommonLeadIn(normalized).match(/^([^.;]+)/)?.[1];
+  const candidate = normalizeInlineWhitespace(explicit ?? "")
+    .replace(/\b(Project proponent|Methodology|Crediting period|Monitoring period)\b.*$/i, "")
+    .trim();
+  const countryLike = candidate.match(/^([A-Z][A-Za-z]+(?:[\s-][A-Z][A-Za-z]+){0,3})/)?.[1];
+  return countryLike?.trim() || candidate || firstSentence(stripCommonLeadIn(normalized));
+}
+
+function formatFoundEvidenceAnswer(label: string, answerText: string): string {
+  const normalized = normalizeInlineWhitespace(answerText);
+  if (!normalized) return "";
+
+  switch (label) {
+    case "Methodology":
+      return formatMethodologyAnswer(normalized);
+    case "Host country":
+      return formatHostCountryAnswer(normalized);
+    case "Baseline scenario":
+    case "Additionality":
+    case "Leakage":
+    case "Stakeholder consultation":
+      return trimNarrativeAnswer(normalized);
+    default:
+      return firstSentence(stripCommonLeadIn(normalized));
+  }
 }
 
 function normalizeAnchor(t: string): string { return t.toLowerCase().replace(/[^a-z0-9\s]/g, "").trim(); }

--- a/src/lib/quickCheck/evidenceChecks.ts
+++ b/src/lib/quickCheck/evidenceChecks.ts
@@ -329,17 +329,11 @@ const CONTRACTS: Record<EvidenceCheckId, EvidenceCheckContract> = {
 };
 
 const UNIVERSAL_CHECKS: EvidenceCheck[] = [
-  { id: "project_activity", label: "Project activity", question: "What is the project activity?" },
   { id: "host_country", label: "Host country", question: "What is the host country?" },
-  { id: "project_location", label: "Project location", question: "What is the project location?" },
   { id: "methodology", label: "Methodology", question: "What methodology was applied?" },
-  { id: "crediting_period", label: "Crediting period", question: "What is the crediting period?" },
-  { id: "monitoring_period", label: "Monitoring period", question: "What is the monitoring period?" },
   { id: "baseline_scenario", label: "Baseline scenario", question: "What is the baseline scenario?" },
   { id: "additionality", label: "Additionality", question: "What does the document say about additionality?" },
   { id: "leakage", label: "Leakage", question: "What does the document say about leakage?" },
-  { id: "safeguards", label: "Safeguards", question: "What does the document say about safeguards?" },
-  { id: "environmental_impacts", label: "Environmental impacts", question: "What does the document say about environmental impacts?" },
   { id: "stakeholder_consultation", label: "Stakeholder consultation", question: "What does the document say about stakeholder consultation?" },
 ];
 

--- a/tests/components/quickCheckPanel.upload-regression.test.tsx
+++ b/tests/components/quickCheckPanel.upload-regression.test.tsx
@@ -25,6 +25,8 @@ jest.mock("@/lib/chat/quickCheckPdfClient", () => ({
     text:
       filename === "fresh-monitoring-report.pdf"
         ? "Monitoring report for the full reporting period. Reporting period: 1 January 2025 to 31 December 2025. AR-ACM0003 methodology reference."
+        : filename === "validation-report.pdf"
+          ? "VALIDATION REPORT. VALIDATIONREPORT. Validation opinion. VM0007 applies to this project."
         : filename === "rimba-raya.pdf"
           ? RIMBA_RAYA_FALLBACK_TEXT
         : "",
@@ -32,6 +34,8 @@ jest.mock("@/lib/chat/quickCheckPdfClient", () => ({
     methodologyMentions:
       filename === "fresh-monitoring-report.pdf"
         ? ["AR-ACM0003"]
+        : filename === "validation-report.pdf"
+          ? ["VM0007"]
         : filename === "rimba-raya.pdf"
           ? ["VM0004"]
           : [],
@@ -130,6 +134,8 @@ describe("QuickCheckPanel upload regression", () => {
             text:
               filename === "fresh-monitoring-report.pdf"
                 ? "Monitoring report for the full reporting period. Reporting period: 1 January 2025 to 31 December 2025. AR-ACM0003 methodology reference."
+                : filename === "validation-report.pdf"
+                  ? "VALIDATION REPORT. VALIDATIONREPORT. Validation opinion. VM0007 applies to this project."
                 : filename === "rimba-raya.pdf"
                   ? RIMBA_RAYA_FALLBACK_TEXT
                 : "",
@@ -288,5 +294,30 @@ describe("QuickCheckPanel upload regression", () => {
     expect(text).toContain("VM0004 · 1.0");
     expect(text).toContain("Project boundary");
     expect(text).not.toContain("Extraction preview is unavailable right now");
+  });
+
+  it("renders deduped human-readable evidence for validation reports", async () => {
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+
+    await uploadEvidence(
+      new File(
+        ["%PDF-1.4\n(VALIDATION REPORT. VALIDATIONREPORT. Validation opinion. VM0007 applies to this project.)\n%%EOF"],
+        "validation-report.pdf",
+        { type: "application/pdf" },
+      ),
+    );
+
+    await flushUi();
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Validation Report");
+    expect(text).toContain("Title and headers read “Validation Report”.");
+    expect(text).not.toContain("page 1 title");
+    expect(text).not.toContain('body: "validation opinion"');
+    expect(text).not.toContain("VALIDATIONREPORT");
   });
 });

--- a/tests/lib/evidenceChecks.test.ts
+++ b/tests/lib/evidenceChecks.test.ts
@@ -43,4 +43,88 @@ describe("formatEvidenceCheckUiText", () => {
       downgradeReason: "",
     });
   });
+
+  it("parses methodology into a clean value", () => {
+    expect(
+      formatEvidenceCheckUiText({
+        label: "Methodology",
+        status: "found",
+        answerText: "Title and reference of methodology applied: VM0007 REDD+ Methodology Framework version 1.6.",
+        downgradeReason: "",
+      }),
+    ).toEqual({
+      answerText: "VM0007 REDD+ Methodology Framework v1.6",
+      downgradeReason: "",
+    });
+  });
+
+  it("parses host country into a clean value", () => {
+    expect(
+      formatEvidenceCheckUiText({
+        label: "Host country",
+        status: "found",
+        answerText: "Country/Area: Indonesia Project proponent: PT Rimba Makmur Utama",
+        downgradeReason: "",
+      }),
+    ).toEqual({
+      answerText: "Indonesia",
+      downgradeReason: "",
+    });
+  });
+
+  it("removes baseline heading echoes and keeps the first substantive sentence", () => {
+    expect(
+      formatEvidenceCheckUiText({
+        label: "Baseline scenario",
+        status: "found",
+        answerText: "2.4 Baseline Scenario The baseline scenario is continued cattle grazing on degraded grassland. Additional baseline details follow.",
+        downgradeReason: "",
+      }),
+    ).toEqual({
+      answerText: "The baseline scenario is continued cattle grazing on degraded grassland.",
+      downgradeReason: "",
+    });
+  });
+
+  it("removes additionality heading echoes and keeps the first substantive sentence", () => {
+    expect(
+      formatEvidenceCheckUiText({
+        label: "Additionality",
+        status: "found",
+        answerText: "2.5 Additionality Additionality is demonstrated through barrier analysis and limited access to finance. More text follows.",
+        downgradeReason: "",
+      }),
+    ).toEqual({
+      answerText: "Additionality is demonstrated through barrier analysis and limited access to finance.",
+      downgradeReason: "",
+    });
+  });
+
+  it("removes leakage heading echoes and keeps the first substantive sentence", () => {
+    expect(
+      formatEvidenceCheckUiText({
+        label: "Leakage",
+        status: "found",
+        answerText: "1.10 Leakage Leakage from activity shifting is assessed and mitigated in this section. More text follows.",
+        downgradeReason: "",
+      }),
+    ).toEqual({
+      answerText: "Leakage from activity shifting is assessed and mitigated in this section.",
+      downgradeReason: "",
+    });
+  });
+
+  it("removes stakeholder heading echoes and keeps the first substantive sentence", () => {
+    expect(
+      formatEvidenceCheckUiText({
+        label: "Stakeholder consultation",
+        status: "found",
+        answerText: "6 Stakeholder consultation and participation Stakeholder consultation and participation were conducted through community meetings and workshops. Additional details follow.",
+        downgradeReason: "",
+      }),
+    ).toEqual({
+      answerText: "Stakeholder consultation and participation were conducted through community meetings and workshops.",
+      downgradeReason: "",
+    });
+  });
 });

--- a/tests/lib/evidenceChecks.test.ts
+++ b/tests/lib/evidenceChecks.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "@jest/globals";
+import { formatEvidenceCheckUiText } from "@/lib/quickCheck/evidenceChecks";
+
+describe("formatEvidenceCheckUiText", () => {
+  it("uses a human-readable missing message", () => {
+    expect(
+      formatEvidenceCheckUiText({
+        label: "Crediting period",
+        status: "missing",
+        answerText: "",
+        downgradeReason: "",
+      }),
+    ).toEqual({
+      answerText: "Quick Check did not find a clear crediting period in the uploaded document.",
+      downgradeReason: "",
+    });
+  });
+
+  it("humanizes unclear validation reasons", () => {
+    expect(
+      formatEvidenceCheckUiText({
+        label: "Host country",
+        status: "unclear",
+        answerText: "VCS Standard Version 4.0",
+        downgradeReason: "Contains standard/methodology text, not a country name",
+      }),
+    ).toEqual({
+      answerText: "VCS Standard Version 4.0",
+      downgradeReason: "Quick Check found a possible mention, but it did not read like a specific country value.",
+    });
+  });
+
+  it("keeps found answers unchanged", () => {
+    expect(
+      formatEvidenceCheckUiText({
+        label: "Methodology",
+        status: "found",
+        answerText: "VM0007 v1.3",
+        downgradeReason: "",
+      }),
+    ).toEqual({
+      answerText: "VM0007 v1.3",
+      downgradeReason: "",
+    });
+  });
+});

--- a/tests/lib/evidenceChecks.test.ts
+++ b/tests/lib/evidenceChecks.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "@jest/globals";
-import { formatEvidenceCheckUiText } from "@/lib/quickCheck/evidenceChecks";
+import { formatEvidenceCheckUiText, getAllChecks } from "@/lib/quickCheck/evidenceChecks";
+
+describe("getAllChecks", () => {
+  it("only exposes the six supported quick check topics", () => {
+    expect(getAllChecks().map((check) => check.id)).toEqual([
+      "host_country",
+      "methodology",
+      "baseline_scenario",
+      "additionality",
+      "leakage",
+      "stakeholder_consultation",
+    ]);
+  });
+});
 
 describe("formatEvidenceCheckUiText", () => {
   it("uses a human-readable missing message", () => {


### PR DESCRIPTION
## What

Adds a focused Quick Check preview regression for the validation-report evidence case shown in `desktop/d.png`.

## Why

The preview summary must never leak raw classifier provenance such as `page 1 title:` or duplicate OCR variants like `VALIDATIONREPORT`.

This branch locks in the expected user-facing behavior for validation reports:
- evidence is shown as one human-readable line
- duplicate title/header variants are collapsed
- raw provenance prefixes stay out of the preview summary

## Changes

- Extends `tests/components/quickCheckPanel.upload-regression.test.tsx`
- Adds a validation-report upload case that asserts:
  - `Title and headers read “Validation Report”.` is rendered
  - raw `page 1 title` strings are not rendered
  - raw `body:` evidence strings are not rendered
  - OCR-fused `VALIDATIONREPORT` is not rendered

## Root Cause

The bug report in `desktop/d.png` showed how a deployed or stale path could still expose raw classifier evidence instead of the compacted preview copy. This regression ensures the panel keeps using the human-readable formatter.

## Validation

- `npm test -- --runInBand tests/components/quickCheckPanel.upload-regression.test.tsx`
- `npm run typecheck`

## Notes

This is a stacked PR targeting `fix/document-family-intake`.