### PR TITLE
fix: add strict answer contracts for host country and methodology

### DIFF
--- a/src/lib/quickCheck/evidenceChecks.ts
+++ b/src/lib/quickCheck/evidenceChecks.ts
@@ -932,12 +932,35 @@ function validateCandidate(contract: EvidenceCheckContract, candidate: CheckCand
   }
   if (contract.expectedShape === "country") {
     if (wc > 5) return { valid: false, reason: "Too many words for a country name" };
-    if (/:|;|\(|\)/.test(candidate.text)) return { valid: false, reason: "Contains punctuation (not a country name)" };
+    if (/[():;]/.test(candidate.text)) return { valid: false, reason: "Contains punctuation (not a country name)" };
     if (/\b(?:standard|methodology|version|requirements?|project)\b/i.test(candidate.text)) return { valid: false, reason: "Contains standard/methodology text, not a country name" };
     // Reject obviously non-country values like "ha", "tCO2", "tCO2e", numbers, units
     if (/^[a-z]{1,3}$/i.test(candidate.text.trim()) && !/^[A-Z][a-z]/.test(candidate.text.trim())) return { valid: false, reason: "Too short to be a country name" };
     if (/^\d/.test(candidate.text.trim())) return { valid: false, reason: "Starts with a number — not a country name" };
     if (/\b(?:tCO2|tCO2e|ha|hectare|tonne|kg|m[32]|km2)\b/i.test(candidate.text)) return { valid: false, reason: "Contains unit/measurement, not a country name" };
+    // Reject URLs, query strings, registry profile links, and VVB/buyer/developer addresses
+    if (/https?:\/\//i.test(candidate.text)) return { valid: false, reason: "Contains URL — not a country name" };
+    if (/\?[a-z]+=/i.test(candidate.text)) return { valid: false, reason: "Contains query string — not a country name" };
+    if (/profile\?/i.test(candidate.text)) return { valid: false, reason: "Contains profile reference — not a country name" };
+    if (/\b(?:VVB|validator|verifier|developer|project proponent|buyer)\b/i.test(candidate.text)) return { valid: false, reason: "References registry participant — not a country name" };
+    // Reject generic registry/address text that doesn't name a country
+    if (/\b(?:registry|register)\b/i.test(candidate.text) && !/\b(?:Guinea|Guinea-Bissau|Guinea Bissau|Indonesia|Cambodia|Peru|Brazil|Colombia|Kenya|Uganda|Tanzania|Ethiopia|Ghana|Nigeria|DRC|Congo|Nepal|India|China|Vietnam|Myanmar|Laos|Thailand|Philippines|Papua|Fiji)\b/i.test(candidate.text)) return { valid: false, reason: "Registry reference without recognized country name" };
+  }
+  if (contract.expectedShape === "methodology_name_version") {
+    // Must contain an explicit methodology code (VM####, VMD####, ACM####, etc.)
+    const hasCode = /\b(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM\d{4}|GS-VER\d+|VT\d{4})\b/i.test(candidate.text);
+    if (!hasCode) return { valid: false, reason: "No explicit methodology code found — generic methodology prose rejected" };
+    // Reject if the code appears only in a "modules and tools" list or boilerplate
+    if (/\bmodules? and tools?\b/i.test(candidate.text) && !/\bapplied methodology\b/i.test(candidate.text)) {
+      return { valid: false, reason: "Methodology code appears in module/tool boilerplate — not proven as applied" };
+    }
+    // Reject methodology preamble/instructions that describe the methodology
+    // rather than stating it was applied to this project.
+    if (/^(?:The |This )?methodology (?:provides|describes|is applicable|applies to|establishes|determines|sets out|contains)/i.test(candidate.text)) {
+      return { valid: false, reason: "Describes methodology instructions — not evidence of applied methodology" };
+    }
+    // Accept when the code appears in a title/reference section or fact contract
+    if (candidate.source.startsWith("fact:") && hasCode) return { valid: true, reason: "" };
   }
   return { valid: true, reason: "" };
 }

--- a/tests/lib/evidenceChecks.test.ts
+++ b/tests/lib/evidenceChecks.test.ts
@@ -405,3 +405,90 @@ describe("authoritative evidence check selectors", () => {
     expect(validated.downgradeReason).toBe("");
   });
 });
+
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Host country rejection tests (strict contract)
+// ---------------------------------------------------------------------------
+
+it("rejects profile?countryCode=GW as host country and returns unclear", () => {
+  const result = runCheck({
+    checkId: "host_country",
+    claimText: "What is the host country?",
+    rawText: "The host country is profile?countryCode=GW. The project is located in Guinea-Bissau.",
+  });
+
+  // The validator rejects the URL-containing text. The full line is returned
+  // as unclear, but the downgrade reason shows it was rejected.
+  expect(result.downgradeReason).not.toBe("");
+});
+
+it("rejects URLs as host country", () => {
+  const result = runCheck({
+    checkId: "host_country",
+    claimText: "What is the host country?",
+    rawText: "Project participant: https://registry.verra.org/profile?pid=12345. Host Country: Indonesia",
+  });
+
+  expect(result.answerText).not.toContain("https");
+  expect(result.answerText).not.toContain("registry");
+});
+
+it("rejects VVB/developer references as host country", () => {
+  const result = runCheck({
+    checkId: "host_country",
+    claimText: "What is the host country?",
+    rawText: "VVB: TÜV Rheinland. Project developer: EcoProjects Ltd. Host country: Peru.",
+  });
+
+  expect(result.answerText).not.toContain("VVB");
+  expect(result.answerText).not.toContain("TÜV");
+  expect(result.answerText).toContain("Peru");
+});
+
+it("returns unclear for junk-only host country text", () => {
+  const result = runCheck({
+    checkId: "host_country",
+    claimText: "What is the host country?",
+    rawText: "This validation report covers project PDD v1.5. profile?countryCode=GW is the reference.",
+  });
+
+  // Should contain a downgrade reason about not being a specific country value
+  expect(result.downgradeReason).not.toBe("");
+});
+
+// ---------------------------------------------------------------------------
+// Methodology rejection tests (strict contract)
+// ---------------------------------------------------------------------------
+
+it("rejects generic methodology prose without an explicit methodology code", () => {
+  const result = runCheck({
+    checkId: "methodology",
+    claimText: "What methodology was applied?",
+    rawText: "The methodology provides modules and tools for quantifying emission reductions from reduced deforestation. This section describes the methodology framework applied to the project.",
+  });
+
+  // No VM/ACM/AM code means the result should have a downgrade reason
+  expect(result.downgradeReason).not.toBe("");
+});
+
+it("accepts explicit VM0007 when tied to applied methodology", () => {
+  const result = runCheck({
+    checkId: "methodology",
+    claimText: "What methodology was applied?",
+    rawText: "Title and reference of methodology applied: VM0007 Methodology Framework for REDD+ Projects v1.0. The project applies VM0007 as the baseline and monitoring methodology.",
+  });
+
+  expect(result.answerText).toContain("VM0007");
+});
+
+it("rejects methodology code in module/tool boilerplate without being proven as applied", () => {
+  const result = runCheck({
+    checkId: "methodology",
+    claimText: "What methodology was applied?",
+    rawText: "The modules and tools section describes the VM0007 components. Module VMD0001 describes the carbon accounting approach.",
+  });
+
+  // VM0007 appears in "modules" context — should have a downgrade reason
+  expect(result.downgradeReason).not.toBe("");
+});


### PR DESCRIPTION
## What

Add strict validation contracts for host country and methodology evidence checks.

## Why

Quick Check was accepting clearly wrong values:
- profile?countryCode=GW as host country
- Generic methodology prose without an explicit methodology code
- Module/tool boilerplate as applied methodology
- VVB/registrant references as host country

## Host country contract

Rejects URLs, query strings, profile links, VVB/validator/developer references, and registry references without a recognized country name.

## Methodology contract

Requires an explicit methodology code (VM####, ACM####, AM####, etc.) in an applied context. Rejects module/tool boilerplate and preamble instructions.

## Tests

7 new regression tests covering host country junk rejection, methodology strictness, and explicit code acceptance. All 29 tests pass.

## Signed-off-by
Fred Egbuedike <fredilly@article6.org>