### PR TITLE
feat: Quick Check v2 RC1 — Envira ingestion only

### DIFF
--- a/src/lib/quickCheckV2/ingestion/index.ts
+++ b/src/lib/quickCheckV2/ingestion/index.ts
@@ -102,32 +102,42 @@ function buildSpanId(
 const VCS_PAGE_MARKER_RE = /^v\d+(?:\.\d+)+\s+(\d+)$/;
 
 /**
- * Regex that matches other common page marker formats:
+ * Regex that matches common page marker formats with strong prefix context:
  *   "Page 1", "Page 1 of 142", "1 of 142"
  *
- * These may appear as standalone lines in CDM or other PDD formats.
+ * These must NOT match bare standalone numbers like "0", "1", "25" which
+ * commonly appear in table cells. The regex requires "Page" prefix or "of N" suffix.
  */
-const GENERIC_PAGE_MARKER_RE = /^(?:page\s+)?(\d+)\s*(?:of\s+\d+)?$/i;
+const PAGE_MARKER_RE = /^(?:page\s+(\d+)(?:\s+of\s+\d+)?|(\d+)\s+of\s+\d+)$/i;
 
 /**
  * Check if a line is a standalone page marker (not body text).
+ *
+ * Only accepts page markers that have strong contextual prefixes:
+ * - VCS format:  v3.2 N
+ * - Standard:    Page N, Page N of M
+ * - CDM format:  N of M
+ *
+ * Bare numeric lines like "0", "1", "25" are NOT page markers.
  */
 function isPageMarkerLine(
   line: string,
 ): { isMarker: true; pageNumber: number } | { isMarker: false } {
   const trimmed = line.trim();
 
+  // VCS v3.2 format: "v3.2 1", "v3.2 142" — very specific prefix, low false-positive risk
   const vcsMatch = trimmed.match(VCS_PAGE_MARKER_RE);
   if (vcsMatch) {
     return { isMarker: true, pageNumber: parseInt(vcsMatch[1]!, 10) };
   }
 
-  // Only treat as generic marker if the line is short and exclusively
-  // contains the marker (not a sentence that happens to start with "Page")
-  if (trimmed.length <= 20) {
-    const genericMatch = trimmed.match(GENERIC_PAGE_MARKER_RE);
-    if (genericMatch) {
-      return { isMarker: true, pageNumber: parseInt(genericMatch[1]!, 10) };
+  // Standard page markers with strong prefix context
+  // Only accept if the line looks like a page marker, not a table cell
+  const pageMatch = trimmed.match(PAGE_MARKER_RE);
+  if (pageMatch) {
+    const pageNum = parseInt(pageMatch[1] ?? pageMatch[2]!, 10);
+    if (pageNum > 0) {
+      return { isMarker: true, pageNumber: pageNum };
     }
   }
 
@@ -146,6 +156,19 @@ function isPageMarkerLine(
  */
 const SECTION_HEADING_RE =
   /^\s*(?:section\s+)?([A-Z]\.\d+(?:\.\d+)*|\d+(?:\.\d+)+)\s+[.:]?\s*(.+?)\s*$/i;
+
+/**
+ * Matches top-level integer-only section headings like:
+ *   "1 PROJECT DETAILS"
+ *   "5 ENVIRONMENTAL IMPACT"
+ *   "6 STAKEHOLDER COMMENTS"
+ *
+ * These are single-digit or multi-digit numbers followed by an ALL-CAPS title.
+ * Must be at the start of a line and must have a non-numeric title after the number
+ * (to distinguish from page numbers and table cells).
+ */
+const TOP_LEVEL_HEADING_RE =
+  /^\s*(\d+)\s+([A-Z][A-Z\s\/&-]+)\s*$/;
 
 /**
  * Matches annex/appendix headings like:
@@ -175,6 +198,16 @@ function detectSectionHeading(
       isHeading: true,
       sectionNumber: headingMatch[1]!,
       title: headingMatch[2]!.trim(),
+    };
+  }
+
+  // Top-level integer headings: "5 ENVIRONMENTAL IMPACT"
+  const topLevelMatch = trimmed.match(TOP_LEVEL_HEADING_RE);
+  if (topLevelMatch) {
+    return {
+      isHeading: true,
+      sectionNumber: topLevelMatch[1]!,
+      title: topLevelMatch[2]!.trim(),
     };
   }
 

--- a/src/lib/quickCheckV2/ingestion/index.ts
+++ b/src/lib/quickCheckV2/ingestion/index.ts
@@ -1,0 +1,508 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Quick Check v2 — canonical extracted document block.
+ *
+ * Every block in a canonical extracted document follows this shape.
+ * No scoring, no ranking, no answers — just provenanced text.
+ */
+
+export type QuickCheckV2Block = {
+  /** Stable, deterministic span identifier (hash-based) */
+  spanId: string;
+  /** Page number (1-indexed, from document markers, not inferred) */
+  page: number;
+  /** The extracted text content */
+  text: string;
+  /** Semantic block type */
+  blockType:
+    | "heading"
+    | "body"
+    | "table"
+    | "footer"
+    | "header"
+    | "unknown";
+  /** The nearest section heading text, or null if none */
+  sectionHeading: string | null;
+  /** Ordered path of section identifiers (e.g., ["2", "2.4", "2.4.2"]) */
+  sectionPath: string[];
+  /** Source classification: primary extraction or fallback */
+  source: "primary" | "fallback";
+};
+
+/**
+ * Quick Check v2 — canonical extracted document.
+ *
+ * This is the deterministic artifact produced by ingestion.
+ * All downstream operations (evidence retrieval, answer extraction, status)
+ * read from this document. Tests run against this JSON, not against Blob/upload state.
+ */
+export type QuickCheckV2ExtractedDocument = {
+  /** Document identifier (e.g., "proj-desc-1382" for Envira Amazonia) */
+  documentId: string;
+  /** Parser identifier (e.g., "pyMuPDF-extracted-text") */
+  parser: string;
+  /** Ordered blocks in document order */
+  blocks: QuickCheckV2Block[];
+  /** Diagnostics captured during extraction */
+  diagnostics: {
+    /** Total page count if determinable */
+    pageCount?: number;
+    /** Non-fatal warnings collected during extraction */
+    warnings: string[];
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Stable span ID
+// ---------------------------------------------------------------------------
+
+/**
+ * FNV-1a hash for stable, deterministic span IDs.
+ * Same input always produces same output — no randomness.
+ */
+function fnv1a(value: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16);
+}
+
+function buildSpanId(
+  documentId: string,
+  page: number,
+  blockIndex: number,
+  text: string,
+): string {
+  const normalized = text
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+  const hash = fnv1a(`${documentId}:p${page}:b${blockIndex}:${normalized}`);
+  return `${documentId}:p${page}:b${blockIndex}:${hash}`;
+}
+
+// ---------------------------------------------------------------------------
+// Page marker detection — handles VCS v3.2 "v3.2 N" format specifically
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex that matches VCS v3.2 page markers like "v3.2 1", "v3.2 142".
+ *
+ * These appear as standalone lines in VCS PDDs. The v1 code treated them as
+ * footer noise (FOOTER_RE matches /v\d+(\.\d+)+/) and discarded them,
+ * which caused all blocks to default to page 1.
+ *
+ * v2 recognises them as page separators and uses them to assign real
+ * page numbers.
+ */
+const VCS_PAGE_MARKER_RE = /^v\d+(?:\.\d+)+\s+(\d+)$/;
+
+/**
+ * Regex that matches other common page marker formats:
+ *   "Page 1", "Page 1 of 142", "1 of 142"
+ *
+ * These may appear as standalone lines in CDM or other PDD formats.
+ */
+const GENERIC_PAGE_MARKER_RE = /^(?:page\s+)?(\d+)\s*(?:of\s+\d+)?$/i;
+
+/**
+ * Check if a line is a standalone page marker (not body text).
+ */
+function isPageMarkerLine(
+  line: string,
+): { isMarker: true; pageNumber: number } | { isMarker: false } {
+  const trimmed = line.trim();
+
+  const vcsMatch = trimmed.match(VCS_PAGE_MARKER_RE);
+  if (vcsMatch) {
+    return { isMarker: true, pageNumber: parseInt(vcsMatch[1]!, 10) };
+  }
+
+  // Only treat as generic marker if the line is short and exclusively
+  // contains the marker (not a sentence that happens to start with "Page")
+  if (trimmed.length <= 20) {
+    const genericMatch = trimmed.match(GENERIC_PAGE_MARKER_RE);
+    if (genericMatch) {
+      return { isMarker: true, pageNumber: parseInt(genericMatch[1]!, 10) };
+    }
+  }
+
+  return { isMarker: false };
+}
+
+// ---------------------------------------------------------------------------
+// Section heading detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches section headings like:
+ *   "1.0", "1.", "2.4.2", "A.1", "Section 3.3"
+ *
+ * Does not match lines that are exclusively digits or page numbers.
+ */
+const SECTION_HEADING_RE =
+  /^\s*(?:section\s+)?([A-Z]\.\d+(?:\.\d+)*|\d+(?:\.\d+)+)\s+[.:]?\s*(.+?)\s*$/i;
+
+/**
+ * Matches annex/appendix headings like:
+ *   "Annex 1", "Appendix A", "Annex II"
+ */
+const ANNEX_HEADING_RE =
+  /^\s*(annex|appendix)\s+([A-Z0-9]+)\s*[.:]?\s*(.*)$/i;
+
+/**
+ * Check if a line is a section heading and extract its section number + title.
+ */
+function detectSectionHeading(
+  line: string,
+): { isHeading: true; sectionNumber: string; title: string } | { isHeading: false } {
+  const trimmed = line.trim();
+
+  const annexMatch = trimmed.match(ANNEX_HEADING_RE);
+  if (annexMatch) {
+    const sectionNumber = `${annexMatch[1]!.toLowerCase()}-${annexMatch[2]!.toLowerCase()}`;
+    const title = annexMatch[3]?.trim() || `${annexMatch[1]} ${annexMatch[2]}`;
+    return { isHeading: true, sectionNumber, title };
+  }
+
+  const headingMatch = trimmed.match(SECTION_HEADING_RE);
+  if (headingMatch) {
+    return {
+      isHeading: true,
+      sectionNumber: headingMatch[1]!,
+      title: headingMatch[2]!.trim(),
+    };
+  }
+
+  return { isHeading: false };
+}
+
+/**
+ * Build a section path array from a dotted section number.
+ * E.g., "2.4.2" → ["2", "2.4", "2.4.2"]
+ */
+function buildSectionPath(sectionNumber: string): string[] {
+  const parts = sectionNumber.split(".");
+  return parts.map((_, index) => parts.slice(0, index + 1).join("."));
+}
+
+// ---------------------------------------------------------------------------
+// Table detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Heuristic: a line is likely a table row if it contains pipe characters
+ * or multiple consecutive spaces/tabs separating columns.
+ */
+function isTableLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (/\|/.test(trimmed)) return true;
+  // Multiple spaces or tabs suggest tabular data
+  if (/\S(?:\s{3,}|\t)\S/.test(trimmed)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Block type detection
+// ---------------------------------------------------------------------------
+
+function detectBlockType(
+  line: string,
+  isFirstContentLine: boolean,
+  isRepeatedHeader: boolean,
+  isRepeatedFooter: boolean,
+): QuickCheckV2Block["blockType"] {
+  const trimmed = line.trim();
+  if (!trimmed) return "unknown";
+
+  // Check for repeated headers/footers first (from page-edge detection)
+  if (isRepeatedHeader) return "header";
+  if (isRepeatedFooter) return "footer";
+
+  // Table detection (must precede heading detection)
+  if (isTableLine(trimmed)) return "table";
+
+  // Section headings
+  const headingCheck = detectSectionHeading(trimmed);
+  if (headingCheck.isHeading) return "heading";
+
+  // First non-empty content line with short text → likely a title
+  if (isFirstContentLine && trimmed.length <= 180) return "heading";
+
+  return "body";
+}
+
+// ---------------------------------------------------------------------------
+// Repeated header/footer detection across pages
+// ---------------------------------------------------------------------------
+
+type PageEdgeLines = {
+  headers: Set<string>;
+  footers: Set<string>;
+};
+
+function collectRepeatedPageEdges(pages: { lines: string[] }[]): PageEdgeLines {
+  const headerCounts = new Map<string, number>();
+  const footerCounts = new Map<string, number>();
+
+  for (const page of pages) {
+    const nonEmptyLines = page.lines
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const first = nonEmptyLines[0];
+    const last = nonEmptyLines[nonEmptyLines.length - 1];
+
+    if (first && !isPageMarkerLine(first).isMarker) {
+      headerCounts.set(first, (headerCounts.get(first) ?? 0) + 1);
+    }
+    if (last && !isPageMarkerLine(last).isMarker) {
+      footerCounts.set(last, (footerCounts.get(last) ?? 0) + 1);
+    }
+  }
+
+  return {
+    headers: new Set(
+      Array.from(headerCounts.entries())
+        .filter(([, count]) => count >= 2)
+        .map(([text]) => text),
+    ),
+    footers: new Set(
+      Array.from(footerCounts.entries())
+        .filter(([, count]) => count >= 2)
+        .map(([text]) => text),
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core ingestion function
+// ---------------------------------------------------------------------------
+
+export type ParseOptions = {
+  /**
+   * When true, lines that match VCS page markers ("v3.2 1", etc.) are
+   * NOT included as blocks in the output. They are consumed to determine
+   * page boundaries but do not appear as text blocks.
+   *
+   * Default: true
+   */
+  excludePageMarkers?: boolean;
+
+  /**
+   * When true, repeated header/footer lines (appearing on 2+ pages) are
+   * marked as blockType "header" / "footer" rather than "body".
+   *
+   * Default: true
+   */
+  detectRepeatedHeaders?: boolean;
+};
+
+/**
+ * Parse raw extracted text into a canonical QuickCheckV2ExtractedDocument.
+ *
+ * This is the primary ingestion entry point. It handles:
+ * - VCS v3.2 page markers ("v3.2 N") for page number assignment
+ * - Section heading detection
+ * - Block type classification
+ * - Repeated header/footer filtering
+ * - Stable span ID generation
+ *
+ * @param rawText - The raw extracted text from a PDF parser (e.g., PyMuPDF)
+ * @param documentId - A stable document identifier (e.g., "proj-desc-1382")
+ * @param parser - The parser that produced the raw text
+ * @param options - Parsing options
+ */
+export function parseExtractedText(
+  rawText: string,
+  documentId: string,
+  parser: string,
+  options?: ParseOptions,
+): QuickCheckV2ExtractedDocument {
+  const {
+    excludePageMarkers = true,
+    detectRepeatedHeaders = true,
+  } = options ?? {};
+
+  // -----------------------------------------------------------------------
+  // Step 1: Split raw text into pages using marker lines
+  // -----------------------------------------------------------------------
+
+  const lines = rawText.split("\n");
+
+  // Find all page marker positions
+  interface PageSlice {
+    pageNumber: number;
+    startLine: number; // inclusive
+    endLine: number; // exclusive
+  }
+
+  const pageMarkers: PageSlice[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const markerCheck = isPageMarkerLine(lines[i]!);
+    if (markerCheck.isMarker) {
+      pageMarkers.push({
+        pageNumber: markerCheck.pageNumber,
+        startLine: i + 1, // content starts after the marker
+        endLine: lines.length, // default: until end
+      });
+    }
+  }
+
+  // Set endLine for each marker
+  for (let i = 0; i < pageMarkers.length; i++) {
+    const curr = pageMarkers[i]!;
+    const next = pageMarkers[i + 1];
+    curr.endLine = next ? next.startLine - 1 : lines.length;
+  }
+
+  // If no markers found, treat entire text as single page
+  if (pageMarkers.length === 0) {
+    pageMarkers.push({
+      pageNumber: 1,
+      startLine: 0,
+      endLine: lines.length,
+    });
+  }
+
+  // Build page slices
+  const pageSlices = pageMarkers.map((marker) => ({
+    pageNumber: marker.pageNumber,
+    lines: lines.slice(marker.startLine, marker.endLine),
+  }));
+
+  // -----------------------------------------------------------------------
+  // Step 2: Detect repeated headers/footers across pages
+  // -----------------------------------------------------------------------
+
+  let headerFooterEdges: PageEdgeLines = { headers: new Set(), footers: new Set() };
+
+  if (detectRepeatedHeaders) {
+    headerFooterEdges = collectRepeatedPageEdges(pageSlices);
+  }
+
+  // -----------------------------------------------------------------------
+  // Step 3: Build blocks page by page
+  // -----------------------------------------------------------------------
+
+  const warnings: string[] = [];
+  const blocks: QuickCheckV2Block[] = [];
+  let globalBlockIndex = 0;
+
+  // Track current section heading context (persists across pages)
+  let currentSectionTitle: string | null = null;
+  let currentSectionPath: string[] = [];
+  let hasSeenPrimaryContent = false;
+
+  for (const page of pageSlices) {
+    const { pageNumber } = page;
+
+    for (let lineIndex = 0; lineIndex < page.lines.length; lineIndex++) {
+      const line = page.lines[lineIndex]!;
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      // Skip page marker lines if configured
+      if (excludePageMarkers) {
+        const markerCheck = isPageMarkerLine(trimmed);
+        if (markerCheck.isMarker) continue;
+      }
+
+      // Detect if this is a repeated header or footer
+      const isRepeatedHeader = headerFooterEdges.headers.has(trimmed);
+      const isRepeatedFooter = headerFooterEdges.footers.has(trimmed);
+
+      // Detect block type
+      const blockType = detectBlockType(
+        trimmed,
+        !hasSeenPrimaryContent,
+        isRepeatedHeader,
+        isRepeatedFooter,
+      );
+
+      // Update section heading context
+      const headingResult = detectSectionHeading(trimmed);
+      if (headingResult.isHeading) {
+        currentSectionTitle = headingResult.title;
+        currentSectionPath = buildSectionPath(headingResult.sectionNumber);
+
+        // For annex headings, build a section-path-friendly form
+        if (
+          headingResult.sectionNumber.startsWith("annex-") ||
+          headingResult.sectionNumber.startsWith("appendix-")
+        ) {
+          currentSectionPath = [headingResult.sectionNumber];
+        }
+      }
+
+      // Track primary content
+      if (blockType !== "header" && blockType !== "footer") {
+        hasSeenPrimaryContent = true;
+      }
+
+      // Build the block
+      const blockIndex = globalBlockIndex++;
+      const block: QuickCheckV2Block = {
+        spanId: buildSpanId(documentId, pageNumber, blockIndex, trimmed),
+        page: pageNumber,
+        text: trimmed,
+        blockType,
+        sectionHeading: currentSectionTitle,
+        sectionPath: [...currentSectionPath],
+        source: "primary",
+      };
+
+      blocks.push(block);
+    }
+  }
+
+  // Determine page count
+  const uniquePages = new Set(blocks.map((b) => b.page));
+  const pageCount = uniquePages.size;
+
+  // Check for page 1 defaulting issue
+  if (pageCount <= 1 && pageMarkers.length > 1) {
+    warnings.push(
+      `Only ${pageCount} unique page(s) detected from ${pageMarkers.length} markers. Page provenance may be incomplete.`,
+    );
+  }
+
+  return {
+    documentId,
+    parser,
+    blocks,
+    diagnostics: {
+      pageCount,
+      warnings,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Ingestion from file
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a previously extracted text file and parse it into a canonical document.
+ *
+ * This is the main entry point for tests. The fixture path should point to a
+ * `.txt` file containing the raw extracted text from a PDF parser.
+ */
+export function loadAndParseExtractedText(
+  filePath: string,
+  documentId?: string,
+  parser?: string,
+): QuickCheckV2ExtractedDocument {
+  const resolvedPath = path.resolve(filePath);
+  const rawText = fs.readFileSync(resolvedPath, "utf-8");
+
+  const resolvedDocId =
+    documentId ?? path.basename(filePath, path.extname(filePath));
+  const resolvedParser = parser ?? "extracted-text";
+
+  return parseExtractedText(rawText, resolvedDocId, resolvedParser);
+}

--- a/tests/lib/quickCheckV2/envira-ingestion.test.ts
+++ b/tests/lib/quickCheckV2/envira-ingestion.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  loadAndParseExtractedText,
+  type QuickCheckV2ExtractedDocument,
+} from "@/lib/quickCheckV2/ingestion";
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+const ENVIRA_FIXTURE_PATH =
+  "tests/fixtures/quick-check/proj-desc-1382-extracted.txt";
+
+// ---------------------------------------------------------------------------
+// Required Envira evidence strings with their expected page ranges
+// ---------------------------------------------------------------------------
+
+type EvidenceAssertion = {
+  /** Human-readable label for the assertion */
+  label: string;
+  /** The string that must appear in a block's text (case-insensitive search) */
+  requiredText: string;
+  /** Minimum expected page number for the matching block */
+  minPage?: number;
+  /** Maximum expected page number for the matching block */
+  maxPage?: number;
+  /** Block types that are acceptable (default: any non-footer/header) */
+  acceptableTypes?: string[];
+};
+
+const REQUIRED_EVIDENCE: EvidenceAssertion[] = [
+  {
+    label: "Acre, Brazil",
+    requiredText: "Acre, Brazil",
+    minPage: 1,
+    maxPage: 5,
+    acceptableTypes: ["heading", "body"],
+  },
+  {
+    label: "VM0007: REDD Methodology Modules",
+    requiredText: "VM0007: REDD Methodology Modules",
+    minPage: 30,
+    maxPage: 35,
+    acceptableTypes: ["heading", "body"],
+  },
+  {
+    label: "conversion to pasture",
+    requiredText: "Conversion to Pasture",
+    minPage: 5,
+    maxPage: 15,
+    acceptableTypes: ["body"],
+  },
+  {
+    label: "cattle ranching",
+    requiredText: "cattle ranching",
+    minPage: 1,
+    maxPage: 10,
+    acceptableTypes: ["body"],
+  },
+  {
+    label: "simple cost analysis",
+    requiredText: "Simple Cost Analysis",
+    minPage: 35,
+    maxPage: 45,
+    acceptableTypes: ["heading", "body"],
+  },
+  {
+    label: "carbon finance",
+    requiredText: "carbon finance",
+    minPage: 35,
+    maxPage: 45,
+    acceptableTypes: ["body"],
+  },
+  {
+    label: "VCU revenue",
+    requiredText: "VCU",
+    minPage: 35,
+    maxPage: 45,
+    acceptableTypes: ["body"],
+  },
+  {
+    label: "Leakage emissions",
+    requiredText: "Leakage emissions",
+    minPage: 65,
+    maxPage: 75,
+    acceptableTypes: ["body"],
+  },
+  {
+    label: "41 families",
+    requiredText: "total of 41",
+    minPage: 5,
+    maxPage: 15,
+    acceptableTypes: ["body"],
+  },
+  {
+    label: "FPIC (Free, Prior and Informed Consent)",
+    requiredText: "Free, Prior and Informed Consent",
+    minPage: 5,
+    maxPage: 15,
+    acceptableTypes: ["body"],
+  },
+  {
+    label: "grievance procedure",
+    requiredText: "grievance",
+    minPage: 5,
+    maxPage: 15,
+    acceptableTypes: ["body"],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Quick Check v2 — Envira ingestion", () => {
+  let document: QuickCheckV2ExtractedDocument;
+
+  beforeAll(() => {
+    document = loadAndParseExtractedText(ENVIRA_FIXTURE_PATH);
+  });
+
+  describe("document structure", () => {
+    it("produces a valid document with blocks", () => {
+      expect(document).toBeDefined();
+      expect(document.documentId).toBe("proj-desc-1382-extracted");
+      expect(document.parser).toBe("extracted-text");
+      expect(document.blocks).toBeDefined();
+      expect(document.blocks.length).toBeGreaterThan(0);
+    });
+
+    it("has stable span IDs", () => {
+      for (const block of document.blocks) {
+        expect(block.spanId).toBeTruthy();
+        expect(block.spanId).toMatch(/^proj-desc-1382-extracted:p\d+:b\d+:[a-f0-9]+$/);
+      }
+    });
+
+    it("has page numbers that are not all 1", () => {
+      const pages = new Set(document.blocks.map((b) => b.page));
+      expect(pages.size).toBeGreaterThan(1);
+      // Check that at least one block has a page > 1
+      const hasPageAbove1 = document.blocks.some((b) => b.page > 1);
+      expect(hasPageAbove1).toBe(true);
+    });
+
+    it("has blocks with non-null section paths", () => {
+      for (const block of document.blocks) {
+        expect(block.sectionPath).toBeDefined();
+        expect(Array.isArray(block.sectionPath)).toBe(true);
+      }
+    });
+  });
+
+  describe("diagnostics", () => {
+    it("reports page count", () => {
+      expect(document.diagnostics.pageCount).toBeGreaterThan(0);
+    });
+
+    it("has minimal warnings", () => {
+      // Some warnings are acceptable, but none should indicate total failure
+      expect(document.diagnostics.warnings).toBeDefined();
+    });
+  });
+
+  describe("required Envira evidence strings", () => {
+    for (const assertion of REQUIRED_EVIDENCE) {
+      it(`contains "${assertion.label}"`, () => {
+        const matchingBlocks = document.blocks.filter((block) =>
+          block.text.toLowerCase().includes(assertion.requiredText.toLowerCase()),
+        );
+
+        expect(matchingBlocks.length).toBeGreaterThan(0);
+
+        // Log found blocks for debugging
+        const blockInfo = matchingBlocks.map(
+          (b) => `p${b.page} [${b.blockType}] "${b.text.slice(0, 100)}..."`,
+        );
+
+        // Find the best block (prefer body/heading over header/footer)
+        const bestBlock = matchingBlocks.find(
+          (b) =>
+            b.blockType !== "header" &&
+            b.blockType !== "footer" &&
+            b.blockType !== "unknown",
+        ) ?? matchingBlocks[0]!;
+
+        // Assert page is a real positive number
+        expect(bestBlock.page).toBeGreaterThan(0);
+
+        // Assert span ID exists and is stable
+        expect(bestBlock.spanId).toBeTruthy();
+
+        // Assert acceptable block type
+        if (assertion.acceptableTypes) {
+          expect(assertion.acceptableTypes).toContain(bestBlock.blockType);
+        }
+
+        // Assert page range if specified
+        if (assertion.minPage !== undefined) {
+          expect(bestBlock.page).toBeGreaterThanOrEqual(assertion.minPage);
+        }
+        if (assertion.maxPage !== undefined) {
+          expect(bestBlock.page).toBeLessThanOrEqual(assertion.maxPage);
+        }
+      });
+    }
+  });
+
+  describe("page provenance", () => {
+    it("has correct page for ACRE, Brazil (page 1)", () => {
+      const blocks = document.blocks.filter((b) =>
+        b.text.includes("Acre, Brazil"),
+      );
+      expect(blocks.length).toBeGreaterThan(0);
+      // The title should be on page 1
+      const titleBlock = blocks.find((b) => b.blockType === "heading");
+      if (titleBlock) {
+        expect(titleBlock.page).toBe(1);
+      }
+    });
+
+    it("has correct page for VM0007 methodology (page ~31)", () => {
+      const blocks = document.blocks.filter((b) =>
+        b.text.includes("VM0007: REDD Methodology Modules"),
+      );
+      expect(blocks.length).toBeGreaterThan(0);
+      const methodBlock = blocks[0]!;
+      expect(methodBlock.page).toBeGreaterThanOrEqual(30);
+      expect(methodBlock.page).toBeLessThanOrEqual(35);
+    });
+
+    it("does not assign all blocks to page 1", () => {
+      const page1Count = document.blocks.filter((b) => b.page === 1).length;
+      const totalCount = document.blocks.length;
+      // Fewer than 20% of blocks should be page 1 (some genuinely are on page 1)
+      expect(page1Count / totalCount).toBeLessThan(0.2);
+    });
+
+    it("total unique pages is close to 142 (the v3.2 marker count)", () => {
+      // Count v3.2 markers in the source to confirm our parsing is correct
+      const { readFileSync } = require("node:fs");
+      const raw = readFileSync(ENVIRA_FIXTURE_PATH, "utf-8");
+      const markerCount = (raw.match(/^v3\.2\s+\d+$/gm) ?? []).length;
+
+      // Our parsed page count should be at least close to the marker count
+      expect(document.diagnostics.pageCount).toBeGreaterThanOrEqual(
+        markerCount * 0.9,
+      );
+      expect(document.diagnostics.pageCount).toBeLessThanOrEqual(
+        markerCount * 1.1,
+      );
+    });
+  });
+
+  describe("section provenance", () => {
+    it("tracks section paths for headings", () => {
+      const headings = document.blocks.filter(
+        (b) => b.blockType === "heading" && b.sectionPath.length > 0,
+      );
+      expect(headings.length).toBeGreaterThan(0);
+    });
+
+    it("links body blocks to the correct section", () => {
+      // Find the "Simple Cost Analysis" heading and verify the surrounding body blocks
+      // have the right section context
+      const costHeading = document.blocks.find(
+        (b) =>
+          b.text.includes("Simple Cost Analysis") &&
+          b.blockType === "heading",
+      );
+      expect(costHeading).toBeDefined();
+      if (costHeading) {
+        expect(costHeading.sectionPath.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("reproducibility", () => {
+    it("produces identical output on second parse", () => {
+      const doc2 = loadAndParseExtractedText(ENVIRA_FIXTURE_PATH);
+      expect(doc2.blocks.length).toBe(document.blocks.length);
+
+      // First and last span IDs should match (deterministic)
+      expect(doc2.blocks[0]!.spanId).toBe(document.blocks[0]!.spanId);
+      expect(doc2.blocks[doc2.blocks.length - 1]!.spanId).toBe(
+        document.blocks[document.blocks.length - 1]!.spanId,
+      );
+
+      // Spot check a few random blocks
+      const checkIndices = [0, 10, 100, 500, 1000];
+      for (const idx of checkIndices) {
+        if (idx < document.blocks.length && idx < doc2.blocks.length) {
+          expect(doc2.blocks[idx]!.spanId).toBe(document.blocks[idx]!.spanId);
+          expect(doc2.blocks[idx]!.page).toBe(document.blocks[idx]!.page);
+          expect(doc2.blocks[idx]!.text).toBe(document.blocks[idx]!.text);
+        }
+      }
+    });
+  });
+});

--- a/tests/lib/quickCheckV2/envira-invariants.test.ts
+++ b/tests/lib/quickCheckV2/envira-invariants.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  loadAndParseExtractedText,
+  type QuickCheckV2ExtractedDocument,
+} from "@/lib/quickCheckV2/ingestion";
+
+const ENVIRA_FIXTURE_PATH =
+  "tests/fixtures/quick-check/proj-desc-1382-extracted.txt";
+
+// ---------------------------------------------------------------------------
+// Invariant tests — these must hold for the entire document, not just
+// selected evidence strings
+// ---------------------------------------------------------------------------
+
+describe("canonical JSON invariants", () => {
+  let doc: QuickCheckV2ExtractedDocument;
+
+  beforeAll(() => {
+    doc = loadAndParseExtractedText(ENVIRA_FIXTURE_PATH);
+  });
+
+  describe("page provenance invariants", () => {
+    it("every block has page >= 1 (no page 0 or negative)", () => {
+      const badBlocks = doc.blocks.filter((b) => b.page < 1);
+      expect(badBlocks.length).toBe(0);
+    });
+
+    it("no spanId contains :p0:", () => {
+      const badSpanIds = doc.blocks.filter((b) => b.spanId.includes(":p0:"));
+      expect(badSpanIds.length).toBe(0);
+    });
+
+    it("page numbers are within expected range (1..142)", () => {
+      const pages = [...new Set(doc.blocks.map((b) => b.page))].sort(
+        (a, b) => a - b,
+      );
+      expect(pages[0]).toBeGreaterThanOrEqual(1);
+      expect(pages[pages.length - 1]).toBeLessThanOrEqual(142);
+    });
+
+    it("at least 120 unique pages are represented", () => {
+      const pages = new Set(doc.blocks.map((b) => b.page));
+      expect(pages.size).toBeGreaterThanOrEqual(120);
+    });
+  });
+
+  describe("no phantom page markers from bare numbers", () => {
+    it("bare 0 lines in table context are not treated as page markers", () => {
+      // The Envira fixture has bare "0" lines around lines 4874-4992
+      // (risk-rating table entries). These should appear as body blocks
+      // with the same page as surrounding content, not as page separators.
+      const zeroBlocks = doc.blocks.filter((b) => b.text.trim() === "0");
+      // These should exist (they're real content) but should NOT be on
+      // a page that nothing else shares, and should NOT reset page numbering
+      for (const block of zeroBlocks) {
+        expect(block.page).toBeGreaterThan(0);
+      }
+    });
+
+    it("bare 1 lines are not page markers unless in v3.2 N / Page N format", () => {
+      // The fixture has many lines matching just "1" or "2" in table contexts.
+      // These should not create phantom pages.
+      const blocks = doc.blocks;
+
+      // Check that the first 10 blocks are all page 1 (cover page content)
+      const first10Pages = blocks.slice(0, 10).map((b) => b.page);
+      const allPage1 = first10Pages.every((p) => p === 1);
+      expect(allPage1).toBe(true);
+    });
+  });
+
+  describe("block structure invariants", () => {
+    it("every block has a non-empty spanId", () => {
+      for (const block of doc.blocks) {
+        expect(block.spanId).toBeTruthy();
+        expect(block.spanId.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("every block has a valid blockType", () => {
+      const validTypes = [
+        "heading",
+        "body",
+        "table",
+        "footer",
+        "header",
+        "unknown",
+      ];
+      for (const block of doc.blocks) {
+        expect(validTypes).toContain(block.blockType);
+      }
+    });
+
+    it("every block has a stable spanId format", () => {
+      const pattern =
+        /^proj-desc-1382-extracted:p\d+:b\d+:[a-f0-9]+$/;
+      for (const block of doc.blocks) {
+        expect(block.spanId).toMatch(pattern);
+      }
+    });
+
+    it("every block has a defined sectionPath (possibly empty)", () => {
+      for (const block of doc.blocks) {
+        expect(block.sectionPath).toBeDefined();
+        expect(Array.isArray(block.sectionPath)).toBe(true);
+      }
+    });
+  });
+
+  describe("page adjacency — no gaps or resets", () => {
+    it("page numbers increase monotonically (not strictly but never jump backward)", () => {
+      let lastPage = 0;
+      let sawPageGt1 = false;
+      for (const block of doc.blocks) {
+        if (block.page > 1) sawPageGt1 = true;
+        // Once we've seen content past page 1, we should never see page 1 again
+        // (A single-page jump backward indicates a phantom page reset)
+        if (sawPageGt1 && block.page < lastPage && block.page === 1) {
+          expect(block.page).toBeGreaterThan(1);
+        }
+        if (block.page > lastPage) lastPage = block.page;
+      }
+    });
+
+    it("document reports a reasonable pageCount", () => {
+      expect(doc.diagnostics.pageCount).toBeGreaterThan(120);
+      expect(doc.diagnostics.pageCount).toBeLessThanOrEqual(145);
+    });
+  });
+});


### PR DESCRIPTION
## WHAT

Quick Check v2 RC1: Envira ingestion only.

Adds `src/lib/quickCheckV2/ingestion/` — the first isolated v2 ingestion layer. Produces deterministic canonical extracted JSON with real page/span/section provenance. Handles VCS v3.2 page markers ("v3.2 N") correctly — no more all-page-1 defaulting.

Adds `tests/lib/quickCheckV2/envira-ingestion.test.ts` — 24 assertions proving all 11 required Envira evidence strings exist with real page numbers, span IDs, and section context.

## WHY

v1's page provenance broke because FOOTER_RE discarded v3.2 page markers as footer noise. v2 ingestion fixes this at the parser level by treating v3.2 markers as page separators, not noise.

## WHAT THIS PR DOES NOT DO

No answers. No status (FOUND/UNCLEAR/MISSING). No scoring. No LLM. No router. No Blob dependency. No v1 Quick Check changes. No extra PDFs.

## SIGNED-OFF-BY

Teebot

### Roadmap-Update
- slug: quickcheck-v2
- items:
  - RC1: in_progress