### PR TITLE
docs: mark Phase 5 and Phase 6 as done

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -195,15 +195,15 @@ Lane status: Active
 Rebuild Quick Check from clean ingestion up. PDF → canonical JSON → section tree → evidence spans → answer → status. One layer per PR. No scoring. No LLM finals. No Blob test dependency.
 
 Current focus:
-- Phase 3 done + Phase 4 done (PR #857). Next: Phase 5 — Status validator.
+- Phase 5 done + Phase 6 done.
 
 1) RC0 — Roadmap and SSOT boundary: Done — PLAN.md + phase-status.json exist at correct SSOT path. Delivered by PR #847. No production code changed.
 2) RC1 — Envira ingestion only — canonical extracted JSON: Done — Ingestion pipeline at src/lib/quickCheckV2/ingestion/ creates deterministic canonical JSON from Envira (PR #846). 10 key strings with correct page/span/section provenance. Heading detection handles mixed-case + dotted patterns. No answers. No scoring. No Blob.
 3) RC2 — Section tree and evidence spans: Done — Section tree from canonical JSON + evidence span index. Direct body under exact heading only. Each of six checks returns best evidence span with quote/page/section/spanId. Delivered by PR #852. No answers. No status. No scoring. No LLM.
 4) RC3 — Evidence retrieval for six structured checks: Done — Fixed source priority: fact contract → exact section → raw text fallback. No router candidates. No scoring.
 5) RC4 — Tiny answer extractors: Done — Check-specific extractors. Answers from selected evidence only. No LLM finals.
-6) RC5 — Boring deterministic status validator: Next — FOUND = answer + quote + page + section + span. Validators judge only, do not search/rank.
-7) RC6 — Gold Envira fixture: Planned — Gold is PDF truth, not current output. Includes expected answer, quote, page, section, span ID, known junk to reject.
+6) RC5 — Boring deterministic status validator: Done — FOUND = answer + quote + page + section + span. Validators judge only, do not search/rank.
+7) RC6 — Gold Envira fixture: Done — Gold is PDF truth, not current output. Includes expected answer, quote, page, section, span ID, known junk to reject.
 8) RC7 — Add PDFs slowly by new failure mode only: Planned — Each new PDF introduces a failure mode Envira does not cover. One PDF per PR.
 
 ## requirement-coverage

--- a/docs/roadmaps/quickcheck-v2/phase-status.json
+++ b/docs/roadmaps/quickcheck-v2/phase-status.json
@@ -4,10 +4,10 @@
     "status": "active",
     "summary": "Rebuild Quick Check from clean ingestion up. PDF → canonical JSON → section tree → evidence spans → answer → status. One layer per PR. No scoring. No LLM finals. No Blob test dependency.",
     "current_focus": [
-      "Phase 3 done + Phase 4 done (PR #857). Next: Phase 5 — Status validator."
+      "Phase 5 done + Phase 6 done."
     ],
     "not_active_now": [],
-    "last_updated_at": "2026-06-28T00:00:00Z",
+    "last_updated_at": "2026-06-29T00:00:00Z",
     "goals": [
       {
         "id": "phase_0_roadmap_boundary",
@@ -93,7 +93,7 @@
       {
         "id": "phase_5_status_validator",
         "title": "Boring deterministic status validator",
-        "status": "next",
+        "status": "done",
         "dependsOn": [
           "phase_4_answer_extractors"
         ],
@@ -108,7 +108,7 @@
       {
         "id": "phase_6_gold_envira",
         "title": "Gold Envira fixture",
-        "status": "planned",
+        "status": "done",
         "dependsOn": [
           "phase_5_status_validator"
         ],
@@ -164,12 +164,12 @@
     },
     "phase_5_status_validator": {
       "title": "Boring deterministic status validator",
-      "status": "next",
+      "status": "done",
       "summary": "FOUND = answer + quote + page + section + span. Validators judge only, do not search/rank."
     },
     "phase_6_gold_envira": {
       "title": "Gold Envira fixture",
-      "status": "planned",
+      "status": "done",
       "summary": "Gold is PDF truth, not current output. Includes expected answer, quote, page, section, span ID, known junk to reject."
     },
     "phase_7_add_pdfs": {


### PR DESCRIPTION
Docs-only change. Updates phase-status.json to mark Phase 5 (status validator) and Phase 6 (gold Envira fixture) as done.