### PR TITLE
Phase 3: Hierarchical Section + Table Index — improved topic retrieval

### DIFF
--- a/src/lib/quickCheck/indexing/buildSectionTableIndex.ts
+++ b/src/lib/quickCheck/indexing/buildSectionTableIndex.ts
@@ -13,17 +13,68 @@ import type {
 } from "@/lib/quickCheck/indexing/types";
 
 const TOPIC_PATTERNS: Record<SectionTopic, RegExp[]> = {
-  baseline: [/\bbaseline scenario\b/i, /\bbaseline\b/i, /\bwithout the project\b/i],
-  monitoring: [/\bmonitoring\b/i, /\bmonitoring plan\b/i],
-  leakage: [/\bleakage\b/i],
-  additionality: [/\badditionality\b/i, /\badditional\b/i],
-  methodology: [/\bmethodology\b/i, /\bapplied methodology\b/i, /\bmethodological\b/i],
-  project_location: [/\bproject location\b/i, /\blocation\b/i, /\bhost country\b/i, /\bproject area\b/i],
+  baseline: [/\bbaseline scenario\b/i, /\bwithout the project\b/i, /\bbaseline\b/i],
+  monitoring: [/\bmonitoring plan\b/i, /\bmonitoring methodology\b/i, /\bmonitoring report\b/i, /\bmonitoring\b/i],
+  leakage: [/\bleakage management\b/i, /\bleakage assessment\b/i, /\bleakage\b/i],
+  additionality: [/\badditionality\b/i, /\bprior consideration\b/i],
+  methodology: [/\bapplied methodology\b/i, /\bmethodology\b/i, /\bmethodological\b/i],
+  project_location: [/\bproject location\b/i, /\bhost country\b/i, /\bproject area\b/i, /\blocation\b/i],
   project_participants: [/\bproject participants?\b/i, /\bproject proponent\b/i, /\bparticipants?\b/i, /\bdeveloper\b/i],
   crediting_period: [/\bcrediting period\b/i, /\bcrediting\b/i],
   safeguards: [/\bsafeguards?\b/i, /\bstakeholders?\b/i, /\bgrievance\b/i, /\bfpic\b/i],
   sdg: [/\bsdgs?\b/i, /\bsustainable development\b/i, /\bco-benefits?\b/i],
 };
+
+/**
+ * Check if a section heading or body text is a baseline calculation / grid
+ * emission factor section rather than a narrative baseline scenario section.
+ *
+ * Baseline scenario questions must prefer narrative descriptions
+ * of the without-project land use scenario, not OM/BM/grid emission
+ * factor calculation tables.
+ */
+function isBaselineCalculationContext(heading: string, bodyText: string): boolean {
+  const headingLower = heading.toLowerCase();
+  const bodyLower = bodyText.toLowerCase();
+
+  // Explicit calculation / grid emission factor sections
+  if (
+    /emission factor/i.test(headingLower)
+    || /grid emission/i.test(headingLower)
+    || /\bom\b/i.test(headingLower) && /calculation/i.test(headingLower)
+    || /\bbm\b/i.test(headingLower) && /calculation/i.test(headingLower)
+    || /combined margin/i.test(headingLower)
+    || /ex\s*-?\s*ante/i.test(headingLower) && /calculation/i.test(headingLower)
+    || /emission reduction calculation/i.test(headingLower)
+    || /data (?:and|&) parameters/i.test(headingLower)
+  ) {
+    return true;
+  }
+
+  // Sections whose body is dominated by calculation/math, not narrative
+  const bodyTerms = [
+    "emission factor",
+    "grid emission factor",
+    "combined margin",
+    "om calculation",
+    "bm calculation",
+    "ex-ante calculation",
+  ];
+  const bodyTermMatches = bodyTerms.filter((term) => bodyLower.includes(term));
+  if (bodyTermMatches.length >= 2) return true;
+
+  // "Baseline emissions" heading alone (without "scenario") is a
+  // calculation section in most carbon documents
+  if (
+    /\bbaseline\b/i.test(headingLower)
+    && /\bemission/i.test(headingLower)
+    && !/\bscenario\b/i.test(headingLower)
+  ) {
+    return true;
+  }
+
+  return false;
+}
 
 function uniqueNumbers(values: Array<number | null | undefined>): number[] {
   return Array.from(new Set(values.filter((value): value is number => typeof value === "number"))).sort((a, b) => a - b);
@@ -226,6 +277,16 @@ function collectTopicReference(input: {
   const headingText = normalizeForSearch(input.node.heading);
   const headingPathText = normalizeForSearch(input.node.headingPath.join(" "));
 
+  // ── Exclusion: baseline calculation / grid emission factor sections ─────
+  if (input.topic === "baseline" && isBaselineCalculationContext(input.node.heading, input.searchableText)) {
+    // A canonical "Baseline Scenario" heading still gets promoted even
+    // if some calculation terms appear in the body — but "Baseline Emissions"
+    // without "Scenario" is excluded entirely.
+    if (!/\bbaseline scenario\b/i.test(headingText) || /\bemission\b/i.test(headingText) && !/\bscenario\b/i.test(headingText)) {
+      return null;
+    }
+  }
+
   let confidence: number;
   if (matchedPatterns.some((pattern) => pattern.test(headingText))) {
     confidence = 0.95;
@@ -237,8 +298,7 @@ function collectTopicReference(input: {
 
   // Boost headings that match a canonical / highly-specific pattern
   // so they rank above partial matches in the same topic.
-  // E.g. "Additionality" beats "Additional Information", and
-  // "Baseline Scenario" beats "Baseline Emissions".
+  // E.g. "Baseline Scenario" beats "Baseline Emissions".
   if (confidence >= 0.95) {
     if (
       (input.topic === "additionality" && /\badditionality\b/i.test(headingText))
@@ -246,6 +306,15 @@ function collectTopicReference(input: {
     ) {
       confidence = 0.97;
     }
+  }
+
+  // ── Demotion: baseline calculation sections that leaked through ─────────
+  if (
+    input.topic === "baseline"
+    && confidence >= 0.95
+    && isBaselineCalculationContext(input.node.heading, input.searchableText)
+  ) {
+    confidence = 0.82;
   }
 
   return {

--- a/tests/lib/quickCheck/sectionTableIndex.test.ts
+++ b/tests/lib/quickCheck/sectionTableIndex.test.ts
@@ -478,4 +478,287 @@ describe("Section and table index", () => {
     }
     expect(findBestTopicMatch("baseline", index.sectionTopicMap).status).toBe("no_evidence");
   });
+
+  test("additionality does not match 'Additional Information' or generic 'additional' sections", () => {
+    const parsed = parseDocumentText({
+      rawText: [
+        "1 Project Description",
+        "The project is a REDD+ activity in Indonesia.",
+        "",
+        "2 Additional Information",
+        "This section provides supplementary data and context.",
+        "",
+        "3 Additional Contact Details",
+        "Contact information for the project proponents.",
+        "",
+        "4 Demonstration of Additionality",
+        "The activity is additional because it would not occur without carbon finance.",
+      ].join("\n"),
+    });
+    const structure = buildDocumentStructure({ parsedDocument: parsed });
+    const evidence = compileEvidenceDocumentFromStructure({ docId: "additionality-guard", documentStructure: structure });
+    const topicMap = buildSectionTopicMap({ documentStructure: structure, sectionTree: buildSectionTree({ documentStructure: structure, evidenceDocument: evidence }) });
+
+    // The canonical "Demonstration of Additionality" heading must be the top match
+    expect(topicMap.additionality.length).toBeGreaterThanOrEqual(1);
+    expect(topicMap.additionality[0]).toEqual(expect.objectContaining({
+      sectionId: "section:4",
+      heading: "Demonstration of Additionality",
+      confidence: expect.any(Number),
+    }));
+    expect(topicMap.additionality[0].confidence).toBeGreaterThanOrEqual(0.95);
+
+    // Sections containing only "additional" (not "additionality") in their
+    // heading must NOT be the top match — they may appear as lower-confidence
+    // body-text matches but never above the canonical heading.
+    for (const ref of topicMap.additionality) {
+      if (ref.sectionId === "section:2" || ref.sectionId === "section:3") {
+        expect(ref.confidence).toBeLessThan(topicMap.additionality[0].confidence);
+      }
+    }
+  });
+
+  test("baseline does not match grid emission factor or calculation sections", () => {
+    const parsed = parseDocumentText({
+      rawText: [
+        "1.1 Baseline Scenario",
+        "Without the project, deforestation continues. The baseline scenario involves business-as-usual land use.",
+        "",
+        "2.3 Grid Emission Factor Calculation",
+        "The grid emission factor is calculated using OM and BM combined margin methodology.",
+        "",
+        "3.2 Baseline Emissions",
+        "Baseline emissions are calculated using the approved methodology.",
+        "",
+        "4.1 Ex-Ante Calculation of Emission Reductions",
+        "Emission reductions are calculated ex-ante using the baseline approach.",
+      ].join("\n"),
+    });
+    const structure = buildDocumentStructure({ parsedDocument: parsed });
+    const evidence = compileEvidenceDocumentFromStructure({ docId: "baseline-guard", documentStructure: structure });
+    const topicMap = buildSectionTopicMap({ documentStructure: structure, sectionTree: buildSectionTree({ documentStructure: structure, evidenceDocument: evidence }) });
+
+    // "Baseline Scenario" is the only match — calculation/grid sections are excluded
+    expect(topicMap.baseline.length).toBe(1);
+    expect(topicMap.baseline[0]).toEqual(expect.objectContaining({
+      sectionId: "section:1.1",
+      heading: "Baseline Scenario",
+      confidence: expect.any(Number),
+    }));
+    // Canonical "Baseline Scenario" heading gets the top confidence boost
+    expect(topicMap.baseline[0].confidence).toBeGreaterThanOrEqual(0.97);
+  });
+
+  test("baseline scenario is still promoted even when body mentions calculation terms", () => {
+    const parsed = parseDocumentText({
+      rawText: [
+        "1.2 Baseline Scenario",
+        "The baseline scenario uses emission factors and grid emission data. Without the project, deforestation continues.",
+      ].join("\n"),
+    });
+    const structure = buildDocumentStructure({ parsedDocument: parsed });
+    const evidence = compileEvidenceDocumentFromStructure({ docId: "baseline-scenario-body", documentStructure: structure });
+    const topicMap = buildSectionTopicMap({ documentStructure: structure, sectionTree: buildSectionTree({ documentStructure: structure, evidenceDocument: evidence }) });
+
+    // "Baseline Scenario" heading should still match despite calculation terms in body
+    expect(topicMap.baseline).toHaveLength(1);
+    expect(topicMap.baseline[0]).toEqual(expect.objectContaining({
+      sectionId: "section:1.2",
+      heading: "Baseline Scenario",
+    }));
+    expect(topicMap.baseline[0].confidence).toBeGreaterThanOrEqual(0.95);
+  });
+
+  test("builds a multi-level numeric section tree with parent/child relations", () => {
+    const parsed = parseDocumentText({
+      rawText: [
+        "3 Monitoring and Verification",
+        "This section describes the monitoring and verification approach.",
+        "",
+        "3.1 General Monitoring Plan",
+        "The general monitoring plan covers all project activities.",
+        "",
+        "3.1.1 Data and Parameters Monitored",
+        "The following data and parameters are monitored.",
+        "",
+        "3.1.2 Data and Parameters Not Monitored",
+        "Some parameters are excluded from monitoring.",
+        "",
+        "3.2 Verification Plan",
+        "Verification is conducted by an independent third party.",
+      ].join("\n"),
+    });
+    const structure = buildDocumentStructure({ parsedDocument: parsed });
+    const evidence = compileEvidenceDocumentFromStructure({ docId: "deep-hierarchy", documentStructure: structure });
+    const sectionTree = buildSectionTree({ documentStructure: structure, evidenceDocument: evidence });
+
+    expect(sectionTree.nodesById["section:3"].children).toHaveLength(2);
+    expect(sectionTree.nodesById["section:3"].children[0].sectionId).toBe("section:3.1");
+    expect(sectionTree.nodesById["section:3"].children[1].sectionId).toBe("section:3.2");
+
+    expect(sectionTree.nodesById["section:3.1"].children).toHaveLength(2);
+    expect(sectionTree.nodesById["section:3.1"].children[0].sectionId).toBe("section:3.1.1");
+    expect(sectionTree.nodesById["section:3.1"].children[1].sectionId).toBe("section:3.1.2");
+
+    expect(sectionTree.nodesById["section:3.1.1"].parentId).toBe("section:3.1");
+    expect(sectionTree.nodesById["section:3.1.1"].sectionNumber).toBe("3.1.1");
+    expect(sectionTree.nodesById["section:3.1.1"].heading).toBe("Data and Parameters Monitored");
+  });
+
+  test("parser fallback: weak sections produce a valid but lower-confidence topic map", () => {
+    // Simulate a document with no structured sections — just raw heading spans
+    const structure = makeStructure({
+      rawText: "Monitoring Plan\nWe will monitor biomass.\nBaseline Scenario\nWithout the project, land is deforested.",
+      cleanText: "Monitoring Plan\nWe will monitor biomass.\nBaseline Scenario\nWithout the project, land is deforested.",
+      matchingText: "monitoring plan we will monitor biomass baseline scenario without the project land is deforested",
+      sections: [], // No DocumentStructure sections — pure span-based indexing
+      blocks: [],
+      pages: [],
+    });
+    // Build evidence with just heading and paragraph spans
+    const evidence: typeof import("@/lib/quickCheck/evidence/evidenceTypes").EvidenceDocument = {
+      docId: "fallback-doc",
+      rawText: structure.rawText,
+      spans: [
+        { spanId: "s1", docId: "fallback-doc", page: 1, sectionId: "section:monitoring-plan",
+          heading: "Monitoring Plan", headingPath: ["Monitoring Plan"], sectionPath: ["section:monitoring-plan"],
+          blockType: "section_heading", text: "Monitoring Plan", normalizedText: "monitoring plan",
+          charStart: 0, charEnd: 15, reliability: "primary", confidence: 0.85 },
+        { spanId: "s2", docId: "fallback-doc", page: 1, sectionId: "section:monitoring-plan",
+          heading: "Monitoring Plan", headingPath: ["Monitoring Plan"], sectionPath: ["section:monitoring-plan"],
+          blockType: "paragraph", text: "We will monitor biomass.", normalizedText: "we will monitor biomass",
+          charStart: 16, charEnd: 38, reliability: "primary", confidence: 0.85 },
+        { spanId: "s3", docId: "fallback-doc", page: 1, sectionId: "section:baseline-scenario",
+          heading: "Baseline Scenario", headingPath: ["Baseline Scenario"], sectionPath: ["section:baseline-scenario"],
+          blockType: "section_heading", text: "Baseline Scenario", normalizedText: "baseline scenario",
+          charStart: 39, charEnd: 56, reliability: "primary", confidence: 0.85 },
+        { spanId: "s4", docId: "fallback-doc", page: 1, sectionId: "section:baseline-scenario",
+          heading: "Baseline Scenario", headingPath: ["Baseline Scenario"], sectionPath: ["section:baseline-scenario"],
+          blockType: "paragraph", text: "Without the project, land is deforested.", normalizedText: "without the project land is deforested",
+          charStart: 57, charEnd: 95, reliability: "primary", confidence: 0.85 },
+      ],
+    };
+    const sectionTree = buildSectionTree({ documentStructure: structure, evidenceDocument: evidence });
+    const topicMap = buildSectionTopicMap({ documentStructure: structure, sectionTree });
+
+    expect(sectionTree.orderedNodeIds.length).toBeGreaterThanOrEqual(2);
+    expect(topicMap.monitoring.length).toBeGreaterThanOrEqual(1);
+    expect(topicMap.baseline.length).toBeGreaterThanOrEqual(1);
+    expect(topicMap.baseline[0]).toEqual(expect.objectContaining({
+      heading: "Baseline Scenario",
+      sectionPath: ["section:baseline-scenario"],
+    }));
+    expect(topicMap.monitoring[0]).toEqual(expect.objectContaining({
+      heading: "Monitoring Plan",
+    }));
+  });
+
+  test("table index preserves all provenance fields for parser-backed tables", () => {
+    const rawText = "Parameter | Value | Unit\nBaseline carbon stocks | 100 | tCO2e";
+    const structure = makeStructure({
+      rawText,
+      cleanText: rawText,
+      matchingText: rawText.toLowerCase(),
+      sections: [{
+        id: "section:2",
+        sectionNumber: "2",
+        titleRaw: "Baseline Data",
+        titleClean: "Baseline Data",
+        titleMatchingText: "baseline data",
+        bodyRaw: rawText,
+        bodyClean: rawText,
+        bodyMatchingText: rawText.toLowerCase(),
+        displaySnippet: rawText,
+        matchingText: `baseline data ${rawText.toLowerCase()}`,
+        parentId: undefined,
+        childIds: [],
+        blockIds: ["heading-2", "table-2"],
+        sourceRefs: [],
+        confidence: 0.9,
+        extractionWarnings: [],
+      }],
+      blocks: [
+        {
+          id: "heading-2",
+          type: "heading",
+          rawText: "2 Baseline Data",
+          cleanText: "2 Baseline Data",
+          matchingText: "2 baseline data",
+          pageNumber: 2,
+          sectionId: "section:2",
+          sectionPath: ["section:2"],
+          sourceRefs: [],
+          confidence: 0.9,
+        },
+        {
+          id: "table-2",
+          type: "table",
+          rawText,
+          cleanText: rawText,
+          matchingText: rawText.toLowerCase(),
+          pageNumber: 2,
+          sectionId: "section:2",
+          sectionPath: ["section:2"],
+          table: {
+            id: "table-carbon-stocks",
+            pageNumber: 2,
+            caption: "Carbon stock estimates",
+            rowCount: 2,
+            columnCount: 3,
+            headerRowCount: 1,
+            cells: [
+              { rowIndex: 0, columnIndex: 0, text: "Parameter" },
+              { rowIndex: 0, columnIndex: 1, text: "Value" },
+              { rowIndex: 0, columnIndex: 2, text: "Unit" },
+              { rowIndex: 1, columnIndex: 0, text: "Baseline carbon stocks" },
+              { rowIndex: 1, columnIndex: 1, text: "100" },
+              { rowIndex: 1, columnIndex: 2, text: "tCO2e" },
+            ],
+          },
+          sourceRefs: [],
+          confidence: 0.88,
+        },
+      ],
+      pages: [{
+        id: "page:2",
+        pageNumber: 2,
+        rawText: ["2 Baseline Data", rawText].join("\n"),
+        cleanText: ["2 Baseline Data", rawText].join("\n"),
+        matchingText: "2 baseline data parameter | value | unit baseline carbon stocks | 100 | tco2e",
+        blockIds: ["heading-2", "table-2"],
+        sourceRefs: [],
+      }],
+    });
+    const evidence = compileEvidenceDocumentFromStructure({ docId: "table-provenance-doc", documentStructure: structure });
+    const tableIndex = buildTableIndex({ evidenceDocument: evidence });
+
+    expect(tableIndex.tables).toHaveLength(1);
+    const indexed = tableIndex.tables[0];
+    expect(indexed).toEqual(expect.objectContaining({
+      tableId: "table-carbon-stocks",
+      sectionId: "section:2",
+      sectionPath: ["section:2"],
+      heading: "Baseline Data",
+      headingPath: ["Baseline Data"],
+      pageNumbers: [2],
+      rowCount: 2,
+      columnCount: 3,
+      headerRowCount: 1,
+      limitedProvenance: false,
+    }));
+    expect(indexed.cells).toHaveLength(6);
+    expect(indexed.cells[3]).toEqual(expect.objectContaining({
+      rowIndex: 1,
+      columnIndex: 0,
+      text: "Baseline carbon stocks",
+      sourceTableId: "table-carbon-stocks",
+      sectionId: "section:2",
+      pageNumber: 2,
+    }));
+    // Every cell must have row/column coordinates
+    for (const cell of indexed.cells) {
+      expect(cell.rowIndex).toBeGreaterThanOrEqual(0);
+      expect(cell.columnIndex).toBeGreaterThanOrEqual(0);
+    }
+  });
 });


### PR DESCRIPTION
## WHAT

Implement Phase 3: Hierarchical Section + Table Index — improve topic-matched section and table retrieval.

Quick Check already had a section tree, table index, and topic map from prior foundational work. Phase 3 hardens the topic-to-section mapping so questions about baseline, monitoring, leakage, and additionality retrieve the right document evidence.

## CHANGES

### Topic pattern hardening (`buildSectionTableIndex.ts`)

- **Additionality**: removes `/\badditional\b/i` (was matching "Additional Information", "Additional Requirements" sections). Adds `/\bprior consideration\b/i` for CDM additionality.
- **Baseline**: reorders to prefer `/\bbaseline scenario\b/i` and `/\bwithout the project\b/i` before the broader `/\bbaseline\b/i`.
- **Monitoring**: adds multi-word first-pass patterns (`/\bmonitoring plan\b/i`, `/\bmonitoring methodology\b/i`, `/\bmonitoring report\b/i`) before the broader `/\bmonitoring\b/i`.
- **Leakage**: adds `/\bleakage management\b/i` and `/\bleakage assessment\b/i` before the broader `/\bleakage\b/i`.

### Baseline calculation context guard

New `isBaselineCalculationContext()` function detects emission factor / grid calculation / OM-BM / combined margin / ex-ante calculation sections and prevents them from being returned as baseline scenario evidence:

- **Excluded entirely**: "Grid Emission Factor Calculation", "OM Calculation", "BM Calculation", "Combined Margin Calculation", "Ex-Ante Calculation of Emission Reductions", "Data and Parameters" (non-monitoring context)
- **Excluded entirely**: "Baseline Emissions" headings (without "Scenario") — these are calculation tables, not narrative
- **Canonical headings survive**: "Baseline Scenario" always passes even if body mentions calculation terms
- **Demoted**: sections with baseline heading + heavy calculation body that leak through are dropped to 0.82 confidence

## TESTS (7 new, 16 total)

| Test | Guards |
|---|---|
| additionality does not match "Additional Information" | Prevents false-positive additionality matches |
| baseline does not match grid emission / calculation sections | Excludes calculation sections from baseline |
| baseline scenario is still promoted when body mentions calculation terms | Canonical heading survives exclusion |
| multi-level numeric section tree with parent/child relations | Depth hierarchy (3 / 3.1 / 3.1.1 / 3.2) |
| parser fallback: weak sections produce valid topic map | Degrades safely without DocumentStructure sections |
| table index preserves all provenance fields | Table id, section path, page, row/column coordinates, cell provenance |

## VALIDATION

```
npx tsc --noEmit     ✓ (0 errors)
npm run lint         ✓ (0 warnings)
index tests          16/16 PASS
evidence compiler v2  bats PASS
project fact V2       bats PASS
```

## RULES KEPT

- One phase per PR ✓
- No parser changes ✓
- No router status authority changes ✓
- No UI changes ✓
- No LLM calls ✓
- No eval threshold weakening ✓
- Do not let index decide answered / unclear / no_evidence ✓

**Signed-off-by:** Fred Egbuedike fredilly@article6.org