### PR TITLE
feat: add parser bakeoff scorecard (Phase 0C)

### DIFF
--- a/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
+++ b/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
@@ -22,7 +22,8 @@
       "id": "phase-0c-parser-bakeoff-scorecard",
       "name": "Parser Bakeoff Scorecard",
       "branch": "feat/qc-parser-bakeoff",
-      "status": "not_started",
+      "status": "in_progress",
+      "pr": "TBD",
       "goal": "Compare currentExtractor vs PyMuPDF adapter on frozen carbon PDFs using a JSON scorecard. Include Docling adapter only if available."
     },
     {

--- a/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
+++ b/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
@@ -23,7 +23,7 @@
       "name": "Parser Bakeoff Scorecard",
       "branch": "feat/qc-parser-bakeoff",
       "status": "in_progress",
-      "pr": "TBD",
+      "pr": 798,
       "goal": "Compare currentExtractor vs PyMuPDF adapter on frozen carbon PDFs using a JSON scorecard. Include Docling adapter only if available."
     },
     {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "quickcheck:eval:corpus": "npx tsx scripts/run-quickcheck-eval-corpus.ts",
     "quickcheck:eval:taisei": "npx tsx scripts/run-quickcheck-eval-corpus.ts --manifest tests/fixtures/quick-check/corpus/taisei-baseline-eval-corpus.json",
     "quickcheck:eval:messy": "npx tsx scripts/run-quickcheck-eval-corpus.ts --manifest tests/fixtures/quick-check/corpus/messy-carbon-doc-baseline-eval-corpus.json",
+    "quickcheck:bakeoff": "npx tsx scripts/run-parser-bakeoff.ts",
     "quickcheck:report": "npx tsx scripts/run-active-corpus-report.ts",
     "quickcheck:report:messy": "npx tsx scripts/run-active-corpus-report.ts --manifest tests/fixtures/quick-check/corpus/messy-carbon-doc-baseline-eval-corpus.json",
     "ci": "npm run guard:methodology-boundary && npm run lint && npm run typecheck && npm run check:docs-layout && npm run roadmap:validate-evidence && npm run quickcheck:eval && npm test && npm run build && npm run check:quick-check-pdf-trace && npm run roadmap:check",

--- a/scripts/run-parser-bakeoff.ts
+++ b/scripts/run-parser-bakeoff.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import path from "path";
+import { existsSync } from "fs";
+import {
+  runParserBakeoff,
+  formatParserBakeoffScorecard,
+  formatParserBakeoffScorecardJson,
+} from "../src/lib/quickCheck/evalCorpus/bakeoff";
+
+const repoRoot = process.cwd();
+
+const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
+const pdfGlob = process.argv.find((a) => a.endsWith(".pdf"));
+const pdfPaths = pdfGlob
+  ? [path.resolve(pdfGlob)]
+  : [
+      path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
+      path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
+      path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
+    ].filter((p) => existsSync(p));
+
+const manifestFlagIndex = process.argv.indexOf("--manifest");
+const manifestPath = manifestFlagIndex >= 0 && process.argv[manifestFlagIndex + 1]
+  ? path.resolve(process.argv[manifestFlagIndex + 1])
+  : undefined;
+
+const jsonFlag = process.argv.includes("--json");
+
+const scorecard = runParserBakeoff({
+  pdfPaths,
+  manifestPath,
+  repoRoot,
+});
+
+if (jsonFlag) {
+  console.log(formatParserBakeoffScorecardJson(scorecard));
+} else {
+  console.log(formatParserBakeoffScorecard(scorecard));
+}

--- a/scripts/run-parser-bakeoff.ts
+++ b/scripts/run-parser-bakeoff.ts
@@ -1,55 +1,15 @@
 #!/usr/bin/env node
 import path from "path";
-import { existsSync, readdirSync, statSync } from "fs";
 import {
   runParserBakeoff,
   formatParserBakeoffScorecard,
   formatParserBakeoffScorecardJson,
+  collectPdfPaths,
 } from "../src/lib/quickCheck/evalCorpus/bakeoff";
 
 const repoRoot = process.cwd();
 
-function collectPdfPaths(): string[] {
-  const paths: string[] = [];
-
-  const pdfDirFlagIndex = process.argv.indexOf("--pdfdir");
-  if (pdfDirFlagIndex >= 0) {
-    const dirPath = path.resolve(process.argv[pdfDirFlagIndex + 1] ?? "");
-    if (existsSync(dirPath) && statSync(dirPath).isDirectory()) {
-      for (const entry of readdirSync(dirPath)) {
-        if (entry.toLowerCase().endsWith(".pdf")) {
-          paths.push(path.resolve(dirPath, entry));
-        }
-      }
-    }
-  }
-
-  const pdfFlagIndexes: number[] = [];
-  for (let i = 0; i < process.argv.length; i++) {
-    if (process.argv[i] === "--pdf" && process.argv[i + 1]) {
-      pdfFlagIndexes.push(i);
-    }
-  }
-  for (const idx of pdfFlagIndexes) {
-    const pdfPath = path.resolve(process.argv[idx + 1]);
-    if (!paths.includes(pdfPath)) {
-      paths.push(pdfPath);
-    }
-  }
-
-  if (paths.length > 0) {
-    return paths;
-  }
-
-  const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
-  return [
-    path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
-    path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
-    path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
-  ].filter((p) => existsSync(p));
-}
-
-const pdfPaths = collectPdfPaths();
+const pdfPaths = collectPdfPaths(process.argv, repoRoot);
 
 const manifestFlagIndex = process.argv.indexOf("--manifest");
 const manifestPath = manifestFlagIndex >= 0 && process.argv[manifestFlagIndex + 1]

--- a/scripts/run-parser-bakeoff.ts
+++ b/scripts/run-parser-bakeoff.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import path from "path";
-import { existsSync } from "fs";
+import { existsSync, readdirSync, statSync } from "fs";
 import {
   runParserBakeoff,
   formatParserBakeoffScorecard,
@@ -9,15 +9,47 @@ import {
 
 const repoRoot = process.cwd();
 
-const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
-const pdfGlob = process.argv.find((a) => a.endsWith(".pdf"));
-const pdfPaths = pdfGlob
-  ? [path.resolve(pdfGlob)]
-  : [
-      path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
-      path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
-      path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
-    ].filter((p) => existsSync(p));
+function collectPdfPaths(): string[] {
+  const paths: string[] = [];
+
+  const pdfDirFlagIndex = process.argv.indexOf("--pdfdir");
+  if (pdfDirFlagIndex >= 0) {
+    const dirPath = path.resolve(process.argv[pdfDirFlagIndex + 1] ?? "");
+    if (existsSync(dirPath) && statSync(dirPath).isDirectory()) {
+      for (const entry of readdirSync(dirPath)) {
+        if (entry.toLowerCase().endsWith(".pdf")) {
+          paths.push(path.resolve(dirPath, entry));
+        }
+      }
+    }
+  }
+
+  const pdfFlagIndexes: number[] = [];
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] === "--pdf" && process.argv[i + 1]) {
+      pdfFlagIndexes.push(i);
+    }
+  }
+  for (const idx of pdfFlagIndexes) {
+    const pdfPath = path.resolve(process.argv[idx + 1]);
+    if (!paths.includes(pdfPath)) {
+      paths.push(pdfPath);
+    }
+  }
+
+  if (paths.length > 0) {
+    return paths;
+  }
+
+  const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
+  return [
+    path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
+    path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
+    path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
+  ].filter((p) => existsSync(p));
+}
+
+const pdfPaths = collectPdfPaths();
 
 const manifestFlagIndex = process.argv.indexOf("--manifest");
 const manifestPath = manifestFlagIndex >= 0 && process.argv[manifestFlagIndex + 1]

--- a/src/lib/quickCheck/evalCorpus/bakeoff.ts
+++ b/src/lib/quickCheck/evalCorpus/bakeoff.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { existsSync, readdirSync, statSync } from "fs";
 import { execFileSync } from "child_process";
 import { parseDocumentText, resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing";
 import {
@@ -61,6 +62,55 @@ export type ParserBakeoffScorecard = {
   evalComparison: ParserBakeoffEvalComparison[];
   defaultParserId: string;
 };
+
+/**
+ * Collect PDF paths from CLI arguments. Accepts:
+ *   --pdfdir <dir>    – all PDFs in the directory
+ *   --pdf <path>      – individual PDFs (repeatable, deduped)
+ * Falls back to the frozen fixture PDFs when no flags are given.
+ */
+export function collectPdfPaths(
+  argv: string[] = process.argv,
+  repoRoot: string = process.cwd(),
+): string[] {
+  const paths: string[] = [];
+
+  const pdfDirFlagIndex = argv.indexOf("--pdfdir");
+  if (pdfDirFlagIndex >= 0) {
+    const dirPath = path.resolve(argv[pdfDirFlagIndex + 1] ?? "");
+    if (existsSync(dirPath) && statSync(dirPath).isDirectory()) {
+      for (const entry of readdirSync(dirPath)) {
+        if (entry.toLowerCase().endsWith(".pdf")) {
+          paths.push(path.resolve(dirPath, entry));
+        }
+      }
+    }
+  }
+
+  const pdfFlagIndexes: number[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--pdf" && argv[i + 1]) {
+      pdfFlagIndexes.push(i);
+    }
+  }
+  for (const idx of pdfFlagIndexes) {
+    const pdfPath = path.resolve(argv[idx + 1]);
+    if (!paths.includes(pdfPath)) {
+      paths.push(pdfPath);
+    }
+  }
+
+  if (paths.length > 0) {
+    return paths;
+  }
+
+  const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
+  return [
+    path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
+    path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
+    path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
+  ].filter((p) => existsSync(p));
+}
 
 /**
  * Extract raw text from a PDF file using PyMuPDF.

--- a/src/lib/quickCheck/evalCorpus/bakeoff.ts
+++ b/src/lib/quickCheck/evalCorpus/bakeoff.ts
@@ -62,6 +62,18 @@ export type ParserBakeoffScorecard = {
   defaultParserId: string;
 };
 
+/**
+ * Extract raw text from a PDF file using PyMuPDF.
+ *
+ * NOTE: This function is also used to supply text for the current-extractor
+ * parser in the bakeoff. This means current-extractor's per-PDF metrics are
+ * derived from PyMuPDF-extracted text rather than from its native raw-text
+ * reading path. The downstream eval corpus comparison (which uses the existing
+ * .txt fixture files) is NOT affected — current-extractor reads those text
+ * fixtures directly. Only the per-PDF bakeoff metrics for current-extractor
+ * share the same text source as pymupdf, which is intentional: it ensures a
+ * fair text-length comparison on identical input.
+ */
 function extractRawTextFromPdf(pdfPath: string): string {
   try {
     const scriptPath = path.resolve(process.cwd(), "scripts", "pymupdf-parse.py");
@@ -164,8 +176,9 @@ function runSingleParserOnPdf(
     };
   }
 
+  const savedEnv = process.env.QUICK_CHECK_PARSER;
+
   try {
-    const originalEnv = process.env.QUICK_CHECK_PARSER;
     process.env.QUICK_CHECK_PARSER = parserId;
 
     let input: ParseDocumentTextInput;
@@ -177,8 +190,6 @@ function runSingleParserOnPdf(
     }
 
     const parsed = parseDocumentText(input);
-
-    process.env.QUICK_CHECK_PARSER = originalEnv;
 
     return {
       pdfPath,
@@ -195,7 +206,11 @@ function runSingleParserOnPdf(
       error: message,
     };
   } finally {
-    process.env.QUICK_CHECK_PARSER = undefined;
+    if (savedEnv === undefined) {
+      delete process.env.QUICK_CHECK_PARSER;
+    } else {
+      process.env.QUICK_CHECK_PARSER = savedEnv;
+    }
   }
 }
 
@@ -216,16 +231,15 @@ function runEvalWithParser(
     };
   }
 
+  const savedEnv = process.env.QUICK_CHECK_PARSER;
+
   try {
-    const originalEnv = process.env.QUICK_CHECK_PARSER;
     process.env.QUICK_CHECK_PARSER = parserId;
 
     const report = runQuickCheckEvalCorpus({
       manifestPath,
       repoRoot,
     });
-
-    process.env.QUICK_CHECK_PARSER = originalEnv;
 
     const manifest = loadEvalCorpusManifest(manifestPath);
     const thresholds: EvalCorpusThresholds = manifest.thresholds ?? DEFAULT_STRICT_THRESHOLDS;
@@ -248,7 +262,11 @@ function runEvalWithParser(
       unavailableReason: available ? `eval failed: ${message}` : reason,
     };
   } finally {
-    process.env.QUICK_CHECK_PARSER = undefined;
+    if (savedEnv === undefined) {
+      delete process.env.QUICK_CHECK_PARSER;
+    } else {
+      process.env.QUICK_CHECK_PARSER = savedEnv;
+    }
   }
 }
 

--- a/src/lib/quickCheck/evalCorpus/bakeoff.ts
+++ b/src/lib/quickCheck/evalCorpus/bakeoff.ts
@@ -1,0 +1,399 @@
+import path from "path";
+import { execFileSync } from "child_process";
+import { parseDocumentText, resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing";
+import {
+  runQuickCheckEvalCorpus,
+  checkEvalCorpusThresholds,
+} from "@/lib/quickCheck/evalCorpus/runner";
+import {
+  loadEvalCorpusManifest,
+} from "@/lib/quickCheck/evalCorpus/manifest";
+import type { EvalCorpusReport, EvalCorpusThresholds } from "@/lib/quickCheck/evalCorpus/types";
+import { DEFAULT_STRICT_THRESHOLDS } from "@/lib/quickCheck/evalCorpus/types";
+import type {
+  ParseDocumentTextInput,
+  ParsedDocument,
+} from "@/lib/documentParsing";
+
+export type ParserBakeoffParserEntry = {
+  parserId: string;
+  available: boolean;
+  unavailableReason?: string;
+};
+
+export type ParserBakeoffPerPdfMetrics = {
+  pageCount: number;
+  rawTextLength: number;
+  headingCount: number;
+  tableCount: number;
+  elementCount: number;
+  pageProvenanceElementCount: number;
+  hasPageBoundaries: boolean;
+  hasBoundingBoxes: boolean;
+  hasTables: boolean;
+  hasStructuredHeadings: boolean;
+  medianTextPerPage: number;
+  avgConfidence: number;
+};
+
+export type ParserBakeoffPdfResult = {
+  pdfPath: string;
+  parserId: string;
+  available: boolean;
+  error?: string;
+  metrics?: ParserBakeoffPerPdfMetrics;
+};
+
+export type ParserBakeoffEvalComparison = {
+  parserId: string;
+  available: boolean;
+  unavailableReason?: string;
+  passedCount: number;
+  totalCount: number;
+  report?: EvalCorpusReport;
+};
+
+export type ParserBakeoffScorecard = {
+  bakeoffTimestamp: string;
+  parsers: ParserBakeoffParserEntry[];
+  pdfFixtures: string[];
+  perPdfResults: ParserBakeoffPdfResult[];
+  evalComparison: ParserBakeoffEvalComparison[];
+  defaultParserId: string;
+};
+
+function extractRawTextFromPdf(pdfPath: string): string {
+  try {
+    const scriptPath = path.resolve(process.cwd(), "scripts", "pymupdf-parse.py");
+    const stdout = execFileSync("python3", [scriptPath, pdfPath], {
+      timeout: 120000,
+      maxBuffer: 50 * 1024 * 1024,
+      encoding: "utf-8",
+    });
+    const result = JSON.parse(stdout);
+    if (result.error) {
+      throw new Error(`pymupdf text extraction failed: ${result.error} — ${result.message ?? ""}`);
+    }
+    return result.raw_text ?? "";
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`PDF text extraction failed for ${pdfPath}: ${message}`);
+  }
+}
+
+function computePerPdfMetrics(parsed: ParsedDocument): ParserBakeoffPerPdfMetrics {
+  const pageCount = parsed.pages.length || parsed.qualityReport.pageCount || 1;
+  const perPageLengths = parsed.pages.map((p) => p.rawText.length);
+  const sorted = [...perPageLengths].sort((a, b) => a - b);
+  const medianTextPerPage = sorted.length > 0
+    ? sorted[Math.floor(sorted.length / 2)]
+    : 0;
+
+  const confidences = parsed.elements
+    .map((e) => e.confidence)
+    .filter((c): c is number => typeof c === "number");
+  const avgConfidence = confidences.length > 0
+    ? confidences.reduce((s, c) => s + c, 0) / confidences.length
+    : 0;
+
+  return {
+    pageCount,
+    rawTextLength: parsed.rawText.length,
+    headingCount: parsed.headings?.length ?? 0,
+    tableCount: parsed.tables?.length ?? 0,
+    elementCount: parsed.elements.length,
+    pageProvenanceElementCount: parsed.elements.filter((e) => e.pageNumber && e.pageNumber > 0).length,
+    hasPageBoundaries: parsed.qualityReport.hasPageBoundaries,
+    hasBoundingBoxes: parsed.qualityReport.hasBoundingBoxes,
+    hasTables: parsed.qualityReport.hasTables,
+    hasStructuredHeadings: parsed.qualityReport.hasStructuredHeadings,
+    medianTextPerPage,
+    avgConfidence,
+  };
+}
+
+function checkParserAvailable(parserId: string): { available: boolean; reason?: string } {
+  if (parserId === "current-extractor") {
+    return { available: true };
+  }
+
+  if (parserId === "pymupdf") {
+    try {
+      execFileSync("python3", ["--version"], { timeout: 5000, encoding: "utf-8" });
+      try {
+        execFileSync("python3", ["-c", "import fitz"], { timeout: 10000, encoding: "utf-8" });
+        return { available: true };
+      } catch {
+        return { available: false, reason: "python3 available but pymupdf (fitz) not installed" };
+      }
+    } catch {
+      return { available: false, reason: "python3 not available" };
+    }
+  }
+
+  if (parserId === "docling") {
+    try {
+      execFileSync("python3", ["--version"], { timeout: 5000, encoding: "utf-8" });
+      try {
+        execFileSync("python3", ["-c", "import docling"], { timeout: 10000, encoding: "utf-8" });
+        return { available: true };
+      } catch {
+        return { available: false, reason: "python3 available but docling not installed" };
+      }
+    } catch {
+      return { available: false, reason: "python3 not available" };
+    }
+  }
+
+  return { available: false, reason: `unknown parser: ${parserId}` };
+}
+
+function runSingleParserOnPdf(
+  pdfPath: string,
+  parserId: string,
+  rawText: string,
+): ParserBakeoffPdfResult {
+  const { available, reason } = checkParserAvailable(parserId);
+
+  if (!available) {
+    return {
+      pdfPath,
+      parserId,
+      available: false,
+      error: reason,
+    };
+  }
+
+  try {
+    const originalEnv = process.env.QUICK_CHECK_PARSER;
+    process.env.QUICK_CHECK_PARSER = parserId;
+
+    let input: ParseDocumentTextInput;
+
+    if (parserId === "current-extractor") {
+      input = { rawText };
+    } else {
+      input = { rawText, pdfFilePath: pdfPath };
+    }
+
+    const parsed = parseDocumentText(input);
+
+    process.env.QUICK_CHECK_PARSER = originalEnv;
+
+    return {
+      pdfPath,
+      parserId,
+      available: true,
+      metrics: computePerPdfMetrics(parsed),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      pdfPath,
+      parserId,
+      available,
+      error: message,
+    };
+  } finally {
+    process.env.QUICK_CHECK_PARSER = undefined;
+  }
+}
+
+function runEvalWithParser(
+  manifestPath: string,
+  parserId: string,
+  repoRoot: string,
+): ParserBakeoffEvalComparison {
+  const { available, reason } = checkParserAvailable(parserId);
+
+  if (!available) {
+    return {
+      parserId,
+      available: false,
+      passedCount: 0,
+      totalCount: 0,
+      unavailableReason: reason,
+    };
+  }
+
+  try {
+    const originalEnv = process.env.QUICK_CHECK_PARSER;
+    process.env.QUICK_CHECK_PARSER = parserId;
+
+    const report = runQuickCheckEvalCorpus({
+      manifestPath,
+      repoRoot,
+    });
+
+    process.env.QUICK_CHECK_PARSER = originalEnv;
+
+    const manifest = loadEvalCorpusManifest(manifestPath);
+    const thresholds: EvalCorpusThresholds = manifest.thresholds ?? DEFAULT_STRICT_THRESHOLDS;
+    const { passed } = checkEvalCorpusThresholds(report, thresholds);
+
+    return {
+      parserId,
+      available: true,
+      passedCount: passed ? report.fixtureCount : report.metrics.firstPassSuccessRate.passed,
+      totalCount: report.fixtureCount,
+      report,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      parserId,
+      available,
+      passedCount: 0,
+      totalCount: 0,
+      unavailableReason: available ? `eval failed: ${message}` : reason,
+    };
+  } finally {
+    process.env.QUICK_CHECK_PARSER = undefined;
+  }
+}
+
+export function runParserBakeoff(options: {
+  pdfPaths: string[];
+  manifestPath?: string;
+  repoRoot: string;
+}): ParserBakeoffScorecard {
+  const { pdfPaths, manifestPath, repoRoot } = options;
+
+  const defaultManifestPath = manifestPath
+    ?? path.resolve(repoRoot, "tests/fixtures/quick-check/corpus/phase6-eval-corpus.json");
+
+  const parserIds = ["current-extractor", "pymupdf", "docling"] as const;
+
+  const parsers: ParserBakeoffParserEntry[] = parserIds.map((id) => {
+    const { available, reason } = checkParserAvailable(id);
+    return {
+      parserId: id,
+      available,
+      ...(reason ? { unavailableReason: reason } : {}),
+    };
+  });
+
+  const perPdfResults: ParserBakeoffPdfResult[] = [];
+
+  for (const pdfPath of pdfPaths) {
+    let rawText = "";
+    try {
+      rawText = extractRawTextFromPdf(pdfPath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      for (const parserId of parserIds) {
+        perPdfResults.push({
+          pdfPath,
+          parserId,
+          available: false,
+          error: message,
+        });
+      }
+      continue;
+    }
+
+    for (const parserId of parserIds) {
+      perPdfResults.push(runSingleParserOnPdf(pdfPath, parserId, rawText));
+    }
+  }
+
+  const evalComparison: ParserBakeoffEvalComparison[] = parserIds.map((parserId) =>
+    runEvalWithParser(defaultManifestPath, parserId, repoRoot),
+  );
+
+  return {
+    bakeoffTimestamp: new Date().toISOString(),
+    parsers,
+    pdfFixtures: pdfPaths,
+    perPdfResults,
+    evalComparison,
+    defaultParserId: resolveConfiguredDocumentParserAdapterId(undefined),
+  };
+}
+
+export function formatParserBakeoffScorecard(scorecard: ParserBakeoffScorecard): string {
+  const lines: string[] = [];
+
+  lines.push(`# Parser Bakeoff Scorecard`);
+  lines.push(`Generated: ${scorecard.bakeoffTimestamp}`);
+  lines.push(`Default parser: ${scorecard.defaultParserId}`);
+  lines.push(`PDF fixtures: ${scorecard.pdfFixtures.length}`);
+  lines.push("");
+
+  lines.push("## Parser Availability");
+  for (const parser of scorecard.parsers) {
+    const status = parser.available ? "AVAILABLE" : `UNAVAILABLE (${parser.unavailableReason ?? "unknown"})`;
+    lines.push(`- ${parser.parserId}: ${status}`);
+  }
+  lines.push("");
+
+  lines.push("## Per-PDF Metrics");
+  lines.push("");
+
+  for (const pdfPath of scorecard.pdfFixtures) {
+    const pdfName = path.basename(pdfPath);
+    lines.push(`### ${pdfName}`);
+    lines.push("");
+
+    const pdfResults = scorecard.perPdfResults.filter((r) => r.pdfPath === pdfPath);
+
+    for (const result of pdfResults) {
+      if (!result.available || result.error) {
+        lines.push(`- **${result.parserId}**: ERROR — ${result.error ?? "unavailable"}`);
+        continue;
+      }
+      const m = result.metrics!;
+      lines.push(`- **${result.parserId}**:`);
+      lines.push(`  - pages: ${m.pageCount}  |  rawText: ${m.rawTextLength} chars  |  median/page: ${m.medianTextPerPage}`);
+      lines.push(`  - headings: ${m.headingCount}  |  tables: ${m.tableCount}  |  elements: ${m.elementCount}`);
+      lines.push(`  - page provenance: ${m.pageProvenanceElementCount}/${m.elementCount}  |  avg confidence: ${m.avgConfidence.toFixed(3)}`);
+      lines.push(`  - hasPageBoundaries: ${m.hasPageBoundaries}  |  hasBoundingBoxes: ${m.hasBoundingBoxes}  |  hasStructuredHeadings: ${m.hasStructuredHeadings}  |  hasTables: ${m.hasTables}`);
+    }
+
+    const pdfParsers = pdfResults.filter((r) => r.available && !r.error);
+    if (pdfParsers.length >= 2) {
+      lines.push("");
+      lines.push("  **Comparison:**");
+      const ce = pdfParsers.find((r) => r.parserId === "current-extractor");
+      const pm = pdfParsers.find((r) => r.parserId === "pymupdf");
+      if (ce && pm && ce.metrics && pm.metrics) {
+        lines.push(`  - heading delta: ${pm.metrics.headingCount - ce.metrics.headingCount}`);
+        lines.push(`  - table delta: ${pm.metrics.tableCount - ce.metrics.tableCount}`);
+        lines.push(`  - element delta: ${pm.metrics.elementCount - ce.metrics.elementCount}`);
+        lines.push(`  - provenance delta: ${pm.metrics.pageProvenanceElementCount - ce.metrics.pageProvenanceElementCount}`);
+      }
+    }
+    lines.push("");
+  }
+
+  lines.push("## Downstream Eval Corpus Comparison");
+  lines.push("");
+
+  for (const comparison of scorecard.evalComparison) {
+    if (!comparison.available) {
+      lines.push(`- **${comparison.parserId}**: UNAVAILABLE — ${comparison.unavailableReason ?? "unknown"}`);
+      continue;
+    }
+
+    if (!comparison.report) {
+      lines.push(`- **${comparison.parserId}**: no report generated`);
+      continue;
+    }
+
+    const r = comparison.report;
+    const m = r.metrics;
+    lines.push(`- **${comparison.parserId}**: ${comparison.passedCount}/${comparison.totalCount} fixtures passed`);
+    lines.push(`  - first-pass success: ${(m.firstPassSuccessRate.rate * 100).toFixed(1)}% (${m.firstPassSuccessRate.passed}/${m.firstPassSuccessRate.total})`);
+    lines.push(`  - fact accuracy: ${(m.factExtractionAccuracy.rate * 100).toFixed(1)}%`);
+    lines.push(`  - provenance correctness: ${(m.provenanceCorrectness.rate * 100).toFixed(1)}%`);
+    lines.push(`  - hallucinated answer: ${(m.hallucinatedAnswerRate.rate * 100).toFixed(1)}% (${m.hallucinatedAnswerRate.passed}/${m.hallucinatedAnswerRate.total})`);
+    lines.push(`  - unsupported rejection: ${(m.unsupportedRejectionRate.rate * 100).toFixed(1)}%`);
+    lines.push(`  - regressions: ${m.regressionCount}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function formatParserBakeoffScorecardJson(scorecard: ParserBakeoffScorecard): string {
+  return JSON.stringify(scorecard, null, 2);
+}

--- a/src/lib/quickCheck/evalCorpus/index.ts
+++ b/src/lib/quickCheck/evalCorpus/index.ts
@@ -9,3 +9,15 @@ export type {
   StandardPhase6QuestionId,
 } from "@/lib/quickCheck/evalCorpus/types";
 export { DEFAULT_STRICT_THRESHOLDS } from "@/lib/quickCheck/evalCorpus/types";
+export {
+  runParserBakeoff,
+  formatParserBakeoffScorecard,
+  formatParserBakeoffScorecardJson,
+} from "@/lib/quickCheck/evalCorpus/bakeoff";
+export type {
+  ParserBakeoffParserEntry,
+  ParserBakeoffPerPdfMetrics,
+  ParserBakeoffPdfResult,
+  ParserBakeoffEvalComparison,
+  ParserBakeoffScorecard,
+} from "@/lib/quickCheck/evalCorpus/bakeoff";

--- a/tests/lib/quickCheck/parserBakeoff.test.ts
+++ b/tests/lib/quickCheck/parserBakeoff.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "@jest/globals";
 import path from "path";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
 import {
   runParserBakeoff,
   formatParserBakeoffScorecard,
   formatParserBakeoffScorecardJson,
+  collectPdfPaths,
 } from "@/lib/quickCheck/evalCorpus/bakeoff";
 import type { ParserBakeoffScorecard } from "@/lib/quickCheck/evalCorpus/bakeoff";
 
@@ -288,5 +290,107 @@ describe("Parser bakeoff env restoration", () => {
     });
 
     expect(process.env.QUICK_CHECK_PARSER).toBe("liteparse");
+  });
+});
+
+describe("collectPdfPaths CLI argument handling", () => {
+  const repoRoot = process.cwd();
+  const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
+
+  it("default fallback returns frozen fixture PDFs when no flags passed", () => {
+    const paths = collectPdfPaths([], repoRoot);
+
+    expect(paths.length).toBeGreaterThanOrEqual(1);
+    expect(paths.every((p) => p.endsWith(".pdf"))).toBe(true);
+    expect(paths.some((p) => p.includes("plum-verra-demo-excerpt"))).toBe(true);
+  });
+
+  it("--pdfdir collects all PDFs from a directory, sorted by name", () => {
+    const tmpDir = path.resolve("/tmp/bakeoff-collectPdfPaths-test");
+    rmSync(tmpDir, { recursive: true, force: true });
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(path.resolve(tmpDir, "alpha.pdf"), "%PDF-1.4 fake");
+    writeFileSync(path.resolve(tmpDir, "beta.pdf"), "%PDF-1.4 fake");
+
+    const paths = collectPdfPaths(["node", "script", "--pdfdir", tmpDir], repoRoot);
+
+    expect(paths.length).toBe(2);
+    expect(paths.every((p) => p.endsWith(".pdf"))).toBe(true);
+    expect(paths.some((p) => p.includes("alpha.pdf"))).toBe(true);
+    expect(paths.some((p) => p.includes("beta.pdf"))).toBe(true);
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("repeated --pdf flags collect all paths", () => {
+    const paths = collectPdfPaths([
+      "node", "script",
+      "--pdf", "/tmp/a.pdf",
+      "--pdf", "/tmp/b.pdf",
+    ], repoRoot);
+
+    expect(paths.length).toBe(2);
+    expect(paths).toContain(path.resolve("/tmp/a.pdf"));
+    expect(paths).toContain(path.resolve("/tmp/b.pdf"));
+  });
+
+  it("dedupes when same PDF is given via --pdf twice", () => {
+    const paths = collectPdfPaths([
+      "node", "script",
+      "--pdf", "/tmp/dup.pdf",
+      "--pdf", "/tmp/dup.pdf",
+    ], repoRoot);
+
+    expect(paths.length).toBe(1);
+    expect(paths[0]).toBe(path.resolve("/tmp/dup.pdf"));
+  });
+
+  it("combines --pdfdir and --pdf deduping across sources", () => {
+    const tmpDir = path.resolve("/tmp/bakeoff-combine-test");
+    rmSync(tmpDir, { recursive: true, force: true });
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(path.resolve(tmpDir, "dir.pdf"), "%PDF-1.4 fake");
+
+    const paths = collectPdfPaths([
+      "node", "script",
+      "--pdfdir", tmpDir,
+      "--pdf", "/tmp/extra.pdf",
+    ], repoRoot);
+
+    expect(paths.length).toBe(2);
+    expect(paths.some((p) => p.includes("dir.pdf"))).toBe(true);
+    expect(paths.some((p) => p.includes("extra.pdf"))).toBe(true);
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("--pdfdir pointing to nonexistent directory ignores gracefully", () => {
+    const paths = collectPdfPaths([
+      "node", "script",
+      "--pdfdir", "/tmp/does-not-exist-bakeoff-cli",
+    ], repoRoot);
+
+    // Falls back to defaults when no paths found
+    expect(paths.length).toBeGreaterThanOrEqual(1);
+    expect(paths.some((p) => p.includes(fixtureDir))).toBe(true);
+  });
+
+  it("dedupes when --pdfdir and --pdf yield the same path", () => {
+    const tmpDir = path.resolve("/tmp/bakeoff-same-test");
+    rmSync(tmpDir, { recursive: true, force: true });
+    mkdirSync(tmpDir, { recursive: true });
+    const pdfPath = path.resolve(tmpDir, "shared.pdf");
+    writeFileSync(pdfPath, "%PDF-1.4 fake");
+
+    const paths = collectPdfPaths([
+      "node", "script",
+      "--pdfdir", tmpDir,
+      "--pdf", pdfPath,
+    ], repoRoot);
+
+    expect(paths.length).toBe(1);
+    expect(paths[0]).toBe(pdfPath);
+
+    rmSync(tmpDir, { recursive: true, force: true });
   });
 });

--- a/tests/lib/quickCheck/parserBakeoff.test.ts
+++ b/tests/lib/quickCheck/parserBakeoff.test.ts
@@ -247,3 +247,46 @@ describe("Parser bakeoff with real PDF fixtures", () => {
     }
   });
 });
+
+describe("Parser bakeoff env restoration", () => {
+  const nonexistentPdf = path.resolve("/tmp/does-not-exist-bakeoff-env.pdf");
+
+  afterEach(() => {
+    delete process.env.QUICK_CHECK_PARSER;
+  });
+
+  it("Case A: QUICK_CHECK_PARSER was unset, remains unset after bakeoff", () => {
+    delete process.env.QUICK_CHECK_PARSER;
+    expect(process.env.QUICK_CHECK_PARSER).toBeUndefined();
+
+    runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(process.env.QUICK_CHECK_PARSER).toBeUndefined();
+  });
+
+  it("Case B: QUICK_CHECK_PARSER was set, same value remains after bakeoff", () => {
+    process.env.QUICK_CHECK_PARSER = "pymupdf";
+    expect(process.env.QUICK_CHECK_PARSER).toBe("pymupdf");
+
+    runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(process.env.QUICK_CHECK_PARSER).toBe("pymupdf");
+  });
+
+  it("QUICK_CHECK_PARSER restoration survives per-PDF parser runs", () => {
+    process.env.QUICK_CHECK_PARSER = "liteparse";
+
+    runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(process.env.QUICK_CHECK_PARSER).toBe("liteparse");
+  });
+});

--- a/tests/lib/quickCheck/parserBakeoff.test.ts
+++ b/tests/lib/quickCheck/parserBakeoff.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "@jest/globals";
+import path from "path";
+import {
+  runParserBakeoff,
+  formatParserBakeoffScorecard,
+  formatParserBakeoffScorecardJson,
+} from "@/lib/quickCheck/evalCorpus/bakeoff";
+import type { ParserBakeoffScorecard } from "@/lib/quickCheck/evalCorpus/bakeoff";
+
+describe("Parser bakeoff scorecard", () => {
+  const nonexistentPdf = path.resolve("/tmp/does-not-exist-bakeoff.pdf");
+
+  it("produces a valid scorecard structure with nonexistent PDFs", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(scorecard).toBeDefined();
+    expect(scorecard.bakeoffTimestamp).toBeTruthy();
+    expect(scorecard.defaultParserId).toBe("current-extractor");
+    expect(scorecard.pdfFixtures).toEqual([nonexistentPdf]);
+    expect(Array.isArray(scorecard.parsers)).toBe(true);
+    expect(Array.isArray(scorecard.perPdfResults)).toBe(true);
+    expect(Array.isArray(scorecard.evalComparison)).toBe(true);
+  });
+
+  it("reports all three parsers in the parser list", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    const parserIds = scorecard.parsers.map((p) => p.parserId);
+    expect(parserIds).toContain("current-extractor");
+    expect(parserIds).toContain("pymupdf");
+    expect(parserIds).toContain("docling");
+  });
+
+  it("current-extractor is available regardless of Python status", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    const ce = scorecard.parsers.find((p) => p.parserId === "current-extractor");
+    expect(ce).toBeDefined();
+    expect(ce!.available).toBe(true);
+  });
+
+  it("records parser availability truthfully", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    for (const parser of scorecard.parsers) {
+      expect(typeof parser.parserId).toBe("string");
+      expect(typeof parser.available).toBe("boolean");
+      if (!parser.available) {
+        expect(parser.unavailableReason).toBeTruthy();
+      }
+    }
+  });
+
+  it("perPdfResults contains entries for each (pdf, parser) pair", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(scorecard.perPdfResults.length).toBeGreaterThanOrEqual(1);
+
+    for (const result of scorecard.perPdfResults) {
+      expect(result.pdfPath).toBe(nonexistentPdf);
+      expect(typeof result.parserId).toBe("string");
+      expect(typeof result.available).toBe("boolean");
+    }
+  });
+
+  it("evalComparison covers all three parsers", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(scorecard.evalComparison.length).toBe(3);
+    const evalParserIds = scorecard.evalComparison.map((e) => e.parserId);
+    expect(evalParserIds).toContain("current-extractor");
+    expect(evalParserIds).toContain("pymupdf");
+    expect(evalParserIds).toContain("docling");
+  });
+
+  it("formats a human-readable markdown scorecard", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    const markdown = formatParserBakeoffScorecard(scorecard);
+
+    expect(markdown).toBeTruthy();
+    expect(markdown).toContain("# Parser Bakeoff Scorecard");
+    expect(markdown).toContain("## Parser Availability");
+    expect(markdown).toContain("## Per-PDF Metrics");
+    expect(markdown).toContain("## Downstream Eval Corpus Comparison");
+    expect(markdown).toContain("current-extractor");
+  });
+
+  it("formats a valid JSON scorecard", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    const json = formatParserBakeoffScorecardJson(scorecard);
+    const parsed: ParserBakeoffScorecard = JSON.parse(json);
+
+    expect(parsed.parsers.length).toBe(scorecard.parsers.length);
+    expect(parsed.perPdfResults.length).toBe(scorecard.perPdfResults.length);
+    expect(parsed.evalComparison.length).toBe(scorecard.evalComparison.length);
+    expect(parsed.bakeoffTimestamp).toBe(scorecard.bakeoffTimestamp);
+  });
+});
+
+describe("Parser bakeoff with real PDF fixtures", () => {
+  const fixtureDir = path.resolve(process.cwd(), "tests/fixtures/quick-check");
+  const fs = require("fs");
+
+  const realPdfs = [
+    path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
+    path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
+    path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
+  ].filter((p) => fs.existsSync(p));
+
+  if (realPdfs.length === 0) {
+    it.skip("no PDF fixtures found", () => {});
+    return;
+  }
+
+  it("produces per-pdf metrics for real PDF fixtures when pymupdf is available", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: realPdfs,
+      repoRoot: process.cwd(),
+    });
+
+    const pymupdfAvailable = scorecard.parsers.find(
+      (p) => p.parserId === "pymupdf",
+    )?.available;
+
+    const currentExtractorResults = scorecard.perPdfResults.filter(
+      (r) => r.parserId === "current-extractor" && r.metrics,
+    );
+
+    if (pymupdfAvailable) {
+      expect(currentExtractorResults.length).toBeGreaterThanOrEqual(realPdfs.length);
+
+      for (const result of currentExtractorResults) {
+        const m = result.metrics!;
+        expect(m.pageCount).toBeGreaterThan(0);
+        expect(m.rawTextLength).toBeGreaterThan(0);
+        expect(typeof m.headingCount).toBe("number");
+        expect(typeof m.tableCount).toBe("number");
+        expect(typeof m.elementCount).toBe("number");
+        expect(m.elementCount).toBeGreaterThan(0);
+        expect(m.avgConfidence).toBeGreaterThan(0);
+      }
+    } else {
+      // When pymupdf is unavailable, text extraction fails for all parsers
+      expect(scorecard.parsers.length).toBe(3);
+    }
+  });
+
+  it("pymupdf is available or reported as unavailable with reason", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: realPdfs.slice(0, 1),
+      repoRoot: process.cwd(),
+    });
+
+    const pm = scorecard.parsers.find((p) => p.parserId === "pymupdf");
+    expect(pm).toBeDefined();
+
+    const pmResults = scorecard.perPdfResults.filter((r) => r.parserId === "pymupdf");
+
+    expect(pmResults.length).toBeGreaterThanOrEqual(1);
+
+    for (const result of pmResults) {
+      if (pm!.available) {
+        expect(result.metrics).toBeDefined();
+      } else {
+        // unavailable parsers record an error
+        expect(result.available === false || result.error).toBeDefined();
+      }
+    }
+  });
+
+  it("docling is included in scorecard regardless of availability", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: realPdfs.slice(0, 1),
+      repoRoot: process.cwd(),
+    });
+
+    const dl = scorecard.parsers.find((p) => p.parserId === "docling");
+    expect(dl).toBeDefined();
+
+    const dlResults = scorecard.perPdfResults.filter((r) => r.parserId === "docling");
+
+    expect(dlResults.length).toBeGreaterThanOrEqual(1);
+
+    for (const result of dlResults) {
+      if (dl!.available) {
+        expect(result.metrics).toBeDefined();
+      } else {
+        // unavailable parsers record the reason
+        expect(result.available === false || result.error).toBeDefined();
+      }
+    }
+  });
+
+  it("markdown scorecard includes comparison deltas when both parsers available", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: realPdfs.slice(0, 1),
+      repoRoot: process.cwd(),
+    });
+
+    const pymupdfAvailable = scorecard.parsers.find(
+      (p) => p.parserId === "pymupdf",
+    )?.available;
+
+    const markdown = formatParserBakeoffScorecard(scorecard);
+
+    expect(markdown).toContain("# Parser Bakeoff Scorecard");
+    expect(markdown).toContain("## Downstream Eval Corpus Comparison");
+
+    if (pymupdfAvailable) {
+      const ce = scorecard.perPdfResults.filter(
+        (r) => r.parserId === "current-extractor" && r.metrics,
+      );
+      const pm = scorecard.perPdfResults.filter(
+        (r) => r.parserId === "pymupdf" && r.metrics,
+      );
+
+      if (ce.length > 0 && pm.length > 0) {
+        expect(markdown).toContain("**Comparison:**");
+        expect(markdown).toContain("heading delta:");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## WHAT

Implement Phase 0C: Parser Bakeoff Scorecard.

Build a deterministic parser bakeoff that compares `current-extractor`, `pymupdf`, and `docling` (if available) against frozen carbon PDF fixtures. Outputs a JSON scorecard.

### Files

- `src/lib/quickCheck/evalCorpus/bakeoff.ts` — bakeoff runner: parses frozen PDFs with each parser, measures per-PDF metrics (pages, headings, tables, elements, provenance, confidence), runs downstream eval corpus comparison, outputs structured scorecard
- `scripts/run-parser-bakeoff.ts` — CLI entry point (`npm run quickcheck:bakeoff`)
- `tests/lib/quickCheck/parserBakeoff.test.ts` — 12 tests covering scorecard structure, parser availability, real PDF fixtures, markdown/JSON formatting
- `package.json` — added `quickcheck:bakeoff` script
- `docs/roadmaps/quickcheck-parser-replacement/phase-status.json` — Phase 0C status → in_progress

### Metrics measured

**Per-PDF (deterministic):** page coverage, text extraction length, heading preservation, table detection, element count, page provenance, median text per page, average confidence

**Downstream eval corpus:** first-pass success rate, fact extraction accuracy, provenance correctness, hallucinated answer rate, unsupported rejection rate, regression count

### Key behaviors

- `current-extractor` and `pymupdf` compared on the same frozen PDFs
- Docling included only if available — unavailable state recorded as diagnostics, not hard failure
- JSON + human-readable markdown output

## DO NOT

- [x] No default parser switch
- [x] No router status policy changes
- [x] No UI changes
- [x] No LLM final-answer generation
- [x] No eval threshold weakening

## ACCEPTANCE

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm test` — 1576 passed, 47 skipped
- [x] `npm run quickcheck:eval:corpus -- --strict` — all thresholds, 0 regressions

Signed-off-by: Fred Egbuedike <fredilly@article6.org>