### PR TITLE
docs: add VM0007 judgement fixtures roadmap

### DIFF
--- a/docs/roadmaps/INDEX.md
+++ b/docs/roadmaps/INDEX.md
@@ -1,0 +1,41 @@
+# Roadmaps Index
+
+This file classifies roadmap folders under `docs/roadmaps/`.
+
+Active roadmaps are limited to:
+
+- `quickcheck-v2`
+- `vm0007-judgement-fixtures`
+
+## active
+
+- `quickcheck-v2` - stable Quick Check rebuild from clean ingestion upward
+- `vm0007-judgement-fixtures` - VM0007 judgment-fixture and report-summary contract hardening
+
+## paused
+
+- `project-verification` - useful roadmap, but not currently one of the active lanes
+- `safe-learning-intake-pipeline` - preserved for later intake work, not in the active pair
+
+## completed
+
+- `data-integrity-exports`
+- `phase-assurance-surface-mvp`
+- `quickcheck-eval-learning`
+- `review-grade-quick-check`
+- `review-grade-evidence-intelligence`
+- `requirement-coverage`
+- `standard-registry-wiring`
+- `traceable-rule-review-mvp`
+
+## superseded
+
+- `quickcheck-parser-replacement`
+- `project-readiness-verification-output`
+- `verifier-moat`
+- `quick-check-document-pipeline` - historical transition lane now superseded by the cleaner Quick Check v2 rebuild
+
+## archived
+
+- `agentic-verification` - frozen future work, retained for reference only
+

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -345,7 +345,7 @@ Not active now:
 - Quick Check v2 Phase 7 work
 
 1) RC0 — Roadmap Boundary: Active — Define the scope of VM0007 judgment fixtures and keep the lane separate from production logic and Quick Check v2 Phase 7.
-2) RC1 — Envira VM0007 Judgment Fixtures: Planned — Add fixture coverage for Envira VM0007 cases with explicit accepted evidence, rejected evidence, and expected statuses.
+2) RC1 — Envira VM0007 Judgment Fixtures: Planned — Add 5-10 Envira VM0007 judgment fixtures with explicit accepted evidence, rejected generic evidence examples, false-supported coverage, and expected statuses plus client actions where weak or missing.
 3) RC2 — PD_REDD VM0007 Judgment Fixtures: Planned — Add fixture coverage for PD_REDD VM0007 cases using the same judgment contract discipline.
 4) RC3 — Full 58-Rule Audit Fixture Shape: Planned — Stabilize the complete VM0007 audit fixture shape across all 58 rules.
 5) RC4 — Report Fixture Layer: Planned — Add internal preview report expectations for summary sections and row grouping.

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, quick-check-document-pipeline, quickcheck-v2, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp.
+Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, quick-check-document-pipeline, quickcheck-v2, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp, vm0007-judgement-fixtures.
 Frozen lanes: agentic-verification.
 
 
@@ -323,3 +323,30 @@ Not active now:
 - AI-assisted review (post-moat)
 - Multi-methodology cross-referencing (Phase 5+)
 
+
+## vm0007-judgement-fixtures
+
+Status SSOT: `docs/roadmaps/vm0007-judgement-fixtures/phase-status.json`
+Details: `docs/roadmaps/vm0007-judgement-fixtures/PLAN.md`
+
+Lane status: Active
+Tighten VM0007 gap report accuracy by improving rule-level judgment fixtures and contracts without changing production audit logic.
+
+Current focus:
+- Phase 0 is the immediate boundary: define the scope and keep this lane separate from Quick Check v2 Phase 7
+- Capture accepted and rejected evidence explicitly so the report can distinguish supported, weak, missing, and not-applicable rows
+- Keep audit-summary and report-summary expectations fixture-driven
+
+Not active now:
+- Production audit logic changes
+- Report UI redesign
+- Client-facing report changes
+- LLM final judgment
+- Quick Check v2 Phase 7 work
+
+1) RC0 — Roadmap Boundary: Active — Define the scope of VM0007 judgment fixtures and keep the lane separate from production logic and Quick Check v2 Phase 7.
+2) RC1 — Envira VM0007 Judgment Fixtures: Planned — Add fixture coverage for Envira VM0007 cases with explicit accepted evidence, rejected evidence, and expected statuses.
+3) RC2 — PD_REDD VM0007 Judgment Fixtures: Planned — Add fixture coverage for PD_REDD VM0007 cases using the same judgment contract discipline.
+4) RC3 — Full 58-Rule Audit Fixture Shape: Planned — Stabilize the complete VM0007 audit fixture shape across all 58 rules.
+5) RC4 — Report Fixture Layer: Planned — Add internal preview report expectations for summary sections and row grouping.
+6) RC5 — Client-Readiness Gate: Planned — Keep internal preview output separate from any later client-ready reporting work.

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -1,0 +1,59 @@
+# VM0007 Judgement Fixtures Roadmap
+
+Status is sourced from `docs/roadmaps/vm0007-judgement-fixtures/phase-status.json`; docs must not drift.
+
+## Goal
+
+Improve VM0007 gap report accuracy by tightening rule-level judgment fixtures and contracts.
+
+This roadmap focuses on the evidence and status layer, not production logic, not report UI redesign, and not client-facing outputs.
+
+## Core Focus
+
+- accepted evidence
+- rejected evidence
+- expected status
+- weak / missing / not-applicable logic
+- audit summary expectations
+- report summary expectations
+
+## Boundary
+
+This lane is separate from Quick Check v2 Phase 7.
+
+Do not mix judgment-fixture work into the Quick Check v2 parser / ingestion rebuild unless a later roadmap explicitly calls for that overlap.
+
+## Phases
+
+### Phase 0 — Roadmap Boundary
+
+Define the scope of VM0007 judgment fixtures and lock the separation from production logic and Quick Check v2 Phase 7.
+
+### Phase 1 — Envira VM0007 Judgment Fixtures
+
+Add and harden fixtures that capture Envira-specific VM0007 judgments, including accepted and rejected evidence with expected statuses.
+
+### Phase 2 — PD_REDD VM0007 Judgment Fixtures
+
+Add and harden fixtures for PD_REDD-style VM0007 judgments with the same evidence/status contract discipline.
+
+### Phase 3 — Full 58-Rule Audit Fixture Shape
+
+Stabilize the full audit fixture structure for all 58 VM0007 rules so the report can be tested against a complete rule set.
+
+### Phase 4 — Report Fixture Layer
+
+Add report-facing fixture expectations for summary sections, row grouping, and internal preview output.
+
+### Phase 5 — Client-Readiness Gate
+
+Define the gate that keeps internal preview output distinct from any later client-ready reporting work.
+
+## Non-Goals
+
+- No production logic changes
+- No report UI redesign
+- No client-facing report changes
+- No LLM final judgment
+- No mixing into Quick Check v2 Phase 7
+

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -31,7 +31,15 @@ Define the scope of VM0007 judgment fixtures and lock the separation from produc
 
 ### Phase 1 — Envira VM0007 Judgment Fixtures
 
-Add and harden fixtures that capture Envira-specific VM0007 judgments, including accepted and rejected evidence with expected statuses.
+Add and harden fixtures that capture Envira-specific VM0007 judgments, including:
+
+- 5-10 rule-level judgment fixtures
+- accepted evidence requirements
+- rejected generic evidence examples
+- at least one false-supported case
+- at least one case where generic methodology/module-table evidence must not count as supported
+- expected status for each fixture
+- expected client action where status is weak or missing
 
 ### Phase 2 — PD_REDD VM0007 Judgment Fixtures
 
@@ -56,4 +64,3 @@ Define the gate that keeps internal preview output distinct from any later clien
 - No client-facing report changes
 - No LLM final judgment
 - No mixing into Quick Check v2 Phase 7
-

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -1,0 +1,129 @@
+{
+  "name": "VM0007 Judgement Fixtures",
+  "roadmapId": "vm0007-judgement-fixtures",
+  "phase_meta": {
+    "status": "active",
+    "summary": "Tighten VM0007 gap report accuracy by improving rule-level judgment fixtures and contracts without changing production audit logic.",
+    "current_focus": [
+      "Phase 0 is the immediate boundary: define the scope and keep this lane separate from Quick Check v2 Phase 7",
+      "Capture accepted and rejected evidence explicitly so the report can distinguish supported, weak, missing, and not-applicable rows",
+      "Keep audit-summary and report-summary expectations fixture-driven"
+    ],
+    "not_active_now": [
+      "Production audit logic changes",
+      "Report UI redesign",
+      "Client-facing report changes",
+      "LLM final judgment",
+      "Quick Check v2 Phase 7 work"
+    ],
+    "last_updated_at": "2026-07-01T00:00:00Z"
+  },
+  "goals": [
+    {
+      "id": "phase_0_roadmap_boundary",
+      "title": "Roadmap Boundary",
+      "status": "active",
+      "dependsOn": [],
+      "doneCriteria": [
+        "Roadmap scope is clearly separated from production logic",
+        "Quick Check v2 Phase 7 is explicitly out of scope",
+        "Fixture expectations are defined for judgment and summary layers"
+      ]
+    },
+    {
+      "id": "phase_1_envira_vm0007_judgment_fixtures",
+      "title": "Envira VM0007 Judgment Fixtures",
+      "status": "planned",
+      "dependsOn": [
+        "phase_0_roadmap_boundary"
+      ],
+      "doneCriteria": [
+        "Accepted evidence is explicitly fixture-encoded",
+        "Rejected evidence is explicitly fixture-encoded",
+        "Expected statuses are fixture-encoded for Envira cases"
+      ]
+    },
+    {
+      "id": "phase_2_pd_redd_vm0007_judgment_fixtures",
+      "title": "PD_REDD VM0007 Judgment Fixtures",
+      "status": "planned",
+      "dependsOn": [
+        "phase_1_envira_vm0007_judgment_fixtures"
+      ],
+      "doneCriteria": [
+        "PD_REDD judgments follow the same accepted/rejected evidence contract",
+        "Weak / missing / not-applicable logic is exercised with fixture coverage"
+      ]
+    },
+    {
+      "id": "phase_3_full_58_rule_audit_fixture_shape",
+      "title": "Full 58-Rule Audit Fixture Shape",
+      "status": "planned",
+      "dependsOn": [
+        "phase_2_pd_redd_vm0007_judgment_fixtures"
+      ],
+      "doneCriteria": [
+        "All 58 VM0007 rules are represented in the fixture shape",
+        "Audit-level expected status is stable and reviewable",
+        "Fixture shape supports summary verification"
+      ]
+    },
+    {
+      "id": "phase_4_report_fixture_layer",
+      "title": "Report Fixture Layer",
+      "status": "planned",
+      "dependsOn": [
+        "phase_3_full_58_rule_audit_fixture_shape"
+      ],
+      "doneCriteria": [
+        "Report summary expectations are fixture-driven",
+        "Row grouping and summary sections are testable from fixtures",
+        "Internal preview output is clearly distinguished from client-ready output"
+      ]
+    },
+    {
+      "id": "phase_5_client_readiness_gate",
+      "title": "Client-Readiness Gate",
+      "status": "planned",
+      "dependsOn": [
+        "phase_4_report_fixture_layer"
+      ],
+      "doneCriteria": [
+        "A gate exists to prevent fixture drift from being mistaken for client-ready output",
+        "Client-readiness remains explicitly separate from internal preview work"
+      ]
+    }
+  ],
+  "phases": {
+    "phase_0_roadmap_boundary": {
+      "title": "Roadmap Boundary",
+      "status": "active",
+      "summary": "Define the scope of VM0007 judgment fixtures and keep the lane separate from production logic and Quick Check v2 Phase 7."
+    },
+    "phase_1_envira_vm0007_judgment_fixtures": {
+      "title": "Envira VM0007 Judgment Fixtures",
+      "status": "planned",
+      "summary": "Add fixture coverage for Envira VM0007 cases with explicit accepted evidence, rejected evidence, and expected statuses."
+    },
+    "phase_2_pd_redd_vm0007_judgment_fixtures": {
+      "title": "PD_REDD VM0007 Judgment Fixtures",
+      "status": "planned",
+      "summary": "Add fixture coverage for PD_REDD VM0007 cases using the same judgment contract discipline."
+    },
+    "phase_3_full_58_rule_audit_fixture_shape": {
+      "title": "Full 58-Rule Audit Fixture Shape",
+      "status": "planned",
+      "summary": "Stabilize the complete VM0007 audit fixture shape across all 58 rules."
+    },
+    "phase_4_report_fixture_layer": {
+      "title": "Report Fixture Layer",
+      "status": "planned",
+      "summary": "Add internal preview report expectations for summary sections and row grouping."
+    },
+    "phase_5_client_readiness_gate": {
+      "title": "Client-Readiness Gate",
+      "status": "planned",
+      "summary": "Keep internal preview output separate from any later client-ready reporting work."
+    }
+  }
+}

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -38,9 +38,13 @@
         "phase_0_roadmap_boundary"
       ],
       "doneCriteria": [
-        "Accepted evidence is explicitly fixture-encoded",
-        "Rejected evidence is explicitly fixture-encoded",
-        "Expected statuses are fixture-encoded for Envira cases"
+        "5-10 rule-level judgment fixtures exist for Envira",
+        "Accepted evidence requirements are explicitly fixture-encoded",
+        "Rejected generic evidence examples are explicitly fixture-encoded",
+        "At least one false-supported case is covered",
+        "At least one case rejects generic methodology/module-table evidence as supported",
+        "Expected status is explicit for each fixture",
+        "Expected client action is explicit where status is weak or missing"
       ]
     },
     {
@@ -103,7 +107,7 @@
     "phase_1_envira_vm0007_judgment_fixtures": {
       "title": "Envira VM0007 Judgment Fixtures",
       "status": "planned",
-      "summary": "Add fixture coverage for Envira VM0007 cases with explicit accepted evidence, rejected evidence, and expected statuses."
+      "summary": "Add 5-10 Envira VM0007 judgment fixtures with explicit accepted evidence, rejected generic evidence examples, false-supported coverage, and expected statuses plus client actions where weak or missing."
     },
     "phase_2_pd_redd_vm0007_judgment_fixtures": {
       "title": "PD_REDD VM0007 Judgment Fixtures",


### PR DESCRIPTION
## What changed

Added a new VM0007 judgment-fixtures roadmap under `docs/roadmaps/vm0007-judgement-fixtures/` and created `docs/roadmaps/INDEX.md` to classify roadmap folders.

## Why

VM0007 gap-report accuracy needs fixture-level judgment hardening without mixing that work into Quick Check v2 Phase 7 or production logic.

## Impact

- New roadmap boundary for accepted/rejected evidence, expected status, and report-summary expectations.
- Active roadmaps are now limited to `quickcheck-v2` and `vm0007-judgement-fixtures` in the index.
- Historical roadmap folders are retained and classified instead of deleted.

## Validation

- `git diff --check`
- `gh auth status`
- branch push succeeded
