### PR TITLE
feat: add expectedAnswer and failureReason to eval corpus metadata

### DIFF
--- a/src/lib/quickCheck/evalCorpus/manifest.ts
+++ b/src/lib/quickCheck/evalCorpus/manifest.ts
@@ -15,6 +15,7 @@ const questionExpectationSchema = z.object({
   expectedRoute: z.enum(["project_fact_contract", "section_index", "table_index", "lexical_retrieval", "fallback"]).optional(),
   expectedEvidenceEmpty: z.boolean().optional(),
   goldEvidence: goldEvidenceSchema.optional(),
+  expectedAnswer: z.string().min(1).optional(),
   visibleAnswerStatus: z.enum(["likely_yes", "likely_no", "unclear"]).optional(),
   visibleAnswerTextContains: z.string().min(1).optional(),
   visibleAnswerEvidenceMin: z.number().int().min(0).optional(),
@@ -52,6 +53,7 @@ const fixtureSchema = z.object({
     questionExpectations: questionExpectationsSchema,
   }).strict(),
   notes: z.string().optional(),
+  failureReason: z.string().min(1).optional(),
 }).strict();
 
 const manifestSchema = z.object({

--- a/src/lib/quickCheck/evalCorpus/types.ts
+++ b/src/lib/quickCheck/evalCorpus/types.ts
@@ -32,6 +32,7 @@ export type EvalCorpusQuestionExpectation = {
   expectedRoute?: DeterministicRouterRoute;
   expectedEvidenceEmpty?: boolean;
   goldEvidence?: EvalCorpusGoldEvidence;
+  expectedAnswer?: string;
   visibleAnswerStatus?: DocumentAnswerStatus;
   visibleAnswerTextContains?: string;
   visibleAnswerEvidenceMin?: number;
@@ -61,6 +62,7 @@ export type EvalCorpusFixtureManifestEntry = {
   methodologyContext: EvalCorpusMethodologyContext;
   gold: EvalCorpusFixtureGold;
   notes?: string;
+  failureReason?: string;
 };
 
 export type EvalCorpusManifest = {


### PR DESCRIPTION
Goal 1: Extend existing eval corpus metadata.

Adds two optional fields to support the eval-driven learning loop without changing the runner:

- **`expectedAnswer`** on `EvalCorpusQuestionExpectation` — the exact expected answer text for a question (complements existing `visibleAnswerTextContains` substring check)
- **`failureReason`** on `EvalCorpusFixtureManifestEntry` — documents why this fixture exists / what real-world failure it catches

### Changes
- `src/lib/quickCheck/evalCorpus/types.ts` — 2 new optional fields
- `src/lib/quickCheck/evalCorpus/manifest.ts` — 2 new Zod schemas, `.strict()` preserved

### Verification
- `npx tsc --noEmit` ✓
- `npm run lint` ✓
- `npm test` (138 eval tests + full suite) ✓
- Existing corpus manifest loads and validates ✓
- No parallel runner, no threshold changes

### Next
Goal 2: Add Taisei PDD gold fixture using these new fields.