### PR TITLE
feat: add VM0007 validation readiness gap report renderer

### DIFF
--- a/src/components/preverif/Vm0007GapReportView.tsx
+++ b/src/components/preverif/Vm0007GapReportView.tsx
@@ -1,0 +1,282 @@
+import type { Vm0007GapReport, Vm0007GapReportDisplayStatus, Vm0007GapReportFinding } from "@/lib/preverif/vm0007GapReport";
+
+type Vm0007GapReportViewProps = {
+  report: Vm0007GapReport;
+};
+
+function sectionCard(children: React.ReactNode) {
+  return <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">{children}</section>;
+}
+
+function statusTone(status: Vm0007GapReportDisplayStatus): string {
+  if (status === "supported") return "border-emerald-200 bg-emerald-50 text-emerald-900";
+  if (status === "weak") return "border-amber-200 bg-amber-50 text-amber-900";
+  if (status === "missing") return "border-rose-200 bg-rose-50 text-rose-900";
+  return "border-sky-200 bg-sky-50 text-sky-900";
+}
+
+function renderFindingCard(finding: Vm0007GapReportFinding) {
+  return (
+    <article key={finding.ruleId} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-semibold text-slate-950">{finding.ruleId}</span>
+        <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold capitalize ${statusTone(finding.status)}`}>
+          {finding.status}
+        </span>
+        <span className="text-xs text-slate-600">{finding.title}</span>
+      </div>
+      <div className="mt-3 text-sm font-medium text-slate-900">{finding.issue}</div>
+      <div className="mt-2 text-sm text-slate-700">
+        <span className="font-semibold text-slate-900">Current PDD evidence:</span> {finding.currentPddEvidence}
+      </div>
+      <div className="mt-2 text-sm text-slate-700">
+        <span className="font-semibold text-slate-900">Why it is weak or missing:</span> {finding.whyItMatters}
+      </div>
+      <div className="mt-2 text-sm text-slate-700">
+        <span className="font-semibold text-slate-900">What to add:</span> {finding.whatToAdd}
+      </div>
+      <div className="mt-2 text-xs text-slate-500">
+        {finding.section ? `Section: ${finding.section}` : "Section not identified"}
+        {finding.page ? ` · Page ${finding.page}` : ""}
+      </div>
+    </article>
+  );
+}
+
+function emptyState(text: string) {
+  return <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600">{text}</div>;
+}
+
+export default function Vm0007GapReportView({ report }: Vm0007GapReportViewProps) {
+  return (
+    <article className="grid gap-4" data-testid="vm0007-gap-report-view">
+      <section className="rounded-[28px] border border-slate-200 bg-[linear-gradient(135deg,#f8fafc_0%,#eef6ff_100%)] p-6 shadow-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full border border-slate-300 bg-white px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-700">
+            VM0007
+          </span>
+          <span className="rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-800">
+            Validation readiness gap report
+          </span>
+        </div>
+        <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight text-slate-950">{report.reportName}</h1>
+            <div className="mt-2 text-base text-slate-700">{report.projectSnapshot.name}</div>
+            <div className="mt-3 text-sm text-slate-700">{report.executiveSummary.headline}</div>
+            <div className="mt-4 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800">
+              {report.statementOfCoverage}
+            </div>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Report context</div>
+            <div className="mt-2 grid gap-1 text-sm text-slate-700">
+              <div><span className="font-semibold text-slate-900">Methodology:</span> {report.methodologyScope.code}@{report.methodologyScope.version}</div>
+              <div><span className="font-semibold text-slate-900">Report ID:</span> {report.reportId}</div>
+              <div><span className="font-semibold text-slate-900">Generated:</span> {report.generatedAt}</div>
+              {report.projectSnapshot.projectId ? <div><span className="font-semibold text-slate-900">Project ID:</span> {report.projectSnapshot.projectId}</div> : null}
+              {report.projectSnapshot.proponent ? <div><span className="font-semibold text-slate-900">Proponent:</span> {report.projectSnapshot.proponent}</div> : null}
+              {report.projectSnapshot.region ? <div><span className="font-semibold text-slate-900">Region:</span> {report.projectSnapshot.region}</div> : null}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Executive Summary</h2>
+            <div className="mt-1 text-sm text-slate-600">Rule totals are evidence-readiness categories drawn from the existing VM0007 audit output.</div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-emerald-800">Supported</div>
+                <div className="mt-1 text-2xl font-semibold text-emerald-950">{report.executiveSummary.totals.supported}</div>
+              </div>
+              <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-amber-800">Weak</div>
+                <div className="mt-1 text-2xl font-semibold text-amber-950">{report.executiveSummary.totals.weak}</div>
+              </div>
+              <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-rose-800">Missing</div>
+                <div className="mt-1 text-2xl font-semibold text-rose-950">{report.executiveSummary.totals.missing}</div>
+              </div>
+              <div className="rounded-2xl border border-sky-200 bg-sky-50 p-4">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-sky-800">Not applicable</div>
+                <div className="mt-1 text-2xl font-semibold text-sky-950">{report.executiveSummary.totals.notApplicable}</div>
+              </div>
+            </div>
+            <div className="mt-4 grid gap-2">
+              {report.executiveSummary.highlights.map((item) => (
+                <div key={item} className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">{item}</div>
+              ))}
+            </div>
+          </>,
+        )}
+
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Project Snapshot</h2>
+            <div className="mt-3 grid gap-2 text-sm text-slate-700">
+              <div><span className="font-semibold text-slate-900">Project:</span> {report.projectSnapshot.name}</div>
+              {report.projectSnapshot.projectId ? <div><span className="font-semibold text-slate-900">Project ID:</span> {report.projectSnapshot.projectId}</div> : null}
+              {report.projectSnapshot.proponent ? <div><span className="font-semibold text-slate-900">Proponent:</span> {report.projectSnapshot.proponent}</div> : null}
+              {report.projectSnapshot.region ? <div><span className="font-semibold text-slate-900">Region:</span> {report.projectSnapshot.region}</div> : null}
+              {report.projectSnapshot.description ? <div><span className="font-semibold text-slate-900">Description:</span> {report.projectSnapshot.description}</div> : null}
+            </div>
+          </>,
+        )}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Methodology Scope</h2>
+            <div className="mt-2 text-sm text-slate-700">{report.methodologyScope.summary}</div>
+            {report.methodologyScope.name ? (
+              <div className="mt-2 text-sm text-slate-700">
+                <span className="font-semibold text-slate-900">Methodology name:</span> {report.methodologyScope.name}
+              </div>
+            ) : null}
+            {report.methodologyScope.scope ? (
+              <div className="mt-2 text-sm text-slate-700">
+                <span className="font-semibold text-slate-900">Scope note:</span> {report.methodologyScope.scope}
+              </div>
+            ) : null}
+            <div className="mt-3 grid gap-2">
+              {report.methodologyScope.notes.map((item) => (
+                <div key={item} className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">{item}</div>
+              ))}
+            </div>
+          </>,
+        )}
+
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Key Supported Findings</h2>
+            <div className="mt-1 text-sm text-slate-600">These rules currently have the strongest project-linked support in the audit results.</div>
+            <div className="mt-3 grid gap-3">
+              {report.keySupportedFindings.length ? report.keySupportedFindings.map(renderFindingCard) : emptyState("No supported findings are available yet.")}
+            </div>
+          </>,
+        )}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Not Applicable Rules</h2>
+            <div className="mt-1 text-sm text-slate-600">Rules appear here only when the current PDD supports a not-applicable conclusion.</div>
+            <div className="mt-3 grid gap-3">
+              {report.notApplicableRules.length ? report.notApplicableRules.map(renderFindingCard) : emptyState("No VM0007 rules are currently classified as not applicable.")}
+            </div>
+          </>,
+        )}
+
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Main Evidence Gaps</h2>
+            <div className="mt-1 text-sm text-slate-600">Weak and missing items are shown here so the project team can prioritize the next PDD updates.</div>
+            <div className="mt-3 grid gap-3">
+              {report.mainEvidenceGaps.length ? report.mainEvidenceGaps.map(renderFindingCard) : emptyState("No main evidence gaps are currently listed.")}
+            </div>
+          </>,
+        )}
+      </div>
+
+      {sectionCard(
+        <>
+          <h2 className="text-lg font-semibold text-slate-950">Client Action List</h2>
+          <div className="mt-1 text-sm text-slate-600">Each weak or missing rule includes the issue, the current PDD evidence, why it is weak or missing, and what to add.</div>
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full border-separate border-spacing-0 text-left text-sm">
+              <thead>
+                <tr>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Rule</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Issue</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Current PDD evidence</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Why it is weak or missing</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">What to add</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.clientActionList.length ? report.clientActionList.map((item) => (
+                  <tr key={item.ruleId} className="align-top">
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-950">{item.ruleId}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{item.issue}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{item.currentPddEvidence}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{item.whyItMatters}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{item.whatToAdd}</td>
+                  </tr>
+                )) : (
+                  <tr>
+                    <td className="px-3 py-3 text-slate-600" colSpan={5}>No client action items are currently listed.</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>,
+      )}
+
+      {sectionCard(
+        <>
+          <h2 className="text-lg font-semibold text-slate-950">Full VM0007 Rule Audit Table</h2>
+          <div className="mt-1 text-sm text-slate-600">All 58 VM0007 rules are listed below using client-safe readiness language only.</div>
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full border-separate border-spacing-0 text-left text-sm">
+              <thead>
+                <tr>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Rule</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Title</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Status</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Section</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Evidence summary</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Gap guidance</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.fullRuleAuditTable.map((row) => (
+                  <tr key={row.ruleId} className="align-top" data-status={row.status}>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-950">{row.ruleId}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{row.title}</td>
+                    <td className="border-b border-slate-100 px-3 py-3">
+                      <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold capitalize ${statusTone(row.status)}`}>
+                        {row.status}
+                      </span>
+                    </td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{row.section}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{row.evidenceSummary}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{row.gapGuidance}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>,
+      )}
+
+      {sectionCard(
+        <>
+          <h2 className="text-lg font-semibold text-slate-950">Evidence Appendix</h2>
+          <div className="mt-1 text-sm text-slate-600">Evidence quotes are reproduced from the existing audit output only.</div>
+          <div className="mt-4 grid gap-3">
+            {report.evidenceAppendix.map((entry) => (
+              <article key={entry.ruleId} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-xs font-semibold text-slate-950">{entry.ruleId}</span>
+                  <span className="text-xs text-slate-600">{entry.title}</span>
+                </div>
+                <div className="mt-2 text-sm text-slate-700">{entry.quote}</div>
+                <div className="mt-2 text-xs text-slate-500">
+                  {entry.section}
+                  {entry.page ? ` · Page ${entry.page}` : ""}
+                </div>
+                <div className="mt-2 text-xs text-slate-500">{entry.reasonSelected}</div>
+              </article>
+            ))}
+          </div>
+        </>,
+      )}
+    </article>
+  );
+}

--- a/src/lib/preverif/vm0007GapReport.ts
+++ b/src/lib/preverif/vm0007GapReport.ts
@@ -163,7 +163,7 @@ function sortGapFindings(left: Vm0007GapReportFinding, right: Vm0007GapReportFin
 
 function makeHeadline(input: Vm0007GapReport["executiveSummary"]["totals"]): string {
   if (input.supported === 58) {
-    return "The current PDD shows broad rule-level support, with no remaining client evidence actions.";
+    return "The current audit output identifies supported evidence across the VM0007 rule set, with no weak or missing evidence items listed.";
   }
   if (input.needsClientAction === 0) {
     return "The current PDD supports most VM0007 rules, with remaining items limited to scope-based not-applicable decisions.";

--- a/src/lib/preverif/vm0007GapReport.ts
+++ b/src/lib/preverif/vm0007GapReport.ts
@@ -1,0 +1,271 @@
+import type {
+  EvidenceAuditStatus,
+  MethodologyEvidenceAuditResult,
+  MethodologyEvidenceAuditSummary,
+} from "@/lib/preverif/evidenceAudit";
+
+export type Vm0007GapReportInput = {
+  reportId: string;
+  generatedAt: string;
+  project: {
+    name: string;
+    projectId?: string;
+    proponent?: string;
+    region?: string;
+    description?: string;
+  };
+  methodology: {
+    code: string;
+    version: string;
+    name?: string;
+    scope?: string;
+  };
+  audit: MethodologyEvidenceAuditSummary;
+};
+
+export type Vm0007GapReportDisplayStatus =
+  | "supported"
+  | "weak"
+  | "missing"
+  | "not applicable";
+
+export type Vm0007GapReportFinding = {
+  ruleId: string;
+  title: string;
+  status: Vm0007GapReportDisplayStatus;
+  issue: string;
+  currentPddEvidence: string;
+  whyItMatters: string;
+  whatToAdd: string;
+  section: string | null;
+  page: number | null;
+  confidence: MethodologyEvidenceAuditResult["confidence"];
+};
+
+export type Vm0007GapReport = {
+  reportId: string;
+  generatedAt: string;
+  reportName: "Validation Readiness Gap Report";
+  statementOfCoverage: string;
+  executiveSummary: {
+    headline: string;
+    totals: {
+      supported: number;
+      weak: number;
+      missing: number;
+      notApplicable: number;
+      needsClientAction: number;
+    };
+    highlights: string[];
+    limitations: string[];
+  };
+  projectSnapshot: Vm0007GapReportInput["project"];
+  methodologyScope: {
+    code: string;
+    version: string;
+    name?: string;
+    scope?: string;
+    summary: string;
+    notes: string[];
+  };
+  keySupportedFindings: Vm0007GapReportFinding[];
+  notApplicableRules: Vm0007GapReportFinding[];
+  mainEvidenceGaps: Vm0007GapReportFinding[];
+  clientActionList: Vm0007GapReportFinding[];
+  fullRuleAuditTable: Array<{
+    ruleId: string;
+    title: string;
+    status: Vm0007GapReportDisplayStatus;
+    section: string;
+    evidenceSummary: string;
+    gapGuidance: string;
+    clientAction: string;
+  }>;
+  evidenceAppendix: Array<{
+    ruleId: string;
+    title: string;
+    quote: string;
+    section: string;
+    page: number | null;
+    reasonSelected: string;
+  }>;
+};
+
+const NO_PDD_EVIDENCE_TEXT = "Evidence is not currently available in the PDD.";
+
+function toDisplayStatus(status: EvidenceAuditStatus): Vm0007GapReportDisplayStatus {
+  switch (status) {
+    case "supported_by_pdd":
+      return "supported";
+    case "missing_evidence":
+      return "missing";
+    case "not_applicable":
+      return "not applicable";
+    case "partially_supported":
+    case "manual_review_needed":
+      return "weak";
+  }
+}
+
+function compareRuleIds(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { numeric: true });
+}
+
+function evidenceText(result: MethodologyEvidenceAuditResult): string {
+  return result.bestEvidenceQuote?.trim() || NO_PDD_EVIDENCE_TEXT;
+}
+
+function issueLabel(result: MethodologyEvidenceAuditResult): string {
+  switch (result.status) {
+    case "supported_by_pdd":
+      return "Current PDD support is usable for this rule.";
+    case "not_applicable":
+      return "Current PDD evidence supports a not-applicable conclusion.";
+    case "missing_evidence":
+      return "Current PDD support is missing for this rule.";
+    case "manual_review_needed":
+      return "Current PDD support is too unclear to classify confidently.";
+    case "partially_supported":
+      return "Current PDD support is present but incomplete.";
+  }
+}
+
+function gapGuidance(result: MethodologyEvidenceAuditResult): string {
+  return result.gap.trim() || result.clientAction.trim();
+}
+
+function toFinding(result: MethodologyEvidenceAuditResult): Vm0007GapReportFinding {
+  return {
+    ruleId: result.ruleId,
+    title: result.title,
+    status: toDisplayStatus(result.status),
+    issue: issueLabel(result),
+    currentPddEvidence: evidenceText(result),
+    whyItMatters: result.assessmentReason,
+    whatToAdd: result.clientAction,
+    section: result.section,
+    page: result.page,
+    confidence: result.confidence,
+  };
+}
+
+function sortGapFindings(left: Vm0007GapReportFinding, right: Vm0007GapReportFinding): number {
+  const severity = new Map<Vm0007GapReportDisplayStatus, number>([
+    ["missing", 0],
+    ["weak", 1],
+    ["not applicable", 2],
+    ["supported", 3],
+  ]);
+  const severityDiff = (severity.get(left.status) ?? 99) - (severity.get(right.status) ?? 99);
+  if (severityDiff !== 0) return severityDiff;
+  return compareRuleIds(left.ruleId, right.ruleId);
+}
+
+function makeHeadline(input: Vm0007GapReport["executiveSummary"]["totals"]): string {
+  if (input.supported === 58) {
+    return "The current PDD shows broad rule-level support, with no remaining client evidence actions.";
+  }
+  if (input.needsClientAction === 0) {
+    return "The current PDD supports most VM0007 rules, with remaining items limited to scope-based not-applicable decisions.";
+  }
+  if (input.supported >= input.needsClientAction) {
+    return "The current PDD shows a usable base of support, but several VM0007 rules still need clearer client evidence before validation readiness improves.";
+  }
+  return "The current PDD still has material evidence gaps across VM0007 and needs targeted client follow-up before validation readiness improves.";
+}
+
+export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapReport {
+  const findings = input.audit.results.map(toFinding);
+  const supported = findings.filter((finding) => finding.status === "supported");
+  const weak = findings.filter((finding) => finding.status === "weak");
+  const missing = findings.filter((finding) => finding.status === "missing");
+  const notApplicable = findings.filter((finding) => finding.status === "not applicable");
+  const needsClientAction = findings.filter((finding) =>
+    finding.status === "weak" || finding.status === "missing",
+  );
+
+  const totals = {
+    supported: supported.length,
+    weak: weak.length,
+    missing: missing.length,
+    notApplicable: notApplicable.length,
+    needsClientAction: needsClientAction.length,
+  };
+
+  const keySupportedFindings = supported
+    .slice()
+    .sort((left, right) => compareRuleIds(left.ruleId, right.ruleId))
+    .slice(0, 10);
+
+  const notApplicableRules = notApplicable
+    .slice()
+    .sort((left, right) => compareRuleIds(left.ruleId, right.ruleId));
+
+  const mainEvidenceGaps = needsClientAction
+    .slice()
+    .sort(sortGapFindings);
+
+  return {
+    reportId: input.reportId,
+    generatedAt: input.generatedAt,
+    reportName: "Validation Readiness Gap Report",
+    statementOfCoverage: `${input.audit.totalRules} VM0007 rules assessed for validation readiness.`,
+    executiveSummary: {
+      headline: makeHeadline(totals),
+      totals,
+      highlights: [
+        `${totals.supported} rules currently show supported PDD evidence.`,
+        `${totals.weak} rules show weak support and need clearer project-specific detail.`,
+        `${totals.missing} rules do not yet show the required evidence in the current PDD.`,
+        `${totals.notApplicable} rules are treated as not applicable only where the PDD itself supports that conclusion.`,
+      ],
+      limitations: [
+        "This report summarizes current PDD support and evidence gaps for project-team follow-up.",
+        "Evidence quotes are limited to the audit results already selected by the existing VM0007 evidence audit.",
+        "Weak and missing items should be resolved with clearer project-specific PDD content before relying on this draft for external use.",
+      ],
+    },
+    projectSnapshot: input.project,
+    methodologyScope: {
+      code: input.methodology.code,
+      version: input.methodology.version,
+      name: input.methodology.name,
+      scope: input.methodology.scope,
+      summary: `${input.methodology.code}@${input.methodology.version} audit output rendered into a client-facing readiness gap report.`,
+      notes: [
+        "The renderer uses existing VM0007 audit results only and does not rerun methodology logic.",
+        "Status language is limited to supported, weak, missing, and not applicable.",
+        "Every weak or missing rule is paired with client action guidance from the audit output.",
+      ],
+    },
+    keySupportedFindings,
+    notApplicableRules,
+    mainEvidenceGaps,
+    clientActionList: mainEvidenceGaps,
+    fullRuleAuditTable: input.audit.results
+      .slice()
+      .sort((left, right) => compareRuleIds(left.ruleId, right.ruleId))
+      .map((result) => ({
+        ruleId: result.ruleId,
+        title: result.title,
+        status: toDisplayStatus(result.status),
+        section: result.section ?? "Section not identified",
+        evidenceSummary: evidenceText(result),
+        gapGuidance: gapGuidance(result),
+        clientAction: result.clientAction,
+      })),
+    evidenceAppendix: input.audit.results
+      .slice()
+      .sort((left, right) => compareRuleIds(left.ruleId, right.ruleId))
+      .map((result) => ({
+        ruleId: result.ruleId,
+        title: result.title,
+        quote: evidenceText(result),
+        section: result.section ?? "Section not identified",
+        page: result.page,
+        reasonSelected: result.reasonSelected,
+      })),
+  };
+}
+
+export { NO_PDD_EVIDENCE_TEXT };

--- a/tests/components/vm0007GapReportView.test.tsx
+++ b/tests/components/vm0007GapReportView.test.tsx
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "@jest/globals";
+import { renderToStaticMarkup } from "react-dom/server";
+import Vm0007GapReportView from "@/components/preverif/Vm0007GapReportView";
+import type { MethodologyEvidenceAuditResult, MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
+import { buildVm0007GapReport } from "@/lib/preverif/vm0007GapReport";
+
+function makeResult(overrides: Partial<MethodologyEvidenceAuditResult> = {}): MethodologyEvidenceAuditResult {
+  return {
+    ruleId: "R-1-0001",
+    stableId: "R-1-0001",
+    title: "Forest definition",
+    ruleLogic: "Forest definition",
+    status: "supported_by_pdd",
+    bestEvidenceQuote: "The project area remained forest land for the ten years before project start.",
+    page: 4,
+    section: "Eligibility",
+    span: "span-1",
+    reasonSelected: "Selected the strongest project-specific paragraph.",
+    assessmentReason: "The selected PDD span aligns with the rule logic.",
+    gap: "",
+    clientAction: "Add the numeric forest threshold references.",
+    confidence: "high",
+    ...overrides,
+  };
+}
+
+function buildAuditForRendering(): MethodologyEvidenceAuditSummary {
+  const seeded: MethodologyEvidenceAuditResult[] = [
+    makeResult({
+      ruleId: "R-1-0001",
+      title: "Forest definition",
+      status: "supported_by_pdd",
+      bestEvidenceQuote: "The project area remained forest land for the ten years before project start.",
+    }),
+    makeResult({
+      ruleId: "R-1-0002",
+      title: "Baseline category",
+      status: "partially_supported",
+      bestEvidenceQuote: "The PDD names planned deforestation but does not yet explain the category choice.",
+      gap: "The category rationale is still incomplete.",
+      clientAction: "Add the project-specific category rationale and supporting land-use evidence.",
+      assessmentReason: "The current PDD names the category but does not fully justify it.",
+    }),
+    makeResult({
+      ruleId: "R-1-0003",
+      title: "AUDef agents",
+      status: "missing_evidence",
+      bestEvidenceQuote: null,
+      section: null,
+      page: null,
+      reasonSelected: "No reliable project-specific span was selected for this rule.",
+      gap: "The current PDD does not show the relevant agent evidence.",
+      clientAction: "Add the project-specific agent evidence and the baseline-pressure explanation.",
+      assessmentReason: "The current PDD does not yet show project-specific evidence for this rule.",
+    }),
+    makeResult({
+      ruleId: "R-1-0005",
+      title: "WRC prohibition",
+      status: "not_applicable",
+      bestEvidenceQuote: "This is a REDD/APD project in upland forest landscapes with no peat soils or tidal wetland activity.",
+      section: "Project Activity Description",
+      page: 2,
+      gap: "",
+      clientAction: "State the scope basis clearly in the activity description.",
+      assessmentReason: "The current PDD scope statement shows this wetland-specific rule does not apply.",
+    }),
+  ];
+
+  const filler = Array.from({ length: 54 }, (_, index) => {
+    const ruleNumber = String(index + 4).padStart(4, "0");
+    return makeResult({
+      ruleId: `R-6-${ruleNumber}`,
+      stableId: `R-6-${ruleNumber}`,
+      title: `Monitoring item ${index + 4}`,
+      ruleLogic: `Monitoring item ${index + 4}`,
+      status: "supported_by_pdd",
+      bestEvidenceQuote: `Monitoring evidence quote ${index + 4}.`,
+      span: `span-${index + 4}`,
+      reasonSelected: `Selected monitoring evidence ${index + 4}.`,
+    });
+  });
+
+  const results = [...seeded, ...filler];
+  return {
+    results,
+    totals: {
+      supported_by_pdd: results.filter((result) => result.status === "supported_by_pdd").length,
+      partially_supported: results.filter((result) => result.status === "partially_supported").length,
+      missing_evidence: results.filter((result) => result.status === "missing_evidence").length,
+      not_applicable: results.filter((result) => result.status === "not_applicable").length,
+      manual_review_needed: results.filter((result) => result.status === "manual_review_needed").length,
+    },
+    totalRules: results.length,
+  };
+}
+
+function buildHtml() {
+  const report = buildVm0007GapReport({
+    reportId: "VRGR-VM0007-002",
+    generatedAt: "2026-07-01T11:00:00Z",
+    project: {
+      name: "Envira Amazonia",
+      projectId: "VM0007-ENV-002",
+      proponent: "Envira Project Dev",
+      region: "Brazil",
+    },
+    methodology: {
+      code: "VM0007",
+      version: "4.2",
+      name: "REDD+ Methodology Framework",
+      scope: "Presentation-only rendering from the existing evidence audit output.",
+    },
+    audit: buildAuditForRendering(),
+  });
+
+  return renderToStaticMarkup(<Vm0007GapReportView report={report} />);
+}
+
+describe("Vm0007GapReportView", () => {
+  test("renders the required VM0007 gap report sections and all 58 rules", () => {
+    const html = buildHtml();
+    const rowCount = (html.match(/data-status=\"/g) ?? []).length;
+
+    expect(html).toContain("Validation Readiness Gap Report");
+    expect(html).toContain("58 VM0007 rules assessed for validation readiness.");
+    expect(html).toContain("Executive Summary");
+    expect(html).toContain("Project Snapshot");
+    expect(html).toContain("Methodology Scope");
+    expect(html).toContain("Key Supported Findings");
+    expect(html).toContain("Not Applicable Rules");
+    expect(html).toContain("Main Evidence Gaps");
+    expect(html).toContain("Client Action List");
+    expect(html).toContain("Full VM0007 Rule Audit Table");
+    expect(html).toContain("Evidence Appendix");
+    expect(rowCount).toBe(58);
+  });
+
+  test("renders supported, weak, missing, and not-applicable states in the full rule table", () => {
+    const html = buildHtml();
+
+    expect(html).toContain('data-status="supported"');
+    expect(html).toContain('data-status="weak"');
+    expect(html).toContain('data-status="missing"');
+    expect(html).toContain('data-status="not applicable"');
+  });
+
+  test("shows client action guidance for weak and missing rules and preserves appendix evidence handling", () => {
+    const html = buildHtml();
+
+    expect(html).toContain("What to add");
+    expect(html).toContain("Add the project-specific category rationale and supporting land-use evidence.");
+    expect(html).toContain("Add the project-specific agent evidence and the baseline-pressure explanation.");
+    expect(html).toContain("Evidence is not currently available in the PDD.");
+    expect(html).toContain("The project area remained forest land for the ten years before project start.");
+  });
+
+  test("keeps banned wording and fake pass claims out of the rendered output", () => {
+    const html = buildHtml().toLowerCase();
+    const banned = [
+      ["VVB", "-grade"].join(""),
+      ["veri", "fied"].join(""),
+      ["validation", " opinion"].join(""),
+      ["assurance", " opinion"].join(""),
+      ["all", " clear"].join(""),
+    ];
+
+    expect(html).not.toContain("58 vm0007 rules passed.");
+    expect(html).not.toContain("100% pass");
+    for (const item of banned) {
+      expect(html).not.toContain(item.toLowerCase());
+    }
+  });
+});

--- a/tests/lib/preverif.vm0007GapReport.test.ts
+++ b/tests/lib/preverif.vm0007GapReport.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "@jest/globals";
+import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import {
+  auditEvidence,
+  type MethodologyEvidenceAuditResult,
+  type MethodologyEvidenceAuditSummary,
+} from "@/lib/preverif/evidenceAudit";
+import {
+  NO_PDD_EVIDENCE_TEXT,
+  buildVm0007GapReport,
+} from "@/lib/preverif/vm0007GapReport";
+import {
+  getVm0007EvidenceContract,
+  normalizeVm0007RuleId,
+} from "@/lib/preverif/vm0007EvidenceContracts";
+import {
+  readQuickCheckFixtureText,
+  VM0007_SYNCED_RULES,
+} from "./preverifVm0007Fixtures";
+
+const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
+
+function auditText(rawText: string): MethodologyEvidenceAuditSummary {
+  const context = getStructuredQueryContext(rawText);
+  return auditEvidence({
+    rules: VM0007_SYNCED_RULES,
+    evidenceDocument: context.evidenceDocument,
+    getContract: getVm0007EvidenceContract,
+    normalizeRuleId: normalizeVm0007RuleId,
+    sections: context.documentStructure.sections,
+    rawText,
+  });
+}
+
+function withStatus(
+  result: MethodologyEvidenceAuditResult,
+  overrides: Partial<MethodologyEvidenceAuditResult>,
+): MethodologyEvidenceAuditResult {
+  return { ...result, ...overrides };
+}
+
+function retotal(results: MethodologyEvidenceAuditResult[]): MethodologyEvidenceAuditSummary["totals"] {
+  return {
+    supported_by_pdd: results.filter((result) => result.status === "supported_by_pdd").length,
+    partially_supported: results.filter((result) => result.status === "partially_supported").length,
+    missing_evidence: results.filter((result) => result.status === "missing_evidence").length,
+    not_applicable: results.filter((result) => result.status === "not_applicable").length,
+    manual_review_needed: results.filter((result) => result.status === "manual_review_needed").length,
+  };
+}
+
+function buildMixedAudit(): MethodologyEvidenceAuditSummary {
+  const base = auditText(ENVIRA_TEXT);
+  const results = base.results.map((result) => {
+    if (result.ruleId === "R-1-0002") {
+      return withStatus(result, {
+        status: "partially_supported",
+        gap: "The current PDD names the baseline category but does not explain why that category fits the project area.",
+        clientAction: "Add the project-specific baseline deforestation category rationale and the supporting land-use evidence.",
+      });
+    }
+    if (result.ruleId === "R-1-0003") {
+      return withStatus(result, {
+        status: "missing_evidence",
+        bestEvidenceQuote: null,
+        section: null,
+        page: null,
+        gap: "The current PDD does not show the AUDef agent evidence required for this rule.",
+        clientAction: "Add the project-specific evidence for the relevant deforestation agents and explain how they drive baseline pressure.",
+        assessmentReason: "The current PDD does not yet show project-specific evidence for this rule.",
+        reasonSelected: "No reliable project-specific span was selected for this rule.",
+      });
+    }
+    if (result.ruleId === "R-1-0005") {
+      return withStatus(result, {
+        status: "not_applicable",
+        bestEvidenceQuote: "This is a REDD/APD project in upland forest landscapes. No peat soils or tidal wetland activity occur in the project area.",
+        section: "Project Activity Description",
+        page: 2,
+        gap: "",
+        assessmentReason: "The current PDD scope statement shows this wetland-specific rule does not apply to the project.",
+      });
+    }
+    return result;
+  });
+
+  return {
+    results,
+    totals: retotal(results),
+    totalRules: results.length,
+  };
+}
+
+function buildReport(audit: MethodologyEvidenceAuditSummary) {
+  return buildVm0007GapReport({
+    reportId: "VRGR-VM0007-001",
+    generatedAt: "2026-07-01T10:00:00Z",
+    project: {
+      name: "Envira Amazonia",
+      projectId: "VM0007-ENV-001",
+      proponent: "Envira Project Dev",
+      region: "Brazil",
+      description: "Avoided deforestation project with community-focused leakage controls and monitoring procedures.",
+    },
+    methodology: {
+      code: "VM0007",
+      version: "4.2",
+      name: "REDD+ Methodology Framework",
+      scope: "Audit output rendered for client-facing validation readiness follow-up.",
+    },
+    audit,
+  });
+}
+
+describe("buildVm0007GapReport", () => {
+  it("builds a 58-rule report from existing VM0007 audit output", () => {
+    const report = buildReport(auditText(ENVIRA_TEXT));
+
+    expect(report.statementOfCoverage).toBe("58 VM0007 rules assessed for validation readiness.");
+    expect(report.fullRuleAuditTable).toHaveLength(58);
+    expect(report.evidenceAppendix).toHaveLength(58);
+  });
+
+  it("keeps client action guidance on every weak or missing rule", () => {
+    const report = buildReport(buildMixedAudit());
+    const weakOrMissing = report.fullRuleAuditTable.filter((row) =>
+      row.status === "weak" || row.status === "missing",
+    );
+
+    expect(report.clientActionList).toHaveLength(weakOrMissing.length);
+    for (const row of weakOrMissing) {
+      expect(row.gapGuidance.trim().length).toBeGreaterThan(0);
+      expect(row.clientAction.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses selected evidence quotes where available and the fallback text where they are not", () => {
+    const report = buildReport(buildMixedAudit());
+    const supported = report.evidenceAppendix.find((entry) => entry.ruleId === "R-1-0001");
+    const missing = report.evidenceAppendix.find((entry) => entry.ruleId === "R-1-0003");
+
+    expect(supported?.quote).toContain("Leakage Management procedures");
+    expect(missing?.quote).toBe(NO_PDD_EVIDENCE_TEXT);
+  });
+
+  it("keeps banned wording out of the report data", () => {
+    const reportJson = JSON.stringify(buildReport(buildMixedAudit())).toLowerCase();
+    const banned = [
+      ["VVB", "-grade"].join(""),
+      ["veri", "fied"].join(""),
+      ["validation", " opinion"].join(""),
+      ["assurance", " opinion"].join(""),
+      ["all", " clear"].join(""),
+    ];
+
+    expect(reportJson).not.toContain("58 vm0007 rules passed.");
+    for (const item of banned) {
+      expect(reportJson).not.toContain(item.toLowerCase());
+    }
+  });
+});


### PR DESCRIPTION
## What changed
- add a VM0007-specific validation readiness gap report builder that consumes existing audit results without rerunning methodology logic
- add a client-facing renderer for the VM0007 report sections, including the 58-rule audit table, evidence appendix, and client action list
- add focused library and component tests covering wording, 58-rule coverage, gap guidance, and status rendering

## Why
PR #880 and the audit-engine follow-up established the evidence contracts and rule-by-rule audit output. This PR turns that existing output into a client-facing readiness gap report without implying formal third-party conclusions.

## User impact
Project teams can now review supported evidence, weak or missing areas, and specific follow-up actions before paying for validation work.

## Validation
- `npx jest tests/lib/preverif.vm0007GapReport.test.ts --runInBand`
- `npx jest tests/components/vm0007GapReportView.test.tsx --runInBand`
- `npm run typecheck`
- `npm test` *(currently blocked by unrelated baseline failures in `tests/lib/evidence/reviewGrade.test.ts` and local optional Python module imports for `fitz` / `docling`)*
