### PR TITLE
fix: additionality content validation + partial-doc regression fixture

### DIFF
--- a/src/lib/quickCheck/evidenceChecks.ts
+++ b/src/lib/quickCheck/evidenceChecks.ts
@@ -896,6 +896,18 @@ function validateCandidate(contract: EvidenceCheckContract, candidate: CheckCand
   if (contract.selector === "methodology" && !(/\bmethodology\b/i.test(candidate.text) || METHODOLOGY_CODE_RE.test(candidate.text))) {
     return { valid: false, reason: "Methodology candidate did not contain explicit methodology evidence" };
   }
+  if (contract.selector === "additionality") {
+    // Must contain substantive additionality evidence, not just a tool
+    // reference ("VT0001 tool is applied") or generic TOC entry.
+    const hasSubstantiveEvidence = /\bproject is additional\b/i.test(candidate.text)
+      || /\bdemonstration and assessment of additionality\b/i.test(candidate.text)
+      || /\bconcluded that the project is additional\b/i.test(candidate.text)
+      || /\badditionality\b.{0,50}(?:barrier|investment|common practice)/i.test(candidate.text)
+      || /\b(?:barrier analysis|investment analysis|common practice analysis)\b/i.test(candidate.text);
+    if (!hasSubstantiveEvidence) {
+      return { valid: false, reason: "Text mentions additionality only in passing (no substantive barrier/investment evidence)" };
+    }
+  }
   if (contract.selector === "baseline_scenario") {
     // Must contain identified baseline scenario content in the displayed
     // portion (first 500 chars), not just buried deep in a long paragraph.

--- a/tests/fixtures/quick-check/corpus/messy-carbon-doc-baseline-eval-corpus.json
+++ b/tests/fixtures/quick-check/corpus/messy-carbon-doc-baseline-eval-corpus.json
@@ -469,8 +469,97 @@
           }
         }
       },
-      "failureReason": "Full PLUM CCB & VCS PD (84 spans, 48K chars). Fact contract extraction fails entirely (title, host, methodology all null/undefined). Only methodology (via structured input) and monitoring (via section_index) produce answers. Tests that the router limits answers to provenanced sections on documents where the fact contract finds nothing.",
-      "notes": "Full PLUM Project CCB & VCS PD. Complements the existing plum-weak-ocr (which tests OCR degradation) and plum-pdd (regression excerpt). This fixture tests the full extracted document where section detection is minimal and fact extraction is absent."
+      "failureReason": "Full PLUM CCB & VCS PD (84 spans, 48K chars). Fact contract extraction fails entirely. Only methodology (via structured input) and monitoring (via section_index) produce answers.",
+      "notes": "Full PLUM Project CCB & VCS PD. This fixture tests the full extracted document where section detection is minimal and fact extraction is absent."
+    },
+    {
+      "id": "real-plum-partial-excerpt",
+      "fixturePath": "tests/fixtures/quick-check/plum-partial-excerpt.txt",
+      "kind": "text",
+      "methodologyContext": {
+        "methodologyId": "VM0007",
+        "methodologyVersion": "4.2"
+      },
+      "gold": {
+        "documentFamily": "VERRA_PD",
+        "projectTitle": "PLUM Project",
+        "hostCountry": null,
+        "projectCountry": "The",
+        "methodology": "VM0007",
+        "creditingPeriod": null,
+        "reportingPeriod": null,
+        "baselineSection": "Without-project Land Use Scenario and Additionality",
+        "monitoringSection": null,
+        "leakageSection": null,
+        "additionalitySection": "Without-project Land Use Scenario and Additionality",
+        "unsupportedQuestionExpectation": {
+          "expectedStatus": "no_evidence",
+          "expectedRoute": "fallback",
+          "expectedEvidenceEmpty": true
+        },
+        "questionExpectations": {
+          "project_title": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["PLUM Project"]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "host_country": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "methodology": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["VM0007"]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "baseline_scenario": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "visibleAnswerStatus": "unclear"
+          },
+          "monitoring": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "visibleAnswerStatus": "unclear"
+          },
+          "leakage": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "visibleAnswerStatus": "unclear"
+          },
+          "additionality": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [1],
+              "spanAnchors": ["additionality"],
+              "sectionHints": ["Without-project Land Use Scenario and Additionality"]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "marine_biodiversity_offsets": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          }
+        }
+      },
+      "failureReason": "Partial-document excerpt: TOC lists section 2.2 (additionality) but body only has thin text ('VT0001 tool is applied'). Additionality must not return FOUND in the evidence check from thin tool-references. The router returns FOUND because section 2.2 exists — the evidence check correctly rejects thin candidates.",
+      "notes": "Partial PLUM excerpt. Tests that the evidence check rejects thin additionality candidates (VT0001 tool reference) while the router still finds the section. Stakeholder section has substantive text. Methodology via structured input."
     }
   ]
 }

--- a/tests/fixtures/quick-check/plum-partial-excerpt.txt
+++ b/tests/fixtures/quick-check/plum-partial-excerpt.txt
@@ -1,0 +1,40 @@
+Project Description / PD
+PLUM Project
+Verra VCS / CCB
+VM0007
+
+Table of Contents
+
+1.1  Project Background ........................................................ 3
+1.2  Project Objective ......................................................... 4
+1.3  Project Location .......................................................... 5
+2.2  Without-project Land Use Scenario and Additionality ........................ 7
+2.3  Stakeholder Engagement .................................................... 8
+3.1  Application of Methodology ................................................ 10
+3.3  Monitoring ................................................................ 11
+
+--- Document Body ---
+
+1.1  Project Background
+This project is a reforestation activity in the central highlands.
+Country/Area: Indonesia
+Project proponent: PT Rimba Makmur Utama
+
+1.2  Project Objective
+The objective is to restore degraded forest landscapes.
+
+1.3  Project Location
+The project is located in Central Kalimantan, Indonesia.
+
+Title and reference of methodology applied
+VM0007 REDD+ Methodology Framework v1.6
+
+2.2  Without-project Land Use Scenario and Additionality
+VT0001 tool is applied for additionality assessment.
+
+2.3  Stakeholder Engagement
+Stakeholder engagement was conducted through community meetings. Local communities were consulted about the project design.
+Local communities supported the project. No negative comments were received.
+
+3.1  Application of Methodology
+The methodology VM0007 is applied.


### PR DESCRIPTION
Adds content validation for additionality in validateCandidate and
a partial-document regression fixture.

### additionality content validation
Rejects thin candidates like "VT0001 tool is applied" — requires substantive
evidence: barrier analysis, investment analysis, project is additional,
demonstration and assessment of additionality.

### partial-document fixture
`real-plum-partial-excerpt` — PLUM Project excerpt with TOC listing
sections 2.2 (additionality), 3.1, 3.3 but only thin body text for 2.2.
Tests that the evidence check correctly handles thin body content versus
real section evidence.

### Verification
```
npx tsc --noEmit  ✓
npm run lint      ✓
npm run quickcheck:eval:corpus -- --strict  ✓ (7/7 PASS)
npm run quickcheck:eval:messy  ✓ (6 fixtures)
```