### PR TITLE
feat: add client-side LLM extraction helper with 11 supported fields

### DIFF
--- a/src/app/api/quick-check/llm-extract/route.ts
+++ b/src/app/api/quick-check/llm-extract/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { withMetrics } from "@/lib/metrics";
+import { isLlmFactExtractorEnabled, extractFieldCandidates } from "@/lib/quickCheck/llmFactExtractor";
+
+async function handlePost(request: Request) {
+  if (!isLlmFactExtractorEnabled()) {
+    return NextResponse.json(
+      { error: "LLM fact extractor is not enabled. Set QUICK_CHECK_LLM_FACT_EXTRACTOR=ollama." },
+      { status: 400 },
+    );
+  }
+
+  let body: {
+    field?: string;
+    spans?: Array<{ id: string; text: string; page: number | null }>;
+    question?: string;
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { field, spans, question } = body;
+
+  if (!field || typeof field !== "string") {
+    return NextResponse.json({ error: "Missing or invalid 'field' (string)." }, { status: 400 });
+  }
+
+  if (!Array.isArray(spans) || spans.length === 0) {
+    return NextResponse.json({ error: "Missing or empty 'spans' array." }, { status: 400 });
+  }
+
+  const candidates = await extractFieldCandidates(field, spans, question);
+
+  return NextResponse.json({
+    field,
+    question,
+    candidates,
+    count: candidates.length,
+  });
+}
+
+export const POST = withMetrics("api/quick-check/llm-extract:POST", handlePost);

--- a/src/lib/quickCheck/llmFactExtractor.ts
+++ b/src/lib/quickCheck/llmFactExtractor.ts
@@ -53,12 +53,21 @@ const SUPPORTED_FIELDS = [
   "hostCountry",
   "projectTitle",
   "methodologyPrimary",
+  "baselineScenario",
+  "additionality",
+  "leakage",
+  "stakeholderConsultation",
+  "monitoringPlan",
+  "projectBoundary",
+  "creditingPeriod",
+  "emissionReductionCalculation",
+  "applicabilityConditions",
 ] as const;
 
 const JSON_SHAPE_DESCRIPTION = `{
   "fields": [
     {
-      "field": "hostCountry" | "projectTitle" | "methodologyPrimary",
+      "field": "hostCountry" | "projectTitle" | "methodologyPrimary" | "baselineScenario" | "additionality" | "leakage" | "stakeholderConsultation" | "monitoringPlan" | "projectBoundary" | "creditingPeriod" | "emissionReductionCalculation" | "applicabilityConditions",
       "value": "extracted value as string",
       "quote": "exact verbatim text from the document that supports this value",
       "page": number or null,
@@ -78,12 +87,16 @@ export function isLlmFactExtractorEnabled(): boolean {
  * Build a prompt for the LLM from candidate evidence spans.
  * Only feeds relevant spans (not the full PDD text) to keep context small.
  */
-function buildPrompt(field: string, spans: InputSpan[]): string {
+function buildPrompt(field: string, spans: InputSpan[], question?: string): string {
   const snippetPreview = spans
     .map((s, i) => `[span ${i + 1}] (page ${s.page ?? "?"}): ${s.text}`)
     .join("\n");
 
-  return `You are a carbon project document analyst. Extract the "${field}" field from the following document spans.
+  const questionLine = question
+    ? `\nContext question: "${question}"`
+    : "";
+
+  return `You are a carbon project document analyst. Extract the "${field}" field from the following document spans.${questionLine}
 
 Rules:
 - Return ONLY valid JSON matching the shape below.
@@ -198,11 +211,13 @@ export function parseAndValidateCandidates(
  *
  * @param field - The field to extract (e.g. "hostCountry")
  * @param spans - Array of structured input spans with id, text, page
+ * @param question - Optional context question to guide extraction
  * @returns Array of validated candidate proposals (may be empty)
  */
 export async function extractFieldCandidates(
   field: string,
   spans: InputSpan[],
+  question?: string,
 ): Promise<LlmFactCandidate[]> {
   if (!isLlmFactExtractorEnabled()) return [];
   if (!SUPPORTED_FIELDS.includes(field as typeof SUPPORTED_FIELDS[number])) return [];
@@ -211,7 +226,7 @@ export async function extractFieldCandidates(
   // Limit spans to keep context small
   const limitedSpans = spans.slice(0, 20);
 
-  const prompt = buildPrompt(field, limitedSpans);
+  const prompt = buildPrompt(field, limitedSpans, question);
   const response = await callOllama(prompt);
 
   if (!response || response.error || !response.response) {

--- a/src/lib/quickCheck/llmUiClient.ts
+++ b/src/lib/quickCheck/llmUiClient.ts
@@ -1,0 +1,97 @@
+/**
+ * Client-side bridge to the LLM fact extraction API.
+ *
+ * After Quick Check completes deterministic extraction, call
+ * this for each check that returned "missing" or "unclear".
+ * Returns validated candidates with span provenance, or empty
+ * array if LLM is unavailable or couldn't find the answer.
+ */
+import type { InputSpan, LlmFactCandidate } from "@/lib/quickCheck/llmFactExtractor";
+
+const LLM_API_PATH = "/api/quick-check/llm-extract";
+
+/**
+ * Map check IDs to LLM field names and the question context to send.
+ */
+const CHECK_TO_FIELD: Record<string, { field: string; question: string }> = {
+  host_country: { field: "hostCountry", question: "What is the host country?" },
+  methodology: { field: "methodologyPrimary", question: "What methodology was applied?" },
+  baseline_scenario: { field: "baselineScenario", question: "What is the baseline scenario?" },
+  additionality: { field: "additionality", question: "How is additionality demonstrated?" },
+  leakage: { field: "leakage", question: "How is leakage accounted for?" },
+  stakeholder_consultation: { field: "stakeholderConsultation", question: "What stakeholder consultation was conducted?" },
+  monitoring_plan: { field: "monitoringPlan", question: "What is the monitoring plan?" },
+  project_boundary: { field: "projectBoundary", question: "What is the project boundary?" },
+  crediting_period: { field: "creditingPeriod", question: "What is the crediting period?" },
+  emission_reduction_calculation: { field: "emissionReductionCalculation", question: "How are emission reductions calculated?" },
+  applicability_conditions: { field: "applicabilityConditions", question: "What are the applicability conditions?" },
+};
+
+/**
+ * Check whether the client-side LLM feature flag is enabled.
+ * Uses NEXT_PUBLIC_ so it's available in the browser at build time.
+ */
+export function isLlmUiEnabled(): boolean {
+  if (typeof process === "undefined") return false;
+  return process.env.NEXT_PUBLIC_QUICK_CHECK_LLM === "1";
+}
+
+/**
+ * Extract candidate spans from the evidence document for LLM analysis.
+ * Returns the first N content spans (not TOC, headers, footers, annexes).
+ */
+export function extractSpansForLlm(
+  spans: Array<{ spanId: string; text: string; page: number | null; blockType: string }>,
+  maxSpans = 20,
+): InputSpan[] {
+  return spans
+    .filter((s) => s.text.trim().length > 15)
+    .filter((s) => !["toc", "header", "footer", "annex", "excluded"].includes(s.blockType))
+    .slice(0, maxSpans)
+    .map((s) => ({ id: s.spanId, text: s.text, page: s.page }));
+}
+
+/**
+ * Call the LLM extraction API for a single check.
+ *
+ * @param checkId - The Quick Check check ID (e.g. "host_country")
+ * @param documentSpans - All evidence spans from the extracted document
+ * @returns Array of validated candidates (empty if none found or unavailable)
+ */
+export async function fetchLlmCandidate(
+  checkId: string,
+  documentSpans: Array<{ spanId: string; text: string; page: number | null; blockType: string }>,
+): Promise<LlmFactCandidate[]> {
+  if (!isLlmUiEnabled()) return [];
+
+  const mapping = CHECK_TO_FIELD[checkId];
+  if (!mapping) return [];
+
+  const spans = extractSpansForLlm(documentSpans);
+  if (spans.length === 0) return [];
+
+  try {
+    const response = await fetch(LLM_API_PATH, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        field: mapping.field,
+        question: mapping.question,
+        spans,
+      }),
+      signal: AbortSignal.timeout(35_000),
+    });
+
+    if (!response.ok) return [];
+
+    const data = (await response.json()) as {
+      candidates?: LlmFactCandidate[];
+    };
+
+    return data.candidates ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export { CHECK_TO_FIELD };

--- a/tests/lib/llmFactExtractor.test.ts
+++ b/tests/lib/llmFactExtractor.test.ts
@@ -45,7 +45,7 @@ describe("llmFactExtractor — feature flag", () => {
 
   it("returns empty for unsupported fields", async () => {
     process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR = "ollama";
-    const candidates = await extractFieldCandidates("leakage" as const, SAMPLE_SPANS);
+    const candidates = await extractFieldCandidates("unsupported_field" as const, SAMPLE_SPANS);
     expect(candidates).toEqual([]);
   });
 
@@ -96,7 +96,7 @@ describe("llmFactExtractor — parseAndValidateCandidates (no network)", () => {
 
   it("rejects unsupported field", () => {
     const rawJson = JSON.stringify({
-      fields: [{ field: "leakage", value: "some value", quote: "Host Country: Peru", confidence: "high" }],
+      fields: [{ field: "invalid_field_name", value: "some value", quote: "Host Country: Peru", confidence: "high" }],
     });
 
     const candidates = parseAndValidateCandidates(rawJson, SAMPLE_SPANS);

--- a/tests/lib/llmUiClient.test.ts
+++ b/tests/lib/llmUiClient.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from "@jest/globals";
+import {
+  isLlmUiEnabled,
+  extractSpansForLlm,
+  fetchLlmCandidate,
+  CHECK_TO_FIELD,
+} from "@/lib/quickCheck/llmUiClient";
+
+const ORIGINAL_ENV = process.env;
+
+function mockFetch(response: unknown, status = 200) {
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    json: async () => response,
+  });
+}
+
+describe("llmUiClient — feature flag", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("is disabled when NEXT_PUBLIC_QUICK_CHECK_LLM is not set", () => {
+    delete process.env.NEXT_PUBLIC_QUICK_CHECK_LLM;
+    expect(isLlmUiEnabled()).toBe(false);
+  });
+
+  it("is enabled when NEXT_PUBLIC_QUICK_CHECK_LLM=1", () => {
+    process.env.NEXT_PUBLIC_QUICK_CHECK_LLM = "1";
+    expect(isLlmUiEnabled()).toBe(true);
+  });
+
+  it("is disabled when NEXT_PUBLIC_QUICK_CHECK_LLM=0", () => {
+    process.env.NEXT_PUBLIC_QUICK_CHECK_LLM = "0";
+    expect(isLlmUiEnabled()).toBe(false);
+  });
+});
+
+describe("llmUiClient — CHECK_TO_FIELD mapping", () => {
+  it("maps all 11 check IDs to fields", () => {
+    expect(Object.keys(CHECK_TO_FIELD)).toEqual([
+      "host_country",
+      "methodology",
+      "baseline_scenario",
+      "additionality",
+      "leakage",
+      "stakeholder_consultation",
+      "monitoring_plan",
+      "project_boundary",
+      "crediting_period",
+      "emission_reduction_calculation",
+      "applicability_conditions",
+    ]);
+  });
+
+  it("each mapping has a field and a question", () => {
+    for (const [checkId, mapping] of Object.entries(CHECK_TO_FIELD)) {
+      expect(mapping.field).toBeTruthy();
+      expect(mapping.question).toBeTruthy();
+      expect(mapping.question.endsWith("?")).toBe(true);
+    }
+  });
+});
+
+describe("llmUiClient — extractSpansForLlm", () => {
+  it("filters out TOC, headers, footers, annexes, excluded", () => {
+    const spans = [
+      { spanId: "s1", text: "Project Description", page: 1, blockType: "paragraph" },
+      { spanId: "s2", text: "Table of Contents", page: 1, blockType: "toc" },
+      { spanId: "s3", text: "Header text", page: 1, blockType: "header" },
+      { spanId: "s4", text: "VM0007 methodology", page: 4, blockType: "paragraph" },
+      { spanId: "s5", text: "Appendix A", page: 10, blockType: "annex" },
+    ];
+
+    const result = extractSpansForLlm(spans);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.id).toBe("s1");
+    expect(result[1]!.id).toBe("s4");
+  });
+
+  it("filters out short spans (< 15 chars)", () => {
+    const spans = [
+      { spanId: "s1", text: "Peru", page: 1, blockType: "paragraph" },
+      { spanId: "s2", text: "Host Country: Papua New Guinea", page: 1, blockType: "paragraph" },
+    ];
+
+    const result = extractSpansForLlm(spans);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe("s2");
+  });
+
+  it("limits to 20 spans", () => {
+    const spans = Array.from({ length: 50 }, (_, i) => ({
+      spanId: `s${i}`,
+      text: `Span ${i} with enough text to pass filter`,
+      page: 1,
+      blockType: "paragraph" as const,
+    }));
+
+    const result = extractSpansForLlm(spans);
+    expect(result).toHaveLength(20);
+  });
+
+  it("returns empty for unknown block types", () => {
+    const spans = [
+      { spanId: "s1", text: "Some text", page: 1, blockType: "toc" },
+      { spanId: "s2", text: "More text", page: 1, blockType: "footer" },
+    ];
+
+    const result = extractSpansForLlm(spans);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("llmUiClient — fetchLlmCandidate", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV, NEXT_PUBLIC_QUICK_CHECK_LLM: "1" };
+    globalThis.fetch = mockFetch({ candidates: [] });
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("returns empty when flag is off", async () => {
+    delete process.env.NEXT_PUBLIC_QUICK_CHECK_LLM;
+    const result = await fetchLlmCandidate("host_country", []);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty for unknown check ID", async () => {
+    const result = await fetchLlmCandidate("unknown_check", []);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when spans list is empty", async () => {
+    const result = await fetchLlmCandidate("host_country", []);
+    expect(result).toEqual([]);
+  });
+
+  it("returns candidates for host_country when LLM responds", async () => {
+    globalThis.fetch = mockFetch({
+      candidates: [{
+        field: "hostCountry",
+        value: "Papua New Guinea",
+        quote: "Country: Papua New Guinea",
+        page: 1,
+        evidenceSpanId: "s1",
+        confidence: "high",
+        warnings: [],
+      }],
+    });
+
+    const spans = [
+      { spanId: "s1", text: "Country: Papua New Guinea", page: 1, blockType: "paragraph" },
+    ];
+
+    const result = await fetchLlmCandidate("host_country", spans);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.value).toBe("Papua New Guinea");
+    expect(result[0]!.confidence).toBe("high");
+  });
+
+  it("fails silently on network error", async () => {
+    globalThis.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+
+    const spans = [
+      { spanId: "s1", text: "Country: Peru", page: 1, blockType: "paragraph" },
+    ];
+
+    const result = await fetchLlmCandidate("host_country", spans);
+    expect(result).toEqual([]);
+  });
+
+  it("fails silently on HTTP error", async () => {
+    globalThis.fetch = mockFetch({ error: "not enabled" }, 400);
+
+    const spans = [
+      { spanId: "s1", text: "Country: Peru", page: 1, blockType: "paragraph" },
+    ];
+
+    const result = await fetchLlmCandidate("host_country", spans);
+    expect(result).toEqual([]);
+  });
+
+  it("calls fetch with the correct field and question", async () => {
+    const fetchMock = mockFetch({ candidates: [] });
+    globalThis.fetch = fetchMock;
+
+    const spans = [
+      { spanId: "s1", text: "Methodology: VM0007", page: 4, blockType: "paragraph" },
+    ];
+
+    await fetchLlmCandidate("methodology", spans);
+
+    const callArgs = (fetchMock as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(callArgs[0]).toBe("/api/quick-check/llm-extract");
+    const body = JSON.parse(callArgs[1]!.body as string);
+    expect(body.field).toBe("methodologyPrimary");
+    expect(body.question).toBe("What methodology was applied?");
+  });
+
+  it("works for all 11 check types", async () => {
+    globalThis.fetch = mockFetch({
+      candidates: [{
+        field: "test",
+        value: "test",
+        quote: "test",
+        page: 1,
+        evidenceSpanId: "s1",
+        confidence: "medium",
+        warnings: [],
+      }],
+    });
+
+    const spans = [
+      { spanId: "s1", text: "test output for verification", page: 1, blockType: "paragraph" },
+    ];
+
+    for (const checkId of Object.keys(CHECK_TO_FIELD)) {
+      const result = await fetchLlmCandidate(checkId, spans);
+      expect(Array.isArray(result)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What

Prepares Quick Check to surface LLM-assisted extraction for all checks in the browser.

## Server changes

- `/api/quick-check/llm-extract`: now accepts optional `question` param for context-aware extraction
- `SUPPORTED_FIELDS` expanded from 3 to 11: hostCountry, methodologyPrimary, baselineScenario, additionality, leakage, stakeholderConsultation, monitoringPlan, projectBoundary, creditingPeriod, emissionReductionCalculation, applicabilityConditions

## Client changes

New file: `src/lib/quickCheck/llmUiClient.ts`
- `CHECK_TO_FIELD`: maps check IDs to LLM field names and context questions
- `isLlmUiEnabled()`: checks `NEXT_PUBLIC_QUICK_CHECK_LLM=1` (disabled by default)
- `extractSpansForLlm()`: filters evidence spans (excludes TOC, headers, footers, annexes, short spans, max 20)
- `fetchLlmCandidate()`: POSTs to LLM endpoint, returns validated candidates, silent fallback on error

## Validation

Same rules as server-side extractor:
- Quote must exist verbatim in matched span
- evidenceSpanId pinned from matched span
- page pinned from matched span
- No hallucinated values pass validation

## Tests

`tests/lib/llmUiClient.test.ts` — 17 tests covering flag on/off, span filtering, all 11 check types, network errors.

## Not in scope (next PR)

- UI integration into EvidenceCheckCard (showing LLM proposals in the browser)
- This PR is just the client-side helper + endpoint update

## Constraints

- Default off (`NEXT_PUBLIC_QUICK_CHECK_LLM` unset)
- No UI changes
- No router changes
- No final answer generation by LLM