### PR TITLE
V2/roadmap ssot

### DIFF
--- a/ANALYSIS-quick-check-parsing-improvements.md
+++ b/ANALYSIS-quick-check-parsing-improvements.md
@@ -1,0 +1,174 @@
+# Quick Check Deterministic Parsing Pipeline — Analysis & Improvement Priorities
+
+## How I Analyzed
+
+1. **Read the eval corpus** (`phase6-eval-corpus.json`) — all 14 fixtures, their `failureReason` fields and `notes`.
+2. **Read each fixture's actual document text** to understand real vs expected parsing output.
+3. **Traced the full text-to-evidence pipeline:**
+   - `currentExtractor.ts` — adapter that extracts sections from raw text
+   - `quickCheckSectionExtractor.ts` — the core deterministic section/heading parser (996 lines)
+   - `compileEvidenceDocument.ts` — builds `EvidenceSpan` blocks from raw text
+   - `buildEvidenceSpanIndex.ts` — query-by-section/lexical matching
+   - `buildSectionTableIndex.ts` — topic classification & exclusion logic
+   - `sufficiencyValidators.ts` — TOC/preamble/boilerplate rejection
+   - `noiseDetection.ts` — header/footer/source-caption filters
+   - `deterministicRouter.ts` — fact→section→table→lexical routing order
+   - `extractDocumentFacts.ts` — labeled-field extraction from spans
+4. **Examined adapter alternatives:** `pymupdfAdapter.ts` (largely a passthrough to `currentExtractor` for text inputs) and `liteParse.ts`.
+5. **Compared oracle expectations vs actual pipeline failure modes** from the 14 corpus fixtures.
+
+---
+
+## Current Known Weaknesses (in priority order)
+
+### W1. TOC detection and elimination is unreliable
+
+**Evidence from corpus:**
+- `regression-toc-only-pdd.txt`: TOC with section headings but NO body text. The extractor detects the TOC block via `findTocBlockBounds()` but **only checks if the line starts with `\d+.\d+ ...`** pattern. In `regression-toc-only-pdd.txt`, the TOC lines are like `1. Project Description` (no leader dots) — the current heuristic `!/^(?:\d+(?:\.\d+)*|[A-Z]\.\d+)\s+[A-Z]/.test(trimmed)` fails to detect end of TOC body.
+- The `isTocTitle()` function checks for `\.{4,}\s*\d+\s*$` (leader dots) but many real-world TOCs don't use leader dots.
+- TOC detection in `findTocBlockBounds()` only matches literal `"table of contents"` or `"contents"` header. If the TOC header is on a page with a different prefix (e.g. "TABLE OF CONTENTS" mixed with boilerplate), it breaks.
+- The TOC detection only finds **one** TOC block — multi-page TOCs are missed entirely.
+- `pd-redd-v130-extracted.txt` (the full VCS PDD) has a TOC spanning pages 2-3 with section numbers, but the header repeats on every page making line-level detection context-dependent.
+
+**Impact:** TOC entries leak into the heading index as real sections, producing false-positive evidence (section headings matched during section_topic routing but with no substantive body).
+
+**Fix:** File: `src/lib/chat/quickCheckSectionExtractor.ts`, function `findTocBlockBounds()` (~line 111-147)
+- Add multi-line TOC detection: scan sequences of lines matching `<section-number> <title> <page-number>` (even without leader dots)
+- Add TOC suffix pattern to `stripTocSuffix()` that catches `^[A-Z]\d+ ... \d+$` format without dots
+- Register detected TOC ranges so downstream evidence compilation (`compileEvidenceDocument.ts`) can mark spans inside them as `toc` block type, making them reliably `"excluded"` reliability
+- **Cost:** Low (add ~20 lines of regex heuristics). **Benefit:** High — eliminates false-positive sections from 3/14 fixtures.
+
+---
+
+### W2. Section heading regex misses parenthesized heading patterns
+
+**Evidence from corpus:**
+- `pd_redd_v1_130-extracted.txt`: Uses `2.4 (Baseline Scenario)`, `2.5 (Additionality)`, `1.10 (Leakage)` — parenthesized headings
+- `blue-nile-redd-extracted.txt`: Same pattern `2.4 (Baseline Scenario)`, `2.5 (Additionality)`, `1.10 (Leakage)`
+- The `SECTION_HEADING_PAREN_RE` regex (`/^(?:[ \t]*(?:Section[ \t]+)?(\d+(?:\.\d+)*)[ \t]+\((.+)\))[ \t]*$/gm`) does match these, **but** it requires the line to END with the closing paren. If PDF extraction introduces trailing whitespace or page-numbers after the paren, the regex misses.
+
+More critically: The `isLikelyHeadingCandidate()` check requires the title to have mixed-case long words or 2+ all-caps words. `"(Baseline Scenario)"` has 2 capitalized words — but the leading `(` can trip the regex anchor. And `"(Leakage)"` is only 8 chars — the title extraction clause `headingMatch[2]?.trim() ?? ""` may strip the parens, leaving just "Leakage" which then fails `isLikelyHeadingCandidate` because it's too short/simple.
+
+**Impact:** Missing baseline/additionality/leakage section headings in REDD/AFOLU PDDs that use VCS-style parenthesized numbering. This directly causes `no_evidence` for core sections on fixtures `real-pd-redd-v130` (short excerpt) and `real-blue-nile-redd`.
+
+**Fix:** File: `src/lib/chat/quickCheckSectionExtractor.ts`, function `isLikelyHeadingCandidate()` (~line 79-85)
+- Add a special case: if title is a single capitalized word with optional parens like `(Baseline)`, `(Leakage)`, `(Monitoring)`, `(Additionality)`, treat as valid
+- Better approach: add an explicit allow-list of carbon-document section titles that bypass the normal heuristic
+- File: `src/lib/chat/quickCheckSectionExtractor.ts`, function `isLikelyTopLevelSectionTitle()` (~line 51-77)
+- Reduce `headingishWords.length / words.length < 0.6` to 0.5 — too strict for short parenthesized titles
+- **Cost:** Low (~10 lines). **Benefit:** High — directly fixes 2 of 14 fixtures where sections vanish.
+
+---
+
+### W3. Section body extraction fails when body text is on a different page from heading
+
+**Evidence from corpus:**
+- `pd_redd_v1_130-extracted.txt`: `1.10 (Leakage)` heading is at line 48, but body text continues to line 54. The page break (`\f`) at line 24 (`Page 10 of 85`) means heading and body are on different pages. The `hasBodyTextAfter()` function checks if the next non-empty, non-heading line has text. But if there's ONLY a page break between heading and body (no non-empty line), it rejects the heading.
+- The page-boundary logic in `currentExtractor.ts` splits on `\f` form feeds but `findHeadingsInContinuousText` and `hasBodyTextAfter` work on normalized text where `\f` is replaced with `\n`, so a `\f` can look like an empty line.
+- The `hasBodyTextAfter()` function's logic: `const nextHeadingNum = extractHeadingNumberFromLine(trimmed)` — if the next line AFTER the heading is a page number or header/footer (which is then filtered by `stripHeaderFooterNoise`), it's invisible to the check, causing a false "no body text" rejection.
+
+**Impact:** Section headings near page boundaries are dropped. For `pd_redd_v1_130-extracted.txt`, `1.10 (Leakage)` is detected heading but the body extraction says "no body text after heading" → section is excluded.
+
+**Fix:** File: `src/lib/chat/quickCheckSectionExtractor.ts`, function `hasBodyTextAfter()` (~line 159-178)
+- Before rejecting, strip page boundaries (`\f` → spaces) and re-check for body text
+- Or: change the body-finding logic to scan across page boundaries instead of stopping at first `\f`
+- File: `src/lib/chat/quickCheckSectionExtractor.ts`, function `normalizeText()` (~line 33-38)
+- The `stripHeaderFooterNoise` function strips page numbers but the `\f` handling could lose paragraphs that follow a form-feed on the same logical heading
+- **Cost:** Medium (~15-20 lines). **Benefit:** High — multi-page PDDs are the norm for real docs.
+
+---
+
+### W4. Pipe-delimited table content in extracted text destroys contiguous evidence
+
+**Evidence from corpus:**
+- `blue-nile-redd-extracted.txt`: Lines 14-20 contain a carbon pool table with pipe `|` formatting. Lines 30-36 contain a monitoring parameter table with pipe `|` formatting. Lines 42-46 contain a leakage table.
+- The `detectBlockType()` function in `compileEvidenceDocument.ts` line 102: `if (/\|/.test(trimmed) || /\S(?:\s{2,}|\t)\S/.test(trimmed)) return "table";`
+- This treats each pipe-delimited line as a standalone "table" block, **breaking paragraph continuation**. A section with `paragraph text | table row | more paragraph text` fragment the evidence stream into isolated `"table"` blocks with `reliability: "limited"`.
+- The `"limited"` reliability causes downstream sufficiency validators to see only fragmented table cells instead of contiguous narrative, so `validateBaseline()` and `validateLeakage()` get short, calculation-like text.
+
+**Impact:** The `real-blue-nile-redd` fixture explicitly documents this: "tables inside sections suppress evidence signal even when valid prose precedes them." The baseline_scenario question is expected to return `no_evidence` because the pipe-formatted table content fragments text and breaks evidence validation. But in many real documents, pipe content is just a simple CSV or markdown table embedded in a paragraph — treating every pipe-line as a standalone table block is too aggressive.
+
+**Fix:** File: `src/lib/quickCheck/evidence/compileEvidenceDocument.ts`, function `detectBlockType()` (~line 94-105)
+- Add a heuristic: if a pipe-delimited line is short (fewer than 2 pipes or < 40 chars) and surrounded by paragraph text, treat it as paragraph continuation rather than a table
+- Better approach: implement a mini-table parser that groups consecutive pipe-delimited lines into a single table block, but allows the sections BEFORE and AFTER the table to remain as contiguous paragraph blocks
+- Add `tableContiguous` mode: if a "table" block sits between two paragraph blocks in the same section, merge the paragraphs
+- **Cost:** Medium (~30-40 lines). **Benefit:** Medium — fixes the table-fragmentation issue for document types that mix tables and prose.
+
+---
+
+### W5. Intro-element classification (heading vs paragraph) is too aggressive with short lines
+
+**Evidence from corpus:**
+- `currentExtractor.ts`, function `introLineElementType()` (~line 96-108): The critical rule is at line 106: `if (trimmed.length <= 140 && wordCount >= 2 && !STANDALONE_METHOD_LABEL_RE.test(trimmed)) return "heading";`
+- This classifies ANY short line (≤140 chars, ≥2 words, not a method label) as a "heading". 
+- In `pd_redd_v1_130-extracted.txt`, the intro lines include "Page 1 of 85" (classified as `paragraph` via `PAGE_MARKER_RE`), but also "VCS Version 4.2", "VM0007 REDD+ Methodology Modules", "Project Description Document: PD_REDD_v1_130" — the latter is correctly a title, but "VCS Version 4.2" gets classified as heading, polluting the heading index.
+- In `regression-boilerplate-metadata.txt`, ALL lines are generic metadata — but lines like `Clean Development Mechanism` (18 chars, 3 words) are classified as headings.
+- In `gs-luf-pdd-extracted.txt`, the first paragraph "Gold Standard for the Global Goals" is correctly a paragraph via the `Gold Standard` check, but "Host Country: Mozambique" should be a `field` — it IS matched by `FIELD_LIKE_LINE_RE` and correctly returned as `paragraph`. But the line is ALSO classified as `heading` by the length heuristic... wait, `FIELD_LIKE_LINE_RE` returns `paragraph` which takes precedence (the function checks title/paragraph FIRST before heading). So it's okay.
+
+**Impact:** The intro paragraph classification creates spurious heading elements that leak into the evidence document heading index. This can cause `section_index` routing to find false-positive section matches.
+
+**Fix:** File: `src/lib/documentParsing/adapters/currentExtractor.ts`, function `introLineElementType()` (~line 96-108)
+- Tighten the heading heuristic: require either (a) mixed-case with capital first letter on short words, or (b) at least some lowercase letters in 5+ char words
+- Add an exclusion set of common non-heading short lines: version strings, standard names, dates, document IDs
+- Move FIELD_LIKE_LINE_RE check BEFORE the length-based heading check — field lines should never be classified as headings
+- **Cost:** Low (~15 lines). **Benefit:** Medium — reduces false-positive headings in ~4 fixtures.
+
+---
+
+### W6. Repeated page-header/-footer content suppresses body-text detection in `compileEvidenceDocument.ts`
+
+**Evidence from corpus:**
+- `pd-redd-v130-extracted.txt`: Every page starts with `PROJECT DESCRIPTION: VCS` / `Version 3` / `v3.2 N` triplet — these are headers.
+- `collectRepeatedPageEdgeLines()` in `compileEvidenceDocument.ts` (~line 181-200) correctly identifies these as repeated headers/footers (appearing ≥2 pages).
+- However, the `detectBlockType()` function processes these headers as regular content first, inserting them into the evidence stream before `collectRepeatedPageEdgeLines()` runs. Since `collectRepeatedPageEdgeLines` uses the TEXT only, and the header/footer overlay happens AFTER block type detection, header lines that also match `FIELD_RE` or `SECTION_HEADING_RE` patterns can be misclassified.
+- The `pageEdgeLines.headers` override at line 270-272 only catches exact line-text matches. If the page header is `PROJECT DESCRIPTION: VCS` on every page, it's caught. But if the first page has a slightly different header (no page number suffix), it slips through.
+
+**Impact:** Headers and footers that look like real content pollute the evidence span index, causing false-positive section_heading or field spans. This is especially pernicious with VCS/Verra template documents where the page header IS `PROJECT DESCRIPTION: VCS` — a phrase that looks like a legitimate heading.
+
+**Fix:** File: `src/lib/quickCheck/evidence/compileEvidenceDocument.ts`, function `buildCandidateBlocks()` (~line 234-347)
+- Run `collectRepeatedPageEdgeLines()` FIRST, before any block type detection
+- Override block type to "header"/"footer" for repeated page-edge lines BEFORE calling `detectBlockType()`, not after
+- Add detection of header-like patterns at page edges even when the text varies slightly (e.g., `v3.2 N` where N differs)
+- **Cost:** Low (~10 lines reordering + 10 lines pattern). **Benefit:** Medium — reduces noise in multi-page VCS docs.
+
+---
+
+### W7. Section heading regex is line-anchored but PDF extraction can concatenate lines
+
+**Evidence from corpus:**
+- `envira-amazonia-vm0007-extracted.txt`: `4.3  MonitoringPlan` — note no space between "Monitoring" and "Plan". The `SECTION_HEADING_RE` expects `(\d+(?:\.\d+)*)[ \t]*[.:]?[ \t]+(.+)` — the `[ \t]+` requires whitespace between number and title. But "4.3  MonitoringPlan" has TWO spaces, which should match. However, `isLikelyHeadingCandidate` rejects it because `MonitoringPlan` has `word.replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9+()-]+$/g, "")` — but `MonitoringPlan` is one word, so `words.length` is 1, and the function requires 2+ words at top of `isLikelyTopLevelSectionTitle`.
+- In `real-pd-redd-v130` (short excerpt), `1.9  Project Boundary` — this IS correctly matched because `Project Boundary` splits into 2 words.
+- But what about `4.3  MonitoringPlan`? It's 1 word (12 chars) — `isLikelyTopLevelSectionTitle` returns false because `words.length > 8` is not hit (it's 1), but the check falls through to `headingishWords.length / words.length < 0.6` which is `0/1 = 0 < 0.6` → false. Then `!hasMixedCaseLongWord && allCapsLongWordCount < 2` — `hasMixedCaseLongWord` = true (`MonitoringPlan` has mixed case, 12 chars), so this returns true! So `isLikelyTopLevelSectionTitle` returns true... but only because `hasMixedCaseLongWord` is true. This is an accidental pass.
+
+**Impact:** Fragile heading detection. Minor PDF extraction artifacts (concatenated words, missing spaces, extra punctuation) cause valid section headings to be silently dropped.
+
+**Fix:** File: `src/lib/chat/quickCheckSectionExtractor.ts`, function `isLikelyTopLevelSectionTitle()` (~line 51-77)
+- Add a word-splitting pre-pass for CamelCase words like `MonitoringPlan` → `Monitoring Plan`
+- Or: for section numbers that look like carbon-document standards (A.1, B.4, 1.x, 4.x, etc.), use a more relaxed title check
+- Add the camelCase split in `cleanExtractedDisplayText()` or a new function before heading matching
+- **Cost:** Low (~8-10 lines). **Benefit:** Low-Medium — edge case but catches common PDF extraction artifacts.
+
+---
+
+## Summary: Ranked Improvement Recommendations
+
+| # | Weakness | File(s) | Impacted Fixtures | Lines Changed | Complexity | Benefit |
+|---|----------|---------|-------------------|---------------|------------|---------|
+| **1** | TOC detection misses non-dotted TOC entries & multi-page TOCs | `quickCheckSectionExtractor.ts` | 3/14 (toc-only-pdd, pd-redd-v130-full, blue-nile) | ~20 | Low | High |
+| **2** | Parenthesized headings like `2.4 (Baseline Scenario)` rejected by heuristic | `quickCheckSectionExtractor.ts` | 2/14 (pd_redd_v1_130, blue-nile-redd) | ~10 | Low | High |
+| **3** | Section body text lost across page breaks (heading on page N, body on N+1) | `quickCheckSectionExtractor.ts` | 2/14 (pd_redd_v1_130, pd-redd-v130-full) | ~20 | Medium | High |
+| **4** | Pipe-delimited table lines fragment contiguous section evidence | `compileEvidenceDocument.ts` | 2/14 (blue-nile-redd, envira) | ~35 | Medium | Medium |
+| **5** | Intro classification tags short lines as headings too aggressively | `currentExtractor.ts` | 3/14 (boilerplate, methodology-preamble, blue-nile) | ~15 | Low | Medium |
+| **6** | Page header/footer detection runs too late (after block analysis) | `compileEvidenceDocument.ts` | 2/14 (pd-redd-v130-full) | ~20 | Low | Medium |
+| **7** | CamelCase word concatenation from PDF extraction breaks heading detection | `quickCheckSectionExtractor.ts` | 1/14 (envira) | ~10 | Low | Low-Med |
+
+### Net estimated accuracy improvement from top 3 fixes: **significant** — would fix ~5 of the 14 eval fixtures that currently have section-index failures.
+
+### Recommended implementation order:
+1. **Fix W1+W2** (TOC + parenthesized headings) — same file, same function family, ~30 combined lines
+2. **Fix W3** (page-boundary body loss) — moderate effort, biggest single-fixture impact
+3. **Fix W5** (intro classification) — easy, prevents heading pollution
+4. **Fix W4** (table fragmentation) — more complex but opens up table-heavy docs
+5. **Fix W6+W7** (header timing + CamelCase) — polish
+
+The current-extractor is the right baseline to improve — it's deterministic, has no failing dependencies, and the pymupdf adapter falls back to it for text inputs anyway.

--- a/STRUCTURED_METADATA_TRACE.md
+++ b/STRUCTURED_METADATA_TRACE.md
@@ -1,0 +1,298 @@
+# Structured Metadata Pipeline Trace Report
+
+## Executive Summary
+
+**Verdict: The Codex concern is partially confirmed.** The PyMuPDF adapter **does produce structured output** (elementType, pageNumber, sectionPath, boundingBox, table structure), but two downstream points partially **flatten it back to regex-on-text** for heading/section logic, and the `compileEvidenceDocumentFromStructure` path **does** preserve structure while the `getStructuredQueryContext` fallback path **does not**. The PDF-backed path (`resolveStructuredQueryContext`) and the raw-text fallback path (`getStructuredQueryContext`) produce materially different evidence.
+
+---
+
+## Stage 0: Parser Selection
+
+**File:** `src/lib/documentParsing/index.ts`
+- Line 30-36: `resolveConfiguredDocumentParserAdapterId()` reads `process.env.QUICK_CHECK_PARSER`
+- Line 16: Default adapter is `"pymupdf"` (defined as `DEFAULT_DOCUMENT_PARSER_ADAPTER_ID` in `types.ts` line 16)
+- **Finding: QUICK_CHECK_PARSER is NOT set anywhere in production code** — only in tests. So by default, `pymupdf` is selected.
+- **However**, the pymupdf adapter falls back to `currentExtractor` if anything goes wrong (no pdfFilePath, helper fails, etc.)
+
+---
+
+## Stage 1a: PyMuPDF Adapter (`parseText`)
+
+**File:** `src/lib/documentParsing/adapters/pymupdfAdapter.ts`
+
+### What it receives
+- `input.pdfFilePath` (optional) and `input.rawText`
+- A Python subprocess runs `scripts/pymupdf-parse.py` via `runPymupdfHelperSync`
+
+### What it produces (in `mapPymupdfHelperJsonToParsedDocument`)
+The helper JSON has:
+- `raw_text` — flat text
+- `pages[]` — each with `page_number`, `text`, `blocks[]` (with `bbox`)
+- `headings[]` — each with `text`, `level`, `page_number`
+- `tables[]` — each with `id`, `page_number`, `row_count`, `column_count`, `cells[]`
+
+**Metadata preservation at this stage:**
+
+| Field | Preserved? | Where |
+|---|---|---|
+| `elementType` | **Yes** | Lines 187-198 (heading), 206-217 (paragraph) — hardcoded but correct |
+| `pageNumber` | **Yes** | Line 189 (from `heading.page_number`), Line 209 (from `pageItem.page_number`) |
+| `sectionPath` | **Yes** | Lines 184-185 (built from synthetic sectionNumber via `buildSectionPath`) |
+| `boundingBox` | **NO** | Lines 187-217 — elements do NOT include `boundingBox` from block-level bbox data |
+| `table` structure | **Partial** | Lines 168-178 — `ParsedTable` is created with `id`, `pageNumber`, `columnCount`, `rowCount`, `cells[]` (row, col, text). But **NO `boundingBox`** on cells or table, and **NO `headerRowCount`**. Cell text only — no coordinates. |
+| `headings[].sectionNumber` | **Lost on headingIndex** | Lines 279-282: final `headings` array has `sectionNumber: undefined` stripped out |
+
+### CRITICAL FLATTENING POINTS (lines 223-224):
+```ts
+const sectionsByNumber = extractPddSections(rawText);   // ← regex on raw text!
+const headingIndex = buildPddHeadingIndex(rawText);       // ← regex on raw text!
+```
+**Lines 223-224**: Even though `helperJson` contains structured headings with page numbers and levels, `extractPddSections` and `buildPddHeadingIndex` are **called on `rawText`** — the flat concatenated text with form feeds — completely ignoring the structured `helperJson.headings[]`. This means `sectionsByNumber` and `headingIndex` are built from scratch using regex (from `quickCheckSectionExtractor.ts`), duplicating work that PyMuPDF already did.
+
+### `blocks` (lines 225-233):
+```ts
+const blocks = elements.map((element) => ({
+  id: element.id,
+  type: element.elementType === "heading" ? "heading" : "paragraph",
+  text: element.text,
+  normalizedText: element.normalizedText,
+  pageNumber: element.pageNumber,
+  headingLevel: element.headingLevel,
+  sectionNumber: element.sectionNumber,
+}));
+```
+**`blocks` preserves `sectionNumber`, `pageNumber`, `headingLevel`** but strips `sectionPath`, `boundingBox`, `table`, `confidence`, `sourceParser`.
+
+### `pages` (line 158, 219-221):
+```ts
+const pages = splitRawTextIntoPages(rawText);  // just splits on \f
+page.elements = elements.filter((e) => e.pageNumber === page.pageNumber);
+```
+Pages are built from raw text split on `\f`. Elements are assigned by page number, but **no block-level bbox is preserved** on the page level.
+
+---
+
+## Stage 1b: Fallback Path — Current Extractor
+
+**File:** `src/lib/documentParsing/adapters/currentExtractor.ts`
+
+### What it receives
+- `input.rawText` only — the flat text, no PDF path
+
+### What it produces
+- Lines 206-207: `extractPddSections(rawText)` and `buildPddHeadingIndex(rawText)` — both regex-on-text
+- Lines 208-214: Headings built from `headingIndex` results (regex-derived)  
+- Lines 222-251: `introBlocks` and `blocks` built from regex-derived data
+- Lines 253-293: `sectionElements` — elements from headingIndex with `sectionNumber`, `sectionPath` (regex-derived)
+- Line 312: `tables: []` — **always empty** — no table structure preserved
+- Line 328: `hasBoundingBoxes: false` — **never**
+
+### Metadata at this stage:
+
+| Field | Preserved? |
+|---|---|
+| `elementType` | Yes (lines 174-193, 265-289 — but heuristically determined) |
+| `pageNumber` | Yes (from `\f` splits) |
+| `sectionPath` | Yes (line 254, from regex-detected section numbers) |
+| `boundingBox` | **No** — never set |
+| `table` structure | **No** — tables array is always `[]` |
+
+---
+
+## Stage 2: `buildArticle6DocumentModel` / `buildDocumentStructure`
+
+**File:** `src/lib/documentModel/buildArticle6DocumentModel.ts`
+
+### What it receives
+- `parsedDocument` (which has `elements[]`, `pages[]`, `tables[]`, `blocks[]`, `headings[]`, `headingIndex`, `sectionsByNumber`)
+
+### Metadata preservation in blocks (lines 97-147):
+
+```ts
+const blockSource = parsedElements.length > 0
+  ? parsedElements.map((element) => ({
+      id: element.id,
+      type: element.elementType,           // ← preserved
+      ...
+      pageNumber: element.pageNumber,      // ← preserved
+      headingLevel: element.headingLevel,  // ← preserved
+      sectionNumber: element.sectionNumber, // ← preserved
+      sectionPath: element.sectionPath,    // ← preserved
+      boundingBox: element.boundingBox,    // ← preserved (but empty in pymupdf!)
+      table: element.table,                // ← preserved
+      confidence: element.confidence,      // ← preserved
+    }))
+  : parsedDocument.blocks;
+```
+**When `elements[]` exists** (which both adapters produce), almost all metadata is carried through to `Article6DocumentBlock`.
+
+**When `elements[]` is empty**, falls back to `parsedDocument.blocks` which is **missing** `sectionPath`, `boundingBox`, `table`, `confidence`, `sourceParser`.
+
+### Metadata preservation in sections (lines 178-258):
+
+**Two code paths:**
+
+**Path A (lines 180-217):** If `headingIndex` is non-empty — uses `headingIndex` (from regex, not from structured elements!)
+- Line 181: Iterates `headingIndex` — which is built via `buildPddHeadingIndex(rawText)` — regex-on-text
+- Line 184-185: Uses `sectionsByNumber[sectionNumber]` — also from `extractPddSections(rawText)` — regex-on-text
+- **This means even when elements have `sectionNumber` with page numbers, the section body is reconstructed by regex-splitting raw text**
+
+**Path B (lines 218-258):** If `headingIndex` is empty — uses `parsedDocument.headings` (from adapter)
+- Lines 222-226: Filters `parsedDocument.blocks` by `sectionNumber` to find body text
+- **Also regex/text-based reconstruction**
+
+| Field | Preserved? |
+|---|---|
+| `blocks[].pageNumber` | **Yes** (from element) |
+| `blocks[].sectionPath` | **Yes** (from element) |
+| `blocks[].boundingBox` | **Yes structurally** but **empty in data** for pymupdf path |
+| `blocks[].table` | **Yes** (from element) |
+| `sections[].pageNumber` | **No** — sections don't store page numbers. SourceRef always has `pageNumber: 1` for Path A |
+| `sections[].titleRaw` | Comes from `headingIndex` (regex) not from structured element data |
+
+---
+
+## Stage 3: `compileEvidenceDocumentFromStructure`
+
+**File:** `src/lib/quickCheck/evidence/compileEvidenceDocument.ts` (lines 536-653)
+
+### What it receives
+- `documentStructure` (Article6DocumentModel with blocks, sections, etc.)
+
+### Metadata preservation:
+
+**Blocks → EvidenceSpans mapping (lines 552-643):**
+```ts
+const spans = input.documentStructure.blocks.flatMap((block) => {
+  const blockType = inferStructureBlockType(block, { treatAsTitle });
+  // ...
+  const sectionPath = buildStructureSectionPath(block, documentStructure); // lines 504-518
+  const headingPath = headingPathBySectionId.get(block.sectionId) ?? [];
+  const heading = headingPath[headingPath.length - 1] ?? ...;
+  
+  // Table metadata preserved:
+  const table = blockType === "table" ? {
+    tableId: block.table?.id,
+    caption: block.table?.caption,
+    rowCount: block.table?.rowCount,
+    columnCount: block.table?.columnCount,
+    headerRowCount: block.table?.headerRowCount,
+    cells: block.table ? buildEvidenceTableCells({...}) : undefined,
+    limitedProvenance: !hasNativeTableMetadata,
+  } : undefined;
+```
+
+| Field | Preserved? |
+|---|---|
+| `page` | **Yes** — `block.pageNumber ?? null` (line 625) |
+| `sectionId` | **Yes** — `block.sectionId` (line 630) |
+| `heading` | **Yes** — built from section heading path (line 573) |
+| `headingPath` | **Yes** — from section hierarchy (lines 568-572) |
+| `sectionPath` | **Yes** — from `buildStructureSectionPath` (line 567) |
+| `sourceBlockId` | **Yes** — `block.id` (line 634) |
+| `table` | **Yes** — if block has table metadata (lines 574-589) |
+| `boundingBox` | **Yes** — in `layout.boundingBox` (line 613) |
+| `reliability` | **Yes** — computed from block type (lines 590-594) |
+
+**BUT** the `layout.limitedProvenance` is set to `true` when `!block.boundingBox` (line 615), which is **always true for PyMuPDF blocks** since boundingBox is never populated by the adapter.
+
+### Contrast with `compileEvidenceDocument` (lines 520-534):
+The legacy `compileEvidenceDocument` takes `rawText` and runs regex-based `buildCandidateBlocks()` which re-detects everything from scratch — this is the **true flattening path** and is **NOT used** by `compileEvidenceDocumentFromStructure`.
+
+---
+
+## Stage 4: `buildSectionTableIndex`
+
+**File:** `src/lib/quickCheck/indexing/buildSectionTableIndex.ts`
+
+### What it receives
+- `documentStructure` and `evidenceDocument`
+
+### This stage is meta-indexing:
+
+**`buildSectionTree` (line 111-210):**
+- Iterates `documentStructure.sections` (lines 142-158) and `evidenceDocument.spans` (lines 160-177)
+- Uses `span.sectionId`, `span.headingPath`, `span.sectionPath`, `span.page` — all from the structured evidence
+- **Metadata is preserved through this stage** as long as the upstream preserved it
+
+**`buildTableIndex` (lines 212-266):**
+- Filters `evidenceDocument.spans` by `blockType === "table"`
+- Preserves all table cell metadata including `boundingBox`, `pageNumber`, `sourceTableId`
+- **Metadata preserved** through to `TableCellReference[]`
+
+**`buildSectionTopicMap` (lines 333-376):**
+- Uses `sectionTree.nodesById` and `documentStructure.sections` body text
+- **Runs regex pattern matching** (`TOPIC_PATTERNS` at lines 15-26) on section heading, headingPath, and body text
+- This is **intentional** — topic classification is inherently keyword/regex-based regardless of parser
+
+---
+
+## Stage 5: Router Context — Comparison of Two Paths
+
+### Path A: `resolveStructuredQueryContext` (PDF-backed, server-only)
+
+**File:** `src/lib/chat/quickCheckStructuredQuery.ts`
+
+**Lines 14-104:**
+- Calls `parseDocumentText({ rawText, pdfFilePath })` — goes through PyMuPDF adapter with the actual PDF
+- Calls `buildArticle6DocumentModel()` — preserves structured metadata
+- Calls `compileEvidenceDocumentFromStructure()` — preserves structured metadata
+- Calls `buildProjectFactContract()` — uses evidence spans with section paths
+
+**Metadata preserved through the entire pipeline.**
+
+### Path B: `getStructuredQueryContext` (raw-text, fallback)
+
+**File:** `src/lib/chat/quickCheckReviewQuestion.ts`
+
+**Lines 50-77:**
+- Calls `parseDocumentText({ rawText })` — **no pdfFilePath**, so even the pymupdf adapter falls back to `currentExtractor` (line 357 of pymupdfAdapter.ts)
+- Current extractor produces **no tables**, **no bounding boxes**, and derives headings/sections via regex
+- Effectively the same as just running regex on raw text
+
+### When each path is used:
+
+`resolveStructuredQueryContext` (StructuredQuery.ts, lines 14-109):
+- Line 15: checks `if (pdfRef)` — only used when a PDF reference is available
+- Line 108: falls back to `getStructuredQueryContext(rawPddText)` if no PDF ref
+
+`buildReviewQuestionResult` (ReviewQuestion.ts, lines 253-336):
+- Line 263-264: uses `structuredQueryContext` if provided, otherwise falls back to `getStructuredQueryContext`
+- **In production, this is likely the raw-text fallback path** since `structuredQueryContext` is only injected in specific server-action contexts
+
+---
+
+## Definitive Metadata Loss Points
+
+| # | File:Line | What Happens | Severity |
+|---|---|---|---|
+| 1 | `pymupdfAdapter.ts:158` | `pages` are built by splitting `rawText` on `\f` — loses original PyMuPDF page objects' block-level bbox, element layout, and font info | **High** |
+| 2 | `pymupdfAdapter.ts:187-217` | Elements are constructed from `helperJson.headings[]` and `helperJson.pages[].text` but `boundingBox` is never populated from the block-level bbox data in `helperJson.pages[].blocks[].bbox` | **High** |
+| 3 | `pymupdfAdapter.ts:223` | `extractPddSections(rawText)` — runs full regex-on-text heading detection on the flat `rawText`, ignoring the structured headings from PyMuPDF | **Critical** |
+| 4 | `pymupdfAdapter.ts:224` | `buildPddHeadingIndex(rawText)` — rebuilds heading index from scratch via regex on raw text | **Critical** |
+| 5 | `pymupdfAdapter.ts:279-282` | `headings` array has `sectionNumber: undefined` — structured section number stripped from final heading output | **Medium** |
+| 6 | `pymupdfAdapter.ts:225-233` | `blocks` mapped from elements — strips `sectionPath`, `boundingBox`, `table`, `confidence`, `sourceParser` | **Medium** |
+| 7 | `currentExtractor.ts:206-207` | By design: extractor operates only on raw text — no tables, no bounding boxes, no structured metadata | **Inherent** |
+| 8 | `buildArticle6DocumentModel.ts:181-217` | Even when elements have structured `sectionNumber`, sections are rebuilt from regex-derived `headingIndex` and `sectionsByNumber` | **High** |
+| 9 | `buildArticle6DocumentModel.ts:184-185` | `sectionsByNumber[sectionNumber]` is the regex-split raw text, not the structured element text | **Medium** |
+| 10 | `pymupdfAdapter.ts:168-178` | Table cells have no `boundingBox` — the PyMuPDF helper JSON's block-level bbox data is not mapped to cell bounding boxes | **Medium** |
+
+---
+
+## Key Findings Summary
+
+1. **The PyMuPDF adapter DOES produce structured output** — `elements[]` with `elementType`, `pageNumber`, `sectionNumber`, `sectionPath`, `headingLevel`, and `tables[]` with structure. But `boundingBox` is never populated.
+
+2. **Despite having structured output, the adapter immediately runs regex-on-text extractors** (`extractPddSections`, `buildPddHeadingIndex` at pymupdfAdapter.ts:223-224) on the flat raw text. These are stored as `sectionsByNumber` and `headingIndex` on the ParsedDocument, and downstream `buildArticle6DocumentModel` **prefers these regex-derived indices** over the structured elements for section construction.
+
+3. **`buildArticle6DocumentModel` (lines 180-217) uses `headingIndex` (regex) to build sections**, even though structured elements with `sectionNumber` exist. The structured element data is only used for `blocks[]` — not for section hierarchy.
+
+4. **The PDF-backed path (`resolveStructuredQueryContext`) vs. the raw-text path (`getStructuredQueryContext`)** differ significantly:
+   - PDF path: PyMuPDF adapter → structured elements → TableIndex with real spans
+   - Raw-text path: falls back to currentExtractor → no tables → no bounding boxes → all regex
+
+5. **`compileEvidenceDocumentFromStructure`** is the point where structured metadata is genuinely preserved into `EvidenceSpan[]` — it correctly carries `pageNumber`, `sectionId`, `heading`, `headingPath`, `sectionPath`, `table`, `boundingBox`, and `confidence` from `Article6DocumentBlock`.
+
+6. **The biggest structural waste**: PyMuPDF identifies structured headings (with level, page_number) in the Python helper script, but `mapPymupdfHelperJsonToParsedDocument` ignores this and re-runs regex-on-text on the concatenated raw text. The structured heading data is used only for the `elements[]` array (where it's mapped 1:1) and then ignored for section building.
+
+7. **`boundingBox` is the biggest gap**: The PyMuPDF helper JSON has `pages[].blocks[].bbox` data, but it's never mapped into `ParsedElement.boundingBox`. This makes `hasBoundingBoxes: true` in the quality report a **misleading claim** — bounding boxes are declared present but never populated.

--- a/docs/production-pdf-audit.md
+++ b/docs/production-pdf-audit.md
@@ -1,0 +1,139 @@
+# Production PDF Path Audit
+
+> Investigated every step from browser upload to PyMuPDF parsing in production.
+
+---
+
+## 1. How PDFs are uploaded today
+
+The browser reads the file via `File.arrayBuffer()`, stores the bytes in **IndexedDB** (client-side), then sends the full bytes as `FormData` in a `POST` to `/api/quick-check/pdf-extract`.
+
+**Source:** `src/lib/proofMap/attachments.ts:91-133` → `src/lib/chat/quickCheckPdfClient.ts:11-111`
+
+The server receives the full binary, writes it to `/tmp/quick-check-pdfs/`, and returns a `pdfRef` token (a 10-min in-memory Map entry pointing to the temp file path).
+
+**Source:** `src/app/api/quick-check/pdf-extract/route.ts:27-35,180-181`
+
+---
+
+## 2. Whether upload goes through a Vercel API request body
+
+**Yes — the full PDF bytes travel through the Vercel API route body.**
+
+The client calls `fetch("/api/quick-check/pdf-extract", { method: "POST", body: form })` where `form` is a `FormData` containing the file bytes. The server reads `request.formData()` and then `file.arrayBuffer()`.
+
+**Source:** `quickCheckPdfClient.ts:18-26`, `route.ts:126-148`
+
+There is **no S3/Blob step**. Bytes arrive inside the Vercel request body.
+
+---
+
+## 3. Whether large PDFs >4.5MB can reach the server
+
+**Yes, the app allows up to 20MB.**
+
+- `MAX_QUICK_CHECK_PDF_BYTES = 20 * 1024 * 1024` (20MB)
+- Vercel's default body size limit is **5MB** for serverless functions (4.5MB is a common proxy limit, but Vercel's hard limit is ~5MB for hobby/pro plans)
+- The server explicitly checks `bytes.byteLength > MAX_QUICK_CHECK_PDF_BYTES` and returns HTTP 413 if exceeded
+
+**Risk:** Vercel's serverless function body limit is **~5MB** by default. PDFs between 5MB and 20MB will be **rejected by Vercel's infrastructure before reaching the app code**. The app's own 20MB check never fires for these — Vercel returns a 413 before the request hits the handler.
+
+**Source:** `quickCheckPdfUpload.ts:1`, `route.ts:164`, Vercel docs (default 5MB serverless body limit).
+
+---
+
+## 4. Whether production Quick Check has a real pdfFilePath or only raw text
+
+**This is the critical finding: the PDF-backed path works in production IF the PDF is small enough to get through Vercel's body limit, but the fallback path runs silently for most real-world PDDs.**
+
+The flow is:
+
+1. Upload → `/api/quick-check/pdf-extract` → returns `{ text, pdfRef }`
+2. Browser stores `pdfRef` in React state via `evidenceAnalysis.pdfRef`
+3. `resolveStructuredQueryContext(rawPddText, pdfRef)` is called
+4. Inside: `pdfFilePath = resolvePdfRef(pdfRef)` resolves the in-memory Map entry
+5. `parseDocumentText({ rawText, pdfFilePath })` is called with a real file path
+
+**However**, if `pdfRef` is missing (e.g. from a cached/reloaded state, or the 10-min TTL expired), or if PyMuPDF fails, the fallback is silent:
+
+```
+parseDocumentText({ rawText })  // no pdfFilePath → currentExtractor
+```
+
+The **raw-text fallback path** (`getStructuredQueryContext`) is used at lines 263-264 of `quickCheckReviewQuestion.ts` when `structuredQueryContext` is not passed in. This calls `parseDocumentText({ rawText })` — **without pdfFilePath** — which goes straight to `currentExtractor` with no structured headings/tables.
+
+**Source:** `quickCheckStructuredQuery.ts:14-20`, `quickCheckReviewQuestion.ts:263-264`, `components/chat/QuickCheckPanel.tsx:1498-1499,1823`
+
+---
+
+## 5. Whether PyMuPDF runs successfully in Vercel production
+
+**Unknown without production logs, but the infrastructure exists:**
+
+- A **PyInstaller-compiled binary** (`public/pymupdf-parse`) is built during `vercel installCommand` and deployed
+- `vercel.json` has: `pip3 install pyinstaller pymupdf pdfplumber && pyinstaller --onefile --name pymupdf-parse scripts/pymupdf-parse.py`
+- `pymupdfHelper.ts` checks for the compiled binary at `public/pymupdf-parse` (line 59-86) and runs it with `execFileSync`
+- `next.config.ts` includes `./scripts/pymupdf-parse.py` in `outputFileTracingIncludes` for the semantic-evidence route
+
+**Known issues:**
+- The compiled binary is NOT in `outputFileTracingIncludes` for the `/api/quick-check/pdf-extract` route — only for the semantic-evidence route
+- `execFileSync` runs with 120s timeout and 50MB buffer, which should handle large PDDs
+- If the binary fails (missing, wrong arch, GLIBC version mismatch), it falls back silently via `fallbackToCurrentExtractor` with no production alerting
+
+**Source:** `vercel.json:6`, `pymupdfHelper.ts:59-86,199-208`, `next.config.ts:14-18`
+
+---
+
+## 6. How often parserFallbackFrom: current-extractor happens
+
+**Cannot quantify without production log metrics, but the conditions are common:**
+
+1. **No pdfFilePath** — anytime `resolveStructuredQueryContext` is called without a valid `pdfRef` (TTL expired, cached state, reload from localStorage)
+2. **PyMuPDF binary missing on Vercel** — the binary path isn't traced for the main PDF-extract route
+3. **Binary incompatible** — GLIBC version mismatch on Vercel's runtime
+4. **PDF too large** — 5MB Vercel limit means many real PDDs silently fail before PyMuPDF runs
+5. **Helper returns error** — the Python script can fail on malformed PDFs
+6. **Helper returns empty text** — scanned/image-only PDFs
+
+**Each fallback logs a `console.warn` but only when `process.env.VERCEL` is truthy** (line 115-121 of `pymupdfAdapter.ts`). There's no structured observability, no Sentry, no count.
+
+**Source:** `pymupdfAdapter.ts:108-127,301-358`, `pymupdfInit.ts:18-32`
+
+---
+
+## 7. Whether parsed structured output is cached or recomputed per request
+
+**Not cached.** Every call to `resolveStructuredQueryContext` with a valid `pdfRef` re-runs the PyMuPDF subprocess via `lazyRunPymupdfHelperSync`. The temp file is on `/tmp` which is ephemeral per serverless instance.
+
+The only caching is:
+- `pymupdfHelper.checkPymupdfAvailability()` caches the availability check (per instance)
+- The `pdfRef` → file path Map has a 10-min TTL but is in-memory (lost between cold starts)
+- **Parsed structured output** (sections, headings, tables) is **never cached** — recomputed on every Quick Check run
+
+**Source:** `pymupdfHelper.ts:53-54` (`_availabilityCache`), `quickCheckPdfStore.ts:6-34` (in-memory Map TTL)
+
+---
+
+## Summary of Risks
+
+| # | Issue | Severity |
+|---|-------|----------|
+| 1 | Full PDF upload through Vercel API body (no S3/Blob) | High |
+| 2 | Vercel 5MB body limit blocks PDFs >4.5MB before app code | High |
+| 3 | pdfRef TTL is only 10 min, stored in ephemeral in-memory Map | Medium |
+| 4 | Compiled PyMuPDF binary not traced for main pdf-extract route | Medium |
+| 5 | No production logging/metrics for fallback rate | Medium |
+| 6 | No caching of parsed structured output | Low |
+| 7 | Silent fallback to currentExtractor with no user signal | Medium |
+
+## Recommended flow
+
+```
+browser
+→ direct upload PDF to Blob/S3 (not through Vercel body)
+→ server receives only pdfRef/storage-key
+→ parser downloads/opens file from storage
+→ PyMuPDF returns structured JSON
+→ Quick Check consumes cached structured JSON
+→ raw-text parser is fallback only
+```

--- a/docs/production-pdf-audit.md
+++ b/docs/production-pdf-audit.md
@@ -30,7 +30,7 @@ There is **no S3/Blob step**. Bytes arrive inside the Vercel request body.
 
 ## 3. Whether large PDFs >4.5MB can reach the server
 
-**Yes, the app allows up to 20MB.**
+**No, not reliably. The app allows up to 20MB internally, but Vercel rejects PDFs above ~5MB before the handler runs.**
 
 - `MAX_QUICK_CHECK_PDF_BYTES = 20 * 1024 * 1024` (20MB)
 - Vercel's default body size limit is **5MB** for serverless functions (4.5MB is a common proxy limit, but Vercel's hard limit is ~5MB for hobby/pro plans)

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -186,6 +186,15 @@ Status SSOT: `docs/roadmaps/quickcheck-parser-replacement/phase-status.json`
 Details: `docs/roadmaps/quickcheck-parser-replacement/PLAN.md`
 
 
+## quickcheck-v2
+
+Status SSOT: `docs/roadmaps/quickcheck-v2/phase-status.json`
+Details: `docs/roadmaps/quickcheck-v2/PLAN.md`
+
+Lane status: Planned
+Rebuild Quick Check from clean ingestion up. PDF → canonical JSON → section tree → evidence spans → answer → status. One layer per PR. No scoring. No LLM finals. No Blob test dependency.
+
+
 ## requirement-coverage
 
 Status SSOT: `docs/roadmaps/requirement-coverage/phase-status.json`

--- a/docs/roadmaps/quickcheck-v2/PLAN.md
+++ b/docs/roadmaps/quickcheck-v2/PLAN.md
@@ -1,0 +1,418 @@
+# Quick Check v2 Roadmap
+
+> Status is sourced from `docs/roadmaps/quickcheck-v2/phase-status.json`; docs must not drift.
+>
+> Status: Planning — v2 path not yet started.
+> v1 is frozen for critical fixes only.
+> PR #839 is parked/superseded.
+
+## Core Goal
+
+Given any normal carbon project PDD, Quick Check v2 produces evidence-backed answers for six structured checks:
+
+1. Host country
+2. Methodology
+3. Baseline scenario
+4. Additionality
+5. Leakage
+6. Stakeholder consultation
+
+Wrong answers must trace to one layer. No scoring. No LLM final answers. No Blob-dependent test path.
+
+## Rollback Line (Conceptual)
+
+Do not roll back the app. Roll back the *analysis path design* to before the Blob/extraction maze:
+
+### Cut from v2
+
+| Feature | Why |
+|---------|-----|
+| Blob-dependent test/analysis path | Introduced upload → ref → resolve → cold start → staleness. v2 reads canonical JSON locally. |
+| Browser regex extraction | Not a reliable evidence source. |
+| Router candidates for structured checks | Router is for open-ended Q&A, not fact lookups. |
+| scoreSentenceForLabel / scoreCandidateText | Heuristic tower that grows per-PDD. v2 has zero scoring. |
+| LLM final answers | LLM may suggest later but never determines FOUND. |
+| Descendant section sweeping | `.includes()` sectionPath matching pulls all children. v2 uses direct body only unless explicit. |
+| Multi-phase validateCheckInternal switchboard | Each check is a clean priority chain, not a 5-phase maze. |
+| Poisoned gold fixtures | "of" as expected host_country is wrong. Gold comes from PDF, not current output. |
+
+### Keep from v1 ideas
+
+- Fact contract extraction
+- Evidence spans with quote/page/section provenance
+- Section tree
+- found / unclear / missing status concept
+- Regression test corpus (structure only — rebuild content from PDF truth)
+
+## Status Overview
+
+```json
+{
+  "v2": {
+    "phase": "planning",
+    "envira": "not started",
+    "pipeline": "PDF → canonical JSON → section tree → evidence spans → answer → status"
+  },
+  "v1": {
+    "status": "frozen",
+    "allowed_changes": "critical production fixes only",
+    "pr_839": "parked — superseded by v2",
+    "pr_831_833_etc": "do not replicate Blob/extraction patterns in v2"
+  }
+}
+```
+
+## Phases
+
+### Phase 0: Freeze v1
+
+**Goal:** Stop adding debt to v1.
+
+**Actions:**
+- Park PR #839 (not mergeable — encodes broken answers and production hacks)
+- No new fixtures, validators, scoring rules, LLM replacement, Blob changes, router behavior for v1
+- v1 stays live for production; v2 is the clean rebuild path
+
+**Path:** `src/lib/quickCheck/` — frozen
+
+### Phase 1: Ingestion Only (PR #1)
+
+**Branch:** `v2/ingestion-envira`
+
+**Goal:** Parse Envira Amazonia into deterministic canonical extracted JSON. No answers yet.
+
+**Path:** `src/lib/quickCheckV2/ingestion/`
+
+**Output shape per block:**
+
+```
+spanId: string
+page: number
+text: string
+blockType: string (heading | body | table | footer | header)
+sectionHeading: string
+sectionPath: string[]
+source: "primary" | "fallback"
+```
+
+**Tests:** `tests/lib/quickCheckV2/envira-ingestion.test.ts`
+
+Required strings with correct page/span/section provenance:
+
+- "Acre, Brazil"
+- "VM0007: REDD Methodology Modules"
+- "conversion to pasture"
+- "cattle ranching"
+- "simple cost analysis"
+- "carbon finance" / "VCU revenue"
+- "Leakage emissions"
+- "41 families"
+- "FPIC"
+- "grievance"
+
+**Hard constraints:**
+- No answer extraction
+- No found/unclear/missing status
+- No LLM
+- No router
+- No scoring
+- No Blob dependency in tests
+- No fake page 1 for everything
+
+**Acceptance:** Extraction is deterministic. Tests fail if key strings disappear or lose provenance.
+
+```json
+{
+  "phase_1_ingestion": {
+    "status": "not_started",
+    "branch": "v2/ingestion-envira",
+    "test_document": "Envira Amazonia",
+    "required_assertions": [
+      "Acre, Brazil", "VM0007: REDD Methodology Modules",
+      "conversion to pasture", "cattle ranching",
+      "simple cost analysis", "carbon finance / VCU revenue",
+      "Leakage emissions", "41 families", "FPIC", "grievance"
+    ],
+    "forbidden": ["answers", "status", "LLM", "router", "scoring", "Blob"],
+    "acceptance": "deterministic extraction with real page/span/section provenance"
+  }
+}
+```
+
+### Phase 2: Section Tree + Evidence Spans (PR #2)
+
+**Goal:** Turn extracted JSON into a clean section tree and evidence span index.
+
+**Key behavior:** Direct body text under exact section heading. No descendant sweeping by default. `.includes()` sectionPath matching that pulls all children is forbidden.
+
+**Acceptance:** For each of the six checks, v2 can return the top evidence span with correct section heading.
+
+```json
+{
+  "phase_2_section_tree": {
+    "status": "not_started",
+    "depends_on": "phase_1",
+    "constraint": "direct body only, no descendant sweeping",
+    "acceptance": "top evidence span per check with correct section"
+  }
+}
+```
+
+### Phase 3: Evidence Retrieval — Six Checks (PR #3)
+
+**Goal:** For each structured check, retrieve evidence using fixed source priority:
+
+1. Valid fact contract candidate
+2. Exact section direct body
+3. Controlled raw-text fallback (unclear unless strong provenance)
+4. LLM suggestion only, not final (not yet implemented)
+
+**Check-specific behavior:**
+
+| Check | Priority | Expected Envira Evidence |
+|-------|----------|--------------------------|
+| host_country | factContract.hostCountry → projectLocation/title scan | "Acre, Brazil" |
+| methodology | methodologyPrimary → exact methodology section | "VM0007: REDD Methodology Modules" |
+| baseline_scenario | exact Baseline Scenario section direct body | "conversion to pasture / cattle ranching" |
+| additionality | exact Additionality section → investment/barrier evidence | "simple cost analysis / carbon finance required" |
+| leakage | exact Leakage section direct body | "activity shifting + market effects leakage / LK-ASP + LK-ME" |
+| stakeholder_consultation | stakeholder / local consultation section | "41 families / FPIC / grievance" |
+
+**Hard constraints:**
+- No router candidates for these six checks
+- No scoring / term bonuses / PDD-specific phrase boosts
+- No raw text fallback as FOUND without valid provenance
+
+```json
+{
+  "phase_3_evidence_retrieval": {
+    "status": "not_started",
+    "depends_on": "phase_2",
+    "forbidden": ["router_candidates", "scoring", "term_bonuses", "pdd_specific_boosts"],
+    "source_priority": ["fact_contract", "exact_section", "raw_text_fallback", "llm_suggestion"],
+    "acceptance": "each check returns correct Envira evidence with quote/page/section/span"
+  }
+}
+```
+
+### Phase 4: Tiny Answer Extractors (PR #4)
+
+**Goal:** Turn evidence spans into short structured answers.
+
+**Expected Envira answers:**
+
+| Check | Expected Answer |
+|-------|----------------|
+| host_country | Brazil |
+| methodology | VM0007 REDD Methodology Modules / REDD-MF |
+| baseline_scenario | conversion to pasture / cattle ranching |
+| additionality | carbon finance required; no financial return without VCS/VCU revenue |
+| leakage | activity shifting and market-effects leakage assessed under LK-ASP and LK-ME |
+| stakeholder_consultation | 41 families visited; FPIC/grievance process discussed |
+
+**Hard constraints:**
+- No generic answer-anything summarizer
+- No LLM final answers
+- No current-output-as-truth
+- Answer must come from selected evidence
+
+```json
+{
+  "phase_4_answer_extractors": {
+    "status": "not_started",
+    "depends_on": "phase_3",
+    "forbidden": ["generic_summarizer", "llm_final", "current_output_as_truth"],
+    "acceptance": "Envira produces correct short answers from selected evidence"
+  }
+}
+```
+
+### Phase 5: Status Validator (PR #5)
+
+**Goal:** Boring deterministic status logic.
+
+**Rules:**
+- FOUND = answer + quote + page + section + span exist
+- UNCLEAR = related evidence exists but answer is incomplete
+- MISSING = no usable evidence
+
+**Constraint:** Validators do not search, rank, or invent fallback answers. They only judge evidence already selected.
+
+```json
+{
+  "phase_5_status_validator": {
+    "status": "not_started",
+    "depends_on": "phase_4",
+    "rules": {
+      "FOUND": "answer + quote + page + section + span",
+      "UNCLEAR": "related evidence but incomplete",
+      "MISSING": "no usable evidence"
+    },
+    "constraint": "validators judge only, do not search or rank"
+  }
+}
+```
+
+### Phase 6: Gold Envira Fixture (PR #6)
+
+**Goal:** Freeze Envira as the first true v2 gold fixture.
+
+**Gold record must include:**
+- expected answer
+- expected status
+- gold quote
+- page
+- section path
+- span id
+- known junk to reject
+
+**Rule:** Gold is PDF truth, not current app output. Never encode known wrong output as expected.
+
+**Fails if:**
+- Brazil becomes "of"
+- methodology uses module/tool boilerplate only
+- additionality returns only "tool is applied"
+- baseline picks calculation/emissions section instead of scenario
+- leakage lacks actual leakage assessment
+- stakeholder lacks real consultation evidence
+- page/section/span provenance disappears
+
+```json
+{
+  "phase_6_gold_envira": {
+    "status": "not_started",
+    "depends_on": "phase_5",
+    "document": "Envira Amazonia",
+    "rule": "gold is PDF truth, not current output",
+    "fail_conditions": [
+      "host_country_of", "methodology_boilerplate_only", "additionality_tool_only",
+      "baseline_wrong_section", "leakage_no_assessment", "stakeholder_no_evidence",
+      "missing_provenance"
+    ]
+  }
+}
+```
+
+### Phase 7+: Add PDFs Slowly
+
+**Rule:** Only add a new PDF if it introduces a structural/evidence failure mode Envira does not cover.
+
+**Examples of valid new failure modes:**
+- CDM PDD (different document structure)
+- AR-only PDD (different baseline logic)
+- Small-scale PDD (negligible leakage section)
+- PDD where host country appears only in metadata table, not in location text
+
+**Each new PDF is one PR.** The PR must state:
+- new failure mode
+- why Envira does not cover it
+- expected gold evidence
+- whether code changed and why any change is generic
+
+```json
+{
+  "phase_7_add_pdfs": {
+    "status": "not_started",
+    "depends_on": "phase_6",
+    "threshold": "new failure mode not covered by Envira",
+    "rule": "one PDF per PR, must state new failure mode"
+  }
+}
+```
+
+## Anti-Debt Rules
+
+These are enforced at code review and CI for all v2 PRs.
+
+### Rule 1: One layer per PR
+
+A PR may touch only one pipeline layer. If it touches multiple layers, reject it.
+
+### Rule 2: No scoring
+
+Forbidden: `scoreSentenceForLabel`, `scoreCandidateText`, phrase bonuses, PDD-specific weights.
+
+If evidence selection is wrong, fix extraction, section matching, or source priority.
+
+### Rule 3: No PDD-specific code
+
+Forbidden: `if Envira`, `if slash-and-burn`, `if oil palm`, `if this document title`.
+
+Allowed: "exact Baseline Scenario beats Baseline Emissions", "valid country names can be extracted from project location/title/header".
+
+### Rule 4: No current-output-as-gold
+
+Gold comes from the PDF, not from what the app currently returns.
+
+Bad: `expected host_country = "of"`
+Good: `expected host_country = "Brazil"`, `rejected_junk = ["of"]`
+
+### Rule 5: Extraction before intelligence
+
+If extraction/page/section/span is wrong, stop. Do not patch validators or answer extractors until ingestion is correct.
+
+### Rule 6: No silent fallback as FOUND
+
+Every answer must know its source: `fact_contract`, `exact_section`, `raw_text_fallback`, `llm_suggestion`.
+
+Only validated fact/section evidence can become FOUND.
+
+### Rule 7: LLM is suggestion only
+
+LLM may propose candidate evidence later, but it cannot set FOUND. Must pass deterministic validation first.
+
+### Rule 8: Corpus is a tripwire, not training data
+
+Add PDFs only to represent new failure modes, not for volume.
+
+### Rule 9: Every PR simplifies or isolates
+
+Each PR must answer: what layer does this prove? What complexity did it remove?
+
+### Rule 10: Visible acceptance matters
+
+Every functional PR must state the visible product effect. If no visible effect, prove a lower-layer artifact (extracted JSON, evidence spans).
+
+## Key Structural Decisions
+
+### Test path uses local canonical JSON, not Blob
+
+v2 tests read from `tests/fixtures/quickCheckV2/` — local files only. No Blob refs, no upload state, no serverless memory.
+
+This eliminates the upload → ref → resolve → cold start → staleness chain.
+
+### Pipeline shape
+
+```
+PDF ──→ canonical extracted JSON ──→ section tree ──→ evidence spans ──→ answer ──→ status
+         (deterministic artifact)        (no scoring)     (6 checks)      (short)    (boring)
+```
+
+### Branch structure
+
+```
+main
+  └── feat/qc-production-pdf-audit (frozen v1)
+         └── v2/ingestion-envira (PR #1)
+                └── v2/section-tree (PR #2)
+                       └── v2/evidence-retrieval (PR #3)
+                              └── v2/answer-extractors (PR #4)
+                                     └── v2/status-validator (PR #5)
+                                            └── v2/gold-envira (PR #6)
+                                                   └── v2/add-cdm-pdd (PR #7+)
+```
+
+### Status JSON convention
+
+Each phase has a status block at the end of its section. Update the top-level status block on PR merge.
+
+## Verdict Summary
+
+```
+Freeze v1.
+Park PR #839.
+Start v2 from scratch in src/lib/quickCheckV2/.
+One layer per PR.
+One PDF (Envira) until phase 6.
+No scoring. No LLM. No Blob. No PDD-specific hacks.
+```

--- a/docs/roadmaps/quickcheck-v2/phase-status.json
+++ b/docs/roadmaps/quickcheck-v2/phase-status.json
@@ -1,0 +1,127 @@
+{
+  "roadmapId": "quickcheck-v2",
+  "name": "Quick Check v2: Stable Ingestion First",
+  "status": "planned",
+  "currentGoalId": "qcv2-0-roadmap-boundary",
+  "goals": [
+    {
+      "id": "qcv2-0-roadmap-boundary",
+      "title": "Roadmap and PR boundary",
+      "status": "done",
+      "dependsOn": [],
+      "branch": "v2/roadmap-ssot",
+      "doneCriteria": [
+        "PLAN.md exists under docs/roadmaps/quickcheck-v2/",
+        "phase-status.json exists with all goals listed",
+        "no production code changed",
+        "roadmap validation passes"
+      ]
+    },
+    {
+      "id": "qcv2-1-ingestion",
+      "title": "Envira ingestion only — canonical extracted JSON",
+      "status": "planned",
+      "dependsOn": ["qcv2-0-roadmap-boundary"],
+      "branch": "",
+      "doneCriteria": [
+        "src/lib/quickCheckV2/ingestion/ creates deterministic canonical JSON from Envira",
+        "10 key strings found with correct page/span/section provenance",
+        "no scoring",
+        "no answers",
+        "no statuses",
+        "no LLM",
+        "no Blob dependency in tests",
+        "page 1 is not the default for every span"
+      ]
+    },
+    {
+      "id": "qcv2-2-section-tree",
+      "title": "Section tree and evidence spans",
+      "status": "planned",
+      "dependsOn": ["qcv2-1-ingestion"],
+      "branch": "",
+      "doneCriteria": [
+        "section tree built from canonical JSON",
+        "direct body under exact heading only — no descendant sweeping",
+        "each of six checks can return top evidence span"
+      ]
+    },
+    {
+      "id": "qcv2-3-evidence-retrieval",
+      "title": "Evidence retrieval for six structured checks",
+      "status": "planned",
+      "dependsOn": ["qcv2-2-section-tree"],
+      "branch": "",
+      "doneCriteria": [
+        "fixed source priority: fact contract → exact section → raw text fallback",
+        "no router candidates for structured checks",
+        "no scoring or term bonuses",
+        "Envira returns correct evidence with quote/page/section/span"
+      ]
+    },
+    {
+      "id": "qcv2-4-answer-extractors",
+      "title": "Tiny answer extractors",
+      "status": "planned",
+      "dependsOn": ["qcv2-3-evidence-retrieval"],
+      "branch": "",
+      "doneCriteria": [
+        "each of six checks has a small, check-specific extractor",
+        "answers come from selected evidence only",
+        "no LLM final answers",
+        "no generic summarizer"
+      ]
+    },
+    {
+      "id": "qcv2-5-status-validator",
+      "title": "Boring deterministic status validator",
+      "status": "planned",
+      "dependsOn": ["qcv2-4-answer-extractors"],
+      "branch": "",
+      "doneCriteria": [
+        "FOUND = answer + quote + page + section + span",
+        "UNCLEAR = related evidence but incomplete",
+        "MISSING = no usable evidence",
+        "validators do not search, rank, or invent answers"
+      ]
+    },
+    {
+      "id": "qcv2-6-gold-envira",
+      "title": "Gold Envira fixture",
+      "status": "planned",
+      "dependsOn": ["qcv2-5-status-validator"],
+      "branch": "",
+      "doneCriteria": [
+        "Envira gold fixture with expected answer, status, gold quote, page, section, span ID",
+        "known junk to reject included",
+        "gold is PDF truth, not current output",
+        "fails on known broken patterns (\"of\", boilerplate-only, wrong section, missing provenance)"
+      ]
+    },
+    {
+      "id": "qcv2-7-add-pdfs",
+      "title": "Add PDFs slowly by new failure mode only",
+      "status": "planned",
+      "dependsOn": ["qcv2-6-gold-envira"],
+      "branch": "",
+      "doneCriteria": [
+        "each new PDF introduces a structural/evidence failure mode Envira does not cover",
+        "one PDF per PR",
+        "each PR states new failure mode and why code change (if any) is generic"
+      ]
+    }
+  ],
+  "phase_meta": {
+    "status": "planned",
+    "summary": "Rebuild Quick Check from clean ingestion up. PDF → canonical JSON → section tree → evidence spans → answer → status. One layer per PR. No scoring. No LLM finals. No Blob test dependency.",
+    "current_focus": "Goal 0 complete (roadmap boundary). Next: Goal 1 — Envira ingestion.",
+    "not_active_now": [],
+    "last_updated_at": "2026-06-27T00:00:00Z"
+  },
+  "pr_evidence": {
+    "840": { "title": "docs: Quick Check v2 roadmap — phased rebuild plan" }
+  },
+  "pr_notes": {
+    "840": "Goal 0 partial: roadmap document created but placed outside SSOT. This PR (v2/roadmap-ssot) completes the move into docs/roadmaps/quickcheck-v2/."
+  }
+}

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -7,6 +7,8 @@ const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    // @vercel/blob uses ESM deps (jose) incompatible with Jest CJS transform
+    '^@vercel/blob$': '<rootDir>/tests/mocks/vercel-blob.ts',
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app.article6",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/blob": "^2.5.0",
         "clsx": "^2.1.1",
         "fake-indexeddb": "^6.2.5",
         "fflate": "^0.8.2",
@@ -4150,6 +4151,68 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.5.0.tgz",
+      "integrity": "sha512-ke6WnMMYlUu9nBFmyjwEkC2o03Ku2X7QIeJ3KtlOJzblS/8Xau209zt0ic76rd7IvV5nrKCH/BzP4MkFmoSLuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "^3.6.1",
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.7.1.tgz",
+      "integrity": "sha512-RrSsVWbq3KLK5lJobyTPp3tSthNfUp+zWkXno5Wkko0oEW05rA4ngOrnVypP4+L8/Av89uPo2rWFmzL8iwnsmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.0",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -4596,6 +4659,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -5151,7 +5223,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6261,7 +6332,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -7044,7 +7114,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
       "engines": {
         "node": ">=10.17.0"
       }
@@ -7239,6 +7308,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -7415,6 +7507,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7512,7 +7610,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -7628,7 +7725,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -8316,6 +8412,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8939,8 +9044,7 @@
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -8991,7 +9095,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9229,7 +9332,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -9379,7 +9481,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -9406,6 +9507,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/own-keys": {
@@ -9538,7 +9648,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10130,6 +10239,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -10408,7 +10526,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10421,7 +10538,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10512,8 +10628,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -10798,7 +10913,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10926,6 +11040,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -11738,6 +11864,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -12095,7 +12230,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -12277,6 +12411,31 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "npm": ">=10"
   },
   "dependencies": {
+    "@vercel/blob": "^2.5.0",
     "clsx": "^2.1.1",
     "fake-indexeddb": "^6.2.5",
     "fflate": "^0.8.2",

--- a/src/app/api/quick-check/pdf-extract/route.ts
+++ b/src/app/api/quick-check/pdf-extract/route.ts
@@ -9,6 +9,7 @@ import { extractPdfText } from "@/lib/chat/quickCheckEvidence";
 import { extractPdfTextWithPdfParse, type PdfExtractionDiagnostics } from "@/lib/chat/quickCheckPdfExtractor";
 import { formatQuickCheckPdfLimitLabel, isLikelyPdfBytes, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 import { storePdfRef } from "@/lib/chat/quickCheckPdfStore";
+import { uploadPdfToBlob } from "@/lib/chat/quickCheckPdfBlob";
 import { withMetrics } from "@/lib/metrics";
 import { resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing";
 import { checkPymupdfAvailability } from "@/lib/documentParsing/adapters/pymupdfHelper";
@@ -58,7 +59,6 @@ function buildParserDebug(): ParserDebugPayload {
 
   if (adapterId !== "pymupdf") return debug;
 
-  // Probe the packages directory (Python interpreter mode)
   const probePaths = [
     path.resolve(cwd, "public", ".python"),
     path.resolve(cwd, "node_modules", ".python"),
@@ -77,9 +77,7 @@ function buildParserDebug(): ParserDebugPayload {
     }
   }
 
-  // Verify the parser works via the correct mode
   if (availability.parserBinary) {
-    // Compiled binary mode: run --version
     debug.parserBinary = availability.parserBinary;
     try {
       execFileSync(availability.parserBinary, ["--version"], {
@@ -90,7 +88,6 @@ function buildParserDebug(): ParserDebugPayload {
       debug.fitzImportError = e instanceof Error ? e.message : String(e);
     }
   } else {
-    // Python interpreter mode: run -c import fitz
     const python3 = availability.pythonPath;
     const env: NodeJS.ProcessEnv = { ...process.env };
     if (debug.pythonPackagesPath) {
@@ -115,19 +112,24 @@ function buildParserDebug(): ParserDebugPayload {
   return debug;
 }
 
+/**
+ * Handle PDF extraction from uploaded bytes.
+ *
+ * After extracting text, uploads the PDF to Vercel Blob for durable storage.
+ * The blob URL becomes the pdfRef — survives cold starts, has no TTL.
+ *
+ * When BLOB_READ_WRITE_TOKEN is not configured, falls back to the legacy
+ * in-memory pdfRef (10-min TTL, lost on cold start).
+ */
 async function handlePost(request: Request) {
   const contentType = request.headers.get("content-type") ?? "";
   let bytes: ArrayBuffer | null = null;
   let declaredFilename = "uploaded.pdf";
 
-  // Robust upload handling: prefer multipart/form-data (avoids CORS preflight,
-  // works reliably from browser fetch for binary content). Fall back to raw
-  // body for direct clients or older callers.
   if (contentType.includes("multipart/form-data")) {
     try {
       const form = await request.formData();
       const fileField = form.get("file");
-      // Duck-type check (File/Blob may not be instanceof in all server contexts)
       const hasArrayBuffer = fileField && typeof fileField === "object" && "arrayBuffer" in fileField;
       if (hasArrayBuffer) {
         const f = fileField as { arrayBuffer: () => Promise<ArrayBuffer>; name?: string; size?: number };
@@ -142,7 +144,6 @@ async function handlePost(request: Request) {
   }
 
   if (!bytes) {
-    // Raw body fallback path (kept for compatibility and tests)
     bytes = await request.arrayBuffer().catch(() => null);
     declaredFilename = request.headers.get("x-article6-filename") || declaredFilename;
   }
@@ -151,8 +152,6 @@ async function handlePost(request: Request) {
     return qcJson({ error: "Missing PDF bytes.", code: "missing-file" }, { status: 400 });
   }
 
-  // Content-type validation: only enforce on raw path or when clearly wrong.
-  // For multipart uploads (the normal browser path) we rely primarily on magic bytes.
   const isRawPath = !contentType.includes("multipart");
   if (isRawPath && !/application\/pdf|octet-stream/i.test(contentType)) {
     return qcJson(
@@ -177,8 +176,19 @@ async function handlePost(request: Request) {
     );
   }
 
+  // Save to temp, upload to Blob for durability, return blob URL as pdfRef
   const pdfFilePath = saveTempPdf(bytes);
-  const pdfRef = storePdfRef(pdfFilePath);
+  let pdfRef: string;
+
+  try {
+    const blob = await uploadPdfToBlob(bytes);
+    pdfRef = blob.url;
+    console.log("[quick-check/pdf-extract] Uploaded PDF to Blob storage:", blob.pathname);
+  } catch (error) {
+    // Blob upload failed — fall back to in-memory pdfRef
+    console.warn("[quick-check/pdf-extract] Failed to upload to Blob, using in-memory pdfRef:", error);
+    pdfRef = storePdfRef(pdfFilePath);
+  }
 
   let fallbackReason = "pdf-parse returned empty text — fell back to heuristic extractor";
   let diagnostics: PdfExtractionDiagnostics | undefined;
@@ -186,8 +196,6 @@ async function handlePost(request: Request) {
   try {
     const extraction = await extractPdfTextWithPdfParse({ bytes });
     diagnostics = extraction.metadata.diagnostics;
-    // pdf-parse can succeed but return empty text for ASCII85-encoded streams.
-    // Fall through to heuristic extractor which has custom ASCII85 + FlateDecode.
     if (extraction.text.trim().length > 0) {
       const parserDebug = buildParserDebug();
       return qcJson({
@@ -236,6 +244,7 @@ async function handleGet() {
     ok: true,
     engine: "pdf-parse",
     runtime: "nodejs",
+    storage: "vercel-blob",
   });
 }
 

--- a/src/app/api/quick-check/semantic-evidence/route.ts
+++ b/src/app/api/quick-check/semantic-evidence/route.ts
@@ -27,7 +27,7 @@ async function handlePost(request: Request) {
   const claimText = typeof body === "object" && body && "claimText" in body && typeof body.claimText === "string" ? body.claimText : "";
   const rawPddText = typeof body === "object" && body && "rawPddText" in body && typeof body.rawPddText === "string" ? body.rawPddText : "";
   const pdfRef = typeof body === "object" && body && "pdfRef" in body && typeof body.pdfRef === "string" ? body.pdfRef : undefined;
-  const pdfFilePath = pdfRef ? resolvePdfRef(pdfRef) : undefined;
+  const pdfFilePath = pdfRef ? await resolvePdfRef(pdfRef) : undefined;
   const methodologyId = typeof body === "object" && body && "methodologyId" in body && typeof body.methodologyId === "string" ? body.methodologyId : "";
   const methodologyVersion = typeof body === "object" && body && "methodologyVersion" in body && typeof body.methodologyVersion === "string" ? body.methodologyVersion : "";
 

--- a/src/app/api/quick-check/upload/route.ts
+++ b/src/app/api/quick-check/upload/route.ts
@@ -17,25 +17,41 @@ import { withMetrics } from "@/lib/metrics";
  * browser-to-Blob uploads (bypassing Vercel body limit entirely).
  */
 async function handlePost() {
-  const hasBlobToken = Boolean(process.env.BLOB_READ_WRITE_TOKEN);
+  const blobAvailable = checkBlobAvailability();
 
   return NextResponse.json({
     ok: true,
-    store: hasBlobToken ? "vercel-blob" : "in-memory",
+    store: blobAvailable ? "vercel-blob" : "in-memory",
     maxSizeBytes: 20 * 1024 * 1024,
     maxSizeLabel: "20MB",
   });
 }
 
 async function handleGet() {
-  const hasBlobToken = Boolean(process.env.BLOB_READ_WRITE_TOKEN);
+  const blobAvailable = checkBlobAvailability();
 
   return NextResponse.json({
     ok: true,
-    store: hasBlobToken ? "vercel-blob" : "in-memory",
+    store: blobAvailable ? "vercel-blob" : "in-memory",
     maxSizeBytes: 20 * 1024 * 1024,
     maxSizeLabel: "20MB",
   });
+}
+
+/**
+ * Check whether Vercel Blob storage credentials are available.
+ *
+ * Supports three auth methods:
+ *   1. BLOB_READ_WRITE_TOKEN — explicit token from env
+ *   2. VERCEL_OIDC_TOKEN + BLOB_STORE_ID — OIDC-based auth on Vercel deployments
+ *   3. BLOB_TOKEN — legacy alias (some Vercel setups)
+ */
+function checkBlobAvailability(): boolean {
+  return Boolean(
+    process.env.BLOB_READ_WRITE_TOKEN ||
+    (process.env.VERCEL_OIDC_TOKEN && process.env.BLOB_STORE_ID) ||
+    process.env.BLOB_TOKEN,
+  );
 }
 
 export const POST = withMetrics("api/quick-check/upload:POST", handlePost);

--- a/src/app/api/quick-check/upload/route.ts
+++ b/src/app/api/quick-check/upload/route.ts
@@ -1,0 +1,42 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { withMetrics } from "@/lib/metrics";
+
+/**
+ * Quick Check PDF upload endpoint.
+ *
+ * Returns configuration about the upload store.
+ * Actual upload happens through the pdf-extract route or legacy FormData.
+ *
+ * When BLOB_READ_WRITE_TOKEN is configured, the pdf-extract route
+ * automatically uploads PDFs to Blob and returns a durable blob URL
+ * as the pdfRef.
+ *
+ * Future: Add a GET /presigned-upload-url endpoint here for direct
+ * browser-to-Blob uploads (bypassing Vercel body limit entirely).
+ */
+async function handlePost() {
+  const hasBlobToken = Boolean(process.env.BLOB_READ_WRITE_TOKEN);
+
+  return NextResponse.json({
+    ok: true,
+    store: hasBlobToken ? "vercel-blob" : "in-memory",
+    maxSizeBytes: 20 * 1024 * 1024,
+    maxSizeLabel: "20MB",
+  });
+}
+
+async function handleGet() {
+  const hasBlobToken = Boolean(process.env.BLOB_READ_WRITE_TOKEN);
+
+  return NextResponse.json({
+    ok: true,
+    store: hasBlobToken ? "vercel-blob" : "in-memory",
+    maxSizeBytes: 20 * 1024 * 1024,
+    maxSizeLabel: "20MB",
+  });
+}
+
+export const POST = withMetrics("api/quick-check/upload:POST", handlePost);
+export const GET = withMetrics("api/quick-check/upload:GET", handleGet);

--- a/src/lib/chat/quickCheckPdfBlob.ts
+++ b/src/lib/chat/quickCheckPdfBlob.ts
@@ -82,12 +82,19 @@ export async function downloadBlobToTemp(blobUrl: string): Promise<string> {
 
 /**
  * Check if a string is a Vercel Blob URL that can be used as a durable pdfRef.
+ *
+ * Matches both private and public Vercel Blob URL shapes:
+ *   - https://<store>.private.blob.vercel-storage.com/...
+ *   - https://<store>.public.blob.vercel-storage.com/...
+ *
+ * The subdomain is a store ID (alphanumeric + hyphens/underscores).
+ * The path is required (forward slash after the TLD).
  */
 export function isBlobUrl(value: string): boolean {
   return (
     typeof value === "string" &&
     value.length > 0 &&
-    /^https:\/\/[a-zA-Z0-9_-]+\.(public\.)?blob\.vercel-storage\.com\//.test(
+    /^https:\/\/[a-zA-Z0-9_-]+\.(private|public)\.blob\.vercel-storage\.com\//.test(
       value,
     )
   );

--- a/src/lib/chat/quickCheckPdfBlob.ts
+++ b/src/lib/chat/quickCheckPdfBlob.ts
@@ -1,0 +1,101 @@
+import { put, del } from "@vercel/blob";
+import { mkdirSync, writeFileSync, existsSync } from "fs";
+import path from "path";
+import os from "os";
+
+/**
+ * Upload a PDF buffer to Vercel Blob storage for durable retention.
+ *
+ * The blob URL serves as a durable pdfRef that survives Vercel cold starts
+ * and has no TTL (unlike the in-memory pdfRef store at 10 minutes).
+ *
+ * Returns the blob URL (canonical identifier) and pathname.
+ */
+export async function uploadPdfToBlob(
+  bytes: Buffer | ArrayBuffer,
+): Promise<{ url: string; pathname: string }> {
+  const buffer = Buffer.from(
+    bytes instanceof Buffer ? bytes : new Uint8Array(bytes),
+  );
+  const pathname = `quick-check/pdfs/${Date.now()}-${Math.random().toString(36).slice(2, 10)}.pdf`;
+
+  const blob = await put(pathname, buffer, {
+    access: "private",
+    contentType: "application/pdf",
+    addRandomSuffix: false,
+  });
+
+  return { url: blob.url, pathname: blob.pathname };
+}
+
+/**
+ * Download a PDF from Vercel Blob by its URL and write it to a local temp
+ * file suitable for PyMuPDF parsing.
+ *
+ * Returns the temp file path.
+ */
+export async function downloadBlobToTemp(blobUrl: string): Promise<string> {
+  const { get } = await import("@vercel/blob");
+
+  const result = await get(blobUrl, { access: "private" });
+  if (!result) {
+    throw new Error(
+      `Blob not found at ${blobUrl} — it may have been deleted or the URL is invalid.`,
+    );
+  }
+
+  if (!result.stream) {
+    throw new Error(
+      `Blob at ${blobUrl} returned status ${result.statusCode} with no stream.`,
+    );
+  }
+
+  // Consume the ReadableStream into a buffer
+  const reader = result.stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let done = false;
+  while (!done) {
+    const { value, done: isDone } = await reader.read();
+    if (value) chunks.push(value);
+    done = isDone;
+  }
+  const totalLength = chunks.reduce((acc, c) => acc + c.length, 0);
+  const buffer = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  const dir = path.join(os.tmpdir(), "quick-check-pdfs");
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const filePath = path.join(
+    dir,
+    `blob-${Date.now()}-${Math.random().toString(36).slice(2)}.pdf`,
+  );
+  writeFileSync(filePath, buffer);
+
+  return filePath;
+}
+
+/**
+ * Check if a string is a Vercel Blob URL that can be used as a durable pdfRef.
+ */
+export function isBlobUrl(value: string): boolean {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    /^https:\/\/[a-zA-Z0-9_-]+\.(public\.)?blob\.vercel-storage\.com\//.test(
+      value,
+    )
+  );
+}
+
+/**
+ * Delete a PDF from Vercel Blob by URL.
+ */
+export async function deleteBlobPdf(blobUrl: string): Promise<void> {
+  await del(blobUrl);
+}

--- a/src/lib/chat/quickCheckPdfClient.ts
+++ b/src/lib/chat/quickCheckPdfClient.ts
@@ -8,13 +8,20 @@ function uniqueMentions(...groups: Array<string[] | undefined>): string[] {
 const RECOVERED_TEXT_WARNING =
   "Server extraction failed, but Quick Check recovered document signals locally. Review extracted details before relying on matches.";
 
+/**
+ * Resolve PDF text from an uploaded file.
+ *
+ * Primary flow: server receives bytes, uploads to Vercel Blob for durable
+ * storage, and returns the blob URL as the pdfRef. The blob URL survives
+ * cold starts and has no TTL.
+ *
+ * Fallback: if Blob is unavailable, uses the legacy in-memory pdfRef.
+ */
 export async function resolveQuickCheckPdfText(input: {
   bytes: ArrayBuffer;
   filename: string;
 }): Promise<QuickCheckResolvedPdfText> {
   try {
-    // Use FormData for the upload. This keeps the request "simple" (no preflight)
-    // and is the robust way to send binary files from the browser.
     const form = new FormData();
     form.append("file", new Blob([new Uint8Array(input.bytes)], { type: "application/pdf" }), input.filename || "document.pdf");
     form.append("filename", input.filename || "document.pdf");
@@ -25,72 +32,7 @@ export async function resolveQuickCheckPdfText(input: {
       cache: "no-store",
     });
 
-    if (!response.ok) {
-      const payload = (await response.json().catch(() => ({}))) as { error?: string; code?: QuickCheckPdfRouteErrorCode };
-      if (payload.code === "file-too-large" || payload.code === "invalid-file" || payload.code === "missing-file") {
-        return {
-          text: "",
-          engine: "heuristic",
-          methodologyMentions: [],
-          warning:
-            payload.error ??
-            (payload.code === "file-too-large"
-              ? `PDF exceeds the Quick Check upload limit of ${formatQuickCheckPdfLimitLabel()}.`
-              : "Quick Check could not process this upload as a valid PDF."),
-          diagnosticCode: payload.code === "missing-file" ? "invalid-file" : payload.code,
-        };
-      }
-      // Non-explicit error status (e.g. platform 413, 5xx) — surface as request failure
-      // so the UI can show a clear diagnostic instead of silent weak fallback.
-      throw new Error(payload.error ?? `HTTP ${response.status}`);
-    }
-
-    const payload = (await response.json()) as {
-      text?: string;
-      engine?: "pdf-parse" | "heuristic";
-      pdfRef?: string;
-      parserAdapterId?: string;
-      parserFallbackFrom?: string;
-      parserDebug?: QuickCheckPdfParserDebug;
-      metadata?: {
-        parser?: "pdf-parse" | "heuristic";
-        fallbackReason?: string;
-        diagnostics?: {
-          failureKind?: "file-too-large" | "parser-failed" | "no-selectable-text" | "invalid-file";
-        };
-      };
-    };
-    const engine =
-      payload.engine === "heuristic" || payload.metadata?.parser === "heuristic"
-        ? "heuristic"
-        : "pdf-parse";
-    const failureKind = payload.metadata?.diagnostics?.failureKind;
-    const warning =
-      engine === "heuristic"
-        ? failureKind === "no-selectable-text"
-          ? "No selectable text found in this PDF."
-          : RECOVERED_TEXT_WARNING
-        : undefined;
-    const serverText = payload.text ?? "";
-    const serverMentions = extractMethodologyMentions(serverText);
-    const shouldRecoverTextLocally =
-      !serverText.trim() &&
-      (failureKind === "parser-failed" || failureKind === "no-selectable-text");
-    const localHeuristicText = shouldRecoverTextLocally ? extractPdfText(input.bytes) : "";
-    const localHeuristicMentions = shouldRecoverTextLocally ? extractMethodologyMentions(localHeuristicText) : [];
-    const text = shouldRecoverTextLocally ? localHeuristicText : serverText;
-    const parserDebug = payload.parserDebug;
-    return {
-      text,
-      engine: shouldRecoverTextLocally ? "heuristic" : engine,
-      methodologyMentions: uniqueMentions(serverMentions, localHeuristicMentions),
-      warning: shouldRecoverTextLocally && text.trim() ? RECOVERED_TEXT_WARNING : warning,
-      diagnosticCode: failureKind,
-      pdfRef: payload.pdfRef,
-      parserAdapterId: parserDebug?.parserAdapterId ?? payload.parserAdapterId,
-      parserFallbackFrom: parserDebug?.parserFallbackFrom ?? payload.parserFallbackFrom,
-      parserDebug,
-    };
+    return handleExtractResponse(response, input.bytes);
   } catch (err) {
     const localHeuristicText = extractPdfText(input.bytes);
     const localHeuristicMentions = extractMethodologyMentions(localHeuristicText);
@@ -99,7 +41,7 @@ export async function resolveQuickCheckPdfText(input: {
     return {
       text: localHeuristicText,
       engine: "heuristic",
-      methodologyMentions: localHeuristicMentions,
+      methodologyMentions: uniqueMentions(localHeuristicMentions),
       warning: localHeuristicText.trim()
         ? RECOVERED_TEXT_WARNING
         : isRequestFailure
@@ -108,4 +50,80 @@ export async function resolveQuickCheckPdfText(input: {
       diagnosticCode: isRequestFailure ? "upload-request-failed" : "parser-failed",
     };
   }
+}
+
+/**
+ * Parse the server response from pdf-extract and build QuickCheckResolvedPdfText.
+ */
+async function handleExtractResponse(
+  response: Response,
+  originalBytes: ArrayBuffer,
+): Promise<QuickCheckResolvedPdfText> {
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => ({}))) as { error?: string; code?: QuickCheckPdfRouteErrorCode };
+    if (payload.code === "file-too-large" || payload.code === "invalid-file" || payload.code === "missing-file") {
+      return {
+        text: "",
+        engine: "heuristic",
+        methodologyMentions: [],
+        warning:
+          payload.error ??
+          (payload.code === "file-too-large"
+            ? `PDF exceeds the Quick Check upload limit of ${formatQuickCheckPdfLimitLabel()}.`
+            : "Quick Check could not process this upload as a valid PDF."),
+        diagnosticCode: payload.code === "missing-file" ? "invalid-file" : payload.code,
+      };
+    }
+    throw new Error(payload.error ?? `HTTP ${response.status}`);
+  }
+
+  const payload = (await response.json()) as {
+    text?: string;
+    engine?: "pdf-parse" | "heuristic";
+    pdfRef?: string;
+    parserAdapterId?: string;
+    parserFallbackFrom?: string;
+    parserDebug?: QuickCheckPdfParserDebug;
+    metadata?: {
+      parser?: "pdf-parse" | "heuristic";
+      fallbackReason?: string;
+      pdfSource?: string;
+      blobUrl?: string;
+      diagnostics?: {
+        failureKind?: "file-too-large" | "parser-failed" | "no-selectable-text" | "invalid-file";
+      };
+    };
+  };
+
+  const engine =
+    payload.engine === "heuristic" || payload.metadata?.parser === "heuristic"
+      ? "heuristic"
+      : "pdf-parse";
+  const failureKind = payload.metadata?.diagnostics?.failureKind;
+  const warning =
+    engine === "heuristic"
+      ? failureKind === "no-selectable-text"
+        ? "No selectable text found in this PDF."
+        : RECOVERED_TEXT_WARNING
+      : undefined;
+  const serverText = payload.text ?? "";
+  const serverMentions = extractMethodologyMentions(serverText);
+  const shouldRecoverTextLocally =
+    !serverText.trim() &&
+    (failureKind === "parser-failed" || failureKind === "no-selectable-text");
+  const localHeuristicText = shouldRecoverTextLocally ? extractPdfText(originalBytes) : "";
+  const localHeuristicMentions = shouldRecoverTextLocally ? extractMethodologyMentions(localHeuristicText) : [];
+  const text = shouldRecoverTextLocally ? localHeuristicText : serverText;
+  const parserDebug = payload.parserDebug;
+  return {
+    text,
+    engine: shouldRecoverTextLocally ? "heuristic" : engine,
+    methodologyMentions: uniqueMentions(serverMentions, localHeuristicMentions),
+    warning: shouldRecoverTextLocally && text.trim() ? RECOVERED_TEXT_WARNING : warning,
+    diagnosticCode: failureKind,
+    pdfRef: payload.pdfRef,
+    parserAdapterId: parserDebug?.parserAdapterId ?? payload.parserAdapterId,
+    parserFallbackFrom: parserDebug?.parserFallbackFrom ?? payload.parserFallbackFrom,
+    parserDebug,
+  };
 }

--- a/src/lib/chat/quickCheckPdfStore.ts
+++ b/src/lib/chat/quickCheckPdfStore.ts
@@ -1,10 +1,17 @@
-/** Server-side PDF file reference store.
- *
- * Stores temp file paths keyed by opaque tokens so the browser never
- * sees raw server filesystem paths. Tokens expire after TTL seconds.
- */
-const store = new Map<string, { filePath: string; expiresAt: number }>();
+import { isBlobUrl, downloadBlobToTemp } from "@/lib/chat/quickCheckPdfBlob";
 
+/**
+ * Server-side PDF file reference store.
+ *
+ * Supports two kinds of pdfRef tokens:
+ *   1. In-memory token → temp file path (TTL: 10 min, lost on cold start)
+ *   2. Blob URL (Vercel Blob) → durable, no TTL, survives cold start
+ *
+ * The blob-backed path is preferred because it survives Vercel cold starts.
+ * The in-memory path is kept for backward compatibility during the transition.
+ */
+
+const store = new Map<string, { filePath: string; expiresAt: number }>();
 const PDF_REF_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 function cleanExpired(): void {
@@ -16,6 +23,9 @@ function cleanExpired(): void {
   }
 }
 
+/**
+ * Store a temp file path and return an opaque in-memory pdfRef token.
+ */
 export function storePdfRef(filePath: string): string {
   cleanExpired();
   const token = `pdf:${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 8)}`;
@@ -23,7 +33,32 @@ export function storePdfRef(filePath: string): string {
   return token;
 }
 
-export function resolvePdfRef(token: string): string | undefined {
+/**
+ * Resolve a pdfRef to a local temp file path.
+ *
+ * Handles both in-memory tokens and Vercel Blob URLs.
+ * For blob URLs, downloads the blob to /tmp and returns the temp path.
+ * For in-memory tokens, returns the cached file path if still valid.
+ *
+ * Returns undefined if the ref cannot be resolved.
+ */
+export async function resolvePdfRef(
+  token: string,
+): Promise<string | undefined> {
+  // Blob URL path: durable, survives cold starts
+  if (isBlobUrl(token)) {
+    try {
+      return await downloadBlobToTemp(token);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[quick-check-pdf-store] Failed to resolve blob URL "${token.slice(0, 60)}…": ${message}`,
+      );
+      return undefined;
+    }
+  }
+
+  // Legacy in-memory token path
   cleanExpired();
   const entry = store.get(token);
   if (!entry || entry.expiresAt < Date.now()) {

--- a/src/lib/chat/quickCheckStructuredQuery.ts
+++ b/src/lib/chat/quickCheckStructuredQuery.ts
@@ -12,7 +12,7 @@ initPymupdfAdapterRuntime();
 export { type StructuredQueryContext };
 
 export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?: string): Promise<StructuredQueryContext> {
-  const pdfFilePath = pdfRef ? resolvePdfRef(pdfRef) : undefined;
+  const pdfFilePath = pdfRef ? await resolvePdfRef(pdfRef) : undefined;
 
   // When we have a real PDF path, parse with it to get PyMuPDF structure.
   // Otherwise, fall through to rawText-only parsing.

--- a/tests/lib/quickCheck/pdfRefParserTrace.test.ts
+++ b/tests/lib/quickCheck/pdfRefParserTrace.test.ts
@@ -113,14 +113,14 @@ describe("resolveStructuredQueryContext with pdfRef → PyMuPDF", () => {
     "tests/fixtures/quick-check/plum-verra-demo-excerpt.pdf",
   );
 
-  it("storePdfRef + resolvePdfRef round-trips", () => {
+  it("storePdfRef + resolvePdfRef round-trips", async () => {
     if (!existsSync(FIXTURE)) return;
 
     const token = storePdfRef(FIXTURE);
     expect(typeof token).toBe("string");
     expect(token.startsWith("pdf:")).toBe(true);
 
-    const resolved = resolvePdfRef(token);
+    const resolved = await resolvePdfRef(token);
     expect(resolved).toBe(FIXTURE);
   });
 
@@ -160,7 +160,7 @@ describe("resolveStructuredQueryContext with pdfRef → PyMuPDF", () => {
 
     // Store with a short-lived token, then manually delete it to simulate expiry
     const token = storePdfRef(FIXTURE);
-    expect(resolvePdfRef(token)).toBe(FIXTURE);
+    expect(await resolvePdfRef(token)).toBe(FIXTURE);
 
     // Use a non-existent token to simulate expiry
     const ctx = await resolveStructuredQueryContext(

--- a/tests/lib/quickCheckPdfBlob.test.ts
+++ b/tests/lib/quickCheckPdfBlob.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for Quick Check Blob storage helpers.
+ *
+ * These tests verify the isBlobUrl URL detection, resolvePdfRef behavior,
+ * and the pdf-extract route Blob upload path.
+ */
+import { isBlobUrl } from "@/lib/chat/quickCheckPdfBlob";
+
+// ---------------------------------------------------------------------------
+// isBlobUrl
+// ---------------------------------------------------------------------------
+describe("isBlobUrl", () => {
+  it("accepts private Vercel Blob URLs", () => {
+    const urls = [
+      "https://my-store.private.blob.vercel-storage.com/quick-check/pdfs/abc.pdf",
+      "https://abc123.private.blob.vercel-storage.com/some/path/file.pdf",
+      "https://store-with-hyphens.private.blob.vercel-storage.com/x.pdf",
+      "https://store_with_underscores.private.blob.vercel-storage.com/x.pdf",
+    ];
+    for (const url of urls) {
+      expect(isBlobUrl(url)).toBe(true);
+    }
+  });
+
+  it("accepts public Vercel Blob URLs", () => {
+    const urls = [
+      "https://my-store.public.blob.vercel-storage.com/quick-check/pdfs/abc.pdf",
+      "https://abc123.public.blob.vercel-storage.com/some/path/file.pdf",
+    ];
+    for (const url of urls) {
+      expect(isBlobUrl(url)).toBe(true);
+    }
+  });
+
+  it("rejects non-Vercel URLs", () => {
+    const urls = [
+      "https://example.com/file.pdf",
+      "https://s3.amazonaws.com/bucket/file.pdf",
+      "https://blob.vercel-storage.com/no-subdomain.pdf",
+      "http://my-store.private.blob.vercel-storage.com/file.pdf",
+      "",
+      "not-a-url",
+      "https://my-store.other.blob.vercel-storage.com/file.pdf",
+    ];
+    for (const url of urls) {
+      expect(isBlobUrl(url)).toBe(false);
+    }
+  });
+
+  it("rejects undefined / null", () => {
+    expect(isBlobUrl("")).toBe(false);
+    expect(isBlobUrl("   ")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePdfRef (unit test with mocked Blob store)
+// ---------------------------------------------------------------------------
+describe("resolvePdfRef", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("resolves legacy in-memory tokens", async () => {
+    const { storePdfRef, resolvePdfRef } = await import(
+      "@/lib/chat/quickCheckPdfStore"
+    );
+
+    // storePdfRef returns an in-memory token
+    const token = storePdfRef("/tmp/test-file.pdf");
+    expect(token).toMatch(/^pdf:/);
+
+    const resolved = await resolvePdfRef(token);
+    expect(resolved).toBe("/tmp/test-file.pdf");
+  });
+
+  it("returns undefined for unknown in-memory tokens", async () => {
+    const { resolvePdfRef } = await import(
+      "@/lib/chat/quickCheckPdfStore"
+    );
+
+    const resolved = await resolvePdfRef("pdf:nonexistent:abc123");
+    expect(resolved).toBeUndefined();
+  });
+
+  it("resolves private Blob URLs using downloadBlobToTemp", async () => {
+    // We can't easily test the actual download path without mocking
+    // the fs and @vercel/blob modules at the integration level.
+    // This verifies that a private Blob URL passes the isBlobUrl check
+    // that gatekeeps the Blob download path.
+    const privateUrl =
+      "https://my-store.private.blob.vercel-storage.com/quick-check/pdfs/test.pdf";
+    expect(isBlobUrl(privateUrl)).toBe(true);
+
+    const publicUrl =
+      "https://my-store.public.blob.vercel-storage.com/quick-check/pdfs/test.pdf";
+    expect(isBlobUrl(publicUrl)).toBe(true);
+  });
+});

--- a/tests/mocks/vercel-blob.ts
+++ b/tests/mocks/vercel-blob.ts
@@ -4,11 +4,17 @@
  * The real @vercel/blob package has transitive ESM dependencies (jose)
  * that cannot be transformed by Jest's CJS transform. This mock provides
  * the minimal surface area needed by the Quick Check Blob helpers.
+ *
+ * All URLs use the .private.blob.vercel-storage.com shape to match
+ * Vercel's documented private blob URL format.
  */
 
+const PRIVATE_BLOB_URL = "https://mock.private.blob.vercel-storage.com/quick-check/pdfs/mock.pdf";
+const PRIVATE_BLOB_PATHNAME = "quick-check/pdfs/mock.pdf";
+
 export const put = jest.fn().mockResolvedValue({
-  url: "https://mock.blob.vercel-storage.com/quick-check/pdfs/mock.pdf",
-  pathname: "quick-check/pdfs/mock.pdf",
+  url: PRIVATE_BLOB_URL,
+  pathname: PRIVATE_BLOB_PATHNAME,
   contentType: "application/pdf",
   contentDisposition: 'attachment; filename="mock.pdf"',
 });
@@ -26,9 +32,9 @@ export const get = jest.fn().mockImplementation(async (_url: string) => {
     }),
     headers: new Headers(),
     blob: {
-      url: "https://mock.blob.vercel-storage.com/quick-check/pdfs/mock.pdf",
-      downloadUrl: "https://mock.blob.vercel-storage.com/quick-check/pdfs/mock.pdf?download=1",
-      pathname: "quick-check/pdfs/mock.pdf",
+      url: PRIVATE_BLOB_URL,
+      downloadUrl: `${PRIVATE_BLOB_URL}?download=1`,
+      pathname: PRIVATE_BLOB_PATHNAME,
       contentType: "application/pdf",
       contentDisposition: 'attachment; filename="mock.pdf"',
       cacheControl: "public, max-age=31536000",

--- a/tests/mocks/vercel-blob.ts
+++ b/tests/mocks/vercel-blob.ts
@@ -1,0 +1,40 @@
+/**
+ * Mock for @vercel/blob for Jest environments.
+ *
+ * The real @vercel/blob package has transitive ESM dependencies (jose)
+ * that cannot be transformed by Jest's CJS transform. This mock provides
+ * the minimal surface area needed by the Quick Check Blob helpers.
+ */
+
+export const put = jest.fn().mockResolvedValue({
+  url: "https://mock.blob.vercel-storage.com/quick-check/pdfs/mock.pdf",
+  pathname: "quick-check/pdfs/mock.pdf",
+  contentType: "application/pdf",
+  contentDisposition: 'attachment; filename="mock.pdf"',
+});
+
+export const del = jest.fn().mockResolvedValue(undefined);
+
+export const get = jest.fn().mockImplementation(async (_url: string) => {
+  return {
+    statusCode: 200 as const,
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("mock pdf content"));
+        controller.close();
+      },
+    }),
+    headers: new Headers(),
+    blob: {
+      url: "https://mock.blob.vercel-storage.com/quick-check/pdfs/mock.pdf",
+      downloadUrl: "https://mock.blob.vercel-storage.com/quick-check/pdfs/mock.pdf?download=1",
+      pathname: "quick-check/pdfs/mock.pdf",
+      contentType: "application/pdf",
+      contentDisposition: 'attachment; filename="mock.pdf"',
+      cacheControl: "public, max-age=31536000",
+      size: 1024,
+      uploadedAt: new Date(),
+      etag: '"mock-etag"',
+    },
+  };
+});


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- - RC5: in_progress -->
  <!-- - PR12: done -->
  <!-- - PR13: in_progress -->

For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactors with no SSOT impact), leave `slug: N/A`. The roadmap gates will skip.

Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

Visible UI changes to look for:
