### PR TITLE
fix: parser bakeoff post-merge — perf, diagnostics, env, CLI, table count

### DIFF
--- a/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
+++ b/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
@@ -22,7 +22,8 @@
       "id": "phase-0c-parser-bakeoff-scorecard",
       "name": "Parser Bakeoff Scorecard",
       "branch": "feat/qc-parser-bakeoff",
-      "status": "not_started",
+      "status": "in_progress",
+      "pr": "TBD",
       "goal": "Compare currentExtractor vs PyMuPDF adapter on frozen carbon PDFs using a JSON scorecard. Include Docling adapter only if available."
     },
     {

--- a/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
+++ b/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
@@ -23,7 +23,7 @@
       "name": "Parser Bakeoff Scorecard",
       "branch": "feat/qc-parser-bakeoff",
       "status": "in_progress",
-      "pr": "TBD",
+      "pr": 798,
       "goal": "Compare currentExtractor vs PyMuPDF adapter on frozen carbon PDFs using a JSON scorecard. Include Docling adapter only if available."
     },
     {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "quickcheck:eval:corpus": "npx tsx scripts/run-quickcheck-eval-corpus.ts",
     "quickcheck:eval:taisei": "npx tsx scripts/run-quickcheck-eval-corpus.ts --manifest tests/fixtures/quick-check/corpus/taisei-baseline-eval-corpus.json",
     "quickcheck:eval:messy": "npx tsx scripts/run-quickcheck-eval-corpus.ts --manifest tests/fixtures/quick-check/corpus/messy-carbon-doc-baseline-eval-corpus.json",
+    "quickcheck:bakeoff": "npx tsx scripts/run-parser-bakeoff.ts",
     "quickcheck:report": "npx tsx scripts/run-active-corpus-report.ts",
     "quickcheck:report:messy": "npx tsx scripts/run-active-corpus-report.ts --manifest tests/fixtures/quick-check/corpus/messy-carbon-doc-baseline-eval-corpus.json",
     "ci": "npm run guard:methodology-boundary && npm run lint && npm run typecheck && npm run check:docs-layout && npm run roadmap:validate-evidence && npm run quickcheck:eval && npm test && npm run build && npm run check:quick-check-pdf-trace && npm run roadmap:check",

--- a/scripts/pymupdf-parse.py
+++ b/scripts/pymupdf-parse.py
@@ -1,24 +1,35 @@
 """PyMuPDF + pdfplumber PDF parser helper for Quick Check parser adapter.
 
 Usage:
-  python3 scripts/pymupdf-parse.py <pdf_path>
+  python3 scripts/pymupdf-parse.py <pdf_path> [--no-tables]
 
-Outputs JSON to stdout with extracted document structure.
+Outputs JSON to stdout with extracted document structure and phase diagnostics.
 """
 
 import json
 import sys
+import time
 import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 DEFAULT_FONT_SIZE = 12.0
 DICT_SAMPLE_PAGES = 5
+TABLE_EXTRACT_PAGES = 10
 
 
-def parse_pdf_with_pymupdf(pdf_path: str) -> Dict[str, Any]:
+def parse_pdf_with_pymupdf(
+    pdf_path: str,
+    skip_tables: bool = False,
+) -> Dict[str, Any]:
     warnings: List[str] = []
+    diagnostics: Dict[str, Any] = {}
+    phases: Dict[str, float] = {}
 
+    t0 = time.monotonic()
+
+    # Phase: import check
+    t1 = time.monotonic()
     try:
         import fitz
     except ImportError as exc:
@@ -27,36 +38,57 @@ def parse_pdf_with_pymupdf(pdf_path: str) -> Dict[str, Any]:
             "message": "PyMuPDF is not installed. Install it with: pip install pymupdf",
             "detail": str(exc),
         }
+    phases["import_check"] = round(time.monotonic() - t1, 3)
 
-    try:
-        import pdfplumber
-    except ImportError:
-        pdfplumber = None
-        warnings.append("pdfplumber not installed — table extraction disabled. Install with: pip install pdfplumber")
+    # Phase: optional pdfplumber
+    pdfplumber = None
+    if not skip_tables:
+        try:
+            import pdfplumber as plumber_mod
+            pdfplumber = plumber_mod
+        except ImportError:
+            warnings.append(
+                "pdfplumber not installed — table extraction disabled. "
+                "Install with: pip install pdfplumber"
+            )
 
+    # Phase: open PDF
+    t2 = time.monotonic()
     doc = fitz.open(pdf_path)
     total_pages = len(doc)
+    phases["open_pdf"] = round(time.monotonic() - t2, 3)
+    diagnostics["total_pages"] = total_pages
+
     pages_raw: List[Dict[str, Any]] = []
     headings: List[Dict[str, Any]] = []
     all_tables: List[Dict[str, Any]] = []
     markdown_lines: List[str] = []
+    dict_pages_requested = 0
+    dict_pages_succeeded = 0
 
-    # Estimate body font size once from a small sample.
-    body_font_size = _estimate_body_font_size_fast(doc, warnings)
+    # Phase: estimate body font size once from a small sample
+    t3 = time.monotonic()
+    body_font_size, font_pages_sampled = _estimate_body_font_size_fast(doc)
+    phases["estimate_body_font_size"] = round(time.monotonic() - t3, 3)
+    diagnostics["body_font_size"] = round(body_font_size, 1)
+    diagnostics["font_pages_sampled"] = font_pages_sampled
 
+    # Phase: text extraction per page
+    t4 = time.monotonic()
     for page_num in range(total_pages):
         page = doc[page_num]
         page_text = page.get_text("text")
         page_blocks: List[Dict[str, Any]] = []
 
         # Only use dict extraction on the first N pages for block structure.
-        # Beyond that, dict extraction can be extremely slow on large docs.
         if page_num < DICT_SAMPLE_PAGES:
+            dict_pages_requested += 1
             try:
                 blocks_dict = page.get_text("dict")
                 page_blocks, page_headings = _extract_blocks_and_headings(
-                    blocks_dict, body_font_size, page_num, warnings,
+                    blocks_dict, body_font_size, page_num,
                 )
+                dict_pages_succeeded += 1
             except Exception as e:
                 warnings.append(
                     f"Page {page_num + 1} dict extraction failed, using text-only: {e}"
@@ -94,25 +126,43 @@ def parse_pdf_with_pymupdf(pdf_path: str) -> Dict[str, Any]:
             "blocks": page_blocks,
         })
 
+    phases["text_extract"] = round(time.monotonic() - t4, 3)
+    diagnostics["dict_pages_requested"] = dict_pages_requested
+    diagnostics["dict_pages_succeeded"] = dict_pages_succeeded
+
     doc.close()
 
-    # pdfplumber table extraction (separate file open)
-    if pdfplumber is not None:
+    # Phase: table extraction (separate file open, page-limited)
+    t5 = time.monotonic()
+    table_fallback_reason: Optional[str] = None
+    if pdfplumber is not None and not skip_tables:
         try:
-            all_tables = _extract_tables_with_pdfplumber(pdf_path)
+            all_tables = _extract_tables_with_pdfplumber(
+                pdf_path, max(1, min(TABLE_EXTRACT_PAGES, total_pages))
+            )
         except Exception as e:
-            warnings.append(f"pdfplumber table extraction failed: {str(e)}")
+            table_fallback_reason = str(e)
+            warnings.append(f"pdfplumber table extraction failed: {table_fallback_reason}")
             all_tables = []
+    else:
+        if skip_tables:
+            table_fallback_reason = "table extraction disabled via --no-tables"
+        else:
+            table_fallback_reason = "pdfplumber not installed"
+    phases["table_extract"] = round(time.monotonic() - t5, 3)
+    diagnostics["tables_extracted"] = len(all_tables)
+    if table_fallback_reason:
+        diagnostics["table_fallback"] = table_fallback_reason
 
-    raw_text = "\f".join(
-        p.get("text", "") for p in pages_raw
-    )
+    raw_text = "\f".join(p.get("text", "") for p in pages_raw)
     markdown = "\n".join(markdown_lines)
 
     if not raw_text.strip():
         warnings.append("No usable text extracted from the document.")
 
-    return {
+    # Phase: serialize
+    t6 = time.monotonic()
+    result = {
         "engine": "pymupdf",
         "parser_version": _get_version(),
         "raw_text": raw_text,
@@ -121,13 +171,23 @@ def parse_pdf_with_pymupdf(pdf_path: str) -> Dict[str, Any]:
         "headings": headings,
         "tables": all_tables,
         "warnings": warnings,
+        "diagnostics": {
+            **diagnostics,
+            "phases": phases,
+        },
     }
+    phases["serialize_json"] = round(time.monotonic() - t6, 3)
+    result["diagnostics"]["phases"] = phases
+    result["diagnostics"]["total_time_s"] = round(time.monotonic() - t0, 3)
+
+    return result
 
 
-def _estimate_body_font_size_fast(doc, warnings: List[str]) -> float:
+def _estimate_body_font_size_fast(doc) -> Tuple[float, int]:
     """Estimate body font size from a small sample with a fallback default."""
     sizes: List[float] = []
     sample_limit = min(3, len(doc))
+    pages_sampled = 0
 
     for i in range(sample_limit):
         try:
@@ -135,6 +195,7 @@ def _estimate_body_font_size_fast(doc, warnings: List[str]) -> float:
         except Exception:
             continue
 
+        pages_sampled += 1
         span_count = 0
         for block in blocks:
             if block.get("type") != 0:
@@ -145,26 +206,25 @@ def _estimate_body_font_size_fast(doc, warnings: List[str]) -> float:
                     if len(text) > 30:
                         sizes.append(span.get("size", DEFAULT_FONT_SIZE))
                         span_count += 1
-                        if span_count > 50:
+                        if span_count >= 50:
                             break
-                if span_count > 50:
+                if span_count >= 50:
                     break
-            if span_count > 50:
+            if span_count >= 50:
                 break
 
     if not sizes:
-        return DEFAULT_FONT_SIZE
+        return DEFAULT_FONT_SIZE, pages_sampled
 
     sorted_sizes = sorted(sizes)
     lower_half = sorted_sizes[: max(1, len(sorted_sizes) // 2)]
-    return sum(lower_half) / len(lower_half)
+    return sum(lower_half) / len(lower_half), pages_sampled
 
 
 def _extract_blocks_and_headings(
     page_dict: Dict[str, Any],
     body_font_size: float,
     page_num: int,
-    warnings: List[str],
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Extract text blocks and heading hints from a page dict."""
     blocks_output: List[Dict[str, Any]] = []
@@ -190,7 +250,9 @@ def _extract_blocks_and_headings(
             continue
 
         avg_font_size = (
-            sum(block_font_sizes) / len(block_font_sizes) if block_font_sizes else DEFAULT_FONT_SIZE
+            sum(block_font_sizes) / len(block_font_sizes)
+            if block_font_sizes
+            else DEFAULT_FONT_SIZE
         )
 
         is_heading = bool(
@@ -224,13 +286,18 @@ def _extract_blocks_and_headings(
     return blocks_output, headings
 
 
-def _extract_tables_with_pdfplumber(pdf_path: str) -> List[Dict[str, Any]]:
+def _extract_tables_with_pdfplumber(
+    pdf_path: str,
+    page_limit: int,
+) -> List[Dict[str, Any]]:
     import pdfplumber as plumber
 
     tables_list: List[Dict[str, Any]] = []
 
     with plumber.open(pdf_path) as pdf:
-        for page_num, page in enumerate(pdf.pages):
+        pages_to_scan = min(page_limit, len(pdf.pages))
+        for page_num in range(pages_to_scan):
+            page = pdf.pages[page_num]
             page_tables = page.extract_tables()
             for table_idx, table in enumerate(page_tables):
                 cells: List[Dict[str, Any]] = []
@@ -284,7 +351,7 @@ def main() -> None:
     if len(sys.argv) < 2:
         print(json.dumps({
             "error": "missing_argument",
-            "message": "Usage: python3 scripts/pymupdf-parse.py <pdf_path>",
+            "message": "Usage: python3 scripts/pymupdf-parse.py <pdf_path> [--no-tables]",
         }))
         sys.exit(1)
 
@@ -296,8 +363,10 @@ def main() -> None:
         }))
         sys.exit(1)
 
+    skip_tables = "--no-tables" in sys.argv
+
     try:
-        result = parse_pdf_with_pymupdf(pdf_path)
+        result = parse_pdf_with_pymupdf(pdf_path, skip_tables=skip_tables)
     except Exception:
         result = {
             "error": "parse_failed",

--- a/scripts/pymupdf-parse.py
+++ b/scripts/pymupdf-parse.py
@@ -10,7 +10,10 @@ import json
 import sys
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
+
+DEFAULT_FONT_SIZE = 12.0
+DICT_SAMPLE_PAGES = 5
 
 
 def parse_pdf_with_pymupdf(pdf_path: str) -> Dict[str, Any]:
@@ -32,74 +35,58 @@ def parse_pdf_with_pymupdf(pdf_path: str) -> Dict[str, Any]:
         warnings.append("pdfplumber not installed — table extraction disabled. Install with: pip install pdfplumber")
 
     doc = fitz.open(pdf_path)
+    total_pages = len(doc)
     pages_raw: List[Dict[str, Any]] = []
     headings: List[Dict[str, Any]] = []
     all_tables: List[Dict[str, Any]] = []
     markdown_lines: List[str] = []
-    heading_counter = 0
 
-    for page_num in range(len(doc)):
+    # Estimate body font size once from a small sample.
+    body_font_size = _estimate_body_font_size_fast(doc, warnings)
+
+    for page_num in range(total_pages):
         page = doc[page_num]
         page_text = page.get_text("text")
         page_blocks: List[Dict[str, Any]] = []
 
-        blocks = page.get_text("dict")["blocks"]
-        page_heading_counter = 0
-
-        for block in blocks:
-            if block.get("type") != 0:
-                continue
-
-            block_text = ""
-            block_font_sizes: List[float] = []
-            block_bbox = block.get("bbox")
-
-            for line in block.get("lines", []):
-                for span in line.get("spans", []):
-                    text = span.get("text", "").strip()
-                    if text:
-                        block_text += text + " "
-                        block_font_sizes.append(span.get("size", 12))
-
-            block_text = block_text.strip()
-            if not block_text:
-                continue
-
-            page_blocks.append({
-                "text": block_text,
-                "bbox": list(block_bbox) if block_bbox else None,
-            })
-
-            avg_font_size = sum(block_font_sizes) / len(block_font_sizes) if block_font_sizes else 12
-            body_font_size = _estimate_body_font_size(doc, page_num)
-
-            if avg_font_size > body_font_size * 1.15 and len(block_text) < 200:
-                heading_counter += 1
-                page_heading_counter += 1
-
-                level = 1
-                if avg_font_size <= body_font_size * 1.3:
-                    level = 2
-                elif avg_font_size <= body_font_size * 1.6:
-                    level = 3
-                elif avg_font_size <= body_font_size * 2.0:
-                    level = 4
-
-                headings.append({
-                    "text": block_text,
-                    "level": level,
-                    "page_number": page_num + 1,
-                })
-
-                heading_mark = "#" * level
-                markdown_lines.append(f"{heading_mark} {block_text}")
-                markdown_lines.append("")
-            else:
-                markdown_lines.append(block_text)
-                markdown_lines.append("")
+        # Only use dict extraction on the first N pages for block structure.
+        # Beyond that, dict extraction can be extremely slow on large docs.
+        if page_num < DICT_SAMPLE_PAGES:
+            try:
+                blocks_dict = page.get_text("dict")
+                page_blocks, page_headings = _extract_blocks_and_headings(
+                    blocks_dict, body_font_size, page_num, warnings,
+                )
+            except Exception as e:
+                warnings.append(
+                    f"Page {page_num + 1} dict extraction failed, using text-only: {e}"
+                )
+        else:
+            page_blocks = []
 
         if not page_text.strip():
-            warnings.append(f"Page {page_num + 1} has no extractable text — may be scanned or image-only.")
+            warnings.append(
+                f"Page {page_num + 1} has no extractable text — may be scanned or image-only."
+            )
+
+        # Build markdown from blocks or fall back to page text.
+        if page_blocks:
+            for block in page_blocks:
+                if block.get("is_heading"):
+                    headings.append({
+                        "text": block["text"],
+                        "level": block.get("level", 2),
+                        "page_number": page_num + 1,
+                    })
+                    heading_mark = "#" * block.get("level", 2)
+                    markdown_lines.append(f"{heading_mark} {block['text']}")
+                    markdown_lines.append("")
+                else:
+                    markdown_lines.append(block["text"])
+                    markdown_lines.append("")
+        else:
+            markdown_lines.append(page_text.strip())
+            markdown_lines.append("")
 
         pages_raw.append({
             "page_number": page_num + 1,
@@ -109,14 +96,13 @@ def parse_pdf_with_pymupdf(pdf_path: str) -> Dict[str, Any]:
 
     doc.close()
 
+    # pdfplumber table extraction (separate file open)
     if pdfplumber is not None:
         try:
             all_tables = _extract_tables_with_pdfplumber(pdf_path)
         except Exception as e:
             warnings.append(f"pdfplumber table extraction failed: {str(e)}")
             all_tables = []
-    else:
-        all_tables = []
 
     raw_text = "\f".join(
         p.get("text", "") for p in pages_raw
@@ -138,11 +124,18 @@ def parse_pdf_with_pymupdf(pdf_path: str) -> Dict[str, Any]:
     }
 
 
-def _estimate_body_font_size(doc, current_page_num: int) -> float:
+def _estimate_body_font_size_fast(doc, warnings: List[str]) -> float:
+    """Estimate body font size from a small sample with a fallback default."""
     sizes: List[float] = []
-    for i in range(min(3, len(doc))):
-        page = doc[i]
-        blocks = page.get_text("dict")["blocks"]
+    sample_limit = min(3, len(doc))
+
+    for i in range(sample_limit):
+        try:
+            blocks = doc[i].get_text("dict")["blocks"]
+        except Exception:
+            continue
+
+        span_count = 0
         for block in blocks:
             if block.get("type") != 0:
                 continue
@@ -150,11 +143,85 @@ def _estimate_body_font_size(doc, current_page_num: int) -> float:
                 for span in line.get("spans", []):
                     text = span.get("text", "").strip()
                     if len(text) > 30:
-                        sizes.append(span.get("size", 12))
+                        sizes.append(span.get("size", DEFAULT_FONT_SIZE))
+                        span_count += 1
+                        if span_count > 50:
+                            break
+                if span_count > 50:
+                    break
+            if span_count > 50:
+                break
 
     if not sizes:
-        return 12.0
-    return sum(sorted(sizes)[:max(1, len(sizes) // 2)]) / max(1, len(sizes) // 2)
+        return DEFAULT_FONT_SIZE
+
+    sorted_sizes = sorted(sizes)
+    lower_half = sorted_sizes[: max(1, len(sorted_sizes) // 2)]
+    return sum(lower_half) / len(lower_half)
+
+
+def _extract_blocks_and_headings(
+    page_dict: Dict[str, Any],
+    body_font_size: float,
+    page_num: int,
+    warnings: List[str],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Extract text blocks and heading hints from a page dict."""
+    blocks_output: List[Dict[str, Any]] = []
+    headings: List[Dict[str, Any]] = []
+
+    for block in page_dict.get("blocks", []):
+        if block.get("type") != 0:
+            continue
+
+        block_text = ""
+        block_font_sizes: List[float] = []
+        block_bbox = block.get("bbox")
+
+        for line in block.get("lines", []):
+            for span in line.get("spans", []):
+                text = span.get("text", "").strip()
+                if text:
+                    block_text += text + " "
+                    block_font_sizes.append(span.get("size", DEFAULT_FONT_SIZE))
+
+        block_text = block_text.strip()
+        if not block_text:
+            continue
+
+        avg_font_size = (
+            sum(block_font_sizes) / len(block_font_sizes) if block_font_sizes else DEFAULT_FONT_SIZE
+        )
+
+        is_heading = bool(
+            avg_font_size > body_font_size * 1.15 and len(block_text) < 200
+        )
+
+        level = 1
+        if is_heading:
+            if avg_font_size <= body_font_size * 1.3:
+                level = 2
+            elif avg_font_size <= body_font_size * 1.6:
+                level = 3
+            elif avg_font_size <= body_font_size * 2.0:
+                level = 4
+
+        blocks_output.append({
+            "text": block_text,
+            "bbox": list(block_bbox) if block_bbox else None,
+            "is_heading": is_heading,
+            "level": level,
+            "avg_font_size": round(avg_font_size, 1),
+        })
+
+        if is_heading:
+            headings.append({
+                "text": block_text,
+                "level": level,
+                "page_number": page_num + 1,
+            })
+
+    return blocks_output, headings
 
 
 def _extract_tables_with_pdfplumber(pdf_path: str) -> List[Dict[str, Any]]:
@@ -215,12 +282,18 @@ def _get_version() -> str:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print(json.dumps({"error": "missing_argument", "message": "Usage: python3 scripts/pymupdf-parse.py <pdf_path>"}))
+        print(json.dumps({
+            "error": "missing_argument",
+            "message": "Usage: python3 scripts/pymupdf-parse.py <pdf_path>",
+        }))
         sys.exit(1)
 
     pdf_path = sys.argv[1]
     if not Path(pdf_path).exists():
-        print(json.dumps({"error": "file_not_found", "message": f"PDF file not found: {pdf_path}"}))
+        print(json.dumps({
+            "error": "file_not_found",
+            "message": f"PDF file not found: {pdf_path}",
+        }))
         sys.exit(1)
 
     try:

--- a/scripts/run-parser-bakeoff.ts
+++ b/scripts/run-parser-bakeoff.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import path from "path";
+import { existsSync } from "fs";
+import {
+  runParserBakeoff,
+  formatParserBakeoffScorecard,
+  formatParserBakeoffScorecardJson,
+} from "../src/lib/quickCheck/evalCorpus/bakeoff";
+
+const repoRoot = process.cwd();
+
+const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
+const pdfGlob = process.argv.find((a) => a.endsWith(".pdf"));
+const pdfPaths = pdfGlob
+  ? [path.resolve(pdfGlob)]
+  : [
+      path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
+      path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
+      path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
+    ].filter((p) => existsSync(p));
+
+const manifestFlagIndex = process.argv.indexOf("--manifest");
+const manifestPath = manifestFlagIndex >= 0 && process.argv[manifestFlagIndex + 1]
+  ? path.resolve(process.argv[manifestFlagIndex + 1])
+  : undefined;
+
+const jsonFlag = process.argv.includes("--json");
+
+const scorecard = runParserBakeoff({
+  pdfPaths,
+  manifestPath,
+  repoRoot,
+});
+
+if (jsonFlag) {
+  console.log(formatParserBakeoffScorecardJson(scorecard));
+} else {
+  console.log(formatParserBakeoffScorecard(scorecard));
+}

--- a/scripts/run-parser-bakeoff.ts
+++ b/scripts/run-parser-bakeoff.ts
@@ -1,55 +1,15 @@
 #!/usr/bin/env node
 import path from "path";
-import { existsSync, readdirSync, statSync } from "fs";
 import {
   runParserBakeoff,
   formatParserBakeoffScorecard,
   formatParserBakeoffScorecardJson,
+  collectPdfPaths,
 } from "../src/lib/quickCheck/evalCorpus/bakeoff";
 
 const repoRoot = process.cwd();
 
-function collectPdfPaths(): string[] {
-  const paths: string[] = [];
-
-  const pdfDirFlagIndex = process.argv.indexOf("--pdfdir");
-  if (pdfDirFlagIndex >= 0) {
-    const dirPath = path.resolve(process.argv[pdfDirFlagIndex + 1] ?? "");
-    if (existsSync(dirPath) && statSync(dirPath).isDirectory()) {
-      for (const entry of readdirSync(dirPath)) {
-        if (entry.toLowerCase().endsWith(".pdf")) {
-          paths.push(path.resolve(dirPath, entry));
-        }
-      }
-    }
-  }
-
-  const pdfFlagIndexes: number[] = [];
-  for (let i = 0; i < process.argv.length; i++) {
-    if (process.argv[i] === "--pdf" && process.argv[i + 1]) {
-      pdfFlagIndexes.push(i);
-    }
-  }
-  for (const idx of pdfFlagIndexes) {
-    const pdfPath = path.resolve(process.argv[idx + 1]);
-    if (!paths.includes(pdfPath)) {
-      paths.push(pdfPath);
-    }
-  }
-
-  if (paths.length > 0) {
-    return paths;
-  }
-
-  const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
-  return [
-    path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
-    path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
-    path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
-  ].filter((p) => existsSync(p));
-}
-
-const pdfPaths = collectPdfPaths();
+const pdfPaths = collectPdfPaths(process.argv, repoRoot);
 
 const manifestFlagIndex = process.argv.indexOf("--manifest");
 const manifestPath = manifestFlagIndex >= 0 && process.argv[manifestFlagIndex + 1]

--- a/scripts/run-parser-bakeoff.ts
+++ b/scripts/run-parser-bakeoff.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import path from "path";
-import { existsSync } from "fs";
+import { existsSync, readdirSync, statSync } from "fs";
 import {
   runParserBakeoff,
   formatParserBakeoffScorecard,
@@ -9,15 +9,47 @@ import {
 
 const repoRoot = process.cwd();
 
-const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
-const pdfGlob = process.argv.find((a) => a.endsWith(".pdf"));
-const pdfPaths = pdfGlob
-  ? [path.resolve(pdfGlob)]
-  : [
-      path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
-      path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
-      path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
-    ].filter((p) => existsSync(p));
+function collectPdfPaths(): string[] {
+  const paths: string[] = [];
+
+  const pdfDirFlagIndex = process.argv.indexOf("--pdfdir");
+  if (pdfDirFlagIndex >= 0) {
+    const dirPath = path.resolve(process.argv[pdfDirFlagIndex + 1] ?? "");
+    if (existsSync(dirPath) && statSync(dirPath).isDirectory()) {
+      for (const entry of readdirSync(dirPath)) {
+        if (entry.toLowerCase().endsWith(".pdf")) {
+          paths.push(path.resolve(dirPath, entry));
+        }
+      }
+    }
+  }
+
+  const pdfFlagIndexes: number[] = [];
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] === "--pdf" && process.argv[i + 1]) {
+      pdfFlagIndexes.push(i);
+    }
+  }
+  for (const idx of pdfFlagIndexes) {
+    const pdfPath = path.resolve(process.argv[idx + 1]);
+    if (!paths.includes(pdfPath)) {
+      paths.push(pdfPath);
+    }
+  }
+
+  if (paths.length > 0) {
+    return paths;
+  }
+
+  const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
+  return [
+    path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
+    path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
+    path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
+  ].filter((p) => existsSync(p));
+}
+
+const pdfPaths = collectPdfPaths();
 
 const manifestFlagIndex = process.argv.indexOf("--manifest");
 const manifestPath = manifestFlagIndex >= 0 && process.argv[manifestFlagIndex + 1]

--- a/src/lib/documentParsing/adapters/pymupdfHelper.ts
+++ b/src/lib/documentParsing/adapters/pymupdfHelper.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "child_process";
+import { existsSync } from "fs";
 import path from "path";
 
 export type PymupdfHelperJsonBlock = {
@@ -41,9 +42,17 @@ export function parsePymupdfHelperOutput(stdout: string): PymupdfHelperJson {
 
 export function runPymupdfHelperSync(pdfPath: string): string {
   const scriptPath = path.resolve(process.cwd(), "scripts", "pymupdf-parse.py");
-  return execFileSync("python3", [scriptPath, pdfPath], {
+  const python3 = _resolvePython3Path();
+  return execFileSync(python3, [scriptPath, pdfPath], {
     timeout: 120000,
     maxBuffer: 50 * 1024 * 1024,
     encoding: "utf-8",
   });
+}
+
+function _resolvePython3Path(): string {
+  if (process.env.PYTHON3) return process.env.PYTHON3;
+  const venvPath = path.resolve(process.cwd(), ".venv/bin/python3");
+  if (existsSync(venvPath)) return venvPath;
+  return "python3";
 }

--- a/src/lib/quickCheck/evalCorpus/bakeoff.ts
+++ b/src/lib/quickCheck/evalCorpus/bakeoff.ts
@@ -1,6 +1,10 @@
 import path from "path";
 import { existsSync, readdirSync, statSync } from "fs";
 import { execFileSync } from "child_process";
+
+function resolvePython3Path(): string {
+  return process.env.PYTHON3 ?? "python3";
+}
 import { parseDocumentText, resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing";
 import {
   runQuickCheckEvalCorpus,
@@ -127,7 +131,7 @@ export function collectPdfPaths(
 function extractRawTextFromPdf(pdfPath: string): string {
   try {
     const scriptPath = path.resolve(process.cwd(), "scripts", "pymupdf-parse.py");
-    const stdout = execFileSync("python3", [scriptPath, pdfPath], {
+    const stdout = execFileSync(resolvePython3Path(), [scriptPath, pdfPath], {
       timeout: 120000,
       maxBuffer: 50 * 1024 * 1024,
       encoding: "utf-8",
@@ -181,9 +185,9 @@ function checkParserAvailable(parserId: string): { available: boolean; reason?: 
 
   if (parserId === "pymupdf") {
     try {
-      execFileSync("python3", ["--version"], { timeout: 5000, encoding: "utf-8" });
+      execFileSync(resolvePython3Path(), ["--version"], { timeout: 5000, encoding: "utf-8" });
       try {
-        execFileSync("python3", ["-c", "import fitz"], { timeout: 10000, encoding: "utf-8" });
+        execFileSync(resolvePython3Path(), ["-c", "import fitz"], { timeout: 10000, encoding: "utf-8" });
         return { available: true };
       } catch {
         return { available: false, reason: "python3 available but pymupdf (fitz) not installed" };
@@ -195,9 +199,9 @@ function checkParserAvailable(parserId: string): { available: boolean; reason?: 
 
   if (parserId === "docling") {
     try {
-      execFileSync("python3", ["--version"], { timeout: 5000, encoding: "utf-8" });
+      execFileSync(resolvePython3Path(), ["--version"], { timeout: 5000, encoding: "utf-8" });
       try {
-        execFileSync("python3", ["-c", "import docling"], { timeout: 10000, encoding: "utf-8" });
+        execFileSync(resolvePython3Path(), ["-c", "import docling"], { timeout: 10000, encoding: "utf-8" });
         return { available: true };
       } catch {
         return { available: false, reason: "python3 available but docling not installed" };

--- a/src/lib/quickCheck/evalCorpus/bakeoff.ts
+++ b/src/lib/quickCheck/evalCorpus/bakeoff.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { existsSync, readdirSync, statSync } from "fs";
 import { execFileSync } from "child_process";
 import { parseDocumentText, resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing";
 import {
@@ -61,6 +62,55 @@ export type ParserBakeoffScorecard = {
   evalComparison: ParserBakeoffEvalComparison[];
   defaultParserId: string;
 };
+
+/**
+ * Collect PDF paths from CLI arguments. Accepts:
+ *   --pdfdir <dir>    – all PDFs in the directory
+ *   --pdf <path>      – individual PDFs (repeatable, deduped)
+ * Falls back to the frozen fixture PDFs when no flags are given.
+ */
+export function collectPdfPaths(
+  argv: string[] = process.argv,
+  repoRoot: string = process.cwd(),
+): string[] {
+  const paths: string[] = [];
+
+  const pdfDirFlagIndex = argv.indexOf("--pdfdir");
+  if (pdfDirFlagIndex >= 0) {
+    const dirPath = path.resolve(argv[pdfDirFlagIndex + 1] ?? "");
+    if (existsSync(dirPath) && statSync(dirPath).isDirectory()) {
+      for (const entry of readdirSync(dirPath)) {
+        if (entry.toLowerCase().endsWith(".pdf")) {
+          paths.push(path.resolve(dirPath, entry));
+        }
+      }
+    }
+  }
+
+  const pdfFlagIndexes: number[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--pdf" && argv[i + 1]) {
+      pdfFlagIndexes.push(i);
+    }
+  }
+  for (const idx of pdfFlagIndexes) {
+    const pdfPath = path.resolve(argv[idx + 1]);
+    if (!paths.includes(pdfPath)) {
+      paths.push(pdfPath);
+    }
+  }
+
+  if (paths.length > 0) {
+    return paths;
+  }
+
+  const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
+  return [
+    path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
+    path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
+    path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
+  ].filter((p) => existsSync(p));
+}
 
 /**
  * Extract raw text from a PDF file using PyMuPDF.

--- a/src/lib/quickCheck/evalCorpus/bakeoff.ts
+++ b/src/lib/quickCheck/evalCorpus/bakeoff.ts
@@ -62,6 +62,18 @@ export type ParserBakeoffScorecard = {
   defaultParserId: string;
 };
 
+/**
+ * Extract raw text from a PDF file using PyMuPDF.
+ *
+ * NOTE: This function is also used to supply text for the current-extractor
+ * parser in the bakeoff. This means current-extractor's per-PDF metrics are
+ * derived from PyMuPDF-extracted text rather than from its native raw-text
+ * reading path. The downstream eval corpus comparison (which uses the existing
+ * .txt fixture files) is NOT affected — current-extractor reads those text
+ * fixtures directly. Only the per-PDF bakeoff metrics for current-extractor
+ * share the same text source as pymupdf, which is intentional: it ensures a
+ * fair text-length comparison on identical input.
+ */
 function extractRawTextFromPdf(pdfPath: string): string {
   try {
     const scriptPath = path.resolve(process.cwd(), "scripts", "pymupdf-parse.py");
@@ -164,8 +176,9 @@ function runSingleParserOnPdf(
     };
   }
 
+  const savedEnv = process.env.QUICK_CHECK_PARSER;
+
   try {
-    const originalEnv = process.env.QUICK_CHECK_PARSER;
     process.env.QUICK_CHECK_PARSER = parserId;
 
     let input: ParseDocumentTextInput;
@@ -177,8 +190,6 @@ function runSingleParserOnPdf(
     }
 
     const parsed = parseDocumentText(input);
-
-    process.env.QUICK_CHECK_PARSER = originalEnv;
 
     return {
       pdfPath,
@@ -195,7 +206,11 @@ function runSingleParserOnPdf(
       error: message,
     };
   } finally {
-    process.env.QUICK_CHECK_PARSER = undefined;
+    if (savedEnv === undefined) {
+      delete process.env.QUICK_CHECK_PARSER;
+    } else {
+      process.env.QUICK_CHECK_PARSER = savedEnv;
+    }
   }
 }
 
@@ -216,16 +231,15 @@ function runEvalWithParser(
     };
   }
 
+  const savedEnv = process.env.QUICK_CHECK_PARSER;
+
   try {
-    const originalEnv = process.env.QUICK_CHECK_PARSER;
     process.env.QUICK_CHECK_PARSER = parserId;
 
     const report = runQuickCheckEvalCorpus({
       manifestPath,
       repoRoot,
     });
-
-    process.env.QUICK_CHECK_PARSER = originalEnv;
 
     const manifest = loadEvalCorpusManifest(manifestPath);
     const thresholds: EvalCorpusThresholds = manifest.thresholds ?? DEFAULT_STRICT_THRESHOLDS;
@@ -248,7 +262,11 @@ function runEvalWithParser(
       unavailableReason: available ? `eval failed: ${message}` : reason,
     };
   } finally {
-    process.env.QUICK_CHECK_PARSER = undefined;
+    if (savedEnv === undefined) {
+      delete process.env.QUICK_CHECK_PARSER;
+    } else {
+      process.env.QUICK_CHECK_PARSER = savedEnv;
+    }
   }
 }
 

--- a/src/lib/quickCheck/evalCorpus/bakeoff.ts
+++ b/src/lib/quickCheck/evalCorpus/bakeoff.ts
@@ -1,0 +1,399 @@
+import path from "path";
+import { execFileSync } from "child_process";
+import { parseDocumentText, resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing";
+import {
+  runQuickCheckEvalCorpus,
+  checkEvalCorpusThresholds,
+} from "@/lib/quickCheck/evalCorpus/runner";
+import {
+  loadEvalCorpusManifest,
+} from "@/lib/quickCheck/evalCorpus/manifest";
+import type { EvalCorpusReport, EvalCorpusThresholds } from "@/lib/quickCheck/evalCorpus/types";
+import { DEFAULT_STRICT_THRESHOLDS } from "@/lib/quickCheck/evalCorpus/types";
+import type {
+  ParseDocumentTextInput,
+  ParsedDocument,
+} from "@/lib/documentParsing";
+
+export type ParserBakeoffParserEntry = {
+  parserId: string;
+  available: boolean;
+  unavailableReason?: string;
+};
+
+export type ParserBakeoffPerPdfMetrics = {
+  pageCount: number;
+  rawTextLength: number;
+  headingCount: number;
+  tableCount: number;
+  elementCount: number;
+  pageProvenanceElementCount: number;
+  hasPageBoundaries: boolean;
+  hasBoundingBoxes: boolean;
+  hasTables: boolean;
+  hasStructuredHeadings: boolean;
+  medianTextPerPage: number;
+  avgConfidence: number;
+};
+
+export type ParserBakeoffPdfResult = {
+  pdfPath: string;
+  parserId: string;
+  available: boolean;
+  error?: string;
+  metrics?: ParserBakeoffPerPdfMetrics;
+};
+
+export type ParserBakeoffEvalComparison = {
+  parserId: string;
+  available: boolean;
+  unavailableReason?: string;
+  passedCount: number;
+  totalCount: number;
+  report?: EvalCorpusReport;
+};
+
+export type ParserBakeoffScorecard = {
+  bakeoffTimestamp: string;
+  parsers: ParserBakeoffParserEntry[];
+  pdfFixtures: string[];
+  perPdfResults: ParserBakeoffPdfResult[];
+  evalComparison: ParserBakeoffEvalComparison[];
+  defaultParserId: string;
+};
+
+function extractRawTextFromPdf(pdfPath: string): string {
+  try {
+    const scriptPath = path.resolve(process.cwd(), "scripts", "pymupdf-parse.py");
+    const stdout = execFileSync("python3", [scriptPath, pdfPath], {
+      timeout: 120000,
+      maxBuffer: 50 * 1024 * 1024,
+      encoding: "utf-8",
+    });
+    const result = JSON.parse(stdout);
+    if (result.error) {
+      throw new Error(`pymupdf text extraction failed: ${result.error} — ${result.message ?? ""}`);
+    }
+    return result.raw_text ?? "";
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`PDF text extraction failed for ${pdfPath}: ${message}`);
+  }
+}
+
+function computePerPdfMetrics(parsed: ParsedDocument): ParserBakeoffPerPdfMetrics {
+  const pageCount = parsed.pages.length || parsed.qualityReport.pageCount || 1;
+  const perPageLengths = parsed.pages.map((p) => p.rawText.length);
+  const sorted = [...perPageLengths].sort((a, b) => a - b);
+  const medianTextPerPage = sorted.length > 0
+    ? sorted[Math.floor(sorted.length / 2)]
+    : 0;
+
+  const confidences = parsed.elements
+    .map((e) => e.confidence)
+    .filter((c): c is number => typeof c === "number");
+  const avgConfidence = confidences.length > 0
+    ? confidences.reduce((s, c) => s + c, 0) / confidences.length
+    : 0;
+
+  return {
+    pageCount,
+    rawTextLength: parsed.rawText.length,
+    headingCount: parsed.headings?.length ?? 0,
+    tableCount: parsed.tables?.length ?? 0,
+    elementCount: parsed.elements.length,
+    pageProvenanceElementCount: parsed.elements.filter((e) => e.pageNumber && e.pageNumber > 0).length,
+    hasPageBoundaries: parsed.qualityReport.hasPageBoundaries,
+    hasBoundingBoxes: parsed.qualityReport.hasBoundingBoxes,
+    hasTables: parsed.qualityReport.hasTables,
+    hasStructuredHeadings: parsed.qualityReport.hasStructuredHeadings,
+    medianTextPerPage,
+    avgConfidence,
+  };
+}
+
+function checkParserAvailable(parserId: string): { available: boolean; reason?: string } {
+  if (parserId === "current-extractor") {
+    return { available: true };
+  }
+
+  if (parserId === "pymupdf") {
+    try {
+      execFileSync("python3", ["--version"], { timeout: 5000, encoding: "utf-8" });
+      try {
+        execFileSync("python3", ["-c", "import fitz"], { timeout: 10000, encoding: "utf-8" });
+        return { available: true };
+      } catch {
+        return { available: false, reason: "python3 available but pymupdf (fitz) not installed" };
+      }
+    } catch {
+      return { available: false, reason: "python3 not available" };
+    }
+  }
+
+  if (parserId === "docling") {
+    try {
+      execFileSync("python3", ["--version"], { timeout: 5000, encoding: "utf-8" });
+      try {
+        execFileSync("python3", ["-c", "import docling"], { timeout: 10000, encoding: "utf-8" });
+        return { available: true };
+      } catch {
+        return { available: false, reason: "python3 available but docling not installed" };
+      }
+    } catch {
+      return { available: false, reason: "python3 not available" };
+    }
+  }
+
+  return { available: false, reason: `unknown parser: ${parserId}` };
+}
+
+function runSingleParserOnPdf(
+  pdfPath: string,
+  parserId: string,
+  rawText: string,
+): ParserBakeoffPdfResult {
+  const { available, reason } = checkParserAvailable(parserId);
+
+  if (!available) {
+    return {
+      pdfPath,
+      parserId,
+      available: false,
+      error: reason,
+    };
+  }
+
+  try {
+    const originalEnv = process.env.QUICK_CHECK_PARSER;
+    process.env.QUICK_CHECK_PARSER = parserId;
+
+    let input: ParseDocumentTextInput;
+
+    if (parserId === "current-extractor") {
+      input = { rawText };
+    } else {
+      input = { rawText, pdfFilePath: pdfPath };
+    }
+
+    const parsed = parseDocumentText(input);
+
+    process.env.QUICK_CHECK_PARSER = originalEnv;
+
+    return {
+      pdfPath,
+      parserId,
+      available: true,
+      metrics: computePerPdfMetrics(parsed),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      pdfPath,
+      parserId,
+      available,
+      error: message,
+    };
+  } finally {
+    process.env.QUICK_CHECK_PARSER = undefined;
+  }
+}
+
+function runEvalWithParser(
+  manifestPath: string,
+  parserId: string,
+  repoRoot: string,
+): ParserBakeoffEvalComparison {
+  const { available, reason } = checkParserAvailable(parserId);
+
+  if (!available) {
+    return {
+      parserId,
+      available: false,
+      passedCount: 0,
+      totalCount: 0,
+      unavailableReason: reason,
+    };
+  }
+
+  try {
+    const originalEnv = process.env.QUICK_CHECK_PARSER;
+    process.env.QUICK_CHECK_PARSER = parserId;
+
+    const report = runQuickCheckEvalCorpus({
+      manifestPath,
+      repoRoot,
+    });
+
+    process.env.QUICK_CHECK_PARSER = originalEnv;
+
+    const manifest = loadEvalCorpusManifest(manifestPath);
+    const thresholds: EvalCorpusThresholds = manifest.thresholds ?? DEFAULT_STRICT_THRESHOLDS;
+    const { passed } = checkEvalCorpusThresholds(report, thresholds);
+
+    return {
+      parserId,
+      available: true,
+      passedCount: passed ? report.fixtureCount : report.metrics.firstPassSuccessRate.passed,
+      totalCount: report.fixtureCount,
+      report,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      parserId,
+      available,
+      passedCount: 0,
+      totalCount: 0,
+      unavailableReason: available ? `eval failed: ${message}` : reason,
+    };
+  } finally {
+    process.env.QUICK_CHECK_PARSER = undefined;
+  }
+}
+
+export function runParserBakeoff(options: {
+  pdfPaths: string[];
+  manifestPath?: string;
+  repoRoot: string;
+}): ParserBakeoffScorecard {
+  const { pdfPaths, manifestPath, repoRoot } = options;
+
+  const defaultManifestPath = manifestPath
+    ?? path.resolve(repoRoot, "tests/fixtures/quick-check/corpus/phase6-eval-corpus.json");
+
+  const parserIds = ["current-extractor", "pymupdf", "docling"] as const;
+
+  const parsers: ParserBakeoffParserEntry[] = parserIds.map((id) => {
+    const { available, reason } = checkParserAvailable(id);
+    return {
+      parserId: id,
+      available,
+      ...(reason ? { unavailableReason: reason } : {}),
+    };
+  });
+
+  const perPdfResults: ParserBakeoffPdfResult[] = [];
+
+  for (const pdfPath of pdfPaths) {
+    let rawText = "";
+    try {
+      rawText = extractRawTextFromPdf(pdfPath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      for (const parserId of parserIds) {
+        perPdfResults.push({
+          pdfPath,
+          parserId,
+          available: false,
+          error: message,
+        });
+      }
+      continue;
+    }
+
+    for (const parserId of parserIds) {
+      perPdfResults.push(runSingleParserOnPdf(pdfPath, parserId, rawText));
+    }
+  }
+
+  const evalComparison: ParserBakeoffEvalComparison[] = parserIds.map((parserId) =>
+    runEvalWithParser(defaultManifestPath, parserId, repoRoot),
+  );
+
+  return {
+    bakeoffTimestamp: new Date().toISOString(),
+    parsers,
+    pdfFixtures: pdfPaths,
+    perPdfResults,
+    evalComparison,
+    defaultParserId: resolveConfiguredDocumentParserAdapterId(undefined),
+  };
+}
+
+export function formatParserBakeoffScorecard(scorecard: ParserBakeoffScorecard): string {
+  const lines: string[] = [];
+
+  lines.push(`# Parser Bakeoff Scorecard`);
+  lines.push(`Generated: ${scorecard.bakeoffTimestamp}`);
+  lines.push(`Default parser: ${scorecard.defaultParserId}`);
+  lines.push(`PDF fixtures: ${scorecard.pdfFixtures.length}`);
+  lines.push("");
+
+  lines.push("## Parser Availability");
+  for (const parser of scorecard.parsers) {
+    const status = parser.available ? "AVAILABLE" : `UNAVAILABLE (${parser.unavailableReason ?? "unknown"})`;
+    lines.push(`- ${parser.parserId}: ${status}`);
+  }
+  lines.push("");
+
+  lines.push("## Per-PDF Metrics");
+  lines.push("");
+
+  for (const pdfPath of scorecard.pdfFixtures) {
+    const pdfName = path.basename(pdfPath);
+    lines.push(`### ${pdfName}`);
+    lines.push("");
+
+    const pdfResults = scorecard.perPdfResults.filter((r) => r.pdfPath === pdfPath);
+
+    for (const result of pdfResults) {
+      if (!result.available || result.error) {
+        lines.push(`- **${result.parserId}**: ERROR — ${result.error ?? "unavailable"}`);
+        continue;
+      }
+      const m = result.metrics!;
+      lines.push(`- **${result.parserId}**:`);
+      lines.push(`  - pages: ${m.pageCount}  |  rawText: ${m.rawTextLength} chars  |  median/page: ${m.medianTextPerPage}`);
+      lines.push(`  - headings: ${m.headingCount}  |  tables: ${m.tableCount}  |  elements: ${m.elementCount}`);
+      lines.push(`  - page provenance: ${m.pageProvenanceElementCount}/${m.elementCount}  |  avg confidence: ${m.avgConfidence.toFixed(3)}`);
+      lines.push(`  - hasPageBoundaries: ${m.hasPageBoundaries}  |  hasBoundingBoxes: ${m.hasBoundingBoxes}  |  hasStructuredHeadings: ${m.hasStructuredHeadings}  |  hasTables: ${m.hasTables}`);
+    }
+
+    const pdfParsers = pdfResults.filter((r) => r.available && !r.error);
+    if (pdfParsers.length >= 2) {
+      lines.push("");
+      lines.push("  **Comparison:**");
+      const ce = pdfParsers.find((r) => r.parserId === "current-extractor");
+      const pm = pdfParsers.find((r) => r.parserId === "pymupdf");
+      if (ce && pm && ce.metrics && pm.metrics) {
+        lines.push(`  - heading delta: ${pm.metrics.headingCount - ce.metrics.headingCount}`);
+        lines.push(`  - table delta: ${pm.metrics.tableCount - ce.metrics.tableCount}`);
+        lines.push(`  - element delta: ${pm.metrics.elementCount - ce.metrics.elementCount}`);
+        lines.push(`  - provenance delta: ${pm.metrics.pageProvenanceElementCount - ce.metrics.pageProvenanceElementCount}`);
+      }
+    }
+    lines.push("");
+  }
+
+  lines.push("## Downstream Eval Corpus Comparison");
+  lines.push("");
+
+  for (const comparison of scorecard.evalComparison) {
+    if (!comparison.available) {
+      lines.push(`- **${comparison.parserId}**: UNAVAILABLE — ${comparison.unavailableReason ?? "unknown"}`);
+      continue;
+    }
+
+    if (!comparison.report) {
+      lines.push(`- **${comparison.parserId}**: no report generated`);
+      continue;
+    }
+
+    const r = comparison.report;
+    const m = r.metrics;
+    lines.push(`- **${comparison.parserId}**: ${comparison.passedCount}/${comparison.totalCount} fixtures passed`);
+    lines.push(`  - first-pass success: ${(m.firstPassSuccessRate.rate * 100).toFixed(1)}% (${m.firstPassSuccessRate.passed}/${m.firstPassSuccessRate.total})`);
+    lines.push(`  - fact accuracy: ${(m.factExtractionAccuracy.rate * 100).toFixed(1)}%`);
+    lines.push(`  - provenance correctness: ${(m.provenanceCorrectness.rate * 100).toFixed(1)}%`);
+    lines.push(`  - hallucinated answer: ${(m.hallucinatedAnswerRate.rate * 100).toFixed(1)}% (${m.hallucinatedAnswerRate.passed}/${m.hallucinatedAnswerRate.total})`);
+    lines.push(`  - unsupported rejection: ${(m.unsupportedRejectionRate.rate * 100).toFixed(1)}%`);
+    lines.push(`  - regressions: ${m.regressionCount}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function formatParserBakeoffScorecardJson(scorecard: ParserBakeoffScorecard): string {
+  return JSON.stringify(scorecard, null, 2);
+}

--- a/src/lib/quickCheck/evalCorpus/bakeoff.ts
+++ b/src/lib/quickCheck/evalCorpus/bakeoff.ts
@@ -6,6 +6,8 @@ function resolvePython3Path(): string {
   return process.env.PYTHON3 ?? "python3";
 }
 import { parseDocumentText, resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing";
+import { setPymupdfHelperRunnerForTests } from "@/lib/documentParsing/adapters/pymupdfAdapter";
+import { runPymupdfHelperSync, parsePymupdfHelperOutput } from "@/lib/documentParsing/adapters/pymupdfHelper";
 import {
   runQuickCheckEvalCorpus,
   checkEvalCorpusThresholds,
@@ -329,6 +331,9 @@ export function runParserBakeoff(options: {
   manifestPath?: string;
   repoRoot: string;
 }): ParserBakeoffScorecard {
+  // Wire real helper runner so the adapter can call the Python script.
+  setPymupdfHelperRunnerForTests(runPymupdfHelperSync, parsePymupdfHelperOutput);
+
   const { pdfPaths, manifestPath, repoRoot } = options;
 
   const defaultManifestPath = manifestPath

--- a/src/lib/quickCheck/evalCorpus/index.ts
+++ b/src/lib/quickCheck/evalCorpus/index.ts
@@ -9,3 +9,15 @@ export type {
   StandardPhase6QuestionId,
 } from "@/lib/quickCheck/evalCorpus/types";
 export { DEFAULT_STRICT_THRESHOLDS } from "@/lib/quickCheck/evalCorpus/types";
+export {
+  runParserBakeoff,
+  formatParserBakeoffScorecard,
+  formatParserBakeoffScorecardJson,
+} from "@/lib/quickCheck/evalCorpus/bakeoff";
+export type {
+  ParserBakeoffParserEntry,
+  ParserBakeoffPerPdfMetrics,
+  ParserBakeoffPdfResult,
+  ParserBakeoffEvalComparison,
+  ParserBakeoffScorecard,
+} from "@/lib/quickCheck/evalCorpus/bakeoff";

--- a/tests/lib/quickCheck/parserBakeoff.test.ts
+++ b/tests/lib/quickCheck/parserBakeoff.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "@jest/globals";
 import path from "path";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
 import {
   runParserBakeoff,
   formatParserBakeoffScorecard,
   formatParserBakeoffScorecardJson,
+  collectPdfPaths,
 } from "@/lib/quickCheck/evalCorpus/bakeoff";
 import type { ParserBakeoffScorecard } from "@/lib/quickCheck/evalCorpus/bakeoff";
 
@@ -288,5 +290,107 @@ describe("Parser bakeoff env restoration", () => {
     });
 
     expect(process.env.QUICK_CHECK_PARSER).toBe("liteparse");
+  });
+});
+
+describe("collectPdfPaths CLI argument handling", () => {
+  const repoRoot = process.cwd();
+  const fixtureDir = path.resolve(repoRoot, "tests/fixtures/quick-check");
+
+  it("default fallback returns frozen fixture PDFs when no flags passed", () => {
+    const paths = collectPdfPaths([], repoRoot);
+
+    expect(paths.length).toBeGreaterThanOrEqual(1);
+    expect(paths.every((p) => p.endsWith(".pdf"))).toBe(true);
+    expect(paths.some((p) => p.includes("plum-verra-demo-excerpt"))).toBe(true);
+  });
+
+  it("--pdfdir collects all PDFs from a directory, sorted by name", () => {
+    const tmpDir = path.resolve("/tmp/bakeoff-collectPdfPaths-test");
+    rmSync(tmpDir, { recursive: true, force: true });
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(path.resolve(tmpDir, "alpha.pdf"), "%PDF-1.4 fake");
+    writeFileSync(path.resolve(tmpDir, "beta.pdf"), "%PDF-1.4 fake");
+
+    const paths = collectPdfPaths(["node", "script", "--pdfdir", tmpDir], repoRoot);
+
+    expect(paths.length).toBe(2);
+    expect(paths.every((p) => p.endsWith(".pdf"))).toBe(true);
+    expect(paths.some((p) => p.includes("alpha.pdf"))).toBe(true);
+    expect(paths.some((p) => p.includes("beta.pdf"))).toBe(true);
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("repeated --pdf flags collect all paths", () => {
+    const paths = collectPdfPaths([
+      "node", "script",
+      "--pdf", "/tmp/a.pdf",
+      "--pdf", "/tmp/b.pdf",
+    ], repoRoot);
+
+    expect(paths.length).toBe(2);
+    expect(paths).toContain(path.resolve("/tmp/a.pdf"));
+    expect(paths).toContain(path.resolve("/tmp/b.pdf"));
+  });
+
+  it("dedupes when same PDF is given via --pdf twice", () => {
+    const paths = collectPdfPaths([
+      "node", "script",
+      "--pdf", "/tmp/dup.pdf",
+      "--pdf", "/tmp/dup.pdf",
+    ], repoRoot);
+
+    expect(paths.length).toBe(1);
+    expect(paths[0]).toBe(path.resolve("/tmp/dup.pdf"));
+  });
+
+  it("combines --pdfdir and --pdf deduping across sources", () => {
+    const tmpDir = path.resolve("/tmp/bakeoff-combine-test");
+    rmSync(tmpDir, { recursive: true, force: true });
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(path.resolve(tmpDir, "dir.pdf"), "%PDF-1.4 fake");
+
+    const paths = collectPdfPaths([
+      "node", "script",
+      "--pdfdir", tmpDir,
+      "--pdf", "/tmp/extra.pdf",
+    ], repoRoot);
+
+    expect(paths.length).toBe(2);
+    expect(paths.some((p) => p.includes("dir.pdf"))).toBe(true);
+    expect(paths.some((p) => p.includes("extra.pdf"))).toBe(true);
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("--pdfdir pointing to nonexistent directory ignores gracefully", () => {
+    const paths = collectPdfPaths([
+      "node", "script",
+      "--pdfdir", "/tmp/does-not-exist-bakeoff-cli",
+    ], repoRoot);
+
+    // Falls back to defaults when no paths found
+    expect(paths.length).toBeGreaterThanOrEqual(1);
+    expect(paths.some((p) => p.includes(fixtureDir))).toBe(true);
+  });
+
+  it("dedupes when --pdfdir and --pdf yield the same path", () => {
+    const tmpDir = path.resolve("/tmp/bakeoff-same-test");
+    rmSync(tmpDir, { recursive: true, force: true });
+    mkdirSync(tmpDir, { recursive: true });
+    const pdfPath = path.resolve(tmpDir, "shared.pdf");
+    writeFileSync(pdfPath, "%PDF-1.4 fake");
+
+    const paths = collectPdfPaths([
+      "node", "script",
+      "--pdfdir", tmpDir,
+      "--pdf", pdfPath,
+    ], repoRoot);
+
+    expect(paths.length).toBe(1);
+    expect(paths[0]).toBe(pdfPath);
+
+    rmSync(tmpDir, { recursive: true, force: true });
   });
 });

--- a/tests/lib/quickCheck/parserBakeoff.test.ts
+++ b/tests/lib/quickCheck/parserBakeoff.test.ts
@@ -247,3 +247,46 @@ describe("Parser bakeoff with real PDF fixtures", () => {
     }
   });
 });
+
+describe("Parser bakeoff env restoration", () => {
+  const nonexistentPdf = path.resolve("/tmp/does-not-exist-bakeoff-env.pdf");
+
+  afterEach(() => {
+    delete process.env.QUICK_CHECK_PARSER;
+  });
+
+  it("Case A: QUICK_CHECK_PARSER was unset, remains unset after bakeoff", () => {
+    delete process.env.QUICK_CHECK_PARSER;
+    expect(process.env.QUICK_CHECK_PARSER).toBeUndefined();
+
+    runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(process.env.QUICK_CHECK_PARSER).toBeUndefined();
+  });
+
+  it("Case B: QUICK_CHECK_PARSER was set, same value remains after bakeoff", () => {
+    process.env.QUICK_CHECK_PARSER = "pymupdf";
+    expect(process.env.QUICK_CHECK_PARSER).toBe("pymupdf");
+
+    runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(process.env.QUICK_CHECK_PARSER).toBe("pymupdf");
+  });
+
+  it("QUICK_CHECK_PARSER restoration survives per-PDF parser runs", () => {
+    process.env.QUICK_CHECK_PARSER = "liteparse";
+
+    runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(process.env.QUICK_CHECK_PARSER).toBe("liteparse");
+  });
+});

--- a/tests/lib/quickCheck/parserBakeoff.test.ts
+++ b/tests/lib/quickCheck/parserBakeoff.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "@jest/globals";
+import path from "path";
+import {
+  runParserBakeoff,
+  formatParserBakeoffScorecard,
+  formatParserBakeoffScorecardJson,
+} from "@/lib/quickCheck/evalCorpus/bakeoff";
+import type { ParserBakeoffScorecard } from "@/lib/quickCheck/evalCorpus/bakeoff";
+
+describe("Parser bakeoff scorecard", () => {
+  const nonexistentPdf = path.resolve("/tmp/does-not-exist-bakeoff.pdf");
+
+  it("produces a valid scorecard structure with nonexistent PDFs", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(scorecard).toBeDefined();
+    expect(scorecard.bakeoffTimestamp).toBeTruthy();
+    expect(scorecard.defaultParserId).toBe("current-extractor");
+    expect(scorecard.pdfFixtures).toEqual([nonexistentPdf]);
+    expect(Array.isArray(scorecard.parsers)).toBe(true);
+    expect(Array.isArray(scorecard.perPdfResults)).toBe(true);
+    expect(Array.isArray(scorecard.evalComparison)).toBe(true);
+  });
+
+  it("reports all three parsers in the parser list", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    const parserIds = scorecard.parsers.map((p) => p.parserId);
+    expect(parserIds).toContain("current-extractor");
+    expect(parserIds).toContain("pymupdf");
+    expect(parserIds).toContain("docling");
+  });
+
+  it("current-extractor is available regardless of Python status", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    const ce = scorecard.parsers.find((p) => p.parserId === "current-extractor");
+    expect(ce).toBeDefined();
+    expect(ce!.available).toBe(true);
+  });
+
+  it("records parser availability truthfully", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    for (const parser of scorecard.parsers) {
+      expect(typeof parser.parserId).toBe("string");
+      expect(typeof parser.available).toBe("boolean");
+      if (!parser.available) {
+        expect(parser.unavailableReason).toBeTruthy();
+      }
+    }
+  });
+
+  it("perPdfResults contains entries for each (pdf, parser) pair", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(scorecard.perPdfResults.length).toBeGreaterThanOrEqual(1);
+
+    for (const result of scorecard.perPdfResults) {
+      expect(result.pdfPath).toBe(nonexistentPdf);
+      expect(typeof result.parserId).toBe("string");
+      expect(typeof result.available).toBe("boolean");
+    }
+  });
+
+  it("evalComparison covers all three parsers", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    expect(scorecard.evalComparison.length).toBe(3);
+    const evalParserIds = scorecard.evalComparison.map((e) => e.parserId);
+    expect(evalParserIds).toContain("current-extractor");
+    expect(evalParserIds).toContain("pymupdf");
+    expect(evalParserIds).toContain("docling");
+  });
+
+  it("formats a human-readable markdown scorecard", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    const markdown = formatParserBakeoffScorecard(scorecard);
+
+    expect(markdown).toBeTruthy();
+    expect(markdown).toContain("# Parser Bakeoff Scorecard");
+    expect(markdown).toContain("## Parser Availability");
+    expect(markdown).toContain("## Per-PDF Metrics");
+    expect(markdown).toContain("## Downstream Eval Corpus Comparison");
+    expect(markdown).toContain("current-extractor");
+  });
+
+  it("formats a valid JSON scorecard", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: [nonexistentPdf],
+      repoRoot: process.cwd(),
+    });
+
+    const json = formatParserBakeoffScorecardJson(scorecard);
+    const parsed: ParserBakeoffScorecard = JSON.parse(json);
+
+    expect(parsed.parsers.length).toBe(scorecard.parsers.length);
+    expect(parsed.perPdfResults.length).toBe(scorecard.perPdfResults.length);
+    expect(parsed.evalComparison.length).toBe(scorecard.evalComparison.length);
+    expect(parsed.bakeoffTimestamp).toBe(scorecard.bakeoffTimestamp);
+  });
+});
+
+describe("Parser bakeoff with real PDF fixtures", () => {
+  const fixtureDir = path.resolve(process.cwd(), "tests/fixtures/quick-check");
+  const fs = require("fs");
+
+  const realPdfs = [
+    path.resolve(fixtureDir, "plum-verra-demo-excerpt.pdf"),
+    path.resolve(fixtureDir, "malawi-strong-signal-evidence.pdf"),
+    path.resolve(fixtureDir, "kenya-second-check-evidence.pdf"),
+  ].filter((p) => fs.existsSync(p));
+
+  if (realPdfs.length === 0) {
+    it.skip("no PDF fixtures found", () => {});
+    return;
+  }
+
+  it("produces per-pdf metrics for real PDF fixtures when pymupdf is available", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: realPdfs,
+      repoRoot: process.cwd(),
+    });
+
+    const pymupdfAvailable = scorecard.parsers.find(
+      (p) => p.parserId === "pymupdf",
+    )?.available;
+
+    const currentExtractorResults = scorecard.perPdfResults.filter(
+      (r) => r.parserId === "current-extractor" && r.metrics,
+    );
+
+    if (pymupdfAvailable) {
+      expect(currentExtractorResults.length).toBeGreaterThanOrEqual(realPdfs.length);
+
+      for (const result of currentExtractorResults) {
+        const m = result.metrics!;
+        expect(m.pageCount).toBeGreaterThan(0);
+        expect(m.rawTextLength).toBeGreaterThan(0);
+        expect(typeof m.headingCount).toBe("number");
+        expect(typeof m.tableCount).toBe("number");
+        expect(typeof m.elementCount).toBe("number");
+        expect(m.elementCount).toBeGreaterThan(0);
+        expect(m.avgConfidence).toBeGreaterThan(0);
+      }
+    } else {
+      // When pymupdf is unavailable, text extraction fails for all parsers
+      expect(scorecard.parsers.length).toBe(3);
+    }
+  });
+
+  it("pymupdf is available or reported as unavailable with reason", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: realPdfs.slice(0, 1),
+      repoRoot: process.cwd(),
+    });
+
+    const pm = scorecard.parsers.find((p) => p.parserId === "pymupdf");
+    expect(pm).toBeDefined();
+
+    const pmResults = scorecard.perPdfResults.filter((r) => r.parserId === "pymupdf");
+
+    expect(pmResults.length).toBeGreaterThanOrEqual(1);
+
+    for (const result of pmResults) {
+      if (pm!.available) {
+        expect(result.metrics).toBeDefined();
+      } else {
+        // unavailable parsers record an error
+        expect(result.available === false || result.error).toBeDefined();
+      }
+    }
+  });
+
+  it("docling is included in scorecard regardless of availability", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: realPdfs.slice(0, 1),
+      repoRoot: process.cwd(),
+    });
+
+    const dl = scorecard.parsers.find((p) => p.parserId === "docling");
+    expect(dl).toBeDefined();
+
+    const dlResults = scorecard.perPdfResults.filter((r) => r.parserId === "docling");
+
+    expect(dlResults.length).toBeGreaterThanOrEqual(1);
+
+    for (const result of dlResults) {
+      if (dl!.available) {
+        expect(result.metrics).toBeDefined();
+      } else {
+        // unavailable parsers record the reason
+        expect(result.available === false || result.error).toBeDefined();
+      }
+    }
+  });
+
+  it("markdown scorecard includes comparison deltas when both parsers available", () => {
+    const scorecard = runParserBakeoff({
+      pdfPaths: realPdfs.slice(0, 1),
+      repoRoot: process.cwd(),
+    });
+
+    const pymupdfAvailable = scorecard.parsers.find(
+      (p) => p.parserId === "pymupdf",
+    )?.available;
+
+    const markdown = formatParserBakeoffScorecard(scorecard);
+
+    expect(markdown).toContain("# Parser Bakeoff Scorecard");
+    expect(markdown).toContain("## Downstream Eval Corpus Comparison");
+
+    if (pymupdfAvailable) {
+      const ce = scorecard.perPdfResults.filter(
+        (r) => r.parserId === "current-extractor" && r.metrics,
+      );
+      const pm = scorecard.perPdfResults.filter(
+        (r) => r.parserId === "pymupdf" && r.metrics,
+      );
+
+      if (ce.length > 0 && pm.length > 0) {
+        expect(markdown).toContain("**Comparison:**");
+        expect(markdown).toContain("heading delta:");
+      }
+    }
+  });
+});

--- a/tests/lib/quickCheck/pymupdfHelperSmoke.test.ts
+++ b/tests/lib/quickCheck/pymupdfHelperSmoke.test.ts
@@ -1,0 +1,171 @@
+import { afterAll, describe, expect, it } from "@jest/globals";
+import { execFileSync } from "child_process";
+import { existsSync, rmSync, writeFileSync } from "fs";
+import path from "path";
+
+const SCRIPT = path.resolve(process.cwd(), "scripts", "pymupdf-parse.py");
+
+function resolvePython3(): string {
+  if (process.env.PYTHON3) return process.env.PYTHON3;
+  const venvPython3 = path.resolve(process.cwd(), ".venv/bin/python3");
+  if (existsSync(venvPython3)) return venvPython3;
+  return "python3";
+}
+
+function makeSyntheticPdf(pdfPath: string, pageCount: number): void {
+  const pythonPath = resolvePython3();
+  const pyScript = `
+import fitz
+doc = fitz.open()
+for p in range(${pageCount}):
+    page = doc.new_page(width=595, height=842)
+    page.insert_text((72, 72 + min(p, 5) * 8), f"Heading on Page {p+1}", fontsize=max(8, 14 - min(p, 5) * 1.2))
+    for i, line in enumerate(["Line one of body text.", "Line two of body text.", "Line three with more content about carbon projects."]):
+        page.insert_text((72, 200 + i * 20), f"{line} (p{p+1})", fontsize=12)
+doc.save("${pdfPath}")
+doc.close()
+print("ok")
+`;
+  execFileSync(pythonPath, ["-c", pyScript], { timeout: 30000, encoding: "utf-8" });
+}
+
+describe("pymupdf-parse.py smoke tests", () => {
+  const SYNTHETIC_PDF = path.resolve("/tmp/pymupdf-smoke-60.pdf");
+
+  afterAll(() => {
+    try { rmSync(SYNTHETIC_PDF); } catch { /* ok */ }
+  });
+
+  it("parses a 1-page synthetic PDF and returns valid JSON", () => {
+    const onePage = path.resolve("/tmp/pymupdf-smoke-1.pdf");
+    try {
+      makeSyntheticPdf(onePage, 1);
+
+      const stdout = execFileSync(resolvePython3(), [SCRIPT, onePage], {
+        timeout: 30000,
+        encoding: "utf-8",
+      });
+      const result = JSON.parse(stdout);
+
+      expect(result.error).toBeUndefined();
+      expect(result.engine).toBe("pymupdf");
+      expect(result.pages).toHaveLength(1);
+      expect(result.pages[0]?.page_number).toBe(1);
+      expect(result.raw_text).toBeTruthy();
+      expect(result.diagnostics).toBeDefined();
+      expect(result.diagnostics.phases).toBeDefined();
+    } finally {
+      try { rmSync(onePage); } catch { /* ok */ }
+    }
+  });
+
+  it("parses a 60-page synthetic PDF under 15 seconds", () => {
+    makeSyntheticPdf(SYNTHETIC_PDF, 60);
+
+    const start = Date.now();
+    const stdout = execFileSync(resolvePython3(), [SCRIPT, SYNTHETIC_PDF], {
+      timeout: 60000,
+      encoding: "utf-8",
+    });
+    const elapsed = Date.now() - start;
+
+    const result = JSON.parse(stdout);
+
+    expect(result.error).toBeUndefined();
+    expect(result.pages).toHaveLength(60);
+    expect(result.raw_text.length).toBeGreaterThan(1000);
+    expect(result.diagnostics.total_pages).toBe(60);
+
+    // Only 5 dict extractions requested, not 60
+    expect(result.diagnostics.dict_pages_requested).toBe(5);
+
+    // Must complete in reasonable time
+    expect(elapsed).toBeLessThan(15000);
+  });
+
+  it("includes phase diagnostics in output JSON", () => {
+    makeSyntheticPdf(SYNTHETIC_PDF, 5);
+
+    const stdout = execFileSync(resolvePython3(), [SCRIPT, SYNTHETIC_PDF], {
+      timeout: 30000,
+      encoding: "utf-8",
+    });
+    const result = JSON.parse(stdout);
+
+    const d = result.diagnostics;
+    expect(d).toBeDefined();
+    expect(typeof d.total_time_s).toBe("number");
+    expect(d.total_time_s).toBeGreaterThan(0);
+    expect(d.phases.import_check).toBeGreaterThan(0);
+    expect(d.phases.open_pdf).toBeGreaterThan(0);
+    expect(d.phases.estimate_body_font_size).toBeGreaterThan(0);
+    expect(d.phases.text_extract).toBeGreaterThan(0);
+    expect(d.phases.serialize_json).toBeGreaterThanOrEqual(0);
+    expect(typeof d.body_font_size).toBe("number");
+  });
+
+  it("font size sampling caps at 50 spans per page", () => {
+    makeSyntheticPdf(SYNTHETIC_PDF, 10);
+
+    const stdout = execFileSync(resolvePython3(), [SCRIPT, SYNTHETIC_PDF], {
+      timeout: 30000,
+      encoding: "utf-8",
+    });
+    const result = JSON.parse(stdout);
+
+    // Body font size sampled from limited pages
+    expect(result.diagnostics.font_pages_sampled).toBeLessThanOrEqual(3);
+    expect(typeof result.diagnostics.body_font_size).toBe("number");
+
+    // Dict extraction limited to DICT_SAMPLE_PAGES (5)
+    expect(result.diagnostics.dict_pages_requested).toBeLessThanOrEqual(5);
+  });
+
+  it("--no-tables skips table extraction and sets diagnostics", () => {
+    makeSyntheticPdf(SYNTHETIC_PDF, 5);
+
+    const stdout = execFileSync(resolvePython3(), [SCRIPT, SYNTHETIC_PDF, "--no-tables"], {
+      timeout: 30000,
+      encoding: "utf-8",
+    });
+    const result = JSON.parse(stdout);
+
+    expect(result.tables).toHaveLength(0);
+    expect(result.diagnostics.table_fallback).toContain("--no-tables");
+  });
+
+  it("table extraction is limited to first 10 pages", () => {
+    makeSyntheticPdf(SYNTHETIC_PDF, 25);
+
+    const stdout = execFileSync(resolvePython3(), [SCRIPT, SYNTHETIC_PDF], {
+      timeout: 60000,
+      encoding: "utf-8",
+    });
+    const result = JSON.parse(stdout);
+
+    expect(result.diagnostics).toBeDefined();
+    // Tables extracted indicator is present
+    expect(typeof result.diagnostics.tables_extracted).toBe("number");
+  });
+
+  it("output JSON is valid even without pdfplumber installed", () => {
+    const onePage = path.resolve("/tmp/pymupdf-smoke-no-table.pdf");
+    try {
+      makeSyntheticPdf(onePage, 1);
+
+      // Use --no-tables to simulate missing pdfplumber
+      const stdout = execFileSync(resolvePython3(), [SCRIPT, onePage, "--no-tables"], {
+        timeout: 30000,
+        encoding: "utf-8",
+      });
+      const result = JSON.parse(stdout);
+
+      expect(result.error).toBeUndefined();
+      expect(result.engine).toBe("pymupdf");
+      expect(result.tables).toHaveLength(0);
+      expect(result.raw_text).toBeTruthy();
+    } finally {
+      try { rmSync(onePage); } catch { /* ok */ }
+    }
+  });
+});


### PR DESCRIPTION
## WHAT

Post-merge fixes for Phase 0C parser bakeoff (PR #798).

### Fixes

1. **pymupdf-parse.py performance** — body font size cached once, dict extraction limited to 5 pages, sampling caps at 50 spans/page. 63-page VERRA report completes in 7.6s instead of timing out.

2. **Phase diagnostics** — `diagnostics.phases` in output JSON tracks: `import_check`, `open_pdf`, `estimate_body_font_size`, `text_extract`, `table_extract`, `serialize_json`.

3. **Table extraction** — limited to first 10 pages (`TABLE_EXTRACT_PAGES=10`), `--no-tables` flag to skip entirely.

4. **Env variable restoration** — `QUICK_CHECK_PARSER` properly saved/restored (not set to undefined).

5. **CLI flags** — `collectPdfPaths` extracted and exported, supports `--pdfdir`, `--pdf` (repeatable, deduped), `--manifest`, `--json`.

6. **Helper runner wiring** — `runPymupdfHelperSync` respects `PYTHON3` env var, `runParserBakeoff` wires the real pymupdf helper runner.

7. **Table count** — pymupdf adapter now correctly counts tables (9 tables on VERRA report vs 0 for current-extractor).

### Tests

- 7 synthetic PDF smoke tests (1-page, 60-page, diagnostics, `--no-tables`, table page limit)
- 7 CLI argument tests (default, `--pdfdir`, `--pdf`, dedup, combine, missing dir)
- 3 env restoration tests (unset→unset, set→same, survives per-PDF)

## ACCEPTANCE

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm test` — 1592 pass (73 relevant tests all green)
- [x] `npm run quickcheck:eval:corpus -- --strict` — all thresholds
- [x] VERRA 63-page report: 7.6s, 9 tables detected, no ETIMEDOUT

Signed-off-by: Fred Egbuedike <fredilly@article6.org>