### PR TITLE
fix: preserve null primary methodology for CCB validation reports

### DIFF
--- a/src/lib/chat/methodologyRoleClassifier.ts
+++ b/src/lib/chat/methodologyRoleClassifier.ts
@@ -56,6 +56,22 @@ const BACKGROUND_NEGATIVE_PATTERNS = [
   /\bannex\b/i,
 ];
 
+const JOINT_ASSESSMENT_PATTERNS = [
+  /\bjoint\s+assessment\b/i,
+  /\bauditor\s+qualifications?\b/i,
+  /\bwork\s+carried\s+out\s+by\b/i,
+  /\btechnical\s+expert\b/i,
+  /\btechnical\s+reviewer\b/i,
+];
+
+const CCB_FAMILY_PATTERNS = [
+  /\bccba\s+(?:project\s+)?validation\s+report\b/i,
+  /\bclimate,\s*community\s*and\s*biodiversity\s+(?:project\s+)?design\s+standards?\b/i,
+  /\bccb\s+(?:standards?\s+)?second\s+edition\b/i,
+  /\bccb[- ]?validation\s+conclusion\b/i,
+  /\bgold\s+level\b.*\bccb\b/i,
+];
+
 const CALCULATION_CONTEXT_PATTERNS = [
   /calculated using/i,
   /as per methodology/i,
@@ -266,6 +282,22 @@ function dedupeEntries(entries: MethodologyEntry[]): MethodologyEntry[] {
   return Array.from(seen.values());
 }
 
+function detectDocumentFamily(rawText: string): string | null {
+  if (!rawText?.trim()) return null;
+  const header = rawText.slice(0, 2000).toLowerCase();
+  let ccbScore = 0;
+  for (const pattern of CCB_FAMILY_PATTERNS) {
+    if (pattern.test(header)) ccbScore += 1;
+  }
+  return ccbScore > 0 ? "CCBA/CCB" : null;
+}
+
+function isJointAssessmentContext(lines: string[], lineIndex: number): boolean {
+  const windowLines = getLineWindow(lines, lineIndex, LINE_WINDOW);
+  const windowText = windowLines.join("\n");
+  return JOINT_ASSESSMENT_PATTERNS.some((p) => p.test(windowText));
+}
+
 export function classifyMethodologyRoles(rawText: string): MethodologyClassification {
   if (!rawText?.trim()) {
     return { primaryMethodology: null, monitoringMethodology: null, referencedMethods: [] };
@@ -293,6 +325,7 @@ export function classifyMethodologyRoles(rawText: string): MethodologyClassifica
   const uniqueMatches = Array.from(seen.values());
 
   const entries: MethodologyEntry[] = [];
+  const documentFamily = detectDocumentFamily(rawText);
   for (const match of uniqueMatches) {
     const version = extractNearbyVersion(lines, match.lineIndex);
     const sectionTitles = extractSectionTitles(lines, match.lineIndex);
@@ -303,13 +336,23 @@ export function classifyMethodologyRoles(rawText: string): MethodologyClassifica
       sectionTitles,
     );
 
+    // CCBA/CCB document family override: VM methods in joint-assessment context
+    // are supporting carbon-accounting references, not primary methodology
+    let effectiveRole = role;
+    let effectiveReason = reason;
+    const isVMMethod = /^VM\d{4}$/i.test(match.code);
+    if (documentFamily === "CCBA/CCB" && isVMMethod && isJointAssessmentContext(lines, match.lineIndex)) {
+      effectiveRole = "REFERENCED_CALCULATION_METHOD";
+      effectiveReason = "VM method in CCBA/CCB joint-assessment context — supporting reference, not primary";
+    }
+
     entries.push({
       id: match.code,
       version,
-      role,
+      role: effectiveRole,
       confidence,
       evidenceSection,
-      reason,
+      reason: effectiveReason,
     });
   }
 

--- a/src/lib/chat/quickCheckMethodSignals.ts
+++ b/src/lib/chat/quickCheckMethodSignals.ts
@@ -122,7 +122,8 @@ const PRIMARY_ALIASES: AliasEntry[] = [
 const PROGRAM_SIGNALS: ProgramEntry[] = [
   { pattern: /^Verra$/i, program: "Verra", priority: 0 },
   { pattern: /^VCS$/i, program: "Verra", priority: 1 },
-  { pattern: /^CCB$/i, program: "Verra", priority: 2 },
+  { pattern: /^CCB$/i, program: "CCBA", priority: 2 },
+  { pattern: /^CCBA$/i, program: "CCBA", priority: 2 },
   { pattern: /^Verified\s*Carbon\s*Standard$/i, program: "Verra", priority: 1 },
   { pattern: /^UNFCCC$/i, program: "UNFCCC", priority: 0 },
   { pattern: /^CDM$/i, program: "UNFCCC", priority: 1 },

--- a/src/lib/chat/quickCheckMethodology.ts
+++ b/src/lib/chat/quickCheckMethodology.ts
@@ -56,6 +56,15 @@ export type QuickCheckMethodologyResolution =
       primaryMethodology: QuickCheckPrimaryMethodology;
     }
   | {
+      status: "deferred";
+      rawMentions: string[];
+      programSignals: string[];
+      signals: QuickCheckMethodologySignal[];
+      matchedMethods: QuickCheckResolvedMethodology[];
+      unsupportedCanonicalKeys: string[];
+      primaryMethodology: null;
+    }
+  | {
       status: "multiple";
       rawMentions: string[];
       programSignals: string[];
@@ -239,6 +248,28 @@ const NEGATIVE_CONTEXT_PATTERNS = [
   /\bannex\b/i,
 ];
 
+const JOINT_ASSESSMENT_PATTERNS = [
+  /\bjoint\s+assessment\b/i,
+  /\bauditor\s+qualifications?\b/i,
+  /\bwork\s+carried\s+out\s+by\b/i,
+  /\btechnical\s+expert\b/i,
+  /\btechnical\s+reviewer\b/i,
+];
+
+const CCB_FAMILY_PATTERNS = [
+  /\bccba\s+(?:project\s+)?validation\s+report\b/i,
+  /\bclimate,\s*community\s*and\s*biodiversity\s+(?:project\s+)?design\s+standards?\b/i,
+  /\bccb\s+(?:standards?\s+)?second\s+edition\b/i,
+  /\bccb[- ]?validation\s+conclusion\b/i,
+  /\bgold\s+level\b.*\bccb\b/i,
+];
+
+const VCS_FAMILY_PATTERNS = [
+  /\bvcs\s+version\s+\d+\b/i,
+  /\bverified\s+carbon\s+standard\s+version\s+\d+(?:\.\d+)?\b/i,
+  /\bvalidation\s+report:?\s*vcs\b/i,
+];
+
 function buildSignalSearchPatterns(signal: QuickCheckMethodologySignal): RegExp[] {
   const canonical = signal.canonicalKey;
   const patterns = new Set<string>([canonical, signal.raw.trim().toUpperCase()]);
@@ -254,11 +285,27 @@ function buildSignalSearchPatterns(signal: QuickCheckMethodologySignal): RegExp[
   return Array.from(patterns).map((pattern) => new RegExp(`\\b${pattern}\\b`, "i"));
 }
 
-function scoreMethodologyContext(rawText: string | undefined, signal: QuickCheckMethodologySignal): number {
+function detectDocumentFamily(rawText: string | undefined): string | null {
+  if (!rawText?.trim()) return null;
+  const header = rawText.slice(0, 2000).toLowerCase();
+  let ccbScore = 0;
+  let vcsScore = 0;
+  for (const pattern of CCB_FAMILY_PATTERNS) {
+    if (pattern.test(header)) ccbScore += 1;
+  }
+  for (const pattern of VCS_FAMILY_PATTERNS) {
+    if (pattern.test(header)) vcsScore += 1;
+  }
+  if (ccbScore > 0 && ccbScore >= vcsScore) return "CCBA/CCB";
+  if (vcsScore > 0) return "VCS";
+  return null;
+}
+
+function scoreMethodologyContext(rawText: string | undefined, signal: QuickCheckMethodologySignal, documentFamily?: string | null): number {
   if (!rawText?.trim()) return 0;
   const lines = rawText.split(/\r?\n/);
   const searchPatterns = buildSignalSearchPatterns(signal);
-  let bestScore = 0;
+  let bestScore: number | null = null;
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
@@ -276,10 +323,16 @@ function scoreMethodologyContext(rawText: string | undefined, signal: QuickCheck
     if (POSITIVE_CONTEXT_PATTERNS.some((pattern) => pattern.test(localWindow))) score += 20;
     if (NEGATIVE_CONTEXT_PATTERNS.some((pattern) => pattern.test(localWindow))) score -= 80;
 
-    bestScore = Math.max(bestScore, score);
+    // CCBA/CCB joint-assessment penalty: VM methods mentioned in assessment context are supporting references
+    const isVMMethod = /^VM\d{4}$/i.test(signal.canonicalKey);
+    if (documentFamily === "CCBA/CCB" && isVMMethod) {
+      if (JOINT_ASSESSMENT_PATTERNS.some((pattern) => pattern.test(localWindow))) score -= 120;
+    }
+
+    if (bestScore === null || score < bestScore) bestScore = score;
   }
 
-  return bestScore;
+  return bestScore ?? 0;
 }
 
 export function resolvePrimaryMethodology(input: {
@@ -295,7 +348,8 @@ export function resolvePrimaryMethodology(input: {
     const signal = parseMethodologySignal(mention);
     if (!signal || signal.kind !== "method") continue;
     const candidates = methodIndex.get(signal.canonicalKey) ?? [];
-    const contextScore = scoreMethodologyContext(input.rawText, signal);
+    const documentFamily = detectDocumentFamily(input.rawText);
+    const contextScore = scoreMethodologyContext(input.rawText, signal, documentFamily);
     const existing = scoredCandidates.get(signal.canonicalKey);
     const next = {
       canonicalKey: signal.canonicalKey,
@@ -309,7 +363,9 @@ export function resolvePrimaryMethodology(input: {
     }
     existing.supported = existing.supported || next.supported;
     existing.priority = Math.min(existing.priority, next.priority);
-    existing.contextScore = Math.max(existing.contextScore, next.contextScore);
+    existing.contextScore = existing.contextScore === null
+      ? next.contextScore
+      : Math.min(existing.contextScore, next.contextScore ?? 0);
   }
 
   const ranked = Array.from(scoredCandidates.values()).sort(
@@ -323,7 +379,8 @@ export function resolvePrimaryMethodology(input: {
 
   const top = ranked[0]!;
   const second = ranked[1] ?? null;
-  if (ranked.length > 1 && top.contextScore <= 0) return null;
+  // Reject when the best candidate has negative context score (e.g. CCBA/CCB joint-assessment penalty)
+  if ((!second && top.contextScore < 0) || (input.rawText?.trim() && ranked.length > 1 && top.contextScore <= 0)) return null;
   const ambiguous = second && top.contextScore === second.contextScore && top.priority === second.priority;
   const effectiveTop = ambiguous ? null : top;
   if (!effectiveTop) return null;
@@ -447,6 +504,17 @@ export function resolveQuickCheckMethodology(input: {
   }
 
   if (resolvedMethods.length === 1 && unsupportedCanonicalKeys.length === 0) {
+    if (!primaryMethodology) {
+      return {
+        status: "deferred",
+        rawMentions,
+        programSignals,
+        signals,
+        matchedMethods: resolvedMethods,
+        unsupportedCanonicalKeys: [],
+        primaryMethodology: null,
+      };
+    }
     return {
       status: "single",
       rawMentions,
@@ -454,12 +522,7 @@ export function resolveQuickCheckMethodology(input: {
       signals,
       matchedMethods: [resolvedMethods[0]!],
       unsupportedCanonicalKeys: [],
-      primaryMethodology: primaryMethodology ?? {
-        canonicalKey: resolvedMethods[0]!.canonicalKeys[0] ?? resolvedMethods[0]!.methodologyId,
-        supported: true,
-        matchedMethod: resolvedMethods[0]!,
-        secondaryCanonicalKeys: [],
-      },
+      primaryMethodology,
     };
   }
 
@@ -467,7 +530,7 @@ export function resolveQuickCheckMethodology(input: {
       const hasStrongPrimary =
         (primaryMethodology.matchedMethod.contextScore ?? 0) > 0 ||
         primaryMethodology.secondaryCanonicalKeys.length > 0;
-    if (hasStrongPrimary) {
+    if (hasStrongPrimary && resolvedMethods.length <= 1) {
       return {
         status: "single",
         rawMentions,
@@ -481,6 +544,17 @@ export function resolveQuickCheckMethodology(input: {
   }
 
   if (resolvedMethods.length > 0) {
+    if (!primaryMethodology) {
+      return {
+        status: "deferred",
+        rawMentions,
+        programSignals,
+        signals,
+        matchedMethods: resolvedMethods,
+        unsupportedCanonicalKeys,
+        primaryMethodology: null,
+      };
+    }
     return {
       status: "multiple",
       rawMentions,
@@ -488,12 +562,19 @@ export function resolveQuickCheckMethodology(input: {
       signals,
       matchedMethods: resolvedMethods,
       unsupportedCanonicalKeys,
-      primaryMethodology: primaryMethodology ?? {
-        canonicalKey: resolvedMethods[0]!.canonicalKeys[0] ?? resolvedMethods[0]!.methodologyId,
-        supported: true,
-        matchedMethod: resolvedMethods[0]!,
-        secondaryCanonicalKeys: resolvedMethods.slice(1).map((method) => method.canonicalKeys[0] ?? method.methodologyId),
-      },
+      primaryMethodology,
+    };
+  }
+
+  if (!primaryMethodology && unsupportedCanonicalKeys.length === 0) {
+    return {
+      status: "none",
+      rawMentions,
+      programSignals,
+      signals,
+      matchedMethods: [],
+      unsupportedCanonicalKeys: [],
+      primaryMethodology: null,
     };
   }
 

--- a/src/lib/chat/quickCheckUi.ts
+++ b/src/lib/chat/quickCheckUi.ts
@@ -539,6 +539,9 @@ export function buildExtractionPreviewViewModel(input: {
     methodologyConfidence = confidenceBucket(input.analysis.extractionConfidence) === "low" ? "medium" : confidenceBucket(input.analysis.extractionConfidence);
   } else if (input.methodologyResolution?.status === "multiple" || input.methodologyResolution?.status === "unsupported") {
     methodologyConfidence = "low";
+  } else if (input.methodologyResolution?.status === "deferred") {
+    detectedMethodology = "Not confidently detected";
+    methodologyConfidence = "low";
   }
 
   const warning =

--- a/tests/fixtures/quick-check/ccb-validation-report-extracted.txt
+++ b/tests/fixtures/quick-check/ccb-validation-report-extracted.txt
@@ -1,0 +1,24 @@
+CCBA Project Validation Report
+Climate, Community & Biodiversity Project Design Standards Second Edition
+
+Project Title: Cordillera Azul National Park REDD Project
+Document Prepared By: EcoDecisión
+Project Location: Peru
+
+Section 1: Project Description
+This project is located in the Cordillera Azul National Park in Peru.
+
+Section 2: Joint Assessment
+This validation report documents the joint assessment of the project. The validation was carried out under the Verified Carbon Standard (VCS) and the REDD methodology VM0007, in combination with the Climate, Community and Biodiversity (CCB) Standards.
+
+Section 3: Audit Summary
+A team of auditors including a VCS AFOLU expert reviewed the project documentation.
+The auditor qualifications are attached in Appendix A.
+
+Section 4: CCB Standards Assessment
+The validation assessed compliance with CCB Standards Second Edition for Gold Level criteria. The validation conclusion is that the project meets the requirements.
+
+References:
+The project uses the REDD Methodology Framework (REDD-MF) based on VM0007. Supporting documents are referenced in the annex.
+
+VM0007

--- a/tests/lib/ccb-methodology-regression.test.ts
+++ b/tests/lib/ccb-methodology-regression.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import { resolveQuickCheckMethodology, resolvePrimaryMethodology } from "@/lib/chat/quickCheckMethodology";
+
+const methods = [
+  { code: "VM0007", latestVersion: "v1-0", versions: ["v1-0"] },
+];
+
+const CCB_RAW_TEXT = `CCBA Project Validation Report
+Climate, Community & Biodiversity Project Design Standards Second Edition
+
+Section 2: Joint Assessment
+This validation report documents the joint assessment of the project. The validation was carried out under the Verified Carbon Standard (VCS) and the REDD methodology VM0007, in combination with the Climate, Community and Biodiversity (CCB) Standards.
+
+Section 3: Audit Summary
+A team of auditors including a VCS AFOLU expert reviewed the project documentation.
+The auditor qualifications are attached in Appendix A.
+
+VM0007
+`;
+
+const VCS_RAW_TEXT = `VALIDATION REPORT VCS Version 3
+against the Verified Carbon Standard version 3.3 and its supporting documents including the approved methodology VM0007 version 1.3 REDD Methodology Modules
+VM0007
+`;
+
+describe("CCB regression — resolvePrimaryMethodology", () => {
+  it("must return null for CCB validation report text (VM0007 in joint-assessment context)", () => {
+    const result = resolvePrimaryMethodology({
+      mentions: ["VM0007", "VCS", "CCB"],
+      methods,
+      rawText: CCB_RAW_TEXT,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("must return VM0007 for VCS validation report text (primary context)", () => {
+    const result = resolvePrimaryMethodology({
+      mentions: ["VM0007", "VCS"],
+      methods,
+      rawText: VCS_RAW_TEXT,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.canonicalKey).toBe("VM0007");
+  });
+
+  it("must return 'deferred' status for CCB report in resolveQuickCheckMethodology", () => {
+    const result = resolveQuickCheckMethodology({
+      mentions: ["VM0007", "VCS", "CCB", "VM0007"],
+      methods,
+      rawText: CCB_RAW_TEXT,
+    });
+    expect(result.status).toBe("deferred");
+    expect(result.primaryMethodology).toBeNull();
+    expect(result.matchedMethods.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("must return 'single' for VCS report in resolveQuickCheckMethodology", () => {
+    const result = resolveQuickCheckMethodology({
+      mentions: ["VM0007", "VCS"],
+      methods,
+      rawText: VCS_RAW_TEXT,
+    });
+    expect(result.status).toBe("single");
+    expect(result.primaryMethodology?.canonicalKey).toBe("VM0007");
+  });
+});

--- a/tests/lib/ccb-validation-report.regression.test.ts
+++ b/tests/lib/ccb-validation-report.regression.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import { classifyMethodologyRoles } from "@/lib/chat/methodologyRoleClassifier";
+
+describe("CCB validation report fixture", () => {
+  it("classifyMethodologyRoles must NOT promote VM0007 to primary for CCB report text", () => {
+    const text = fs.readFileSync(
+      path.join(process.cwd(), "tests/fixtures/quick-check/ccb-validation-report-extracted.txt"),
+      "utf-8",
+    );
+    const result = classifyMethodologyRoles(text);
+    expect(result.primaryMethodology).toBeNull();
+    expect(result.referencedMethods.some((m) => m.id === "VM0007")).toBe(true);
+  });
+});

--- a/tests/lib/quickCheckMethodSignals.cordillera.test.ts
+++ b/tests/lib/quickCheckMethodSignals.cordillera.test.ts
@@ -268,7 +268,7 @@ describe("Cordillera Azul — current behavior (all pass)", () => {
 //
 // Run them explicitly: npx jest --no-coverage tests/lib/quickCheckMethodSignals.cordillera.test.ts
 
-describe.skip("Cordillera Azul — gap detectors (will pass after fixes)", () => {
+describe.skip("Cordillera Azul — gap detectors (will pass after full-text awareness)", () => {
   it("CCB report: VM0007 must NOT resolve as primary methodology", () => {
     const mentions = ccbReportMentions();
     const result = resolveMethodologySignals(mentions, FULL_INVENTORY);
@@ -306,20 +306,6 @@ describe.skip("Cordillera Azul — gap detectors (will pass after fixes)", () =>
     expect(label).toBeNull();
   });
 
-  it("PDD: Dual VCS+CCB standards must NOT collapse into single Verra bucket", () => {
-    const mentions = pddMentions();
-    const result = resolveMethodologySignals(mentions, FULL_INVENTORY);
-    const uniquePrograms = new Set(result.detectedPrograms.map((p) => p.program));
-    expect(uniquePrograms.size).toBeGreaterThanOrEqual(2);
-  });
-
-  it("Monitoring: Dual VCS+CCB must not collapse into single Verra bucket", () => {
-    const mentions = monitoringMentions();
-    const result = resolveMethodologySignals(mentions, FULL_INVENTORY);
-    const uniquePrograms = new Set(result.detectedPrograms.map((p) => p.program));
-    expect(uniquePrograms.size).toBeGreaterThanOrEqual(2);
-  });
-
   it("Cross-doc: methodology role NOT decided by mention count alone", () => {
     const ccbMentions = ccbReportMentions();
     const vcsMentions = vcsReportMentions();
@@ -354,6 +340,27 @@ describe.skip("Cordillera Azul — gap detectors (will pass after fixes)", () =>
   });
 });
 
+// ─── Recently enabled gap detectors ──────────────────────────────────────
+//
+// These were previously in describe.skip but now PASS with the
+// CCBA program signal fix in quickCheckMethodSignals.ts.
+
+describe("Cordillera Azul — newly enabled (previously gap detectors)", () => {
+  it("PDD: Dual VCS+CCB standards must NOT collapse into single Verra bucket", () => {
+    const mentions = pddMentions();
+    const result = resolveMethodologySignals(mentions, FULL_INVENTORY);
+    const uniquePrograms = new Set(result.detectedPrograms.map((p) => p.program));
+    expect(uniquePrograms.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("Monitoring: Dual VCS+CCB must not collapse into single Verra bucket", () => {
+    const mentions = monitoringMentions();
+    const result = resolveMethodologySignals(mentions, FULL_INVENTORY);
+    const uniquePrograms = new Set(result.detectedPrograms.map((p) => p.program));
+    expect(uniquePrograms.size).toBeGreaterThanOrEqual(2);
+  });
+});
+
 // ─── Before/after behavior documentation ─────────────────────────────────
 //
 // BEFORE FIX:
@@ -362,7 +369,7 @@ describe.skip("Cordillera Azul — gap detectors (will pass after fixes)", () =>
 //   VCS and CCB reports → identical program resolution (both "Verra")
 //
 // AFTER FIX:
-//   ccbReportMentions() → resolveMethodologySignals → noMethodDetected: true
+//   ccbReportMentions() → resolveMethodologySignals → noMethodDetected: true (needs full-text awareness)
 //   CCB program → "CCBA/CCB" (separate family)
 //   VCS report → program "Verra/VCS"
 //   CCB report → program "CCBA/CCB"

--- a/tests/lib/quickCheckMethodSignals.test.ts
+++ b/tests/lib/quickCheckMethodSignals.test.ts
@@ -152,13 +152,13 @@ describe("Program signals (Tier 2)", () => {
     expect(result.detectedPrograms[0]!.program).toBe("Verra");
   });
 
-  it("detects CCB as Verra program", () => {
+  it("detects CCB as CCBA program", () => {
     const result = resolveMethodologySignals(
       ["CCB"],
       makeInventory(["VM0007"]),
     );
     expect(result.programOnly).toBe(true);
-    expect(result.detectedPrograms[0]!.program).toBe("Verra");
+    expect(result.detectedPrograms[0]!.program).toBe("CCBA");
   });
 
   it("detects UNFCCC as program only", () => {


### PR DESCRIPTION
This PR proves and fixes the Cordillera CCB VM0007 primary-methodology bug on current main.

**Context:** PR #664 originally added methodology context ranking (`scoreMethodologyContext`, `resolvePrimaryMethodology`), but the CCB validation report still shows VM0007 as primary methodology on the live site. Live QA confirmed the bug persists.

**Root cause:** PR #664's merge was incomplete — no CCB/CCBA document family detection existed, no joint-assessment context penalty was applied, and fallback logic always synthesized a primary methodology even when `resolvePrimaryMethodology` returned null.

**What this PR does:**
- Adds CCBA/CCB document family detection in both `quickCheckMethodology.ts` and `methodologyRoleClassifier.ts`
- Adds joint-assessment context penalty (-120) for VM methods in CCBA/CCB documents
- Changes context score aggregation from Math.max (best) to worst-case tracking so negative penalties are preserved
- Adds `"deferred"` status to `QuickCheckMethodologyResolution` — methodology mentioned but not primary
- Fixes signal-level resolver: CCB/CCBA now maps to program `"CCBA"` (not `"Verra"`)
- Negative-context-score rejection for single-candidate cases

**Regression prevented:** CCB reports that mention VM0007 in joint-assessment/auditor-qualifications context cannot promote VM0007 to primary methodology.

**Verified behavior:**
| Doc | Current → Fixed | Status |
|---|---|---|
| CCB Validation | Primary: VM0007 ❌ → Primary: null, Supporting: VM0007 | ✅ Fixed |
| VCS Validation | Primary: VM0007 · 1.3 ✅ | ✅ Unchanged |
| PDD | Primary: Not detected ❌ (413 blocked) | ⚠️ Unchanged |
| Monitoring | Primary: Not detected ❌ (413 blocked) | ⚠️ Unchanged |

**Remaining gap:** PDD/Monitoring upload 413 if still blocked — no change to payload limits in this PR.