### PR TITLE
test: add Envira VM0007 judgment fixtures

### DIFF
--- a/tests/fixtures/preverif/envira-vm0007-judgment-fixtures.json
+++ b/tests/fixtures/preverif/envira-vm0007-judgment-fixtures.json
@@ -1,0 +1,239 @@
+{
+  "fixtureSetId": "envira-vm0007-judgment-fixtures",
+  "title": "Envira VM0007 Judgment Fixtures",
+  "inputPdfName": "PROJ_DESC_1382_04APR2015.pdf",
+  "inputPdfPath": "/Users/stphen/Desktop/PROJ_DESC_1382_04APR2015.pdf",
+  "sourcePdfTitle": "Microsoft Word - Envira Amazonia VCS PD 2015.04.03",
+  "documentFamily": "Project Description / PD",
+  "methodology": "VM0007",
+  "fixtureTruthPolicy": "Use exact quotes, page numbers, and section headings from PROJ_DESC_1382_04APR2015.pdf only. Do not use current app output as gold.",
+  "expectedWarnings": [
+    "Generic methodology or module-table text must not count as project evidence.",
+    "Weak evidence must stay UNCLEAR and missing evidence must stay MISSING.",
+    "TOC rows, URLs, registry links, and generic country references must not count as proof."
+  ],
+  "checks": [
+    {
+      "checkId": "R-1-0002",
+      "checkName": "REDD baseline deforestation category",
+      "expectedStatus": "FOUND",
+      "expectedAnswer": "Baseline deforestation is planned deforestation because the project proponent is the agent of deforestation.",
+      "goldQuote": "Baseline deforestation in the project area falls within the planned deforestation category, as the agents of deforestation is the project proponent.",
+      "page": 32,
+      "sectionHeading": "2.2 Applicability of Methodology",
+      "spanId": null,
+      "whyQuoteIsSufficientOrInsufficient": "The quote directly states the category and the project-specific reason for that classification.",
+      "knownBadQuotesToReject": [
+        {
+          "quote": "The Envira Amazonia Project",
+          "rejectionReason": "The project title does not classify the baseline deforestation category."
+        },
+        {
+          "quote": "Table of Contents",
+          "rejectionReason": "TOC text is navigation, not evidence."
+        }
+      ],
+      "expectedClientAction": null,
+      "coverageTags": [
+        "clean_found"
+      ]
+    },
+    {
+      "checkId": "R-2-0003",
+      "checkName": "Exclusion of land in other GHG programs",
+      "expectedStatus": "FOUND",
+      "expectedAnswer": "The Envira Amazonia Project is not registered and is not seeking registration under any other GHG programs.",
+      "goldQuote": "The Envira Amazonia Project has not been registered, nor is seeking registration, under any other GHG programs. The Envira Amazonia Project is seeking registration under the Climate, Community and Biodiversity Alliance Standard.",
+      "page": 29,
+      "sectionHeading": "1.12.4 Participation under Other GHG Programs",
+      "spanId": null,
+      "whyQuoteIsSufficientOrInsufficient": "The quote directly states the project's status under other GHG programs.",
+      "knownBadQuotesToReject": [
+        {
+          "quote": "A Tropical Forest Conservation Project in Acre, Brazil",
+          "rejectionReason": "Generic country and title text do not prove exclusion from other GHG programs."
+        },
+        {
+          "quote": "http://climate-standards.org/projects/",
+          "rejectionReason": "A registry URL is not evidence that the Envira project is excluded from other GHG programs."
+        }
+      ],
+      "expectedClientAction": null,
+      "coverageTags": [
+        "found",
+        "reject_generic_country_reference",
+        "reject_registry_url"
+      ]
+    },
+    {
+      "checkId": "R-2-0014",
+      "checkName": "Crediting period duration",
+      "expectedStatus": "FOUND",
+      "expectedAnswer": "The initial project crediting period is 30 years, from August 2, 2012 through August 1, 2042.",
+      "goldQuote": "The Envira Amazonia Project has an initial project crediting period of 30 years, starting on August 2, 2012. The initial baseline period started on August 2, 2012 and is set to continue through August 1, 2022. The initial project crediting period is set to end on August 1, 2042.",
+      "page": 7,
+      "sectionHeading": "1.6 Project Crediting Period",
+      "spanId": null,
+      "whyQuoteIsSufficientOrInsufficient": "The quote explicitly states the duration, start date, and end date of the crediting period.",
+      "knownBadQuotesToReject": [
+        {
+          "quote": "Leakage Management",
+          "rejectionReason": "Leakage-management text does not prove the crediting-period duration and was a false-supported selection risk."
+        }
+      ],
+      "expectedClientAction": null,
+      "coverageTags": [
+        "found",
+        "false_supported_risk"
+      ]
+    },
+    {
+      "checkId": "R-3-0001",
+      "checkName": "Baseline scenario determination via VT0001",
+      "expectedStatus": "FOUND",
+      "expectedAnswer": "VT0001 is applied to identify the baseline scenario, and the alternatives include continuation without VCS registration and conversion to pasture.",
+      "goldQuote": "The VCS “Tool for the Demonstration and Assessment of Additionality in VCS Agriculture, Forestry and Other Land Use (AFOLU) Project Activities” is applied to identify the baseline scenario of the project. As the outcome of sub-step 1a of the tool, the following alternative land use scenarios were identified. 1. Continuation of pre-project land use / Project activity on the land within the project boundary performed without being registered as a VCS AFOLU project. 2. Conversion to Pasture.",
+      "page": 37,
+      "sectionHeading": "2.4 Baseline Scenario",
+      "spanId": null,
+      "whyQuoteIsSufficientOrInsufficient": "The quote names VT0001 and shows the actual baseline-scenario determination path used in the PDD.",
+      "knownBadQuotesToReject": [
+        {
+          "quote": "No methodology deviations from VM0007 were applied in the project scenario.",
+          "rejectionReason": "Methodology-deviation text does not show the VT0001 baseline-scenario determination."
+        }
+      ],
+      "expectedClientAction": null,
+      "coverageTags": [
+        "found",
+        "false_supported_risk"
+      ]
+    },
+    {
+      "checkId": "R-3-0005",
+      "checkName": "REDD baseline modules",
+      "expectedStatus": "UNCLEAR",
+      "expectedAnswer": "The PDD lists BL-PL as the baseline module, but the fixture must not treat the generic module list as sufficient proof that the baseline-module rule is fully satisfied.",
+      "goldQuote": "Baseline module: BL-PL “VMD0006 Estimation of baseline carbon stock changes and greenhouse gas emissions from planned deforestation”, version 1.2",
+      "page": 31,
+      "sectionHeading": "2.1 Title and Reference of Methodology",
+      "spanId": null,
+      "whyQuoteIsSufficientOrInsufficient": "This quote is related, but it is still generic module-list text and does not show the project-specific baseline-module judgment needed for a FOUND outcome.",
+      "knownBadQuotesToReject": [
+        {
+          "quote": "Use of modules, REDD-MF, M-MON, T-ADD, T-BAR, X-UNC, and X–STR, is always mandatory when using the VM0007 methodology.",
+          "rejectionReason": "Mandatory-module text is methodology boilerplate, not project-specific evidence."
+        },
+        {
+          "quote": "LK-ASP “VMD0009 Estimation of emissions from activity shifting for avoided planned deforestation”, version 1.1",
+          "rejectionReason": "A leakage-module row does not prove the baseline-module judgment for this rule."
+        }
+      ],
+      "expectedClientAction": "Add the project-specific baseline-module rationale, the reason BL-PL applies here, and the citations tying that module choice to the Envira project facts.",
+      "coverageTags": [
+        "unclear",
+        "reject_generic_methodology_text",
+        "reject_module_table_text"
+      ]
+    },
+    {
+      "checkId": "R-5-0003",
+      "checkName": "REDD leakage components",
+      "expectedStatus": "FOUND",
+      "expectedAnswer": "Leakage is assessed with LK-ASP for activity-shifting leakage and LK-ME for market-effects leakage related to timber extraction.",
+      "goldQuote": "Leakage emissions from displacement of planned deforestation are estimated in conformance with the VCS modular REDD methodology VM0007, specifically the LK-ASP and LK-ME modules. These modules provide for accounting for activity shifting leakage resulting from displacement of deforestation activities by the agent of deforestation and estimating GHG emissions caused by the market-effects leakage related to extraction of wood for timber.",
+      "page": 69,
+      "sectionHeading": "3.3 Leakage",
+      "spanId": null,
+      "whyQuoteIsSufficientOrInsufficient": "The quote directly identifies the leakage components and ties them to project leakage treatment.",
+      "knownBadQuotesToReject": [
+        {
+          "quote": "LK-ASP “VMD0009 Estimation of emissions from activity shifting for avoided planned deforestation”, version 1.1",
+          "rejectionReason": "A module-list entry is generic methodology evidence, not direct project leakage evidence."
+        },
+        {
+          "quote": "3.3 Leakage",
+          "rejectionReason": "A heading alone does not prove the leakage components."
+        }
+      ],
+      "expectedClientAction": null,
+      "coverageTags": [
+        "found",
+        "reject_generic_methodology_text"
+      ]
+    },
+    {
+      "checkId": "R-6-0002",
+      "checkName": "Monitoring plan content requirements",
+      "expectedStatus": "FOUND",
+      "expectedAnswer": "The monitoring plan covers monitoring deforestation, illegal degradation, natural disturbance, project emissions ex-post, and baseline updates.",
+      "goldQuote": "This monitoring plan has been developed in close conjunction with module VMD0015 of the REDD Methodological Module, “Methods for monitoring of greenhouse gas emissions and removals (M-MON).” This section focuses on establishing procedures for monitoring deforestation, illegal degradation, natural disturbance, and project emissions ex-post in the project area and leakage areas. Further, procedures for updating the forest carbon stocks and revising the baseline are also provided below.",
+      "page": 107,
+      "sectionHeading": "4.3 Monitoring Plan",
+      "spanId": null,
+      "whyQuoteIsSufficientOrInsufficient": "The quote directly describes the monitoring-plan content areas the rule expects.",
+      "knownBadQuotesToReject": [
+        {
+          "quote": "Data and parameters which will need to be monitored include those listed in this section.",
+          "rejectionReason": "A generic data-table preface does not prove the monitoring-plan content requirements."
+        }
+      ],
+      "expectedClientAction": null,
+      "coverageTags": [
+        "found"
+      ]
+    },
+    {
+      "checkId": "R-1-0004",
+      "checkName": "APDef legal authorization",
+      "expectedStatus": "UNCLEAR",
+      "expectedAnswer": "The PDD says legal permission is inferred, but it does not identify the actual authorization document or issuing authority needed for a FOUND determination.",
+      "goldQuote": "Deforestation is inferred to be legally permitted as the property is fully georeferenced and registered with INCRA and the CAR and under the oversight of the state of Acre;",
+      "page": 49,
+      "sectionHeading": "3.1.2. Identifying proxy areas",
+      "spanId": null,
+      "whyQuoteIsSufficientOrInsufficient": "The quote is related evidence, but it is still an inference and does not cite the actual conversion authorization document, issuing authority, scope, or dates.",
+      "knownBadQuotesToReject": [
+        {
+          "quote": "the land is legally permitted to be converted to non-forest",
+          "rejectionReason": "Generic methodology-applicability language is not the underlying authorization document."
+        },
+        {
+          "quote": "Project Description",
+          "rejectionReason": "The document label is not evidence of APDef legal authorization."
+        }
+      ],
+      "expectedClientAction": "Add the conversion authorization document, the issuing authority, the area and dates it covers, and the citation tying it to APDef.",
+      "coverageTags": [
+        "unclear",
+        "false_supported_risk"
+      ]
+    },
+    {
+      "checkId": "R-6-0007",
+      "checkName": "Expert judgment documentation",
+      "expectedStatus": "MISSING",
+      "expectedAnswer": "No usable expert-judgment documentation is shown in the Envira PDD for this rule.",
+      "goldQuote": null,
+      "page": null,
+      "sectionHeading": null,
+      "spanId": null,
+      "whyQuoteIsSufficientOrInsufficient": "No direct PDF-backed quote in the Envira PDD documents expert-judgment inputs, rationale, or retained evidence for this rule.",
+      "knownBadQuotesToReject": [
+        {
+          "quote": "Data and parameters which will need to be monitored include those listed in this section.",
+          "rejectionReason": "A generic data-parameter preface is not expert-judgment documentation."
+        },
+        {
+          "quote": "This monitoring plan has been developed in close conjunction with module VMD0015",
+          "rejectionReason": "Monitoring-plan process text does not document expert judgment."
+        }
+      ],
+      "expectedClientAction": "Add the expert-judgment basis, who applied it, what decision it informed, and the retained evidence or appendix references that support that judgment.",
+      "coverageTags": [
+        "missing",
+        "false_supported_risk"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/preverif/envira-vm0007-report-fixture.json
+++ b/tests/fixtures/preverif/envira-vm0007-report-fixture.json
@@ -1,0 +1,48 @@
+{
+  "fixtureSetId": "envira-vm0007-report-fixture",
+  "title": "Envira VM0007 Report Fixture Expectations",
+  "expectedReportTitle": "Internal VM0007 Gap Report Preview",
+  "expectedSectionOrdering": [
+    "Executive Summary",
+    "Project Snapshot",
+    "Methodology Scope",
+    "Key Supported Findings",
+    "Not Applicable Rules",
+    "Main Evidence Gaps",
+    "Follow-up Action List",
+    "Full VM0007 Rule Audit Table",
+    "Evidence Appendix"
+  ],
+  "expectedStatusCounts": {
+    "supported": 6,
+    "weak": 2,
+    "missing": 1,
+    "notApplicable": 0
+  },
+  "expectedVisibleWording": [
+    "Internal preview only. This report shows current audit output and has not been manually reviewed.",
+    "Current PDD support is too unclear to classify confidently.",
+    "Current PDD support is missing for this rule.",
+    "What to add",
+    "Follow-up Action List"
+  ],
+  "bannedWording": [
+    "all clear",
+    "passed",
+    "confirmed"
+  ],
+  "expectedEvidenceRendering": [
+    "Baseline deforestation in the project area falls within the planned deforestation category, as the agents of deforestation is the project proponent.",
+    "The Envira Amazonia Project has not been registered, nor is seeking registration, under any other GHG programs.",
+    "Leakage emissions from displacement of planned deforestation are estimated in conformance with the VCS modular REDD methodology VM0007, specifically the LK-ASP and LK-ME modules."
+  ],
+  "expectedWeakOrMissingExplanation": [
+    "The quote is related evidence, but it is still an inference and does not cite the actual conversion authorization document, issuing authority, scope, or dates.",
+    "No direct PDF-backed quote in the Envira PDD documents expert-judgment inputs, rationale, or retained evidence for this rule."
+  ],
+  "expectedClientActionWording": [
+    "Add the project-specific baseline-module rationale, the reason BL-PL applies here, and the citations tying that module choice to the Envira project facts.",
+    "Add the conversion authorization document, the issuing authority, the area and dates it covers, and the citation tying it to APDef.",
+    "Add the expert-judgment basis, who applied it, what decision it informed, and the retained evidence or appendix references that support that judgment."
+  ]
+}

--- a/tests/fixtures/preverif/envira-vm0007-source-excerpts.json
+++ b/tests/fixtures/preverif/envira-vm0007-source-excerpts.json
@@ -1,0 +1,23 @@
+{
+  "inputPdfName": "PROJ_DESC_1382_04APR2015.pdf",
+  "inputPdfPath": "/Users/stphen/Desktop/PROJ_DESC_1382_04APR2015.pdf",
+  "sourcePdfTitle": "Microsoft Word - Envira Amazonia VCS PD 2015.04.03",
+  "documentFamily": "Project Description / PD",
+  "sourceTypeConfirmation": {
+    "page": 1,
+    "sectionHeading": "Cover Page",
+    "quote": "PROJECT DESCRIPTION: VCS Version 3 THE ENVIRA AMAZONIA PROJECT"
+  },
+  "pageExcerpts": {
+    "1": "PROJECT DESCRIPTION: VCS Version 3 THE ENVIRA AMAZONIA PROJECT\nA Tropical Forest Conservation Project in Acre, Brazil\nProject Title\nThe Envira Amazonia Project",
+    "2": "PROJECT DESCRIPTION: VCS Version 3\nTable of Contents\n2 APPLICATION OF METHODOLOGY\n2.1 Title and Reference of Methodology\n2.2 Applicability of Methodology",
+    "7": "1.6 Project Crediting Period\nThe Envira Amazonia Project has an initial project crediting period of 30 years, starting on August 2, 2012. The initial baseline period started on August 2, 2012 and is set to continue through August 1, 2022. The initial project crediting period is set to end on August 1, 2042.",
+    "29": "1.12.4 Participation under Other GHG Programs\nThe Envira Amazonia Project has not been registered, nor is seeking registration, under any other GHG programs. The Envira Amazonia Project is seeking registration under the Climate, Community and Biodiversity Alliance Standard.\n32 The CCB project document is available at http://climate-standards.org/projects/",
+    "31": "2.1 Title and Reference of Methodology\nBaseline module:\nBL-PL “VMD0006 Estimation of baseline carbon stock changes and greenhouse gas emissions from planned deforestation”, version 1.2\nLeakage modules:\nLK-ASP “VMD0009 Estimation of emissions from activity shifting for avoided planned deforestation”, version 1.1",
+    "32": "2.2 Applicability of Methodology\nUse of modules, REDD-MF, M-MON, T-ADD, T-BAR, X-UNC, and X–STR, is always mandatory when using the VM0007 methodology.\nBaseline deforestation in the project area falls within the planned deforestation category, as the agents of deforestation is the project proponent.",
+    "37": "2.4 Baseline Scenario\nThe VCS “Tool for the Demonstration and Assessment of Additionality in VCS Agriculture, Forestry and Other Land Use (AFOLU) Project Activities” is applied to identify the baseline scenario of the project.\nAs the outcome of sub-step 1a of the tool, the following alternative land use scenarios were identified.\n1. Continuation of pre-project land use / Project activity on the land within the project boundary performed without being registered as a VCS AFOLU project.\n2. Conversion to Pasture.",
+    "49": "3.1.2. Identifying proxy areas\nDeforestation is inferred to be legally permitted as the property is fully georeferenced and registered with INCRA and the CAR and under the oversight of the state of Acre;",
+    "69": "3.3 Leakage\nLeakage emissions from displacement of planned deforestation are estimated in conformance with the VCS modular REDD methodology VM0007, specifically the LK-ASP and LK-ME modules. These modules provide for accounting for activity shifting leakage resulting from displacement of deforestation activities by the agent of deforestation and estimating GHG emissions caused by the market-effects leakage related to extraction of wood for timber.",
+    "107": "4.3 Monitoring Plan\nThis monitoring plan has been developed in close conjunction with module VMD0015 of the REDD Methodological Module, “Methods for monitoring of greenhouse gas emissions and removals (M-MON).” This section focuses on establishing procedures for monitoring deforestation, illegal degradation, natural disturbance, and project emissions ex-post in the project area and leakage areas. Further, procedures for updating the forest carbon stocks and revising the baseline are also provided below.\nA separate section on quality assurance/quality control and data archiving procedures covers all monitoring tasks."
+  }
+}

--- a/tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts
+++ b/tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts
@@ -1,0 +1,272 @@
+import fs from "node:fs";
+import { describe, expect, it } from "@jest/globals";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import Vm0007GapReportView from "@/components/preverif/Vm0007GapReportView";
+import { buildVm0007GapReport } from "@/lib/preverif/vm0007GapReport";
+import type { EvidenceAuditStatus, MethodologyEvidenceAuditResult, MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
+
+type FixtureStatus = "FOUND" | "UNCLEAR" | "MISSING" | "N/A";
+
+type RejectedQuote = {
+  quote: string;
+  rejectionReason: string;
+};
+
+type JudgmentFixture = {
+  checkId: string;
+  checkName: string;
+  expectedStatus: FixtureStatus;
+  expectedAnswer: string;
+  goldQuote: string | null;
+  page: number | null;
+  sectionHeading: string | null;
+  spanId: string | null;
+  whyQuoteIsSufficientOrInsufficient: string;
+  knownBadQuotesToReject: RejectedQuote[];
+  expectedClientAction: string | null;
+  coverageTags: string[];
+};
+
+type JudgmentFixtureSet = {
+  fixtureSetId: string;
+  title: string;
+  inputPdfName: string;
+  inputPdfPath: string;
+  sourcePdfTitle: string;
+  documentFamily: string;
+  methodology: string;
+  fixtureTruthPolicy: string;
+  expectedWarnings: string[];
+  checks: JudgmentFixture[];
+};
+
+type ReportFixture = {
+  fixtureSetId: string;
+  title: string;
+  expectedReportTitle: string;
+  expectedSectionOrdering: string[];
+  expectedStatusCounts: {
+    supported: number;
+    weak: number;
+    missing: number;
+    notApplicable: number;
+  };
+  expectedVisibleWording: string[];
+  bannedWording: string[];
+  expectedEvidenceRendering: string[];
+  expectedWeakOrMissingExplanation: string[];
+  expectedClientActionWording: string[];
+};
+
+type SourceExcerpts = {
+  inputPdfName: string;
+  inputPdfPath: string;
+  sourcePdfTitle: string;
+  documentFamily: string;
+  sourceTypeConfirmation: {
+    page: number;
+    sectionHeading: string;
+    quote: string;
+  };
+  pageExcerpts: Record<string, string>;
+};
+
+const AUDIT_FIXTURE = JSON.parse(
+  fs.readFileSync("tests/fixtures/preverif/envira-vm0007-judgment-fixtures.json", "utf8"),
+) as JudgmentFixtureSet;
+
+const REPORT_FIXTURE = JSON.parse(
+  fs.readFileSync("tests/fixtures/preverif/envira-vm0007-report-fixture.json", "utf8"),
+) as ReportFixture;
+
+const SOURCE_EXCERPTS = JSON.parse(
+  fs.readFileSync("tests/fixtures/preverif/envira-vm0007-source-excerpts.json", "utf8"),
+) as SourceExcerpts;
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function toAuditStatus(status: FixtureStatus): EvidenceAuditStatus {
+  switch (status) {
+    case "FOUND":
+      return "supported_by_pdd";
+    case "UNCLEAR":
+      return "manual_review_needed";
+    case "MISSING":
+      return "missing_evidence";
+    case "N/A":
+      return "not_applicable";
+  }
+}
+
+function buildAuditFromFixtures(checks: JudgmentFixture[]): MethodologyEvidenceAuditSummary {
+  const results: MethodologyEvidenceAuditResult[] = checks.map((check) => ({
+    ruleId: check.checkId,
+    stableId: check.checkId,
+    title: check.checkName,
+    ruleLogic: check.checkName,
+    status: toAuditStatus(check.expectedStatus),
+    bestEvidenceQuote: check.goldQuote,
+    page: check.page,
+    section: check.sectionHeading,
+    span: check.spanId,
+    reasonSelected: check.goldQuote
+      ? "Fixture-provided PDF-backed quote selected for report expectation coverage."
+      : "No usable PDF-backed quote exists for this fixture.",
+    assessmentReason: check.whyQuoteIsSufficientOrInsufficient,
+    gap: check.expectedStatus === "FOUND" || check.expectedStatus === "N/A"
+      ? ""
+      : check.whyQuoteIsSufficientOrInsufficient,
+    clientAction: check.expectedClientAction ?? "",
+    confidence: check.expectedStatus === "FOUND" ? "high" : "medium",
+  }));
+
+  return {
+    results,
+    totals: {
+      supported_by_pdd: results.filter((result) => result.status === "supported_by_pdd").length,
+      partially_supported: 0,
+      missing_evidence: results.filter((result) => result.status === "missing_evidence").length,
+      not_applicable: results.filter((result) => result.status === "not_applicable").length,
+      manual_review_needed: results.filter((result) => result.status === "manual_review_needed").length,
+    },
+    totalRules: results.length,
+  };
+}
+
+describe("Envira VM0007 judgment fixtures", () => {
+  it("confirms Phase 0 is documented and the exact source document is the Envira project description PDF", () => {
+    const phase0Plan = fs.readFileSync("docs/roadmaps/vm0007-judgement-fixtures/PLAN.md", "utf8");
+
+    expect(phase0Plan).toContain("Phase 0 is documentation-only.");
+    expect(phase0Plan).toContain("fixtures must use PDF truth, not current app output");
+    expect(AUDIT_FIXTURE.inputPdfName).toBe("PROJ_DESC_1382_04APR2015.pdf");
+    expect(AUDIT_FIXTURE.inputPdfPath).toBe("/Users/stphen/Desktop/PROJ_DESC_1382_04APR2015.pdf");
+    expect(AUDIT_FIXTURE.sourcePdfTitle).toBe("Microsoft Word - Envira Amazonia VCS PD 2015.04.03");
+    expect(AUDIT_FIXTURE.documentFamily).toBe("Project Description / PD");
+    expect(AUDIT_FIXTURE.fixtureTruthPolicy).toContain("exact quotes, page numbers, and section headings");
+    expect(SOURCE_EXCERPTS.sourceTypeConfirmation.page).toBe(1);
+    expect(SOURCE_EXCERPTS.sourceTypeConfirmation.quote).toContain("PROJECT DESCRIPTION");
+    expect(SOURCE_EXCERPTS.pageExcerpts["1"]).toContain("THE ENVIRA AMAZONIA PROJECT");
+  });
+
+  it("defines a complete 5-10 check fixture contract with required status and rejection coverage", () => {
+    expect(AUDIT_FIXTURE.methodology).toBe("VM0007");
+    expect(AUDIT_FIXTURE.checks.length).toBeGreaterThanOrEqual(5);
+    expect(AUDIT_FIXTURE.checks.length).toBeLessThanOrEqual(10);
+    expect(AUDIT_FIXTURE.expectedWarnings).toHaveLength(3);
+
+    expect(AUDIT_FIXTURE.checks.some((check) => check.coverageTags.includes("clean_found"))).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.expectedStatus === "UNCLEAR")).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.expectedStatus === "MISSING")).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.coverageTags.includes("false_supported_risk"))).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.coverageTags.includes("reject_module_table_text"))).toBe(true);
+    expect(
+      AUDIT_FIXTURE.checks.some((check) =>
+        check.coverageTags.includes("reject_registry_url") || check.coverageTags.includes("reject_generic_country_reference"),
+      ),
+    ).toBe(true);
+
+    for (const check of AUDIT_FIXTURE.checks) {
+      expect(check.checkId).toMatch(/^R-\d-\d{4}$/);
+      expect(check.checkName.trim().length).toBeGreaterThan(0);
+      expect(check.expectedAnswer.trim().length).toBeGreaterThan(0);
+      expect(check.whyQuoteIsSufficientOrInsufficient.trim().length).toBeGreaterThan(0);
+      expect(check.knownBadQuotesToReject.length).toBeGreaterThan(0);
+
+      if (check.expectedStatus === "FOUND") {
+        expect(check.goldQuote).not.toBeNull();
+        expect(check.page).not.toBeNull();
+        expect(check.sectionHeading).not.toBeNull();
+        expect(check.spanId ?? check.sectionHeading).not.toBeNull();
+      }
+
+      if (check.expectedStatus === "UNCLEAR" || check.expectedStatus === "MISSING") {
+        expect(check.expectedClientAction?.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("anchors every gold quote and section heading to exact excerpts from the specified PDF", () => {
+    expect(SOURCE_EXCERPTS.inputPdfName).toBe(AUDIT_FIXTURE.inputPdfName);
+    expect(SOURCE_EXCERPTS.inputPdfPath).toBe(AUDIT_FIXTURE.inputPdfPath);
+    expect(SOURCE_EXCERPTS.sourcePdfTitle).toBe(AUDIT_FIXTURE.sourcePdfTitle);
+    expect(SOURCE_EXCERPTS.documentFamily).toBe(AUDIT_FIXTURE.documentFamily);
+
+    for (const check of AUDIT_FIXTURE.checks) {
+      if (check.page == null) {
+        expect(check.goldQuote).toBeNull();
+        expect(check.sectionHeading).toBeNull();
+        continue;
+      }
+
+      const excerpt = SOURCE_EXCERPTS.pageExcerpts[String(check.page)];
+      expect(excerpt).toBeTruthy();
+      expect(normalizeText(excerpt)).toContain(normalizeText(check.sectionHeading));
+      expect(normalizeText(excerpt)).toContain(normalizeText(check.goldQuote));
+
+      for (const rejected of check.knownBadQuotesToReject) {
+        expect(rejected.rejectionReason.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("renders the fixture-backed report contract without misleading wording", () => {
+    const report = buildVm0007GapReport({
+      reportId: "fixture-report",
+      generatedAt: "2026-07-01T00:00:00Z",
+      project: {
+        name: "The Envira Amazonia Project",
+        projectId: "envira-fixture",
+        region: "Acre, Brazil",
+      },
+      methodology: {
+        code: "VM0007",
+        version: "4.2",
+        name: "VM0007: REDD Methodology Modules (REDD-MF)",
+      },
+      audit: buildAuditFromFixtures(AUDIT_FIXTURE.checks),
+    });
+
+    const reportHtml = renderToStaticMarkup(createElement(Vm0007GapReportView, { report }));
+    const reportJson = JSON.stringify(report).toLowerCase();
+
+    expect(report.reportName).toBe(REPORT_FIXTURE.expectedReportTitle);
+    expect({
+      supported: report.executiveSummary.totals.supported,
+      weak: report.executiveSummary.totals.weak,
+      missing: report.executiveSummary.totals.missing,
+      notApplicable: report.executiveSummary.totals.notApplicable,
+    }).toEqual(REPORT_FIXTURE.expectedStatusCounts);
+
+    for (const wording of REPORT_FIXTURE.expectedVisibleWording) {
+      expect(reportHtml).toContain(wording);
+    }
+    for (const evidenceText of REPORT_FIXTURE.expectedEvidenceRendering) {
+      expect(reportHtml).toContain(evidenceText);
+    }
+    for (const explanation of REPORT_FIXTURE.expectedWeakOrMissingExplanation) {
+      expect(reportHtml).toContain(explanation);
+    }
+    for (const action of REPORT_FIXTURE.expectedClientActionWording) {
+      expect(reportHtml).toContain(action);
+    }
+    for (const banned of REPORT_FIXTURE.bannedWording) {
+      expect(reportJson).not.toContain(banned.toLowerCase());
+    }
+
+    expect([
+      "Executive Summary",
+      "Project Snapshot",
+      "Methodology Scope",
+      "Key Supported Findings",
+      "Not Applicable Rules",
+      "Main Evidence Gaps",
+      "Follow-up Action List",
+      "Full VM0007 Rule Audit Table",
+      "Evidence Appendix",
+    ]).toEqual(REPORT_FIXTURE.expectedSectionOrdering);
+  });
+});


### PR DESCRIPTION
## WHAT
Add strict Envira VM0007 judgment fixtures sourced only from `PROJ_DESC_1382_04APR2015.pdf`.

## SCOPE
- fixture-only
- no production audit logic changes
- no report UI changes
- no client-facing behavior changes
- no Quick Check v2 Phase 7 work

## INCLUDED
- `tests/fixtures/preverif/envira-vm0007-judgment-fixtures.json`
- `tests/fixtures/preverif/envira-vm0007-report-fixture.json`
- `tests/fixtures/preverif/envira-vm0007-source-excerpts.json`
- `tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts`

## NOTES
- Source PDF confirmed at `/Users/stphen/Desktop/PROJ_DESC_1382_04APR2015.pdf`
- Source document confirmed as project description / PD
- Gold truth uses exact PDF quotes, page numbers, and section headings from that file only
- Fixtures cover FOUND, UNCLEAR, MISSING, false-supported risk, generic methodology/module-table rejection, and URL/generic-country rejection

## VALIDATION
- `npx jest tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts --runInBand`
- pre-push hook passed `lint` and `typecheck`
- full `npm run pr:gate` was started locally; an earlier run hit local disk-pressure (`ENOSPC`) during `next build`, then rerun after cache cleanup

Signed-off-by: Fred Egbuedike <fredilly@article6.org>
