### PR TITLE
docs: mark Envira VM0007 judgment fixtures done

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -333,8 +333,9 @@ Lane status: Active
 Tighten VM0007 gap report accuracy by improving rule-level judgment fixtures and contracts without changing production audit logic.
 
 Current focus:
-- Phase 0 done: boundary-only fixture contract is documented and ready to guide Phase 1
-- Phase 1 is next: add 5-10 Envira VM0007 judgment fixtures
+- Phase 0 done: boundary-only fixture contract is documented
+- Phase 1 done: Envira VM0007 judgment fixtures were delivered by PR #897
+- Phase 2 is next: add PD_REDD VM0007 judgment fixtures using the same accepted/rejected evidence contract
 - Capture accepted and rejected evidence explicitly so the report can distinguish supported, weak, missing, and not-applicable rows
 - Keep audit-summary and report-summary expectations fixture-driven
 
@@ -346,7 +347,7 @@ Not active now:
 - Quick Check v2 Phase 7 work
 
 1) RC0 — Roadmap Boundary: Done — Define a boundary-only contract for VM0007 judgment fixtures: PDF truth over current output, accepted and rejected evidence requirements, UNCLEAR/MISSING discipline, no production or UI changes, and clear acceptance criteria for future fixture PRs. Delivered by PR #895.
-2) RC1 — Envira VM0007 Judgment Fixtures: Planned — Add 5-10 Envira VM0007 judgment fixtures with explicit accepted evidence, rejected generic evidence examples, false-supported coverage, and expected statuses plus client actions where weak or missing.
+2) RC1 — Envira VM0007 Judgment Fixtures: Done — Add Envira VM0007 judgment fixtures with explicit accepted evidence, rejected generic evidence examples, false-supported coverage, and expected statuses plus client actions where weak or missing. Delivered by PR #897.
 3) RC2 — PD_REDD VM0007 Judgment Fixtures: Planned — Add fixture coverage for PD_REDD VM0007 cases using the same judgment contract discipline.
 4) RC3 — Full 58-Rule Audit Fixture Shape: Planned — Stabilize the complete VM0007 audit fixture shape across all 58 rules.
 5) RC4 — Report Fixture Layer: Planned — Add internal preview report expectations for summary sections and row grouping.

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -5,8 +5,9 @@
     "status": "active",
     "summary": "Tighten VM0007 gap report accuracy by improving rule-level judgment fixtures and contracts without changing production audit logic.",
     "current_focus": [
-      "Phase 0 done: boundary-only fixture contract is documented and ready to guide Phase 1",
-      "Phase 1 is next: add 5-10 Envira VM0007 judgment fixtures",
+      "Phase 0 done: boundary-only fixture contract is documented",
+      "Phase 1 done: Envira VM0007 judgment fixtures were delivered by PR #897",
+      "Phase 2 is next: add PD_REDD VM0007 judgment fixtures using the same accepted/rejected evidence contract",
       "Capture accepted and rejected evidence explicitly so the report can distinguish supported, weak, missing, and not-applicable rows",
       "Keep audit-summary and report-summary expectations fixture-driven"
     ],
@@ -17,7 +18,7 @@
       "LLM final judgment",
       "Quick Check v2 Phase 7 work"
     ],
-    "last_updated_at": "2026-07-01T00:00:00Z"
+    "last_updated_at": "2026-07-01T13:31:04Z"
   },
   "goals": [
     {
@@ -42,10 +43,12 @@
     {
       "id": "phase_1_envira_vm0007_judgment_fixtures",
       "title": "Envira VM0007 Judgment Fixtures",
-      "status": "planned",
+      "status": "done",
       "dependsOn": [
         "phase_0_roadmap_boundary"
       ],
+      "branch": "test/envira-vm0007-judgment-fixtures",
+      "pr": 897,
       "doneCriteria": [
         "5-10 rule-level judgment fixtures exist for Envira",
         "Accepted evidence requirements are explicitly fixture-encoded",
@@ -53,7 +56,8 @@
         "At least one false-supported case is covered",
         "At least one case rejects generic methodology/module-table evidence as supported",
         "Expected status is explicit for each fixture",
-        "Expected client action is explicit where status is weak or missing"
+        "Expected client action is explicit where status is weak or missing",
+        "GitHub pr-gate and Next.js build passed on the merged PR"
       ]
     },
     {
@@ -115,8 +119,8 @@
     },
     "phase_1_envira_vm0007_judgment_fixtures": {
       "title": "Envira VM0007 Judgment Fixtures",
-      "status": "planned",
-      "summary": "Add 5-10 Envira VM0007 judgment fixtures with explicit accepted evidence, rejected generic evidence examples, false-supported coverage, and expected statuses plus client actions where weak or missing."
+      "status": "done",
+      "summary": "Add Envira VM0007 judgment fixtures with explicit accepted evidence, rejected generic evidence examples, false-supported coverage, and expected statuses plus client actions where weak or missing. Delivered by PR #897."
     },
     "phase_2_pd_redd_vm0007_judgment_fixtures": {
       "title": "PD_REDD VM0007 Judgment Fixtures",


### PR DESCRIPTION
## WHAT
Mark VM0007 Judgement Fixtures Phase 1 as done after PR #897 merged.

## CHANGES
- Updates `docs/roadmaps/vm0007-judgement-fixtures/phase-status.json`
- Records Phase 1 branch and PR number
- Moves current focus to Phase 2: PD_REDD VM0007 judgment fixtures

## SCOPE
- docs/status only
- no production logic
- no fixture changes
- no report UI changes
- no Quick Check v2 Phase 7 work

## BASIS
PR #897 is merged and its GitHub checks passed before marking Phase 1 done.