### PR TITLE
docs: mark Goals 0-3 done, advance to Goal 4

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, quick-check-document-pipeline, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
+Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, quick-check-document-pipeline, quickcheck-eval-learning, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
 Frozen lanes: agentic-verification.
 
 
@@ -176,12 +176,11 @@ Not active now:
 Status SSOT: `docs/roadmaps/quickcheck-eval-learning/phase-status.json`
 Details: `docs/roadmaps/quickcheck-eval-learning/ROADMAP.md`
 
-Lane status: Unknown
+Lane status: Active
 Make Quick Check improve from real PDD/document failures through controlled gold fixtures, regression tests, selector fixes, and strict eval gates. Production may collect corrections, but only reviewed fixtures and PRs may change behavior.
 
 Not active now:
-- All implementation goals (Goals 1–8)
-- Selector fixes
+- Goals 5–8
 - Correction export UI
 - Active corpus reporting
 

--- a/docs/roadmaps/quickcheck-eval-learning/phase-status.json
+++ b/docs/roadmaps/quickcheck-eval-learning/phase-status.json
@@ -1,13 +1,13 @@
 {
   "roadmapId": "quickcheck-eval-learning",
   "name": "Quick Check Eval-Driven Learning Loop",
-  "status": "not_started",
-  "currentGoalId": "qcel-0-roadmap-boundary",
+  "status": "active",
+  "currentGoalId": "qcel-4-messy-pdd-fixture-pack",
   "goals": [
     {
       "id": "qcel-0-roadmap-boundary",
       "title": "Roadmap and PR boundary",
-      "status": "not_started",
+      "status": "done",
       "dependsOn": [],
       "branch": "docs/quickcheck-eval-learning-roadmap",
       "doneCriteria": [
@@ -20,7 +20,7 @@
     {
       "id": "qcel-1-eval-corpus-metadata",
       "title": "Extend existing eval corpus metadata",
-      "status": "not_started",
+      "status": "done",
       "dependsOn": ["qcel-0-roadmap-boundary"],
       "branch": "feat/quickcheck-eval-corpus-metadata",
       "doneCriteria": [
@@ -33,9 +33,9 @@
     {
       "id": "qcel-2-taisei-gold-fixture",
       "title": "Add Taisei PDD gold fixture",
-      "status": "not_started",
+      "status": "done",
       "dependsOn": ["qcel-1-eval-corpus-metadata"],
-      "branch": "feat/quickcheck-taisei-gold-fixture",
+      "branch": "feat/quickcheck-taisei-pdd-gold-fixture",
       "doneCriteria": [
         "Taisei fixture added to existing eval corpus",
         "expected answers, quote anchors, pages, and section hints included",
@@ -45,7 +45,7 @@
     {
       "id": "qcel-3-core-selector-fixes",
       "title": "Fix five core selectors against Taisei",
-      "status": "not_started",
+      "status": "done",
       "dependsOn": ["qcel-2-taisei-gold-fixture"],
       "branch": "fix/quickcheck-core-authoritative-selectors",
       "doneCriteria": [
@@ -117,17 +117,26 @@
     }
   ],
   "phase_meta": {
-    "status": "not_started",
+    "status": "active",
     "summary": "Make Quick Check improve from real PDD/document failures through controlled gold fixtures, regression tests, selector fixes, and strict eval gates. Production may collect corrections, but only reviewed fixtures and PRs may change behavior.",
-    "current_focus": "Goal 0: Create roadmap files and separate this work from any in-flight selector PR.",
+    "current_focus": "Goal 4: Add representative messy PDD fixture pack to cover diverse document patterns.",
     "not_active_now": [
-      "All implementation goals (Goals 1–8)",
-      "Selector fixes",
+      "Goals 5–8",
       "Correction export UI",
       "Active corpus reporting"
     ],
     "last_updated_at": "2026-06-18T00:00:00Z"
   },
-  "pr_evidence": {},
-  "pr_notes": {}
+  "pr_evidence": {
+    "779": { "title": "docs: Quick Check eval-driven learning loop roadmap" },
+    "780": { "title": "feat: add expectedAnswer and failureReason to eval corpus metadata" },
+    "781": { "title": "test: add Taisei PDD gold fixture to eval corpus" },
+    "782": { "title": "fix: authoritative selectors for project title, host country, methodology" }
+  },
+  "pr_notes": {
+    "779": "Goal 0 complete: roadmap files created.",
+    "780": "Goal 1 complete: expectedAnswer and failureReason fields added to eval corpus types.",
+    "781": "Goal 2 complete: Taisei PDD gold fixture with baseline failure report, separate non-blocking manifest.",
+    "782": "Goal 3 complete: 5/6 core checks answered with provenance. Leakage/additionality unclear due to parser limitations."
+  }
 }


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- - RC5: in_progress -->
  <!-- - PR12: done -->
  <!-- - PR13: in_progress -->

For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactors with no SSOT impact), leave `slug: N/A`. The roadmap gates will skip.

Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

Visible UI changes to look for:
