### PR TITLE
docs: define VM0007 judgment fixtures Phase 0 boundary

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -344,7 +344,7 @@ Not active now:
 - LLM final judgment
 - Quick Check v2 Phase 7 work
 
-1) RC0 — Roadmap Boundary: Active — Define the scope of VM0007 judgment fixtures and keep the lane separate from production logic and Quick Check v2 Phase 7.
+1) RC0 — Roadmap Boundary: Active — Define a boundary-only contract for VM0007 judgment fixtures: PDF truth over current output, accepted and rejected evidence requirements, UNCLEAR/MISSING discipline, no production or UI changes, and clear acceptance criteria for future fixture PRs.
 2) RC1 — Envira VM0007 Judgment Fixtures: Planned — Add 5-10 Envira VM0007 judgment fixtures with explicit accepted evidence, rejected generic evidence examples, false-supported coverage, and expected statuses plus client actions where weak or missing.
 3) RC2 — PD_REDD VM0007 Judgment Fixtures: Planned — Add fixture coverage for PD_REDD VM0007 cases using the same judgment contract discipline.
 4) RC3 — Full 58-Rule Audit Fixture Shape: Planned — Stabilize the complete VM0007 audit fixture shape across all 58 rules.

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -333,7 +333,8 @@ Lane status: Active
 Tighten VM0007 gap report accuracy by improving rule-level judgment fixtures and contracts without changing production audit logic.
 
 Current focus:
-- Phase 0 is the immediate boundary: define the scope and keep this lane separate from Quick Check v2 Phase 7
+- Phase 0 done: boundary-only fixture contract is documented and ready to guide Phase 1
+- Phase 1 is next: add 5-10 Envira VM0007 judgment fixtures
 - Capture accepted and rejected evidence explicitly so the report can distinguish supported, weak, missing, and not-applicable rows
 - Keep audit-summary and report-summary expectations fixture-driven
 
@@ -344,7 +345,7 @@ Not active now:
 - LLM final judgment
 - Quick Check v2 Phase 7 work
 
-1) RC0 — Roadmap Boundary: Active — Define a boundary-only contract for VM0007 judgment fixtures: PDF truth over current output, accepted and rejected evidence requirements, UNCLEAR/MISSING discipline, no production or UI changes, and clear acceptance criteria for future fixture PRs.
+1) RC0 — Roadmap Boundary: Done — Define a boundary-only contract for VM0007 judgment fixtures: PDF truth over current output, accepted and rejected evidence requirements, UNCLEAR/MISSING discipline, no production or UI changes, and clear acceptance criteria for future fixture PRs. Delivered by PR #895.
 2) RC1 — Envira VM0007 Judgment Fixtures: Planned — Add 5-10 Envira VM0007 judgment fixtures with explicit accepted evidence, rejected generic evidence examples, false-supported coverage, and expected statuses plus client actions where weak or missing.
 3) RC2 — PD_REDD VM0007 Judgment Fixtures: Planned — Add fixture coverage for PD_REDD VM0007 cases using the same judgment contract discipline.
 4) RC3 — Full 58-Rule Audit Fixture Shape: Planned — Stabilize the complete VM0007 audit fixture shape across all 58 rules.

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -29,6 +29,45 @@ Do not mix judgment-fixture work into the Quick Check v2 parser / ingestion rebu
 
 Define the scope of VM0007 judgment fixtures and lock the separation from production logic and Quick Check v2 Phase 7.
 
+Phase 0 is documentation-only. It defines the contract for future fixture PRs before any Envira or PD_REDD fixture files are added.
+
+#### Phase 0 Scope
+
+- this lane is for VM0007 judgment fixtures only
+- fixtures must use PDF truth, not current app output
+- each fixture must encode accepted evidence
+- each fixture must encode rejected weak or generic evidence
+- weak evidence must stay `UNCLEAR`, not `FOUND`
+- missing evidence must stay `MISSING`
+- no production audit logic changes
+- no report UI changes
+- no client-facing report behavior changes
+- no Quick Check v2 Phase 7 work
+
+#### Future Fixture PR Contract
+
+Every future fixture PR in this lane must:
+
+- stay docs or fixture scoped unless a separate production-logic roadmap explicitly allows broader work
+- identify the rule IDs covered by the fixture set
+- state the PDF source of truth for each fixture set
+- encode accepted evidence that is sufficient for the expected status
+- encode rejected weak or generic evidence that must not upgrade a row to `FOUND`
+- preserve `UNCLEAR` for weak evidence and `MISSING` for absent evidence
+- define expected status per fixture
+- define expected client action whenever status is weak or missing
+- avoid using current app output as fixture truth
+
+#### Acceptance For Future Fixture PRs
+
+- fixture scope is limited to VM0007 judgment fixtures
+- PDF truth is explicit
+- accepted and rejected evidence are explicit
+- status expectations are explicit
+- weak evidence remains `UNCLEAR`
+- missing evidence remains `MISSING`
+- tests and CI are not weakened
+
 ### Phase 1 — Envira VM0007 Judgment Fixtures
 
 Add and harden fixtures that capture Envira-specific VM0007 judgments, including:

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -25,9 +25,15 @@
       "status": "active",
       "dependsOn": [],
       "doneCriteria": [
-        "Roadmap scope is clearly separated from production logic",
+        "Roadmap scope is explicitly limited to VM0007 judgment fixtures",
+        "PDF truth is required instead of current app output",
+        "Fixture contract requires accepted evidence and rejected weak/generic evidence",
+        "Weak evidence is explicitly kept UNCLEAR, not FOUND",
+        "Missing evidence is explicitly kept MISSING",
         "Quick Check v2 Phase 7 is explicitly out of scope",
-        "Fixture expectations are defined for judgment and summary layers"
+        "No production audit logic, report UI, or client-facing behavior changes are allowed in Phase 0",
+        "Future fixture PR acceptance criteria are documented",
+        "Tests and CI are not weakened"
       ]
     },
     {
@@ -102,7 +108,7 @@
     "phase_0_roadmap_boundary": {
       "title": "Roadmap Boundary",
       "status": "active",
-      "summary": "Define the scope of VM0007 judgment fixtures and keep the lane separate from production logic and Quick Check v2 Phase 7."
+      "summary": "Define a boundary-only contract for VM0007 judgment fixtures: PDF truth over current output, accepted and rejected evidence requirements, UNCLEAR/MISSING discipline, no production or UI changes, and clear acceptance criteria for future fixture PRs."
     },
     "phase_1_envira_vm0007_judgment_fixtures": {
       "title": "Envira VM0007 Judgment Fixtures",

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -5,7 +5,8 @@
     "status": "active",
     "summary": "Tighten VM0007 gap report accuracy by improving rule-level judgment fixtures and contracts without changing production audit logic.",
     "current_focus": [
-      "Phase 0 is the immediate boundary: define the scope and keep this lane separate from Quick Check v2 Phase 7",
+      "Phase 0 done: boundary-only fixture contract is documented and ready to guide Phase 1",
+      "Phase 1 is next: add 5-10 Envira VM0007 judgment fixtures",
       "Capture accepted and rejected evidence explicitly so the report can distinguish supported, weak, missing, and not-applicable rows",
       "Keep audit-summary and report-summary expectations fixture-driven"
     ],
@@ -22,8 +23,10 @@
     {
       "id": "phase_0_roadmap_boundary",
       "title": "Roadmap Boundary",
-      "status": "active",
+      "status": "done",
       "dependsOn": [],
+      "branch": "docs/vm0007-judgement-fixtures-phase0-boundary",
+      "pr": 895,
       "doneCriteria": [
         "Roadmap scope is explicitly limited to VM0007 judgment fixtures",
         "PDF truth is required instead of current app output",
@@ -107,8 +110,8 @@
   "phases": {
     "phase_0_roadmap_boundary": {
       "title": "Roadmap Boundary",
-      "status": "active",
-      "summary": "Define a boundary-only contract for VM0007 judgment fixtures: PDF truth over current output, accepted and rejected evidence requirements, UNCLEAR/MISSING discipline, no production or UI changes, and clear acceptance criteria for future fixture PRs."
+      "status": "done",
+      "summary": "Define a boundary-only contract for VM0007 judgment fixtures: PDF truth over current output, accepted and rejected evidence requirements, UNCLEAR/MISSING discipline, no production or UI changes, and clear acceptance criteria for future fixture PRs. Delivered by PR #895."
     },
     "phase_1_envira_vm0007_judgment_fixtures": {
       "title": "Envira VM0007 Judgment Fixtures",


### PR DESCRIPTION
## What changed

This PR adds the Phase 0 boundary contract for the VM0007 judgment-fixtures lane.

It documents that this lane is fixture-only work before any Envira fixture payloads are added, and it tightens the roadmap contract around:

- PDF truth over current app output
- accepted evidence requirements
- rejected weak or generic evidence requirements
- `UNCLEAR` for weak evidence
- `MISSING` for absent evidence
- future fixture-PR acceptance criteria

## Why

The follow-up Phase 0 scope work should not continue on the already merged roadmap-creation branch.

This PR cleanly separates the boundary contract into a new branch and PR based on current `main`.

## Impact

- No production audit logic changes
- No report UI changes
- No client-facing report behavior changes
- No Quick Check v2 Phase 7 work
- Future fixture PRs now have an explicit contract to follow

## Root cause

The previous follow-up docs changes were made on a source branch after its original roadmap PR had already merged. This PR republishes the intended Phase 0 delta from a fresh branch off `main`.

## Validation

- `git diff --check`
- `npm run roadmap:check`
- pre-push `lint`
- pre-push `typecheck`
