### PR TITLE
fix: evidence provenance, span resolution, intake profile, reporting period guard

### DIFF
--- a/src/lib/chat/documentIntakeProfile.ts
+++ b/src/lib/chat/documentIntakeProfile.ts
@@ -1,4 +1,5 @@
 import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+import { resolveEvidenceSpans } from "@/lib/quickCheck/evidence/resolveEvidenceSpans";
 
 export type DetectedContent = {
   label: string;
@@ -16,107 +17,81 @@ export type DocumentIntakeProfile = {
 };
 
 /**
- * Build a DocumentIntakeProfile from parsed evidence.
+ * Evidence-backed intake signal.  Every positive signal includes span IDs
+ * and page numbers from the resolved EvidenceDocument.  Signals without
+ * evidence are omitted (not emitted with empty provenance).
+ */
+export type IntakeSignal = {
+  label: string;
+  confidence: number;
+  reason: string;
+  evidenceSpanIds: string[];
+  pageNumbers: number[];
+  negativeWarning?: string;
+};
+
+/**
+ * Build a DocumentIntakeProfile from evidence-backed signals.
  *
- * Unlike the loose keyword-based `derivePdfFactsFromText`, this profile
- * is evidence-backed: every detected content includes span IDs and page
- * numbers from the resolved EvidenceDocument.
+ * Only signals with non-empty `evidenceSpanIds` are emitted.  If
+ * `evidenceDocument` is provided and a signal is missing its own span
+ * IDs, matching spans are derived from body-text evidence.
  */
 export function buildDocumentIntakeProfile(input: {
   documentType: string;
   documentFamily: string;
   evidenceDocument?: EvidenceDocument;
-  containsMonitoringPlan: boolean;
-  containsLeakage: boolean;
-  containsProjectBoundary: boolean;
-  containsAdditionality: boolean;
-  containsBaselineScenario: boolean;
-  containsValidationEvidence: boolean;
-  containsReportingPeriod: boolean;
+  signals: IntakeSignal[];
 }): DocumentIntakeProfile {
   const contents: DetectedContent[] = [];
 
-  // Map evidence-backed signals to detected content items.
-  // Each uses resolved EvidenceSpan provenance where available.
-
-  const addContent = (params: {
-    label: string;
-    confidence: number;
-    reason: string;
-    negativeWarning?: string;
-    hasEvidence: boolean;
-    evidenceSpanIds?: string[];
-    pageNumbers?: number[];
-  }) => {
-    if (!params.hasEvidence) return;
+  // Document type itself is metadata (no evidence spans), but it is
+  // always emitted because it classifies the document.
+  if (input.documentType) {
     contents.push({
-      label: params.label,
-      confidence: params.confidence,
-      evidenceSpanIds: params.evidenceSpanIds ?? [],
-      pageNumbers: params.pageNumbers ?? [],
-      reason: params.reason,
-      negativeWarning: params.negativeWarning,
+      label: input.documentType,
+      confidence: 0.95,
+      evidenceSpanIds: [],
+      pageNumbers: [],
+      reason: `Document classified as ${input.documentType}`,
     });
-  };
+  }
 
-  addContent({
-    label: input.documentType,
-    confidence: 0.95,
-    reason: `Document classified as ${input.documentType}`,
-    hasEvidence: Boolean(input.documentType),
-  });
+  for (const signal of input.signals) {
+    // Derive evidence from the EvidenceDocument if the signal doesn't
+    // provide its own span IDs but claims to have evidence.
+    let spans = signal.evidenceSpanIds;
+    let pages = signal.pageNumbers;
 
-  addContent({
-    label: "Project boundary",
-    confidence: 0.88,
-    reason: "Document contains project boundary information",
-    hasEvidence: input.containsProjectBoundary,
-  });
+    if (spans.length === 0 && input.evidenceDocument) {
+      const resolution = resolveEvidenceSpans(
+        input.evidenceDocument.spans.map((s) => s.spanId),
+        input.evidenceDocument,
+      );
+      // Keep only body-text spans whose normalized text contains any
+      // signal-relevant keywords (from the label).
+      const keywords = signal.label.toLowerCase().split(/\s+/).filter((w) => w.length > 3);
+      const matching = resolution.resolved.filter((r) =>
+        keywords.some((kw) => r.normalizedText.includes(kw)),
+      );
+      spans = matching.map((r) => r.spanId);
+      pages = matching
+        .map((r) => r.page)
+        .filter((p): p is number => typeof p === "number");
+    }
 
-  addContent({
-    label: "Monitoring plan",
-    confidence: 0.88,
-    reason: "Document describes monitoring plan or procedures",
-    hasEvidence: input.containsMonitoringPlan,
-  });
+    // Only emit if there is real evidence (span IDs)
+    if (spans.length === 0) continue;
 
-  addContent({
-    label: "Leakage",
-    confidence: 0.90,
-    reason: "Document contains leakage assessment or management information",
-    hasEvidence: input.containsLeakage,
-  });
-
-  addContent({
-    label: "Baseline scenario",
-    confidence: 0.90,
-    reason: "Document describes the baseline scenario",
-    hasEvidence: input.containsBaselineScenario,
-  });
-
-  addContent({
-    label: "Additionality",
-    confidence: 0.90,
-    reason: "Document demonstrates project additionality",
-    hasEvidence: input.containsAdditionality,
-  });
-
-  addContent({
-    label: "Validation evidence",
-    confidence: 0.92,
-    reason: "Document is or contains a validation report or opinion",
-    hasEvidence: input.containsValidationEvidence,
-  });
-
-  addContent({
-    label: "Reporting period",
-    confidence: 0.85,
-    reason: "Document contains an explicit reporting or monitoring period with a date range",
-    hasEvidence: input.containsReportingPeriod,
-    negativeWarning: !input.containsReportingPeriod
-      ? "No explicit reporting period date range found"
-      : undefined,
-  });
+    contents.push({
+      label: signal.label,
+      confidence: signal.confidence,
+      evidenceSpanIds: spans,
+      pageNumbers: Array.from(new Set(pages)).sort((a, b) => a - b),
+      reason: signal.reason,
+      negativeWarning: signal.negativeWarning,
+    });
+  }
 
   return {
     documentType: input.documentType,

--- a/src/lib/chat/documentIntakeProfile.ts
+++ b/src/lib/chat/documentIntakeProfile.ts
@@ -1,0 +1,126 @@
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+
+export type DetectedContent = {
+  label: string;
+  confidence: number;
+  evidenceSpanIds: string[];
+  pageNumbers: number[];
+  reason: string;
+  negativeWarning?: string;
+};
+
+export type DocumentIntakeProfile = {
+  documentType: string;
+  documentFamily: string;
+  detectedContents: DetectedContent[];
+};
+
+/**
+ * Build a DocumentIntakeProfile from parsed evidence.
+ *
+ * Unlike the loose keyword-based `derivePdfFactsFromText`, this profile
+ * is evidence-backed: every detected content includes span IDs and page
+ * numbers from the resolved EvidenceDocument.
+ */
+export function buildDocumentIntakeProfile(input: {
+  documentType: string;
+  documentFamily: string;
+  evidenceDocument?: EvidenceDocument;
+  containsMonitoringPlan: boolean;
+  containsLeakage: boolean;
+  containsProjectBoundary: boolean;
+  containsAdditionality: boolean;
+  containsBaselineScenario: boolean;
+  containsValidationEvidence: boolean;
+  containsReportingPeriod: boolean;
+}): DocumentIntakeProfile {
+  const contents: DetectedContent[] = [];
+
+  // Map evidence-backed signals to detected content items.
+  // Each uses resolved EvidenceSpan provenance where available.
+
+  const addContent = (params: {
+    label: string;
+    confidence: number;
+    reason: string;
+    negativeWarning?: string;
+    hasEvidence: boolean;
+    evidenceSpanIds?: string[];
+    pageNumbers?: number[];
+  }) => {
+    if (!params.hasEvidence) return;
+    contents.push({
+      label: params.label,
+      confidence: params.confidence,
+      evidenceSpanIds: params.evidenceSpanIds ?? [],
+      pageNumbers: params.pageNumbers ?? [],
+      reason: params.reason,
+      negativeWarning: params.negativeWarning,
+    });
+  };
+
+  addContent({
+    label: input.documentType,
+    confidence: 0.95,
+    reason: `Document classified as ${input.documentType}`,
+    hasEvidence: Boolean(input.documentType),
+  });
+
+  addContent({
+    label: "Project boundary",
+    confidence: 0.88,
+    reason: "Document contains project boundary information",
+    hasEvidence: input.containsProjectBoundary,
+  });
+
+  addContent({
+    label: "Monitoring plan",
+    confidence: 0.88,
+    reason: "Document describes monitoring plan or procedures",
+    hasEvidence: input.containsMonitoringPlan,
+  });
+
+  addContent({
+    label: "Leakage",
+    confidence: 0.90,
+    reason: "Document contains leakage assessment or management information",
+    hasEvidence: input.containsLeakage,
+  });
+
+  addContent({
+    label: "Baseline scenario",
+    confidence: 0.90,
+    reason: "Document describes the baseline scenario",
+    hasEvidence: input.containsBaselineScenario,
+  });
+
+  addContent({
+    label: "Additionality",
+    confidence: 0.90,
+    reason: "Document demonstrates project additionality",
+    hasEvidence: input.containsAdditionality,
+  });
+
+  addContent({
+    label: "Validation evidence",
+    confidence: 0.92,
+    reason: "Document is or contains a validation report or opinion",
+    hasEvidence: input.containsValidationEvidence,
+  });
+
+  addContent({
+    label: "Reporting period",
+    confidence: 0.85,
+    reason: "Document contains an explicit reporting or monitoring period with a date range",
+    hasEvidence: input.containsReportingPeriod,
+    negativeWarning: !input.containsReportingPeriod
+      ? "No explicit reporting period date range found"
+      : undefined,
+  });
+
+  return {
+    documentType: input.documentType,
+    documentFamily: input.documentFamily,
+    detectedContents: contents,
+  };
+}

--- a/src/lib/chat/quickCheckEvidence.ts
+++ b/src/lib/chat/quickCheckEvidence.ts
@@ -762,7 +762,6 @@ function derivePdfFactsFromText(text: string, sourceLabel: string): QuickCheckEv
   const workbookPattern = /(workbook|spreadsheet|excel)/i;
   const monitoringEvidencePattern = /(monitoring plan|monitoring report|monitoring records|monitoring data|monitoring procedures)/i;
   const projectAreaDetail = extractLabeledDetail(text, /(project area|project location)\s*[:\-]?\s*/i);
-  const reportingPeriodDetail = extractReportingPeriodDetail(text);
   const monitoringClaimDetail = extractLabeledDetail(text, /(claim support|primary claim)\s*[:\-]?\s*/i);
 
   if (projectDocumentPattern.test(haystack)) {
@@ -826,13 +825,22 @@ function derivePdfFactsFromText(text: string, sourceLabel: string): QuickCheckEv
   }
 
   if (reportingPeriodPattern.test(haystack)) {
-    addFact(next, {
-      category: "reporting-period",
-      summary: "The PDF states a monitoring or reporting period",
-      matchText: "reporting period stated",
-      sourceLabel,
-      detail: reportingPeriodDetail ?? extractMatchSnippet(text, reportingPeriodPattern),
-    });
+    // Only add as evidence-backed when an explicit date range is found
+    // (e.g. "01 January 2024 to 31 December 2024"), not when a document
+    // merely mentions "reporting period" or "monitoring period" in passing.
+    const periodDetail = extractReportingPeriodDetail(text);
+    const hasDateRange = periodDetail != null
+      && /\b\d{4}\b/.test(periodDetail ?? "")
+      && /\b\d{1,2}\s+[A-Z][a-z]+\s+\d{4}\b|\b\d{4}\s*(?:to|-)\s*\d{4}\b/.test(periodDetail);
+    if (hasDateRange) {
+      addFact(next, {
+        category: "reporting-period",
+        summary: "The file contains an explicit reporting or monitoring period with a date range",
+        matchText: "reporting period explicitly stated",
+        sourceLabel,
+        detail: periodDetail,
+      });
+    }
   }
 
   if (baselineScenarioPattern.test(haystack)) {

--- a/src/lib/chat/quickCheckEvidence.ts
+++ b/src/lib/chat/quickCheckEvidence.ts
@@ -182,8 +182,11 @@ function extractLabeledDetail(text: string, pattern: RegExp, maxLength = 120): s
   return detail.length > maxLength ? `${detail.slice(0, maxLength - 3).trimEnd()}...` : detail;
 }
 
-function extractReportingPeriodDetail(text: string): string | undefined {
+export function extractReportingPeriodDetail(text: string): string | undefined {
   const normalized = normalizeSnippetText(text);
+  // Require an explicit start-to-end date range: both a start and end date
+  // separated by "to" or "-".  Single dates or incidental mentions are
+  // not valid reporting periods.
   const explicitDateRange =
     normalized.match(/\b\d{1,2}\s+[A-Z][a-z]+\s+\d{4}\s*(?:to|-)\s*\d{1,2}\s+[A-Z][a-z]+\s+\d{4}\b/) ??
     normalized.match(/\b\d{4}\s*Q[1-4]\s*(?:to|-)\s*\d{4}\s*Q[1-4]\b/i);
@@ -192,7 +195,8 @@ function extractReportingPeriodDetail(text: string): string | undefined {
     return `Reporting period ${normalizeSnippetText(explicitDateRange[0])}.`;
   }
 
-  return extractLabeledDetail(normalized, /(reporting period|monitoring period)\s*[:\-]?\s*/i);
+  // No fallback — only explicit date ranges are valid evidence.
+  return undefined;
 }
 
 function asLower(value: string): string {
@@ -825,13 +829,12 @@ function derivePdfFactsFromText(text: string, sourceLabel: string): QuickCheckEv
   }
 
   if (reportingPeriodPattern.test(haystack)) {
-    // Only add as evidence-backed when an explicit date range is found
+    // Only add as evidence-backed when an explicit date RANGE is found
     // (e.g. "01 January 2024 to 31 December 2024"), not when a document
-    // merely mentions "reporting period" or "monitoring period" in passing.
+    // merely mentions "reporting period" or has only a single date.
     const periodDetail = extractReportingPeriodDetail(text);
     const hasDateRange = periodDetail != null
-      && /\b\d{4}\b/.test(periodDetail ?? "")
-      && /\b\d{1,2}\s+[A-Z][a-z]+\s+\d{4}\b|\b\d{4}\s*(?:to|-)\s*\d{4}\b/.test(periodDetail);
+      && /\b\d{1,2}\s+[A-Z][a-z]+\s+\d{4}\s*(?:to|-)\s*\d{1,2}\s+[A-Z][a-z]+\s+\d{4}\b/i.test(periodDetail);
     if (hasDateRange) {
       addFact(next, {
         category: "reporting-period",

--- a/src/lib/quickCheck/evidence/resolveEvidenceSpans.ts
+++ b/src/lib/quickCheck/evidence/resolveEvidenceSpans.ts
@@ -1,0 +1,114 @@
+import type { EvidenceDocument, EvidenceSpan } from "@/lib/quickCheck/evidence/evidenceTypes";
+
+export type ResolvedSpan = {
+  span: EvidenceSpan;
+  spanId: string;
+  page: number | null;
+  sectionId?: string;
+  heading?: string;
+  headingPath: string[];
+  sectionPath: string[];
+  text: string;
+  normalizedText: string;
+  blockType: string;
+  reliability: string;
+  confidence: number;
+  tableId?: string;
+};
+
+export type EvidenceSpanResolution = {
+  resolved: ResolvedSpan[];
+  unresolvedIds: string[];
+  allResolved: boolean;
+  warnings: string[];
+};
+
+/**
+ * Canonically resolve evidenceSpanIds to EvidenceSpan objects.
+ * This is the SINGLE source of truth for page/section/quote provenance
+ * across the entire Quick Check pipeline.
+ */
+export function resolveEvidenceSpans(
+  evidenceSpanIds: string[],
+  document: EvidenceDocument,
+): EvidenceSpanResolution {
+  const spanLookup = new Map<string, EvidenceSpan>(
+    document.spans.map((span) => [span.spanId, span]),
+  );
+
+  const resolved: ResolvedSpan[] = [];
+  const unresolvedIds: string[] = [];
+  const warnings: string[] = [];
+
+  for (const spanId of evidenceSpanIds) {
+    const span = spanLookup.get(spanId);
+    if (!span) {
+      unresolvedIds.push(spanId);
+      warnings.push(`evidenceSpanId "${spanId}" not found in EvidenceDocument`);
+      continue;
+    }
+
+    resolved.push({
+      span,
+      spanId: span.spanId,
+      page: span.page,
+      sectionId: span.sectionId,
+      heading: span.heading,
+      headingPath: span.headingPath,
+      sectionPath: span.sectionPath,
+      text: span.text,
+      normalizedText: span.normalizedText,
+      blockType: span.blockType,
+      reliability: span.reliability,
+      confidence: span.confidence,
+      tableId: span.table?.tableId,
+    });
+  }
+
+  if (unresolvedIds.length > 0 && resolved.length === 0) {
+    warnings.push("All evidenceSpanIds failed to resolve — provenance is lost");
+  }
+
+  return {
+    resolved,
+    unresolvedIds,
+    allResolved: unresolvedIds.length === 0,
+    warnings,
+  };
+}
+
+/**
+ * Extract canonical pages from resolved spans.
+ * Returns deduped, sorted array. Empty if no resolved spans have pages.
+ */
+export function pagesFromResolvedSpans(resolution: EvidenceSpanResolution): number[] {
+  return Array.from(
+    new Set(
+      resolution.resolved
+        .map((r) => r.page)
+        .filter((page): page is number => typeof page === "number"),
+    ),
+  ).sort((a, b) => a - b);
+}
+
+/**
+ * Extract canonical section paths from resolved spans.
+ */
+export function sectionsFromResolvedSpans(resolution: EvidenceSpanResolution): string[] {
+  return Array.from(
+    new Set(
+      resolution.resolved
+        .filter((r) => r.sectionPath.length > 0)
+        .map((r) => r.sectionPath.join(" > ")),
+    ),
+  );
+}
+
+/**
+ * Build quote text from resolved spans.
+ */
+export function quotesFromResolvedSpans(resolution: EvidenceSpanResolution): string[] {
+  return Array.from(
+    new Set(resolution.resolved.map((r) => r.text)),
+  );
+}

--- a/src/lib/quickCheck/evidenceChecks.ts
+++ b/src/lib/quickCheck/evidenceChecks.ts
@@ -4,6 +4,7 @@
 
 import type { DeterministicRouterResult } from "@/lib/quickCheck/retrieval/types";
 import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+import { resolveEvidenceSpans, pagesFromResolvedSpans } from "@/lib/quickCheck/evidence/resolveEvidenceSpans";
 import type { ProjectFactContract, ProjectFactField } from "@/lib/quickCheck/projectFacts/types";
 import type { SectionTableIndex } from "@/lib/quickCheck/indexing";
 import { findBestTopicMatch, type SectionTopic } from "@/lib/quickCheck/indexing";
@@ -942,9 +943,33 @@ export function validateCheck(contract: EvidenceCheckContract, ctx: CheckValidat
   const result = validateCheckInternal(contract, ctx);
   // Build provenance from the best candidate that passed validation
   const quotes: string[] = result.candidateText ? [result.candidateText] : [];
-  const pages: number[] = result.candidatePage != null ? [result.candidatePage] : [];
+  let pages: number[] = result.candidatePage != null && result.candidatePage > 0 ? [result.candidatePage] : [];
   const sections: string[] = result.candidateSectionPath ?? [];
-  const evidenceSpanIds: string[] = result.candidateSpanId ? [result.candidateSpanId] : [];
+  let evidenceSpanIds: string[] = result.candidateSpanId ? [result.candidateSpanId] : [];
+  const warnings: string[] = [];
+
+  // Resolve candidate span against the canonical EvidenceDocument to confirm
+  // page provenance.  If the candidate's page disagrees with the resolved
+  // span, prefer the resolved span and emit a warning.
+  if (result.candidateSpanId && ctx.evidenceDocument) {
+    const resolution = resolveEvidenceSpans([result.candidateSpanId], ctx.evidenceDocument);
+    if (resolution.resolved.length > 0) {
+      const resolvedSpan = resolution.resolved[0];
+      const resolvedQuotes = [resolvedSpan.text];
+      const resolvedPages = pagesFromResolvedSpans(resolution);
+      if (quotes.length === 0) quotes.push(...resolvedQuotes);
+      if (pages.length === 0) {
+        pages = resolvedPages;
+      } else if (resolvedPages.length > 0 && !pages.some((p) => resolvedPages.includes(p))) {
+        pages = resolvedPages;
+        warnings.push("Candidate page provenance corrected from resolved span");
+      }
+      evidenceSpanIds = [resolvedSpan.spanId];
+    } else {
+      warnings.push("Candidate evidenceSpanId could not be resolved — provenance may be incomplete");
+    }
+  }
+
   return {
     checkId: "" as EvidenceCheckId,
     status: result.status,
@@ -954,7 +979,7 @@ export function validateCheck(contract: EvidenceCheckContract, ctx: CheckValidat
     pages,
     sections,
     evidenceSpanIds,
-    warnings: [],
+    warnings,
   };
 }
 

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -1,6 +1,7 @@
 import type { EvidenceDocument, EvidenceSpan, QuoteValidationInput } from "@/lib/quickCheck/evidence/evidenceTypes";
 import { validateQuotes } from "@/lib/quickCheck/evidence/validateQuotes";
 import { buildEvidenceSpanIndex } from "@/lib/quickCheck/evidence/buildEvidenceSpanIndex";
+import { resolveEvidenceSpans, pagesFromResolvedSpans, sectionsFromResolvedSpans, quotesFromResolvedSpans } from "@/lib/quickCheck/evidence/resolveEvidenceSpans";
 import type { SectionNode, SectionTableIndex, TableCellReference, IndexedTable } from "@/lib/quickCheck/indexing";
 import type { ProjectFactContract, ProjectFactField, ProjectFactConfidence, ProjectFactValue } from "@/lib/quickCheck/projectFacts/types";
 import type { QueryIntentAnalysis, ProjectFactId } from "@/lib/quickCheck/queryIntent";
@@ -144,17 +145,27 @@ function finalizeCandidate(document: EvidenceDocument, candidate: RouterCandidat
 
   const matchedSpanIds = dedupe(validQuotes.flatMap(({ validation }) => validation.matchedSpanIds));
   const spanLookup = getSpanLookup(document);
-  const pages = dedupe([
-    ...matchedSpanIds
-      .map((spanId) => spanLookup.get(spanId)?.page)
-      .filter((page): page is number => typeof page === "number"),
-  ]).sort((left, right) => left - right);
+
+  // Resolve candidate's original evidenceSpanIds as the canonical provenance
+  // source. Quote-validation matchedSpanIds may span pages differently,
+  // especially when EvidenceSpan.page is null (filterCandidateSpans skips
+  // the page guard, letting page-1 spans compete).
+  const canonicalResolution = resolveEvidenceSpans(candidate.evidenceSpanIds, document);
+  const matchingResolution = resolveEvidenceSpans(matchedSpanIds, document);
+
+  // Prefer resolved candidate spans for pages; fall back to quote-matched
+  // spans only when the candidate spans have no pages (parser limitation).
+  const resolvedPages = pagesFromResolvedSpans(canonicalResolution);
+  const quotePages = pagesFromResolvedSpans(matchingResolution);
+  const pages = resolvedPages.length > 0
+    ? resolvedPages
+    : quotePages.length > 0
+      ? quotePages
+      : [];
   const sectionPaths = dedupe([
     ...candidate.sectionPaths,
-    ...matchedSpanIds
-      .map((spanId) => spanLookup.get(spanId)?.sectionPath ?? [])
-      .filter((path) => path.length > 0)
-      .map((path) => formatSectionPath(path)),
+    ...sectionsFromResolvedSpans(canonicalResolution),
+    ...(resolvedPages.length === 0 ? sectionsFromResolvedSpans(matchingResolution) : []),
   ]);
   const headingPaths = dedupe(matchedSpanIds
     .map((spanId) => spanLookup.get(spanId)?.headingPath ?? [])
@@ -167,7 +178,16 @@ function finalizeCandidate(document: EvidenceDocument, candidate: RouterCandidat
       : pages.length > 0
         ? ["Document root"]
         : [];
-  const quotes = dedupe(validQuotes.map(({ quoteInput }) => quoteInput.quote));
+  const quotes = quotesFromResolvedSpans(canonicalResolution).length > 0
+    ? quotesFromResolvedSpans(canonicalResolution)
+    : quotesFromResolvedSpans(matchingResolution);
+
+  if (!canonicalResolution.allResolved) {
+    candidate.warnings.push("Some candidate evidenceSpanIds could not be resolved");
+  }
+  if (resolvedPages.length === 0 && quotePages.length > 0) {
+    candidate.warnings.push("Candidate spans had no page provenance — using quote-matched pages");
+  }
 
   if (matchedSpanIds.length === 0 || quotes.length === 0 || pages.length === 0 || structuralPaths.length === 0) {
     return buildFallback({

--- a/src/lib/quickCheck/router/deterministicRouter.ts
+++ b/src/lib/quickCheck/router/deterministicRouter.ts
@@ -198,12 +198,20 @@ function finalizeCandidate(document: EvidenceDocument, candidate: RouterCandidat
     });
   }
 
+  // evidenceSpanIds must match the provenance source: canonical candidate
+  // spans when they provided the pages/quotes, quote-matched spans only when
+  // used as fallback.
+  const usingCanonicalProvenance = resolvedPages.length > 0;
+  const evidenceSpanIds = usingCanonicalProvenance
+    ? candidate.evidenceSpanIds
+    : matchedSpanIds;
+
   return {
     answerText: candidate.answerText,
     status: candidate.confidence >= ANSWER_CONFIDENCE_THRESHOLD ? "answered" : "unclear",
     route: candidate.route,
     confidence: clampConfidence(candidate.confidence),
-    evidenceSpanIds: matchedSpanIds,
+    evidenceSpanIds,
     quotes,
     pages,
     sectionPaths: structuralPaths,

--- a/tests/lib/chat/documentIntakeProfile.test.ts
+++ b/tests/lib/chat/documentIntakeProfile.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "@jest/globals";
+import { buildDocumentIntakeProfile } from "@/lib/chat/documentIntakeProfile";
+
+describe("buildDocumentIntakeProfile", () => {
+  test("produces evidence-backed profile for a validation report", () => {
+    const profile = buildDocumentIntakeProfile({
+      documentType: "Validation Report",
+      documentFamily: "VCS",
+      containsMonitoringPlan: true,
+      containsLeakage: true,
+      containsProjectBoundary: true,
+      containsAdditionality: true,
+      containsBaselineScenario: true,
+      containsValidationEvidence: true,
+      containsReportingPeriod: false,
+    });
+
+    expect(profile.documentType).toBe("Validation Report");
+    expect(profile.documentFamily).toBe("VCS");
+    expect(profile.detectedContents.length).toBeGreaterThanOrEqual(6);
+
+    const labels = profile.detectedContents.map((c) => c.label);
+    expect(labels).toContain("Validation Report");
+    expect(labels).toContain("Project boundary");
+    expect(labels).toContain("Monitoring plan");
+    expect(labels).toContain("Leakage");
+    expect(labels).toContain("Baseline scenario");
+    expect(labels).toContain("Additionality");
+    expect(labels).toContain("Validation evidence");
+    // Reporting period must NOT appear when evidence is absent
+    expect(labels).not.toContain("Reporting period");
+  });
+
+  test("produces a reduced profile when only some evidence is present", () => {
+    const profile = buildDocumentIntakeProfile({
+      documentType: "Validation Report",
+      documentFamily: "VCS",
+      containsMonitoringPlan: false,
+      containsLeakage: false,
+      containsProjectBoundary: false,
+      containsAdditionality: false,
+      containsBaselineScenario: false,
+      containsValidationEvidence: true,
+      containsReportingPeriod: false,
+    });
+
+    const labels = profile.detectedContents.map((c) => c.label);
+    expect(labels).toContain("Validation Report");
+    expect(labels).toContain("Validation evidence");
+    expect(labels).not.toContain("Reporting period");
+    expect(labels).not.toContain("Monitoring plan");
+    expect(labels).not.toContain("Leakage");
+  });
+
+  test("includes reporting period only when date-range evidence is present", () => {
+    const profile = buildDocumentIntakeProfile({
+      documentType: "Monitoring Report",
+      documentFamily: "VERRA",
+      containsMonitoringPlan: true,
+      containsLeakage: false,
+      containsProjectBoundary: false,
+      containsAdditionality: false,
+      containsBaselineScenario: false,
+      containsValidationEvidence: false,
+      containsReportingPeriod: true,
+    });
+
+    const labels = profile.detectedContents.map((c) => c.label);
+    expect(labels).toContain("Reporting period");
+    expect(labels).toContain("Monitoring plan");
+  });
+
+  test("each detected content carries required fields", () => {
+    const profile = buildDocumentIntakeProfile({
+      documentType: "PDD",
+      documentFamily: "CDM",
+      containsMonitoringPlan: true,
+      containsLeakage: false,
+      containsProjectBoundary: false,
+      containsAdditionality: false,
+      containsBaselineScenario: false,
+      containsValidationEvidence: false,
+      containsReportingPeriod: false,
+    });
+
+    for (const content of profile.detectedContents) {
+      expect(content).toHaveProperty("label");
+      expect(content).toHaveProperty("confidence");
+      expect(content).toHaveProperty("reason");
+      expect(content).toHaveProperty("evidenceSpanIds");
+      expect(content).toHaveProperty("pageNumbers");
+      expect(typeof content.label).toBe("string");
+      expect(content.label.length).toBeGreaterThan(0);
+      expect(content.confidence).toBeGreaterThan(0);
+      expect(content.confidence).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/tests/lib/chat/documentIntakeProfile.test.ts
+++ b/tests/lib/chat/documentIntakeProfile.test.ts
@@ -1,18 +1,48 @@
 import { describe, expect, test } from "@jest/globals";
-import { buildDocumentIntakeProfile } from "@/lib/chat/documentIntakeProfile";
+import { buildDocumentIntakeProfile, type IntakeSignal } from "@/lib/chat/documentIntakeProfile";
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+
+function makeDoc(overrides: Partial<EvidenceDocument>): EvidenceDocument {
+  return {
+    docId: "test-doc",
+    rawText: overrides.rawText ?? "",
+    spans: overrides.spans ?? [],
+  };
+}
+
+function signal(label: string, spanIds: string[], pages: number[]): IntakeSignal {
+  return {
+    label,
+    confidence: 0.90,
+    reason: `Document contains ${label.toLowerCase()} information`,
+    evidenceSpanIds: spanIds,
+    pageNumbers: pages,
+  };
+}
+
+function metadataSignal(label: string): IntakeSignal {
+  return {
+    label,
+    confidence: 0.95,
+    reason: `Document classified as ${label}`,
+    evidenceSpanIds: [],
+    pageNumbers: [],
+  };
+}
 
 describe("buildDocumentIntakeProfile", () => {
-  test("produces evidence-backed profile for a validation report", () => {
+  test("produces evidence-backed profile for a validation report with real spans", () => {
     const profile = buildDocumentIntakeProfile({
       documentType: "Validation Report",
       documentFamily: "VCS",
-      containsMonitoringPlan: true,
-      containsLeakage: true,
-      containsProjectBoundary: true,
-      containsAdditionality: true,
-      containsBaselineScenario: true,
-      containsValidationEvidence: true,
-      containsReportingPeriod: false,
+      signals: [
+        signal("Validation evidence", ["span:v1", "span:v2"], [2, 3]),
+        signal("Project boundary", ["span:b1"], [1]),
+        signal("Monitoring plan", ["span:m1", "span:m2"], [4, 5]),
+        signal("Leakage", ["span:l1"], [6]),
+        signal("Baseline scenario", ["span:bs1"], [3]),
+        signal("Additionality", ["span:a1"], [4]),
+      ],
     });
 
     expect(profile.documentType).toBe("Validation Report");
@@ -27,60 +57,69 @@ describe("buildDocumentIntakeProfile", () => {
     expect(labels).toContain("Baseline scenario");
     expect(labels).toContain("Additionality");
     expect(labels).toContain("Validation evidence");
-    // Reporting period must NOT appear when evidence is absent
     expect(labels).not.toContain("Reporting period");
+
+    // Every evidence-backed content must have non-empty provenance
+    for (const content of profile.detectedContents) {
+      if (content.label === "Validation Report") continue; // metadata OK
+      expect(content.evidenceSpanIds.length).toBeGreaterThan(0);
+    }
   });
 
-  test("produces a reduced profile when only some evidence is present", () => {
-    const profile = buildDocumentIntakeProfile({
-      documentType: "Validation Report",
-      documentFamily: "VCS",
-      containsMonitoringPlan: false,
-      containsLeakage: false,
-      containsProjectBoundary: false,
-      containsAdditionality: false,
-      containsBaselineScenario: false,
-      containsValidationEvidence: true,
-      containsReportingPeriod: false,
-    });
-
-    const labels = profile.detectedContents.map((c) => c.label);
-    expect(labels).toContain("Validation Report");
-    expect(labels).toContain("Validation evidence");
-    expect(labels).not.toContain("Reporting period");
-    expect(labels).not.toContain("Monitoring plan");
-    expect(labels).not.toContain("Leakage");
-  });
-
-  test("includes reporting period only when date-range evidence is present", () => {
+  test("signals without span IDs are omitted (not emitted with empty evidence)", () => {
     const profile = buildDocumentIntakeProfile({
       documentType: "Monitoring Report",
       documentFamily: "VERRA",
-      containsMonitoringPlan: true,
-      containsLeakage: false,
-      containsProjectBoundary: false,
-      containsAdditionality: false,
-      containsBaselineScenario: false,
-      containsValidationEvidence: false,
-      containsReportingPeriod: true,
+      signals: [
+        signal("Monitoring plan", ["span:m1"], [2]),
+        signal("Leakage", [], []), // empty evidence — must not appear
+        { label: "Reporting period", confidence: 0.85, reason: "rw reason",
+          evidenceSpanIds: [], pageNumbers: [] },
+      ],
     });
 
     const labels = profile.detectedContents.map((c) => c.label);
-    expect(labels).toContain("Reporting period");
+    expect(labels).toContain("Monitoring Report");
     expect(labels).toContain("Monitoring plan");
+    expect(labels).not.toContain("Leakage");
+    expect(labels).not.toContain("Reporting period");
+  });
+
+  test("derives evidence from evidenceDocument when signal lacks its own span IDs", () => {
+    const evDoc = makeDoc({
+      spans: [
+        { spanId: "s1", docId: "test", page: 3, sectionId: "section:3",
+          heading: "Leakage", headingPath: ["Leakage"], sectionPath: ["section:3"],
+          blockType: "paragraph", text: "Leakage is not expected for this project.",
+          normalizedText: "leakage is not expected for this project",
+          charStart: 0, charEnd: 47, reliability: "primary", confidence: 0.9,
+        } as EvidenceDocument["spans"][number],
+      ],
+    });
+
+    const profile = buildDocumentIntakeProfile({
+      documentType: "PDD",
+      documentFamily: "CDM",
+      evidenceDocument: evDoc,
+      signals: [
+        { label: "Leakage", confidence: 0.90, reason: "Document mentions leakage",
+          evidenceSpanIds: [], pageNumbers: [] },
+      ],
+    });
+
+    const leakage = profile.detectedContents.find((c) => c.label === "Leakage");
+    expect(leakage).toBeDefined();
+    expect(leakage!.evidenceSpanIds.length).toBeGreaterThan(0);
+    expect(leakage!.pageNumbers).toContain(3);
   });
 
   test("each detected content carries required fields", () => {
     const profile = buildDocumentIntakeProfile({
       documentType: "PDD",
       documentFamily: "CDM",
-      containsMonitoringPlan: true,
-      containsLeakage: false,
-      containsProjectBoundary: false,
-      containsAdditionality: false,
-      containsBaselineScenario: false,
-      containsValidationEvidence: false,
-      containsReportingPeriod: false,
+      signals: [
+        signal("Monitoring plan", ["span:m1"], [2]),
+      ],
     });
 
     for (const content of profile.detectedContents) {
@@ -93,6 +132,10 @@ describe("buildDocumentIntakeProfile", () => {
       expect(content.label.length).toBeGreaterThan(0);
       expect(content.confidence).toBeGreaterThan(0);
       expect(content.confidence).toBeLessThanOrEqual(1);
+      // documentType is metadata (may have empty arrays), others must have evidence
+      if (content.label !== "PDD") {
+        expect(content.evidenceSpanIds.length).toBeGreaterThan(0);
+      }
     }
   });
 });

--- a/tests/lib/quickCheck/resolveEvidenceSpans.test.ts
+++ b/tests/lib/quickCheck/resolveEvidenceSpans.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "@jest/globals";
+import { resolveEvidenceSpans, pagesFromResolvedSpans, sectionsFromResolvedSpans, quotesFromResolvedSpans } from "@/lib/quickCheck/evidence/resolveEvidenceSpans";
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+
+function makeTestDoc(overrides: Partial<EvidenceDocument>): EvidenceDocument {
+  return {
+    docId: "test-doc",
+    rawText: overrides.rawText ?? "",
+    spans: overrides.spans ?? [],
+  };
+}
+
+function makeSpan(overrides: Record<string, unknown>): EvidenceDocument["spans"][number] {
+  return {
+    spanId: (overrides.spanId as string) ?? "span:1",
+    docId: "test-doc",
+    page: "page" in overrides ? (overrides.page as number | null) : 1,
+    sectionId: (overrides.sectionId as string) ?? undefined,
+    heading: (overrides.heading as string) ?? undefined,
+    headingPath: (overrides.headingPath as string[]) ?? [],
+    sectionPath: (overrides.sectionPath as string[]) ?? [],
+    blockType: (overrides.blockType as string) ?? "paragraph",
+    text: (overrides.text as string) ?? "Test text",
+    normalizedText: (overrides.normalizedText as string) ?? "test text",
+    charStart: (overrides.charStart as number | null) ?? 0,
+    charEnd: (overrides.charEnd as number | null) ?? 9,
+    reliability: (overrides.reliability as string) ?? "primary",
+    confidence: (overrides.confidence as number) ?? 0.9,
+    table: (overrides.table as EvidenceDocument["spans"][number]["table"]) ?? undefined,
+  } as EvidenceDocument["spans"][number];
+}
+
+describe("resolveEvidenceSpans", () => {
+  test("resolves valid span IDs to span data", () => {
+    const doc = makeTestDoc({
+      spans: [
+        makeSpan({ spanId: "span:1", page: 5, text: "Section 4.2.4 body text" }),
+        makeSpan({ spanId: "span:2", page: 3, text: "Methodology description" }),
+      ],
+    });
+
+    const result = resolveEvidenceSpans(["span:1"], doc);
+    expect(result.allResolved).toBe(true);
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].page).toBe(5);
+    expect(result.resolved[0].spanId).toBe("span:1");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("flags unresolved span IDs with warnings", () => {
+    const doc = makeTestDoc({
+      spans: [makeSpan({ spanId: "span:1", page: 1 })],
+    });
+
+    const result = resolveEvidenceSpans(["span:missing", "span:also-missing"], doc);
+    expect(result.allResolved).toBe(false);
+    expect(result.resolved).toHaveLength(0);
+    expect(result.unresolvedIds).toHaveLength(2);
+    expect(result.warnings).toContain("All evidenceSpanIds failed to resolve — provenance is lost");
+  });
+
+  test("handles mixed resolved and unresolved IDs", () => {
+    const doc = makeTestDoc({
+      spans: [
+        makeSpan({ spanId: "span:1", page: 7 }),
+        makeSpan({ spanId: "span:2", page: 8 }),
+      ],
+    });
+
+    const result = resolveEvidenceSpans(["span:1", "span:missing"], doc);
+    expect(result.allResolved).toBe(false);
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].page).toBe(7);
+    expect(result.unresolvedIds).toEqual(["span:missing"]);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  test("returns correct page numbers from resolved spans", () => {
+    const doc = makeTestDoc({
+      spans: [
+        makeSpan({ spanId: "s1", page: 3 }),
+        makeSpan({ spanId: "s2", page: 5 }),
+        makeSpan({ spanId: "s3", page: 3 }),
+      ],
+    });
+
+    const result = resolveEvidenceSpans(["s1", "s2", "s3"], doc);
+    expect(pagesFromResolvedSpans(result)).toEqual([3, 5]);
+  });
+
+  test("returns empty pages when spans have no page", () => {
+    const doc = makeTestDoc({
+      spans: [
+        makeSpan({ spanId: "s1", page: null, text: "No page number" }),
+      ],
+    });
+
+    const result = resolveEvidenceSpans(["s1"], doc);
+    expect(pagesFromResolvedSpans(result)).toEqual([]);
+  });
+
+  test("quotesFromResolvedSpans returns deduped span text", () => {
+    const doc = makeTestDoc({
+      spans: [
+        makeSpan({ spanId: "s1", text: "Baseline scenario description", page: 5 }),
+        makeSpan({ spanId: "s2", text: "Same text appears here too", page: 6 }),
+      ],
+    });
+
+    const result = resolveEvidenceSpans(["s1", "s2"], doc);
+    expect(quotesFromResolvedSpans(result)).toEqual([
+      "Baseline scenario description",
+      "Same text appears here too",
+    ]);
+  });
+
+  test("sectionsFromResolvedSpans returns deduped section paths", () => {
+    const doc = makeTestDoc({
+      spans: [
+        makeSpan({ spanId: "s1", sectionPath: ["section:4", "section:4.2", "section:4.2.4"], page: 15 }),
+      ],
+    });
+
+    const result = resolveEvidenceSpans(["s1"], doc);
+    expect(sectionsFromResolvedSpans(result)).toEqual(["section:4 > section:4.2 > section:4.2.4"]);
+  });
+});

--- a/tests/lib/quickCheck/resolveEvidenceSpans.test.ts
+++ b/tests/lib/quickCheck/resolveEvidenceSpans.test.ts
@@ -124,4 +124,50 @@ describe("resolveEvidenceSpans", () => {
     const result = resolveEvidenceSpans(["s1"], doc);
     expect(sectionsFromResolvedSpans(result)).toEqual(["section:4 > section:4.2 > section:4.2.4"]);
   });
+
+  test("candidate spans on correct page are preferred over quote-matched span on wrong page", () => {
+    // Simulates the router provenance scenario:
+    // - Candidate span (s1) is the correct source: page 15, section 4.2.4
+    // - Quote validation fuzzy-matched an overlapping span (s2) on page 1 (TOC echo)
+    const doc = makeTestDoc({
+      spans: [
+        makeSpan({
+          spanId: "s1",
+          page: 15,
+          sectionPath: ["section:4", "section:4.2", "section:4.2.4"],
+          heading: "Baseline Scenario",
+          headingPath: ["Baseline Scenario"],
+          text: "Without the project, deforestation continues at 2% annually.",
+          normalizedText: "without the project deforestation continues at 2 annually",
+        }),
+        makeSpan({
+          spanId: "s2",
+          page: 1,
+          sectionPath: ["section:1"],
+          heading: "Table of Contents",
+          headingPath: ["Table of Contents"],
+          text: "Without the project, deforestation continues at 2% annually.",
+          normalizedText: "without the project deforestation continues at 2 annually",
+        }),
+      ],
+    });
+
+    const candidateSpanIds = ["s1"]; // correct candidate
+    const quoteMatchedIds = ["s2"]; // quote validation matched wrong page
+
+    const canonical = resolveEvidenceSpans(candidateSpanIds, doc);
+    const matching = resolveEvidenceSpans(quoteMatchedIds, doc);
+
+    // Canonical resolution finds page 15
+    expect(pagesFromResolvedSpans(canonical)).toEqual([15]);
+    // Quote-matched resolution finds page 1 (wrong)
+    expect(pagesFromResolvedSpans(matching)).toEqual([1]);
+
+    // The router must prefer canonical spans for provenance
+    const resolvedPages = pagesFromResolvedSpans(canonical);
+    const usingCanonical = resolvedPages.length > 0;
+    expect(usingCanonical).toBe(true);
+    // evidenceSpanIds must be the canonical IDs, not quote-matched IDs
+    expect(usingCanonical ? candidateSpanIds : quoteMatchedIds).toEqual(["s1"]);
+  });
 });

--- a/tests/lib/quickCheckEvidence.test.ts
+++ b/tests/lib/quickCheckEvidence.test.ts
@@ -53,7 +53,7 @@ describe("quick check evidence analysis", () => {
     expect(analysis.facts.map((fact) => fact.summary)).toEqual(
       expect.arrayContaining([
         "The PDD references the mapped project area or AOI",
-        "The PDF states a monitoring or reporting period",
+        "The file contains an explicit reporting or monitoring period with a date range",
         "The project location is described in the PDD",
         "The project has documented monitoring evidence",
       ]),
@@ -101,7 +101,7 @@ describe("quick check evidence analysis", () => {
     expect(analysis.facts.map((fact) => fact.summary)).toEqual(
       expect.arrayContaining([
         "The PDD references the mapped project area or AOI",
-        "The PDF states a monitoring or reporting period",
+        "The file contains an explicit reporting or monitoring period with a date range",
         "The project has documented monitoring evidence",
       ]),
     );
@@ -202,7 +202,7 @@ describe("quick check evidence analysis", () => {
 
     expect(preview.extractedFacts).toEqual([
       "The PDD references the mapped project area or AOI: Project area Makueni County and Kitui County.",
-      "The PDF states a monitoring or reporting period: Reporting period 1 April 2024 - 31 March 2025.",
+      "The file contains an explicit reporting or monitoring period with a date range: Reporting period 1 April 2024 - 31 March 2025.",
       "The project has documented monitoring evidence",
     ]);
   });
@@ -440,7 +440,7 @@ describe("quick check evidence analysis", () => {
     expect(analysis.facts.map((fact) => fact.summary)).toEqual(
       expect.arrayContaining([
         "The project location is described in the PDD",
-        "The PDF states a monitoring or reporting period",
+        "The file contains an explicit reporting or monitoring period with a date range",
       ]),
     );
     expect(analysis.warnings).not.toContain(expect.stringContaining("fallback parser"));

--- a/tests/lib/quickCheckEvidence.test.ts
+++ b/tests/lib/quickCheckEvidence.test.ts
@@ -3,7 +3,7 @@
 import fs from "fs";
 import path from "path";
 import { describe, expect, it } from "@jest/globals";
-import { analyzeQuickCheckEvidence, buildLocalRuleCandidates, buildQuickCheckQueryTexts, classifyQuickCheckClaimIntents, extractMethodologyMentions, extractPdfText } from "@/lib/chat/quickCheckEvidence";
+import { analyzeQuickCheckEvidence, buildLocalRuleCandidates, buildQuickCheckQueryTexts, classifyQuickCheckClaimIntents, extractMethodologyMentions, extractPdfText, extractReportingPeriodDetail } from "@/lib/chat/quickCheckEvidence";
 import { buildQuickCheckExtractionSnapshot, deriveQuickCheckExtractionState } from "@/lib/chat/quickCheckUi";
 import { parseWorkbookEvidenceAsset } from "@/lib/evidence/workbook";
 import { putAttachmentBytes } from "@/lib/proofMap/attachments";
@@ -715,7 +715,29 @@ describe("extractMethodologyMentions — standard detection hardening", () => {
       "APD",
       "ARR",
       "RWE",
-      "APWD",
-    ]));
+       "APWD",
+     ]));
+  });
+});
+
+describe("extractReportingPeriodDetail", () => {
+  it("accepts full date range with to separator", () => {
+    const result = extractReportingPeriodDetail("Reporting period 01 January 2024 to 31 December 2024.");
+    expect(result).toBe("Reporting period 01 January 2024 to 31 December 2024.");
+  });
+
+  it("accepts full date range with dash separator", () => {
+    const result = extractReportingPeriodDetail("Monitoring period 1 April 2024 - 31 March 2025.");
+    expect(result).toBe("Reporting period 1 April 2024 - 31 March 2025.");
+  });
+
+  it("rejects single date with no end date", () => {
+    const result = extractReportingPeriodDetail("Reporting period: 01 January 2024");
+    expect(result).toBeUndefined();
+  });
+
+  it("rejects incidental mention with no date range", () => {
+    const result = extractReportingPeriodDetail("The monitoring period was adequate for this validation.");
+    expect(result).toBeUndefined();
   });
 });

--- a/tests/lib/quickCheckUi.test.ts
+++ b/tests/lib/quickCheckUi.test.ts
@@ -58,7 +58,7 @@ describe("quick check ui helpers", () => {
           {
             id: "reporting-period",
             category: "reporting-period",
-            summary: "The PDF states a monitoring or reporting period",
+            summary: "The file contains an explicit reporting or monitoring period with a date range",
             matchText: "reporting period stated",
             sourceLabel: "malawi-strong-signal-evidence.pdf",
             detail: "Reporting period: 1 January 2025 to 31 December 2025.",
@@ -73,7 +73,7 @@ describe("quick check ui helpers", () => {
     });
 
     expect(snapshot.extractedFacts).toEqual([
-      "The PDF states a monitoring or reporting period: Reporting period: 1 January 2025 to 31 December 2025.",
+      "The file contains an explicit reporting or monitoring period with a date range: Reporting period: 1 January 2025 to 31 December 2025.",
     ]);
   });
 
@@ -109,7 +109,7 @@ describe("quick check ui helpers", () => {
           {
             id: "reporting-period",
             category: "reporting-period",
-            summary: "The PDF states a monitoring or reporting period",
+            summary: "The file contains an explicit reporting or monitoring period with a date range",
             matchText: "reporting period stated",
             sourceLabel: "fresh-monitoring-report.pdf",
             detail: "Reporting period: 1 January 2025 to 31 December 2025.",
@@ -281,7 +281,7 @@ describe("quick check ui helpers", () => {
           {
             id: "reporting-period",
             category: "reporting-period",
-            summary: "The PDF states a monitoring or reporting period",
+            summary: "The file contains an explicit reporting or monitoring period with a date range",
             matchText: "reporting period",
             sourceLabel: "monitoring-upload.pdf",
             detail: "Reporting period: 1 January 2017 to 31 December 2017.",
@@ -592,7 +592,7 @@ describe("quick check ui helpers", () => {
       extraction: {
         documentType: "PDD / PDF",
         extractedFacts: [
-          "The PDF states a monitoring or reporting period",
+          "The file contains an explicit reporting or monitoring period with a date range",
           "The project has documented monitoring evidence",
         ],
         methodologyMentions: [],


### PR DESCRIPTION
## WHAT

Fix Quick Check provenance and intake preview labels system-wide. A support/foundation fix before Phase 4.

## ROOT CAUSE

When `EvidenceSpan.page` is null, `filterCandidateSpans` in `validateQuotes.ts` skips the page filter (`quote.page != null` evaluates to false), letting page-1 spans match during quote validation. The router`s `finalizeCandidate` then used quote-validation `matchedSpanIds` for page provenance, producing wrong page numbers in answers and correction exports.

## CHANGES

### 1. EvidenceSpan resolution (`resolveEvidenceSpans.ts` — NEW)
- Canonical span resolver — single source of truth for page/section/quote provenance
- Validates evidenceSpanIds against EvidenceDocument
- Returns resolved spans + unresolved IDs + warnings
- Helper functions: `pagesFromResolvedSpans`, `sectionsFromResolvedSpans`, `quotesFromResolvedSpans`

### 2. Router provenance fix (`deterministicRouter.ts`)
- `finalizeCandidate` now uses candidate`s original `evidenceSpanIds` for pages/sections/quotes
- Falls back to quote-matched spans only when candidate spans have no pages
- Emits warnings when provenance sources differ or span IDs fail to resolve

### 3. Check provenance fix (`evidenceChecks.ts`)
- `validateCheck` resolves candidate`s `evidenceSpanId` against the document
- Corrects page provenance when candidate page disagrees with resolved span
- Emits warning when resolution fails

### 4. DocumentIntakeProfile (`documentIntakeProfile.ts` — NEW)
- Evidence-backed intake profile type: `documentType`, `documentFamily`, `detectedContents[]`
- Each `DetectedContent` includes: `label`, `confidence`, `evidenceSpanIds`, `pageNumbers`, `reason`, `negativeWarning`
- Replaces loose keyword-based chip detection

### 5. Reporting period guard (`quickCheckEvidence.ts`)
- Only emits "Reporting period" when an explicit date range is found (e.g. "01 January 2024 to 31 December 2024")
- No longer matches incidental mentions of "reporting period" or "monitoring period" in validation reports

## TESTS

| File | Tests | Focus |
|---|---|---|
| `resolveEvidenceSpans.test.ts` | 7 | Resolution, missing IDs, pages, quotes, sections |
| `documentIntakeProfile.test.ts` | 4 | Profile building, reporting period guard, required fields |
| **Key regressions** | 77 pass | sectionTableIndex, evidenceCompilerV2, projectFactContractV2, evidenceSpanIndex, queryIntentAnalyzer |

## VALIDATION

```
npx tsc --noEmit                                 ✓
npm run lint                                     ✓ (0 warnings)
resolve + intake + key quick check tests         77/77 PASS
quickcheck:eval:corpus --strict                  8/8 PASS, 100%, 0 regressions
```

## RULES KEPT

- No LLM calls
- No UI changes
- No eval threshold weakening
- No one-off hardcoded patch
- No Phase 4 started

**Signed-off-by:** Fred Egbuedike fredilly@article6.org