### PR TITLE
fix: enable LLM suggestions for found-but-short answers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_GIT_SHA: gitSha,
     NEXT_PUBLIC_APP_VERSION: appVersion,
+    NEXT_PUBLIC_QUICK_CHECK_LLM: process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR === "ollama" ? "1" : "0",
   },
   serverExternalPackages: ["pdf-parse", "pdfjs-dist", "@napi-rs/canvas"],
   outputFileTracingIncludes: {

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1870,8 +1870,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setRunningEvidenceChecks(false);
 
     // LLM-assisted suggestions (feature-flagged, default off, non-blocking)
-    // Fetches candidate suggestions for missing/unclear checks only.
-    // Never overrides deterministic status or answer.
+    // Fetches candidate suggestions for missing, unclear, or suspiciously
+    // short found answers only. Never overrides deterministic status or answer.
     // Runs after checks complete so it doesn't block the spinner.
     if (isLlmUiEnabled()) {
       const evidenceSpans = structuredQueryContext.evidenceDocument.spans?.map((s: { spanId: string; text: string; page: number | null; blockType: string }) => ({
@@ -1882,7 +1882,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       })) ?? [];
 
       const missingOrUnclear = results.filter(
-        (r: EvidenceCheckResult) => r.status === "missing" || r.status === "unclear",
+        (r: EvidenceCheckResult) =>
+          r.status === "missing"
+          || r.status === "unclear"
+          || (r.status === "found" && r.answerText.trim().length < 3),
       );
 
       // Fire-and-forget: deterministic results are already visible


### PR DESCRIPTION
## What

Two small fixes to make LLM suggestions actually appear in the UI:

1. `next.config.ts`: Wire `NEXT_PUBLIC_QUICK_CHECK_LLM` to follow `QUICK_CHECK_LLM_FACT_EXTRACTOR` so the client flag stays in sync with the server flag at build time. Previously the env var was never baked into the client bundle.

2. `QuickCheckPanel.tsx`: Also trigger LLM suggestions for checks with status `"found"` but answer text under 3 characters (e.g. host country truncated to "ha"). Previously only `"missing"` and `"unclear"` triggered LLM calls.