### PR TITLE
feat: correction ingestion tests and answer synthesis (Goal 6)

### DIFF
--- a/src/lib/quickCheck/evidenceChecks.ts
+++ b/src/lib/quickCheck/evidenceChecks.ts
@@ -273,8 +273,12 @@ function scoreCandidateText(contract: EvidenceCheckContract, text: string): numb
 }
 
 function trimNarrativeAnswer(label: string, value: string): string {
-  const sentence = firstSentence(chooseNarrativeSentence(label, value));
-  return sentence.length > 240 ? `${sentence.slice(0, 237).trimEnd()}...` : sentence;
+  const chosen = chooseNarrativeSentence(label, value);
+  // Ensure the answer ends with a period (complete sentence).
+  let result = chosen.trim();
+  if (result.length > 0 && !/[.!?]$/.test(result)) result += ".";
+  if (result.length > 300) result = `${result.slice(0, 297).trimEnd()}...`;
+  return result;
 }
 
 function formatLeakageAnswer(value: string): string {
@@ -298,8 +302,14 @@ function formatMethodologyAnswer(value: string): string {
   const normalized = normalizeInlineWhitespace(firstSentence(stripCommonLeadIn(value))).replace(/\.$/, "");
   const withNormalizedVersion = normalized.replace(/\bversion\s*(\d+(?:[.-]\d+)*)$/i, "v$1");
   const codeMatch = withNormalizedVersion.match(/\b(VM\d{4}|VMD\d{4}|GS-VER\d+|AR-[A-Z0-9.-]+|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+)\b/i);
-  if (!codeMatch) return withNormalizedVersion;
-  return withNormalizedVersion.replace(codeMatch[1], codeMatch[1].toUpperCase()).trim();
+  const code = codeMatch?.[1]?.toUpperCase() ?? "";
+  // Extract methodology name: everything after the code, or the full text if no code found
+  const name = code
+    ? withNormalizedVersion.slice(withNormalizedVersion.toUpperCase().indexOf(code)).replace(/^[A-Z0-9.-]+\s*(?:\([^)]*\))?\s*/i, "").replace(/^[",\s>»]+/, "").trim()
+    : withNormalizedVersion;
+  if (!code && !name) return "";
+  if (!name) return `The project uses ${code}.`;
+  return `The project uses ${code}: ${name}.`;
 }
 
 function formatHostCountryAnswer(value: string): string {
@@ -310,8 +320,10 @@ function formatHostCountryAnswer(value: string): string {
   const candidate = normalizeInlineWhitespace(explicit ?? "")
     .replace(/\b(Project proponent|Methodology|Crediting period|Monitoring period)\b.*$/i, "")
     .trim();
-  const countryLike = candidate.match(/^([A-Z][A-Za-z]+(?:[\s-][A-Z][A-Za-z]+){0,3})/)?.[1];
-  return countryLike?.trim() || candidate || firstSentence(stripCommonLeadIn(normalized));
+  const countryLike = candidate.match(/^([A-Z][A-Za-z\u2019']+(?:[\s-][A-Za-z\u2019']+){0,5})/)?.[1];
+  const country = countryLike?.trim() || candidate || firstSentence(stripCommonLeadIn(normalized));
+  if (!country) return "";
+  return `The host country is ${country}.`;
 }
 
 function formatFoundEvidenceAnswer(label: string, answerText: string): string {

--- a/tests/fixtures/quick-check/corrections/taisei-host-country.json
+++ b/tests/fixtures/quick-check/corrections/taisei-host-country.json
@@ -1,0 +1,19 @@
+{
+  "documentId": "taisei-china-pdd",
+  "documentName": "2006Taisei_jChina_PDD.pdf",
+  "documentType": "CDM PDD",
+  "methodologyId": "ACM0010",
+  "checkId": "host_country",
+  "currentAnswer": "The People's Republic of China",
+  "currentStatus": "found",
+  "currentQuote": "The People's Republic of China",
+  "currentPage": 4,
+  "currentSection": "A.4.1.1 Host Party",
+  "evidenceSpanIds": ["host-country-span-1"],
+  "correctedAnswer": "The host country is the People's Republic of China.",
+  "correctedQuote": "The People's Republic of China",
+  "correctedPage": 4,
+  "correctedSection": "A.4.1.1 Host Party(ies)",
+  "confidence": 0.95,
+  "failureReason": ""
+}

--- a/tests/lib/evidenceChecks.test.ts
+++ b/tests/lib/evidenceChecks.test.ts
@@ -99,7 +99,7 @@ describe("formatEvidenceCheckUiText", () => {
         downgradeReason: "",
       }),
     ).toEqual({
-      answerText: "VM0007 v1.3",
+      answerText: "The project uses VM0007: v1.3.",
       downgradeReason: "",
     });
   });
@@ -113,7 +113,7 @@ describe("formatEvidenceCheckUiText", () => {
         downgradeReason: "",
       }),
     ).toEqual({
-      answerText: "VM0007 REDD+ Methodology Framework v1.6",
+      answerText: "The project uses VM0007: REDD+ Methodology Framework v1.6.",
       downgradeReason: "",
     });
   });
@@ -127,7 +127,7 @@ describe("formatEvidenceCheckUiText", () => {
         downgradeReason: "",
       }),
     ).toEqual({
-      answerText: "Indonesia",
+      answerText: "The host country is Indonesia.",
       downgradeReason: "",
     });
   });
@@ -252,7 +252,7 @@ describe("authoritative evidence check selectors", () => {
       rawText: PLUM_A_DOC_TEXT,
     });
 
-    expect(result.answerText).toBe("Indonesia");
+    expect(result.answerText).toBe("The host country is Indonesia.");
   });
 
   it("finds methodology from alternate methodology headings in PLUM", () => {

--- a/tests/lib/quickCheck/correctionIngestion.test.ts
+++ b/tests/lib/quickCheck/correctionIngestion.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import { buildReviewQuestionResult } from "@/lib/chat/quickCheckReviewQuestion";
+import { formatEvidenceCheckUiText } from "@/lib/quickCheck/evidenceChecks";
+
+const CORRECTIONS_DIR = path.resolve(process.cwd(), "tests/fixtures/quick-check/corrections");
+const FIXTURE_TEXT_DIR = path.resolve(process.cwd(), "tests/fixtures/quick-check");
+
+type CorrectionEntry = {
+  documentId: string;
+  documentName: string;
+  documentType: string;
+  methodologyId: string;
+  checkId: string;
+  correctedAnswer: string;
+  correctedQuote?: string;
+  correctedPage?: number | null;
+  correctedSection?: string;
+  confidence?: number;
+  failureReason?: string;
+};
+
+type CheckQuestion = {
+  id: string;
+  question: string;
+};
+
+const CHECK_QUESTIONS: Record<string, CheckQuestion> = {
+  host_country: { id: "host_country", question: "What is the host country?" },
+  methodology: { id: "methodology", question: "What methodology was applied?" },
+  baseline_scenario: { id: "baseline_scenario", question: "What is the baseline scenario?" },
+  additionality: { id: "additionality", question: "What does the document say about additionality?" },
+  leakage: { id: "leakage", question: "What does the document say about leakage?" },
+  stakeholder_consultation: { id: "stakeholder_consultation", question: "What does the document say about stakeholder consultation?" },
+  project_title: { id: "project_title", question: "What is the project title?" },
+};
+
+// Maps correction documentIds to raw PDD fixture files
+const DOCUMENT_FIXTURES: Record<string, string> = {
+  "taisei-china-pdd": "taisei-china-pdd-extracted.txt",
+};
+
+function loadCorrections(): CorrectionEntry[] {
+  const entries: CorrectionEntry[] = [];
+  if (!fs.existsSync(CORRECTIONS_DIR)) return entries;
+
+  for (const file of fs.readdirSync(CORRECTIONS_DIR)) {
+    if (!file.endsWith(".json")) continue;
+    const raw = fs.readFileSync(path.join(CORRECTIONS_DIR, file), "utf-8");
+    entries.push(JSON.parse(raw) as CorrectionEntry);
+  }
+  return entries;
+}
+
+function loadRawText(documentId: string): string {
+  const fixtureFile = DOCUMENT_FIXTURES[documentId];
+  if (!fixtureFile) throw new Error(`No fixture mapping for documentId: ${documentId}`);
+  return fs.readFileSync(path.join(FIXTURE_TEXT_DIR, fixtureFile), "utf-8");
+}
+
+function isCompleteSentence(text: string): boolean {
+  return /[.!?]$/.test(text.trim()) && text.trim().length >= 10;
+}
+
+function isGrammatical(text: string): boolean {
+  // Reject answers that start mid-word or with connector fragments
+  const trimmed = text.trim();
+  if (/^[a-z]/.test(trimmed)) return false;
+  if (/^(and|or|but|also|additionally|furthermore|moreover|however|therefore|thus|then|hence|so|>>|»)\b/i.test(trimmed)) return false;
+  if (/^project activity\s*:/i.test(trimmed)) return false;
+  if (trimmed.split(/\s+/).length < 3) return false;
+  return true;
+}
+
+function isTraceableToEvidence(answer: string, correction: CorrectionEntry): boolean {
+  const answerLower = answer.toLowerCase();
+  const expectedLower = correction.correctedAnswer.toLowerCase();
+  // Extract substantive terms from the corrected answer (skip articles/prepositions)
+  const keyTerms = expectedLower
+    .replace(/[.,;:!?()"“”']/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 3 && !["the", "this", "that", "with", "from", "does", "what", "says", "about", "project", "document", "host", "country", "uses", "people's"].includes(w));
+  if (keyTerms.length === 0) return true;
+  const missingTerms = keyTerms.filter((term) => !answerLower.includes(term));
+  return missingTerms.length <= Math.ceil(keyTerms.length * 0.5);
+}
+
+describe("Quick Check correction ingestion", () => {
+  const corrections = loadCorrections();
+
+  if (corrections.length === 0) {
+    it.skip("no correction fixtures found", () => {});
+    return;
+  }
+
+  test.each(corrections)("$checkId on $documentId produces a complete, grammatical, traceable answer", (correction) => {
+    const checkQuestion = CHECK_QUESTIONS[correction.checkId];
+    expect(checkQuestion).toBeDefined();
+
+    const rawText = loadRawText(correction.documentId);
+    const result = buildReviewQuestionResult({
+      claimText: checkQuestion.question,
+      methodologyId: correction.methodologyId,
+      methodologyVersion: "02",
+      rawPddText: rawText,
+    });
+
+    // Run through the same UI formatting pipeline
+    const formatted = formatEvidenceCheckUiText({
+      label: correction.checkId === "host_country" ? "Host country"
+        : correction.checkId === "methodology" ? "Methodology"
+        : correction.checkId === "baseline_scenario" ? "Baseline scenario"
+        : correction.checkId === "additionality" ? "Additionality"
+        : correction.checkId === "leakage" ? "Leakage"
+        : correction.checkId === "stakeholder_consultation" ? "Stakeholder consultation"
+        : correction.checkId,
+      status: result.routerResult.status === "answered" ? "found"
+        : result.routerResult.status === "unclear" ? "unclear"
+        : result.routerResult.status === "no_evidence" ? "missing"
+        : "unclear",
+      answerText: result.routerResult.answerText || "",
+      downgradeReason: result.routerResult.warnings.join("; "),
+    });
+
+    const answer = formatted.answerText.trim();
+
+    // Assert completeness: answer is a full sentence ending with punctuation
+    expect(isCompleteSentence(answer)).toBe(true);
+
+    // Assert grammaticality: answer doesn't start mid-word or with connectors
+    expect(isGrammatical(answer)).toBe(true);
+
+    // Assert traceability: answer contains key terms from the expected answer
+    expect(isTraceableToEvidence(answer, correction)).toBe(true);
+  });
+});
+
+describe("Quick Check answer synthesis — host_country", () => {
+  it("produces 'The host country is X.' format", () => {
+    const rawText = loadRawText("taisei-china-pdd");
+    const result = buildReviewQuestionResult({
+      claimText: "What is the host country?",
+      methodologyId: "ACM0010",
+      methodologyVersion: "02",
+      rawPddText: rawText,
+    });
+
+    expect(result.routerResult.status).toBe("answered");
+
+    const formatted = formatEvidenceCheckUiText({
+      label: "Host country",
+      status: "found",
+      answerText: result.routerResult.answerText || "",
+      downgradeReason: "",
+    });
+
+    expect(formatted.answerText.trim()).toMatch(/^The host country is /);
+    expect(formatted.answerText.trim()).toMatch(/\.$/);
+    expect(formatted.answerText.toLowerCase()).toContain("republic of china");
+  });
+});
+
+describe("Quick Check answer synthesis — methodology", () => {
+  it("produces 'The project uses CODE: description.' format", () => {
+    const rawText = loadRawText("taisei-china-pdd");
+    const result = buildReviewQuestionResult({
+      claimText: "What methodology was applied?",
+      methodologyId: "ACM0010",
+      methodologyVersion: "02",
+      rawPddText: rawText,
+    });
+
+    expect(result.routerResult.status).toBe("answered");
+
+    const formatted = formatEvidenceCheckUiText({
+      label: "Methodology",
+      status: "found",
+      answerText: result.routerResult.answerText || "",
+      downgradeReason: "",
+    });
+
+    // Methodology answers start with complete sentence
+    expect(formatted.answerText.trim()).toMatch(/^The project uses /);
+    expect(formatted.answerText.toLowerCase()).toContain("acm0010");
+  });
+});
+
+describe("Quick Check answer synthesis — narrative checks", () => {
+  const narrativeChecks: Array<{ checkId: string; question: string; expectedContains: string }> = [
+    { checkId: "baseline_scenario", question: "What is the baseline scenario?", expectedContains: "baseline" },
+    { checkId: "additionality", question: "What does the document say about additionality?", expectedContains: "additional" },
+    { checkId: "leakage", question: "What does the document say about leakage?", expectedContains: "leakage" },
+  ];
+
+  test.each(narrativeChecks)("$checkId produces a complete sentence answer", ({ checkId, question, expectedContains }) => {
+    const rawText = loadRawText("taisei-china-pdd");
+    const result = buildReviewQuestionResult({
+      claimText: question,
+      methodologyId: "ACM0010",
+      methodologyVersion: "02",
+      rawPddText: rawText,
+    });
+
+    if (result.routerResult.status !== "answered") {
+      // Skip assertion for unclear/no_evidence — these are document limitations, not formatting bugs
+      return;
+    }
+
+    const formatted = formatEvidenceCheckUiText({
+      label: checkId === "baseline_scenario" ? "Baseline scenario"
+        : checkId === "additionality" ? "Additionality"
+        : "Leakage",
+      status: "found",
+      answerText: result.routerResult.answerText || "",
+      downgradeReason: "",
+    });
+
+    const answer = formatted.answerText.trim();
+    // Narrative answers must end with proper punctuation
+    expect(/[.!?]$/.test(answer)).toBe(true);
+    // Must contain topic-relevant terms
+    expect(answer.toLowerCase()).toContain(expectedContains);
+    // Must not start mid-word or be a bare fragment
+    expect(/^[A-Z]/.test(answer)).toBe(true);
+    expect(answer.split(/\s+/).length).toBeGreaterThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
Goal 6: Add correction fixture ingestion tests and check-specific answer synthesis.

### Answer synthesis

| Check | Format |
|-------|--------|
| `host_country` | "The host country is {country}." |
| `methodology` | "The project uses {code}: {name}." |
| `baseline_scenario` | Complete sentence with period |
| `additionality` | Complete sentence with period |
| `leakage` | Complete sentence with period |
| `stakeholder_consultation` | Complete sentence with period |

### Correction ingestion test

`tests/lib/quickCheck/correctionIngestion.test.ts` validates:
- **Completeness** — answer ends with punctuation
- **Grammaticality** — no mid-word starts, connector fragments, or bare prefixes
- **Traceability** — key terms from corrected answer appear in output

Corrections go in `tests/fixtures/quick-check/corrections/` as JSON files.

No server writes, no model training — deterministic formatting only.

### Verification

```
npx tsc --noEmit  ✓
npm run lint      ✓
npm test          ✓ (152 suites)
npm run quickcheck:eval:corpus -- --strict  ✓ (7/7 PASS)
```