### PR TITLE
feat: add internal VM0007 gap report preview and PDF export

### DIFF
--- a/src/app/internal/reports/vm0007-gap/[auditId]/page.tsx
+++ b/src/app/internal/reports/vm0007-gap/[auditId]/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import Vm0007GapReportPreview from "@/components/preverif/Vm0007GapReportPreview";
+
+export const metadata: Metadata = {
+  title: "VM0007 Gap Report Preview | app.article6",
+  description: "Internal VM0007 validation readiness gap report preview for manual PDF export.",
+};
+
+export default async function Vm0007GapReportPreviewPage({
+  params,
+}: {
+  params: Promise<{ auditId: string }>;
+}) {
+  const { auditId } = await params;
+  return <Vm0007GapReportPreview auditId={auditId} />;
+}

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -860,6 +860,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       : null;
   const canRenderResult = Boolean(result && activeResultKey && validatedResultKey === activeResultKey);
   const renderedResult = canRenderResult ? result : null;
+  const isVm0007RenderedResult = Boolean(renderedResult && draft.methodologyId.trim().toUpperCase() === "VM0007");
   const extractionPreview = useMemo(
     () => (extractionState.analysis ? buildQuickCheckExtractionSnapshot({ claimText: effectiveClaimText, analysis: extractionState.analysis }) : null),
     [effectiveClaimText, extractionState.analysis],
@@ -3379,19 +3380,20 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   {normalizedResult.extractionState.label} evidence signal
                 </span>
               </div>
-              <div className="mt-4">
-                <div className="flex flex-wrap items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={handleContinueToWorkspace}
-                    className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
-                  >
-                    <FolderOpen className="h-4 w-4" />
-                    Open full review
-                  </button>
-                  <Vm0007GapReportLaunchButton auditId={renderedResult?.vm0007GapReportAuditId} />
-                </div>
+              <div className="mt-4 flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  onClick={handleContinueToWorkspace}
+                  className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
+                >
+                  <FolderOpen className="h-4 w-4" />
+                  Open full review
+                </button>
               </div>
+              <Vm0007GapReportLaunchButton
+                isVm0007Result={isVm0007RenderedResult}
+                auditId={renderedResult?.vm0007GapReportAuditId}
+              />
             </div>
           ) : null}
 

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -121,6 +121,13 @@ type ExtractionState = {
   error: string | null;
 };
 
+export function resolveGapReportSourceAnalysis(
+  analysisFromOptions: QuickCheckEvidenceAnalysis | null | undefined,
+  analysisFromState: QuickCheckEvidenceAnalysis | null | undefined,
+): QuickCheckEvidenceAnalysis | null {
+  return analysisFromOptions ?? analysisFromState ?? null;
+}
+
 type StructuredEvidenceCheckResult = {
   checkId: StructuredCheckId;
   status: "found" | "missing" | "unclear";
@@ -1356,21 +1363,22 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       };
 
       const inventory = loadQuickCheckInventory(candidate.methodologyId, candidate.methodologyVersion);
-      const extraction = options?.analysis
+      const sourceAnalysis = resolveGapReportSourceAnalysis(options?.analysis, extractionState.analysis);
+      const extraction = sourceAnalysis
         ? buildQuickCheckExtractionSnapshot({
             claimText: resolveEffectiveClaimText(activeDraft.claimText),
-            analysis: options.analysis,
+            analysis: sourceAnalysis,
           })
         : null;
       let vm0007GapReportAuditId: string | undefined;
-      if (candidate.methodologyId.trim().toUpperCase() === "VM0007" && options?.analysis?.rawPddText?.trim()) {
+      if (candidate.methodologyId.trim().toUpperCase() === "VM0007" && sourceAnalysis?.rawPddText?.trim()) {
         try {
           const auditRules = await fetchRules(candidate.methodologyId, candidate.methodologyVersion);
           const savedAudit = buildAndSaveVm0007GapReportAudit({
             methodologyId: candidate.methodologyId,
             methodologyVersion: candidate.methodologyVersion,
             evidenceFileName: activeDraft.evidenceFileName,
-            rawPddText: options.analysis.rawPddText,
+            rawPddText: sourceAnalysis.rawPddText,
             rules: auditRules,
           });
           vm0007GapReportAuditId = savedAudit?.auditId;

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -686,6 +686,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [documentPurpose, setDocumentPurpose] = useState<DocumentPurpose | null>(null);
   const [evidenceCheckResults, setEvidenceCheckResults] = useState<StructuredEvidenceCheckResult[]>([]);
   const [runningEvidenceChecks, setRunningEvidenceChecks] = useState(false);
+  const [uploadVm0007GapReportAuditId, setUploadVm0007GapReportAuditId] = useState<string | null>(null);
+  const [generatingUploadVm0007GapReport, setGeneratingUploadVm0007GapReport] = useState(false);
   const [selectedHeading, setSelectedHeading] = useState<DocumentHeading | null>(null);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
@@ -884,6 +886,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     () => resolveQuickCheckMethodology({ mentions: detectedMethodologyMentions, methods, rawText: extractionState.analysis?.rawPddText }),
     [detectedMethodologyMentions, extractionState.analysis?.rawPddText, methods],
   );
+  const detectedVm0007Method = useMemo(
+    () => methodologyResolution.matchedMethods.find((method) => method.methodologyId.trim().toUpperCase() === "VM0007") ?? null,
+    [methodologyResolution],
+  );
   const resolvedWorkspaceMethod = useMemo(
     () => (methodologyResolution.status === "single" ? methodologyResolution.matchedMethods[0] ?? null : null),
     [methodologyResolution],
@@ -985,6 +991,19 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     }
     return null;
   }, [extractionPreview, methodologyMismatch, methodologyResolution]);
+  const showUploadVm0007ReportCard = useMemo(
+    () =>
+      activeSourceMode === "uploaded_file"
+      && Boolean(extractionState.analysis?.rawPddText?.trim())
+      && evidenceMentionsMethodologyCode(extractionState.analysis, "VM0007"),
+    [activeSourceMode, extractionState.analysis],
+  );
+  const uploadVm0007ReportAuditId = uploadVm0007GapReportAuditId ?? renderedResult?.vm0007GapReportAuditId ?? null;
+  const canGenerateUploadVm0007Report = Boolean(
+    showUploadVm0007ReportCard
+    && detectedVm0007Method?.methodologyVersion
+    && extractionState.analysis?.rawPddText?.trim(),
+  );
   const showAdvancedOptions = showAdvanced || showSavedEvidence || showMethodology;
   const extractionPreviewView = useMemo(
     () =>
@@ -1144,7 +1163,38 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setShowExtractionDetails(false);
     setEvidenceCheckResults([]);
     setRunningEvidenceChecks(false);
+    setUploadVm0007GapReportAuditId(null);
+    setGeneratingUploadVm0007GapReport(false);
     setDocumentPurpose(null);
+  }
+
+  async function handleGenerateUploadVm0007GapReport() {
+    if (!detectedVm0007Method?.methodologyVersion) return;
+    const rawPddText = extractionState.analysis?.rawPddText?.trim();
+    if (!rawPddText) return;
+
+    setGeneratingUploadVm0007GapReport(true);
+    setFieldErrors({});
+    try {
+      const rules = await fetchRules(detectedVm0007Method.methodologyId, detectedVm0007Method.methodologyVersion);
+      const savedAudit = buildAndSaveVm0007GapReportAudit({
+        methodologyId: detectedVm0007Method.methodologyId,
+        methodologyVersion: detectedVm0007Method.methodologyVersion,
+        evidenceFileName: draft.evidenceFileName || selectedEvidenceLabel,
+        rawPddText,
+        rules,
+      });
+      if (!savedAudit?.auditId) {
+        throw new Error("Quick Check could not generate the VM0007 gap report preview.");
+      }
+      setUploadVm0007GapReportAuditId(savedAudit.auditId);
+    } catch (error) {
+      setFieldErrors({
+        general: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setGeneratingUploadVm0007GapReport(false);
+    }
   }
 
   function openFullReviewFromRecovery() {
@@ -2129,6 +2179,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     selectedEvidenceRunKey,
   ]);
 
+  useEffect(() => {
+    setUploadVm0007GapReportAuditId(null);
+    setGeneratingUploadVm0007GapReport(false);
+  }, [selectedEvidenceRunKey]);
+
   async function handleTryDemoCheck() {
     setSubmitting(true);
     resetQuickCheckUi();
@@ -2675,6 +2730,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 </div>
               ) : null}
             </div>
+          ) : null}
+
+          {showUploadVm0007ReportCard && !submitting ? (
+            <Vm0007GapReportLaunchButton
+              isVm0007Result
+              auditId={uploadVm0007ReportAuditId}
+              title="Internal VM0007 report"
+              onGenerate={handleGenerateUploadVm0007GapReport}
+              generating={generatingUploadVm0007GapReport}
+              generateDisabled={!canGenerateUploadVm0007Report}
+              testId="vm0007-upload-report-section"
+            />
           ) : null}
 
           <div className={`rounded-[1.6rem] border px-4 py-4 ${showMethodology ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -79,6 +79,10 @@ import type { FixtureContract } from "@/lib/dev/fixtureReplay";
 import { parseExtractedText, type StructuredCheckId } from "@/lib/quickCheckV2/evidence";
 import { extractAnswersForAllChecks } from "@/lib/quickCheckV2/answers";
 import { validateAnswerResults, type StatusReason } from "@/lib/quickCheckV2/status";
+import Vm0007GapReportLaunchButton from "@/components/preverif/Vm0007GapReportLaunchButton";
+import {
+  buildAndSaveVm0007GapReportAudit,
+} from "@/lib/preverif/vm0007GapReportStore";
 
 type MethodInventoryRecord = {
   code: string;
@@ -1357,6 +1361,24 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             analysis: options.analysis,
           })
         : null;
+      let vm0007GapReportAuditId: string | undefined;
+      if (candidate.methodologyId.trim().toUpperCase() === "VM0007" && options?.analysis?.rawPddText?.trim()) {
+        try {
+          const auditRules = await fetchRules(candidate.methodologyId, candidate.methodologyVersion);
+          const savedAudit = buildAndSaveVm0007GapReportAudit({
+            methodologyId: candidate.methodologyId,
+            methodologyVersion: candidate.methodologyVersion,
+            evidenceFileName: activeDraft.evidenceFileName,
+            rawPddText: options.analysis.rawPddText,
+            rules: auditRules,
+          });
+          vm0007GapReportAuditId = savedAudit?.auditId;
+        } catch (error) {
+          if (process.env.NODE_ENV !== "production") {
+            console.error("Failed to save VM0007 gap report audit output.", error);
+          }
+        }
+      }
       const nextResult = buildQuickCheckResult({
         draft: nextDraft,
         rule: {
@@ -1385,6 +1407,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           : ["Quick Check is preliminary. Open full review to confirm the requirement against the full methodology context."],
         extraction,
       });
+      nextResult.vm0007GapReportAuditId = vm0007GapReportAuditId;
 
       const checkedDraft: QuickCheckDraft = {
         ...nextDraft,
@@ -3357,14 +3380,17 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 </span>
               </div>
               <div className="mt-4">
-                <button
-                  type="button"
-                  onClick={handleContinueToWorkspace}
-                  className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
-                >
-                  <FolderOpen className="h-4 w-4" />
-                  Open full review
-                </button>
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={handleContinueToWorkspace}
+                    className="inline-flex items-center gap-2 rounded-full bg-black px-4 py-2 text-sm font-semibold text-white"
+                  >
+                    <FolderOpen className="h-4 w-4" />
+                    Open full review
+                  </button>
+                  <Vm0007GapReportLaunchButton auditId={renderedResult?.vm0007GapReportAuditId} />
+                </div>
               </div>
             </div>
           ) : null}

--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -1,23 +1,33 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, Loader2 } from "lucide-react";
 import { buildVm0007GapReportHref } from "@/lib/preverif/vm0007GapReportStore";
 
 type Vm0007GapReportLaunchButtonProps = {
   isVm0007Result: boolean;
   auditId?: string | null;
+  title?: string;
+  onGenerate?: (() => void) | null;
+  generating?: boolean;
+  generateDisabled?: boolean;
+  testId?: string;
 };
 
 export default function Vm0007GapReportLaunchButton({
   isVm0007Result,
   auditId,
+  title = "Internal report",
+  onGenerate = null,
+  generating = false,
+  generateDisabled = false,
+  testId = "vm0007-internal-report-section",
 }: Vm0007GapReportLaunchButtonProps) {
   if (!isVm0007Result) return null;
 
   return (
-    <div className="mt-4 rounded-xl border border-slate-200 bg-white/80 px-4 py-4" data-testid="vm0007-internal-report-section">
-      <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Internal report</div>
+    <div className="mt-4 rounded-xl border border-slate-200 bg-white/80 px-4 py-4" data-testid={testId}>
+      <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{title}</div>
       {auditId?.trim() ? (
         <>
           <div className="mt-2 text-sm text-slate-600">
@@ -31,6 +41,23 @@ export default function Vm0007GapReportLaunchButton({
               <ArrowUpRight className="h-4 w-4" />
               View Gap Report
             </Link>
+          </div>
+        </>
+      ) : onGenerate ? (
+        <>
+          <div className="mt-2 text-sm text-slate-600">
+            Generate the internal VM0007 gap report preview from the extracted PDD text.
+          </div>
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={onGenerate}
+              disabled={generating || generateDisabled}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
+            >
+              {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUpRight className="h-4 w-4" />}
+              Generate Gap Report Preview
+            </button>
           </div>
         </>
       ) : (

--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { ArrowUpRight } from "lucide-react";
+import {
+  buildVm0007GapReportHref,
+  hasVm0007GapReportAudit,
+} from "@/lib/preverif/vm0007GapReportStore";
+
+type Vm0007GapReportLaunchButtonProps = {
+  auditId?: string | null;
+};
+
+export default function Vm0007GapReportLaunchButton({ auditId }: Vm0007GapReportLaunchButtonProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(hasVm0007GapReportAudit(auditId));
+  }, [auditId]);
+
+  if (!auditId?.trim() || !visible) return null;
+
+  return (
+    <Link
+      href={buildVm0007GapReportHref(auditId)}
+      className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700"
+    >
+      <ArrowUpRight className="h-4 w-4" />
+      View Gap Report
+    </Link>
+  );
+}

--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -1,33 +1,54 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
 import { ArrowUpRight } from "lucide-react";
-import {
-  buildVm0007GapReportHref,
-  hasVm0007GapReportAudit,
-} from "@/lib/preverif/vm0007GapReportStore";
+import { buildVm0007GapReportHref } from "@/lib/preverif/vm0007GapReportStore";
 
 type Vm0007GapReportLaunchButtonProps = {
+  isVm0007Result: boolean;
   auditId?: string | null;
 };
 
-export default function Vm0007GapReportLaunchButton({ auditId }: Vm0007GapReportLaunchButtonProps) {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    setVisible(hasVm0007GapReportAudit(auditId));
-  }, [auditId]);
-
-  if (!auditId?.trim() || !visible) return null;
+export default function Vm0007GapReportLaunchButton({
+  isVm0007Result,
+  auditId,
+}: Vm0007GapReportLaunchButtonProps) {
+  if (!isVm0007Result) return null;
 
   return (
-    <Link
-      href={buildVm0007GapReportHref(auditId)}
-      className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700"
-    >
-      <ArrowUpRight className="h-4 w-4" />
-      View Gap Report
-    </Link>
+    <div className="mt-4 rounded-xl border border-slate-200 bg-white/80 px-4 py-4" data-testid="vm0007-internal-report-section">
+      <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Internal report</div>
+      {auditId?.trim() ? (
+        <>
+          <div className="mt-2 text-sm text-slate-600">
+            Open the internal VM0007 gap report preview for manual browser print or PDF save.
+          </div>
+          <div className="mt-3">
+            <Link
+              href={buildVm0007GapReportHref(auditId)}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700"
+            >
+              <ArrowUpRight className="h-4 w-4" />
+              View Gap Report
+            </Link>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="mt-2">
+            <button
+              type="button"
+              disabled
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-500"
+            >
+              Gap report not available yet
+            </button>
+          </div>
+          <div className="mt-3 text-sm text-slate-600">
+            Run a VM0007 evidence audit to generate the internal report preview.
+          </div>
+        </>
+      )}
+    </div>
   );
 }

--- a/src/components/preverif/Vm0007GapReportPreview.tsx
+++ b/src/components/preverif/Vm0007GapReportPreview.tsx
@@ -60,11 +60,17 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
   }
 
   return (
-    <main className="vm0007-gap-report-preview min-h-screen bg-slate-50 px-4 py-8">
+    <main className="vm0007-gap-report-preview vm0007-gap-report-preview-page min-h-screen bg-slate-50 px-4 py-8">
       <style jsx global>{`
         @media print {
           body {
             background: #fff !important;
+          }
+          .vm0007-gap-report-preview-page header,
+          .vm0007-gap-report-preview-page footer,
+          .vm0007-gap-report-preview-page nav,
+          .vm0007-gap-report-preview-page aside {
+            display: none !important;
           }
           .vm0007-gap-report-preview {
             background: #fff !important;
@@ -85,7 +91,7 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
           <div>
             <div className="text-sm font-semibold text-slate-950">Internal VM0007 Gap Report Preview</div>
             <div className="mt-1 text-xs text-slate-500">
-              Manual browser print is intended for PDF delivery. This page uses saved audit output only.
+              Manual browser print is intended for internal PDF save or review. This page uses saved audit output only.
             </div>
           </div>
           <button

--- a/src/components/preverif/Vm0007GapReportPreview.tsx
+++ b/src/components/preverif/Vm0007GapReportPreview.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Vm0007GapReportView from "@/components/preverif/Vm0007GapReportView";
+import { buildVm0007GapReport } from "@/lib/preverif/vm0007GapReport";
+import {
+  deriveVm0007ProjectName,
+  loadVm0007GapReportAudit,
+  type Vm0007GapReportAuditRecord,
+} from "@/lib/preverif/vm0007GapReportStore";
+
+type Vm0007GapReportPreviewProps = {
+  auditId: string;
+};
+
+export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPreviewProps) {
+  const [record, setRecord] = useState<Vm0007GapReportAuditRecord | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    setRecord(loadVm0007GapReportAudit(auditId));
+    setLoaded(true);
+  }, [auditId]);
+
+  const report = useMemo(() => {
+    if (!record) return null;
+    return buildVm0007GapReport({
+      reportId: record.auditId,
+      generatedAt: record.generatedAt,
+      project: {
+        name: deriveVm0007ProjectName(record.evidenceFileName),
+        description: "Internal Article6 preview rendered from saved VM0007 evidence audit output.",
+      },
+      methodology: {
+        code: record.methodologyId,
+        version: record.methodologyVersion,
+      },
+      audit: record.audit,
+    });
+  }, [record]);
+
+  if (!loaded) {
+    return (
+      <main className="min-h-screen bg-slate-50 px-4 py-10">
+        <div className="mx-auto max-w-6xl rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600">
+          Loading saved gap report preview...
+        </div>
+      </main>
+    );
+  }
+
+  if (!record || !report) {
+    return (
+      <main className="min-h-screen bg-slate-50 px-4 py-10">
+        <div className="mx-auto max-w-3xl rounded-2xl border border-amber-200 bg-white p-6 text-sm text-slate-700">
+          No saved VM0007 audit output was found for this preview link.
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="vm0007-gap-report-preview min-h-screen bg-slate-50 px-4 py-8">
+      <style jsx global>{`
+        @media print {
+          body {
+            background: #fff !important;
+          }
+          .vm0007-gap-report-preview {
+            background: #fff !important;
+            padding: 0 !important;
+          }
+          .vm0007-gap-report-preview .no-print {
+            display: none !important;
+          }
+          .vm0007-gap-report-preview section,
+          .vm0007-gap-report-preview article,
+          .vm0007-gap-report-preview table {
+            break-inside: avoid;
+          }
+        }
+      `}</style>
+      <div className="mx-auto max-w-7xl">
+        <div className="no-print mb-5 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-sm">
+          <div>
+            <div className="text-sm font-semibold text-slate-950">Internal VM0007 Gap Report Preview</div>
+            <div className="mt-1 text-xs text-slate-500">
+              Manual browser print is intended for PDF delivery. This page uses saved audit output only.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="rounded-full border border-slate-900 bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+          >
+            Print / Save PDF
+          </button>
+        </div>
+        <Vm0007GapReportView report={report} />
+      </div>
+    </main>
+  );
+}

--- a/src/components/preverif/Vm0007GapReportView.tsx
+++ b/src/components/preverif/Vm0007GapReportView.tsx
@@ -16,6 +16,16 @@ function statusTone(status: Vm0007GapReportDisplayStatus): string {
 }
 
 function renderFindingCard(finding: Vm0007GapReportFinding) {
+  const isSupported = finding.status === "supported";
+  const isNotApplicable = finding.status === "not applicable";
+  const explanationLabel = isSupported
+    ? "Why this was marked supported:"
+    : isNotApplicable
+      ? "Why this was marked not applicable:"
+      : "Why it is weak or missing:";
+  const actionLabel = isNotApplicable ? "Scope note:" : "What to add:";
+  const showAction = !isSupported && finding.whatToAdd.trim().length > 0;
+
   return (
     <article key={finding.ruleId} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
       <div className="flex flex-wrap items-center gap-2">
@@ -30,11 +40,13 @@ function renderFindingCard(finding: Vm0007GapReportFinding) {
         <span className="font-semibold text-slate-900">Current PDD evidence:</span> {finding.currentPddEvidence}
       </div>
       <div className="mt-2 text-sm text-slate-700">
-        <span className="font-semibold text-slate-900">Why it is weak or missing:</span> {finding.whyItMatters}
+        <span className="font-semibold text-slate-900">{explanationLabel}</span> {finding.whyItMatters}
       </div>
-      <div className="mt-2 text-sm text-slate-700">
-        <span className="font-semibold text-slate-900">What to add:</span> {finding.whatToAdd}
-      </div>
+      {showAction ? (
+        <div className="mt-2 text-sm text-slate-700">
+          <span className="font-semibold text-slate-900">{actionLabel}</span> {finding.whatToAdd}
+        </div>
+      ) : null}
       <div className="mt-2 text-xs text-slate-500">
         {finding.section ? `Section: ${finding.section}` : "Section not identified"}
         {finding.page ? ` · Page ${finding.page}` : ""}
@@ -63,7 +75,15 @@ export default function Vm0007GapReportView({ report }: Vm0007GapReportViewProps
           <div>
             <h1 className="text-3xl font-semibold tracking-tight text-slate-950">{report.reportName}</h1>
             <div className="mt-2 text-base text-slate-700">{report.projectSnapshot.name}</div>
+            <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900">
+              {report.limitationBanner}
+            </div>
             <div className="mt-3 text-sm text-slate-700">{report.executiveSummary.headline}</div>
+            {report.executiveSummary.allSupportedWarning ? (
+              <div className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-900">
+                {report.executiveSummary.allSupportedWarning}
+              </div>
+            ) : null}
             <div className="mt-4 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800">
               {report.statementOfCoverage}
             </div>
@@ -153,7 +173,7 @@ export default function Vm0007GapReportView({ report }: Vm0007GapReportViewProps
         {sectionCard(
           <>
             <h2 className="text-lg font-semibold text-slate-950">Key Supported Findings</h2>
-            <div className="mt-1 text-sm text-slate-600">These rules currently have the strongest project-linked support in the audit results.</div>
+            <div className="mt-1 text-sm text-slate-600">These rules currently have the strongest support signals in the audit output and still require human review.</div>
             <div className="mt-3 grid gap-3">
               {report.keySupportedFindings.length ? report.keySupportedFindings.map(renderFindingCard) : emptyState("No supported findings are available yet.")}
             </div>
@@ -185,8 +205,8 @@ export default function Vm0007GapReportView({ report }: Vm0007GapReportViewProps
 
       {sectionCard(
         <>
-          <h2 className="text-lg font-semibold text-slate-950">Client Action List</h2>
-          <div className="mt-1 text-sm text-slate-600">Each weak or missing rule includes the issue, the current PDD evidence, why it is weak or missing, and what to add.</div>
+          <h2 className="text-lg font-semibold text-slate-950">Follow-up Action List</h2>
+          <div className="mt-1 text-sm text-slate-600">Each weak or missing rule includes the issue, the current PDD evidence, why it is weak or missing, and the suggested follow-up.</div>
           <div className="mt-4 overflow-x-auto">
             <table className="min-w-full border-separate border-spacing-0 text-left text-sm">
               <thead>
@@ -209,7 +229,7 @@ export default function Vm0007GapReportView({ report }: Vm0007GapReportViewProps
                   </tr>
                 )) : (
                   <tr>
-                    <td className="px-3 py-3 text-slate-600" colSpan={5}>No client action items are currently listed.</td>
+                    <td className="px-3 py-3 text-slate-600" colSpan={5}>No follow-up action items are currently listed.</td>
                   </tr>
                 )}
               </tbody>
@@ -221,7 +241,7 @@ export default function Vm0007GapReportView({ report }: Vm0007GapReportViewProps
       {sectionCard(
         <>
           <h2 className="text-lg font-semibold text-slate-950">Full VM0007 Rule Audit Table</h2>
-          <div className="mt-1 text-sm text-slate-600">All 58 VM0007 rules are listed below using client-safe readiness language only.</div>
+          <div className="mt-1 text-sm text-slate-600">All 58 VM0007 rules are listed below using internal preview language only.</div>
           <div className="mt-4 overflow-x-auto">
             <table className="min-w-full border-separate border-spacing-0 text-left text-sm">
               <thead>

--- a/src/components/preverif/Vm0007GapReportView.tsx
+++ b/src/components/preverif/Vm0007GapReportView.tsx
@@ -1,0 +1,282 @@
+import type { Vm0007GapReport, Vm0007GapReportDisplayStatus, Vm0007GapReportFinding } from "@/lib/preverif/vm0007GapReport";
+
+type Vm0007GapReportViewProps = {
+  report: Vm0007GapReport;
+};
+
+function sectionCard(children: React.ReactNode) {
+  return <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">{children}</section>;
+}
+
+function statusTone(status: Vm0007GapReportDisplayStatus): string {
+  if (status === "supported") return "border-emerald-200 bg-emerald-50 text-emerald-900";
+  if (status === "weak") return "border-amber-200 bg-amber-50 text-amber-900";
+  if (status === "missing") return "border-rose-200 bg-rose-50 text-rose-900";
+  return "border-sky-200 bg-sky-50 text-sky-900";
+}
+
+function renderFindingCard(finding: Vm0007GapReportFinding) {
+  return (
+    <article key={finding.ruleId} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-semibold text-slate-950">{finding.ruleId}</span>
+        <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold capitalize ${statusTone(finding.status)}`}>
+          {finding.status}
+        </span>
+        <span className="text-xs text-slate-600">{finding.title}</span>
+      </div>
+      <div className="mt-3 text-sm font-medium text-slate-900">{finding.issue}</div>
+      <div className="mt-2 text-sm text-slate-700">
+        <span className="font-semibold text-slate-900">Current PDD evidence:</span> {finding.currentPddEvidence}
+      </div>
+      <div className="mt-2 text-sm text-slate-700">
+        <span className="font-semibold text-slate-900">Why it is weak or missing:</span> {finding.whyItMatters}
+      </div>
+      <div className="mt-2 text-sm text-slate-700">
+        <span className="font-semibold text-slate-900">What to add:</span> {finding.whatToAdd}
+      </div>
+      <div className="mt-2 text-xs text-slate-500">
+        {finding.section ? `Section: ${finding.section}` : "Section not identified"}
+        {finding.page ? ` · Page ${finding.page}` : ""}
+      </div>
+    </article>
+  );
+}
+
+function emptyState(text: string) {
+  return <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600">{text}</div>;
+}
+
+export default function Vm0007GapReportView({ report }: Vm0007GapReportViewProps) {
+  return (
+    <article className="grid gap-4" data-testid="vm0007-gap-report-view">
+      <section className="rounded-[28px] border border-slate-200 bg-[linear-gradient(135deg,#f8fafc_0%,#eef6ff_100%)] p-6 shadow-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full border border-slate-300 bg-white px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-700">
+            VM0007
+          </span>
+          <span className="rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-800">
+            Validation readiness gap report
+          </span>
+        </div>
+        <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight text-slate-950">{report.reportName}</h1>
+            <div className="mt-2 text-base text-slate-700">{report.projectSnapshot.name}</div>
+            <div className="mt-3 text-sm text-slate-700">{report.executiveSummary.headline}</div>
+            <div className="mt-4 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800">
+              {report.statementOfCoverage}
+            </div>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Report context</div>
+            <div className="mt-2 grid gap-1 text-sm text-slate-700">
+              <div><span className="font-semibold text-slate-900">Methodology:</span> {report.methodologyScope.code}@{report.methodologyScope.version}</div>
+              <div><span className="font-semibold text-slate-900">Report ID:</span> {report.reportId}</div>
+              <div><span className="font-semibold text-slate-900">Generated:</span> {report.generatedAt}</div>
+              {report.projectSnapshot.projectId ? <div><span className="font-semibold text-slate-900">Project ID:</span> {report.projectSnapshot.projectId}</div> : null}
+              {report.projectSnapshot.proponent ? <div><span className="font-semibold text-slate-900">Proponent:</span> {report.projectSnapshot.proponent}</div> : null}
+              {report.projectSnapshot.region ? <div><span className="font-semibold text-slate-900">Region:</span> {report.projectSnapshot.region}</div> : null}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Executive Summary</h2>
+            <div className="mt-1 text-sm text-slate-600">Rule totals are evidence-readiness categories drawn from the existing VM0007 audit output.</div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-emerald-800">Supported</div>
+                <div className="mt-1 text-2xl font-semibold text-emerald-950">{report.executiveSummary.totals.supported}</div>
+              </div>
+              <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-amber-800">Weak</div>
+                <div className="mt-1 text-2xl font-semibold text-amber-950">{report.executiveSummary.totals.weak}</div>
+              </div>
+              <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-rose-800">Missing</div>
+                <div className="mt-1 text-2xl font-semibold text-rose-950">{report.executiveSummary.totals.missing}</div>
+              </div>
+              <div className="rounded-2xl border border-sky-200 bg-sky-50 p-4">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-sky-800">Not applicable</div>
+                <div className="mt-1 text-2xl font-semibold text-sky-950">{report.executiveSummary.totals.notApplicable}</div>
+              </div>
+            </div>
+            <div className="mt-4 grid gap-2">
+              {report.executiveSummary.highlights.map((item) => (
+                <div key={item} className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">{item}</div>
+              ))}
+            </div>
+          </>,
+        )}
+
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Project Snapshot</h2>
+            <div className="mt-3 grid gap-2 text-sm text-slate-700">
+              <div><span className="font-semibold text-slate-900">Project:</span> {report.projectSnapshot.name}</div>
+              {report.projectSnapshot.projectId ? <div><span className="font-semibold text-slate-900">Project ID:</span> {report.projectSnapshot.projectId}</div> : null}
+              {report.projectSnapshot.proponent ? <div><span className="font-semibold text-slate-900">Proponent:</span> {report.projectSnapshot.proponent}</div> : null}
+              {report.projectSnapshot.region ? <div><span className="font-semibold text-slate-900">Region:</span> {report.projectSnapshot.region}</div> : null}
+              {report.projectSnapshot.description ? <div><span className="font-semibold text-slate-900">Description:</span> {report.projectSnapshot.description}</div> : null}
+            </div>
+          </>,
+        )}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Methodology Scope</h2>
+            <div className="mt-2 text-sm text-slate-700">{report.methodologyScope.summary}</div>
+            {report.methodologyScope.name ? (
+              <div className="mt-2 text-sm text-slate-700">
+                <span className="font-semibold text-slate-900">Methodology name:</span> {report.methodologyScope.name}
+              </div>
+            ) : null}
+            {report.methodologyScope.scope ? (
+              <div className="mt-2 text-sm text-slate-700">
+                <span className="font-semibold text-slate-900">Scope note:</span> {report.methodologyScope.scope}
+              </div>
+            ) : null}
+            <div className="mt-3 grid gap-2">
+              {report.methodologyScope.notes.map((item) => (
+                <div key={item} className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">{item}</div>
+              ))}
+            </div>
+          </>,
+        )}
+
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Key Supported Findings</h2>
+            <div className="mt-1 text-sm text-slate-600">These rules currently have the strongest project-linked support in the audit results.</div>
+            <div className="mt-3 grid gap-3">
+              {report.keySupportedFindings.length ? report.keySupportedFindings.map(renderFindingCard) : emptyState("No supported findings are available yet.")}
+            </div>
+          </>,
+        )}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Not Applicable Rules</h2>
+            <div className="mt-1 text-sm text-slate-600">Rules appear here only when the current PDD supports a not-applicable conclusion.</div>
+            <div className="mt-3 grid gap-3">
+              {report.notApplicableRules.length ? report.notApplicableRules.map(renderFindingCard) : emptyState("No VM0007 rules are currently classified as not applicable.")}
+            </div>
+          </>,
+        )}
+
+        {sectionCard(
+          <>
+            <h2 className="text-lg font-semibold text-slate-950">Main Evidence Gaps</h2>
+            <div className="mt-1 text-sm text-slate-600">Weak and missing items are shown here so the project team can prioritize the next PDD updates.</div>
+            <div className="mt-3 grid gap-3">
+              {report.mainEvidenceGaps.length ? report.mainEvidenceGaps.map(renderFindingCard) : emptyState("No main evidence gaps are currently listed.")}
+            </div>
+          </>,
+        )}
+      </div>
+
+      {sectionCard(
+        <>
+          <h2 className="text-lg font-semibold text-slate-950">Client Action List</h2>
+          <div className="mt-1 text-sm text-slate-600">Each weak or missing rule includes the issue, the current PDD evidence, why it is weak or missing, and what to add.</div>
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full border-separate border-spacing-0 text-left text-sm">
+              <thead>
+                <tr>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Rule</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Issue</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Current PDD evidence</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Why it is weak or missing</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">What to add</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.clientActionList.length ? report.clientActionList.map((item) => (
+                  <tr key={item.ruleId} className="align-top">
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-950">{item.ruleId}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{item.issue}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{item.currentPddEvidence}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{item.whyItMatters}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{item.whatToAdd}</td>
+                  </tr>
+                )) : (
+                  <tr>
+                    <td className="px-3 py-3 text-slate-600" colSpan={5}>No client action items are currently listed.</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>,
+      )}
+
+      {sectionCard(
+        <>
+          <h2 className="text-lg font-semibold text-slate-950">Full VM0007 Rule Audit Table</h2>
+          <div className="mt-1 text-sm text-slate-600">All 58 VM0007 rules are listed below using client-safe readiness language only.</div>
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full border-separate border-spacing-0 text-left text-sm">
+              <thead>
+                <tr>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Rule</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Title</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Status</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Section</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Evidence summary</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Gap guidance</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.fullRuleAuditTable.map((row) => (
+                  <tr key={row.ruleId} className="align-top" data-status={row.status}>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-950">{row.ruleId}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{row.title}</td>
+                    <td className="border-b border-slate-100 px-3 py-3">
+                      <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold capitalize ${statusTone(row.status)}`}>
+                        {row.status}
+                      </span>
+                    </td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{row.section}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{row.evidenceSummary}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{row.gapGuidance}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>,
+      )}
+
+      {sectionCard(
+        <>
+          <h2 className="text-lg font-semibold text-slate-950">Evidence Appendix</h2>
+          <div className="mt-1 text-sm text-slate-600">Evidence quotes are reproduced from the existing audit output only.</div>
+          <div className="mt-4 grid gap-3">
+            {report.evidenceAppendix.map((entry) => (
+              <article key={entry.ruleId} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-xs font-semibold text-slate-950">{entry.ruleId}</span>
+                  <span className="text-xs text-slate-600">{entry.title}</span>
+                </div>
+                <div className="mt-2 text-sm text-slate-700">{entry.quote}</div>
+                <div className="mt-2 text-xs text-slate-500">
+                  {entry.section}
+                  {entry.page ? ` · Page ${entry.page}` : ""}
+                </div>
+                <div className="mt-2 text-xs text-slate-500">{entry.reasonSelected}</div>
+              </article>
+            ))}
+          </div>
+        </>,
+      )}
+    </article>
+  );
+}

--- a/src/lib/chat/quickCheck.ts
+++ b/src/lib/chat/quickCheck.ts
@@ -72,6 +72,7 @@ export type QuickCheckResult = {
   extraction?: QuickCheckExtractionSnapshot | null;
   sourceMode?: QuickCheckSourceMode;
   evidenceFileName?: string;
+  vm0007GapReportAuditId?: string;
 };
 
 export type QuickCheckStagedUpload = {
@@ -247,6 +248,7 @@ function normalizeResult(raw: unknown): QuickCheckResult | null {
     extraction,
     sourceMode: normalizeSourceMode(record.sourceMode),
     evidenceFileName: typeof record.evidenceFileName === "string" ? record.evidenceFileName : undefined,
+    vm0007GapReportAuditId: typeof record.vm0007GapReportAuditId === "string" ? record.vm0007GapReportAuditId : undefined,
   };
 }
 

--- a/src/lib/preverif/vm0007GapReport.ts
+++ b/src/lib/preverif/vm0007GapReport.ts
@@ -163,7 +163,7 @@ function sortGapFindings(left: Vm0007GapReportFinding, right: Vm0007GapReportFin
 
 function makeHeadline(input: Vm0007GapReport["executiveSummary"]["totals"]): string {
   if (input.supported === 58) {
-    return "The current PDD shows broad rule-level support, with no remaining client evidence actions.";
+    return "The current audit output identifies supported evidence across the VM0007 rule set, with no weak or missing evidence items listed.";
   }
   if (input.needsClientAction === 0) {
     return "The current PDD supports most VM0007 rules, with remaining items limited to scope-based not-applicable decisions.";

--- a/src/lib/preverif/vm0007GapReport.ts
+++ b/src/lib/preverif/vm0007GapReport.ts
@@ -131,7 +131,21 @@ function issueLabel(result: MethodologyEvidenceAuditResult): string {
 }
 
 function gapGuidance(result: MethodologyEvidenceAuditResult): string {
+  if (result.status === "supported_by_pdd") return "";
+  if (result.status === "not_applicable") {
+    const clientAction = result.clientAction.trim();
+    return /^(no client action required|keep scope basis clear\.?)$/i.test(clientAction) ? clientAction : "";
+  }
   return result.gap.trim() || result.clientAction.trim();
+}
+
+function clientActionText(result: MethodologyEvidenceAuditResult): string {
+  if (result.status === "supported_by_pdd") return "";
+  if (result.status === "not_applicable") {
+    const clientAction = result.clientAction.trim();
+    return /^(no client action required|keep scope basis clear\.?)$/i.test(clientAction) ? clientAction : "";
+  }
+  return result.clientAction;
 }
 
 function toFinding(result: MethodologyEvidenceAuditResult): Vm0007GapReportFinding {
@@ -142,7 +156,7 @@ function toFinding(result: MethodologyEvidenceAuditResult): Vm0007GapReportFindi
     issue: issueLabel(result),
     currentPddEvidence: evidenceText(result),
     whyItMatters: result.assessmentReason,
-    whatToAdd: result.clientAction,
+    whatToAdd: clientActionText(result),
     section: result.section,
     page: result.page,
     confidence: result.confidence,
@@ -252,7 +266,7 @@ export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapRepo
         section: result.section ?? "Section not identified",
         evidenceSummary: evidenceText(result),
         gapGuidance: gapGuidance(result),
-        clientAction: result.clientAction,
+        clientAction: clientActionText(result),
       })),
     evidenceAppendix: input.audit.results
       .slice()

--- a/src/lib/preverif/vm0007GapReport.ts
+++ b/src/lib/preverif/vm0007GapReport.ts
@@ -45,10 +45,12 @@ export type Vm0007GapReportFinding = {
 export type Vm0007GapReport = {
   reportId: string;
   generatedAt: string;
-  reportName: "Validation Readiness Gap Report";
+  reportName: "Internal VM0007 Gap Report Preview";
   statementOfCoverage: string;
+  limitationBanner: string;
   executiveSummary: {
     headline: string;
+    allSupportedWarning: string | null;
     totals: {
       supported: number;
       weak: number;
@@ -176,15 +178,15 @@ function sortGapFindings(left: Vm0007GapReportFinding, right: Vm0007GapReportFin
 
 function makeHeadline(input: Vm0007GapReport["executiveSummary"]["totals"]): string {
   if (input.supported === 58) {
-    return "The current audit output identifies supported evidence across the VM0007 rule set, with no weak or missing evidence items listed.";
+    return "The current audit output marks every VM0007 rule as supported, but evidence quality still requires manual review.";
   }
   if (input.needsClientAction === 0) {
-    return "The current PDD supports most VM0007 rules, with remaining items limited to scope-based not-applicable decisions.";
+    return "The current audit output supports most VM0007 rules, with remaining items limited to scope-based not-applicable decisions.";
   }
   if (input.supported >= input.needsClientAction) {
-    return "The current PDD shows a usable base of support, but several VM0007 rules still need clearer client evidence before validation readiness improves.";
+    return "The current audit output shows a usable base of support, but several VM0007 rules still need clearer project-specific evidence before review confidence improves.";
   }
-  return "The current PDD still has material evidence gaps across VM0007 and needs targeted client follow-up before validation readiness improves.";
+  return "The current audit output still shows material evidence gaps across VM0007 and needs targeted project-team follow-up before review confidence improves.";
 }
 
 export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapReport {
@@ -221,10 +223,15 @@ export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapRepo
   return {
     reportId: input.reportId,
     generatedAt: input.generatedAt,
-    reportName: "Validation Readiness Gap Report",
+    reportName: "Internal VM0007 Gap Report Preview",
     statementOfCoverage: `${input.audit.totalRules} VM0007 rules assessed for validation readiness.`,
+    limitationBanner: "Internal preview only. This report shows current audit output and has not been manually reviewed.",
     executiveSummary: {
       headline: makeHeadline(totals),
+      allSupportedWarning:
+        totals.supported === input.audit.totalRules
+          ? "All rules are currently marked supported. Review evidence quality before relying on this result."
+          : null,
       totals,
       highlights: [
         `${totals.supported} rules currently show supported PDD evidence.`,
@@ -233,9 +240,9 @@ export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapRepo
         `${totals.notApplicable} rules are treated as not applicable only where the PDD itself supports that conclusion.`,
       ],
       limitations: [
-        "This report summarizes current PDD support and evidence gaps for project-team follow-up.",
+        "This preview summarizes current PDD support and evidence gaps for internal project-team follow-up.",
         "Evidence quotes are limited to the audit results already selected by the existing VM0007 evidence audit.",
-        "Weak and missing items should be resolved with clearer project-specific PDD content before relying on this draft for external use.",
+        "Supported outcomes may still rely on broad methodology or project-description text and should be reviewed before reuse.",
       ],
     },
     projectSnapshot: input.project,
@@ -244,11 +251,11 @@ export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapRepo
       version: input.methodology.version,
       name: input.methodology.name,
       scope: input.methodology.scope,
-      summary: `${input.methodology.code}@${input.methodology.version} audit output rendered into a client-facing readiness gap report.`,
+      summary: `${input.methodology.code}@${input.methodology.version} audit output rendered into an internal preview from the existing evidence audit.`,
       notes: [
         "The renderer uses existing VM0007 audit results only and does not rerun methodology logic.",
         "Status language is limited to supported, weak, missing, and not applicable.",
-        "Every weak or missing rule is paired with client action guidance from the audit output.",
+        "Weak and missing rules keep follow-up guidance from the audit output without changing the underlying audit logic.",
       ],
     },
     keySupportedFindings,

--- a/src/lib/preverif/vm0007GapReport.ts
+++ b/src/lib/preverif/vm0007GapReport.ts
@@ -1,0 +1,271 @@
+import type {
+  EvidenceAuditStatus,
+  MethodologyEvidenceAuditResult,
+  MethodologyEvidenceAuditSummary,
+} from "@/lib/preverif/evidenceAudit";
+
+export type Vm0007GapReportInput = {
+  reportId: string;
+  generatedAt: string;
+  project: {
+    name: string;
+    projectId?: string;
+    proponent?: string;
+    region?: string;
+    description?: string;
+  };
+  methodology: {
+    code: string;
+    version: string;
+    name?: string;
+    scope?: string;
+  };
+  audit: MethodologyEvidenceAuditSummary;
+};
+
+export type Vm0007GapReportDisplayStatus =
+  | "supported"
+  | "weak"
+  | "missing"
+  | "not applicable";
+
+export type Vm0007GapReportFinding = {
+  ruleId: string;
+  title: string;
+  status: Vm0007GapReportDisplayStatus;
+  issue: string;
+  currentPddEvidence: string;
+  whyItMatters: string;
+  whatToAdd: string;
+  section: string | null;
+  page: number | null;
+  confidence: MethodologyEvidenceAuditResult["confidence"];
+};
+
+export type Vm0007GapReport = {
+  reportId: string;
+  generatedAt: string;
+  reportName: "Validation Readiness Gap Report";
+  statementOfCoverage: string;
+  executiveSummary: {
+    headline: string;
+    totals: {
+      supported: number;
+      weak: number;
+      missing: number;
+      notApplicable: number;
+      needsClientAction: number;
+    };
+    highlights: string[];
+    limitations: string[];
+  };
+  projectSnapshot: Vm0007GapReportInput["project"];
+  methodologyScope: {
+    code: string;
+    version: string;
+    name?: string;
+    scope?: string;
+    summary: string;
+    notes: string[];
+  };
+  keySupportedFindings: Vm0007GapReportFinding[];
+  notApplicableRules: Vm0007GapReportFinding[];
+  mainEvidenceGaps: Vm0007GapReportFinding[];
+  clientActionList: Vm0007GapReportFinding[];
+  fullRuleAuditTable: Array<{
+    ruleId: string;
+    title: string;
+    status: Vm0007GapReportDisplayStatus;
+    section: string;
+    evidenceSummary: string;
+    gapGuidance: string;
+    clientAction: string;
+  }>;
+  evidenceAppendix: Array<{
+    ruleId: string;
+    title: string;
+    quote: string;
+    section: string;
+    page: number | null;
+    reasonSelected: string;
+  }>;
+};
+
+const NO_PDD_EVIDENCE_TEXT = "Evidence is not currently available in the PDD.";
+
+function toDisplayStatus(status: EvidenceAuditStatus): Vm0007GapReportDisplayStatus {
+  switch (status) {
+    case "supported_by_pdd":
+      return "supported";
+    case "missing_evidence":
+      return "missing";
+    case "not_applicable":
+      return "not applicable";
+    case "partially_supported":
+    case "manual_review_needed":
+      return "weak";
+  }
+}
+
+function compareRuleIds(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { numeric: true });
+}
+
+function evidenceText(result: MethodologyEvidenceAuditResult): string {
+  return result.bestEvidenceQuote?.trim() || NO_PDD_EVIDENCE_TEXT;
+}
+
+function issueLabel(result: MethodologyEvidenceAuditResult): string {
+  switch (result.status) {
+    case "supported_by_pdd":
+      return "Current PDD support is usable for this rule.";
+    case "not_applicable":
+      return "Current PDD evidence supports a not-applicable conclusion.";
+    case "missing_evidence":
+      return "Current PDD support is missing for this rule.";
+    case "manual_review_needed":
+      return "Current PDD support is too unclear to classify confidently.";
+    case "partially_supported":
+      return "Current PDD support is present but incomplete.";
+  }
+}
+
+function gapGuidance(result: MethodologyEvidenceAuditResult): string {
+  return result.gap.trim() || result.clientAction.trim();
+}
+
+function toFinding(result: MethodologyEvidenceAuditResult): Vm0007GapReportFinding {
+  return {
+    ruleId: result.ruleId,
+    title: result.title,
+    status: toDisplayStatus(result.status),
+    issue: issueLabel(result),
+    currentPddEvidence: evidenceText(result),
+    whyItMatters: result.assessmentReason,
+    whatToAdd: result.clientAction,
+    section: result.section,
+    page: result.page,
+    confidence: result.confidence,
+  };
+}
+
+function sortGapFindings(left: Vm0007GapReportFinding, right: Vm0007GapReportFinding): number {
+  const severity = new Map<Vm0007GapReportDisplayStatus, number>([
+    ["missing", 0],
+    ["weak", 1],
+    ["not applicable", 2],
+    ["supported", 3],
+  ]);
+  const severityDiff = (severity.get(left.status) ?? 99) - (severity.get(right.status) ?? 99);
+  if (severityDiff !== 0) return severityDiff;
+  return compareRuleIds(left.ruleId, right.ruleId);
+}
+
+function makeHeadline(input: Vm0007GapReport["executiveSummary"]["totals"]): string {
+  if (input.supported === 58) {
+    return "The current PDD shows broad rule-level support, with no remaining client evidence actions.";
+  }
+  if (input.needsClientAction === 0) {
+    return "The current PDD supports most VM0007 rules, with remaining items limited to scope-based not-applicable decisions.";
+  }
+  if (input.supported >= input.needsClientAction) {
+    return "The current PDD shows a usable base of support, but several VM0007 rules still need clearer client evidence before validation readiness improves.";
+  }
+  return "The current PDD still has material evidence gaps across VM0007 and needs targeted client follow-up before validation readiness improves.";
+}
+
+export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapReport {
+  const findings = input.audit.results.map(toFinding);
+  const supported = findings.filter((finding) => finding.status === "supported");
+  const weak = findings.filter((finding) => finding.status === "weak");
+  const missing = findings.filter((finding) => finding.status === "missing");
+  const notApplicable = findings.filter((finding) => finding.status === "not applicable");
+  const needsClientAction = findings.filter((finding) =>
+    finding.status === "weak" || finding.status === "missing",
+  );
+
+  const totals = {
+    supported: supported.length,
+    weak: weak.length,
+    missing: missing.length,
+    notApplicable: notApplicable.length,
+    needsClientAction: needsClientAction.length,
+  };
+
+  const keySupportedFindings = supported
+    .slice()
+    .sort((left, right) => compareRuleIds(left.ruleId, right.ruleId))
+    .slice(0, 10);
+
+  const notApplicableRules = notApplicable
+    .slice()
+    .sort((left, right) => compareRuleIds(left.ruleId, right.ruleId));
+
+  const mainEvidenceGaps = needsClientAction
+    .slice()
+    .sort(sortGapFindings);
+
+  return {
+    reportId: input.reportId,
+    generatedAt: input.generatedAt,
+    reportName: "Validation Readiness Gap Report",
+    statementOfCoverage: `${input.audit.totalRules} VM0007 rules assessed for validation readiness.`,
+    executiveSummary: {
+      headline: makeHeadline(totals),
+      totals,
+      highlights: [
+        `${totals.supported} rules currently show supported PDD evidence.`,
+        `${totals.weak} rules show weak support and need clearer project-specific detail.`,
+        `${totals.missing} rules do not yet show the required evidence in the current PDD.`,
+        `${totals.notApplicable} rules are treated as not applicable only where the PDD itself supports that conclusion.`,
+      ],
+      limitations: [
+        "This report summarizes current PDD support and evidence gaps for project-team follow-up.",
+        "Evidence quotes are limited to the audit results already selected by the existing VM0007 evidence audit.",
+        "Weak and missing items should be resolved with clearer project-specific PDD content before relying on this draft for external use.",
+      ],
+    },
+    projectSnapshot: input.project,
+    methodologyScope: {
+      code: input.methodology.code,
+      version: input.methodology.version,
+      name: input.methodology.name,
+      scope: input.methodology.scope,
+      summary: `${input.methodology.code}@${input.methodology.version} audit output rendered into a client-facing readiness gap report.`,
+      notes: [
+        "The renderer uses existing VM0007 audit results only and does not rerun methodology logic.",
+        "Status language is limited to supported, weak, missing, and not applicable.",
+        "Every weak or missing rule is paired with client action guidance from the audit output.",
+      ],
+    },
+    keySupportedFindings,
+    notApplicableRules,
+    mainEvidenceGaps,
+    clientActionList: mainEvidenceGaps,
+    fullRuleAuditTable: input.audit.results
+      .slice()
+      .sort((left, right) => compareRuleIds(left.ruleId, right.ruleId))
+      .map((result) => ({
+        ruleId: result.ruleId,
+        title: result.title,
+        status: toDisplayStatus(result.status),
+        section: result.section ?? "Section not identified",
+        evidenceSummary: evidenceText(result),
+        gapGuidance: gapGuidance(result),
+        clientAction: result.clientAction,
+      })),
+    evidenceAppendix: input.audit.results
+      .slice()
+      .sort((left, right) => compareRuleIds(left.ruleId, right.ruleId))
+      .map((result) => ({
+        ruleId: result.ruleId,
+        title: result.title,
+        quote: evidenceText(result),
+        section: result.section ?? "Section not identified",
+        page: result.page,
+        reasonSelected: result.reasonSelected,
+      })),
+  };
+}
+
+export { NO_PDD_EVIDENCE_TEXT };

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -1,0 +1,125 @@
+import type { RuleSummary } from "@/app/m/_lib/methodRules";
+import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import {
+  auditEvidence,
+  type MethodologyEvidenceAuditRule,
+  type MethodologyEvidenceAuditSummary,
+} from "@/lib/preverif/evidenceAudit";
+import {
+  getVm0007EvidenceContract,
+  normalizeVm0007RuleId,
+} from "@/lib/preverif/vm0007EvidenceContracts";
+
+const VM0007_GAP_REPORT_AUDIT_PREFIX = "a6:vm0007-gap-report-audit:v1:";
+
+export type Vm0007GapReportAuditRecord = {
+  auditId: string;
+  methodologyId: string;
+  methodologyVersion: string;
+  generatedAt: string;
+  evidenceFileName?: string;
+  audit: MethodologyEvidenceAuditSummary;
+};
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+function storageKey(auditId: string): string {
+  return `${VM0007_GAP_REPORT_AUDIT_PREFIX}${auditId.trim()}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function mapRule(rule: RuleSummary): MethodologyEvidenceAuditRule {
+  return {
+    id: rule.id,
+    title: rule.title,
+    summary: rule.summary ?? rule.snippet,
+    type: rule.type,
+    logic: rule.logic,
+    text: rule.text,
+  };
+}
+
+export function createVm0007GapReportAuditId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `vm0007-gap-${crypto.randomUUID()}`;
+  }
+  return `vm0007-gap-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function buildVm0007GapReportHref(auditId: string): string {
+  return `/internal/reports/vm0007-gap/${encodeURIComponent(auditId)}`;
+}
+
+export function saveVm0007GapReportAudit(record: Vm0007GapReportAuditRecord): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(storageKey(record.auditId), JSON.stringify(record));
+}
+
+export function loadVm0007GapReportAudit(auditId: string): Vm0007GapReportAuditRecord | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  const raw = storage.getItem(storageKey(auditId));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Vm0007GapReportAuditRecord;
+    if (!parsed || typeof parsed !== "object") return null;
+    if (typeof parsed.auditId !== "string" || typeof parsed.methodologyId !== "string" || typeof parsed.methodologyVersion !== "string") {
+      return null;
+    }
+    if (!parsed.audit || !Array.isArray(parsed.audit.results) || typeof parsed.audit.totalRules !== "number") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function hasVm0007GapReportAudit(auditId: string | null | undefined): boolean {
+  if (!auditId?.trim()) return false;
+  return loadVm0007GapReportAudit(auditId) !== null;
+}
+
+export function deriveVm0007ProjectName(evidenceFileName?: string): string {
+  const trimmed = evidenceFileName?.trim() ?? "";
+  if (!trimmed) return "VM0007 project";
+  const stem = trimmed.replace(/\.[^.]+$/, "").replace(/[_-]+/g, " ").trim();
+  return stem || "VM0007 project";
+}
+
+export function buildAndSaveVm0007GapReportAudit(input: {
+  methodologyId: string;
+  methodologyVersion: string;
+  evidenceFileName?: string;
+  rawPddText: string;
+  rules: readonly RuleSummary[];
+}): Vm0007GapReportAuditRecord | null {
+  if (input.methodologyId.trim().toUpperCase() !== "VM0007") return null;
+  if (!input.rawPddText.trim() || input.rules.length === 0) return null;
+
+  const context = getStructuredQueryContext(input.rawPddText);
+  const audit = auditEvidence({
+    rules: input.rules.map(mapRule),
+    evidenceDocument: context.evidenceDocument,
+    getContract: getVm0007EvidenceContract,
+    normalizeRuleId: normalizeVm0007RuleId,
+    sections: context.documentStructure.sections,
+    rawText: input.rawPddText,
+  });
+
+  const record: Vm0007GapReportAuditRecord = {
+    auditId: createVm0007GapReportAuditId(),
+    methodologyId: input.methodologyId.trim(),
+    methodologyVersion: input.methodologyVersion.trim(),
+    generatedAt: nowIso(),
+    evidenceFileName: input.evidenceFileName?.trim() || undefined,
+    audit,
+  };
+  saveVm0007GapReportAudit(record);
+  return record;
+}

--- a/tests/components/quickCheckPanel.test.tsx
+++ b/tests/components/quickCheckPanel.test.tsx
@@ -2305,6 +2305,40 @@ describe.skip("QuickCheckPanel claim-first flow (phase-3 UI drift - see note abo
     expect(text).not.toContain("No valid analysis path in VM0007");
   });
 
+  it("attaches a VM0007 gap report audit id after manual match selection when extracted PDD text exists", async () => {
+    seedSession({
+      claimText: "The monitoring report covers the full reporting period.",
+      filename: "plum-verra-demo-excerpt.pdf",
+    });
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+
+    await act(async () => {
+      clickButton("Run quick check");
+    });
+
+    await flushUi();
+    expect(container.textContent).toContain("Likely requirement matches");
+
+    await act(async () => {
+      clickButton("Monitoring procedure");
+    });
+
+    await flushUi();
+
+    const sessionRaw = window.localStorage.getItem("a6:quick-check:claim-first:v1") ?? "";
+    const session = JSON.parse(sessionRaw) as {
+      result?: { vm0007GapReportAuditId?: string };
+    };
+
+    expect(session.result?.vm0007GapReportAuditId?.trim().length).toBeGreaterThan(0);
+    expect(container.textContent).toContain("View Gap Report");
+  });
+
   it("opens full review in the detected VM0007 workspace from recovery", async () => {
     seedSession({
       claimText: "The leakage deduction is justified by the evidence.",

--- a/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
+++ b/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
@@ -59,6 +59,7 @@ jest.mock("@/lib/chat/quickCheckPdfClient", () => {
 });
 
 import QuickCheckPanel from "@/components/chat/QuickCheckPanel";
+import { loadVm0007GapReportAudit } from "@/lib/preverif/vm0007GapReportStore";
 
 describe("QuickCheckPanel upload/session boundary smoke test — proves the panel can consume seeded upload/session state; does not test real PDF extraction or parser reliability", () => {
   let container: HTMLDivElement;
@@ -137,12 +138,14 @@ describe("QuickCheckPanel upload/session boundary smoke test — proves the pane
     root = createRoot(container);
     window.localStorage.clear();
 
-    delete (window as any).location;
-    (window as any).location = {
-      assign: jest.fn(),
-      replace: jest.fn(),
-      href: "http://localhost/",
-    };
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        assign: jest.fn(),
+        replace: jest.fn(),
+        href: "http://localhost/",
+      },
+    });
 
     createAndStoreEvidenceAttachmentMock.mockReset();
     createAndStoreEvidenceAttachmentMock.mockImplementation(
@@ -204,6 +207,23 @@ describe("QuickCheckPanel upload/session boundary smoke test — proves the pane
             status: "disabled",
             candidates: [],
             warning: "semantic evidence suggestions disabled in test",
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/methods/VM0007/v/v1-0/rules")) {
+        return new Response(
+          JSON.stringify({
+            rules: [
+              {
+                id: "R-1-0001",
+                title: "Forest definition",
+                snippet: "Forest definition evidence.",
+                summary: "Forest definition evidence.",
+                logic: "Confirm the project remains within the forest definition.",
+                tags: ["vm0007", "eligibility"],
+              },
+            ],
           }),
           { status: 200 },
         );
@@ -312,6 +332,43 @@ describe("QuickCheckPanel upload/session boundary smoke test — proves the pane
         expect(text).toContain(record.sectionHeading);
       }
     }
+  });
+
+  it("shows the VM0007 internal report card in the upload evidence-check flow and generates a preview", async () => {
+    seedSession({
+      claimText: "What is the project title?",
+      filename: "qc-smoke-upload.pdf",
+    });
+    await seedAttachmentText("att-upload-1", `%PDF-1.4\n(${PLUM_PDD_TEXT})\n%%EOF`);
+
+    await act(async () => {
+      root.render(<QuickCheckPanel />);
+    });
+
+    await flushUi();
+    await flushUi();
+
+    const beforeGenerateText = container.textContent ?? "";
+    expect(beforeGenerateText).toContain("Evidence Checks");
+    expect(beforeGenerateText).toContain("Internal VM0007 report");
+    expect(beforeGenerateText).toContain("Generate Gap Report Preview");
+    expect(beforeGenerateText).toContain("Methodology");
+
+    await act(async () => {
+      clickButton("Generate Gap Report Preview");
+    });
+    await flushUi();
+    await flushUi();
+
+    const link = Array.from(container.querySelectorAll("a")).find((node) =>
+      node.textContent?.includes("View Gap Report"),
+    );
+    expect(link).toBeTruthy();
+    const href = link?.getAttribute("href") ?? "";
+    expect(href).toMatch(/^\/internal\/reports\/vm0007-gap\/vm0007-gap-/);
+
+    const auditId = href.split("/").pop() ?? "";
+    expect(loadVm0007GapReportAudit(auditId)).not.toBeNull();
   });
 
   it("shows rejection state for unsupported question from seeded upload/session state", async () => {

--- a/tests/components/quickCheckPanel.vm0007GapReportEntry.test.tsx
+++ b/tests/components/quickCheckPanel.vm0007GapReportEntry.test.tsx
@@ -3,7 +3,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import QuickCheckPanel from "@/components/chat/QuickCheckPanel";
+import QuickCheckPanel, { resolveGapReportSourceAnalysis } from "@/components/chat/QuickCheckPanel";
+import type { QuickCheckEvidenceAnalysis } from "@/lib/chat/quickCheckEvidence";
 
 function seedVm0007Session(auditId?: string) {
   window.localStorage.setItem(
@@ -55,10 +56,10 @@ function seedVm0007Session(auditId?: string) {
   );
 }
 
-describe("QuickCheckPanel VM0007 gap report entry point", () => {
-  let container: HTMLDivElement;
-  let root: ReturnType<typeof createRoot>;
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
 
+describe("QuickCheckPanel VM0007 gap report entry point", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -141,5 +142,22 @@ describe("QuickCheckPanel VM0007 gap report entry point", () => {
     expect(text).toContain("Gap report not available yet");
     expect(text).toContain("Run a VM0007 evidence audit to generate the internal report preview.");
     expect(text).not.toContain("View Gap Report");
+  });
+
+  test("manual match fallback reuses extracted PDD analysis when direct analysis is missing", async () => {
+    const analysisFromState: QuickCheckEvidenceAnalysis = {
+      rawPddText: "VM0007 PDD extracted text.",
+      facts: [],
+      parsedEvidenceLabels: [],
+      documentTypes: ["pdd"],
+      methodologyMentions: ["VM0007"],
+      extractionConfidence: 1,
+      warnings: [],
+      parserAdapterId: "test-parser",
+    };
+
+    expect(resolveGapReportSourceAnalysis(null, analysisFromState)).toBe(analysisFromState);
+    expect(resolveGapReportSourceAnalysis(undefined, analysisFromState)).toBe(analysisFromState);
+    expect(resolveGapReportSourceAnalysis(analysisFromState, null)).toBe(analysisFromState);
   });
 });

--- a/tests/components/quickCheckPanel.vm0007GapReportEntry.test.tsx
+++ b/tests/components/quickCheckPanel.vm0007GapReportEntry.test.tsx
@@ -1,0 +1,145 @@
+/** @jest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import QuickCheckPanel from "@/components/chat/QuickCheckPanel";
+
+function seedVm0007Session(auditId?: string) {
+  window.localStorage.setItem(
+    "a6:quick-check:claim-first:v1",
+    JSON.stringify({
+      draft: {
+        id: "draft-vm0007",
+        claimText: "Does this PDD support the forest definition requirement?",
+        methodologyId: "VM0007",
+        methodologyVersion: "v1-8",
+        evidenceIds: ["upload-1"],
+        status: "checked",
+        matchedRequirementId: "R-1-0001",
+        matchedRequirementLabel: "R-1-0001 · Forest definition",
+        resultId: "result-vm0007",
+        sourceMode: "uploaded_file",
+        evidenceFileName: "envira-amazonia-vm0007.pdf",
+        createdAt: "2026-07-01T00:00:00Z",
+        updatedAt: "2026-07-01T00:00:00Z",
+      },
+      result: {
+        id: "result-vm0007",
+        claimText: "Does this PDD support the forest definition requirement?",
+        requirementId: "R-1-0001",
+        requirementLabel: "R-1-0001 · Forest definition",
+        verdict: "Supported",
+        explanation: "Project-specific evidence supports the forest-definition rule.",
+        citations: ["S-1"],
+        nextStepHint: "Open full review to preserve this check.",
+        extraction: {
+          documentType: "Project Description Document",
+          extractedFacts: ["Project area remained forest land before project start."],
+          methodologyMentions: ["VM0007"],
+          warnings: [],
+          signals: {
+            parsedEvidenceCount: 1,
+            factCount: 1,
+            relevantFactCount: 1,
+            methodologyMentionCount: 1,
+            warningCount: 0,
+          },
+        },
+        sourceMode: "uploaded_file",
+        evidenceFileName: "envira-amazonia-vm0007.pdf",
+        vm0007GapReportAuditId: auditId,
+      },
+      stagedUploads: [],
+    }),
+  );
+}
+
+describe("QuickCheckPanel VM0007 gap report entry point", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    window.localStorage.clear();
+
+    (global.fetch as unknown as typeof fetch) = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/methods/inventory")) {
+        return new Response(
+          JSON.stringify({
+            methods: [{ code: "VM0007", latestVersion: "v1-8", versions: ["v1-8"] }],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/methods/VM0007/v/v1-8/rules")) {
+        return new Response(
+          JSON.stringify({
+            rules: [
+              {
+                id: "R-1-0001",
+                title: "Forest definition",
+                snippet: "Forest definition evidence.",
+                tags: ["vm0007", "eligibility"],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`Unhandled fetch ${url}`);
+    }) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+  });
+
+  test("renders an internal report section with an active View Gap Report link when audit id exists", async () => {
+    seedVm0007Session("audit-quickcheck-1");
+
+    await act(async () => {
+      root.render(<QuickCheckPanel initialMethod="VM0007" initialVersion="v1-8" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Internal report");
+    expect(text).toContain("View Gap Report");
+
+    const link = Array.from(container.querySelectorAll("a")).find((item) => item.textContent?.includes("View Gap Report"));
+    expect(link?.getAttribute("href")).toBe("/internal/reports/vm0007-gap/audit-quickcheck-1");
+  });
+
+  test("renders a disabled helper state when VM0007 result has no report id yet", async () => {
+    seedVm0007Session();
+
+    await act(async () => {
+      root.render(<QuickCheckPanel initialMethod="VM0007" initialVersion="v1-8" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Internal report");
+    expect(text).toContain("Gap report not available yet");
+    expect(text).toContain("Run a VM0007 evidence audit to generate the internal report preview.");
+    expect(text).not.toContain("View Gap Report");
+  });
+});

--- a/tests/components/vm0007GapReportLaunchButton.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.test.tsx
@@ -1,0 +1,87 @@
+/** @jest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import Vm0007GapReportLaunchButton from "@/components/preverif/Vm0007GapReportLaunchButton";
+import type { MethodologyEvidenceAuditResult, MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
+import { saveVm0007GapReportAudit } from "@/lib/preverif/vm0007GapReportStore";
+
+function makeAudit(): MethodologyEvidenceAuditSummary {
+  const results: MethodologyEvidenceAuditResult[] = Array.from({ length: 58 }, (_, index) => ({
+    ruleId: `R-6-${String(index + 1).padStart(4, "0")}`,
+    stableId: `R-6-${String(index + 1).padStart(4, "0")}`,
+    title: `Rule ${index + 1}`,
+    ruleLogic: `Rule logic ${index + 1}`,
+    status: "supported_by_pdd",
+    bestEvidenceQuote: `Evidence quote ${index + 1}.`,
+    page: 1,
+    section: "Monitoring Plan",
+    span: `span-${index + 1}`,
+    reasonSelected: `Selected span ${index + 1}.`,
+    assessmentReason: `Assessment reason ${index + 1}.`,
+    gap: "",
+    clientAction: `Client action ${index + 1}.`,
+    confidence: "high",
+  }));
+
+  return {
+    results,
+    totals: {
+      supported_by_pdd: 58,
+      partially_supported: 0,
+      missing_evidence: 0,
+      not_applicable: 0,
+      manual_review_needed: 0,
+    },
+    totalRules: 58,
+  };
+}
+
+describe("Vm0007GapReportLaunchButton", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    window.localStorage.clear();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+  });
+
+  test("appears when saved VM0007 audit output exists", async () => {
+    saveVm0007GapReportAudit({
+      auditId: "audit-1",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      generatedAt: "2026-07-01T00:00:00Z",
+      evidenceFileName: "envira.pdf",
+      audit: makeAudit(),
+    });
+
+    await act(async () => {
+      root.render(<Vm0007GapReportLaunchButton auditId="audit-1" />);
+    });
+
+    const link = container.querySelector("a");
+    expect(link?.textContent).toContain("View Gap Report");
+    expect(link?.getAttribute("href")).toBe("/internal/reports/vm0007-gap/audit-1");
+  });
+
+  test("does not appear when no saved VM0007 audit output exists", async () => {
+    await act(async () => {
+      root.render(<Vm0007GapReportLaunchButton auditId="missing-audit" />);
+    });
+
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).not.toContain("View Gap Report");
+  });
+});

--- a/tests/components/vm0007GapReportLaunchButton.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.test.tsx
@@ -68,20 +68,33 @@ describe("Vm0007GapReportLaunchButton", () => {
     });
 
     await act(async () => {
-      root.render(<Vm0007GapReportLaunchButton auditId="audit-1" />);
+      root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" />);
     });
 
     const link = container.querySelector("a");
+    expect(container.textContent).toContain("Internal report");
     expect(link?.textContent).toContain("View Gap Report");
     expect(link?.getAttribute("href")).toBe("/internal/reports/vm0007-gap/audit-1");
   });
 
-  test("does not appear when no saved VM0007 audit output exists", async () => {
+  test("shows a disabled helper state when VM0007 result has no audit id yet", async () => {
     await act(async () => {
-      root.render(<Vm0007GapReportLaunchButton auditId="missing-audit" />);
+      root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId={null} />);
     });
 
     expect(container.querySelector("a")).toBeNull();
-    expect(container.textContent).not.toContain("View Gap Report");
+    expect(container.textContent).toContain("Internal report");
+    expect(container.textContent).toContain("Gap report not available yet");
+    expect(container.textContent).toContain("Run a VM0007 evidence audit to generate the internal report preview.");
+    expect(container.querySelector("button")?.hasAttribute("disabled")).toBe(true);
+  });
+
+  test("does not render anything for non-VM0007 results", async () => {
+    await act(async () => {
+      root.render(<Vm0007GapReportLaunchButton isVm0007Result={false} auditId="audit-1" />);
+    });
+
+    expect(container.textContent).not.toContain("Internal report");
+    expect(container.querySelector("a")).toBeNull();
   });
 });

--- a/tests/components/vm0007GapReportLaunchButton.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.test.tsx
@@ -89,6 +89,28 @@ describe("Vm0007GapReportLaunchButton", () => {
     expect(container.querySelector("button")?.hasAttribute("disabled")).toBe(true);
   });
 
+  test("shows a generate action when upload-flow generation is available", async () => {
+    const onGenerate = jest.fn();
+
+    await act(async () => {
+      root.render(
+        <Vm0007GapReportLaunchButton
+          isVm0007Result
+          auditId={null}
+          title="Internal VM0007 report"
+          onGenerate={onGenerate}
+        />,
+      );
+    });
+
+    const button = container.querySelector("button");
+    expect(container.textContent).toContain("Internal VM0007 report");
+    expect(button?.textContent).toContain("Generate Gap Report Preview");
+
+    button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+  });
+
   test("does not render anything for non-VM0007 results", async () => {
     await act(async () => {
       root.render(<Vm0007GapReportLaunchButton isVm0007Result={false} auditId="audit-1" />);

--- a/tests/components/vm0007GapReportPreview.test.tsx
+++ b/tests/components/vm0007GapReportPreview.test.tsx
@@ -136,9 +136,49 @@ describe("Vm0007GapReportPreview", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("Internal VM0007 Gap Report Preview");
     expect(text).toContain("Print / Save PDF");
-    expect(text).toContain("Validation Readiness Gap Report");
+    expect(text).toContain("Internal preview only. This report shows current audit output and has not been manually reviewed.");
     expect(text).toContain("58 VM0007 rules assessed for validation readiness.");
-    expect(text).toContain("Client Action List");
+    expect(text).toContain("Follow-up Action List");
+  });
+
+  test("shows the all-supported caution when every rule is marked supported", async () => {
+    const supportedOnlyResults: MethodologyEvidenceAuditResult[] = Array.from({ length: 58 }, (_, index) =>
+      makeResult({
+        ruleId: `R-6-${String(index + 1).padStart(4, "0")}`,
+        stableId: `R-6-${String(index + 1).padStart(4, "0")}`,
+        title: `Rule ${index + 1}`,
+        status: "supported_by_pdd",
+        bestEvidenceQuote: `Evidence quote ${index + 1}.`,
+      }),
+    );
+
+    saveVm0007GapReportAudit({
+      auditId: "audit-preview-supported",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      generatedAt: "2026-07-01T00:00:00Z",
+      evidenceFileName: "envira-amazonia-vm0007.pdf",
+      audit: {
+        results: supportedOnlyResults,
+        totals: {
+          supported_by_pdd: 58,
+          partially_supported: 0,
+          missing_evidence: 0,
+          not_applicable: 0,
+          manual_review_needed: 0,
+        },
+        totalRules: 58,
+      },
+    });
+
+    await act(async () => {
+      root.render(<Vm0007GapReportPreview auditId="audit-preview-supported" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent ?? "").toContain("All rules are currently marked supported. Review evidence quality before relying on this result.");
   });
 
   test("keeps banned wording out of the rendered internal preview", async () => {
@@ -166,6 +206,8 @@ describe("Vm0007GapReportPreview", () => {
       ["guaran", "tee"].join(""),
       ["compl", "iance"].join(""),
       ["VVB", "-grade"].join(""),
+      ["client", "-facing"].join(""),
+      ["external", " use"].join(""),
     ];
 
     for (const item of banned) {

--- a/tests/components/vm0007GapReportPreview.test.tsx
+++ b/tests/components/vm0007GapReportPreview.test.tsx
@@ -1,0 +1,175 @@
+/** @jest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import Vm0007GapReportPreview from "@/components/preverif/Vm0007GapReportPreview";
+import type { MethodologyEvidenceAuditResult, MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
+import { saveVm0007GapReportAudit } from "@/lib/preverif/vm0007GapReportStore";
+
+function makeResult(overrides: Partial<MethodologyEvidenceAuditResult> = {}): MethodologyEvidenceAuditResult {
+  return {
+    ruleId: "R-1-0001",
+    stableId: "R-1-0001",
+    title: "Forest definition",
+    ruleLogic: "Forest definition",
+    status: "supported_by_pdd",
+    bestEvidenceQuote: "The project area remained forest land for the ten years before project start.",
+    page: 4,
+    section: "Eligibility",
+    span: "span-1",
+    reasonSelected: "Selected the strongest project-specific paragraph.",
+    assessmentReason: "The selected PDD span aligns with the rule logic.",
+    gap: "",
+    clientAction: "Add the numeric forest threshold references.",
+    confidence: "high",
+    ...overrides,
+  };
+}
+
+function buildAudit(): MethodologyEvidenceAuditSummary {
+  const seeded: MethodologyEvidenceAuditResult[] = [
+    makeResult({
+      ruleId: "R-1-0001",
+      title: "Forest definition",
+      status: "supported_by_pdd",
+    }),
+    makeResult({
+      ruleId: "R-1-0002",
+      title: "Baseline category",
+      status: "partially_supported",
+      bestEvidenceQuote: "The PDD names planned deforestation but does not yet explain the category choice.",
+      gap: "The category rationale is still incomplete.",
+      clientAction: "Add the project-specific category rationale and supporting land-use evidence.",
+      assessmentReason: "The current PDD names the category but does not fully justify it.",
+    }),
+    makeResult({
+      ruleId: "R-1-0003",
+      title: "AUDef agents",
+      status: "missing_evidence",
+      bestEvidenceQuote: null,
+      section: null,
+      page: null,
+      reasonSelected: "No reliable project-specific span was selected for this rule.",
+      gap: "The current PDD does not show the relevant agent evidence.",
+      clientAction: "Add the project-specific agent evidence and the baseline-pressure explanation.",
+      assessmentReason: "The current PDD does not yet show project-specific evidence for this rule.",
+    }),
+    makeResult({
+      ruleId: "R-1-0005",
+      title: "WRC prohibition",
+      status: "not_applicable",
+      bestEvidenceQuote: "This is a REDD/APD project in upland forest landscapes with no peat soils or tidal wetland activity.",
+      section: "Project Activity Description",
+      page: 2,
+      gap: "",
+      clientAction: "State the scope basis clearly in the activity description.",
+      assessmentReason: "The current PDD scope statement shows this wetland-specific rule does not apply.",
+    }),
+  ];
+
+  const filler = Array.from({ length: 54 }, (_, index) =>
+    makeResult({
+      ruleId: `R-6-${String(index + 4).padStart(4, "0")}`,
+      stableId: `R-6-${String(index + 4).padStart(4, "0")}`,
+      title: `Monitoring item ${index + 4}`,
+      ruleLogic: `Monitoring item ${index + 4}`,
+      status: "supported_by_pdd",
+      bestEvidenceQuote: `Monitoring evidence quote ${index + 4}.`,
+      span: `span-${index + 4}`,
+      reasonSelected: `Selected monitoring evidence ${index + 4}.`,
+    }),
+  );
+
+  const results = [...seeded, ...filler];
+  return {
+    results,
+    totals: {
+      supported_by_pdd: results.filter((result) => result.status === "supported_by_pdd").length,
+      partially_supported: results.filter((result) => result.status === "partially_supported").length,
+      missing_evidence: results.filter((result) => result.status === "missing_evidence").length,
+      not_applicable: results.filter((result) => result.status === "not_applicable").length,
+      manual_review_needed: results.filter((result) => result.status === "manual_review_needed").length,
+    },
+    totalRules: results.length,
+  };
+}
+
+describe("Vm0007GapReportPreview", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    window.localStorage.clear();
+    window.print = jest.fn();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  test("renders the saved VM0007 audit output into the internal report preview", async () => {
+    saveVm0007GapReportAudit({
+      auditId: "audit-preview",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      generatedAt: "2026-07-01T00:00:00Z",
+      evidenceFileName: "envira-amazonia-vm0007.pdf",
+      audit: buildAudit(),
+    });
+
+    await act(async () => {
+      root.render(<Vm0007GapReportPreview auditId="audit-preview" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Internal VM0007 Gap Report Preview");
+    expect(text).toContain("Print / Save PDF");
+    expect(text).toContain("Validation Readiness Gap Report");
+    expect(text).toContain("58 VM0007 rules assessed for validation readiness.");
+    expect(text).toContain("Client Action List");
+  });
+
+  test("keeps banned wording out of the rendered internal preview", async () => {
+    saveVm0007GapReportAudit({
+      auditId: "audit-preview",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      generatedAt: "2026-07-01T00:00:00Z",
+      evidenceFileName: "envira-amazonia-vm0007.pdf",
+      audit: buildAudit(),
+    });
+
+    await act(async () => {
+      root.render(<Vm0007GapReportPreview auditId="audit-preview" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const text = (container.textContent ?? "").toLowerCase();
+    const banned = [
+      ["veri", "fication"].join(""),
+      ["certi", "fication"].join(""),
+      ["appro", "val"].join(""),
+      ["guaran", "tee"].join(""),
+      ["compl", "iance"].join(""),
+      ["VVB", "-grade"].join(""),
+    ];
+
+    for (const item of banned) {
+      expect(text).not.toContain(item.toLowerCase());
+    }
+  });
+});

--- a/tests/components/vm0007GapReportView.test.tsx
+++ b/tests/components/vm0007GapReportView.test.tsx
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "@jest/globals";
+import { renderToStaticMarkup } from "react-dom/server";
+import Vm0007GapReportView from "@/components/preverif/Vm0007GapReportView";
+import type { MethodologyEvidenceAuditResult, MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
+import { buildVm0007GapReport } from "@/lib/preverif/vm0007GapReport";
+
+function makeResult(overrides: Partial<MethodologyEvidenceAuditResult> = {}): MethodologyEvidenceAuditResult {
+  return {
+    ruleId: "R-1-0001",
+    stableId: "R-1-0001",
+    title: "Forest definition",
+    ruleLogic: "Forest definition",
+    status: "supported_by_pdd",
+    bestEvidenceQuote: "The project area remained forest land for the ten years before project start.",
+    page: 4,
+    section: "Eligibility",
+    span: "span-1",
+    reasonSelected: "Selected the strongest project-specific paragraph.",
+    assessmentReason: "The selected PDD span aligns with the rule logic.",
+    gap: "",
+    clientAction: "Add the numeric forest threshold references.",
+    confidence: "high",
+    ...overrides,
+  };
+}
+
+function buildAuditForRendering(): MethodologyEvidenceAuditSummary {
+  const seeded: MethodologyEvidenceAuditResult[] = [
+    makeResult({
+      ruleId: "R-1-0001",
+      title: "Forest definition",
+      status: "supported_by_pdd",
+      bestEvidenceQuote: "The project area remained forest land for the ten years before project start.",
+    }),
+    makeResult({
+      ruleId: "R-1-0002",
+      title: "Baseline category",
+      status: "partially_supported",
+      bestEvidenceQuote: "The PDD names planned deforestation but does not yet explain the category choice.",
+      gap: "The category rationale is still incomplete.",
+      clientAction: "Add the project-specific category rationale and supporting land-use evidence.",
+      assessmentReason: "The current PDD names the category but does not fully justify it.",
+    }),
+    makeResult({
+      ruleId: "R-1-0003",
+      title: "AUDef agents",
+      status: "missing_evidence",
+      bestEvidenceQuote: null,
+      section: null,
+      page: null,
+      reasonSelected: "No reliable project-specific span was selected for this rule.",
+      gap: "The current PDD does not show the relevant agent evidence.",
+      clientAction: "Add the project-specific agent evidence and the baseline-pressure explanation.",
+      assessmentReason: "The current PDD does not yet show project-specific evidence for this rule.",
+    }),
+    makeResult({
+      ruleId: "R-1-0005",
+      title: "WRC prohibition",
+      status: "not_applicable",
+      bestEvidenceQuote: "This is a REDD/APD project in upland forest landscapes with no peat soils or tidal wetland activity.",
+      section: "Project Activity Description",
+      page: 2,
+      gap: "",
+      clientAction: "State the scope basis clearly in the activity description.",
+      assessmentReason: "The current PDD scope statement shows this wetland-specific rule does not apply.",
+    }),
+  ];
+
+  const filler = Array.from({ length: 54 }, (_, index) => {
+    const ruleNumber = String(index + 4).padStart(4, "0");
+    return makeResult({
+      ruleId: `R-6-${ruleNumber}`,
+      stableId: `R-6-${ruleNumber}`,
+      title: `Monitoring item ${index + 4}`,
+      ruleLogic: `Monitoring item ${index + 4}`,
+      status: "supported_by_pdd",
+      bestEvidenceQuote: `Monitoring evidence quote ${index + 4}.`,
+      span: `span-${index + 4}`,
+      reasonSelected: `Selected monitoring evidence ${index + 4}.`,
+    });
+  });
+
+  const results = [...seeded, ...filler];
+  return {
+    results,
+    totals: {
+      supported_by_pdd: results.filter((result) => result.status === "supported_by_pdd").length,
+      partially_supported: results.filter((result) => result.status === "partially_supported").length,
+      missing_evidence: results.filter((result) => result.status === "missing_evidence").length,
+      not_applicable: results.filter((result) => result.status === "not_applicable").length,
+      manual_review_needed: results.filter((result) => result.status === "manual_review_needed").length,
+    },
+    totalRules: results.length,
+  };
+}
+
+function buildHtml() {
+  const report = buildVm0007GapReport({
+    reportId: "VRGR-VM0007-002",
+    generatedAt: "2026-07-01T11:00:00Z",
+    project: {
+      name: "Envira Amazonia",
+      projectId: "VM0007-ENV-002",
+      proponent: "Envira Project Dev",
+      region: "Brazil",
+    },
+    methodology: {
+      code: "VM0007",
+      version: "4.2",
+      name: "REDD+ Methodology Framework",
+      scope: "Presentation-only rendering from the existing evidence audit output.",
+    },
+    audit: buildAuditForRendering(),
+  });
+
+  return renderToStaticMarkup(<Vm0007GapReportView report={report} />);
+}
+
+describe("Vm0007GapReportView", () => {
+  test("renders the required VM0007 gap report sections and all 58 rules", () => {
+    const html = buildHtml();
+    const rowCount = (html.match(/data-status=\"/g) ?? []).length;
+
+    expect(html).toContain("Validation Readiness Gap Report");
+    expect(html).toContain("58 VM0007 rules assessed for validation readiness.");
+    expect(html).toContain("Executive Summary");
+    expect(html).toContain("Project Snapshot");
+    expect(html).toContain("Methodology Scope");
+    expect(html).toContain("Key Supported Findings");
+    expect(html).toContain("Not Applicable Rules");
+    expect(html).toContain("Main Evidence Gaps");
+    expect(html).toContain("Client Action List");
+    expect(html).toContain("Full VM0007 Rule Audit Table");
+    expect(html).toContain("Evidence Appendix");
+    expect(rowCount).toBe(58);
+  });
+
+  test("renders supported, weak, missing, and not-applicable states in the full rule table", () => {
+    const html = buildHtml();
+
+    expect(html).toContain('data-status="supported"');
+    expect(html).toContain('data-status="weak"');
+    expect(html).toContain('data-status="missing"');
+    expect(html).toContain('data-status="not applicable"');
+  });
+
+  test("shows client action guidance for weak and missing rules and preserves appendix evidence handling", () => {
+    const html = buildHtml();
+
+    expect(html).toContain("What to add");
+    expect(html).toContain("Add the project-specific category rationale and supporting land-use evidence.");
+    expect(html).toContain("Add the project-specific agent evidence and the baseline-pressure explanation.");
+    expect(html).toContain("Evidence is not currently available in the PDD.");
+    expect(html).toContain("The project area remained forest land for the ten years before project start.");
+  });
+
+  test("keeps banned wording and fake pass claims out of the rendered output", () => {
+    const html = buildHtml().toLowerCase();
+    const banned = [
+      ["VVB", "-grade"].join(""),
+      ["veri", "fied"].join(""),
+      ["validation", " opinion"].join(""),
+      ["assurance", " opinion"].join(""),
+      ["all", " clear"].join(""),
+    ];
+
+    expect(html).not.toContain("58 vm0007 rules passed.");
+    expect(html).not.toContain("100% pass");
+    for (const item of banned) {
+      expect(html).not.toContain(item.toLowerCase());
+    }
+  });
+});

--- a/tests/components/vm0007GapReportView.test.tsx
+++ b/tests/components/vm0007GapReportView.test.tsx
@@ -116,12 +116,48 @@ function buildHtml() {
   return renderToStaticMarkup(<Vm0007GapReportView report={report} />);
 }
 
+function buildAllSupportedHtml() {
+  const report = buildVm0007GapReport({
+    reportId: "VRGR-VM0007-ALL",
+    generatedAt: "2026-07-01T11:00:00Z",
+    project: {
+      name: "Envira Amazonia",
+    },
+    methodology: {
+      code: "VM0007",
+      version: "4.2",
+    },
+    audit: {
+      results: Array.from({ length: 58 }, (_, index) =>
+        makeResult({
+          ruleId: `R-6-${String(index + 1).padStart(4, "0")}`,
+          stableId: `R-6-${String(index + 1).padStart(4, "0")}`,
+          title: `Rule ${index + 1}`,
+          status: "supported_by_pdd",
+          bestEvidenceQuote: `Evidence quote ${index + 1}.`,
+        }),
+      ),
+      totals: {
+        supported_by_pdd: 58,
+        partially_supported: 0,
+        missing_evidence: 0,
+        not_applicable: 0,
+        manual_review_needed: 0,
+      },
+      totalRules: 58,
+    },
+  });
+
+  return renderToStaticMarkup(<Vm0007GapReportView report={report} />);
+}
+
 describe("Vm0007GapReportView", () => {
   test("renders the required VM0007 gap report sections and all 58 rules", () => {
     const html = buildHtml();
     const rowCount = (html.match(/data-status=\"/g) ?? []).length;
 
-    expect(html).toContain("Validation Readiness Gap Report");
+    expect(html).toContain("Internal VM0007 Gap Report Preview");
+    expect(html).toContain("Internal preview only. This report shows current audit output and has not been manually reviewed.");
     expect(html).toContain("58 VM0007 rules assessed for validation readiness.");
     expect(html).toContain("Executive Summary");
     expect(html).toContain("Project Snapshot");
@@ -129,7 +165,7 @@ describe("Vm0007GapReportView", () => {
     expect(html).toContain("Key Supported Findings");
     expect(html).toContain("Not Applicable Rules");
     expect(html).toContain("Main Evidence Gaps");
-    expect(html).toContain("Client Action List");
+    expect(html).toContain("Follow-up Action List");
     expect(html).toContain("Full VM0007 Rule Audit Table");
     expect(html).toContain("Evidence Appendix");
     expect(rowCount).toBe(58);
@@ -144,14 +180,22 @@ describe("Vm0007GapReportView", () => {
     expect(html).toContain('data-status="not applicable"');
   });
 
-  test("shows client action guidance for weak and missing rules and preserves appendix evidence handling", () => {
+  test("shows supported-specific framing and keeps follow-up guidance for weak and missing rules", () => {
     const html = buildHtml();
 
+    expect(html).toContain("Why this was marked supported:");
+    expect(html).not.toContain("Why it is weak or missing:</span> The selected PDD span aligns with the rule logic.");
+    expect(html).not.toContain("What to add:</span> Add the numeric forest threshold references.");
     expect(html).toContain("What to add");
     expect(html).toContain("Add the project-specific category rationale and supporting land-use evidence.");
     expect(html).toContain("Add the project-specific agent evidence and the baseline-pressure explanation.");
     expect(html).toContain("Evidence is not currently available in the PDD.");
     expect(html).toContain("The project area remained forest land for the ten years before project start.");
+  });
+
+  test("shows the all-supported caution only when every rule is marked supported", () => {
+    expect(buildAllSupportedHtml()).toContain("All rules are currently marked supported. Review evidence quality before relying on this result.");
+    expect(buildHtml()).not.toContain("All rules are currently marked supported. Review evidence quality before relying on this result.");
   });
 
   test("keeps banned wording and fake pass claims out of the rendered output", () => {
@@ -162,6 +206,8 @@ describe("Vm0007GapReportView", () => {
       ["validation", " opinion"].join(""),
       ["assurance", " opinion"].join(""),
       ["all", " clear"].join(""),
+      ["client", "-facing"].join(""),
+      ["external", " use"].join(""),
     ];
 
     expect(html).not.toContain("58 vm0007 rules passed.");

--- a/tests/lib/preverif.vm0007GapReport.test.ts
+++ b/tests/lib/preverif.vm0007GapReport.test.ts
@@ -92,6 +92,26 @@ function buildMixedAudit(): MethodologyEvidenceAuditSummary {
   };
 }
 
+function buildSupportedOnlyAudit(): MethodologyEvidenceAuditSummary {
+  const base = auditText(ENVIRA_TEXT);
+  const results = Array.from({ length: 58 }, (_, index) =>
+    withStatus(base.results[index]!, {
+      ruleId: `R-6-${String(index + 1).padStart(4, "0")}`,
+      stableId: `R-6-${String(index + 1).padStart(4, "0")}`,
+      title: `Supported rule ${index + 1}`,
+      status: "supported_by_pdd",
+      gap: "",
+      clientAction: "",
+    }),
+  );
+
+  return {
+    results,
+    totals: retotal(results),
+    totalRules: results.length,
+  };
+}
+
 function buildReport(audit: MethodologyEvidenceAuditSummary) {
   return buildVm0007GapReport({
     reportId: "VRGR-VM0007-001",
@@ -107,7 +127,7 @@ function buildReport(audit: MethodologyEvidenceAuditSummary) {
       code: "VM0007",
       version: "4.2",
       name: "REDD+ Methodology Framework",
-      scope: "Audit output rendered for client-facing validation readiness follow-up.",
+      scope: "Audit output rendered for internal preview follow-up.",
     },
     audit,
   });
@@ -117,9 +137,17 @@ describe("buildVm0007GapReport", () => {
   it("builds a 58-rule report from existing VM0007 audit output", () => {
     const report = buildReport(auditText(ENVIRA_TEXT));
 
+    expect(report.reportName).toBe("Internal VM0007 Gap Report Preview");
     expect(report.statementOfCoverage).toBe("58 VM0007 rules assessed for validation readiness.");
     expect(report.fullRuleAuditTable).toHaveLength(58);
     expect(report.evidenceAppendix).toHaveLength(58);
+  });
+
+  it("adds the internal preview limitation banner and all-supported warning when every rule is supported", () => {
+    const report = buildReport(buildSupportedOnlyAudit());
+
+    expect(report.limitationBanner).toBe("Internal preview only. This report shows current audit output and has not been manually reviewed.");
+    expect(report.executiveSummary.allSupportedWarning).toBe("All rules are currently marked supported. Review evidence quality before relying on this result.");
   });
 
   it("keeps client action guidance on every weak or missing rule", () => {
@@ -169,6 +197,8 @@ describe("buildVm0007GapReport", () => {
       ["validation", " opinion"].join(""),
       ["assurance", " opinion"].join(""),
       ["all", " clear"].join(""),
+      ["client", "-facing"].join(""),
+      ["external", " use"].join(""),
     ];
 
     expect(reportJson).not.toContain("58 vm0007 rules passed.");

--- a/tests/lib/preverif.vm0007GapReport.test.ts
+++ b/tests/lib/preverif.vm0007GapReport.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "@jest/globals";
+import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import {
+  auditEvidence,
+  type MethodologyEvidenceAuditResult,
+  type MethodologyEvidenceAuditSummary,
+} from "@/lib/preverif/evidenceAudit";
+import {
+  NO_PDD_EVIDENCE_TEXT,
+  buildVm0007GapReport,
+} from "@/lib/preverif/vm0007GapReport";
+import {
+  getVm0007EvidenceContract,
+  normalizeVm0007RuleId,
+} from "@/lib/preverif/vm0007EvidenceContracts";
+import {
+  readQuickCheckFixtureText,
+  VM0007_SYNCED_RULES,
+} from "./preverifVm0007Fixtures";
+
+const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
+
+function auditText(rawText: string): MethodologyEvidenceAuditSummary {
+  const context = getStructuredQueryContext(rawText);
+  return auditEvidence({
+    rules: VM0007_SYNCED_RULES,
+    evidenceDocument: context.evidenceDocument,
+    getContract: getVm0007EvidenceContract,
+    normalizeRuleId: normalizeVm0007RuleId,
+    sections: context.documentStructure.sections,
+    rawText,
+  });
+}
+
+function withStatus(
+  result: MethodologyEvidenceAuditResult,
+  overrides: Partial<MethodologyEvidenceAuditResult>,
+): MethodologyEvidenceAuditResult {
+  return { ...result, ...overrides };
+}
+
+function retotal(results: MethodologyEvidenceAuditResult[]): MethodologyEvidenceAuditSummary["totals"] {
+  return {
+    supported_by_pdd: results.filter((result) => result.status === "supported_by_pdd").length,
+    partially_supported: results.filter((result) => result.status === "partially_supported").length,
+    missing_evidence: results.filter((result) => result.status === "missing_evidence").length,
+    not_applicable: results.filter((result) => result.status === "not_applicable").length,
+    manual_review_needed: results.filter((result) => result.status === "manual_review_needed").length,
+  };
+}
+
+function buildMixedAudit(): MethodologyEvidenceAuditSummary {
+  const base = auditText(ENVIRA_TEXT);
+  const results = base.results.map((result) => {
+    if (result.ruleId === "R-1-0002") {
+      return withStatus(result, {
+        status: "partially_supported",
+        gap: "The current PDD names the baseline category but does not explain why that category fits the project area.",
+        clientAction: "Add the project-specific baseline deforestation category rationale and the supporting land-use evidence.",
+      });
+    }
+    if (result.ruleId === "R-1-0003") {
+      return withStatus(result, {
+        status: "missing_evidence",
+        bestEvidenceQuote: null,
+        section: null,
+        page: null,
+        gap: "The current PDD does not show the AUDef agent evidence required for this rule.",
+        clientAction: "Add the project-specific evidence for the relevant deforestation agents and explain how they drive baseline pressure.",
+        assessmentReason: "The current PDD does not yet show project-specific evidence for this rule.",
+        reasonSelected: "No reliable project-specific span was selected for this rule.",
+      });
+    }
+    if (result.ruleId === "R-1-0005") {
+      return withStatus(result, {
+        status: "not_applicable",
+        bestEvidenceQuote: "This is a REDD/APD project in upland forest landscapes. No peat soils or tidal wetland activity occur in the project area.",
+        section: "Project Activity Description",
+        page: 2,
+        gap: "",
+        assessmentReason: "The current PDD scope statement shows this wetland-specific rule does not apply to the project.",
+      });
+    }
+    return result;
+  });
+
+  return {
+    results,
+    totals: retotal(results),
+    totalRules: results.length,
+  };
+}
+
+function buildReport(audit: MethodologyEvidenceAuditSummary) {
+  return buildVm0007GapReport({
+    reportId: "VRGR-VM0007-001",
+    generatedAt: "2026-07-01T10:00:00Z",
+    project: {
+      name: "Envira Amazonia",
+      projectId: "VM0007-ENV-001",
+      proponent: "Envira Project Dev",
+      region: "Brazil",
+      description: "Avoided deforestation project with community-focused leakage controls and monitoring procedures.",
+    },
+    methodology: {
+      code: "VM0007",
+      version: "4.2",
+      name: "REDD+ Methodology Framework",
+      scope: "Audit output rendered for client-facing validation readiness follow-up.",
+    },
+    audit,
+  });
+}
+
+describe("buildVm0007GapReport", () => {
+  it("builds a 58-rule report from existing VM0007 audit output", () => {
+    const report = buildReport(auditText(ENVIRA_TEXT));
+
+    expect(report.statementOfCoverage).toBe("58 VM0007 rules assessed for validation readiness.");
+    expect(report.fullRuleAuditTable).toHaveLength(58);
+    expect(report.evidenceAppendix).toHaveLength(58);
+  });
+
+  it("keeps client action guidance on every weak or missing rule", () => {
+    const report = buildReport(buildMixedAudit());
+    const weakOrMissing = report.fullRuleAuditTable.filter((row) =>
+      row.status === "weak" || row.status === "missing",
+    );
+
+    expect(report.clientActionList).toHaveLength(weakOrMissing.length);
+    for (const row of weakOrMissing) {
+      expect(row.gapGuidance.trim().length).toBeGreaterThan(0);
+      expect(row.clientAction.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses selected evidence quotes where available and the fallback text where they are not", () => {
+    const report = buildReport(buildMixedAudit());
+    const supported = report.evidenceAppendix.find((entry) => entry.ruleId === "R-1-0001");
+    const missing = report.evidenceAppendix.find((entry) => entry.ruleId === "R-1-0003");
+
+    expect(supported?.quote).toContain("Leakage Management procedures");
+    expect(missing?.quote).toBe(NO_PDD_EVIDENCE_TEXT);
+  });
+
+  it("keeps banned wording out of the report data", () => {
+    const reportJson = JSON.stringify(buildReport(buildMixedAudit())).toLowerCase();
+    const banned = [
+      ["VVB", "-grade"].join(""),
+      ["veri", "fied"].join(""),
+      ["validation", " opinion"].join(""),
+      ["assurance", " opinion"].join(""),
+      ["all", " clear"].join(""),
+    ];
+
+    expect(reportJson).not.toContain("58 vm0007 rules passed.");
+    for (const item of banned) {
+      expect(reportJson).not.toContain(item.toLowerCase());
+    }
+  });
+});

--- a/tests/lib/preverif.vm0007GapReport.test.ts
+++ b/tests/lib/preverif.vm0007GapReport.test.ts
@@ -78,6 +78,7 @@ function buildMixedAudit(): MethodologyEvidenceAuditSummary {
         section: "Project Activity Description",
         page: 2,
         gap: "",
+        clientAction: "Keep scope basis clear.",
         assessmentReason: "The current PDD scope statement shows this wetland-specific rule does not apply to the project.",
       });
     }
@@ -132,6 +133,24 @@ describe("buildVm0007GapReport", () => {
       expect(row.gapGuidance.trim().length).toBeGreaterThan(0);
       expect(row.clientAction.trim().length).toBeGreaterThan(0);
     }
+  });
+
+  it("does not show remediation guidance on supported rows", () => {
+    const report = buildReport(buildMixedAudit());
+    const supported = report.fullRuleAuditTable.find((row) => row.ruleId === "R-1-0001");
+
+    expect(supported?.status).toBe("supported");
+    expect(supported?.gapGuidance).toBe("");
+    expect(supported?.clientAction).toBe("");
+  });
+
+  it("does not show remediation guidance on not-applicable rows unless explicitly scope-keeping", () => {
+    const report = buildReport(buildMixedAudit());
+    const notApplicable = report.fullRuleAuditTable.find((row) => row.ruleId === "R-1-0005");
+
+    expect(notApplicable?.status).toBe("not applicable");
+    expect(notApplicable?.gapGuidance).toBe("Keep scope basis clear.");
+    expect(notApplicable?.clientAction).toBe("Keep scope basis clear.");
   });
 
   it("uses selected evidence quotes where available and the fallback text where they are not", () => {


### PR DESCRIPTION
## WHAT

Fix PR #892 so the VM0007 report is visible in the actual Quick Check upload flow.

## PROBLEM

The current screen after upload shows:

- Extraction preview
- Evidence Checks
- existing Run Checks button
- six evidence check rows
- Methodology selector

But there is no VM0007 report action.

The existing Run Checks button is not new. It has always existed. The new report preview is not discoverable.

## REQUIRED CHANGE

Add a visible VM0007 report card directly under the Evidence Checks card when the uploaded document is detected as VM0007.

Detection should use the extraction result, not only the methodology dropdown.

Show this after upload/extraction when raw PDD text exists and VM0007 is detected:

Internal VM0007 report  
[Generate Gap Report Preview]

When clicked:
- build/save the VM0007 gap report audit using the existing `buildAndSaveVm0007GapReportAudit()`
- store the generated audit id
- replace/enable the button as:

[View Gap Report]

Clicking `View Gap Report` opens:

`/internal/reports/vm0007-gap/[auditId]`

## IMPORTANT

Do not rely on the old lower Quick Check result area.

The report action must be visible in the upload/evidence-check UI shown immediately after document extraction.

Do not add new audit logic.
Do not add new report conclusions.
Use the existing `buildAndSaveVm0007GapReportAudit()`, `buildVm0007GapReport()`, and `Vm0007GapReportView`.

## ACCEPTANCE

- After uploading a VM0007 PDD, the user sees an `Internal VM0007 report` card
- The card appears near the Evidence Checks section
- User can click `Generate Gap Report Preview`
- After generation, user sees `View Gap Report`
- Report opens successfully
- Report page has `Print / Save PDF`
- No dependency on the methodology dropdown being manually changed from `Any methodology`
- Existing Evidence Checks UI remains unchanged

### Roadmap-Update
- slug: phase-assurance-surface-mvp
- ack: human
- items:
  - PR12: done

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>
