### PR TITLE
Phase 1: Evidence Compiler v2 — noise context detection

### DIFF
--- a/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
+++ b/src/lib/quickCheck/evidence/compileEvidenceDocument.ts
@@ -9,6 +9,7 @@ import type {
   EvidenceTableCellMetadata,
   EvidenceTableMetadata,
 } from "@/lib/quickCheck/evidence/evidenceTypes";
+import { detectNoiseContexts, adjustReliabilityForNoise } from "@/lib/quickCheck/evidence/noiseDetection";
 
 type PageSlice = {
   index: number;
@@ -383,7 +384,12 @@ function buildEvidenceSpan(input: {
   parserAdapterId?: EvidenceDocument["parserAdapterId"];
   documentFamily?: EvidenceDocument["documentFamily"];
   block: CandidateBlock;
+  noiseContexts?: import("@/lib/quickCheck/evidence/evidenceTypes").NoiseContext[];
 }): EvidenceSpan {
+  const noise = input.noiseContexts?.length ? input.noiseContexts : undefined;
+  const reliability = noise?.length
+    ? adjustReliabilityForNoise(input.block.reliability, noise)
+    : input.block.reliability;
   return {
     spanId: buildSpanId({
       docId: input.docId,
@@ -410,8 +416,9 @@ function buildEvidenceSpan(input: {
     documentFamily: input.documentFamily,
     layout: input.block.layout,
     table: input.block.table,
-    reliability: input.block.reliability,
+    reliability,
     confidence: input.block.confidence,
+    noise,
   };
 }
 
@@ -535,6 +542,13 @@ export function compileEvidenceDocumentFromStructure(input: {
   let cursor = 0;
   let hasSeenSectionedHeading = false;
 
+  const pages = splitPages(rawText);
+  const pageEdgeLines = collectRepeatedPageEdgeLines(pages);
+  const sectionHeadings = new Map<string, string>();
+  for (const section of input.documentStructure.sections) {
+    sectionHeadings.set(section.id, section.titleRaw);
+  }
+
   const spans: EvidenceSpan[] = input.documentStructure.blocks.flatMap((block) => {
     const treatAsTitle =
       block.type === "heading"
@@ -579,6 +593,29 @@ export function compileEvidenceDocumentFromStructure(input: {
         || block.type === "list_item",
     });
 
+    // Detect noise contexts
+    const sectionHeading = block.sectionId ? sectionHeadings.get(block.sectionId) : undefined;
+    const isPageEdge = block.type === "header" || block.type === "footer"
+      || pageEdgeLines.headers.has(block.rawText.trim())
+      || pageEdgeLines.footers.has(block.rawText.trim());
+    const noiseContexts = detectNoiseContexts(block.rawText, {
+      blockType: block.type,
+      sectionHeading,
+      isPageEdge,
+      isRepeated:
+        pageEdgeLines.headers.has(block.rawText.trim())
+        || pageEdgeLines.footers.has(block.rawText.trim()),
+      page: block.pageNumber,
+      isFirstPage: block.pageNumber === 1,
+    });
+
+    const layout = {
+      boundingBox: block.boundingBox,
+      repeatedHeaderFooter: block.type === "header" || block.type === "footer",
+      limitedProvenance: block.type === "list_item" || blockType === "table" || !block.boundingBox,
+      noiseContexts: noiseContexts.length > 0 ? noiseContexts : undefined,
+    };
+
     return [buildEvidenceSpan({
       docId: input.docId,
       parserSource: input.documentStructure.source,
@@ -599,12 +636,9 @@ export function compileEvidenceDocumentFromStructure(input: {
         confidence: block.confidence,
         reliability,
         table,
-        layout: {
-          boundingBox: block.boundingBox,
-          repeatedHeaderFooter: block.type === "header" || block.type === "footer",
-          limitedProvenance: block.type === "list_item" || blockType === "table" || !block.boundingBox,
-        },
+        layout,
       },
+      noiseContexts: noiseContexts.length > 0 ? noiseContexts : undefined,
     })];
   });
 

--- a/src/lib/quickCheck/evidence/evidenceTypes.ts
+++ b/src/lib/quickCheck/evidence/evidenceTypes.ts
@@ -18,10 +18,19 @@ export type EvidenceBlockType =
 
 export type EvidenceSpanReliability = "primary" | "limited" | "excluded";
 
+export type NoiseContext =
+  | "header"
+  | "footer"
+  | "toc"
+  | "contact"
+  | "reference"
+  | "source-caption";
+
 export type EvidenceLayoutMetadata = {
   boundingBox?: ParsedBoundingBox;
   repeatedHeaderFooter?: boolean;
   limitedProvenance?: boolean;
+  noiseContexts?: NoiseContext[];
 };
 
 export type EvidenceTableCellMetadata = {
@@ -67,6 +76,7 @@ export type EvidenceSpan = {
   table?: EvidenceTableMetadata;
   reliability: EvidenceSpanReliability;
   confidence: number;
+  noise?: NoiseContext[];
 };
 
 export type EvidenceDocument = {

--- a/src/lib/quickCheck/evidence/noiseDetection.ts
+++ b/src/lib/quickCheck/evidence/noiseDetection.ts
@@ -1,0 +1,114 @@
+import type { NoiseContext } from "@/lib/quickCheck/evidence/evidenceTypes";
+
+const CONTACT_EMAIL_RE = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
+const CONTACT_PHONE_RE = /(?:\+\d{1,3}[-.\s]?)?(?:\(\d{2,4}\)[-.\s]?){2,3}\d{2,6}/;
+const CONTACT_URL_RE = /\b(?:https?:\/\/)?(?:www\.)?[a-z0-9-]+\.(?:com|org|net|io|gov|edu|int)\b/i;
+const CONTACT_TITLE_RE = /\b(?:phone|tel|fax|email|e-mail|website|url|contact|for more information|for further information|coordinator|manager|director)\b/i;
+
+const REFERENCE_RE = /\b(?:(?:[A-Z][a-z]+,\s[A-Z]\.\s*\(?\d{4}\)?)|(?:et al\.?,\s\d{4})|DOI[:\s]|(?:doi\.org\/)|(?:ISBN[:\s])|(?:ISSN[:\s]))/;
+const BIBLIOGRAPHY_SECTION_RE = /\b(?:references?|bibliography|works cited|literature cited|citations?|sources?)\b/i;
+const SOURCE_CAPTION_RE = /\b(?:figure\s+\d+|fig\.?\s*\d+|table\s+\d+|map\s+\d+|source\s*:|adapted from|courtesy of|reproduced from|modified from)\b/i;
+const TOC_EXPLICIT_RE = /^(?:table\s+of\s+contents|contents|list of figures|list of tables|list of abbreviations|acronyms? and abbreviations)$/i;
+const TOC_LEADER_RE = /\.{3,}\s*\d+\s*$/;
+const HEADER_FOOTER_DECLARATION_RE = /^(?:page\s+\d+(?:\s+of\s+\d+)?|\d+\s+of\s+\d+|v\d+(?:\.\d+)+|draft|confidential|for internal use only)\s*$/i;
+
+export function detectNoiseContexts(
+  text: string,
+  options?: {
+    blockType?: string;
+    sectionHeading?: string;
+    isPageEdge?: boolean;
+    isRepeated?: boolean;
+    page?: number | null;
+    isFirstPage?: boolean;
+  },
+): NoiseContext[] {
+  const contexts: NoiseContext[] = [];
+  const trimmed = text.trim();
+  if (!trimmed) return contexts;
+
+  const isShort = trimmed.length < 160;
+  const isStandalone = options?.blockType === "header" || options?.blockType === "footer" || isShort;
+
+  if (options?.isRepeated && options?.isPageEdge) {
+    contexts.push("header");
+  }
+
+  if (options?.blockType === "header" || (isShort && HEADER_FOOTER_DECLARATION_RE.test(trimmed))) {
+    if (!contexts.includes("header")) contexts.push("header");
+  }
+  if (options?.blockType === "footer") {
+    if (!contexts.includes("footer")) contexts.push("footer");
+  }
+
+  if (
+    TOC_EXPLICIT_RE.test(trimmed) ||
+    TOC_LEADER_RE.test(trimmed) ||
+    options?.blockType === "toc"
+  ) {
+    contexts.push("toc");
+  }
+
+  if (
+    CONTACT_EMAIL_RE.test(trimmed) ||
+    CONTACT_PHONE_RE.test(trimmed) ||
+    CONTACT_URL_RE.test(trimmed)
+  ) {
+    contexts.push("contact");
+  }
+
+  if (options?.sectionHeading && BIBLIOGRAPHY_SECTION_RE.test(options.sectionHeading)) {
+    contexts.push("reference");
+  }
+  if (isStandalone && REFERENCE_RE.test(trimmed) && trimmed.length < 300) {
+    contexts.push("reference");
+  }
+
+  if (
+    isStandalone && (
+    SOURCE_CAPTION_RE.test(trimmed) ||
+    (isShort && /^(?:source|figure|map|table|chart)\b/i.test(trimmed)))
+  ) {
+    contexts.push("source-caption");
+  }
+
+  if (
+    !contexts.includes("contact") &&
+    (options?.sectionHeading &&
+     CONTACT_TITLE_RE.test(options.sectionHeading))
+  ) {
+    contexts.push("contact");
+  }
+
+  if (
+    options?.sectionHeading &&
+    BIBLIOGRAPHY_SECTION_RE.test(options.sectionHeading) &&
+    !contexts.includes("reference")
+  ) {
+    contexts.push("reference");
+  }
+
+  return contexts;
+}
+
+export function adjustReliabilityForNoise(
+  reliability: import("@/lib/quickCheck/evidence/evidenceTypes").EvidenceSpanReliability,
+  noise: NoiseContext[],
+): import("@/lib/quickCheck/evidence/evidenceTypes").EvidenceSpanReliability {
+  if (noise.includes("header") || noise.includes("footer")) {
+    return "excluded";
+  }
+  if (noise.includes("toc")) {
+    return "excluded";
+  }
+  if (noise.includes("source-caption")) {
+    return "excluded";
+  }
+  if (noise.includes("contact")) {
+    return "limited";
+  }
+  if (noise.includes("reference")) {
+    return "limited";
+  }
+  return reliability;
+}

--- a/src/lib/quickCheck/evidence/noiseDetection.ts
+++ b/src/lib/quickCheck/evidence/noiseDetection.ts
@@ -7,7 +7,8 @@ const CONTACT_TITLE_RE = /\b(?:phone|tel|fax|email|e-mail|website|url|contact|fo
 
 const REFERENCE_RE = /\b(?:(?:[A-Z][a-z]+,\s[A-Z]\.\s*\(?\d{4}\)?)|(?:et al\.?,\s\d{4})|DOI[:\s]|(?:doi\.org\/)|(?:ISBN[:\s])|(?:ISSN[:\s]))/;
 const BIBLIOGRAPHY_SECTION_RE = /\b(?:references?|bibliography|works cited|literature cited|citations?|sources?)\b/i;
-const SOURCE_CAPTION_RE = /\b(?:figure\s+\d+|fig\.?\s*\d+|table\s+\d+|map\s+\d+|source\s*:|adapted from|courtesy of|reproduced from|modified from)\b/i;
+const CAPTION_PREFIX_RE = /^(?:figure\s+\d+|fig\.?\s*\d+|table\s+\d+|map\s+\d+|chart\s+\d+|source\s*:|adapted\s+from|modified\s+from|reproduced\s+from|courtesy\s+of)\b/i;
+const SOURCE_ATTRIBUTION_RE = /\b(?:source\s*:|adapted\s+from|modified\s+from|reproduced\s+from|courtesy\s+of)\b/i;
 const TOC_EXPLICIT_RE = /^(?:table\s+of\s+contents|contents|list of figures|list of tables|list of abbreviations|acronyms? and abbreviations)$/i;
 const TOC_LEADER_RE = /\.{3,}\s*\d+\s*$/;
 const HEADER_FOOTER_DECLARATION_RE = /^(?:page\s+\d+(?:\s+of\s+\d+)?|\d+\s+of\s+\d+|v\d+(?:\.\d+)+|draft|confidential|for internal use only)\s*$/i;
@@ -64,11 +65,9 @@ export function detectNoiseContexts(
     contexts.push("reference");
   }
 
-  if (
-    isStandalone && (
-    SOURCE_CAPTION_RE.test(trimmed) ||
-    (isShort && /^(?:source|figure|map|table|chart)\b/i.test(trimmed)))
-  ) {
+  if (isStandalone && CAPTION_PREFIX_RE.test(trimmed)) {
+    contexts.push("source-caption");
+  } else if (isStandalone && SOURCE_ATTRIBUTION_RE.test(trimmed)) {
     contexts.push("source-caption");
   }
 

--- a/tests/lib/quickCheck/evidenceCompilerV2.test.ts
+++ b/tests/lib/quickCheck/evidenceCompilerV2.test.ts
@@ -624,6 +624,27 @@ describe("Noise context detection in Evidence Compiler v2", () => {
     }
   });
 
+  test("does not flag body text that mentions a figure as source-caption", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1 Project Location",
+        "The project area is shown in Figure 1 below.",
+      ].join("\n"),
+    });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "body-figure-doc",
+      documentStructure,
+    });
+
+    const bodyTextSpan = compiled.spans.find((span) =>
+      span.text.includes("shown in Figure 1")
+    );
+    expect(bodyTextSpan).toBeDefined();
+    // Body text mentioning a figure should not be excluded
+    expect(bodyTextSpan?.reliability).not.toBe("excluded");
+  });
+
   test("every compiled span has stable provenance fields", () => {
     const parsedDocument = parseDocumentText({
       rawText: [

--- a/tests/lib/quickCheck/evidenceCompilerV2.test.ts
+++ b/tests/lib/quickCheck/evidenceCompilerV2.test.ts
@@ -513,3 +513,144 @@ describe("Evidence Compiler v2", () => {
     expect(missing).toEqual(expect.objectContaining({ valid: false, matchType: "missing", confidence: "low" }));
   });
 });
+
+describe("Noise context detection in Evidence Compiler v2", () => {
+  test("labels TOC lines as toc noise with excluded reliability", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "Table of Contents",
+        "1 Project Details ......... 3",
+        "1.1 Location .............. 5",
+        "2 Baseline Scenario ....... 8",
+        "",
+        "1 Project Details",
+        "The project is located in Indonesia.",
+      ].join("\n"),
+    });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "toc-doc",
+      documentStructure,
+    });
+
+    const tocSpans = compiled.spans.filter((span) => span.noise?.includes("toc"));
+    expect(tocSpans.length).toBeGreaterThan(0);
+    for (const span of tocSpans) {
+      expect(span.reliability).toBe("excluded");
+    }
+
+    const primarySpans = compiled.spans.filter((span) => span.reliability === "primary");
+    expect(primarySpans.length).toBeGreaterThan(0);
+  });
+
+  test("labels contact details as contact noise with limited reliability", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "Contact Information",
+        "For further information contact: coordinator@example.com",
+        "Tel: +62 21 555 1234",
+        "Website: www.example.org",
+        "",
+        "1 Project Details",
+        "Host country: Indonesia",
+      ].join("\n"),
+    });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "contact-doc",
+      documentStructure,
+    });
+
+    const contactSpans = compiled.spans.filter((span) => span.noise?.includes("contact"));
+    expect(contactSpans.length).toBeGreaterThan(0);
+    for (const span of contactSpans) {
+      expect(span.reliability).not.toBe("primary");
+    }
+  });
+
+  test("labels source-caption lines as source-caption noise with excluded reliability", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1 Project Location",
+        "The project area is shown in Figure 1 below.",
+        "Figure 1: Map of project area. Source: Adapted from regional land use plan.",
+        "",
+        "2 Baseline Scenario",
+        "The baseline scenario represents the most likely land use.",
+      ].join("\n"),
+    });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "source-caption-doc",
+      documentStructure,
+    });
+
+    const captionSpans = compiled.spans.filter((span) => span.noise?.includes("source-caption"));
+    expect(captionSpans.length).toBeGreaterThan(0);
+    for (const span of captionSpans) {
+      expect(span.reliability).toBe("excluded");
+    }
+  });
+
+  test("treats headers/footers as excluded noise", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "Project Description Document",
+        "",
+        "1 Project Details",
+        "Host country: Indonesia",
+        "\f",
+        "Project Description Document",
+        "",
+        "2 Baseline Scenario",
+        "Baseline scenario: forest conversion.",
+        "\f",
+        "Project Description Document",
+        "",
+        "3 Monitoring Plan",
+        "The monitoring plan describes annual monitoring.",
+      ].join("\n"),
+    });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "header-doc",
+      documentStructure,
+    });
+
+    const headerSpans = compiled.spans.filter((span) => span.noise?.includes("header"));
+    expect(headerSpans.length).toBeGreaterThan(0);
+    for (const span of headerSpans) {
+      expect(span.reliability).toBe("excluded");
+    }
+  });
+
+  test("every compiled span has stable provenance fields", () => {
+    const parsedDocument = parseDocumentText({
+      rawText: [
+        "1 Project Details",
+        "Host country: Indonesia",
+        "Project location: Central Kalimantan",
+        "",
+        "2 Baseline Scenario",
+        "Baseline scenario: forest conversion without the project.",
+      ].join("\n"),
+    });
+    const documentStructure = buildDocumentStructure({ parsedDocument });
+    const compiled = compileEvidenceDocumentFromStructure({
+      docId: "provenance-doc",
+      documentStructure,
+    });
+
+    for (const span of compiled.spans) {
+      expect(typeof span.spanId).toBe("string");
+      expect(span.spanId.length).toBeGreaterThan(0);
+      expect(span.text).toBeTruthy();
+      expect(span.normalizedText).toBeTruthy();
+      expect(span.reliability).toBeDefined();
+      expect(span.confidence).toBeGreaterThan(0);
+      expect(Array.isArray(span.headingPath)).toBe(true);
+      expect(Array.isArray(span.sectionPath)).toBe(true);
+      expect(["header", "title", "section_heading", "paragraph", "table", "field", "formula", "annex", "toc", "footer"]).toContain(span.blockType);
+    }
+  });
+});


### PR DESCRIPTION
## What

Upgrades the evidence compiler so `DocumentStructure` becomes a stronger canonical `EvidenceDocument`.

Every `EvidenceSpan` now carries:
- stable spanId, normalized text, original text, page number
- sectionId, heading, headingPath, sectionPath
- blockType, parserSource, parserAdapterId
- documentFamily signal where available
- table metadata (tableId, row/cell provenance) where available
- layout metadata (boundingBox, repeatedHeaderFooter)
- confidence, charStart/charEnd
- **new:** `noise` — array of noise context labels
- **new:** `noiseContexts` in layout metadata

## Noise contexts

The compiler now distinguishes evidence-like text from noise-like text via regex-based detection:

| Context | Reliability | Examples |
|---------|-------------|----------|
| header, footer | excluded | Repeated page-edge lines, version strings |
| toc | excluded | Table of contents, leader dots |
| source-caption | excluded | "Figure N", "Table N", "Source:" |
| contact | limited | Email, phone, URL patterns |
| reference | limited | DOI, ISBN, author-year citations |

Context-aware: source-caption and reference detection only applies to short standalone lines; long body paragraphs are not mislabeled.

## Tests added

- TOC lines → excluded noise
- Contact details (email/phone/URL) → limited noise
- Source-caption lines → excluded noise
- Repeated headers/footers → excluded noise
- Every span has stable provenance fields

## Validation

```
tsc --noEmit        ✓
npm run lint        ✓
npm test            ✓  (159 suites, 1606 tests)
npm run quickcheck:eval:corpus -- --strict           ✓  (7/7 PASS)
QUICK_CHECK_PARSER=pymupdf npm run quickcheck:eval:corpus -- --strict  ✓  (7/7 PASS)
```

## No regression

- All existing evidence checks pass
- All eval corpus fixtures pass (0% hallucinations, 100% fact accuracy, 0 regressions)
- Quote validation works (exact + normalized)
- No UI changes
- No LLM calls