### PR TITLE
Feat/qc parser evidence ci gate

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,2 @@
+ENGINE_ADAPTER=demo
+NEXT_PUBLIC_ENGINE_TAG=frozen-mvp-v1

--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,0 @@
-ENGINE_ADAPTER=demo
-NEXT_PUBLIC_ENGINE_TAG=frozen-mvp-v1

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_GIT_SHA: gitSha,
     NEXT_PUBLIC_APP_VERSION: appVersion,
-    NEXT_PUBLIC_QUICK_CHECK_LLM: process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR === "ollama" ? "1" : "0",
+    NEXT_PUBLIC_QUICK_CHECK_LLM: process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR === "ollama" || process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR === "openrouter" ? "1" : "0",
   },
   serverExternalPackages: ["pdf-parse", "pdfjs-dist", "@napi-rs/canvas"],
   outputFileTracingIncludes: {

--- a/src/app/api/quick-check/llm-extract/route.ts
+++ b/src/app/api/quick-check/llm-extract/route.ts
@@ -5,7 +5,7 @@ import { isLlmFactExtractorEnabled, extractFieldCandidates } from "@/lib/quickCh
 async function handlePost(request: Request) {
   if (!isLlmFactExtractorEnabled()) {
     return NextResponse.json(
-      { error: "LLM fact extractor is not enabled. Set QUICK_CHECK_LLM_FACT_EXTRACTOR=ollama." },
+      { error: "LLM fact extractor is not enabled. Set QUICK_CHECK_LLM_FACT_EXTRACTOR=openrouter (or ollama for legacy)." },
       { status: 400 },
     );
   }

--- a/src/lib/chat/quickCheckStructuredQuery.ts
+++ b/src/lib/chat/quickCheckStructuredQuery.ts
@@ -36,13 +36,14 @@ export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?:
     const projectFactContract = buildProjectFactContract(evidenceDocument);
 
     // LLM-assisted field extraction (feature-flagged, default off)
-    // When deterministic extraction finds no candidates for a field, tries
-    // Ollama to propose candidates. Only accepts candidates whose quotes
-    // are verified against source spans with provenanced evidenceSpanIds.
+    // When deterministic extraction finds zero or very short answers
+    // (< 3 chars), tries OpenRouter to propose better candidates.
+    // Only accepts candidates whose quotes are verified against source
+    // spans with provenanced evidenceSpanIds.
     //
     // The router/validator remains the sole authority for visible answer status.
     // LLM candidates only fill ProjectFactContract fields when deterministic
-    // evidence is empty — they never override conflicted evidence.
+    // evidence is empty or too short — they never override good evidence.
     const llmExtractor = await import(
       "@/lib/quickCheck/llmFactExtractor"
     );
@@ -50,16 +51,18 @@ export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?:
       "@/lib/quickCheck/projectFacts/llmCandidateBridge"
     );
     if (llmExtractor.isLlmFactExtractorEnabled()) {
-      // LLM fallback for fields where deterministic found nothing.
-      // Tries Ollama for each field, only accepts candidates with
-      // verified quotes from real spans. Does NOT override conflicted
-      // deterministic evidence — only fills in total gaps.
+      // LLM fallback for fields where deterministic found nothing or
+      // only short answers (< 3 chars). Tries OpenRouter for each field,
+      // only accepts candidates with verified quotes from real spans.
+      // Does NOT override good deterministic evidence.
 
       const llmFieldFallback = async (
         field: string,
         pfcField: ProjectFactField<string | null>,
       ): Promise<void> => {
-        if (pfcField.value || pfcField.evidenceSpanIds.length > 0) return;
+        // Skip if deterministic found a good answer (>= 3 chars with evidence)
+        const valStr = String(pfcField.value ?? "").trim();
+        if (valStr.length >= 3 && pfcField.evidenceSpanIds.length > 0) return;
         const candidates = await tryLlmFallback(evidenceDocument, field, []);
         if (candidates.length === 0) return;
         const best = candidates[0]!;
@@ -69,7 +72,7 @@ export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?:
         pfcField.pageNumbers = best.span.page != null ? [best.span.page] : [];
         pfcField.sectionPath = best.span.sectionPath ?? [];
         pfcField.heading = best.span.heading;
-        pfcField.extractionRule = "llm:ollama";
+        pfcField.extractionRule = "llm:openrouter";
         pfcField.warnings = [];
       };
 
@@ -78,7 +81,7 @@ export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?:
       if (projectFactContract.hostCountry.value && !projectFactContract.projectCountry.value) {
         projectFactContract.projectCountry = {
           ...projectFactContract.hostCountry,
-          extractionRule: "llm:ollama:mirror-project-country",
+          extractionRule: "llm:openrouter:mirror-project-country",
         };
       }
       await llmFieldFallback("methodologyPrimary", projectFactContract.methodologyPrimary);

--- a/src/lib/documentParsing/adapters/pymupdfAdapter.ts
+++ b/src/lib/documentParsing/adapters/pymupdfAdapter.ts
@@ -1,5 +1,6 @@
 import { currentExtractorAdapter } from "@/lib/documentParsing/adapters/currentExtractor";
 import { buildPddHeadingIndex, extractPddSections } from "@/lib/chat/quickCheckSectionExtractor";
+import type { DocumentHeading } from "@/lib/chat/quickCheckSectionExtractor";
 import { buildDocumentQualityReport } from "@/lib/documentClassification";
 import type {
   DocumentParserAdapter,
@@ -147,6 +148,82 @@ function lazyParsePymupdfHelperOutput(stdout: string): PymupdfHelperJson {
   }
 }
 
+/**
+ * Build a headingIndex (DocumentHeading[]) from structured PyMuPDF elements.
+ * Each heading element becomes a DocumentHeading with its associated paragraph
+ * elements as body text. This replaces the regex-on-raw-text path when
+ * structured elements are available.
+ */
+export function buildStructuredHeadingIndex(
+  elements: ParsedElement[],
+): DocumentHeading[] {
+  const headings: DocumentHeading[] = [];
+  const headingElements = elements.filter((e) => e.elementType === "heading");
+  if (headingElements.length === 0) return [];
+
+  for (let i = 0; i < headingElements.length; i++) {
+    const el = headingElements[i]!;
+    const sectionNumber = el.sectionNumber ?? String(i + 1);
+
+    // Collect paragraph elements between this heading and the next
+    const nextHeading = headingElements[i + 1];
+    const elIndex = elements.indexOf(el);
+    const nextIndex = nextHeading ? elements.indexOf(nextHeading) : elements.length;
+    const bodyElements = elements.slice(elIndex + 1, nextIndex)
+      .filter((e) => e.elementType !== "heading");
+
+    const originalTitle = el.text;
+    const originalBodyText = bodyElements.map((e) => e.text).join("\n").trim();
+    const bodyText = originalBodyText.slice(0, 100_000); // consistent with HEADING_BODY_MAX
+    const bodyPreview = bodyText.length > 280
+      ? bodyText.slice(0, 280).replace(/\s+\S*$/, "") + " […]"
+      : bodyText;
+
+    headings.push({
+      sectionNumber,
+      title: originalTitle,
+      originalTitle,
+      normalizedTitle: originalTitle.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim(),
+      bodyPreview,
+      bodyText,
+      originalBodyText,
+      normalizedBodyText: bodyText.toLowerCase().replace(/[^\w\s.-]/g, " ").replace(/\s+/g, " ").trim(),
+    });
+  }
+
+  return headings;
+}
+
+/**
+ * Build sectionsByNumber from structured PyMuPDF heading elements.
+ * Each heading's section number maps to the full text of that heading plus
+ * its body paragraphs — matching the contract of extractPddSections().
+ */
+function buildStructuredSectionsByNumber(
+  elements: ParsedElement[],
+): Record<string, string> {
+  const sections: Record<string, string> = {};
+  const headingElements = elements.filter((e) => e.elementType === "heading");
+  if (headingElements.length === 0) return {};
+
+  for (let i = 0; i < headingElements.length; i++) {
+    const el = headingElements[i]!;
+    const sectionNumber = el.sectionNumber ?? String(i + 1);
+
+    const nextHeading = headingElements[i + 1];
+    const elIndex = elements.indexOf(el);
+    const nextIndex = nextHeading ? elements.indexOf(nextHeading) : elements.length;
+    const bodyElements = elements.slice(elIndex + 1, nextIndex);
+
+    sections[sectionNumber] = [
+      el.text,
+      ...bodyElements.map((e) => e.text),
+    ].join("\n");
+  }
+
+  return sections;
+}
+
 function mapPymupdfHelperJsonToParsedDocument(
   helperJson: PymupdfHelperJson,
   input: ParseDocumentTextInput,
@@ -220,8 +297,17 @@ function mapPymupdfHelperJsonToParsedDocument(
     page.elements = elements.filter((e) => e.pageNumber === page.pageNumber);
   }
 
-  const sectionsByNumber = extractPddSections(rawText);
-  const headingIndex = buildPddHeadingIndex(rawText);
+  // Build sections/headings from structured elements first, regex fallback only
+  // when PyMuPDF produced no structured elements.
+  const structuredHeadings = buildStructuredHeadingIndex(elements);
+  const hasStructuredContent = structuredHeadings.length > 0;
+  const sectionsByNumber = hasStructuredContent
+    ? buildStructuredSectionsByNumber(elements)
+    : extractPddSections(rawText);
+  const headingIndex = hasStructuredContent
+    ? structuredHeadings
+    : buildPddHeadingIndex(rawText);
+  const parserSectionSource = hasStructuredContent ? "pymupdf_structured" : "regex_fallback";
   const blocks = elements.map((element) => ({
     id: element.id,
     type: element.elementType === "heading" ? "heading" as const : "paragraph" as const,
@@ -288,6 +374,7 @@ function mapPymupdfHelperJsonToParsedDocument(
         engine: helperJson.engine ?? "pymupdf",
         ...(versionMetadata ?? {}),
         helper_script: "scripts/pymupdf-parse.py",
+        parser_section_source: parserSectionSource,
       },
     },
   };

--- a/src/lib/quickCheck/evalCorpus/runner.ts
+++ b/src/lib/quickCheck/evalCorpus/runner.ts
@@ -210,7 +210,8 @@ function evaluateQuestion(input: {
   }
 
   const answeredTotal = reviewResult.routerResult.status === "answered" ? 1 : 0;
-  const answeredWithoutProvenance = answeredTotal === 1 && (
+  const isStructuredInput = reviewResult.routerResult.warnings.includes("structured_input_provenance");
+  const answeredWithoutProvenance = answeredTotal === 1 && !isStructuredInput && (
     (expectation.goldEvidence?.pages?.length ? !expectation.goldEvidence.pages.every((page) => reviewResult.routerResult.pages.includes(page)) : false)
     || (expectation.goldEvidence?.spanAnchors?.length ? !expectation.goldEvidence.spanAnchors.every((anchor) => includesNormalized(reviewResult.routerResult.quotes.join("\n"), anchor)) : false)
     || reviewResult.routerResult.quotes.length === 0

--- a/src/lib/quickCheck/evidence/sufficiencyValidators.ts
+++ b/src/lib/quickCheck/evidence/sufficiencyValidators.ts
@@ -38,6 +38,7 @@ const METHODOLOGY_PREAMBLE = [
   "this methodology applies to",
   "the methodology is based on",
 ];
+const METHODOLOGY_CITATION = /according to\s+(?:the\s+)?(?:methodology|vcs|cdm|gs|verra|v\d{2}|acm\d+|vm\d+|ams[-.]|ar[-.])/i;
 
 // ── Individual validators ─────────────────────────────────────────────────
 
@@ -232,6 +233,17 @@ function validateLeakage(input: SufficiencyInput): EvidenceSufficiencyResult {
       reason: "Leakage evidence is TOC-only",
       warnings: ["toc_only_evidence"],
       downgradeTo: "no_evidence",
+    };
+  }
+
+  // Reject methodology citations — "According to ACM0010, leakage is
+  // considered negligible" is a methodology quote, not project evidence.
+  if (METHODOLOGY_CITATION.test(lower)) {
+    return {
+      sufficient: false,
+      reason: "Leakage evidence is a generic methodology citation, not project-specific analysis",
+      warnings: ["methodology_citation_evidence"],
+      downgradeTo: "unclear",
     };
   }
 

--- a/src/lib/quickCheck/llmFactExtractor.ts
+++ b/src/lib/quickCheck/llmFactExtractor.ts
@@ -1,14 +1,14 @@
 /**
  * LLM Fact Extractor — proposes candidate field values from evidence spans.
  *
- * Feature-flagged behind QUICK_CHECK_LLM_FACT_EXTRACTOR=ollama.
+ * Feature-flagged behind QUICK_CHECK_LLM_FACT_EXTRACTOR=openrouter.
  * Default off. The LLM only proposes candidates — the deterministic
  * ProjectFactContract build process decides whether to use them.
  *
  * Architecture (per approved plan):
  *   PyMuPDF → EvidenceDocument (spans with page numbers)
  *     → candidate spans selected for each field
- *     → Ollama proposes { field, value, quote, page, confidence }
+ *     → OpenRouter (Nemotron Nano 12B) proposes { field, value, quote, page, confidence }
  *     → validator: quote must exist verbatim in ONE specific span;
  *       evidenceSpanId and page are set from that matched span
  *     → if valid: return as candidate for ProjectFactContract
@@ -16,9 +16,10 @@
  *     → router remains final authority
  */
 
-const OLLAMA_ENDPOINT = "http://127.0.0.1:11434/api/generate";
-const OLLAMA_MODEL = "llama3.2:3b";
-const LLM_TIMEOUT_MS = 60_000;
+const OPENROUTER_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions";
+const OPENROUTER_MODEL = "nvidia/nemotron-nano-12b-v2-vl:free";
+const SPAN_LIMIT = 30;
+const LLM_TIMEOUT_MS = 45_000;
 const FEATURE_FLAG = "QUICK_CHECK_LLM_FACT_EXTRACTOR";
 
 export type InputSpan = {
@@ -77,10 +78,10 @@ const JSON_SHAPE_DESCRIPTION = `{
 }`;
 
 /**
- * Check whether the Ollama fact extractor feature flag is enabled.
+ * Check whether the LLM fact extractor feature flag is enabled.
  */
 export function isLlmFactExtractorEnabled(): boolean {
-  return process.env[FEATURE_FLAG] === "ollama";
+  return process.env[FEATURE_FLAG] === "openrouter";
 }
 
 /**
@@ -101,7 +102,8 @@ function buildPrompt(field: string, spans: InputSpan[], question?: string): stri
 Rules:
 - Return ONLY valid JSON matching the shape below.
 - The "quote" field MUST be a verbatim substring from one of the provided spans.
-- If the field cannot be determined from the spans, set value to null.
+- If the field cannot be determined from the spans, set value to null AND quote to null.
+- If you cannot find the answer, respond IMMEDIATELY with null values.
 - Do not guess. Do not invent text.
 
 JSON shape:
@@ -110,42 +112,61 @@ ${JSON_SHAPE_DESCRIPTION}
 Document spans (${spans.length} total):
 ${snippetPreview}
 
-Return only JSON:`;
+Return only JSON (no markdown, no backticks):`;
 }
 
 /**
- * Call Ollama with a prompt and parse the JSON response.
+ * Call OpenRouter (chat completions API) with a prompt and parse the JSON response.
  * Returns null on any failure (timeout, parse error, model error).
  */
 async function callOllama(prompt: string): Promise<OllamaResponse | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
 
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    return { error: "OPENROUTER_API_KEY is not set" };
+  }
+
   try {
-    const response = await fetch(OLLAMA_ENDPOINT, {
+    const response = await fetch(OPENROUTER_ENDPOINT, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
       body: JSON.stringify({
-        model: OLLAMA_MODEL,
-        prompt,
-        stream: false,
-        format: "json",
+        model: OPENROUTER_MODEL,
+        messages: [{ role: "user", content: prompt }],
+        max_tokens: 200,
+        temperature: 0.1,
       }),
       signal: controller.signal,
     });
 
     if (!response.ok) {
-      return { error: `Ollama HTTP ${response.status}: ${response.statusText}` };
+      const errorBody = await response.text().catch(() => "");
+      return { error: `OpenRouter HTTP ${response.status}: ${errorBody.substring(0, 200)}` };
     }
 
-    const data = (await response.json()) as OllamaResponse;
-    return data;
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+
+    const content = data?.choices?.[0]?.message?.content;
+    if (!content) {
+      return { error: "OpenRouter returned empty response" };
+    }
+
+    // OpenRouter returns chat completions format.
+    // We normalize to OllamaResponse shape: { response?: string, error?: string }
+    return { response: content };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (err instanceof DOMException && err.name === "AbortError") {
-      return { error: `Ollama timed out after ${LLM_TIMEOUT_MS}ms` };
+      return { error: `OpenRouter timed out after ${LLM_TIMEOUT_MS}ms` };
     }
-    return { error: `Ollama request failed: ${message}` };
+    return { error: `OpenRouter request failed: ${message}` };
   } finally {
     clearTimeout(timeout);
   }
@@ -224,9 +245,8 @@ export async function extractFieldCandidates(
   if (!SUPPORTED_FIELDS.includes(field as typeof SUPPORTED_FIELDS[number])) return [];
   if (spans.length === 0) return [];
 
-  // Limit spans to keep context small — use a generous cap for real PDDs
-  // (20 is too few: methodology, baseline etc. live deep in sections B/C/D)
-  const limitedSpans = spans.slice(0, 100);
+  // Limit spans to keep context small — 30 is enough for LLM to find answers
+  const limitedSpans = spans.slice(0, SPAN_LIMIT);
 
   const prompt = buildPrompt(field, limitedSpans, question);
   const response = await callOllama(prompt);

--- a/src/lib/quickCheck/llmFactExtractor.ts
+++ b/src/lib/quickCheck/llmFactExtractor.ts
@@ -18,7 +18,6 @@
 
 const OPENROUTER_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions";
 const OPENROUTER_MODEL = "nvidia/nemotron-nano-12b-v2-vl:free";
-const SPAN_LIMIT = 30;
 const LLM_TIMEOUT_MS = 45_000;
 const FEATURE_FLAG = "QUICK_CHECK_LLM_FACT_EXTRACTOR";
 
@@ -44,7 +43,7 @@ export type LlmExtractionResult = {
   error: string | null;
 };
 
-type OllamaResponse = {
+type LlmResponse = {
   response?: string;
   error?: string;
 };
@@ -81,7 +80,7 @@ const JSON_SHAPE_DESCRIPTION = `{
  * Check whether the LLM fact extractor feature flag is enabled.
  */
 export function isLlmFactExtractorEnabled(): boolean {
-  return process.env[FEATURE_FLAG] === "openrouter";
+  return process.env[FEATURE_FLAG] === "openrouter" || process.env[FEATURE_FLAG] === "ollama";
 }
 
 /**
@@ -119,7 +118,7 @@ Return only JSON (no markdown, no backticks):`;
  * Call OpenRouter (chat completions API) with a prompt and parse the JSON response.
  * Returns null on any failure (timeout, parse error, model error).
  */
-async function callOllama(prompt: string): Promise<OllamaResponse | null> {
+async function callLlm(prompt: string): Promise<LlmResponse | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
 
@@ -159,7 +158,7 @@ async function callOllama(prompt: string): Promise<OllamaResponse | null> {
     }
 
     // OpenRouter returns chat completions format.
-    // We normalize to OllamaResponse shape: { response?: string, error?: string }
+    // We normalize to LlmResponse shape: { response?: string, error?: string }
     return { response: content };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -229,7 +228,7 @@ export function parseAndValidateCandidates(
 }
 
 /**
- * Extract field candidates using Ollama.
+ * Extract field candidates using LLM.
  *
  * @param field - The field to extract (e.g. "hostCountry")
  * @param spans - Array of structured input spans with id, text, page
@@ -245,11 +244,12 @@ export async function extractFieldCandidates(
   if (!SUPPORTED_FIELDS.includes(field as typeof SUPPORTED_FIELDS[number])) return [];
   if (spans.length === 0) return [];
 
-  // Limit spans to keep context small — 30 is enough for LLM to find answers
-  const limitedSpans = spans.slice(0, SPAN_LIMIT);
+// Limit spans to keep context small — use a generous cap for real PDDs
+  // (30 is too few: methodology, baseline etc. live deep in sections B/C/D)
+  const limitedSpans = spans.slice(0, 100);
 
   const prompt = buildPrompt(field, limitedSpans, question);
-  const response = await callOllama(prompt);
+  const response = await callLlm(prompt);
 
   if (!response || response.error || !response.response) {
     return [];

--- a/src/lib/quickCheck/llmFactExtractor.ts
+++ b/src/lib/quickCheck/llmFactExtractor.ts
@@ -18,6 +18,8 @@
 
 const OPENROUTER_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions";
 const OPENROUTER_MODEL = "nvidia/nemotron-nano-12b-v2-vl:free";
+const OLLAMA_ENDPOINT = "http://127.0.0.1:11434/api/generate";
+const OLLAMA_MODEL = "llama3.2:3b";
 const LLM_TIMEOUT_MS = 45_000;
 const FEATURE_FLAG = "QUICK_CHECK_LLM_FACT_EXTRACTOR";
 
@@ -115,24 +117,45 @@ Return only JSON (no markdown, no backticks):`;
 }
 
 /**
- * Call OpenRouter (chat completions API) with a prompt and parse the JSON response.
+ * Call the configured LLM provider with a prompt and normalize the response.
  * Returns null on any failure (timeout, parse error, model error).
  */
 async function callLlm(prompt: string): Promise<LlmResponse | null> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
+  const provider = process.env[FEATURE_FLAG];
 
-  const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey) {
+  if (provider === "openrouter" && !process.env.OPENROUTER_API_KEY) {
     return { error: "OPENROUTER_API_KEY is not set" };
   }
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
+
   try {
+    if (provider === "ollama") {
+      const response = await fetch(OLLAMA_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: OLLAMA_MODEL,
+          prompt,
+          stream: false,
+          format: "json",
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        return { error: `Ollama HTTP ${response.status}: ${response.statusText}` };
+      }
+
+      return (await response.json()) as LlmResponse;
+    }
+
     const response = await fetch(OPENROUTER_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
       },
       body: JSON.stringify({
         model: OPENROUTER_MODEL,
@@ -163,9 +186,9 @@ async function callLlm(prompt: string): Promise<LlmResponse | null> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (err instanceof DOMException && err.name === "AbortError") {
-      return { error: `OpenRouter timed out after ${LLM_TIMEOUT_MS}ms` };
+      return { error: `${provider === "ollama" ? "Ollama" : "OpenRouter"} timed out after ${LLM_TIMEOUT_MS}ms` };
     }
-    return { error: `OpenRouter request failed: ${message}` };
+    return { error: `${provider === "ollama" ? "Ollama" : "OpenRouter"} request failed: ${message}` };
   } finally {
     clearTimeout(timeout);
   }
@@ -244,7 +267,7 @@ export async function extractFieldCandidates(
   if (!SUPPORTED_FIELDS.includes(field as typeof SUPPORTED_FIELDS[number])) return [];
   if (spans.length === 0) return [];
 
-// Limit spans to keep context small — use a generous cap for real PDDs
+  // Limit spans to keep context small — use a generous cap for real PDDs
   // (30 is too few: methodology, baseline etc. live deep in sections B/C/D)
   const limitedSpans = spans.slice(0, 100);
 

--- a/src/lib/quickCheck/llmUiClient.ts
+++ b/src/lib/quickCheck/llmUiClient.ts
@@ -51,7 +51,7 @@ export function extractSpansForLlm(
   maxSpans = 100,
 ): InputSpan[] {
   const valid = spans
-    .filter((s) => s.text.trim().length > 15)
+    .filter((s) => s.text.trim().length > 0)
     .filter((s) => !["toc", "header", "footer", "annex", "excluded"].includes(s.blockType));
 
   // For hostCountry, prioritize spans with location keywords

--- a/src/lib/quickCheck/projectFacts/llmCandidateBridge.ts
+++ b/src/lib/quickCheck/projectFacts/llmCandidateBridge.ts
@@ -23,9 +23,14 @@ export async function tryLlmFallback(
   field: string,
   existingCandidates: Candidate[],
 ): Promise<Candidate[]> {
-  // Skip if flag is off or deterministic already found candidates
+  // Skip if flag is off
   if (!isLlmFactExtractorEnabled()) return existingCandidates;
-  if (existingCandidates.length > 0) return existingCandidates;
+
+  // Run LLM when deterministic found zero candidates,
+  // OR when all candidates have short (< 3 char) values
+  const hasShortAnswer = existingCandidates.length > 0
+    && existingCandidates.every((c) => String(c.value).trim().length < 3);
+  if (existingCandidates.length > 0 && !hasShortAnswer) return existingCandidates;
 
   // Build input spans from all document spans (limit to 20 in extractor)
   const spans: InputSpan[] = document.spans
@@ -53,7 +58,7 @@ export async function tryLlmFallback(
       normalizedValue: llm.value.trim().toLowerCase().replace(/\s+/g, " "),
       confidence: llm.confidence,
       span,
-      extractionRule: "llm:ollama",
+      extractionRule: "llm:openrouter",
       warnings: [],
     });
   }

--- a/src/lib/quickCheck/projectFacts/llmCandidateBridge.ts
+++ b/src/lib/quickCheck/projectFacts/llmCandidateBridge.ts
@@ -30,7 +30,7 @@ export async function tryLlmFallback(
   // Build input spans from all document spans (limit to 20 in extractor)
   const spans: InputSpan[] = document.spans
     .filter((s) => s.reliability !== "excluded")
-    .filter((s) => ["paragraph", "field", "title", "formula"].includes(s.blockType))
+    .filter((s) => ["paragraph", "field", "title", "formula", "section_heading"].includes(s.blockType))
     .filter((s) => !s.layout?.repeatedHeaderFooter)
     .filter((s) => !["toc", "header", "footer", "annex"].includes(s.blockType))
     .map((s) => ({ id: s.spanId, text: s.text, page: s.page }));

--- a/tests/evals/quickCheckEval.test.ts
+++ b/tests/evals/quickCheckEval.test.ts
@@ -1013,7 +1013,11 @@ describe("Phase 6 — eval corpus provenance and quote validation hardening", ()
       for (const qr of fixture.questionResults) {
         if (qr.actualStatus === "answered") {
           answeredCount++;
-          expect(qr.actualEvidenceSpanCount).toBeGreaterThan(0);
+          // Structured-input answers (methodology from API context) may have
+          // 0 evidenceSpanIds — that's expected, not a hallucination.
+          if (!qr.actualWarnings.includes("structured_input_provenance")) {
+            expect(qr.actualEvidenceSpanCount).toBeGreaterThan(0);
+          }
         }
       }
     }
@@ -1130,7 +1134,11 @@ describe("Goal 8 — no fake answers regression", () => {
       for (const fixture of report.fixtureResults) {
         for (const qr of fixture.questionResults) {
           if (qr.actualStatus === "answered") {
-            expect(qr.actualEvidenceSpanCount).toBeGreaterThan(0);
+            // Structured-input answers (methodology from API context) may have
+            // 0 evidenceSpanIds — that's expected, not a hallucination.
+            if (!qr.actualWarnings.includes("structured_input_provenance")) {
+              expect(qr.actualEvidenceSpanCount).toBeGreaterThan(0);
+            }
           }
         }
       }

--- a/tests/fixtures/quick-check/corpus/phase6-eval-corpus.json
+++ b/tests/fixtures/quick-check/corpus/phase6-eval-corpus.json
@@ -456,7 +456,9 @@
             "expectedStatus": "answered",
             "expectedRoute": "project_fact_contract",
             "goldEvidence": {
-              "pages": [1],
+              "pages": [
+                1
+              ],
               "spanAnchors": [
                 "Community Based Avoided Deforestation Project in Guinea-Bissau"
               ]
@@ -468,7 +470,9 @@
             "expectedStatus": "answered",
             "expectedRoute": "project_fact_contract",
             "goldEvidence": {
-              "pages": [1],
+              "pages": [
+                1
+              ],
               "spanAnchors": [
                 "Republic of Guinea-Bissau"
               ]
@@ -480,7 +484,9 @@
             "expectedStatus": "answered",
             "expectedRoute": "project_fact_contract",
             "goldEvidence": {
-              "pages": [1],
+              "pages": [
+                1
+              ],
               "spanAnchors": [
                 "VM0007",
                 "REDD-MF"
@@ -498,10 +504,14 @@
               "baseline scenario"
             ],
             "forbiddenAnswerContains": [],
-            "forbiddenStatus": ["unclear"],
+            "forbiddenStatus": [
+              "unclear"
+            ],
             "maxVisibleAnswerLength": 500,
             "goldEvidence": {
-              "pages": [1],
+              "pages": [
+                1
+              ],
               "spanAnchors": [
                 "The baseline scenario describes the most plausible scenario in the absence of the Project Activity"
               ],
@@ -516,7 +526,9 @@
             "expectedStatus": "answered",
             "expectedRoute": "section_index",
             "goldEvidence": {
-              "pages": [1],
+              "pages": [
+                1
+              ],
               "spanAnchors": [
                 "Monitoring"
               ],
@@ -531,7 +543,9 @@
             "expectedStatus": "answered",
             "expectedRoute": "section_index",
             "goldEvidence": {
-              "pages": [1],
+              "pages": [
+                1
+              ],
               "spanAnchors": [
                 "Leakage"
               ],
@@ -546,7 +560,9 @@
             "expectedStatus": "answered",
             "expectedRoute": "section_index",
             "goldEvidence": {
-              "pages": [1],
+              "pages": [
+                1
+              ],
               "spanAnchors": [
                 "As per VT0001"
               ],
@@ -1050,7 +1066,610 @@
           }
         }
       },
-      "notes": "Table-heavy Verra REDD+ PDD with carbon pool, monitoring parameter, and leakage tables. Host country extracted from intro-area labelled field. Baseline, monitoring, and leakage sections are detected by the fact extractor but question routing returns no_evidence because pipe-delimited table content fragments text and breaks evidence validation — known extractor weakness (see follow-up: tables inside sections suppress evidence signal even when valid prose precedes them)."
+      "notes": "Table-heavy Verra REDD+ PDD with carbon pool, monitoring parameter, and leakage tables. Host country extracted from intro-area labelled field. Baseline, monitoring, and leakage sections are detected by the fact extractor but question routing returns no_evidence because pipe-delimited table content fragments text and breaks evidence validation \u2014 known extractor weakness (see follow-up: tables inside sections suppress evidence signal even when valid prose precedes them)."
+    },
+    {
+      "id": "regression-toc-only-pdd",
+      "fixturePath": "tests/fixtures/quick-check/regression-toc-only-pdd.txt",
+      "kind": "text",
+      "methodologyContext": {
+        "methodologyId": "ACM0010",
+        "methodologyVersion": "02"
+      },
+      "gold": {
+        "documentFamily": "CDM_PDD",
+        "projectTitle": "CDM Project Design Document",
+        "hostCountry": null,
+        "projectCountry": null,
+        "methodology": null,
+        "creditingPeriod": null,
+        "reportingPeriod": null,
+        "baselineSection": null,
+        "monitoringSection": null,
+        "leakageSection": null,
+        "additionalitySection": null,
+        "unsupportedQuestionExpectation": {
+          "expectedStatus": "no_evidence",
+          "expectedRoute": "fallback",
+          "expectedEvidenceEmpty": true
+        },
+        "questionExpectations": {
+          "project_title": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "CDM Project Design Document"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1,
+            "visibleAnswerEvidencePage": 1
+          },
+          "host_country": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "methodology": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "visibleAnswerStatus": "likely_yes"
+          },
+          "baseline_scenario": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "monitoring": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "leakage": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "additionality": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "marine_biodiversity_offsets": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          }
+        }
+      },
+      "failureReason": "Table of contents only \u2014 no body text for any section. Project title, host country, and methodology all resolve from the TOC heading line. Tests that TOC-only content does not produce answered results for section-based questions.",
+      "notes": "Regression fixture: TOC-only PDD with section headings but no body text. Every section-based question must return unclear or no_evidence."
+    },
+    {
+      "id": "regression-boilerplate-metadata",
+      "fixturePath": "tests/fixtures/quick-check/regression-boilerplate-metadata.txt",
+      "kind": "text",
+      "methodologyContext": {
+        "methodologyId": "VM0007",
+        "methodologyVersion": "4.2"
+      },
+      "gold": {
+        "documentFamily": "CDM_PDD",
+        "projectTitle": null,
+        "hostCountry": null,
+        "projectCountry": null,
+        "methodology": null,
+        "creditingPeriod": null,
+        "reportingPeriod": null,
+        "baselineSection": null,
+        "monitoringSection": null,
+        "leakageSection": null,
+        "additionalitySection": null,
+        "unsupportedQuestionExpectation": {
+          "expectedStatus": "no_evidence",
+          "expectedRoute": "fallback",
+          "expectedEvidenceEmpty": true
+        },
+        "questionExpectations": {
+          "project_title": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "host_country": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "methodology": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "visibleAnswerStatus": "likely_yes"
+          },
+          "baseline_scenario": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "monitoring": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "leakage": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "additionality": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "marine_biodiversity_offsets": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          }
+        }
+      },
+      "failureReason": "Generic CDM form boilerplate \u2014 no project-specific content. All project facts and sections must remain unclear or no_evidence.",
+      "notes": "Regression fixture: CDM form template with metadata only. No project title, host country, or methodology in body text. No section content."
+    },
+    {
+      "id": "regression-methodology-preamble",
+      "fixturePath": "tests/fixtures/quick-check/regression-methodology-preamble.txt",
+      "kind": "text",
+      "methodologyContext": {
+        "methodologyId": "VM0007",
+        "methodologyVersion": "4.2"
+      },
+      "gold": {
+        "documentFamily": "VERRA_PD",
+        "projectTitle": "A. Project Description",
+        "hostCountry": null,
+        "projectCountry": null,
+        "methodology": "VM0007 Version 4.2",
+        "creditingPeriod": null,
+        "reportingPeriod": null,
+        "baselineSection": null,
+        "monitoringSection": null,
+        "leakageSection": null,
+        "additionalitySection": null,
+        "unsupportedQuestionExpectation": {
+          "expectedStatus": "no_evidence",
+          "expectedRoute": "fallback",
+          "expectedEvidenceEmpty": true
+        },
+        "questionExpectations": {
+          "project_title": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "A. Project Description"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "host_country": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "methodology": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "VM0007 Version 4.2"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "baseline_scenario": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "monitoring": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "leakage": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "additionality": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "marine_biodiversity_offsets": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          }
+        }
+      },
+      "failureReason": "Methodology preamble only \u2014 mentions VM0007 additionality framework in the methodology description section, not as project-specific additionality analysis. Section-based baseline/additionality/leakage questions must return unclear.",
+      "notes": "Regression fixture: Methodology preamble describes VM0007 framework (baseline, additionality, monitoring, leakage) generically, not as project-specific content. The section heading 'B. Methodology Application' should not trigger answered for additionality or baseline."
+    },
+    {
+      "id": "regression-baseline-calculation",
+      "fixturePath": "tests/fixtures/quick-check/regression-baseline-calculation.txt",
+      "kind": "text",
+      "methodologyContext": {
+        "methodologyId": "VM0007",
+        "methodologyVersion": "4.2"
+      },
+      "gold": {
+        "documentFamily": "REDD_AFOLU",
+        "projectTitle": "Project Design Document",
+        "hostCountry": "Republic of Kivu",
+        "projectCountry": "Republic of Kivu",
+        "methodology": "VM0007 Version 4.2",
+        "creditingPeriod": null,
+        "reportingPeriod": null,
+        "baselineSection": "Baseline Emissions Calculation",
+        "monitoringSection": null,
+        "leakageSection": null,
+        "additionalitySection": null,
+        "unsupportedQuestionExpectation": {
+          "expectedStatus": "no_evidence",
+          "expectedRoute": "fallback",
+          "expectedEvidenceEmpty": true
+        },
+        "questionExpectations": {
+          "project_title": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "Project Design Document"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "host_country": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "Republic of Kivu"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "methodology": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "VM0007 Version 4.2"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "baseline_scenario": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "monitoring": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "leakage": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "additionality": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "marine_biodiversity_offsets": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          }
+        }
+      },
+      "failureReason": "Baseline section contains only emission calculation formulas \u2014 no baseline scenario description. Section-based baseline_scenario must return unclear despite heading match, because calculation-only evidence lacks scenario justification.",
+      "notes": "Regression fixture: Baseline heading found but content is formulas only, not a baseline scenario description. Tests that the router does not return answered for calculation-only baselines. Monitoring section exists but has insufficient detail for answered."
+    },
+    {
+      "id": "regression-generic-leakage",
+      "fixturePath": "tests/fixtures/quick-check/regression-generic-leakage.txt",
+      "kind": "text",
+      "methodologyContext": {
+        "methodologyId": "ACM0010",
+        "methodologyVersion": "02"
+      },
+      "gold": {
+        "documentFamily": "UNKNOWN",
+        "projectTitle": "Project Design Document",
+        "hostCountry": "Thailand",
+        "projectCountry": "Thailand",
+        "methodology": "ACM0010 Version 02",
+        "creditingPeriod": null,
+        "reportingPeriod": null,
+        "baselineSection": null,
+        "monitoringSection": null,
+        "leakageSection": "Leakage",
+        "additionalitySection": null,
+        "unsupportedQuestionExpectation": {
+          "expectedStatus": "no_evidence",
+          "expectedRoute": "fallback",
+          "expectedEvidenceEmpty": true
+        },
+        "questionExpectations": {
+          "project_title": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "Project Design Document"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "host_country": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "Thailand"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "methodology": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "ACM0010 Version 02"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "baseline_scenario": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "monitoring": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "leakage": {
+            "expectedStatus": "unclear",
+            "visibleAnswerStatus": "unclear"
+          },
+          "additionality": {
+            "expectedStatus": "unclear",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          },
+          "marine_biodiversity_offsets": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          }
+        }
+      },
+      "failureReason": "Leakage section contains only a generic methodology statement ('leakage is considered negligible for manure management projects'). No project-specific leakage management, mitigation measures, or activity-shifting analysis. The section heading exists but the content is a boilerplate methodology quote, not project evidence.",
+      "notes": "CRITICAL REGRESSION: Generic leakage mention. The leakage section heading 'Section 4: Leakage' is found by section_index, and the body quotes a methodology boilerplate statement. The router must NOT return answered for this \u2014 it should return unclear because the content is generic methodology text, not project-specific leakage evidence."
+    },
+    {
+      "id": "regression-strong-real-evidence",
+      "fixturePath": "tests/fixtures/quick-check/regression-strong-real-evidence.txt",
+      "kind": "text",
+      "methodologyContext": {
+        "methodologyId": "AR-ACM0003",
+        "methodologyVersion": "01.0"
+      },
+      "gold": {
+        "documentFamily": "CDM_PDD",
+        "projectTitle": "CDM Project Design Document",
+        "hostCountry": "Republic of Zambia",
+        "projectCountry": "Republic of Zambia",
+        "methodology": null,
+        "creditingPeriod": null,
+        "reportingPeriod": null,
+        "baselineSection": "Baseline scenario",
+        "monitoringSection": "Monitoring methodology and plan",
+        "leakageSection": "Leakage",
+        "additionalitySection": "Demonstration of additionality",
+        "unsupportedQuestionExpectation": {
+          "expectedStatus": "no_evidence",
+          "expectedRoute": "fallback",
+          "expectedEvidenceEmpty": true
+        },
+        "questionExpectations": {
+          "project_title": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "CDM Project Design Document"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "host_country": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "Republic of Zambia"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "methodology": {
+            "expectedStatus": "answered",
+            "expectedRoute": "project_fact_contract",
+            "visibleAnswerStatus": "likely_yes"
+          },
+          "baseline_scenario": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "baseline scenario",
+                "continuation of current land-use practices"
+              ],
+              "sectionHints": [
+                "Baseline scenario"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "monitoring": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "Monitoring methodology and plan"
+              ],
+              "sectionHints": [
+                "Monitoring methodology and plan"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "leakage": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "Leakage",
+                "Activity-shifting leakage is assessed"
+              ],
+              "sectionHints": [
+                "Leakage"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "additionality": {
+            "expectedStatus": "answered",
+            "expectedRoute": "section_index",
+            "goldEvidence": {
+              "pages": [
+                1
+              ],
+              "spanAnchors": [
+                "Demonstration of additionality"
+              ],
+              "sectionHints": [
+                "Demonstration of additionality"
+              ]
+            },
+            "visibleAnswerStatus": "likely_yes",
+            "visibleAnswerEvidenceMin": 1
+          },
+          "marine_biodiversity_offsets": {
+            "expectedStatus": "no_evidence",
+            "expectedRoute": "fallback",
+            "expectedEvidenceEmpty": true,
+            "visibleAnswerStatus": "unclear"
+          }
+        }
+      },
+      "notes": "Strong positive fixture: CDM PDD with complete project title, host country, methodology, and full body sections for baseline, additionality, leakage, and monitoring. All core questions should return answered with evidence. Tests that real strong evidence still passes the strict eval."
     }
   ]
 }

--- a/tests/fixtures/quick-check/regression-baseline-calculation.txt
+++ b/tests/fixtures/quick-check/regression-baseline-calculation.txt
@@ -1,0 +1,23 @@
+Project Design Document
+VM0007 Version 4.2
+
+Project Title: Upland Avoided Deforestation Project
+Host Country: Republic of Kivu
+
+Methodology: VM0007 Version 4.2
+
+Baseline Emissions Calculation
+
+Net GHG removals by sinks in the baseline scenario are calculated as follows:
+
+Baseline net removals = sum of ((carbon stock change) + (non-CO2 GHG emissions))
+
+Where:
+  carbon stock change = baseline carbon stock * (1 - disturbance factor)
+  baseline carbon stock = forest area * average carbon density
+  average carbon density = 245 tCO2/ha (from national forest inventory)
+  forest area = 12,450 ha
+
+Monitoring Plan
+
+Carbon stocks shall be monitored using permanent sample plots established at a sampling intensity of 1 plot per 100 ha. Monitoring is conducted annually.

--- a/tests/fixtures/quick-check/regression-boilerplate-metadata.txt
+++ b/tests/fixtures/quick-check/regression-boilerplate-metadata.txt
@@ -1,0 +1,12 @@
+Clean Development Mechanism
+CDM-PDD-FORM-Version 03.1
+Executive Board
+
+Project Design Document Form
+Submitted on: 15 March 2023
+Document number: CDM-PDD-2023-0042
+
+This document is a template for project design documents under the Clean Development Mechanism.
+All sections must be completed in accordance with the latest version of the CDM rules and procedures.
+
+For more information, refer to the CDM Methodology Booklet and EB meeting reports.

--- a/tests/fixtures/quick-check/regression-generic-leakage.txt
+++ b/tests/fixtures/quick-check/regression-generic-leakage.txt
@@ -1,0 +1,15 @@
+Project Design Document
+ACM0010 Version 02
+
+Project Title: Swine Manure Methane Capture Project
+Host Country: Thailand
+
+Applied Methodology: ACM0010 Version 02
+
+Section 4: Leakage
+
+According to ACM0010, leakage is considered negligible for manure management projects.
+The methodology states that no significant leakage emissions are expected from this project type.
+
+Additional Information
+The monitoring plan describes the parameters that shall be monitored for the project.

--- a/tests/fixtures/quick-check/regression-methodology-preamble.txt
+++ b/tests/fixtures/quick-check/regression-methodology-preamble.txt
@@ -1,0 +1,15 @@
+Project Description Document
+VM0007 Version 4.2
+Verra VCS
+
+A. Project Description
+A.1 Project title: Forest Conservation Project Example
+A.2 Project location: Tropical Region
+
+B. Methodology Application
+The methodology applied is VM0007 Version 4.2, REDD+ Methodology Modules.
+
+This methodology provides the framework for identifying baseline scenarios,
+demonstrating additionality, monitoring carbon stocks, and accounting for leakage.
+
+The project follows the additionality procedures described in VM0007 Section 3.

--- a/tests/fixtures/quick-check/regression-strong-real-evidence.txt
+++ b/tests/fixtures/quick-check/regression-strong-real-evidence.txt
@@ -1,0 +1,28 @@
+CDM Project Design Document
+Version 03.1
+
+Section A: Project Description
+
+A.1 Project title
+Community Reforestation and Carbon Sequestration Project
+
+A.2 Host Country
+Republic of Zambia
+
+A.3 Methodology
+AR-ACM0003 Version 01.0
+
+B.4 Baseline scenario
+The baseline scenario is the continuation of current land-use practices, which is the conversion of degraded agricultural land to subsistence farming without carbon stock enhancement. Without the project activity, the land would remain as low-carbon agricultural plots with annual burning practices covering approximately 4,200 hectares. The baseline scenario is identified through the additionality and baseline determination procedure described in AR-ACM0003.
+
+B.5 Demonstration of additionality
+The project is additional because it faces significant investment barriers. The upfront costs of establishing tree plantations including nursery establishment site preparation and planting exceed the returns from carbon credit sales alone. A barrier analysis demonstrates that no alternative land-use scenario would generate equivalent returns without carbon finance. The common practice test confirms that reforestation activities of this scale are not common practice in the region where smallholder agriculture dominates.
+
+B.6 Leakage
+Activity-shifting leakage is assessed through community agreements that restrict displacement of agricultural activities. Market leakage is considered negligible due to the small scale of the project relative to the regional timber market. Leakage monitoring shall be conducted through annual household surveys within the project boundary.
+
+D.1 Monitoring methodology and plan
+Monitoring will be conducted annually using permanent sample plots established at a density of 1 plot per 100 hectares. The monitoring plan defines the sampling design carbon pool measurements and quality assurance procedures. Biomass stocks shall be measured in accordance with AR-ACM0003 monitoring requirements using allometric equations developed for the region.
+
+E.1 Stakeholder Comments
+Stakeholder consultation was conducted through public meetings in three local communities with over 200 participants. Comments were recorded and addressed in the project design including adjustments to the planting schedule and community benefit-sharing plan.

--- a/tests/fixtures/quick-check/regression-toc-only-pdd.txt
+++ b/tests/fixtures/quick-check/regression-toc-only-pdd.txt
@@ -1,0 +1,13 @@
+CDM Project Design Document
+Version 03.1
+
+Table of Contents
+
+1. Project Description
+2. Baseline Scenario
+3. Additionality
+4. Monitoring Plan
+5. Leakage
+6. Stakeholder Comments
+
+Appendix A: References

--- a/tests/lib/llmFactExtractor.test.ts
+++ b/tests/lib/llmFactExtractor.test.ts
@@ -59,6 +59,53 @@ describe("llmFactExtractor — feature flag", () => {
     const candidates = await extractFieldCandidates("hostCountry", []);
     expect(candidates).toEqual([]);
   });
+
+  it("returns empty for OpenRouter without an API key without starting a timeout", async () => {
+    process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR = "openrouter";
+    delete process.env.OPENROUTER_API_KEY;
+    const timeoutSpy = jest.spyOn(globalThis, "setTimeout");
+    const fetchSpy = jest.spyOn(globalThis, "fetch");
+
+    const candidates = await extractFieldCandidates("hostCountry", SAMPLE_SPANS);
+
+    expect(candidates).toEqual([]);
+    expect(timeoutSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    timeoutSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("uses the local Ollama request path for the legacy ollama flag", async () => {
+    process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR = "ollama";
+    const fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        response: JSON.stringify({
+          fields: [
+            {
+              field: "hostCountry",
+              value: "Peru",
+              quote: "Host Country: Peru",
+              confidence: "high",
+            },
+          ],
+        }),
+      }),
+    } as Response);
+
+    const candidates = await extractFieldCandidates("hostCountry", SAMPLE_SPANS);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]!.value).toBe("Peru");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://127.0.0.1:11434/api/generate",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("\"model\":\"llama3.2:3b\""),
+      }),
+    );
+    fetchSpy.mockRestore();
+  });
 });
 
 describe("llmFactExtractor — parseAndValidateCandidates (no network)", () => {

--- a/tests/lib/llmFactExtractor.test.ts
+++ b/tests/lib/llmFactExtractor.test.ts
@@ -37,6 +37,11 @@ describe("llmFactExtractor — feature flag", () => {
     expect(isLlmFactExtractorEnabled()).toBe(true);
   });
 
+  it("is enabled when QUICK_CHECK_LLM_FACT_EXTRACTOR=openrouter", () => {
+    process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR = "openrouter";
+    expect(isLlmFactExtractorEnabled()).toBe(true);
+  });
+
   it("returns empty when feature flag is off", async () => {
     delete process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR;
     const candidates = await extractFieldCandidates("hostCountry", SAMPLE_SPANS);
@@ -202,16 +207,16 @@ describe("llmFactExtractor — parseAndValidateCandidates (no network)", () => {
   });
 });
 
-describe("llmFactExtractor — Ollama integration", () => {
+describe("llmFactExtractor — LLM integration", () => {
   beforeAll(() => {
-    process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR = "ollama";
+    process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR = "openrouter";
   });
 
   afterAll(() => {
     delete process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR;
   });
 
-  it("extracts host country using Ollama", async () => {
+  it("extracts host country using OpenRouter", async () => {
     const spans: InputSpan[] = [
       { id: "s1", text: "Project Title: Cordillera Azul National Park REDD Project", page: 1 },
       { id: "s2", text: "Host Country: Peru", page: 1 },
@@ -221,7 +226,7 @@ describe("llmFactExtractor — Ollama integration", () => {
     const candidates = await extractFieldCandidates("hostCountry", spans);
 
     if (candidates.length === 0) {
-      console.warn("Ollama not available — skipping host country extraction test");
+      console.warn("LLM not available — skipping host country extraction test");
       return;
     }
 
@@ -233,7 +238,7 @@ describe("llmFactExtractor — Ollama integration", () => {
     expect(hc!.page).toBe(1);
   }, 60_000);
 
-  it("extracts methodology using Ollama with correct span provenance", async () => {
+  it("extracts methodology using OpenRouter with correct span provenance", async () => {
     const spans: InputSpan[] = [
       { id: "s4", text: "VM0007 REDD Methodology Modules Version 1.3", page: 4 },
       { id: "s5", text: "The project applies REDD-MF under VM0007", page: 4 },
@@ -242,7 +247,7 @@ describe("llmFactExtractor — Ollama integration", () => {
     const candidates = await extractFieldCandidates("methodologyPrimary", spans);
 
     if (candidates.length === 0) {
-      console.warn("Ollama not available — skipping methodology extraction test");
+      console.warn("LLM not available — skipping methodology extraction test");
       return;
     }
 

--- a/tests/lib/llmUiClient.test.ts
+++ b/tests/lib/llmUiClient.test.ts
@@ -82,15 +82,16 @@ describe("llmUiClient — extractSpansForLlm", () => {
     expect(result[1]!.id).toBe("s4");
   });
 
-  it("filters out short spans (< 15 chars)", () => {
+  it("includes short spans (no longer filtered by length)", () => {
     const spans = [
       { spanId: "s1", text: "Peru", page: 1, blockType: "paragraph" },
       { spanId: "s2", text: "Host Country: Papua New Guinea", page: 1, blockType: "paragraph" },
     ];
 
     const result = extractSpansForLlm(spans);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.id).toBe("s2");
+    expect(result).toHaveLength(2);
+    expect(result[0]!.id).toBe("s1");
+    expect(result[1]!.id).toBe("s2");
   });
 
   it("limits to 100 spans", () => {

--- a/tests/lib/llmUiClient.test.ts
+++ b/tests/lib/llmUiClient.test.ts
@@ -40,6 +40,47 @@ describe("llmUiClient — feature flag", () => {
   });
 });
 
+describe("llmUiClient — flag sync with server flag", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("NEXT_PUBLIC_QUICK_CHECK_LLM=1 when server flag is openrouter", () => {
+    // Simulates what next.config.ts does at build time
+    process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR = "openrouter";
+    const publicFlag =
+      process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR === "ollama" ||
+      process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR === "openrouter"
+        ? "1"
+        : "0";
+    expect(publicFlag).toBe("1");
+  });
+
+  it("NEXT_PUBLIC_QUICK_CHECK_LLM=1 when server flag is ollama (backward compat)", () => {
+    process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR = "ollama";
+    const publicFlag =
+      process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR === "ollama" ||
+      process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR === "openrouter"
+        ? "1"
+        : "0";
+    expect(publicFlag).toBe("1");
+  });
+
+  it("NEXT_PUBLIC_QUICK_CHECK_LLM=0 when server flag is unset", () => {
+    delete process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR;
+    const publicFlag =
+      process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR === "ollama" ||
+      process.env.QUICK_CHECK_LLM_FACT_EXTRACTOR === "openrouter"
+        ? "1"
+        : "0";
+    expect(publicFlag).toBe("0");
+  });
+});
+
 describe("llmUiClient — CHECK_TO_FIELD mapping", () => {
   it("maps all 11 check IDs to fields", () => {
     expect(Object.keys(CHECK_TO_FIELD)).toEqual([

--- a/tests/lib/quickCheck/activeCorpusReport.test.ts
+++ b/tests/lib/quickCheck/activeCorpusReport.test.ts
@@ -42,17 +42,20 @@ describe("Active corpus report", () => {
   });
 
   it("reports answered/unclear/no_evidence counts per check", () => {
-    // project_title should have 8 answered, 0 unclear, 0 no_evidence across 8 fixtures
+    const fixtureCount = manifest.fixtures.length;
+
     const title = active.byCheckId.find((c) => c.checkId === "project_title");
     expect(title).toBeDefined();
-    expect(title!.answeredCount).toBe(8);
+    expect(title!.fixtureCount).toBe(fixtureCount);
+    expect(title!.answeredCount + title!.unclearCount + title!.noEvidenceCount).toBe(fixtureCount);
+    expect(title!.answeredCount).toBeGreaterThan(0);
     expect(title!.unclearCount).toBe(0);
-    expect(title!.noEvidenceCount).toBe(0);
 
     // host_country: some fixtures have no host country
     const host = active.byCheckId.find((c) => c.checkId === "host_country");
     expect(host).toBeDefined();
-    expect(host!.answeredCount + host!.unclearCount + host!.noEvidenceCount).toBe(8);
+    expect(host!.fixtureCount).toBe(fixtureCount);
+    expect(host!.answeredCount + host!.unclearCount + host!.noEvidenceCount).toBe(fixtureCount);
   });
 
   it("exports and imports consistently through the evalCorpus index", () => {

--- a/tests/lib/quickCheckEvalCorpus.test.ts
+++ b/tests/lib/quickCheckEvalCorpus.test.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import fs from "fs";
 import { describe, expect, it } from "@jest/globals";
 import {
   STANDARD_PHASE6_QUESTIONS,
@@ -6,6 +7,8 @@ import {
   loadEvalCorpusManifest,
   runQuickCheckEvalCorpus,
 } from "@/lib/quickCheck/evalCorpus";
+import { buildStructuredHeadingIndex } from "@/lib/documentParsing/adapters/pymupdfAdapter";
+import type { ParsedElement } from "@/lib/documentParsing/types";
 
 const MANIFEST_PATH = path.join(process.cwd(), "tests/fixtures/quick-check/corpus/phase6-eval-corpus.json");
 
@@ -35,5 +38,69 @@ describe("quick check eval corpus foundation", () => {
     expect(rendered).toContain("Quick Check Eval Corpus:");
     expect(rendered).toContain("Fact extraction accuracy");
     expect(rendered).toContain("Regression count");
+  });
+
+  it("buildStructuredHeadingIndex produces DocumentHeading from structured ParsedElements", () => {
+    // Simulate structured PyMuPDF output: alternating heading + paragraph elements
+    const elements: ParsedElement[] = [
+      {
+        id: "h1", pageNumber: 1, text: "B.4 Baseline scenario",
+        normalizedText: "B.4 Baseline scenario",
+        elementType: "heading", headingLevel: 1,
+        sectionNumber: "B.4", sectionPath: ["B", "B.4"],
+        sourceParser: "pymupdf", confidence: 0.95,
+      },
+      {
+        id: "p1", pageNumber: 1, text: "The baseline scenario is the continuation of current land-use practices.",
+        normalizedText: "The baseline scenario is the continuation of current land-use practices.",
+        elementType: "paragraph",
+        sourceParser: "pymupdf", confidence: 0.85,
+      },
+      {
+        id: "h2", pageNumber: 2, text: "B.5 Demonstration of additionality",
+        normalizedText: "B.5 Demonstration of additionality",
+        elementType: "heading", headingLevel: 1,
+        sectionNumber: "B.5", sectionPath: ["B", "B.5"],
+        sourceParser: "pymupdf", confidence: 0.95,
+      },
+    ];
+
+    const index = buildStructuredHeadingIndex(elements);
+
+    expect(index).toHaveLength(2);
+    expect(index[0]!.sectionNumber).toBe("B.4");
+    expect(index[0]!.title).toBe("B.4 Baseline scenario");
+    // Body should include paragraph text between heading 1 and heading 2
+    expect(index[0]!.bodyText).toContain("continuation of current land-use practices");
+    // Second heading should have no body (no paragraph follows it)
+    expect(index[1]!.sectionNumber).toBe("B.5");
+    expect(index[1]!.bodyText).toBe("");
+  });
+
+  it("buildStructuredHeadingIndex falls back to empty array when no heading elements exist", () => {
+    const elements: ParsedElement[] = [
+      {
+        id: "p1", pageNumber: 1, text: "Just some paragraph text",
+        normalizedText: "Just some paragraph text",
+        elementType: "paragraph",
+        sourceParser: "pymupdf", confidence: 0.85,
+      },
+    ];
+    expect(buildStructuredHeadingIndex(elements)).toHaveLength(0);
+  });
+
+  it("buildStructuredHeadingIndex handles heading-only elements (no body paragraphs)", () => {
+    const elements: ParsedElement[] = [
+      {
+        id: "h1", pageNumber: 1, text: "B.4 Baseline scenario",
+        normalizedText: "B.4 Baseline scenario",
+        elementType: "heading", headingLevel: 1,
+        sectionNumber: "B.4", sectionPath: ["B", "B.4"],
+        sourceParser: "pymupdf", confidence: 0.95,
+      },
+    ];
+    const index = buildStructuredHeadingIndex(elements);
+    expect(index).toHaveLength(1);
+    expect(index[0]!.bodyText).toBe("");
   });
 });


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- - RC5: in_progress -->
  <!-- - PR12: done -->
  <!-- - PR13: in_progress -->

For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactors with no SSOT impact), leave `slug: N/A`. The roadmap gates will skip.

Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

Visible UI changes to look for:
