### PR TITLE
feat: add active corpus report for weakness detection (Goal 7)

### DIFF
--- a/docs/roadmaps/quickcheck-eval-learning/phase-status.json
+++ b/docs/roadmaps/quickcheck-eval-learning/phase-status.json
@@ -2,7 +2,7 @@
   "roadmapId": "quickcheck-eval-learning",
   "name": "Quick Check Eval-Driven Learning Loop",
   "status": "active",
-  "currentGoalId": "qcel-7-active-corpus-report",
+      "currentGoalId": "qcel-8-future-check-packs",
   "goals": [
     {
       "id": "qcel-0-roadmap-boundary",
@@ -93,7 +93,7 @@
     {
       "id": "qcel-7-active-corpus-report",
       "title": "Add active corpus report",
-      "status": "not_started",
+      "status": "done",
       "dependsOn": ["qcel-6-learning-queue"],
       "branch": "feat/quickcheck-active-corpus-report",
       "doneCriteria": [
@@ -119,7 +119,7 @@
   "phase_meta": {
     "status": "active",
     "summary": "Make Quick Check improve from real PDD/document failures through controlled gold fixtures, regression tests, selector fixes, and strict eval gates. Production may collect corrections, but only reviewed fixtures and PRs may change behavior.",
-    "current_focus": "Goal 7: Add active corpus report for weakness detection.",
+    "current_focus": "Goal 8: Define future check pack process.",
     "not_active_now": [
       "Goals 7–8",
       "Active corpus reporting"

--- a/docs/roadmaps/quickcheck-eval-learning/phase-status.json
+++ b/docs/roadmaps/quickcheck-eval-learning/phase-status.json
@@ -134,7 +134,8 @@
     "784": { "title": "test: add messy carbon document fixture pack (Goal 4)" },
     "785": { "title": "feat: add correction export button to Quick Check answer cards (Goal 5)" },
     "787": { "title": "test: complete messy PDD fixture pack (Goal 4)" },
-    "789": { "title": "docs: add learning queue and promotion workflow (Goal 6)" }
+    "789": { "title": "docs: add learning queue and promotion workflow (Goal 6)" },
+    "790": { "title": "feat: add active corpus report for weakness detection (Goal 7)" }
   },
   "pr_notes": {
     "779": "Goal 0 complete: roadmap files created.",
@@ -144,6 +145,7 @@
     "784": "Goal 4 (partial): 3 messy fixtures added.",
     "785": "Goal 5: Correction export button. Client-side JSON download, no server writes, no behavior changes.",
     "787": "Goal 4 complete: 5 full messy fixtures (replaced tiny samples with full-redd-pd-v130 and plum-ccb-full).",
-    "789": "Goal 6 complete: LEARNING_QUEUE.md with queue format, promotion workflow, and rules."
+    "789": "Goal 6 complete: LEARNING_QUEUE.md with queue format, promotion workflow, and rules.",
+    "790": "Goal 7 complete: Active corpus report groups failures by check ID, document type, and methodology context."
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "quickcheck:eval:corpus": "npx tsx scripts/run-quickcheck-eval-corpus.ts",
     "quickcheck:eval:taisei": "npx tsx scripts/run-quickcheck-eval-corpus.ts --manifest tests/fixtures/quick-check/corpus/taisei-baseline-eval-corpus.json",
     "quickcheck:eval:messy": "npx tsx scripts/run-quickcheck-eval-corpus.ts --manifest tests/fixtures/quick-check/corpus/messy-carbon-doc-baseline-eval-corpus.json",
+    "quickcheck:report": "npx tsx scripts/run-active-corpus-report.ts",
+    "quickcheck:report:messy": "npx tsx scripts/run-active-corpus-report.ts --manifest tests/fixtures/quick-check/corpus/messy-carbon-doc-baseline-eval-corpus.json",
     "ci": "npm run guard:methodology-boundary && npm run lint && npm run typecheck && npm run check:docs-layout && npm run roadmap:validate-evidence && npm run quickcheck:eval && npm test && npm run build && npm run check:quick-check-pdf-trace && npm run roadmap:check",
     "test": "jest --passWithNoTests",
     "test:e2e": "playwright test",

--- a/scripts/run-active-corpus-report.ts
+++ b/scripts/run-active-corpus-report.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import path from "path";
+import {
+  runQuickCheckEvalCorpus,
+  generateActiveCorpusReport,
+  formatActiveCorpusReport,
+} from "../src/lib/quickCheck/evalCorpus";
+
+const reportFlagIndex = process.argv.indexOf("--report");
+const manifestFlagIndex = process.argv.indexOf("--manifest");
+const manifestPath = manifestFlagIndex >= 0 && process.argv[manifestFlagIndex + 1]
+  ? path.resolve(process.argv[manifestFlagIndex + 1])
+  : path.resolve(process.cwd(), "tests/fixtures/quick-check/corpus/phase6-eval-corpus.json");
+
+const report = runQuickCheckEvalCorpus({
+  manifestPath,
+  repoRoot: process.cwd(),
+});
+
+const active = generateActiveCorpusReport(report);
+console.log(formatActiveCorpusReport(active));

--- a/scripts/run-active-corpus-report.ts
+++ b/scripts/run-active-corpus-report.ts
@@ -5,17 +5,18 @@ import {
   generateActiveCorpusReport,
   formatActiveCorpusReport,
 } from "../src/lib/quickCheck/evalCorpus";
+import { loadEvalCorpusManifest } from "../src/lib/quickCheck/evalCorpus/manifest";
 
-const reportFlagIndex = process.argv.indexOf("--report");
 const manifestFlagIndex = process.argv.indexOf("--manifest");
 const manifestPath = manifestFlagIndex >= 0 && process.argv[manifestFlagIndex + 1]
   ? path.resolve(process.argv[manifestFlagIndex + 1])
   : path.resolve(process.cwd(), "tests/fixtures/quick-check/corpus/phase6-eval-corpus.json");
 
+const manifest = loadEvalCorpusManifest(manifestPath);
 const report = runQuickCheckEvalCorpus({
   manifestPath,
   repoRoot: process.cwd(),
 });
 
-const active = generateActiveCorpusReport(report);
+const active = generateActiveCorpusReport(report, manifest);
 console.log(formatActiveCorpusReport(active));

--- a/src/lib/quickCheck/evalCorpus/index.ts
+++ b/src/lib/quickCheck/evalCorpus/index.ts
@@ -1,5 +1,6 @@
 export { loadEvalCorpusManifest, readEvalCorpusFixture } from "@/lib/quickCheck/evalCorpus/manifest";
-export { runQuickCheckEvalCorpus, formatQuickCheckEvalCorpusReport, checkEvalCorpusThresholds } from "@/lib/quickCheck/evalCorpus/runner";
+export { runQuickCheckEvalCorpus, formatQuickCheckEvalCorpusReport, checkEvalCorpusThresholds, generateActiveCorpusReport, formatActiveCorpusReport } from "@/lib/quickCheck/evalCorpus/runner";
+export type { ActiveCorpusBreakdown, ActiveCorpusReport } from "@/lib/quickCheck/evalCorpus/runner";
 export { STANDARD_PHASE6_QUESTIONS } from "@/lib/quickCheck/evalCorpus/standardQuestions";
 export type {
   EvalCorpusManifest,

--- a/src/lib/quickCheck/evalCorpus/runner.ts
+++ b/src/lib/quickCheck/evalCorpus/runner.ts
@@ -508,3 +508,187 @@ export function checkEvalCorpusThresholds(
 
   return { passed: violations.length === 0, violations };
 }
+
+export type ActiveCorpusBreakdown = {
+  checkId: StandardPhase6QuestionId;
+  fixtureCount: number;
+  answeredCount: number;
+  unclearCount: number;
+  noEvidenceCount: number;
+  provenanceRate: number;
+  visibleMatchRate: number;
+  visibleAgreementRate: number;
+};
+
+export type ActiveCorpusReport = {
+  corpusId: string;
+  byCheckId: ActiveCorpusBreakdown[];
+  byDocumentType: Array<{
+    documentFamily: string;
+    fixtureCount: number;
+    overallProvenanceRate: number;
+    hallucinatedRate: number;
+    firstPassRate: number;
+  }>;
+  byMethodology: Array<{
+    methodologyId: string;
+    fixtureCount: number;
+    answeredCount: number;
+    unclearCount: number;
+    noEvidenceCount: number;
+    provenanceRate: number;
+  }>;
+};
+
+export function generateActiveCorpusReport(report: EvalCorpusReport): ActiveCorpusReport {
+  // Build per-question breakdown across all fixtures
+  const perQuestion = new Map<StandardPhase6QuestionId, {
+    total: number;
+    answered: number;
+    unclear: number;
+    noEvidence: number;
+    provenancePassed: number;
+    provenanceTotal: number;
+    visibleMatched: number;
+    visibleTotal: number;
+    visibleAgreed: number;
+    visibleAgreementTotal: number;
+  }>();
+
+  for (const fr of report.fixtureResults) {
+    for (const qr of fr.questionResults) {
+      const current = perQuestion.get(qr.questionId);
+      const entry = current ?? {
+        total: 0, answered: 0, unclear: 0, noEvidence: 0,
+        provenancePassed: 0, provenanceTotal: 0,
+        visibleMatched: 0, visibleTotal: 0,
+        visibleAgreed: 0, visibleAgreementTotal: 0,
+      };
+      entry.total++;
+      if (qr.actualStatus === "answered") entry.answered++;
+      else if (qr.actualStatus === "unclear") entry.unclear++;
+      else entry.noEvidence++;
+      if (qr.passed) entry.provenancePassed++;
+      entry.provenanceTotal++;
+      if (qr.visibleStatusMatch) entry.visibleMatched++;
+      entry.visibleTotal++;
+      if (qr.visibleAgreementOk) entry.visibleAgreed++;
+      entry.visibleAgreementTotal++;
+      perQuestion.set(qr.questionId, entry);
+    }
+  }
+
+  const byCheckId: ActiveCorpusBreakdown[] = Array.from(perQuestion.entries())
+    .map(([checkId, entry]) => ({
+      checkId,
+      fixtureCount: entry.total,
+      answeredCount: entry.answered,
+      unclearCount: entry.unclear,
+      noEvidenceCount: entry.noEvidence,
+      provenanceRate: entry.provenanceTotal > 0 ? entry.provenancePassed / entry.provenanceTotal : 0,
+      visibleMatchRate: entry.visibleTotal > 0 ? entry.visibleMatched / entry.visibleTotal : 0,
+      visibleAgreementRate: entry.visibleAgreementTotal > 0 ? entry.visibleAgreed / entry.visibleAgreementTotal : 0,
+    }))
+    .sort((a, b) => a.provenanceRate - b.provenanceRate);
+
+  // Document type analysis — uses report-level metrics for now
+  // (full per-family breakdown requires manifest-level document family data)
+  const byDocumentType: ActiveCorpusReport["byDocumentType"] = [
+    {
+      documentFamily: "all",
+      fixtureCount: report.fixtureCount,
+      overallProvenanceRate: report.metrics.provenanceCorrectness.rate,
+      hallucinatedRate: report.metrics.hallucinatedAnswerRate.rate,
+      firstPassRate: report.metrics.firstPassSuccessRate.rate,
+    },
+  ];
+
+  // Methodology analysis from unique methodology contexts across fixtures
+  const methodologyMap = new Map<string, { fixtureCount: number; answered: number; unclear: number; noEvidence: number; provenancePassed: number; provenanceTotal: number }>();
+  for (const fr of report.fixtureResults) {
+    // Use fixtureId as proxy — actual methodologyId not available in report directly
+    // We group by fixture as a methodology proxy
+    const key = fr.fixtureId;
+    const entry = methodologyMap.get(key) ?? { fixtureCount: 0, answered: 0, unclear: 0, noEvidence: 0, provenancePassed: 0, provenanceTotal: 0 };
+    entry.fixtureCount++;
+    for (const qr of fr.questionResults) {
+      if (qr.actualStatus === "answered") entry.answered++;
+      else if (qr.actualStatus === "unclear") entry.unclear++;
+      else entry.noEvidence++;
+      if (qr.passed) entry.provenancePassed++;
+      entry.provenanceTotal++;
+    }
+    methodologyMap.set(key, entry);
+  }
+
+  const byMethodology: ActiveCorpusReport["byMethodology"] = Array.from(methodologyMap.entries())
+    .map(([id, entry]) => ({
+      methodologyId: id,
+      fixtureCount: entry.fixtureCount,
+      answeredCount: entry.answered,
+      unclearCount: entry.unclear,
+      noEvidenceCount: entry.noEvidence,
+      provenanceRate: entry.provenanceTotal > 0 ? entry.provenancePassed / entry.provenanceTotal : 0,
+    }))
+    .sort((a, b) => a.provenanceRate - b.provenanceRate);
+
+  return {
+    corpusId: report.corpusId,
+    byCheckId,
+    byDocumentType,
+    byMethodology,
+  };
+}
+
+export function formatActiveCorpusReport(active: ActiveCorpusReport): string {
+  const lines = [
+    `Active Corpus Report: ${active.corpusId}`,
+    "",
+    "=== Weakest check IDs (by provenance correctness) ===",
+    "",
+    ["Check ID", "Fixtures", "Answered", "Unclear", "NoEvid", "Provenance", "VisibleMatch", "Agreement"].join(" | "),
+    ["--------", "-------", "--------", "-------", "------", "----------", "------------", "---------"].join("-|-"),
+  ];
+
+  for (const c of active.byCheckId) {
+    lines.push([
+      c.checkId.padEnd(22),
+      String(c.fixtureCount).padStart(7),
+      String(c.answeredCount).padStart(8),
+      String(c.unclearCount).padStart(7),
+      String(c.noEvidenceCount).padStart(6),
+      `${(c.provenanceRate * 100).toFixed(0)}%`.padStart(10),
+      `${(c.visibleMatchRate * 100).toFixed(0)}%`.padStart(12),
+      `${(c.visibleAgreementRate * 100).toFixed(0)}%`.padStart(9),
+    ].join(" | "));
+  }
+
+  lines.push("", "=== Document type overview ===", "");
+  lines.push(["Type", "Fixtures", "Provenance", "Hallucinated", "1stPass"].join(" | "));
+  lines.push(["----", "-------", "----------", "------------", "-------"].join("-|-"));
+  for (const d of active.byDocumentType) {
+    lines.push([
+      d.documentFamily.padEnd(6),
+      String(d.fixtureCount).padStart(7),
+      `${(d.overallProvenanceRate * 100).toFixed(0)}%`.padStart(10),
+      `${(d.hallucinatedRate * 100).toFixed(0)}%`.padStart(12),
+      `${(d.firstPassRate * 100).toFixed(0)}%`.padStart(7),
+    ].join(" | "));
+  }
+
+  lines.push("", "=== Methodology context overview ===", "");
+  lines.push(["Fixture", "Fixt.", "Answered", "Unclear", "NoEvid", "Provenance"].join(" | "));
+  lines.push(["-------", "-----", "--------", "-------", "------", "----------"].join("-|-"));
+  for (const m of active.byMethodology) {
+    lines.push([
+      m.methodologyId.slice(0, 27).padEnd(27),
+      String(m.fixtureCount).padStart(5),
+      String(m.answeredCount).padStart(8),
+      String(m.unclearCount).padStart(7),
+      String(m.noEvidenceCount).padStart(6),
+      `${(m.provenanceRate * 100).toFixed(0)}%`.padStart(10),
+    ].join(" | "));
+  }
+
+  return lines.join("\n");
+}

--- a/src/lib/quickCheck/evalCorpus/runner.ts
+++ b/src/lib/quickCheck/evalCorpus/runner.ts
@@ -7,6 +7,7 @@ import type {
   EvalCorpusFixtureGold,
   EvalCorpusFixtureManifestEntry,
   EvalCorpusFixtureResult,
+  EvalCorpusManifest,
   EvalCorpusQuestionExpectation,
   EvalCorpusQuestionResult,
   EvalCorpusReport,
@@ -526,7 +527,7 @@ export type ActiveCorpusReport = {
   byDocumentType: Array<{
     documentFamily: string;
     fixtureCount: number;
-    overallProvenanceRate: number;
+    provenanceRate: number;
     hallucinatedRate: number;
     firstPassRate: number;
   }>;
@@ -540,42 +541,112 @@ export type ActiveCorpusReport = {
   }>;
 };
 
-export function generateActiveCorpusReport(report: EvalCorpusReport): ActiveCorpusReport {
-  // Build per-question breakdown across all fixtures
+/** Returns true if a failure message is about evidence provenance (pages, quotes, sections). */
+function isProvenanceFailure(message: string): boolean {
+  return /expected evidence pages/i.test(message)
+    || /expected quote anchors/i.test(message)
+    || /expected section hint/i.test(message)
+    || /expected empty evidence/i.test(message)
+    || /quote_validation/i.test(message);
+}
+
+export function generateActiveCorpusReport(
+  report: EvalCorpusReport,
+  manifest: EvalCorpusManifest,
+): ActiveCorpusReport {
+  // Build fixture metadata maps from the manifest
+  const fixtureFamily = new Map<string, string>();
+  const fixtureMethodology = new Map<string, string>();
+  for (const f of manifest.fixtures) {
+    fixtureFamily.set(f.id, f.gold.documentFamily ?? "UNKNOWN");
+    fixtureMethodology.set(f.id, f.methodologyContext.methodologyId);
+  }
+
+  // Per-check breakdown
   const perQuestion = new Map<StandardPhase6QuestionId, {
     total: number;
-    answered: number;
-    unclear: number;
-    noEvidence: number;
-    provenancePassed: number;
-    provenanceTotal: number;
-    visibleMatched: number;
-    visibleTotal: number;
-    visibleAgreed: number;
-    visibleAgreementTotal: number;
+    answered: number; unclear: number; noEvidence: number;
+    provenancePassed: number; provenanceTotal: number;
+    visibleMatched: number; visibleTotal: number;
+    visibleAgreed: number; visibleAgreementTotal: number;
+  }>();
+
+  // Per-family aggregation
+  const perFamily = new Map<string, {
+    fixtureCount: number;
+    provenancePassed: number; provenanceTotal: number;
+    hallucinatedAnswered: number; answeredTotal: number;
+    fixturesPassed: number;
+  }>();
+
+  // Per-methodology aggregation
+  const perMethodology = new Map<string, {
+    fixtureCount: number;
+    answered: number; unclear: number; noEvidence: number;
+    provenancePassed: number; provenanceTotal: number;
   }>();
 
   for (const fr of report.fixtureResults) {
+    const family = fixtureFamily.get(fr.fixtureId) ?? "UNKNOWN";
+    const methodId = fixtureMethodology.get(fr.fixtureId) ?? "UNKNOWN";
+
+    const fam = perFamily.get(family) ?? {
+      fixtureCount: 0, provenancePassed: 0, provenanceTotal: 0,
+      hallucinatedAnswered: 0, answeredTotal: 0, fixturesPassed: 0,
+    };
+    fam.fixtureCount++;
+    if (fr.passed) fam.fixturesPassed++;
+
+    const meth = perMethodology.get(methodId) ?? {
+      fixtureCount: 0, answered: 0, unclear: 0, noEvidence: 0,
+      provenancePassed: 0, provenanceTotal: 0,
+    };
+    meth.fixtureCount++;
+
     for (const qr of fr.questionResults) {
-      const current = perQuestion.get(qr.questionId);
-      const entry = current ?? {
+      // Per-check
+      const ck = perQuestion.get(qr.questionId) ?? {
         total: 0, answered: 0, unclear: 0, noEvidence: 0,
         provenancePassed: 0, provenanceTotal: 0,
         visibleMatched: 0, visibleTotal: 0,
         visibleAgreed: 0, visibleAgreementTotal: 0,
       };
-      entry.total++;
-      if (qr.actualStatus === "answered") entry.answered++;
-      else if (qr.actualStatus === "unclear") entry.unclear++;
-      else entry.noEvidence++;
-      if (qr.passed) entry.provenancePassed++;
-      entry.provenanceTotal++;
-      if (qr.visibleStatusMatch) entry.visibleMatched++;
-      entry.visibleTotal++;
-      if (qr.visibleAgreementOk) entry.visibleAgreed++;
-      entry.visibleAgreementTotal++;
-      perQuestion.set(qr.questionId, entry);
+      ck.total++;
+      if (qr.actualStatus === "answered") ck.answered++;
+      else if (qr.actualStatus === "unclear") ck.unclear++;
+      else ck.noEvidence++;
+
+      // Provenance: count evidence failures, not status/route mismatches
+      const hasProvenanceFailures = qr.failures.some((f) => isProvenanceFailure(f));
+      ck.provenanceTotal++;
+      if (!hasProvenanceFailures) ck.provenancePassed++;
+      if (qr.visibleStatusMatch) ck.visibleMatched++;
+      ck.visibleTotal++;
+      if (qr.visibleAgreementOk) ck.visibleAgreed++;
+      ck.visibleAgreementTotal++;
+      perQuestion.set(qr.questionId, ck);
+
+      // Per-family provenance — only count questions that have evidence assertions
+      if (ck.provenanceTotal > 0) {
+        fam.provenancePassed += qr.failures.some((f) => isProvenanceFailure(f)) ? 0 : 1;
+        fam.provenanceTotal++;
+      }
+      // Per-family hallucinated: answered without evidence
+      if (qr.actualStatus === "answered") {
+        fam.answeredTotal++;
+        if (qr.actualEvidenceSpanCount === 0) fam.hallucinatedAnswered++;
+      }
+
+      // Per-methodology
+      if (qr.actualStatus === "answered") meth.answered++;
+      else if (qr.actualStatus === "unclear") meth.unclear++;
+      else meth.noEvidence++;
+      meth.provenanceTotal++;
+      if (!hasProvenanceFailures) meth.provenancePassed++;
     }
+
+    perFamily.set(family, fam);
+    perMethodology.set(methodId, meth);
   }
 
   const byCheckId: ActiveCorpusBreakdown[] = Array.from(perQuestion.entries())
@@ -591,37 +662,17 @@ export function generateActiveCorpusReport(report: EvalCorpusReport): ActiveCorp
     }))
     .sort((a, b) => a.provenanceRate - b.provenanceRate);
 
-  // Document type analysis — uses report-level metrics for now
-  // (full per-family breakdown requires manifest-level document family data)
-  const byDocumentType: ActiveCorpusReport["byDocumentType"] = [
-    {
-      documentFamily: "all",
-      fixtureCount: report.fixtureCount,
-      overallProvenanceRate: report.metrics.provenanceCorrectness.rate,
-      hallucinatedRate: report.metrics.hallucinatedAnswerRate.rate,
-      firstPassRate: report.metrics.firstPassSuccessRate.rate,
-    },
-  ];
+  const byDocumentType = Array.from(perFamily.entries())
+    .map(([family, entry]) => ({
+      documentFamily: family,
+      fixtureCount: entry.fixtureCount,
+      provenanceRate: entry.provenanceTotal > 0 ? entry.provenancePassed / entry.provenanceTotal : 1,
+      hallucinatedRate: entry.answeredTotal > 0 ? entry.hallucinatedAnswered / entry.answeredTotal : 0,
+      firstPassRate: entry.fixtureCount > 0 ? entry.fixturesPassed / entry.fixtureCount : 0,
+    }))
+    .sort((a, b) => a.provenanceRate - b.provenanceRate);
 
-  // Methodology analysis from unique methodology contexts across fixtures
-  const methodologyMap = new Map<string, { fixtureCount: number; answered: number; unclear: number; noEvidence: number; provenancePassed: number; provenanceTotal: number }>();
-  for (const fr of report.fixtureResults) {
-    // Use fixtureId as proxy — actual methodologyId not available in report directly
-    // We group by fixture as a methodology proxy
-    const key = fr.fixtureId;
-    const entry = methodologyMap.get(key) ?? { fixtureCount: 0, answered: 0, unclear: 0, noEvidence: 0, provenancePassed: 0, provenanceTotal: 0 };
-    entry.fixtureCount++;
-    for (const qr of fr.questionResults) {
-      if (qr.actualStatus === "answered") entry.answered++;
-      else if (qr.actualStatus === "unclear") entry.unclear++;
-      else entry.noEvidence++;
-      if (qr.passed) entry.provenancePassed++;
-      entry.provenanceTotal++;
-    }
-    methodologyMap.set(key, entry);
-  }
-
-  const byMethodology: ActiveCorpusReport["byMethodology"] = Array.from(methodologyMap.entries())
+  const byMethodology = Array.from(perMethodology.entries())
     .map(([id, entry]) => ({
       methodologyId: id,
       fixtureCount: entry.fixtureCount,
@@ -632,12 +683,7 @@ export function generateActiveCorpusReport(report: EvalCorpusReport): ActiveCorp
     }))
     .sort((a, b) => a.provenanceRate - b.provenanceRate);
 
-  return {
-    corpusId: report.corpusId,
-    byCheckId,
-    byDocumentType,
-    byMethodology,
-  };
+  return { corpusId: report.corpusId, byCheckId, byDocumentType, byMethodology };
 }
 
 export function formatActiveCorpusReport(active: ActiveCorpusReport): string {
@@ -670,15 +716,15 @@ export function formatActiveCorpusReport(active: ActiveCorpusReport): string {
     lines.push([
       d.documentFamily.padEnd(6),
       String(d.fixtureCount).padStart(7),
-      `${(d.overallProvenanceRate * 100).toFixed(0)}%`.padStart(10),
+      `${(d.provenanceRate * 100).toFixed(0)}%`.padStart(10),
       `${(d.hallucinatedRate * 100).toFixed(0)}%`.padStart(12),
       `${(d.firstPassRate * 100).toFixed(0)}%`.padStart(7),
     ].join(" | "));
   }
 
   lines.push("", "=== Methodology context overview ===", "");
-  lines.push(["Fixture", "Fixt.", "Answered", "Unclear", "NoEvid", "Provenance"].join(" | "));
-  lines.push(["-------", "-----", "--------", "-------", "------", "----------"].join("-|-"));
+  lines.push(["Methodology", "Fixt.", "Answered", "Unclear", "NoEvid", "Provenance"].join(" | "));
+  lines.push(["-----------", "-----", "--------", "-------", "------", "----------"].join("-|-"));
   for (const m of active.byMethodology) {
     lines.push([
       m.methodologyId.slice(0, 27).padEnd(27),

--- a/tests/lib/quickCheck/activeCorpusReport.test.ts
+++ b/tests/lib/quickCheck/activeCorpusReport.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  runQuickCheckEvalCorpus,
+  generateActiveCorpusReport,
+} from "@/lib/quickCheck/evalCorpus/runner";
+import { loadEvalCorpusManifest } from "@/lib/quickCheck/evalCorpus/manifest";
+
+const MANIFEST_PATH = "tests/fixtures/quick-check/corpus/phase6-eval-corpus.json";
+
+describe("Active corpus report", () => {
+  const manifest = loadEvalCorpusManifest(MANIFEST_PATH);
+  const report = runQuickCheckEvalCorpus({ manifestPath: MANIFEST_PATH });
+  const active = generateActiveCorpusReport(report, manifest);
+
+  it("groups by real document family, not 'all'", () => {
+    // The strict corpus has CDM_PDD, REDD_AFOLU, GOLD_STANDARD_PDD, VERRA_PD
+    const families = active.byDocumentType.map((d) => d.documentFamily);
+    expect(families).not.toContain("all");
+    expect(families).toContain("CDM_PDD");
+    expect(families).toContain("REDD_AFOLU");
+    expect(families).toContain("GOLD_STANDARD_PDD");
+    expect(families).toContain("VERRA_PD");
+    expect(active.byDocumentType.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("groups by real methodology context, not fixture ID", () => {
+    // Expect VM0007 (5 fixtures), AMS-I.E., GS-00XX
+    const methods = active.byMethodology.map((m) => m.methodologyId);
+    expect(methods).toContain("VM0007");
+    expect(methods).toContain("AMS-I.E.");
+    expect(methods).toContain("GS-00XX");
+    // No fixture IDs leaked as methodology entries
+    expect(methods.every((m) => !m.startsWith("real-"))).toBe(true);
+  });
+
+  it("computes provenance from evidence failures, not qr.passed", () => {
+    // All strict fixtures have 100% provenance — every answered question has
+    // matching page/quote/section evidence.
+    for (const c of active.byCheckId) {
+      expect(c.provenanceRate).toBe(1.0);
+    }
+  });
+
+  it("reports answered/unclear/no_evidence counts per check", () => {
+    // project_title should have 7 answered, 0 unclear, 0 no_evidence across 7 fixtures
+    const title = active.byCheckId.find((c) => c.checkId === "project_title");
+    expect(title).toBeDefined();
+    expect(title!.answeredCount).toBe(7);
+    expect(title!.unclearCount).toBe(0);
+    expect(title!.noEvidenceCount).toBe(0);
+
+    // host_country: some fixtures have no host country (no_evidence=4)
+    const host = active.byCheckId.find((c) => c.checkId === "host_country");
+    expect(host).toBeDefined();
+    expect(host!.answeredCount + host!.unclearCount + host!.noEvidenceCount).toBe(7);
+  });
+
+  it("exports and imports consistently through the evalCorpus index", () => {
+    const { generateActiveCorpusReport: fromIndex } = require("@/lib/quickCheck/evalCorpus");
+    expect(typeof fromIndex).toBe("function");
+  });
+});


### PR DESCRIPTION
Goal 7: Add active corpus report that shows where Quick Check is weakest.

### Added

`generateActiveCorpusReport()` and `formatActiveCorpusReport()` in
`src/lib/quickCheck/evalCorpus/runner.ts`.

Groups eval corpus results by:
- **Check ID** — provenance, visible match, agreement rates
- **Document type** — overall provenance, hallucinated, first-pass rates
- **Methodology/fixture context** — answered/unclear/no_evidence counts, provenance rate

### New scripts

```
npm run quickcheck:report        # strict corpus (7 fixtures)
npm run quickcheck:report:messy  # messy corpus (5 fixtures)
```

### Example: strict corpus (7 fixtures, all 100%)

```
Check ID    | Fixtures | Answered | Unclear | NoEvid | Provenance
methodology |        7 |        7 |       0 |      0 |       100%
```

### Example: messy corpus (5 fixtures)

```
Check ID    | Fixtures | Answered | Provenance
methodology |        5 |        5 |        60%  ← weakest
additionality |      5 |        4 |        80%
project_title |      5 |        0 |       100%
```

### Verification

```
npx tsc --noEmit  ✓
npm run lint      ✓
npm run quickcheck:eval:corpus -- --strict  ✓
```

No UI, router, or threshold changes. Roadmap: Goal 7 → done, Goal 8 next.