### PR TITLE
feat: add Phase 0C parser bakeoff scorecard evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ next-env.d.ts
 .venv
 .venv_old/
 *.whl
+real-messy-pdfs/

--- a/docs/quickcheck/parser-bakeoff-corpus.md
+++ b/docs/quickcheck/parser-bakeoff-corpus.md
@@ -1,0 +1,32 @@
+# Parser Bakeoff Corpus — Phase 0C
+
+Real messy carbon PDFs used for the Parser Bakeoff Scorecard.
+
+## Corpus
+
+| # | File | Size | Source | Pages | Tables (pymupdf) |
+|---|------|------|--------|-------|-------------------|
+| 1 | `verra-generation-forest-verification.pdf` | 1.6 MB | Desktop local copy, Verra VCU verification report | 63 | 9 |
+| 2 | `vcs-madre-de-dios-verification-report.pdf` | 628 KB | Downloaded from CeroCO2 (Peru REDD) | 80 | 8 |
+
+All files verified as real PDFs (`%PDF-` header). The two Generation Forest PDFs in the original download list were identical byte-for-byte duplicates; only one is retained.
+
+## Downloads
+
+- `verra-generation-forest-verification.pdf`: local copy from desktop (Verra verification report 2016–2021)
+- `vcs-madre-de-dios-verification-report.pdf`: https://www.ceroco2.org/images/stories/documentos_proyectos/Peru/CCB_VERIF_REP_ENG_844_01JAN2014_31DEC2018.pdf
+
+CDM URLs (cdm.unfccc.int) returned SSL errors and were excluded.
+Gold Standard / JCM URLs were unreachable; may be added in future runs.
+
+## Scorecard Output
+
+- `docs/quickcheck/parser-bakeoff-scorecard.json` — machine-readable JSON
+- `docs/quickcheck/parser-bakeoff-scorecard.md` — human-readable markdown
+
+## Notes
+
+- PDF files are NOT committed (listed in `.gitignore`).
+- The bakeoff compares `current-extractor`, `pymupdf`, and `docling` (if available).
+- `current-extractor` uses PyMuPDF-extracted raw text for page matching; `pymupdf` uses native PDF parsing.
+- Docling remained unavailable on this system.

--- a/docs/quickcheck/parser-bakeoff-scorecard.json
+++ b/docs/quickcheck/parser-bakeoff-scorecard.json
@@ -1,0 +1,1916 @@
+{
+  "bakeoffTimestamp": "2026-06-22T03:39:37.284Z",
+  "parsers": [
+    {
+      "parserId": "current-extractor",
+      "available": true
+    },
+    {
+      "parserId": "pymupdf",
+      "available": true
+    },
+    {
+      "parserId": "docling",
+      "available": false,
+      "unavailableReason": "python3 available but docling not installed"
+    }
+  ],
+  "pdfFixtures": [
+    "/Users/stphen/app.article6/real-messy-pdfs/vcs-madre-de-dios-verification-report.pdf",
+    "/Users/stphen/app.article6/real-messy-pdfs/verra-generation-forest-verification.pdf"
+  ],
+  "perPdfResults": [
+    {
+      "pdfPath": "/Users/stphen/app.article6/real-messy-pdfs/vcs-madre-de-dios-verification-report.pdf",
+      "parserId": "current-extractor",
+      "available": true,
+      "metrics": {
+        "pageCount": 80,
+        "rawTextLength": 245595,
+        "headingCount": 8,
+        "tableCount": 0,
+        "elementCount": 123,
+        "pageProvenanceElementCount": 123,
+        "hasPageBoundaries": true,
+        "hasBoundingBoxes": false,
+        "hasTables": false,
+        "hasStructuredHeadings": true,
+        "medianTextPerPage": 3105,
+        "avgConfidence": 0.85170731707317
+      }
+    },
+    {
+      "pdfPath": "/Users/stphen/app.article6/real-messy-pdfs/vcs-madre-de-dios-verification-report.pdf",
+      "parserId": "pymupdf",
+      "available": true,
+      "metrics": {
+        "pageCount": 80,
+        "rawTextLength": 245595,
+        "headingCount": 6,
+        "tableCount": 8,
+        "elementCount": 86,
+        "pageProvenanceElementCount": 86,
+        "hasPageBoundaries": true,
+        "hasBoundingBoxes": true,
+        "hasTables": true,
+        "hasStructuredHeadings": true,
+        "medianTextPerPage": 3105,
+        "avgConfidence": 0.8569767441860465
+      }
+    },
+    {
+      "pdfPath": "/Users/stphen/app.article6/real-messy-pdfs/vcs-madre-de-dios-verification-report.pdf",
+      "parserId": "docling",
+      "available": false,
+      "error": "python3 available but docling not installed"
+    },
+    {
+      "pdfPath": "/Users/stphen/app.article6/real-messy-pdfs/verra-generation-forest-verification.pdf",
+      "parserId": "current-extractor",
+      "available": true,
+      "metrics": {
+        "pageCount": 63,
+        "rawTextLength": 152052,
+        "headingCount": 15,
+        "tableCount": 0,
+        "elementCount": 107,
+        "pageProvenanceElementCount": 107,
+        "hasPageBoundaries": true,
+        "hasBoundingBoxes": false,
+        "hasTables": false,
+        "hasStructuredHeadings": true,
+        "medianTextPerPage": 2403,
+        "avgConfidence": 0.886074766355141
+      }
+    },
+    {
+      "pdfPath": "/Users/stphen/app.article6/real-messy-pdfs/verra-generation-forest-verification.pdf",
+      "parserId": "pymupdf",
+      "available": true,
+      "metrics": {
+        "pageCount": 63,
+        "rawTextLength": 152052,
+        "headingCount": 7,
+        "tableCount": 9,
+        "elementCount": 70,
+        "pageProvenanceElementCount": 70,
+        "hasPageBoundaries": true,
+        "hasBoundingBoxes": true,
+        "hasTables": true,
+        "hasStructuredHeadings": true,
+        "medianTextPerPage": 2403,
+        "avgConfidence": 0.860000000000001
+      }
+    },
+    {
+      "pdfPath": "/Users/stphen/app.article6/real-messy-pdfs/verra-generation-forest-verification.pdf",
+      "parserId": "docling",
+      "available": false,
+      "error": "python3 available but docling not installed"
+    }
+  ],
+  "evalComparison": [
+    {
+      "parserId": "current-extractor",
+      "available": true,
+      "passedCount": 7,
+      "totalCount": 7,
+      "report": {
+        "corpusId": "phase6-foundation",
+        "fixtureCount": 7,
+        "fixtureResults": [
+          {
+            "fixtureId": "real-cdm-nepal",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-envira-amazonia",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "Methodology inferred from a top-of-document code reference because no explicit methodology label was found."
+                ],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-pd-redd-v130",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "Methodology inferred from a top-of-document code reference because no explicit methodology label was found."
+                ],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-gs-luf",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-plum-pdd",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "Methodology inferred from a top-of-document code reference because no explicit methodology label was found."
+                ],
+                "actualEvidenceSpanCount": 3
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-plum-weak-ocr",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "Methodology inferred from a top-of-document code reference because no explicit methodology label was found."
+                ],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-blue-nile-redd",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "Methodology inferred from a top-of-document code reference because no explicit methodology label was found."
+                ],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          }
+        ],
+        "failures": [],
+        "metrics": {
+          "factExtractionAccuracy": {
+            "passed": 77,
+            "total": 77,
+            "rate": 1
+          },
+          "provenanceCorrectness": {
+            "passed": 68,
+            "total": 68,
+            "rate": 1
+          },
+          "sectionRetrievalPrecision": {
+            "passed": 17,
+            "total": 17,
+            "rate": 1
+          },
+          "sectionRetrievalRecall": {
+            "passed": 17,
+            "total": 17,
+            "rate": 1
+          },
+          "unsupportedRejectionRate": {
+            "passed": 7,
+            "total": 7,
+            "rate": 1
+          },
+          "noEvidenceFalseNegativeRate": {
+            "passed": 0,
+            "total": 15,
+            "rate": 0
+          },
+          "hallucinatedAnswerRate": {
+            "passed": 0,
+            "total": 34,
+            "rate": 0
+          },
+          "firstPassSuccessRate": {
+            "passed": 7,
+            "total": 7,
+            "rate": 1
+          },
+          "visibleAnswerGoldMatch": {
+            "passed": 56,
+            "total": 56,
+            "rate": 1
+          },
+          "visibleAnswerAgreementRate": {
+            "passed": 56,
+            "total": 56,
+            "rate": 1
+          },
+          "regressionCount": 0
+        }
+      }
+    },
+    {
+      "parserId": "pymupdf",
+      "available": true,
+      "passedCount": 7,
+      "totalCount": 7,
+      "report": {
+        "corpusId": "phase6-foundation",
+        "fixtureCount": 7,
+        "fixtureResults": [
+          {
+            "fixtureId": "real-cdm-nepal",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-envira-amazonia",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "Methodology inferred from a top-of-document code reference because no explicit methodology label was found."
+                ],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-pd-redd-v130",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "Methodology inferred from a top-of-document code reference because no explicit methodology label was found."
+                ],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-gs-luf",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-plum-pdd",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "Methodology inferred from a top-of-document code reference because no explicit methodology label was found."
+                ],
+                "actualEvidenceSpanCount": 3
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-plum-weak-ocr",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "Methodology inferred from a top-of-document code reference because no explicit methodology label was found."
+                ],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "unclear",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "ambiguous_intent"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          },
+          {
+            "fixtureId": "real-blue-nile-redd",
+            "passed": true,
+            "factFailures": [],
+            "questionResults": [
+              {
+                "questionId": "project_title",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "host_country",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "methodology",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "project_fact_contract",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "Methodology inferred from a top-of-document code reference because no explicit methodology label was found."
+                ],
+                "actualEvidenceSpanCount": 1
+              },
+              {
+                "questionId": "baseline_scenario",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "monitoring",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "leakage",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "no_validated_route"
+                ],
+                "actualEvidenceSpanCount": 0
+              },
+              {
+                "questionId": "additionality",
+                "passed": true,
+                "actualStatus": "answered",
+                "actualRoute": "section_index",
+                "actualVisibleStatus": "likely_yes",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [],
+                "actualEvidenceSpanCount": 2
+              },
+              {
+                "questionId": "marine_biodiversity_offsets",
+                "passed": true,
+                "actualStatus": "no_evidence",
+                "actualRoute": "fallback",
+                "actualVisibleStatus": "unclear",
+                "visibleStatusMatch": true,
+                "visibleAgreementOk": true,
+                "failures": [],
+                "visibleFailures": [],
+                "actualWarnings": [
+                  "unsupported_or_out_of_scope"
+                ],
+                "actualEvidenceSpanCount": 0
+              }
+            ]
+          }
+        ],
+        "failures": [],
+        "metrics": {
+          "factExtractionAccuracy": {
+            "passed": 77,
+            "total": 77,
+            "rate": 1
+          },
+          "provenanceCorrectness": {
+            "passed": 68,
+            "total": 68,
+            "rate": 1
+          },
+          "sectionRetrievalPrecision": {
+            "passed": 17,
+            "total": 17,
+            "rate": 1
+          },
+          "sectionRetrievalRecall": {
+            "passed": 17,
+            "total": 17,
+            "rate": 1
+          },
+          "unsupportedRejectionRate": {
+            "passed": 7,
+            "total": 7,
+            "rate": 1
+          },
+          "noEvidenceFalseNegativeRate": {
+            "passed": 0,
+            "total": 15,
+            "rate": 0
+          },
+          "hallucinatedAnswerRate": {
+            "passed": 0,
+            "total": 34,
+            "rate": 0
+          },
+          "firstPassSuccessRate": {
+            "passed": 7,
+            "total": 7,
+            "rate": 1
+          },
+          "visibleAnswerGoldMatch": {
+            "passed": 56,
+            "total": 56,
+            "rate": 1
+          },
+          "visibleAnswerAgreementRate": {
+            "passed": 56,
+            "total": 56,
+            "rate": 1
+          },
+          "regressionCount": 0
+        }
+      }
+    },
+    {
+      "parserId": "docling",
+      "available": false,
+      "passedCount": 0,
+      "totalCount": 0,
+      "unavailableReason": "python3 available but docling not installed"
+    }
+  ],
+  "defaultParserId": "current-extractor"
+}

--- a/docs/quickcheck/parser-bakeoff-scorecard.md
+++ b/docs/quickcheck/parser-bakeoff-scorecard.md
@@ -1,0 +1,69 @@
+# Parser Bakeoff Scorecard
+Generated: 2026-06-22T03:40:24.738Z
+Default parser: current-extractor
+PDF fixtures: 2
+
+## Parser Availability
+- current-extractor: AVAILABLE
+- pymupdf: AVAILABLE
+- docling: UNAVAILABLE (python3 available but docling not installed)
+
+## Per-PDF Metrics
+
+### vcs-madre-de-dios-verification-report.pdf
+
+- **current-extractor**:
+  - pages: 80  |  rawText: 245595 chars  |  median/page: 3105
+  - headings: 8  |  tables: 0  |  elements: 123
+  - page provenance: 123/123  |  avg confidence: 0.852
+  - hasPageBoundaries: true  |  hasBoundingBoxes: false  |  hasStructuredHeadings: true  |  hasTables: false
+- **pymupdf**:
+  - pages: 80  |  rawText: 245595 chars  |  median/page: 3105
+  - headings: 6  |  tables: 8  |  elements: 86
+  - page provenance: 86/86  |  avg confidence: 0.857
+  - hasPageBoundaries: true  |  hasBoundingBoxes: true  |  hasStructuredHeadings: true  |  hasTables: true
+- **docling**: ERROR — python3 available but docling not installed
+
+  **Comparison:**
+  - heading delta: -2
+  - table delta: 8
+  - element delta: -37
+  - provenance delta: -37
+
+### verra-generation-forest-verification.pdf
+
+- **current-extractor**:
+  - pages: 63  |  rawText: 152052 chars  |  median/page: 2403
+  - headings: 15  |  tables: 0  |  elements: 107
+  - page provenance: 107/107  |  avg confidence: 0.886
+  - hasPageBoundaries: true  |  hasBoundingBoxes: false  |  hasStructuredHeadings: true  |  hasTables: false
+- **pymupdf**:
+  - pages: 63  |  rawText: 152052 chars  |  median/page: 2403
+  - headings: 7  |  tables: 9  |  elements: 70
+  - page provenance: 70/70  |  avg confidence: 0.860
+  - hasPageBoundaries: true  |  hasBoundingBoxes: true  |  hasStructuredHeadings: true  |  hasTables: true
+- **docling**: ERROR — python3 available but docling not installed
+
+  **Comparison:**
+  - heading delta: -8
+  - table delta: 9
+  - element delta: -37
+  - provenance delta: -37
+
+## Downstream Eval Corpus Comparison
+
+- **current-extractor**: 7/7 fixtures passed
+  - first-pass success: 100.0% (7/7)
+  - fact accuracy: 100.0%
+  - provenance correctness: 100.0%
+  - hallucinated answer: 0.0% (0/34)
+  - unsupported rejection: 100.0%
+  - regressions: 0
+- **pymupdf**: 7/7 fixtures passed
+  - first-pass success: 100.0% (7/7)
+  - fact accuracy: 100.0%
+  - provenance correctness: 100.0%
+  - hallucinated answer: 0.0% (0/34)
+  - unsupported rejection: 100.0%
+  - regressions: 0
+- **docling**: UNAVAILABLE — python3 available but docling not installed


### PR DESCRIPTION
## WHAT
Finish Phase 0C by capturing parser bakeoff scorecard evidence against real messy carbon PDFs.
## Key findings
- current-extractor: 0 tables, 15 headings (Generation Forest)
- pymupdf: 9 tables, 7 headings (Generation Forest)
- Both pass strict eval corpus with 0 regressions
- Docling unavailable (expected)
## Files
docs/quickcheck/parser-bakeoff-corpus.md, parser-bakeoff-scorecard.json, parser-bakeoff-scorecard.md
Signed-off-by: Fred Egbuedike <fredilly@article6.org>