### PR TITLE
docs: mark Phase 2 done (PR #852), Phase 3 as next

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -195,12 +195,12 @@ Lane status: Active
 Rebuild Quick Check from clean ingestion up. PDF → canonical JSON → section tree → evidence spans → answer → status. One layer per PR. No scoring. No LLM finals. No Blob test dependency.
 
 Current focus:
-- Phase 1 done (PR #846). Next: Phase 2 — Section tree and evidence spans.
+- Phase 2 done (PR #852). Next: Phase 3 — Evidence retrieval with source priority.
 
 1) RC0 — Roadmap and SSOT boundary: Done — PLAN.md + phase-status.json exist at correct SSOT path. Delivered by PR #847. No production code changed.
 2) RC1 — Envira ingestion only — canonical extracted JSON: Done — Ingestion pipeline at src/lib/quickCheckV2/ingestion/ creates deterministic canonical JSON from Envira (PR #846). 10 key strings with correct page/span/section provenance. Heading detection handles mixed-case + dotted patterns. No answers. No scoring. No Blob.
-3) RC2 — Section tree and evidence spans: Next — Direct body under exact heading only. No descendant sweeping. Each of six checks can return top evidence span.
-4) RC3 — Evidence retrieval for six structured checks: Planned — Fixed source priority: fact contract → exact section → raw text fallback. No router candidates. No scoring.
+3) RC2 — Section tree and evidence spans: Done — Section tree from canonical JSON + evidence span index. Direct body under exact heading only. Each of six checks returns best evidence span with quote/page/section/spanId. Delivered by PR #852. No answers. No status. No scoring. No LLM.
+4) RC3 — Evidence retrieval for six structured checks: Next — Fixed source priority: fact contract → exact section → raw text fallback. No router candidates. No scoring.
 5) RC4 — Tiny answer extractors: Planned — Check-specific extractors. Answers from selected evidence only. No LLM finals.
 6) RC5 — Boring deterministic status validator: Planned — FOUND = answer + quote + page + section + span. Validators judge only, do not search/rank.
 7) RC6 — Gold Envira fixture: Planned — Gold is PDF truth, not current output. Includes expected answer, quote, page, section, span ID, known junk to reject.

--- a/docs/roadmaps/quickcheck-v2/phase-status.json
+++ b/docs/roadmaps/quickcheck-v2/phase-status.json
@@ -3,7 +3,8 @@
   "name": "Quick Check v2: Stable Ingestion First",
   "pr_evidence": {
     "847": { "title": "docs: Quick Check v2 roadmap SSOT — PLAN.md + phase-status.json in repo roadmaps" },
-    "846": { "title": "feat: Quick Check v2 RC1 — Envira ingestion only — ingestion pipeline + heading detection + tests" }
+    "846": { "title": "feat: Quick Check v2 RC1 — Envira ingestion only — ingestion pipeline + heading detection + tests" },
+    "852": { "title": "feat: Quick Check v2 Phase 2 — section tree and evidence span index" }
   },
   "pr_notes": {
     "840": "Historical — superseded by PR #847",
@@ -22,12 +23,12 @@
     },
     "phase_2_section_tree": {
       "title": "Section tree and evidence spans",
-      "status": "next",
-      "summary": "Direct body under exact heading only. No descendant sweeping. Each of six checks can return top evidence span."
+      "status": "done",
+      "summary": "Section tree from canonical JSON + evidence span index. Direct body under exact heading only. Each of six checks returns best evidence span with quote/page/section/spanId. Delivered by PR #852. No answers. No status. No scoring. No LLM."
     },
     "phase_3_evidence_retrieval": {
       "title": "Evidence retrieval for six structured checks",
-      "status": "planned",
+      "status": "next",
       "summary": "Fixed source priority: fact contract → exact section → raw text fallback. No router candidates. No scoring."
     },
     "phase_4_answer_extractors": {
@@ -54,7 +55,7 @@
   "phase_meta": {
     "status": "active",
     "summary": "Rebuild Quick Check from clean ingestion up. PDF → canonical JSON → section tree → evidence spans → answer → status. One layer per PR. No scoring. No LLM finals. No Blob test dependency.",
-    "current_focus": ["Phase 1 done (PR #846). Next: Phase 2 — Section tree and evidence spans."],
+    "current_focus": ["Phase 2 done (PR #852). Next: Phase 3 — Evidence retrieval with source priority."],
     "not_active_now": [],
     "last_updated_at": "2026-06-28T00:00:00Z",
     "goals": [
@@ -93,9 +94,10 @@
       {
         "id": "phase_2_section_tree",
         "title": "Section tree and evidence spans",
-        "status": "planned",
+        "status": "done",
         "dependsOn": ["phase_1_envira_ingestion"],
-        "branch": "",
+        "branch": "v2/section-tree",
+        "pr": 852,
         "doneCriteria": [
           "section tree built from canonical JSON",
           "direct body under exact heading only — no descendant sweeping",
@@ -105,7 +107,7 @@
       {
         "id": "phase_3_evidence_retrieval",
         "title": "Evidence retrieval for six structured checks",
-        "status": "planned",
+        "status": "next",
         "dependsOn": ["phase_2_section_tree"],
         "branch": "",
         "doneCriteria": [


### PR DESCRIPTION
Updates phase-status.json on main to reflect that Phase 2 (section tree + evidence spans) is done via PR #852, and Phase 3 is now next.

Only docs change — no code.