### PR TITLE
fix: auto-refresh stale app after deployment

### DIFF
--- a/docs/roadmaps/quickcheck-parser-replacement/PLAN.md
+++ b/docs/roadmaps/quickcheck-parser-replacement/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Replace Quick Check's fragile raw-text / regex-based PDF extraction with a higher-fidelity parser, starting with Docling, while keeping Article6 evidence judgment intact.
+Replace Quick Check's fragile raw-text / regex-based PDF extraction with a higher-fidelity parser while keeping Article6 evidence judgment intact.
 
 The parser should improve document structure, reading order, headings, sections, tables, and page provenance.
 
@@ -14,7 +14,7 @@ Parsing is plumbing.
 
 Evidence judgment is the product.
 
-Docling or any future parser may produce better structured document input, but Article6 still owns:
+Docling, PyMuPDF, or any future parser may produce better structured document input, but Article6 still owns:
 
 - EvidenceDocument
 - EvidenceSpanIndex
@@ -29,154 +29,69 @@ Docling or any future parser may produce better structured document input, but A
 
 ### Phase 0A: Parser Adapter Boundary
 
-Status:
-
-`done`
-
-PR:
-
-`#794`
-
-Outcome:
+Status: `done` — PR [#794](https://github.com/Fredilly/app.article6/pull/794)
 
 - `ParserAdapter` boundary exists.
 - Current raw-text extractor is wrapped as an adapter.
-- `ParsedDocument` shape exists.
-- `ParsedDocument` normalizes into the existing evidence path.
-- Existing Quick Check behavior remains unchanged.
-- No external parser dependency was added.
-- Router remains final authority.
-- UI was not changed.
-- Eval thresholds were not weakened.
+- `ParsedDocument` shape exists and normalizes into the existing evidence path.
+- Existing Quick Check behavior unchanged.
+- No external parser dependency added.
 
-## Current phase
+### Phase 0B: Experimental Parser Adapters
 
-### Phase 0B: Docling Experimental Adapter
+Status: `done` — PR [#797](https://github.com/Fredilly/app.article6/pull/797)
 
-Branch:
-
-`feat/qc-docling-adapter`
-
-Goal:
-
-Add Docling as an experimental parser adapter behind a feature flag.
-
-Expected outcome:
-
-- Docling adapter exists.
-- Current raw-text adapter remains default.
-- Docling can parse a PDF into `ParsedDocument`.
-- Docling output normalizes into the existing `DocumentStructure` / `EvidenceDocument` path.
-- No router behavior change.
-- No UI change.
-- No default parser switch yet.
-
-Success criteria:
-
-- Existing tests still pass.
-- Existing strict eval corpus still passes.
-- Docling adapter can be tested locally or in controlled mode.
-- No answer status is decided by Docling.
-- No evidence judgment is bypassed.
-
-## Next phases
+- **PyMuPDF adapter** (`QUICK_CHECK_PARSER=pymupdf`): primary successful Phase 0B adapter.
+- **Docling adapter** (`QUICK_CHECK_PARSER=docling`): optional/unavailable-safe.
+- `current-extractor` remains the default.
+- Both adapters fall back to `current-extractor` on failure.
+- 55+ tests covering both adapters, fallback paths, runtime init.
 
 ### Phase 0C: Parser Bakeoff Scorecard
 
-Branch:
+Status: `done` — PR [#801](https://github.com/Fredilly/app.article6/pull/801)
 
-`feat/qc-parser-bakeoff`
-
-Goal:
-
-Compare current raw-text adapter vs Docling on frozen carbon PDFs.
-
-Score:
-
-- project title extraction
-- host country extraction
-- methodology extraction
-- document family signals
-- heading preservation
-- section hierarchy
-- additionality section retrieval
-- baseline section retrieval
-- monitoring section retrieval
-- leakage section retrieval
-- table extraction
-- page provenance
-- quote validation compatibility
-- latency
-- failure rate
-
-Expected outcome:
-
-- JSON scorecard generated.
-- No default parser switch yet.
-- No eval threshold weakening.
+- Compared `current-extractor` vs PyMuPDF on real messy carbon PDFs.
+- PyMuPDF: 9 tables, 7 headings (vs current-extractor: 0 tables, 15 headings).
+- Docling unavailable (expected).
+- Both parsers pass strict eval corpus with 0 regressions.
+- Bakeoff evidence captured in `docs/quickcheck/parser-bakeoff-scorecard.json`.
 
 ### Phase 0D: Default Parser Switch Decision
 
-Branch:
+Status: `done`
 
-`feat/qc-parser-default-decision`
+- Default parser remains `current-extractor` (PyMuPDF available as opt-in).
+- PyMuPDF adapter is available but not promoted to default — decision can be revisited.
 
-Goal:
+### Phase 1: Evidence Compiler v2 — Noise Context Detection
 
-Switch default parser only if Docling beats the current adapter on frozen PDFs and does not weaken Quick Check reliability.
+Status: `done` — PR [#804](https://github.com/Fredilly/app.article6/pull/804)
 
-Expected outcome:
+- `EvidenceSpan` now carries: stable spanId, normalized/ original text, page number, sectionId, heading, headingPath, sectionPath, blockType, parserSource, parserAdapterId, documentFamily signal, table metadata, layout metadata, confidence, charStart/charEnd.
+- **Noise contexts**: header, footer, toc, source-caption (excluded); contact, reference (limited).
+- Context-aware detection only flags short standalone lines; body paragraphs are not mislabeled.
+- Eval corpus: 100% first-pass with both default and PyMuPDF parsers.
 
-- Docling becomes default only if bakeoff evidence supports it.
-- Raw-text adapter remains available as fallback.
-- Rollback path exists.
-- Strict eval corpus passes.
+### Phase 2: Family-Aware ProjectFactContract v2 — Host-Country Hardening
 
-### Phase 1: Evidence Compiler v2
+Status: `done` — PR [#805](https://github.com/Fredilly/app.article6/pull/805)
 
-Branch:
+- Forbidden section contexts: methodology, baseline, monitoring, leakage, additionality, stakeholder, appendix, annex, references, citations.
+- Forbidden noise contexts: header, footer, toc, source-caption, reference.
+- Preferred sections: project overview, title, location.
+- Methodology-code/version-string preamble rejection.
+- 11 regression tests for weak/ambiguous country match rejection.
+- Exemption: preamble check allows valid country names starting with articles (e.g. "The Gambia").
+- Geo-reference heading no longer banned (preferred host-country context).
 
-`feat/qc-evidence-compiler-v2`
-
-Goal:
-
-Use better parser structure to improve canonical evidence spans.
-
-Expected outcome:
-
-- better page provenance
-- better section provenance
-- better heading hierarchy
-- better span typing
-- better table/cell provenance where available
-- router behavior remains controlled
-
-### Phase 2: Family-Aware ProjectFactContract v2
-
-Branch:
-
-`feat/qc-project-fact-contract-v2`
-
-Goal:
-
-Improve project title, host country, and methodology extraction using document-family-aware rules.
-
-Expected outcome:
-
-- CDM PDD extraction improves
-- VCS/Verra PD extraction improves
-- Gold Standard extraction improves
-- confidence/provenance remains required
+## Current phase
 
 ### Phase 3: Hierarchical Section + Table Index
 
-Branch:
+Branch: `feat/qc-section-table-index-v2`
 
-`feat/qc-section-table-index-v2`
-
-Goal:
-
-Use parser-preserved hierarchy and table structure to improve section/table retrieval.
+Goal: Use parser-preserved hierarchy and table structure to improve section/table retrieval.
 
 Expected outcome:
 
@@ -187,15 +102,13 @@ Expected outcome:
 - better table-backed evidence retrieval
 - router still validates final evidence
 
+## Next phases
+
 ### Phase 4: Evidence Sufficiency Validators
 
-Branch:
+Branch: `feat/qc-evidence-sufficiency-validators`
 
-`feat/qc-evidence-sufficiency-validators`
-
-Goal:
-
-Improve Article6 judgment by requiring check-specific evidence sufficiency before returning `answered`.
+Goal: Improve Article6 judgment by requiring check-specific evidence sufficiency before returning `answered`.
 
 Expected outcome:
 
@@ -208,13 +121,9 @@ Expected outcome:
 
 ### Phase 5: Eval Corpus + CI Gate
 
-Branch:
+Branch: `feat/qc-parser-evidence-ci-gate`
 
-`feat/qc-parser-evidence-ci-gate`
-
-Goal:
-
-Lock parser and evidence improvements into CI.
+Goal: Lock parser and evidence improvements into CI.
 
 Expected outcome:
 

--- a/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
+++ b/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
@@ -1,7 +1,7 @@
 {
   "roadmap": "quickcheck-parser-replacement",
   "status": "active",
-  "current_phase": "phase-1-evidence-compiler-v2",
+  "current_phase": "phase-3-hierarchical-section-table-index",
   "phases": [
     {
       "id": "phase-0a-parser-adapter-boundary",
@@ -38,14 +38,16 @@
       "id": "phase-1-evidence-compiler-v2",
       "name": "Evidence Compiler v2",
       "branch": "feat/qc-evidence-compiler-v2",
-      "status": "not_started",
+      "status": "done",
+      "pr": 804,
       "goal": "Use better parser structure to improve canonical EvidenceDocument spans."
     },
     {
       "id": "phase-2-family-aware-projectfactcontract-v2",
       "name": "Family-Aware ProjectFactContract v2",
       "branch": "feat/qc-project-fact-contract-v2",
-      "status": "not_started",
+      "status": "done",
+      "pr": 805,
       "goal": "Improve project title, host country, and methodology extraction using document-family-aware rules."
     },
     {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,13 @@
 import type { NextConfig } from "next";
 
 const gitSha = process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GIT_SHA ?? "";
+const pkgVersion = "0.1.0";
+const appVersion = gitSha ? `${pkgVersion}+${gitSha.slice(0, 7)}` : pkgVersion;
 
 const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_GIT_SHA: gitSha,
+    NEXT_PUBLIC_APP_VERSION: appVersion,
   },
   serverExternalPackages: ["pdf-parse", "pdfjs-dist", "@napi-rs/canvas"],
   outputFileTracingIncludes: {

--- a/src/app/api/quick-check/pdf-extract/route.ts
+++ b/src/app/api/quick-check/pdf-extract/route.ts
@@ -14,7 +14,7 @@ import { resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing"
 import { checkPymupdfAvailability } from "@/lib/documentParsing/adapters/pymupdfHelper";
 
 function qcJson(body: unknown, init?: ResponseInit): NextResponse {
-  return qcJson(body, {
+  return NextResponse.json(body, {
     ...init,
     headers: {
       "Cache-Control": "no-store, no-cache, must-revalidate",

--- a/src/app/api/quick-check/pdf-extract/route.ts
+++ b/src/app/api/quick-check/pdf-extract/route.ts
@@ -13,6 +13,17 @@ import { withMetrics } from "@/lib/metrics";
 import { resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing";
 import { checkPymupdfAvailability } from "@/lib/documentParsing/adapters/pymupdfHelper";
 
+function qcJson(body: unknown, init?: ResponseInit): NextResponse {
+  return qcJson(body, {
+    ...init,
+    headers: {
+      "Cache-Control": "no-store, no-cache, must-revalidate",
+      "Pragma": "no-cache",
+      ...init?.headers,
+    },
+  });
+}
+
 function saveTempPdf(bytes: ArrayBuffer): string {
   const dir = path.join(os.tmpdir(), "quick-check-pdfs");
   if (!existsSync(dir)) {
@@ -137,21 +148,21 @@ async function handlePost(request: Request) {
   }
 
   if (!bytes || bytes.byteLength === 0) {
-    return NextResponse.json({ error: "Missing PDF bytes.", code: "missing-file" }, { status: 400 });
+    return qcJson({ error: "Missing PDF bytes.", code: "missing-file" }, { status: 400 });
   }
 
   // Content-type validation: only enforce on raw path or when clearly wrong.
   // For multipart uploads (the normal browser path) we rely primarily on magic bytes.
   const isRawPath = !contentType.includes("multipart");
   if (isRawPath && !/application\/pdf|octet-stream/i.test(contentType)) {
-    return NextResponse.json(
+    return qcJson(
       { error: `Uploaded file "${declaredFilename}" must be a PDF.`, code: "invalid-file" },
       { status: 415 },
     );
   }
 
   if (bytes.byteLength > MAX_QUICK_CHECK_PDF_BYTES) {
-    return NextResponse.json(
+    return qcJson(
       {
         error: `PDF "${declaredFilename}" exceeds the Quick Check upload limit of ${formatQuickCheckPdfLimitLabel()}.`,
         code: "file-too-large",
@@ -160,7 +171,7 @@ async function handlePost(request: Request) {
     );
   }
   if (!isLikelyPdfBytes(bytes)) {
-    return NextResponse.json(
+    return qcJson(
       { error: `Uploaded file "${declaredFilename}" is not a valid PDF.`, code: "invalid-file" },
       { status: 400 },
     );
@@ -179,7 +190,7 @@ async function handlePost(request: Request) {
     // Fall through to heuristic extractor which has custom ASCII85 + FlateDecode.
     if (extraction.text.trim().length > 0) {
       const parserDebug = buildParserDebug();
-      return NextResponse.json({
+      return qcJson({
         text: extraction.text,
         engine: extraction.engine,
         metadata: extraction.metadata,
@@ -197,7 +208,7 @@ async function handlePost(request: Request) {
 
   const fallbackText = extractPdfText(bytes);
   const parserDebug = buildParserDebug();
-  return NextResponse.json({
+  return qcJson({
     text: fallbackText,
     engine: "heuristic",
     pdfRef,
@@ -221,7 +232,7 @@ async function handlePost(request: Request) {
 }
 
 async function handleGet() {
-  return NextResponse.json({
+  return qcJson({
     ok: true,
     engine: "pdf-parse",
     runtime: "nodejs",

--- a/src/app/api/quick-check/semantic-evidence/route.ts
+++ b/src/app/api/quick-check/semantic-evidence/route.ts
@@ -6,7 +6,7 @@ import { resolvePdfRef } from "@/lib/chat/quickCheckPdfStore";
 import { suggestSemanticEvidence } from "@/lib/quickCheck/semanticEvidence/huggingFace";
 
 function qcJson(body: unknown, init?: ResponseInit): NextResponse {
-  return qcJson(body, {
+  return NextResponse.json(body, {
     ...init,
     headers: {
       "Cache-Control": "no-store, no-cache, must-revalidate",

--- a/src/app/api/quick-check/semantic-evidence/route.ts
+++ b/src/app/api/quick-check/semantic-evidence/route.ts
@@ -5,12 +5,23 @@ import { withMetrics } from "@/lib/metrics";
 import { resolvePdfRef } from "@/lib/chat/quickCheckPdfStore";
 import { suggestSemanticEvidence } from "@/lib/quickCheck/semanticEvidence/huggingFace";
 
+function qcJson(body: unknown, init?: ResponseInit): NextResponse {
+  return qcJson(body, {
+    ...init,
+    headers: {
+      "Cache-Control": "no-store, no-cache, must-revalidate",
+      "Pragma": "no-cache",
+      ...init?.headers,
+    },
+  });
+}
+
 async function handlePost(request: Request) {
   let body: unknown;
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON body.", code: "invalid-json" }, { status: 400 });
+    return qcJson({ error: "Invalid JSON body.", code: "invalid-json" }, { status: 400 });
   }
 
   const claimText = typeof body === "object" && body && "claimText" in body && typeof body.claimText === "string" ? body.claimText : "";
@@ -21,10 +32,10 @@ async function handlePost(request: Request) {
   const methodologyVersion = typeof body === "object" && body && "methodologyVersion" in body && typeof body.methodologyVersion === "string" ? body.methodologyVersion : "";
 
   if (!claimText.trim() || !rawPddText.trim()) {
-    return NextResponse.json({ error: "claimText and rawPddText are required.", code: "missing-input" }, { status: 400 });
+    return qcJson({ error: "claimText and rawPddText are required.", code: "missing-input" }, { status: 400 });
   }
 
-  return NextResponse.json(await suggestSemanticEvidence({
+  return qcJson(await suggestSemanticEvidence({
     claimText,
     rawPddText,
     pdfFilePath,
@@ -34,7 +45,7 @@ async function handlePost(request: Request) {
 }
 
 async function handleGet() {
-  return NextResponse.json({
+  return qcJson({
     ok: true,
     configured: Boolean(process.env.HF_API_KEY),
     model: "openbmb/MiniCPM5-1B",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import DemoNav from "@/components/DemoNav";
 import FooterHealth from "@/components/FooterHealth";
 import HealthBadge from "@/components/HealthBadge";
+import VersionRefreshGate from "@/components/VersionRefreshGate";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -25,6 +26,7 @@ export default function RootLayout({
         <link rel="preload" href="/fonts/GeistMono-latin.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
       </head>
       <body className="bg-[#f9f9f9] antialiased">
+        <VersionRefreshGate>
         <div className="flex min-h-screen flex-col">
           <header className="sticky top-0 z-40 border-b border-slate-200 bg-white/92 backdrop-blur">
             <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-2.5 md:flex-row md:items-center md:justify-between md:px-8">
@@ -45,6 +47,7 @@ export default function RootLayout({
             </div>
           </footer>
         </div>
+        </VersionRefreshGate>
       </body>
     </html>
   );

--- a/src/components/VersionRefreshGate.tsx
+++ b/src/components/VersionRefreshGate.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+import { detectAppVersionChange } from "@/lib/appVersion";
+
+export default function VersionRefreshGate({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    detectAppVersionChange();
+  }, []);
+
+  return <>{children}</>;
+}

--- a/src/lib/appVersion.ts
+++ b/src/lib/appVersion.ts
@@ -1,6 +1,6 @@
 const APP_VERSION_KEY = "a6:app-version";
 const RELOADED_KEY = "a6:app-version:reloaded";
-const QUICK_CHECK_STORAGE_KEY = "a6:quick-check:claim-first:v1";
+export const QUICK_CHECK_STORAGE_KEY = "a6:quick-check:claim-first:v1";
 
 export function getAppVersion(): string {
   if (typeof process !== "undefined" && process.env?.NEXT_PUBLIC_APP_VERSION) {
@@ -9,7 +9,7 @@ export function getAppVersion(): string {
   return "";
 }
 
-function clearQuickCheckState(): void {
+export function clearQuickCheckState(): void {
   try {
     localStorage.removeItem(QUICK_CHECK_STORAGE_KEY);
   } catch {
@@ -17,7 +17,7 @@ function clearQuickCheckState(): void {
   }
 }
 
-function storeVersion(version: string): void {
+export function storeVersion(version: string): void {
   try {
     localStorage.setItem(APP_VERSION_KEY, version);
   } catch {
@@ -25,7 +25,7 @@ function storeVersion(version: string): void {
   }
 }
 
-function getStoredVersion(): string | null {
+export function getStoredVersion(): string | null {
   try {
     return localStorage.getItem(APP_VERSION_KEY);
   } catch {
@@ -33,17 +33,22 @@ function getStoredVersion(): string | null {
   }
 }
 
-function hasReloaded(): boolean {
+/**
+ * Returns `true` when the given version has already triggered a reload
+ * in this browser session.  When a newer version appears later the guard
+ * will clear and a new reload will be allowed.
+ */
+export function hasReloaded(version: string): boolean {
   try {
-    return sessionStorage.getItem(RELOADED_KEY) === "1";
+    return sessionStorage.getItem(RELOADED_KEY) === version;
   } catch {
     return false;
   }
 }
 
-function markReloaded(): void {
+export function markReloaded(version: string): void {
   try {
-    sessionStorage.setItem(RELOADED_KEY, "1");
+    sessionStorage.setItem(RELOADED_KEY, version);
   } catch {
     // sessionStorage may be unavailable
   }
@@ -57,7 +62,8 @@ function markReloaded(): void {
  *  2. The new version is stored.
  *  3. The page reloads once automatically.
  *
- * Uses sessionStorage to prevent infinite reload loops.
+ * Uses a version-scoped sessionStorage guard so that later deployments
+ * in the same long-lived browser session still trigger a refresh.
  *
  * Returns `true` if a reload is imminent (the caller should bail out),
  * `false` if no action is needed.
@@ -65,13 +71,13 @@ function markReloaded(): void {
 export function detectAppVersionChange(): boolean {
   if (typeof window === "undefined") return false;
 
-  if (hasReloaded()) return false;
-
   const currentVersion = getAppVersion();
   if (!currentVersion) {
     storeVersion("");
     return false;
   }
+
+  if (hasReloaded(currentVersion)) return false;
 
   const stored = getStoredVersion();
 
@@ -83,7 +89,7 @@ export function detectAppVersionChange(): boolean {
   if (stored !== currentVersion) {
     clearQuickCheckState();
     storeVersion(currentVersion);
-    markReloaded();
+    markReloaded(currentVersion);
     window.location.reload();
     return true;
   }

--- a/src/lib/appVersion.ts
+++ b/src/lib/appVersion.ts
@@ -1,0 +1,92 @@
+const APP_VERSION_KEY = "a6:app-version";
+const RELOADED_KEY = "a6:app-version:reloaded";
+const QUICK_CHECK_STORAGE_KEY = "a6:quick-check:claim-first:v1";
+
+export function getAppVersion(): string {
+  if (typeof process !== "undefined" && process.env?.NEXT_PUBLIC_APP_VERSION) {
+    return process.env.NEXT_PUBLIC_APP_VERSION;
+  }
+  return "";
+}
+
+function clearQuickCheckState(): void {
+  try {
+    localStorage.removeItem(QUICK_CHECK_STORAGE_KEY);
+  } catch {
+    // localStorage may be unavailable
+  }
+}
+
+function storeVersion(version: string): void {
+  try {
+    localStorage.setItem(APP_VERSION_KEY, version);
+  } catch {
+    // localStorage may be unavailable
+  }
+}
+
+function getStoredVersion(): string | null {
+  try {
+    return localStorage.getItem(APP_VERSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function hasReloaded(): boolean {
+  try {
+    return sessionStorage.getItem(RELOADED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markReloaded(): void {
+  try {
+    sessionStorage.setItem(RELOADED_KEY, "1");
+  } catch {
+    // sessionStorage may be unavailable
+  }
+}
+
+/**
+ * Checks whether the deployed app version has changed since the user last
+ * visited.  When a new deployment is detected:
+ *
+ *  1. Stale Quick Check local state is cleared.
+ *  2. The new version is stored.
+ *  3. The page reloads once automatically.
+ *
+ * Uses sessionStorage to prevent infinite reload loops.
+ *
+ * Returns `true` if a reload is imminent (the caller should bail out),
+ * `false` if no action is needed.
+ */
+export function detectAppVersionChange(): boolean {
+  if (typeof window === "undefined") return false;
+
+  if (hasReloaded()) return false;
+
+  const currentVersion = getAppVersion();
+  if (!currentVersion) {
+    storeVersion("");
+    return false;
+  }
+
+  const stored = getStoredVersion();
+
+  if (stored == null) {
+    storeVersion(currentVersion);
+    return false;
+  }
+
+  if (stored !== currentVersion) {
+    clearQuickCheckState();
+    storeVersion(currentVersion);
+    markReloaded();
+    window.location.reload();
+    return true;
+  }
+
+  return false;
+}

--- a/src/lib/chat/quickCheckPdfClient.ts
+++ b/src/lib/chat/quickCheckPdfClient.ts
@@ -22,6 +22,7 @@ export async function resolveQuickCheckPdfText(input: {
     const response = await fetch("/api/quick-check/pdf-extract", {
       method: "POST",
       body: form,
+      cache: "no-store",
     });
 
     if (!response.ok) {

--- a/tests/lib/appVersion.test.ts
+++ b/tests/lib/appVersion.test.ts
@@ -1,0 +1,170 @@
+/** @jest-environment jsdom */
+
+import {
+  clearQuickCheckState,
+  detectAppVersionChange,
+  getAppVersion,
+  getStoredVersion,
+  hasReloaded,
+  markReloaded,
+  QUICK_CHECK_STORAGE_KEY,
+  storeVersion,
+} from "@/lib/appVersion";
+
+const TEST_VERSION = "0.1.0+abc1234";
+const TEST_VERSION_2 = "0.1.0+def5678";
+
+function setAppVersion(value: string) {
+  (process.env as Record<string, string | undefined>).NEXT_PUBLIC_APP_VERSION = value;
+}
+
+function makeStorage() {
+  const data = new Map<string, string>();
+  return {
+    getItem: jest.fn((key: string) => data.get(key) ?? null),
+    setItem: jest.fn((key: string, value: string) => { data.set(key, value); }),
+    removeItem: jest.fn((key: string) => { data.delete(key); }),
+  };
+}
+
+beforeEach(() => {
+  // @ts-expect-error: jsdom window mocks
+  delete window.location;
+  // @ts-expect-error: jsdom window mocks
+  window.location = { reload: jest.fn() };
+
+  const localStorageMock = makeStorage();
+  Object.defineProperty(window, "localStorage", { value: localStorageMock, writable: true });
+
+  const sessionStorageMock = makeStorage();
+  Object.defineProperty(window, "sessionStorage", { value: sessionStorageMock, writable: true });
+});
+
+describe("getAppVersion", () => {
+  it("returns the NEXT_PUBLIC_APP_VERSION env var", () => {
+    setAppVersion(TEST_VERSION);
+    expect(getAppVersion()).toBe(TEST_VERSION);
+  });
+
+  it("returns empty string when not set", () => {
+    delete (process.env as Record<string, string | undefined>).NEXT_PUBLIC_APP_VERSION;
+    expect(getAppVersion()).toBe("");
+  });
+});
+
+describe("storeVersion / getStoredVersion", () => {
+  it("stores and retrieves a version", () => {
+    storeVersion(TEST_VERSION);
+    expect(getStoredVersion()).toBe(TEST_VERSION);
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(getStoredVersion()).toBeNull();
+  });
+});
+
+describe("hasReloaded / markReloaded", () => {
+  it("returns true only for the exact version that was marked", () => {
+    expect(hasReloaded(TEST_VERSION)).toBe(false);
+
+    markReloaded(TEST_VERSION);
+    expect(hasReloaded(TEST_VERSION)).toBe(true);
+    expect(hasReloaded(TEST_VERSION_2)).toBe(false);
+  });
+});
+
+describe("clearQuickCheckState", () => {
+  it("removes the Quick Check localStorage key", () => {
+    localStorage.setItem(QUICK_CHECK_STORAGE_KEY, "stale-data");
+    clearQuickCheckState();
+    expect(localStorage.getItem(QUICK_CHECK_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("detectAppVersionChange", () => {
+  it("first visit stores current version and does not reload", () => {
+    setAppVersion(TEST_VERSION);
+
+    const result = detectAppVersionChange();
+
+    expect(result).toBe(false);
+    expect(getStoredVersion()).toBe(TEST_VERSION);
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+
+  it("version change clears Quick Check state and reloads once", () => {
+    setAppVersion(TEST_VERSION);
+    storeVersion(TEST_VERSION_2); // simulate prior deploy
+    localStorage.setItem(QUICK_CHECK_STORAGE_KEY, "stale-data");
+
+    const result = detectAppVersionChange();
+
+    expect(result).toBe(true);
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+    expect(getStoredVersion()).toBe(TEST_VERSION);
+    expect(localStorage.getItem(QUICK_CHECK_STORAGE_KEY)).toBeNull();
+  });
+
+  it("same version does not reload repeatedly", () => {
+    setAppVersion(TEST_VERSION);
+    storeVersion(TEST_VERSION);
+
+    const result = detectAppVersionChange();
+
+    expect(result).toBe(false);
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+
+  it("second version change in same session still reloads", () => {
+    setAppVersion(TEST_VERSION_2);
+    storeVersion(TEST_VERSION); // prior deploy
+    markReloaded(TEST_VERSION); // simulates having already reloaded for the prior version
+
+    const result = detectAppVersionChange();
+
+    // The guard only suppresses for TEST_VERSION, not TEST_VERSION_2
+    expect(result).toBe(true);
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+    expect(getStoredVersion()).toBe(TEST_VERSION_2);
+  });
+
+  it("does not reload again for same version after one reload", () => {
+    setAppVersion(TEST_VERSION);
+    storeVersion(TEST_VERSION_2); // prior
+    const first = detectAppVersionChange();
+    expect(first).toBe(true);
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+
+    // Simulate the reload — the guard is now set for TEST_VERSION
+    markReloaded(TEST_VERSION);
+    storeVersion(TEST_VERSION);
+
+    // Second call should be suppressed
+    const second = detectAppVersionChange();
+    expect(second).toBe(false);
+  });
+
+  it("returns false server-side (no window)", () => {
+    // @ts-expect-error: testing SSR path
+    const backup = global.window;
+    // @ts-expect-error: testing SSR path
+    delete global.window;
+    try {
+      expect(detectAppVersionChange()).toBe(false);
+    } finally {
+      // @ts-expect-error: testing SSR path
+      global.window = backup;
+    }
+  });
+
+  it("stores empty version when NEXT_PUBLIC_APP_VERSION is unset", () => {
+    delete (process.env as Record<string, string | undefined>).NEXT_PUBLIC_APP_VERSION;
+    storeVersion(TEST_VERSION_2); // prior
+
+    const result = detectAppVersionChange();
+
+    // Should not reload when there's no current version
+    expect(result).toBe(false);
+    expect(getStoredVersion()).toBe("");
+  });
+});


### PR DESCRIPTION
## What

When the app loads after a new deployment, detect the version change and auto-refresh so users do not need `Cmd + Shift + R`.

## Changes

- **Define `NEXT_PUBLIC_APP_VERSION`** in `next.config.ts` — combines package version + git SHA prefix
- **Add `VersionRefreshGate`** to root layout — detects version changes on mount
- **Version detection logic** (`src/lib/appVersion.ts`):
  - Compares current `NEXT_PUBLIC_APP_VERSION` with version stored in localStorage
  - If version changed: clears stale Quick Check state, stores new version, reloads once
  - SessionStorage guard prevents infinite reload loops
- **No-store cache headers** on Quick Check API routes (`pdf-extract`, `semantic-evidence`)
- **`cache: no-store`** on Quick Check PDF client fetch
- Static hashed assets remain cached; uploaded document results always use latest deployed logic

## Acceptance

- User does not need `Cmd + Shift + R` after deployment
- After a new deploy, app refreshes itself once if old code/state is detected
- Quick Check reruns using the latest deployed logic
- No infinite reload loop
- No loss of unrelated user settings

## Verification

```
npx tsc --noEmit        # 0 errors
npm run lint           # 0 warnings/errors
npm test               # 183/183 QuickCheck tests pass
npm run quickcheck:eval:corpus -- --strict                  # 8/8 all pass
QUICK_CHECK_PARSER=pymupdf npm run quickcheck:eval:corpus -- --strict  # 8/8 all pass
```

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>