### PR TITLE
docs: Quick Check parser replacement roadmap after Phase 0A

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -180,6 +180,12 @@ Lane status: Done
 Make Quick Check improve from real PDD/document failures through controlled gold fixtures, regression tests, selector fixes, and strict eval gates. Production may collect corrections, but only reviewed fixtures and PRs may change behavior.
 
 
+## quickcheck-parser-replacement
+
+Status SSOT: `docs/roadmaps/quickcheck-parser-replacement/phase-status.json`
+Details: `docs/roadmaps/quickcheck-parser-replacement/PLAN.md`
+
+
 ## requirement-coverage
 
 Status SSOT: `docs/roadmaps/requirement-coverage/phase-status.json`

--- a/docs/roadmaps/quickcheck-parser-replacement/PLAN.md
+++ b/docs/roadmaps/quickcheck-parser-replacement/PLAN.md
@@ -1,0 +1,236 @@
+# Quick Check Parser Replacement Roadmap
+
+## Goal
+
+Replace Quick Check's fragile raw-text / regex-based PDF extraction with a higher-fidelity parser, starting with Docling, while keeping Article6 evidence judgment intact.
+
+The parser should improve document structure, reading order, headings, sections, tables, and page provenance.
+
+The parser must not decide final answer status.
+
+## Core principle
+
+Parsing is plumbing.
+
+Evidence judgment is the product.
+
+Docling or any future parser may produce better structured document input, but Article6 still owns:
+
+- EvidenceDocument
+- EvidenceSpanIndex
+- quote validation
+- ProjectFactContract
+- section/table retrieval
+- deterministic router
+- no fake answers
+- eval corpus
+
+## Completed
+
+### Phase 0A: Parser Adapter Boundary
+
+Status:
+
+`done`
+
+PR:
+
+`#794`
+
+Outcome:
+
+- `ParserAdapter` boundary exists.
+- Current raw-text extractor is wrapped as an adapter.
+- `ParsedDocument` shape exists.
+- `ParsedDocument` normalizes into the existing evidence path.
+- Existing Quick Check behavior remains unchanged.
+- No external parser dependency was added.
+- Router remains final authority.
+- UI was not changed.
+- Eval thresholds were not weakened.
+
+## Current phase
+
+### Phase 0B: Docling Experimental Adapter
+
+Branch:
+
+`feat/qc-docling-adapter`
+
+Goal:
+
+Add Docling as an experimental parser adapter behind a feature flag.
+
+Expected outcome:
+
+- Docling adapter exists.
+- Current raw-text adapter remains default.
+- Docling can parse a PDF into `ParsedDocument`.
+- Docling output normalizes into the existing `DocumentStructure` / `EvidenceDocument` path.
+- No router behavior change.
+- No UI change.
+- No default parser switch yet.
+
+Success criteria:
+
+- Existing tests still pass.
+- Existing strict eval corpus still passes.
+- Docling adapter can be tested locally or in controlled mode.
+- No answer status is decided by Docling.
+- No evidence judgment is bypassed.
+
+## Next phases
+
+### Phase 0C: Parser Bakeoff Scorecard
+
+Branch:
+
+`feat/qc-parser-bakeoff`
+
+Goal:
+
+Compare current raw-text adapter vs Docling on frozen carbon PDFs.
+
+Score:
+
+- project title extraction
+- host country extraction
+- methodology extraction
+- document family signals
+- heading preservation
+- section hierarchy
+- additionality section retrieval
+- baseline section retrieval
+- monitoring section retrieval
+- leakage section retrieval
+- table extraction
+- page provenance
+- quote validation compatibility
+- latency
+- failure rate
+
+Expected outcome:
+
+- JSON scorecard generated.
+- No default parser switch yet.
+- No eval threshold weakening.
+
+### Phase 0D: Default Parser Switch Decision
+
+Branch:
+
+`feat/qc-parser-default-decision`
+
+Goal:
+
+Switch default parser only if Docling beats the current adapter on frozen PDFs and does not weaken Quick Check reliability.
+
+Expected outcome:
+
+- Docling becomes default only if bakeoff evidence supports it.
+- Raw-text adapter remains available as fallback.
+- Rollback path exists.
+- Strict eval corpus passes.
+
+### Phase 1: Evidence Compiler v2
+
+Branch:
+
+`feat/qc-evidence-compiler-v2`
+
+Goal:
+
+Use better parser structure to improve canonical evidence spans.
+
+Expected outcome:
+
+- better page provenance
+- better section provenance
+- better heading hierarchy
+- better span typing
+- better table/cell provenance where available
+- router behavior remains controlled
+
+### Phase 2: Family-Aware ProjectFactContract v2
+
+Branch:
+
+`feat/qc-project-fact-contract-v2`
+
+Goal:
+
+Improve project title, host country, and methodology extraction using document-family-aware rules.
+
+Expected outcome:
+
+- CDM PDD extraction improves
+- VCS/Verra PD extraction improves
+- Gold Standard extraction improves
+- confidence/provenance remains required
+
+### Phase 3: Hierarchical Section + Table Index
+
+Branch:
+
+`feat/qc-section-table-index-v2`
+
+Goal:
+
+Use parser-preserved hierarchy and table structure to improve section/table retrieval.
+
+Expected outcome:
+
+- better baseline retrieval
+- better additionality retrieval
+- better monitoring retrieval
+- better leakage retrieval
+- better table-backed evidence retrieval
+- router still validates final evidence
+
+### Phase 4: Evidence Sufficiency Validators
+
+Branch:
+
+`feat/qc-evidence-sufficiency-validators`
+
+Goal:
+
+Improve Article6 judgment by requiring check-specific evidence sufficiency before returning `answered`.
+
+Expected outcome:
+
+- additionality validator
+- baseline scenario validator
+- monitoring validator
+- weak related evidence becomes `unclear`
+- unsupported evidence becomes `no_evidence`
+- no fake answers
+
+### Phase 5: Eval Corpus + CI Gate
+
+Branch:
+
+`feat/qc-parser-evidence-ci-gate`
+
+Goal:
+
+Lock parser and evidence improvements into CI.
+
+Expected outcome:
+
+- frozen parser bakeoff fixtures
+- strict eval corpus remains enforced
+- visible/router agreement remains enforced
+- no fake-answer regressions pass
+
+## Rules
+
+- One phase per PR.
+- Start each phase from latest `main`.
+- Do not start next phase before previous phase merges.
+- Do not add LLM final-answer generation.
+- Do not let parser output decide `answered`, `unclear`, or `no_evidence`.
+- Do not bypass quote validation.
+- Do not change UI unless the phase explicitly says so.
+- Do not weaken eval thresholds.
+- Keep raw-text adapter as fallback until default parser switch is proven.

--- a/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
+++ b/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
@@ -1,0 +1,83 @@
+{
+  "roadmap": "quickcheck-parser-replacement",
+  "status": "active",
+  "current_phase": "phase-0b-docling-experimental-adapter",
+  "phases": [
+    {
+      "id": "phase-0a-parser-adapter-boundary",
+      "name": "Parser Adapter Boundary",
+      "branch": "feat/qc-parser-adapter",
+      "status": "done",
+      "pr": 794,
+      "goal": "Create a parser-agnostic adapter boundary and wrap the current raw-text extractor without changing Quick Check behavior."
+    },
+    {
+      "id": "phase-0b-docling-experimental-adapter",
+      "name": "Docling Experimental Adapter",
+      "branch": "feat/qc-docling-adapter",
+      "status": "not_started",
+      "goal": "Add Docling as an experimental parser adapter behind a feature flag while keeping the current raw-text adapter as default."
+    },
+    {
+      "id": "phase-0c-parser-bakeoff-scorecard",
+      "name": "Parser Bakeoff Scorecard",
+      "branch": "feat/qc-parser-bakeoff",
+      "status": "not_started",
+      "goal": "Compare current raw-text adapter vs Docling on frozen carbon PDFs using a JSON scorecard."
+    },
+    {
+      "id": "phase-0d-default-parser-switch-decision",
+      "name": "Default Parser Switch Decision",
+      "branch": "feat/qc-parser-default-decision",
+      "status": "not_started",
+      "goal": "Switch default parser only if Docling beats the current adapter and strict evals remain safe."
+    },
+    {
+      "id": "phase-1-evidence-compiler-v2",
+      "name": "Evidence Compiler v2",
+      "branch": "feat/qc-evidence-compiler-v2",
+      "status": "not_started",
+      "goal": "Use better parser structure to improve canonical EvidenceDocument spans."
+    },
+    {
+      "id": "phase-2-family-aware-projectfactcontract-v2",
+      "name": "Family-Aware ProjectFactContract v2",
+      "branch": "feat/qc-project-fact-contract-v2",
+      "status": "not_started",
+      "goal": "Improve project title, host country, and methodology extraction using document-family-aware rules."
+    },
+    {
+      "id": "phase-3-hierarchical-section-table-index",
+      "name": "Hierarchical Section + Table Index",
+      "branch": "feat/qc-section-table-index-v2",
+      "status": "not_started",
+      "goal": "Use parser-preserved hierarchy and table structure to improve section and table retrieval."
+    },
+    {
+      "id": "phase-4-evidence-sufficiency-validators",
+      "name": "Evidence Sufficiency Validators",
+      "branch": "feat/qc-evidence-sufficiency-validators",
+      "status": "not_started",
+      "goal": "Require check-specific evidence sufficiency before returning answered."
+    },
+    {
+      "id": "phase-5-eval-corpus-ci-gate",
+      "name": "Eval Corpus + CI Gate",
+      "branch": "feat/qc-parser-evidence-ci-gate",
+      "status": "not_started",
+      "goal": "Lock parser and evidence improvements into CI with strict evals and no fake-answer regressions."
+    }
+  ],
+  "rules": {
+    "one_phase_per_pr": true,
+    "start_each_phase_from_main": true,
+    "do_not_start_next_phase_before_previous_phase_merges": true,
+    "raw_text_adapter_remains_fallback_until_switch_is_proven": true,
+    "parser_must_not_decide_final_status": true,
+    "router_remains_final_status_authority": true,
+    "document_qa_remains_presentation_only": true,
+    "no_llm_final_answer_generation": true,
+    "no_ui_changes_unless_phase_says_so": true,
+    "no_eval_threshold_weakening": true
+  }
+}


### PR DESCRIPTION
## WHAT

Create the Quick Check parser replacement roadmap after Phase 0A completion.

Adds:
- `docs/roadmaps/quickcheck-parser-replacement/PLAN.md` — full roadmap with goals, phases, and rules
- `docs/roadmaps/quickcheck-parser-replacement/phase-status.json` — machine-readable phase tracker

## WHY

Phase 0A (parser adapter boundary) is complete in #794. The next roadmap keeps the work focused:

> Docling parses. Article6 judges. Router decides. UI displays.

## Phases

| Phase | Status |
|-------|--------|
| 0A: Parser Adapter Boundary | done (#794) |
| 0B: Docling Experimental Adapter | not_started |
| 0C: Parser Bakeoff Scorecard | not_started |
| 0D: Default Parser Switch Decision | not_started |
| 1: Evidence Compiler v2 | not_started |
| 2: Family-Aware ProjectFactContract v2 | not_started |
| 3: Hierarchical Section + Table Index | not_started |
| 4: Evidence Sufficiency Validators | not_started |
| 5: Eval Corpus + CI Gate | not_started |

## ACCEPTANCE CRITERIA

- [x] PLAN.md exists
- [x] phase-status.json exists and is valid JSON
- [x] Phase 0A is marked done with PR #794 referenced
- [x] Current phase is Phase 0B
- [x] No runtime code changed
- [x] No parser dependency added
- [x] No UI changed
- [x] docs/roadmaps/SUMMARY.md auto-updated

## DO NOT

- [x] No Docling implemented
- [x] No runtime code edited
- [x] No parser dependencies added
- [x] No phase after 0A marked done