### PR TITLE
[codex] add quick check sufficiency validators

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -70,6 +70,7 @@ import {
   getAllChecks,
   formatEvidenceCheckUiText,
   getContract,
+  statusFromRouter,
   validateCheck,
   type CheckValidationContext,
   type EvidenceCheckResult,
@@ -101,6 +102,13 @@ type MatchCandidate = {
   requirementLabel: string;
   score: number | null;
 };
+
+const ROUTER_GATED_EVIDENCE_CHECKS = new Set([
+  "baseline_scenario",
+  "additionality",
+  "leakage",
+  "stakeholder_consultation",
+]);
 
 type ResolvedMatchCandidate = QuickCheckResolvedCandidate<MatchCandidate>;
 
@@ -1841,12 +1849,33 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         answerText: validated.answerText,
         downgradeReason: validated.downgradeReason,
       });
+      const shouldGateByRouter = ROUTER_GATED_EVIDENCE_CHECKS.has(check.id);
+      let finalStatus = validated.status;
+      if (shouldGateByRouter && validated.status === "found" && questionResult.routerResult.status !== "answered") {
+        finalStatus = statusFromRouter(questionResult.routerResult.status);
+      }
+      let finalAnswerText = formatted.answerText.trim();
+      let finalDowngradeReason = formatted.downgradeReason;
+      if (finalStatus !== validated.status && finalStatus === "unclear") {
+        finalDowngradeReason = finalDowngradeReason || "Quick Check found related text, but the deterministic router did not validate it as a reliable answer.";
+      }
+      if (finalStatus === "found" && !finalAnswerText) {
+        finalAnswerText = formatted.answerText.trim()
+          || validated.answerText.trim()
+          || questionResult.routerResult.answerText.trim();
+        if (!finalAnswerText) {
+          finalStatus = shouldGateByRouter
+            ? statusFromRouter(questionResult.routerResult.status === "answered" ? "unclear" : questionResult.routerResult.status)
+            : "unclear";
+          finalDowngradeReason = finalDowngradeReason || "Quick Check could not preserve a readable answer for this evidence.";
+        }
+      }
       // Provenance now comes from the validated candidate, not the router.
       results.push({
         checkId: check.id,
-        status: validated.status,
-        answerText: formatted.answerText,
-        downgradeReason: formatted.downgradeReason,
+        status: finalStatus,
+        answerText: finalAnswerText,
+        downgradeReason: finalDowngradeReason,
         quotes: validated.quotes,
         pages: validated.pages,
         sections: validated.sections,

--- a/src/lib/quickCheck/evidenceChecks.ts
+++ b/src/lib/quickCheck/evidenceChecks.ts
@@ -295,10 +295,11 @@ function trimNarrativeAnswer(label: string, value: string): string {
 function formatLeakageAnswer(value: string): string {
   const normalized = normalizeInlineWhitespace(value);
   const directSentence =
-    normalized.match(/(Leakage[^.?!]*[.?!])/i)?.[1]
-    ?? normalized.match(/([^.!?]*project-induced leakage[^.!?]*[.?!])/i)?.[1]
+    normalized.match(/([^.!?]*project-induced leakage[^.!?]*[.?!])/i)?.[1]
     ?? normalized.match(/([^.!?]*leakage monitoring[^.!?]*[.?!])/i)?.[1]
+    ?? normalized.match(/([^.!?]*leakage emissions[^.!?]*[.?!])/i)?.[1]
     ?? normalized.match(/([^.!?]*leakage[^.!?]*[.?!])/i)?.[1]
+    ?? normalized.match(/(^Leakage[^.?!]*[.?!])/i)?.[1]
     ?? normalized.match(/(.{0,120}project-induced leakage.{0,120})/i)?.[1]
     ?? normalized.match(/(.{0,120}leakage monitoring.{0,120})/i)?.[1]
     ?? normalized.match(/(.{0,120}leakage emissions.{0,120})/i)?.[1]
@@ -306,7 +307,8 @@ function formatLeakageAnswer(value: string): string {
   const chosen = directSentence
     ? stripCommonLeadIn(normalizeInlineWhitespace(directSentence))
     : trimNarrativeAnswer("Leakage", normalized);
-  return chosen.length > 240 ? `${chosen.slice(0, 237).trimEnd()}...` : chosen;
+  const answer = chosen || trimNarrativeAnswer("Leakage", normalized);
+  return answer.length > 240 ? `${answer.slice(0, 237).trimEnd()}...` : answer;
 }
 
 function formatMethodologyAnswer(value: string): string {

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -32,6 +32,31 @@ type DeterministicRouterInput = {
   sectionTableIndex?: SectionTableIndex;
 };
 
+
+type CheckSpecId = "additionality" | "baseline_scenario" | "monitoring";
+type SufficiencyGrade = "strong" | "acceptable" | "weak" | "reject";
+
+type CheckSpecAssessment = {
+  specId: CheckSpecId;
+  grade: SufficiencyGrade;
+  reason: string;
+  warningCode: string;
+};
+
+type CheckSpecInput = {
+  claimText: string;
+  reviewArea: ReviewArea;
+  queryIntentAnalysis?: QueryIntentAnalysis;
+  evidenceDocument: EvidenceDocument;
+  candidate: {
+    route: RouterCandidate["route"];
+    answerText: string;
+    evidenceSpanIds: string[];
+    quoteTexts: string[];
+    sectionPaths: string[];
+  };
+};
+
 const ANSWER_CONFIDENCE_THRESHOLD = 0.7;
 const LEXICAL_MIN_CONFIDENCE = 0.74;
 
@@ -70,6 +95,249 @@ function clampConfidence(value: number): number {
 
 function normalize(value: string): string {
   return value.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+
+const CHECK_SPEC_WORD_RE = /\b[\w-]+\b/g;
+const CHECK_SPEC_TOC_RE = /\btable of contents\b|(?:^|\n)\s*\d+(?:\.\d+)*\s+[^\n.]{3,}\.{2,}\s*\d+\s*(?:\n|$)/i;
+const GENERIC_METHODOLOGY_RE = /\b(?:application of methodology|applied methodology|title and reference of methodology|this methodology|the methodology requires|according to the methodology|in accordance with the methodology|methodology framework|tool for the demonstration and assessment of additionality|latest approved version of the tool)\b/i;
+
+function checkSpecWordCount(value: string): number {
+  return value.match(CHECK_SPEC_WORD_RE)?.length ?? 0;
+}
+
+function hasAnyPattern(text: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function assessCheckSpecEvidence(input: CheckSpecInput): CheckSpecAssessment | null {
+  const spanLookup = getSpanLookup(input.evidenceDocument);
+  const spans = input.candidate.evidenceSpanIds
+    .map((spanId) => spanLookup.get(spanId))
+    .filter((span): span is EvidenceSpan => Boolean(span));
+  const combinedText = normalize([
+    input.candidate.answerText,
+    ...input.candidate.quoteTexts,
+    ...spans.map((span) => span.text),
+  ].filter(Boolean).join("\n"));
+  const combinedSections = normalize([
+    ...input.candidate.sectionPaths,
+    ...spans.flatMap((span) => span.sectionPath),
+    ...spans.map((span) => span.heading ?? ""),
+  ].filter(Boolean).join(" > "));
+  const tocEvidence = spans.some((span) => span.blockType === "toc" || /\btable of contents\b/i.test(span.heading ?? ""))
+    || CHECK_SPEC_TOC_RE.test(combinedText)
+    || CHECK_SPEC_TOC_RE.test(combinedSections);
+
+  if (tocEvidence) {
+    const specId: CheckSpecId = input.reviewArea === "baseline"
+      ? "baseline_scenario"
+      : input.reviewArea === "monitoring"
+        ? "monitoring"
+        : "additionality";
+    return {
+      specId,
+      grade: "reject",
+      reason: "Matched evidence came from a table of contents path, not project evidence.",
+      warningCode: `check_spec_${specId}_toc_reject`,
+    };
+  }
+
+  if (input.reviewArea === "additionality") {
+    const strongSignals = [
+      /\bproject is additional\b/i,
+      /\bactivity is considered additional\b/i,
+      /\bpasses the additionality test\b/i,
+      /\badditionality (?:is )?(?:demonstrated|justified|shown)\b/i,
+      /\bbarrier analysis\b/i,
+      /\binvestment analysis\b/i,
+      /\bcommon practice analysis\b/i,
+      /\bwithout carbon (?:revenue|revenues)\b/i,
+      /\bfinancial(?:ly)? (?:unattractive|not attractive|not viable)\b/i,
+      /\bfirst of (?:its|a) kind\b/i,
+    ];
+    const acceptableSignals = [
+      /\bbarrier\b/i,
+      /\bcommon practice\b/i,
+      /\binvestment\b/i,
+      /\badditionality assessment\b/i,
+      /\badditionality (?:has been )?(?:assessed|demonstrated|justified|shown)\b/i,
+    ];
+    const weakSignals = [
+      /\btool is applied\b/i,
+      /\btool .* is applied\b/i,
+      /\bappl(?:y|ies|ied) the tool\b/i,
+      /\bvt0001\b/i,
+      /\btool for the demonstration and assessment of additionality\b/i,
+      /\badditionality tool\b/i,
+    ];
+
+    if (GENERIC_METHODOLOGY_RE.test(combinedText) && !hasAnyPattern(combinedText, strongSignals)) {
+      return {
+        specId: "additionality",
+        grade: "reject",
+        reason: "Matched evidence was methodology preamble text, not project-specific additionality evidence.",
+        warningCode: "check_spec_additionality_methodology_reject",
+      };
+    }
+    if (hasAnyPattern(combinedText, strongSignals)) {
+      return {
+        specId: "additionality",
+        grade: "strong",
+        reason: "Matched evidence includes direct project-specific additionality justification.",
+        warningCode: "check_spec_additionality_strong",
+      };
+    }
+    if (hasAnyPattern(combinedText, acceptableSignals) && checkSpecWordCount(combinedText) >= 12 && !hasAnyPattern(combinedText, weakSignals)) {
+      return {
+        specId: "additionality",
+        grade: "acceptable",
+        reason: "Matched evidence discusses additionality with enough project-specific detail.",
+        warningCode: "check_spec_additionality_acceptable",
+      };
+    }
+    if (hasAnyPattern(combinedText, weakSignals) || /\badditionality\b/i.test(combinedText)) {
+      return {
+        specId: "additionality",
+        grade: "weak",
+        reason: "Matched evidence is related to additionality, but it does not show a project-specific conclusion or analysis.",
+        warningCode: "check_spec_additionality_weak",
+      };
+    }
+    return {
+      specId: "additionality",
+      grade: "reject",
+      reason: "Matched evidence does not address project-specific additionality.",
+      warningCode: "check_spec_additionality_no_project_signal",
+    };
+  }
+
+  if (input.reviewArea === "baseline") {
+    const strongSignals = [
+      /\bbaseline scenario is\b/i,
+      /\bwithout(?: |-)the project\b/i,
+      /\bwithout(?: |-)?project\b/i,
+      /\bin the absence of the project\b/i,
+      /\bmost likely land(?: |-)?use scenario\b/i,
+      /\bwould continue\b/i,
+      /\bcontinu(?:e|ed|ation) of\b/i,
+    ];
+    const methodologyPreambleSignals = [
+      /\bthe methodology .* determines the baseline\b/i,
+      /\bbaseline scenario shall be determined\b/i,
+      /\bbaseline shall be determined\b/i,
+      /\bbaseline emissions are determined\b/i,
+      /\baccording to the methodology\b/i,
+      /\bbaseline methodology\b/i,
+    ];
+
+    if (hasAnyPattern(combinedText, methodologyPreambleSignals) && !hasAnyPattern(combinedText, strongSignals)) {
+      return {
+        specId: "baseline_scenario",
+        grade: "reject",
+        reason: "Matched evidence was methodology text about how to determine a baseline, not the project's baseline scenario.",
+        warningCode: "check_spec_baseline_methodology_reject",
+      };
+    }
+    if (hasAnyPattern(combinedText, strongSignals) && checkSpecWordCount(combinedText) >= 10) {
+      return {
+        specId: "baseline_scenario",
+        grade: "strong",
+        reason: "Matched evidence directly states the project's without-project baseline scenario.",
+        warningCode: "check_spec_baseline_strong",
+      };
+    }
+    if (/\bbaseline scenario\b/i.test(combinedText) && (/\bmost likely\b/i.test(combinedText) || /\bwithout\b/i.test(combinedText))) {
+      return {
+        specId: "baseline_scenario",
+        grade: "acceptable",
+        reason: "Matched evidence describes the baseline scenario with enough project-specific context.",
+        warningCode: "check_spec_baseline_acceptable",
+      };
+    }
+    if (/\bbaseline\b/i.test(combinedText) || /\bwithout-project\b/i.test(combinedSections)) {
+      return {
+        specId: "baseline_scenario",
+        grade: "weak",
+        reason: "Matched evidence is related to baseline, but it does not clearly state the project's baseline scenario.",
+        warningCode: "check_spec_baseline_weak",
+      };
+    }
+    return {
+      specId: "baseline_scenario",
+      grade: "reject",
+      reason: "Matched evidence does not support the project's baseline scenario.",
+      warningCode: "check_spec_baseline_no_project_signal",
+    };
+  }
+
+  if (input.reviewArea === "monitoring") {
+    const strongSignals = [
+      /\bmonitoring plan\b/i,
+      /\bmonitor(?:ed|ing)\b.*\b(?:annually|monthly|quarterly|every \d+|frequency)\b/i,
+      /\bdata source\b/i,
+      /\bparameter\b/i,
+      /\bremote sensing\b/i,
+      /\bqaqc\b/i,
+      /\bsampling\b/i,
+      /\bplot revisit\b/i,
+    ];
+    const genericMethodologySignals = [
+      /\bmonitoring methodology\b/i,
+      /\bthis methodology requires monitoring\b/i,
+      /\baccording to the monitoring methodology\b/i,
+      /\bmonitoring shall be conducted in accordance with\b/i,
+      /\bmethodology requires that\b/i,
+    ];
+
+    if (hasAnyPattern(combinedText, genericMethodologySignals) && !hasAnyPattern(combinedText, strongSignals)) {
+      return {
+        specId: "monitoring",
+        grade: "reject",
+        reason: "Matched evidence was generic methodology text about monitoring, not the project's monitoring plan.",
+        warningCode: "check_spec_monitoring_methodology_reject",
+      };
+    }
+    if (hasAnyPattern(combinedText, strongSignals) && (combinedSections.includes("monitoring plan") || checkSpecWordCount(combinedText) >= 10)) {
+      return {
+        specId: "monitoring",
+        grade: "strong",
+        reason: "Matched evidence describes concrete monitoring plan procedures or frequencies.",
+        warningCode: "check_spec_monitoring_strong",
+      };
+    }
+    const proceduralHits = [
+      /\bmonitoring\b/i,
+      /\bfrequency\b/i,
+      /\bparameter\b/i,
+      /\bmeasure(?:d|ment)?\b/i,
+      /\brecord(?:ed|ing)?\b/i,
+    ].filter((pattern) => pattern.test(combinedText)).length;
+    if (proceduralHits >= 2 && checkSpecWordCount(combinedText) >= 8) {
+      return {
+        specId: "monitoring",
+        grade: "acceptable",
+        reason: "Matched evidence discusses monitoring procedures with enough project-specific detail.",
+        warningCode: "check_spec_monitoring_acceptable",
+      };
+    }
+    if (/\bmonitoring\b/i.test(combinedText) || /\bmonitoring\b/i.test(combinedSections)) {
+      return {
+        specId: "monitoring",
+        grade: "weak",
+        reason: "Matched evidence is related to monitoring, but it does not clearly describe the project's monitoring plan.",
+        warningCode: "check_spec_monitoring_weak",
+      };
+    }
+    return {
+      specId: "monitoring",
+      grade: "reject",
+      reason: "Matched evidence does not support a project monitoring answer.",
+      warningCode: "check_spec_monitoring_no_project_signal",
+    };
+  }
+
+  return null;
 }
 
 function normalizeConfidence(confidence: ProjectFactConfidence): number {
@@ -191,6 +459,60 @@ function finalizeCandidate(document: EvidenceDocument, candidate: RouterCandidat
       ? candidate.warnings
       : [...candidate.warnings, "low_confidence"],
   };
+}
+
+
+function applyCheckSpecGate(input: DeterministicRouterInput, candidate: RouterCandidate): DeterministicRouterResult | null {
+  if (!input.evidenceDocument || candidate.route === "project_fact_contract") return null;
+
+  const assessment = assessCheckSpecEvidence({
+    claimText: input.claimText,
+    reviewArea: input.reviewArea,
+    queryIntentAnalysis: input.queryIntentAnalysis,
+    evidenceDocument: input.evidenceDocument,
+    candidate: {
+      route: candidate.route,
+      answerText: candidate.answerText,
+      evidenceSpanIds: candidate.evidenceSpanIds,
+      quoteTexts: candidate.quoteInputs.map((quote) => quote.quote),
+      sectionPaths: candidate.sectionPaths,
+    },
+  });
+
+  if (!assessment) return null;
+  if (assessment.grade === "strong" || assessment.grade === "acceptable") return null;
+
+  return buildFallback({
+    answerText: assessment.grade === "weak"
+      ? "Quick Check found related evidence, but it was not sufficient to answer this question deterministically."
+      : "Quick Check found no validated evidence path for this question.",
+    status: assessment.grade === "weak" ? "unclear" : "no_evidence",
+    confidence: candidate.confidence,
+    warnings: [...candidate.warnings, assessment.warningCode],
+  });
+}
+
+function finalizeWithRouterAuthority(input: DeterministicRouterInput, candidate: RouterCandidate): DeterministicRouterResult {
+  const gated = applyCheckSpecGate(input, candidate);
+  if (gated) return gated;
+
+  if (candidate.isStructuredInput) {
+    return {
+      answerText: candidate.answerText,
+      status: candidate.confidence >= ANSWER_CONFIDENCE_THRESHOLD ? "answered" : "unclear",
+      route: candidate.route,
+      confidence: clampConfidence(candidate.confidence),
+      evidenceSpanIds: candidate.evidenceSpanIds,
+      quotes: [],
+      pages: candidate.pages,
+      sectionPaths: candidate.sectionPaths,
+      warnings: candidate.confidence >= ANSWER_CONFIDENCE_THRESHOLD
+        ? [...candidate.warnings, "structured_input_provenance"]
+        : [...candidate.warnings, "low_confidence", "structured_input_provenance"],
+    };
+  }
+
+  return finalizeCandidate(input.evidenceDocument!, candidate);
 }
 
 function buildFactCandidate(input: DeterministicRouterInput): RouterCandidate | null {
@@ -688,10 +1010,10 @@ export function buildDeterministicRouterResult(input: DeterministicRouterInput):
             : [...sectionCandidate.warnings, "low_confidence", "structured_input_provenance"],
         };
       }
-      return finalizeCandidate(input.evidenceDocument, sectionCandidate);
+      return finalizeWithRouterAuthority(input, sectionCandidate);
     }
     const lexicalCandidate = buildLexicalCandidate(input);
-    if (lexicalCandidate) return finalizeCandidate(input.evidenceDocument, lexicalCandidate);
+    if (lexicalCandidate) return finalizeWithRouterAuthority(input, lexicalCandidate);
     return buildFallback({
       answerText: "Quick Check found multiple plausible evidence paths and did not choose one deterministically.",
       status: "unclear",
@@ -717,21 +1039,5 @@ export function buildDeterministicRouterResult(input: DeterministicRouterInput):
     });
   }
 
-  if (candidate.isStructuredInput) {
-    return {
-      answerText: candidate.answerText,
-      status: candidate.confidence >= ANSWER_CONFIDENCE_THRESHOLD ? "answered" : "unclear",
-      route: candidate.route,
-      confidence: clampConfidence(candidate.confidence),
-      evidenceSpanIds: candidate.evidenceSpanIds,
-      quotes: [],
-      pages: candidate.pages,
-      sectionPaths: candidate.sectionPaths,
-      warnings: candidate.confidence >= ANSWER_CONFIDENCE_THRESHOLD
-        ? [...candidate.warnings, "structured_input_provenance"]
-        : [...candidate.warnings, "low_confidence", "structured_input_provenance"],
-    };
-  }
-
-  return finalizeCandidate(input.evidenceDocument, candidate);
+  return finalizeWithRouterAuthority(input, candidate);
 }

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -33,17 +33,17 @@ type DeterministicRouterInput = {
 };
 
 
-type CheckSpecId = "additionality" | "baseline_scenario" | "monitoring";
-type SufficiencyGrade = "strong" | "acceptable" | "weak" | "reject";
+export type CheckSpecId = "additionality" | "baseline_scenario" | "monitoring";
+export type SufficiencyGrade = "strong" | "acceptable" | "weak" | "reject";
 
-type CheckSpecAssessment = {
+export type CheckSpecAssessment = {
   specId: CheckSpecId;
   grade: SufficiencyGrade;
   reason: string;
   warningCode: string;
 };
 
-type CheckSpecInput = {
+export type CheckSpecInput = {
   claimText: string;
   reviewArea: ReviewArea;
   queryIntentAnalysis?: QueryIntentAnalysis;
@@ -110,7 +110,7 @@ function hasAnyPattern(text: string, patterns: RegExp[]): boolean {
   return patterns.some((pattern) => pattern.test(text));
 }
 
-function assessCheckSpecEvidence(input: CheckSpecInput): CheckSpecAssessment | null {
+export function assessCheckSpecEvidence(input: CheckSpecInput): CheckSpecAssessment | null {
   const spanLookup = getSpanLookup(input.evidenceDocument);
   const spans = input.candidate.evidenceSpanIds
     .map((spanId) => spanLookup.get(spanId))

--- a/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
+++ b/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
@@ -11,11 +11,16 @@ const PLUM_PDD_TEXT = fs.readFileSync(
   path.join(process.cwd(), "tests/fixtures/quick-check/plum-pdd-regression.txt"),
   "utf-8",
 );
+const PLUM_A_PDF_TEXT = fs.readFileSync(
+  path.join(process.cwd(), "tests/fixtures/quick-check/a-pdf-extracted.txt"),
+  "utf-8",
+);
 
 const createAndStoreEvidenceAttachmentMock = jest.fn();
 
 const PDF_TEXT_BY_FILENAME: Record<string, string> = {
   "qc-smoke-upload.pdf": PLUM_PDD_TEXT,
+  "qc-plum-a-upload.pdf": PLUM_A_PDF_TEXT,
 };
 
 jest.mock("@/lib/proofMap/attachments", () => ({
@@ -111,6 +116,14 @@ describe("QuickCheckPanel upload/session boundary smoke test — proves the pane
     );
     expect(button).toBeTruthy();
     button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  }
+
+  function evidenceCheckSummary(label: string) {
+    const summary = Array.from(container.querySelectorAll("summary")).find((node) =>
+      node.textContent?.includes(label),
+    );
+    expect(summary).toBeTruthy();
+    return summary as HTMLElement;
   }
 
   beforeEach(() => {
@@ -322,4 +335,47 @@ describe("QuickCheckPanel upload/session boundary smoke test — proves the pane
     expect(text).not.toContain("no document text available");
     expect(text).not.toContain("parsed document text was unavailable");
   });
+
+  it("does not mark PLUM methodology/tool text as found additionality in the upload results path", async () => {
+    seedSession({
+      claimText: "What methodology was applied?",
+      filename: "qc-plum-a-upload.pdf",
+      methodologyId: "VM0007",
+      methodologyVersion: "4.2",
+    });
+    await seedAttachmentText("att-upload-1", `%PDF-1.4\n(${PLUM_A_PDF_TEXT})\n%%EOF`);
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+    await flushUi();
+    await act(async () => {
+      clickButton("Run checks");
+    });
+    await flushUi();
+
+    const methodologySummary = evidenceCheckSummary("Methodology");
+    const additionalitySummary = evidenceCheckSummary("Additionality");
+    const leakageSummary = evidenceCheckSummary("Leakage");
+
+    expect(methodologySummary.textContent).toContain("Found");
+    expect(additionalitySummary.textContent).toContain("Unclear");
+    expect(additionalitySummary.textContent).not.toContain("Found");
+    expect(leakageSummary.textContent).not.toContain("Found");
+
+    const additionalityDetails = additionalitySummary.parentElement as HTMLDetailsElement;
+    additionalityDetails.open = true;
+    const leakageDetails = leakageSummary.parentElement as HTMLDetailsElement;
+    leakageDetails.open = true;
+    await flushUi();
+
+    expect(additionalityDetails.textContent).toContain("VT0001");
+    expect(additionalityDetails.textContent).toContain("deterministic router did not validate");
+    expect(leakageDetails.textContent).toContain("demonstrate low potential for project-induced leakage.");
+  }, 20000);
 });

--- a/tests/lib/evidenceChecks.test.ts
+++ b/tests/lib/evidenceChecks.test.ts
@@ -48,6 +48,41 @@ function runCheck(input: {
   });
 }
 
+function runCheckDetailed(input: {
+  checkId: EvidenceCheckId;
+  claimText: string;
+  rawText: string;
+  methodologyId?: string;
+  methodologyVersion?: string;
+}) {
+  const structuredQueryContext = getStructuredQueryContext(input.rawText);
+  const questionResult = buildReviewQuestionResult({
+    claimText: input.claimText,
+    methodologyId: input.methodologyId ?? "",
+    methodologyVersion: input.methodologyVersion ?? "",
+    rawPddText: input.rawText,
+    structuredQueryContext,
+  });
+
+  const validated = validateCheck(getContract(input.checkId), {
+    evidenceDocument: structuredQueryContext.evidenceDocument,
+    projectFactContract: structuredQueryContext.projectFactContract,
+    sectionTableIndex: structuredQueryContext.sectionTableIndex,
+    routerResult: questionResult.routerResult,
+    queryIntentAnalysis: questionResult.queryIntentAnalysis,
+    rawText: input.rawText,
+  });
+
+  const formatted = formatEvidenceCheckUiText({
+    label: getAllChecks().find((check) => check.id === input.checkId)?.label ?? input.checkId,
+    status: validated.status,
+    answerText: validated.answerText,
+    downgradeReason: validated.downgradeReason,
+  });
+
+  return { questionResult, validated, formatted };
+}
+
 describe("getAllChecks", () => {
   it("only exposes the six supported quick check topics", () => {
     expect(getAllChecks().map((check) => check.id)).toEqual([
@@ -277,15 +312,27 @@ describe("authoritative evidence check selectors", () => {
     expect(result.answerText).not.toMatch(/^Quick Check did not find/i);
   });
 
-  it("finds additionality evidence from PLUM even when it is embedded in methodology content", () => {
-    const result = runCheck({
+  it("rejects PLUM methodology/tool text as sufficient additionality evidence", () => {
+    const result = runCheckDetailed({
       checkId: "additionality",
       claimText: "What does the document say about additionality?",
       rawText: PLUM_A_DOC_TEXT,
     });
 
-    expect(result.answerText).toContain("VT0001");
-    expect(result.answerText).not.toMatch(/^Quick Check did not find/i);
+    expect(result.questionResult.routerResult.status).not.toBe("answered");
+    expect(result.validated.status).toBe("found");
+    expect(result.formatted.answerText).toContain("VT0001");
+  });
+
+  it("keeps leakage formatting human-readable when the source sentence ends with leakage", () => {
+    const formatted = formatEvidenceCheckUiText({
+      label: "Leakage",
+      status: "found",
+      answerText: "demonstrate low potential for project-induced leakage.",
+      downgradeReason: "",
+    });
+
+    expect(formatted.answerText).toBe("demonstrate low potential for project-induced leakage.");
   });
 
   it("finds stakeholder consultation evidence from stakeholder engagement or dissemination text in PLUM", () => {

--- a/tests/lib/quickCheckSufficiency.test.ts
+++ b/tests/lib/quickCheckSufficiency.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "@jest/globals";
+import { buildReviewQuestionResult } from "@/lib/chat/quickCheckReviewQuestion";
+
+const STRONG_BASELINE_TEXT = [
+  "2.4 Baseline Scenario",
+  "The baseline scenario is continued grazing pressure and fuelwood extraction without the project.",
+  "Remote sensing and field observations support the without-project scenario.",
+].join("\n");
+
+const BASELINE_METHODOLOGY_FALSE_POSITIVE_TEXT = [
+  "2.4 Baseline Scenario",
+  "According to the methodology, the baseline scenario shall be determined using the applicable module.",
+  "The methodology determines the baseline and leakage approach.",
+].join("\n");
+
+const STRONG_ADDITIONALITY_TEXT = [
+  "2.6 Additionality",
+  "The project is additional because the barrier analysis shows that implementation is financially unattractive without carbon revenues.",
+  "The investment analysis further demonstrates that the project would not proceed under the baseline case.",
+].join("\n");
+
+const WEAK_ADDITIONALITY_TEXT = [
+  "2.6 Additionality",
+  "Additionality is discussed for the project in this section.",
+  "Further evidence is referenced elsewhere.",
+].join("\n");
+
+const REJECT_ADDITIONALITY_TEXT = [
+  "2.6 Additionality",
+  "The latest approved version of the Tool for the Demonstration and Assessment of Additionality is applied.",
+  "The methodology framework is followed.",
+].join("\n");
+
+const STRONG_MONITORING_TEXT = [
+  "4.3 Monitoring Plan",
+  "The monitoring plan measures forest cover change and biomass annually using remote sensing and permanent sample plots.",
+  "Monitoring frequency is annual and the data source for each parameter is recorded in the monitoring database.",
+].join("\n");
+
+const GENERIC_MONITORING_METHODOLOGY_TEXT = [
+  "4.3 Monitoring",
+  "According to the monitoring methodology, parameters shall be monitored in accordance with the methodology requirements.",
+  "This methodology requires monitoring of all relevant parameters.",
+].join("\n");
+
+function buildResult(claimText: string, rawPddText: string) {
+  return buildReviewQuestionResult({
+    claimText,
+    methodologyId: "VM0007",
+    methodologyVersion: "4.2",
+    rawPddText,
+  });
+}
+
+function expectAnsweredProvenance(result: ReturnType<typeof buildResult>) {
+  expect(result.routerResult.status).toBe("answered");
+  expect(result.routerResult.evidenceSpanIds.length).toBeGreaterThan(0);
+  expect(result.routerResult.quotes.length).toBeGreaterThan(0);
+  expect(result.routerResult.pages.length).toBeGreaterThan(0);
+  expect(result.routerResult.sectionPaths.length).toBeGreaterThan(0);
+}
+
+describe("quick check evidence sufficiency", () => {
+  it("accepts strong additionality evidence", () => {
+    const result = buildResult("Is additionality demonstrated?", STRONG_ADDITIONALITY_TEXT);
+
+    expect(result.reviewArea).toBe("additionality");
+    expectAnsweredProvenance(result);
+  });
+
+  it("downgrades weak additionality evidence to unclear", () => {
+    const result = buildResult("Is additionality demonstrated?", WEAK_ADDITIONALITY_TEXT);
+
+    expect(result.reviewArea).toBe("additionality");
+    expect(result.routerResult.status).toBe("unclear");
+    expect(result.routerResult.route).toBe("fallback");
+    expect(result.routerResult.warnings).toContain("check_spec_additionality_weak");
+  });
+
+  it("rejects thin additionality tool evidence", () => {
+    const result = buildResult("Is additionality demonstrated?", REJECT_ADDITIONALITY_TEXT);
+
+    expect(result.reviewArea).toBe("additionality");
+    expect(result.routerResult.status).toBe("no_evidence");
+    expect(result.routerResult.route).toBe("fallback");
+    expect(result.routerResult.warnings).toContain("check_spec_additionality_methodology_reject");
+  });
+
+  it("accepts strong baseline scenario evidence", () => {
+    const result = buildResult("Explain the baseline scenario.", STRONG_BASELINE_TEXT);
+
+    expect(result.reviewArea).toBe("baseline");
+    expectAnsweredProvenance(result);
+  });
+
+  it("rejects baseline methodology-text false positives", () => {
+    const result = buildResult("Explain the baseline scenario.", BASELINE_METHODOLOGY_FALSE_POSITIVE_TEXT);
+
+    expect(result.reviewArea).toBe("baseline");
+    expect(result.routerResult.status).toBe("no_evidence");
+    expect(result.routerResult.route).toBe("fallback");
+    expect(result.routerResult.warnings).toContain("check_spec_baseline_methodology_reject");
+  });
+
+  it("accepts monitoring plan evidence", () => {
+    const result = buildResult("Check the monitoring plan.", STRONG_MONITORING_TEXT);
+
+    expect(result.reviewArea).toBe("monitoring");
+    expectAnsweredProvenance(result);
+  });
+
+  it("rejects generic monitoring methodology false positives", () => {
+    const result = buildResult("Check the monitoring plan.", GENERIC_MONITORING_METHODOLOGY_TEXT);
+
+    expect(result.reviewArea).toBe("monitoring");
+    expect(result.routerResult.status).toBe("no_evidence");
+    expect(result.routerResult.route).toBe("fallback");
+    expect(result.routerResult.warnings).toContain("check_spec_monitoring_methodology_reject");
+  });
+});

--- a/tests/lib/quickCheckSufficiency.test.ts
+++ b/tests/lib/quickCheckSufficiency.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
-import { buildReviewQuestionResult } from "@/lib/chat/quickCheckReviewQuestion";
+import fs from "fs";
+import path from "path";
+import { buildReviewQuestionResult, getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import { assessCheckSpecEvidence } from "@/lib/quickCheck/router/deterministicRouter";
 
 const STRONG_BASELINE_TEXT = [
   "2.4 Baseline Scenario",
@@ -43,12 +46,64 @@ const GENERIC_MONITORING_METHODOLOGY_TEXT = [
   "This methodology requires monitoring of all relevant parameters.",
 ].join("\n");
 
+const FACT_PDD_TEXT = [
+  "Project Title: Coastal Mangrove Restoration Project",
+  "Host Country: Kenya",
+  "Project Proponent: Blue Carbon Initiative",
+  "Methodology Applied: VM0007 REDD+ Methodology Framework",
+  "",
+  "2.2 Project Location",
+  "The project is located in Lamu County, Kenya.",
+].join("\n");
+
+const TOC_ONLY_ADDITIONALITY_TEXT = [
+  "Table of Contents",
+  "3.1 Additionality ........................................................ 12",
+].join("\n");
+
+const TOC_ONLY_BASELINE_TEXT = [
+  "Table of Contents",
+  "2.4 Baseline Scenario .................................................... 8",
+].join("\n");
+
+const TOC_ONLY_MONITORING_TEXT = [
+  "Table of Contents",
+  "4.3 Monitoring Plan ...................................................... 14",
+].join("\n");
+
+const EXISTING_TOC_FIXTURE = fs.readFileSync(
+  path.join(__dirname, "../fixtures/quick-check/eval/plum-toc-only-stakeholder.txt"),
+  "utf8",
+);
+
 function buildResult(claimText: string, rawPddText: string) {
   return buildReviewQuestionResult({
     claimText,
     methodologyId: "VM0007",
     methodologyVersion: "4.2",
     rawPddText,
+  });
+}
+
+function assessResult(
+  claimText: string,
+  rawPddText: string,
+  reviewArea: "additionality" | "baseline" | "monitoring",
+) {
+  const context = getStructuredQueryContext(rawPddText);
+  const spans = context.evidenceDocument.spans.filter((span) => span.reliability !== "excluded");
+
+  return assessCheckSpecEvidence({
+    claimText,
+    reviewArea,
+    evidenceDocument: context.evidenceDocument,
+    candidate: {
+      route: "lexical_retrieval",
+      answerText: spans.map((span) => span.text).join("\n"),
+      evidenceSpanIds: spans.map((span) => span.spanId),
+      quoteTexts: spans.map((span) => span.text),
+      sectionPaths: spans.flatMap((span) => span.sectionPath),
+    },
   });
 }
 
@@ -116,5 +171,54 @@ describe("quick check evidence sufficiency", () => {
     expect(result.routerResult.status).toBe("no_evidence");
     expect(result.routerResult.route).toBe("fallback");
     expect(result.routerResult.warnings).toContain("check_spec_monitoring_methodology_reject");
+  });
+
+  it("rejects TOC-only additionality evidence", () => {
+    const assessment = assessResult("Is additionality demonstrated?", TOC_ONLY_ADDITIONALITY_TEXT, "additionality");
+
+    expect(assessment).toMatchObject({
+      specId: "additionality",
+      grade: "reject",
+      warningCode: "check_spec_additionality_toc_reject",
+    });
+  });
+
+  it("rejects TOC-only baseline evidence", () => {
+    const assessment = assessResult("Explain the baseline scenario.", TOC_ONLY_BASELINE_TEXT, "baseline");
+
+    expect(assessment).toMatchObject({
+      specId: "baseline_scenario",
+      grade: "reject",
+      warningCode: "check_spec_baseline_scenario_toc_reject",
+    });
+  });
+
+  it("rejects TOC-only monitoring evidence", () => {
+    const assessment = assessResult("Check the monitoring plan.", TOC_ONLY_MONITORING_TEXT, "monitoring");
+
+    expect(assessment).toMatchObject({
+      specId: "monitoring",
+      grade: "reject",
+      warningCode: "check_spec_monitoring_toc_reject",
+    });
+  });
+
+  it("does not affect ProjectFactContract fact answers", () => {
+    const result = buildResult("What is the project title and host country?", FACT_PDD_TEXT);
+
+    expect(result.routerResult.route).toBe("project_fact_contract");
+    expect(result.routerResult.status).toBe("answered");
+    expect(result.routerResult.answerText).toContain("Project title:");
+    expect(result.routerResult.answerText).toContain("Host country: Kenya.");
+    expectAnsweredProvenance(result);
+  });
+
+  it("downgrades an existing TOC false positive fixture to unclear", () => {
+    const result = buildResult("Check the monitoring plan.", EXISTING_TOC_FIXTURE);
+
+    expect(result.reviewArea).toBe("monitoring");
+    expect(result.routerResult.status).toBe("unclear");
+    expect(result.routerResult.route).toBe("fallback");
+    expect(result.routerResult.warnings).toContain("ambiguous_intent");
   });
 });


### PR DESCRIPTION
## What changed
Adds a check-specific sufficiency layer inside the deterministic Quick Check router for `additionality`, `baseline scenario`, and `monitoring` questions.

The router now grades retrieved evidence as `strong`, `acceptable`, `weak`, or `reject` before it is allowed to return `answered`.

## Why
Quick Check was already able to retrieve related text, but it was still too permissive about whether that text was sufficient to support a carbon-review answer.

This change tightens judgment without changing extraction behavior, UI behavior, or introducing LLM calls.

## Details
- adds a `CheckSpec`-style sufficiency contract in the router
- blocks `answered` unless evidence is `strong` or `acceptable`
- downgrades weak related evidence to `unclear`
- downgrades unsupported evidence to `no_evidence`
- rejects table-of-contents evidence for these checks
- rejects methodology-preamble evidence for project-specific baseline / monitoring / additionality answers
- rejects thin additionality evidence like generic tool-application language
- preserves router ownership of final status and provenance rules

## Validation
- `npx tsc --noEmit`
- `npm run lint`
- `npm test`
- `npm run quickcheck:eval:corpus -- --strict`

## Impact
Quick Check should now be stricter about when it says a document actually supports additionality, baseline scenario, or monitoring questions, while keeping existing provenance guarantees for every `answered` result.