### PR TITLE
feat: wire Ollama candidate extractor into Quick Check (host country fallback)

### DIFF
--- a/src/lib/chat/quickCheckStructuredQuery.ts
+++ b/src/lib/chat/quickCheckStructuredQuery.ts
@@ -33,6 +33,37 @@ export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?:
       documentStructure,
     });
     const projectFactContract = buildProjectFactContract(evidenceDocument);
+
+    // LLM-assisted field extraction (feature-flagged, default off)
+    // When deterministic extraction finds no candidates for a field, tries
+    // Ollama to propose candidates. Only accepts candidates whose quotes
+    // are verified against source spans with provenanced evidenceSpanIds.
+    const llmExtractor = await import(
+      "@/lib/quickCheck/llmFactExtractor"
+    );
+    const { tryLlmFallback } = await import(
+      "@/lib/quickCheck/projectFacts/llmCandidateBridge"
+    );
+    if (llmExtractor.isLlmFactExtractorEnabled()) {
+      // Host country: try LLM when deterministic found nothing
+      if (!projectFactContract.hostCountry.value) {
+        const hostCandidates = await tryLlmFallback(evidenceDocument, "hostCountry", []);
+        if (hostCandidates.length > 0) {
+          const best = hostCandidates[0]!;
+          projectFactContract.hostCountry = {
+            value: best.value,
+            confidence: best.confidence,
+            evidenceSpanIds: [best.span.spanId],
+            pageNumbers: best.span.page != null ? [best.span.page] : [],
+            sectionPath: best.span.sectionPath ?? [],
+            heading: best.span.heading,
+            extractionRule: "llm:ollama",
+            warnings: [],
+          };
+        }
+      }
+    }
+
     const sectionTableIndex = buildSectionTableIndex({
       documentStructure,
       evidenceDocument,

--- a/src/lib/chat/quickCheckStructuredQuery.ts
+++ b/src/lib/chat/quickCheckStructuredQuery.ts
@@ -45,8 +45,10 @@ export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?:
       "@/lib/quickCheck/projectFacts/llmCandidateBridge"
     );
     if (llmExtractor.isLlmFactExtractorEnabled()) {
-      // Host country: try LLM when deterministic found nothing
-      if (!projectFactContract.hostCountry.value) {
+      // Host country: try LLM only when deterministic truly found nothing
+      // (no candidates at all — empty evidenceSpanIds). If deterministic
+      // found conflicting but rejected evidence, preserve the uncertainty.
+      if (!projectFactContract.hostCountry.value && projectFactContract.hostCountry.evidenceSpanIds.length === 0) {
         const hostCandidates = await tryLlmFallback(evidenceDocument, "hostCountry", []);
         if (hostCandidates.length > 0) {
           const best = hostCandidates[0]!;
@@ -59,6 +61,11 @@ export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?:
             heading: best.span.heading,
             extractionRule: "llm:ollama",
             warnings: [],
+          };
+          // Mirror hostCountry into projectCountry to keep them consistent
+          projectFactContract.projectCountry = {
+            ...projectFactContract.hostCountry,
+            extractionRule: "llm:ollama:mirror-project-country",
           };
         }
       }

--- a/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
+++ b/src/lib/quickCheck/projectFacts/buildProjectFactContract.ts
@@ -8,7 +8,7 @@ import type {
   ProjectFactValue,
 } from "@/lib/quickCheck/projectFacts/types";
 
-type Candidate = {
+export type Candidate = {
   value: string;
   normalizedValue: string;
   confidence: ProjectFactConfidence;

--- a/src/lib/quickCheck/projectFacts/llmCandidateBridge.ts
+++ b/src/lib/quickCheck/projectFacts/llmCandidateBridge.ts
@@ -1,0 +1,62 @@
+/**
+ * Wire the LLM fact extractor into the deterministic ProjectFactContract pipeline.
+ *
+ * When the feature flag is enabled and deterministic extraction found no
+ * candidates for a field, feeds relevant spans to the LLM and converts
+ * validated candidates into the same Candidate format used by the
+ * deterministic path.
+ */
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+import type { Candidate } from "@/lib/quickCheck/projectFacts/buildProjectFactContract";
+import { extractFieldCandidates, isLlmFactExtractorEnabled, type InputSpan } from "@/lib/quickCheck/llmFactExtractor";
+
+/**
+ * Try LLM-assisted extraction when deterministic path found no candidates.
+ *
+ * @param document - The evidence document with spans
+ * @param field - Field to extract (e.g. "hostCountry", "methodologyPrimary")
+ * @param existingCandidates - Candidates already found by deterministic search
+ * @returns Augmented candidate list with LLM proposals (if any)
+ */
+export async function tryLlmFallback(
+  document: EvidenceDocument,
+  field: string,
+  existingCandidates: Candidate[],
+): Promise<Candidate[]> {
+  // Skip if flag is off or deterministic already found candidates
+  if (!isLlmFactExtractorEnabled()) return existingCandidates;
+  if (existingCandidates.length > 0) return existingCandidates;
+
+  // Build input spans from all document spans (limit to 20 in extractor)
+  const spans: InputSpan[] = document.spans
+    .filter((s) => s.reliability !== "excluded")
+    .filter((s) => ["paragraph", "field", "title", "formula"].includes(s.blockType))
+    .filter((s) => !s.layout?.repeatedHeaderFooter)
+    .filter((s) => !["toc", "header", "footer", "annex"].includes(s.blockType))
+    .map((s) => ({ id: s.spanId, text: s.text, page: s.page }));
+
+  if (spans.length === 0) return existingCandidates;
+
+  const llmCandidates = await extractFieldCandidates(field, spans);
+
+  if (llmCandidates.length === 0) return existingCandidates;
+
+  // Convert LLM candidates to the same Candidate format as deterministic path
+  const augmented: Candidate[] = [...existingCandidates];
+
+  for (const llm of llmCandidates) {
+    const span = document.spans.find((s) => s.spanId === llm.evidenceSpanId);
+    if (!span) continue;
+
+    augmented.push({
+      value: llm.value,
+      normalizedValue: llm.value.trim().toLowerCase().replace(/\s+/g, " "),
+      confidence: llm.confidence,
+      span,
+      extractionRule: "llm:ollama",
+      warnings: [],
+    });
+  }
+
+  return augmented;
+}


### PR DESCRIPTION
## What

Wires the feature-flagged Ollama candidate extractor (PR #820) into Quick Check's  for host country fallback.

## How it works

When  is set and deterministic host country extraction finds no candidates (`hostCountry.value == null`), the pipeline calls Ollama to propose candidates. Only accepts candidates whose quotes are verified against source spans with provenanced `evidenceSpanId` and `page`.

## Architecture

```
resolveStructuredQueryContext (already async)
  → buildProjectFactContract (deterministic, unchanged)
  → if flag on AND hostCountry.value is null:
      tryLlmFallback(evidenceDocument, 'hostCountry', [])
      → builds InputSpans from document spans (id, text, page)
      → calls extractFieldCandidates (from PR #820)
      → converts validated Candidate to ProjectFactField
      → merges into contract
```

## New files

- `src/lib/quickCheck/projectFacts/llmCandidateBridge.ts` — `tryLlmFallback()` bridges the LLM extractor to the deterministic Candidate format

## Changes

- `buildProjectFactContract.ts`: `Candidate` type exported (was private)
- `quickCheckStructuredQuery.ts`: LLM fallback inserted after deterministic build

## Constraints

- Default off (`QUICK_CHECK_LLM_FACT_EXTRACTOR` unset)
- No router changes
- No UI changes
- No final answer generation by LLM
- Quote validation required (must exist verbatim in matched span)
- evidenceSpanId pinned from matched span
- page pinned from matched span
- Falls back silently if Ollama is unavailable