### PR TITLE
fix: LLM span depth, timeout, and server-side fallback (no UI status mutation)

### DIFF
--- a/src/lib/chat/quickCheckStructuredQuery.ts
+++ b/src/lib/chat/quickCheckStructuredQuery.ts
@@ -2,6 +2,7 @@
 
 import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
 import type { StructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import type { ProjectFactField } from "@/lib/quickCheck/projectFacts/types";
 import { resolvePdfRef } from "@/lib/chat/quickCheckPdfStore";
 import { parseDocumentText } from "@/lib/documentParsing";
 import { initPymupdfAdapterRuntime } from "@/lib/documentParsing/adapters/pymupdfInit";
@@ -38,6 +39,10 @@ export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?:
     // When deterministic extraction finds no candidates for a field, tries
     // Ollama to propose candidates. Only accepts candidates whose quotes
     // are verified against source spans with provenanced evidenceSpanIds.
+    //
+    // The router/validator remains the sole authority for visible answer status.
+    // LLM candidates only fill ProjectFactContract fields when deterministic
+    // evidence is empty — they never override conflicted evidence.
     const llmExtractor = await import(
       "@/lib/quickCheck/llmFactExtractor"
     );
@@ -45,30 +50,40 @@ export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?:
       "@/lib/quickCheck/projectFacts/llmCandidateBridge"
     );
     if (llmExtractor.isLlmFactExtractorEnabled()) {
-      // Host country: try LLM only when deterministic truly found nothing
-      // (no candidates at all — empty evidenceSpanIds). If deterministic
-      // found conflicting but rejected evidence, preserve the uncertainty.
-      if (!projectFactContract.hostCountry.value && projectFactContract.hostCountry.evidenceSpanIds.length === 0) {
-        const hostCandidates = await tryLlmFallback(evidenceDocument, "hostCountry", []);
-        if (hostCandidates.length > 0) {
-          const best = hostCandidates[0]!;
-          projectFactContract.hostCountry = {
-            value: best.value,
-            confidence: best.confidence,
-            evidenceSpanIds: [best.span.spanId],
-            pageNumbers: best.span.page != null ? [best.span.page] : [],
-            sectionPath: best.span.sectionPath ?? [],
-            heading: best.span.heading,
-            extractionRule: "llm:ollama",
-            warnings: [],
-          };
-          // Mirror hostCountry into projectCountry to keep them consistent
-          projectFactContract.projectCountry = {
-            ...projectFactContract.hostCountry,
-            extractionRule: "llm:ollama:mirror-project-country",
-          };
-        }
+      // LLM fallback for fields where deterministic found nothing.
+      // Tries Ollama for each field, only accepts candidates with
+      // verified quotes from real spans. Does NOT override conflicted
+      // deterministic evidence — only fills in total gaps.
+
+      const llmFieldFallback = async (
+        field: string,
+        pfcField: ProjectFactField<string | null>,
+      ): Promise<void> => {
+        if (pfcField.value || pfcField.evidenceSpanIds.length > 0) return;
+        const candidates = await tryLlmFallback(evidenceDocument, field, []);
+        if (candidates.length === 0) return;
+        const best = candidates[0]!;
+        pfcField.value = best.value;
+        pfcField.confidence = best.confidence;
+        pfcField.evidenceSpanIds = [best.span.spanId];
+        pfcField.pageNumbers = best.span.page != null ? [best.span.page] : [];
+        pfcField.sectionPath = best.span.sectionPath ?? [];
+        pfcField.heading = best.span.heading;
+        pfcField.extractionRule = "llm:ollama";
+        pfcField.warnings = [];
+      };
+
+      await llmFieldFallback("hostCountry", projectFactContract.hostCountry);
+      // Mirror hostCountry into projectCountry
+      if (projectFactContract.hostCountry.value && !projectFactContract.projectCountry.value) {
+        projectFactContract.projectCountry = {
+          ...projectFactContract.hostCountry,
+          extractionRule: "llm:ollama:mirror-project-country",
+        };
       }
+      await llmFieldFallback("methodologyPrimary", projectFactContract.methodologyPrimary);
+      await llmFieldFallback("projectTitle", projectFactContract.projectTitle);
+      await llmFieldFallback("creditingPeriod", projectFactContract.creditingPeriod);
     }
 
     const sectionTableIndex = buildSectionTableIndex({

--- a/src/lib/quickCheck/llmFactExtractor.ts
+++ b/src/lib/quickCheck/llmFactExtractor.ts
@@ -18,7 +18,7 @@
 
 const OLLAMA_ENDPOINT = "http://127.0.0.1:11434/api/generate";
 const OLLAMA_MODEL = "llama3.2:3b";
-const LLM_TIMEOUT_MS = 30_000;
+const LLM_TIMEOUT_MS = 60_000;
 const FEATURE_FLAG = "QUICK_CHECK_LLM_FACT_EXTRACTOR";
 
 export type InputSpan = {
@@ -187,7 +187,8 @@ export function parseAndValidateCandidates(
     if (!SUPPORTED_FIELDS.includes(field as typeof SUPPORTED_FIELDS[number])) continue;
 
     // Find the exact span that contains the quote
-    const matchedSpan = spans.find((s) => s.text.includes(quote));
+    // Find the exact span that contains the quote (lenient: trim whitespace)
+    const matchedSpan = spans.find((s) => s.text.includes(quote) || s.text.includes(quote.trim()));
     if (!matchedSpan) continue;
 
     candidates.push({
@@ -223,8 +224,9 @@ export async function extractFieldCandidates(
   if (!SUPPORTED_FIELDS.includes(field as typeof SUPPORTED_FIELDS[number])) return [];
   if (spans.length === 0) return [];
 
-  // Limit spans to keep context small
-  const limitedSpans = spans.slice(0, 20);
+  // Limit spans to keep context small — use a generous cap for real PDDs
+  // (20 is too few: methodology, baseline etc. live deep in sections B/C/D)
+  const limitedSpans = spans.slice(0, 100);
 
   const prompt = buildPrompt(field, limitedSpans, question);
   const response = await callOllama(prompt);

--- a/src/lib/quickCheck/llmUiClient.ts
+++ b/src/lib/quickCheck/llmUiClient.ts
@@ -5,6 +5,10 @@
  * this for each check that returned "missing" or "unclear".
  * Returns validated candidates with span provenance, or empty
  * array if LLM is unavailable or couldn't find the answer.
+ *
+ * LLM results are NEVER used to mutate EvidenceCheckResult.status.
+ * The router/validator remains the sole authority for visible status.
+ * See: https://github.com/Fredilly/app.article6/pull/825
  */
 import type { InputSpan, LlmFactCandidate } from "@/lib/quickCheck/llmFactExtractor";
 
@@ -38,15 +42,40 @@ export function isLlmUiEnabled(): boolean {
 
 /**
  * Extract candidate spans from the evidence document for LLM analysis.
- * Returns the first N content spans (not TOC, headers, footers, annexes).
+ * Returns content spans relevant to the given field.
+ * For hostCountry, prefers spans mentioning country/location keywords.
  */
 export function extractSpansForLlm(
   spans: Array<{ spanId: string; text: string; page: number | null; blockType: string }>,
-  maxSpans = 20,
+  field?: string,
+  maxSpans = 100,
 ): InputSpan[] {
-  return spans
+  const valid = spans
     .filter((s) => s.text.trim().length > 15)
-    .filter((s) => !["toc", "header", "footer", "annex", "excluded"].includes(s.blockType))
+    .filter((s) => !["toc", "header", "footer", "annex", "excluded"].includes(s.blockType));
+
+  // For hostCountry, prioritize spans with location keywords
+  if (field === "hostCountry") {
+    const countryKeywords = [
+      "country", "location", "papua", "new guinea", "peru", "ghana",
+      "indonesia", "brazil", "colombia", "nigeria", "kenya", "congo",
+      "tanzania", "myanmar", "laos", "cambodia", "vietnam", "chile",
+      "ecuador", "bolivia", "project area",
+    ];
+    const keywordSpans = valid.filter((s) =>
+      countryKeywords.some((kw) => s.text.toLowerCase().includes(kw)),
+    );
+    const otherSpans = valid.filter((s) =>
+      !countryKeywords.some((kw) => s.text.toLowerCase().includes(kw)),
+    );
+    // Prioritize keyword spans, fill rest with other spans up to maxSpans
+    const prioritized = [...keywordSpans, ...otherSpans]
+      .slice(0, maxSpans)
+      .map((s) => ({ id: s.spanId, text: s.text, page: s.page }));
+    return prioritized;
+  }
+
+  return valid
     .slice(0, maxSpans)
     .map((s) => ({ id: s.spanId, text: s.text, page: s.page }));
 }
@@ -57,6 +86,9 @@ export function extractSpansForLlm(
  * @param checkId - The Quick Check check ID (e.g. "host_country")
  * @param documentSpans - All evidence spans from the extracted document
  * @returns Array of validated candidates (empty if none found or unavailable)
+ *
+ * LLM candidates do NOT mutate EvidenceCheckResult.status.
+ * They are suggestions only — the router controls final answer visibility.
  */
 export async function fetchLlmCandidate(
   checkId: string,
@@ -67,7 +99,7 @@ export async function fetchLlmCandidate(
   const mapping = CHECK_TO_FIELD[checkId];
   if (!mapping) return [];
 
-  const spans = extractSpansForLlm(documentSpans);
+  const spans = extractSpansForLlm(documentSpans, mapping.field);
   if (spans.length === 0) return [];
 
   try {
@@ -79,7 +111,7 @@ export async function fetchLlmCandidate(
         question: mapping.question,
         spans,
       }),
-      signal: AbortSignal.timeout(35_000),
+      signal: AbortSignal.timeout(65_000),
     });
 
     if (!response.ok) return [];

--- a/tests/lib/llmUiClient.test.ts
+++ b/tests/lib/llmUiClient.test.ts
@@ -93,8 +93,8 @@ describe("llmUiClient — extractSpansForLlm", () => {
     expect(result[0]!.id).toBe("s2");
   });
 
-  it("limits to 20 spans", () => {
-    const spans = Array.from({ length: 50 }, (_, i) => ({
+  it("limits to 100 spans", () => {
+    const spans = Array.from({ length: 150 }, (_, i) => ({
       spanId: `s${i}`,
       text: `Span ${i} with enough text to pass filter`,
       page: 1,
@@ -102,7 +102,7 @@ describe("llmUiClient — extractSpansForLlm", () => {
     }));
 
     const result = extractSpansForLlm(spans);
-    expect(result).toHaveLength(20);
+    expect(result).toHaveLength(100);
   });
 
   it("returns empty for unknown block types", () => {


### PR DESCRIPTION
## Summary

Safe LLM candidate extraction improvements — no UI status mutation. LLM remains a suggestions-only layer.

## What changed

### llmFactExtractor.ts (server-side validator)
- **Timeout: 30s → 60s** — llama3.2:3b regularly exceeds 30s on large PDDs
- **Max spans: 20 → 100** — methodology, baseline, crediting period live deep in sections B/C/D; 20 spans rarely reach them
- **Lenient quote matching** — also tries `quote.trim()` when exact match fails (whitespace differences from Ollama)

### llmUiClient.ts (client-side bridge)
- **Field-aware span prioritization** — for `hostCountry`, keyword-matched spans (Papua, New Guinea, Indonesia, etc.) are ordered first
- **Max spans: 20 → 100** (matches server)
- **Client timeout: 35s → 65s** (matches 60s server + buffer)
- **Passes `field` to `extractSpansForLlm`** for context-aware filtering

### quickCheckStructuredQuery.ts (server-side, `"use server"`)
- **LLM fallback for 4 fields**: hostCountry, methodologyPrimary, projectTitle, creditingPeriod
- Only triggers when deterministic evidence is **completely empty** (`!pfcField.value && pfcField.evidenceSpanIds.length === 0`)
- Never overrides conflicted deterministic evidence
- All candidates validated through `parseAndValidateCandidates` (quote must match a real span, `evidenceSpanId` and `page` from matched span)

## What did NOT change
- No in-place replace of `EvidenceCheckResult.status` — LLM stays as suggestions only
- No `console.log` in API routes
- No unrelated files (docs, PDFs, fixtures, plans, scripts)
- Router/validator remains the **sole authority** for visible answer status

## Verification
- ✅ tsc --noEmit: 0 errors
- ✅ ESLint: 0 warnings/errors
- ✅ Tests: 37/37 passed
- ✅ Strict eval corpus: all 8 fixtures pass
  - Visible answer gold match: **100%** (64/64)
  - Visible/Technical agreement: **100%** (64/64) — no visible/router disagreement
  - Hallucinated answer rate: **0%** (0/41)
  - Regression count: **0**
