### PR TITLE
chore: mark Phase 0B and 0C done, advance to 0D

### DIFF
--- a/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
+++ b/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
@@ -1,7 +1,7 @@
 {
   "roadmap": "quickcheck-parser-replacement",
   "status": "active",
-  "current_phase": "phase-0b-experimental-parser-adapters",
+  "current_phase": "phase-0d-default-parser-switch-decision",
   "phases": [
     {
       "id": "phase-0a-parser-adapter-boundary",
@@ -16,14 +16,15 @@
       "name": "Experimental Parser Adapters",
       "branch": "feat/qc-experimental-parser-adapters",
       "status": "done",
+      "pr": 797,
       "goal": "Add one or more experimental parser adapters behind feature flags while keeping currentExtractor as the default fallback. Primary successful adapter: PyMuPDF (QUICK_CHECK_PARSER=pymupdf). Docling adapter is also registered (QUICK_CHECK_PARSER=docling) but remains optional/unavailable-safe; Docling installation is not required for Phase 0B completion."
     },
     {
       "id": "phase-0c-parser-bakeoff-scorecard",
       "name": "Parser Bakeoff Scorecard",
       "branch": "feat/qc-parser-bakeoff",
-      "status": "in_progress",
-      "pr": 798,
+      "status": "done",
+      "pr": 801,
       "goal": "Compare currentExtractor vs PyMuPDF adapter on frozen carbon PDFs using a JSON scorecard. Include Docling adapter only if available."
     },
     {


### PR DESCRIPTION
Update roadmap after PR #801 merge.
- Phase 0B: done (PR #797)
- Phase 0C: done (PR #801)
- Current phase: 0D (not started)
Signed-off-by: Fred Egbuedike <fredilly@article6.org>