### PR TITLE
V2/evidence retrieval

### DIFF
--- a/src/lib/quickCheckV2/evidence/barrel.ts
+++ b/src/lib/quickCheckV2/evidence/barrel.ts
@@ -1,0 +1,12 @@
+export {
+  STRUCTURED_CHECK_IDS,
+  retrieveEvidenceForAllChecks,
+  retrieveEvidenceForCheck,
+} from "./index";
+
+export type {
+  StructuredCheckId,
+  EvidenceSourceType,
+  RetrievedEvidence,
+  RetrievedCheckEvidence,
+} from "./index";

--- a/src/lib/quickCheckV2/evidence/index.ts
+++ b/src/lib/quickCheckV2/evidence/index.ts
@@ -1,0 +1,247 @@
+/**
+ * Quick Check v2 — Phase 3 evidence retrieval with fixed source priority.
+ *
+ * Priority:
+ * 1. fact contract
+ * 2. exact section evidence
+ * 3. raw text fallback
+ *
+ * Hard rules:
+ * - No answer extraction
+ * - No FOUND / UNCLEAR / MISSING status
+ * - No scoring
+ * - No candidate ranking
+ * - No LLM
+ */
+
+import type { QuickCheckV2Block, QuickCheckV2ExtractedDocument } from "@/lib/quickCheckV2/ingestion";
+import {
+  CHECK_SECTION_MAPPINGS,
+  buildSectionTree,
+  findSectionsByHeadingText,
+  type EvidenceSpan,
+  type SectionTreeNode,
+} from "@/lib/quickCheckV2/section-tree";
+
+export const STRUCTURED_CHECK_IDS = [
+  "host_country",
+  "methodology",
+  "baseline_scenario",
+  "additionality",
+  "leakage",
+  "stakeholder_consultation",
+] as const;
+
+export type StructuredCheckId = (typeof STRUCTURED_CHECK_IDS)[number];
+
+export type EvidenceSourceType =
+  | "fact_contract"
+  | "exact_section"
+  | "raw_text_fallback";
+
+export type RetrievedEvidence = EvidenceSpan & {
+  sourceType: EvidenceSourceType;
+};
+
+export type RetrievedCheckEvidence = {
+  checkName: StructuredCheckId;
+  evidence: RetrievedEvidence | null;
+};
+
+type FactContractDefinition = {
+  find(blocks: QuickCheckV2Block[]): QuickCheckV2Block | null;
+};
+
+type RawFallbackDefinition = {
+  match(block: QuickCheckV2Block): boolean;
+};
+
+const FACT_CONTRACTS: Partial<Record<StructuredCheckId, FactContractDefinition>> = {
+  host_country: {
+    find(blocks) {
+      return (
+        findFirstBlock(blocks, (block) =>
+          /\blocated\b/i.test(block.text) && /\b[A-Z][a-z]+,\s*[A-Z][a-z]+\b/.test(block.text),
+        ) ??
+        findFirstBlock(blocks, (block) =>
+          /\bproject location\b/i.test(block.sectionHeading ?? "") &&
+          /\b[A-Z][a-z]+,\s*[A-Z][a-z]+\b/.test(block.text),
+        ) ??
+        null
+      );
+    },
+  },
+  methodology: {
+    find(blocks) {
+      return (
+        findFirstBlock(blocks, (block) =>
+          /\bVM\d{4}\b|\bVMD\d{4}\b/.test(block.text),
+        ) ??
+        findFirstBlock(blocks, (block) =>
+          /\bmethodology\b/i.test(block.text),
+        ) ??
+        null
+      );
+    },
+  },
+};
+
+const RAW_TEXT_FALLBACKS: Record<StructuredCheckId, RawFallbackDefinition> = {
+  host_country: {
+    match(block) {
+      return (
+        /\blocated\b/i.test(block.text) &&
+        /\b[A-Z][a-z]+,\s*[A-Z][a-z]+\b/.test(block.text)
+      );
+    },
+  },
+  methodology: {
+    match(block) {
+      return /\bVM\d{4}\b|\bVMD\d{4}\b|\bmethodology\b/i.test(block.text);
+    },
+  },
+  baseline_scenario: {
+    match(block) {
+      return /\bbaseline scenario\b|\bmost likely baseline\b/i.test(block.text);
+    },
+  },
+  additionality: {
+    match(block) {
+      return /\badditionality\b|\badditional\b/i.test(block.text);
+    },
+  },
+  leakage: {
+    match(block) {
+      return /\bleakage\b/i.test(block.text);
+    },
+  },
+  stakeholder_consultation: {
+    match(block) {
+      return /\bstakeholder\b|\bconsultation\b/i.test(block.text);
+    },
+  },
+};
+
+function isEvidenceBlock(block: QuickCheckV2Block): boolean {
+  return block.blockType === "body" || block.blockType === "table";
+}
+
+function getEvidenceBlocks(document: QuickCheckV2ExtractedDocument): QuickCheckV2Block[] {
+  return document.blocks.filter(isEvidenceBlock);
+}
+
+function findFirstBlock(
+  blocks: QuickCheckV2Block[],
+  predicate: (block: QuickCheckV2Block) => boolean,
+): QuickCheckV2Block | null {
+  for (const block of blocks) {
+    if (predicate(block)) {
+      return block;
+    }
+  }
+  return null;
+}
+
+function toEvidence(
+  block: QuickCheckV2Block,
+  sourceType: EvidenceSourceType,
+): RetrievedEvidence {
+  return {
+    sourceType,
+    quote: block.text,
+    page: block.page,
+    sectionHeading: block.sectionHeading,
+    sectionPath: block.sectionPath,
+    spanId: block.spanId,
+  };
+}
+
+function getBestExactSectionBlock(
+  tree: SectionTreeNode[],
+  checkName: StructuredCheckId,
+): QuickCheckV2Block | null {
+  const mapping = CHECK_SECTION_MAPPINGS[checkName];
+  if (!mapping) {
+    return null;
+  }
+
+  let sections = findSectionsByHeadingText(
+    tree,
+    mapping.searchTexts,
+    3,
+    mapping.excludeTexts,
+  );
+
+  if (sections.length === 0 && mapping.fallbackSearchTexts) {
+    sections = findSectionsByHeadingText(
+      tree,
+      mapping.fallbackSearchTexts,
+      3,
+      mapping.excludeTexts,
+    );
+  }
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  const bestSection =
+    sections.find((section) => section.directBodyBlocks.length > 0 && section.heading.page > 2) ??
+    sections.find((section) => section.directBodyBlocks.length > 0) ??
+    null;
+
+  return bestSection?.directBodyBlocks[0] ?? null;
+}
+
+function getFactContractEvidence(
+  document: QuickCheckV2ExtractedDocument,
+  checkName: StructuredCheckId,
+): RetrievedEvidence | null {
+  const definition = FACT_CONTRACTS[checkName];
+  if (!definition) {
+    return null;
+  }
+
+  const block = definition.find(getEvidenceBlocks(document));
+  return block ? toEvidence(block, "fact_contract") : null;
+}
+
+function getExactSectionEvidence(
+  document: QuickCheckV2ExtractedDocument,
+  checkName: StructuredCheckId,
+): RetrievedEvidence | null {
+  const block = getBestExactSectionBlock(buildSectionTree(document), checkName);
+  return block ? toEvidence(block, "exact_section") : null;
+}
+
+function getRawTextFallbackEvidence(
+  document: QuickCheckV2ExtractedDocument,
+  checkName: StructuredCheckId,
+): RetrievedEvidence | null {
+  const definition = RAW_TEXT_FALLBACKS[checkName];
+  const block = findFirstBlock(getEvidenceBlocks(document), definition.match);
+  return block ? toEvidence(block, "raw_text_fallback") : null;
+}
+
+export function retrieveEvidenceForCheck(
+  document: QuickCheckV2ExtractedDocument,
+  checkName: StructuredCheckId,
+): RetrievedCheckEvidence {
+  const evidence =
+    getFactContractEvidence(document, checkName) ??
+    getExactSectionEvidence(document, checkName) ??
+    getRawTextFallbackEvidence(document, checkName);
+
+  return {
+    checkName,
+    evidence,
+  };
+}
+
+export function retrieveEvidenceForAllChecks(
+  document: QuickCheckV2ExtractedDocument,
+): RetrievedCheckEvidence[] {
+  return STRUCTURED_CHECK_IDS.map((checkName) =>
+    retrieveEvidenceForCheck(document, checkName),
+  );
+}

--- a/tests/lib/quickCheckV2/evidence-retrieval.test.ts
+++ b/tests/lib/quickCheckV2/evidence-retrieval.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "@jest/globals";
+import type { QuickCheckV2ExtractedDocument } from "@/lib/quickCheckV2/ingestion";
+import { loadAndParseExtractedText } from "@/lib/quickCheckV2/ingestion";
+import {
+  retrieveEvidenceForAllChecks,
+  retrieveEvidenceForCheck,
+  type RetrievedCheckEvidence,
+} from "@/lib/quickCheckV2/evidence";
+
+const ENVIRA_FIXTURE_PATH =
+  "tests/fixtures/quick-check/proj-desc-1382-extracted.txt";
+
+function makeSyntheticDocument(
+  blocks: QuickCheckV2ExtractedDocument["blocks"],
+): QuickCheckV2ExtractedDocument {
+  return {
+    documentId: "synthetic-doc",
+    parser: "test",
+    blocks,
+    diagnostics: { warnings: [], pageCount: 3 },
+  };
+}
+
+describe("Quick Check v2 — Phase 3 evidence retrieval", () => {
+  const enviraDoc = loadAndParseExtractedText(ENVIRA_FIXTURE_PATH);
+  const allEvidence = retrieveEvidenceForAllChecks(enviraDoc);
+
+  it("returns all six structured checks", () => {
+    expect(allEvidence.map((result) => result.checkName)).toStrictEqual([
+      "host_country",
+      "methodology",
+      "baseline_scenario",
+      "additionality",
+      "leakage",
+      "stakeholder_consultation",
+    ]);
+  });
+
+  it("returns provenance-only evidence fields", () => {
+    for (const result of allEvidence) {
+      expect(Object.keys(result)).toStrictEqual(["checkName", "evidence"]);
+      if (!result.evidence) continue;
+
+      expect(Object.keys(result.evidence)).toStrictEqual([
+        "sourceType",
+        "quote",
+        "page",
+        "sectionHeading",
+        "sectionPath",
+        "spanId",
+      ]);
+      expect(result.evidence.page).toBeGreaterThan(0);
+      expect(result.evidence.spanId).toMatch(/^proj-desc-1382-extracted:/);
+      expect(Array.isArray(result.evidence.sectionPath)).toBe(true);
+      expect(Object.keys(result.evidence)).not.toContain("answer");
+      expect(Object.keys(result.evidence)).not.toContain("status");
+      expect(Object.keys(result.evidence)).not.toContain("score");
+    }
+  });
+
+  it("uses fact contract before exact section for host_country", () => {
+    const result = retrieveEvidenceForCheck(enviraDoc, "host_country");
+    expect(result.evidence).not.toBeNull();
+    expect(result.evidence!.sourceType).toBe("fact_contract");
+    expect(result.evidence!.quote).toContain("Acre, Brazil");
+    expect(result.evidence!.page).toBe(3);
+  });
+
+  it("uses fact contract before exact section for methodology", () => {
+    const result = retrieveEvidenceForCheck(enviraDoc, "methodology");
+    expect(result.evidence).not.toBeNull();
+    expect(result.evidence!.sourceType).toBe("fact_contract");
+    expect(result.evidence!.quote).toMatch(/VM0007|VMD000/i);
+    expect(result.evidence!.page).toBe(31);
+  });
+
+  it("uses exact section evidence for the remaining structured checks on Envira", () => {
+    const expectations: Array<{
+      checkName: RetrievedCheckEvidence["checkName"];
+      sectionText: string;
+      page: number;
+    }> = [
+      { checkName: "baseline_scenario", sectionText: "Baseline Scenario", page: 37 },
+      { checkName: "additionality", sectionText: "Additionality", page: 38 },
+      { checkName: "leakage", sectionText: "Leakage", page: 69 },
+      { checkName: "stakeholder_consultation", sectionText: "STAKEHOLDER COMMENTS", page: 122 },
+    ];
+
+    for (const expectation of expectations) {
+      const result = retrieveEvidenceForCheck(enviraDoc, expectation.checkName);
+      expect(result.evidence).not.toBeNull();
+      expect(result.evidence!.sourceType).toBe("exact_section");
+      expect(result.evidence!.sectionHeading).toContain(expectation.sectionText);
+      expect(result.evidence!.page).toBe(expectation.page);
+    }
+  });
+
+  it("prefers exact section evidence over an earlier raw-text fallback match", () => {
+    const synthetic = makeSyntheticDocument([
+      {
+        spanId: "synthetic-doc:p1:b1:overview",
+        page: 1,
+        text: "Overview: leakage can happen when activity moves elsewhere.",
+        blockType: "body",
+        sectionHeading: "Overview",
+        sectionPath: ["1"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p2:b2:heading",
+        page: 2,
+        text: "3.3 Leakage",
+        blockType: "heading",
+        sectionHeading: "Leakage",
+        sectionPath: ["3", "3.3"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p2:b3:body",
+        page: 2,
+        text: "Leakage emissions are estimated using the project leakage accounting section.",
+        blockType: "body",
+        sectionHeading: "Leakage",
+        sectionPath: ["3", "3.3"],
+        source: "primary",
+      },
+    ]);
+
+    const result = retrieveEvidenceForCheck(synthetic, "leakage");
+    expect(result.evidence).not.toBeNull();
+    expect(result.evidence!.sourceType).toBe("exact_section");
+    expect(result.evidence!.spanId).toBe("synthetic-doc:p2:b3:body");
+  });
+
+  it("falls back to raw text when no fact contract or exact section evidence exists", () => {
+    const synthetic = makeSyntheticDocument([
+      {
+        spanId: "synthetic-doc:p1:b1:heading",
+        page: 1,
+        text: "1 Overview",
+        blockType: "heading",
+        sectionHeading: "Overview",
+        sectionPath: ["1"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b2:body",
+        page: 1,
+        text: "The most likely baseline scenario is conversion to pasture in the project area.",
+        blockType: "body",
+        sectionHeading: "Overview",
+        sectionPath: ["1"],
+        source: "primary",
+      },
+    ]);
+
+    const result = retrieveEvidenceForCheck(synthetic, "baseline_scenario");
+    expect(result.evidence).not.toBeNull();
+    expect(result.evidence!.sourceType).toBe("raw_text_fallback");
+    expect(result.evidence!.quote).toContain("baseline scenario");
+    expect(result.evidence!.page).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Quick Check v2 Phase 3: add evidence retrieval with fixed source priority.

This PR adds a new v2 retrieval layer at `src/lib/quickCheckV2/evidence/` that selects evidence for the six structured checks using:

1. `fact_contract`
2. `exact_section`
3. `raw_text_fallback`

Returned evidence is provenance-only and includes:
- `sourceType`
- `quote`
- `page`
- `sectionHeading`
- `sectionPath`
- `spanId`

Tests cover:
- all six structured checks
- fact-contract preference when available
- exact-section preference over raw fallback
- raw fallback only when higher-priority sources are absent
- no answer/status/score fields in results

### Roadmap-Update
- slug: quickcheck-v2
- ack: human
- items:
  - RC3: in_progress
  - PR854: in_progress

## Scope

Changed files:
- `src/lib/quickCheckV2/evidence/barrel.ts`
- `src/lib/quickCheckV2/evidence/index.ts`
- `tests/lib/quickCheckV2/evidence-retrieval.test.ts`

## Not In Scope

This PR does not add:
- final answers
- FOUND / UNCLEAR / MISSING
- scoring
- candidate ranking
- router behavior
- LLM behavior
- Blob/upload behavior
- UI changes
- Quick Check v1 changes

## Verify

- `npm run lint`
- `npm run typecheck`
- `npm test -- tests/lib/quickCheckV2/section-tree.test.ts tests/lib/quickCheckV2/evidence-retrieval.test.ts --runInBand`
