### PR TITLE
fix: gate VM0007 gap report card to PDD audit output

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -79,6 +79,10 @@ import type { FixtureContract } from "@/lib/dev/fixtureReplay";
 import { parseExtractedText, type StructuredCheckId } from "@/lib/quickCheckV2/evidence";
 import { extractAnswersForAllChecks } from "@/lib/quickCheckV2/answers";
 import { validateAnswerResults, type StatusReason } from "@/lib/quickCheckV2/status";
+import Vm0007GapReportLaunchButton from "@/components/preverif/Vm0007GapReportLaunchButton";
+import {
+  buildAndSaveVm0007GapReportAudit,
+} from "@/lib/preverif/vm0007GapReportStore";
 
 type MethodInventoryRecord = {
   code: string;
@@ -116,6 +120,13 @@ type ExtractionState = {
   analysis: QuickCheckEvidenceAnalysis | null;
   error: string | null;
 };
+
+export function resolveGapReportSourceAnalysis(
+  analysisFromOptions: QuickCheckEvidenceAnalysis | null | undefined,
+  analysisFromState: QuickCheckEvidenceAnalysis | null | undefined,
+): QuickCheckEvidenceAnalysis | null {
+  return analysisFromOptions ?? analysisFromState ?? null;
+}
 
 type StructuredEvidenceCheckResult = {
   checkId: StructuredCheckId;
@@ -675,6 +686,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [documentPurpose, setDocumentPurpose] = useState<DocumentPurpose | null>(null);
   const [evidenceCheckResults, setEvidenceCheckResults] = useState<StructuredEvidenceCheckResult[]>([]);
   const [runningEvidenceChecks, setRunningEvidenceChecks] = useState(false);
+  const [uploadVm0007GapReportAuditId, setUploadVm0007GapReportAuditId] = useState<string | null>(null);
+  const [generatingUploadVm0007GapReport, setGeneratingUploadVm0007GapReport] = useState(false);
   const [selectedHeading, setSelectedHeading] = useState<DocumentHeading | null>(null);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
@@ -856,6 +869,16 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       : null;
   const canRenderResult = Boolean(result && activeResultKey && validatedResultKey === activeResultKey);
   const renderedResult = canRenderResult ? result : null;
+  const isProjectDescriptionDocumentType = (documentType?: string | null) =>
+    typeof documentType === "string" && documentType.toLowerCase().includes("project description");
+  const isProjectDescriptionPdd =
+    documentPurpose === "project_description_pdd"
+    || isProjectDescriptionDocumentType(renderedResult?.extraction?.documentType);
+  const isVm0007RenderedResult = Boolean(
+    renderedResult
+    && draft.methodologyId.trim().toUpperCase() === "VM0007"
+    && isProjectDescriptionPdd,
+  );
   const extractionPreview = useMemo(
     () => (extractionState.analysis ? buildQuickCheckExtractionSnapshot({ claimText: effectiveClaimText, analysis: extractionState.analysis }) : null),
     [effectiveClaimText, extractionState.analysis],
@@ -871,6 +894,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const methodologyResolution = useMemo<QuickCheckMethodologyResolution>(
     () => resolveQuickCheckMethodology({ mentions: detectedMethodologyMentions, methods, rawText: extractionState.analysis?.rawPddText }),
     [detectedMethodologyMentions, extractionState.analysis?.rawPddText, methods],
+  );
+  const detectedVm0007Method = useMemo(
+    () => methodologyResolution.matchedMethods.find((method) => method.methodologyId.trim().toUpperCase() === "VM0007") ?? null,
+    [methodologyResolution],
   );
   const resolvedWorkspaceMethod = useMemo(
     () => (methodologyResolution.status === "single" ? methodologyResolution.matchedMethods[0] ?? null : null),
@@ -973,6 +1000,20 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     }
     return null;
   }, [extractionPreview, methodologyMismatch, methodologyResolution]);
+  const showUploadVm0007ReportCard = useMemo(
+    () =>
+      activeSourceMode === "uploaded_file"
+      && isProjectDescriptionPdd
+      && Boolean(extractionState.analysis?.rawPddText?.trim())
+      && evidenceMentionsMethodologyCode(extractionState.analysis, "VM0007"),
+    [activeSourceMode, extractionState.analysis, isProjectDescriptionPdd],
+  );
+  const uploadVm0007ReportAuditId = uploadVm0007GapReportAuditId ?? renderedResult?.vm0007GapReportAuditId ?? null;
+  const canGenerateUploadVm0007Report = Boolean(
+    showUploadVm0007ReportCard
+    && detectedVm0007Method?.methodologyVersion
+    && extractionState.analysis?.rawPddText?.trim(),
+  );
   const showAdvancedOptions = showAdvanced || showSavedEvidence || showMethodology;
   const extractionPreviewView = useMemo(
     () =>
@@ -1132,7 +1173,39 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setShowExtractionDetails(false);
     setEvidenceCheckResults([]);
     setRunningEvidenceChecks(false);
+    setUploadVm0007GapReportAuditId(null);
+    setGeneratingUploadVm0007GapReport(false);
     setDocumentPurpose(null);
+  }
+
+  async function handleGenerateUploadVm0007GapReport() {
+    if (!detectedVm0007Method?.methodologyVersion) return;
+    if (!isProjectDescriptionPdd) return;
+    const rawPddText = extractionState.analysis?.rawPddText?.trim();
+    if (!rawPddText) return;
+
+    setGeneratingUploadVm0007GapReport(true);
+    setFieldErrors({});
+    try {
+      const rules = await fetchRules(detectedVm0007Method.methodologyId, detectedVm0007Method.methodologyVersion);
+      const savedAudit = buildAndSaveVm0007GapReportAudit({
+        methodologyId: detectedVm0007Method.methodologyId,
+        methodologyVersion: detectedVm0007Method.methodologyVersion,
+        evidenceFileName: draft.evidenceFileName || selectedEvidenceLabel,
+        rawPddText,
+        rules,
+      });
+      if (!savedAudit?.auditId) {
+        throw new Error("Quick Check could not generate the VM0007 gap report preview.");
+      }
+      setUploadVm0007GapReportAuditId(savedAudit.auditId);
+    } catch (error) {
+      setFieldErrors({
+        general: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setGeneratingUploadVm0007GapReport(false);
+    }
   }
 
   function openFullReviewFromRecovery() {
@@ -1351,12 +1424,31 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       };
 
       const inventory = loadQuickCheckInventory(candidate.methodologyId, candidate.methodologyVersion);
-      const extraction = options?.analysis
+      const sourceAnalysis = resolveGapReportSourceAnalysis(options?.analysis, extractionState.analysis);
+      const extraction = sourceAnalysis
         ? buildQuickCheckExtractionSnapshot({
             claimText: resolveEffectiveClaimText(activeDraft.claimText),
-            analysis: options.analysis,
+            analysis: sourceAnalysis,
           })
         : null;
+      let vm0007GapReportAuditId: string | undefined;
+      if (candidate.methodologyId.trim().toUpperCase() === "VM0007" && sourceAnalysis?.rawPddText?.trim()) {
+        try {
+          const auditRules = await fetchRules(candidate.methodologyId, candidate.methodologyVersion);
+          const savedAudit = buildAndSaveVm0007GapReportAudit({
+            methodologyId: candidate.methodologyId,
+            methodologyVersion: candidate.methodologyVersion,
+            evidenceFileName: activeDraft.evidenceFileName,
+            rawPddText: sourceAnalysis.rawPddText,
+            rules: auditRules,
+          });
+          vm0007GapReportAuditId = savedAudit?.auditId;
+        } catch (error) {
+          if (process.env.NODE_ENV !== "production") {
+            console.error("Failed to save VM0007 gap report audit output.", error);
+          }
+        }
+      }
       const nextResult = buildQuickCheckResult({
         draft: nextDraft,
         rule: {
@@ -1385,6 +1477,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           : ["Quick Check is preliminary. Open full review to confirm the requirement against the full methodology context."],
         extraction,
       });
+      nextResult.vm0007GapReportAuditId = vm0007GapReportAuditId;
 
       const checkedDraft: QuickCheckDraft = {
         ...nextDraft,
@@ -2097,6 +2190,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     selectedEvidenceRunKey,
   ]);
 
+  useEffect(() => {
+    setUploadVm0007GapReportAuditId(null);
+    setGeneratingUploadVm0007GapReport(false);
+  }, [selectedEvidenceRunKey]);
+
   async function handleTryDemoCheck() {
     setSubmitting(true);
     resetQuickCheckUi();
@@ -2643,6 +2741,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 </div>
               ) : null}
             </div>
+          ) : null}
+
+          {showUploadVm0007ReportCard && !submitting ? (
+            <Vm0007GapReportLaunchButton
+              isVm0007Result
+              auditId={uploadVm0007ReportAuditId}
+              title="Internal VM0007 report"
+              onGenerate={handleGenerateUploadVm0007GapReport}
+              generating={generatingUploadVm0007GapReport}
+              generateDisabled={!canGenerateUploadVm0007Report}
+              testId="vm0007-upload-report-section"
+            />
           ) : null}
 
           <div className={`rounded-[1.6rem] border px-4 py-4 ${showMethodology ? "border-slate-300 bg-slate-50" : "border-slate-200 bg-white"}`}>
@@ -3356,7 +3466,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   {normalizedResult.extractionState.label} evidence signal
                 </span>
               </div>
-              <div className="mt-4">
+              <div className="mt-4 flex flex-wrap items-center gap-3">
                 <button
                   type="button"
                   onClick={handleContinueToWorkspace}
@@ -3366,6 +3476,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   Open full review
                 </button>
               </div>
+              <Vm0007GapReportLaunchButton
+                isVm0007Result={isVm0007RenderedResult}
+                auditId={renderedResult?.vm0007GapReportAuditId}
+              />
             </div>
           ) : null}
 

--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowUpRight, Loader2 } from "lucide-react";
+import { buildVm0007GapReportHref } from "@/lib/preverif/vm0007GapReportStore";
+
+type Vm0007GapReportLaunchButtonProps = {
+  isVm0007Result: boolean;
+  auditId?: string | null;
+  title?: string;
+  onGenerate?: (() => void) | null;
+  generating?: boolean;
+  generateDisabled?: boolean;
+  testId?: string;
+};
+
+export default function Vm0007GapReportLaunchButton({
+  isVm0007Result,
+  auditId,
+  title = "Internal report",
+  onGenerate = null,
+  generating = false,
+  generateDisabled = false,
+  testId = "vm0007-internal-report-section",
+}: Vm0007GapReportLaunchButtonProps) {
+  if (!isVm0007Result) return null;
+
+  return (
+    <div className="mt-4 rounded-xl border border-slate-200 bg-white/80 px-4 py-4" data-testid={testId}>
+      <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{title}</div>
+      {auditId?.trim() ? (
+        <>
+          <div className="mt-2 text-sm text-slate-600">
+            Open the internal VM0007 gap report preview for manual browser print or PDF save.
+          </div>
+          <div className="mt-3">
+            <Link
+              href={buildVm0007GapReportHref(auditId)}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700"
+            >
+              <ArrowUpRight className="h-4 w-4" />
+              View Gap Report
+            </Link>
+          </div>
+        </>
+      ) : onGenerate ? (
+        <>
+          <div className="mt-2 text-sm text-slate-600">
+            Generate the internal VM0007 gap report preview from the extracted PDD text.
+          </div>
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={onGenerate}
+              disabled={generating || generateDisabled}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
+            >
+              {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUpRight className="h-4 w-4" />}
+              Generate Gap Report Preview
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="mt-2">
+            <button
+              type="button"
+              disabled
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-500"
+            >
+              Gap report not available yet
+            </button>
+          </div>
+          <div className="mt-3 text-sm text-slate-600">
+            Run a VM0007 evidence audit to generate the internal report preview.
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/chat/quickCheck.ts
+++ b/src/lib/chat/quickCheck.ts
@@ -72,6 +72,7 @@ export type QuickCheckResult = {
   extraction?: QuickCheckExtractionSnapshot | null;
   sourceMode?: QuickCheckSourceMode;
   evidenceFileName?: string;
+  vm0007GapReportAuditId?: string;
 };
 
 export type QuickCheckStagedUpload = {
@@ -247,6 +248,7 @@ function normalizeResult(raw: unknown): QuickCheckResult | null {
     extraction,
     sourceMode: normalizeSourceMode(record.sourceMode),
     evidenceFileName: typeof record.evidenceFileName === "string" ? record.evidenceFileName : undefined,
+    vm0007GapReportAuditId: typeof record.vm0007GapReportAuditId === "string" ? record.vm0007GapReportAuditId : undefined,
   };
 }
 

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -1,0 +1,125 @@
+import type { RuleSummary } from "@/app/m/_lib/methodRules";
+import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import {
+  auditEvidence,
+  type MethodologyEvidenceAuditRule,
+  type MethodologyEvidenceAuditSummary,
+} from "@/lib/preverif/evidenceAudit";
+import {
+  getVm0007EvidenceContract,
+  normalizeVm0007RuleId,
+} from "@/lib/preverif/vm0007EvidenceContracts";
+
+const VM0007_GAP_REPORT_AUDIT_PREFIX = "a6:vm0007-gap-report-audit:v1:";
+
+export type Vm0007GapReportAuditRecord = {
+  auditId: string;
+  methodologyId: string;
+  methodologyVersion: string;
+  generatedAt: string;
+  evidenceFileName?: string;
+  audit: MethodologyEvidenceAuditSummary;
+};
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+function storageKey(auditId: string): string {
+  return `${VM0007_GAP_REPORT_AUDIT_PREFIX}${auditId.trim()}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function mapRule(rule: RuleSummary): MethodologyEvidenceAuditRule {
+  return {
+    id: rule.id,
+    title: rule.title,
+    summary: rule.summary ?? rule.snippet,
+    type: rule.type,
+    logic: rule.logic,
+    text: rule.text,
+  };
+}
+
+export function createVm0007GapReportAuditId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `vm0007-gap-${crypto.randomUUID()}`;
+  }
+  return `vm0007-gap-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function buildVm0007GapReportHref(auditId: string): string {
+  return `/internal/reports/vm0007-gap/${encodeURIComponent(auditId)}`;
+}
+
+export function saveVm0007GapReportAudit(record: Vm0007GapReportAuditRecord): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(storageKey(record.auditId), JSON.stringify(record));
+}
+
+export function loadVm0007GapReportAudit(auditId: string): Vm0007GapReportAuditRecord | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  const raw = storage.getItem(storageKey(auditId));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Vm0007GapReportAuditRecord;
+    if (!parsed || typeof parsed !== "object") return null;
+    if (typeof parsed.auditId !== "string" || typeof parsed.methodologyId !== "string" || typeof parsed.methodologyVersion !== "string") {
+      return null;
+    }
+    if (!parsed.audit || !Array.isArray(parsed.audit.results) || typeof parsed.audit.totalRules !== "number") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function hasVm0007GapReportAudit(auditId: string | null | undefined): boolean {
+  if (!auditId?.trim()) return false;
+  return loadVm0007GapReportAudit(auditId) !== null;
+}
+
+export function deriveVm0007ProjectName(evidenceFileName?: string): string {
+  const trimmed = evidenceFileName?.trim() ?? "";
+  if (!trimmed) return "VM0007 project";
+  const stem = trimmed.replace(/\.[^.]+$/, "").replace(/[_-]+/g, " ").trim();
+  return stem || "VM0007 project";
+}
+
+export function buildAndSaveVm0007GapReportAudit(input: {
+  methodologyId: string;
+  methodologyVersion: string;
+  evidenceFileName?: string;
+  rawPddText: string;
+  rules: readonly RuleSummary[];
+}): Vm0007GapReportAuditRecord | null {
+  if (input.methodologyId.trim().toUpperCase() !== "VM0007") return null;
+  if (!input.rawPddText.trim() || input.rules.length === 0) return null;
+
+  const context = getStructuredQueryContext(input.rawPddText);
+  const audit = auditEvidence({
+    rules: input.rules.map(mapRule),
+    evidenceDocument: context.evidenceDocument,
+    getContract: getVm0007EvidenceContract,
+    normalizeRuleId: normalizeVm0007RuleId,
+    sections: context.documentStructure.sections,
+    rawText: input.rawPddText,
+  });
+
+  const record: Vm0007GapReportAuditRecord = {
+    auditId: createVm0007GapReportAuditId(),
+    methodologyId: input.methodologyId.trim(),
+    methodologyVersion: input.methodologyVersion.trim(),
+    generatedAt: nowIso(),
+    evidenceFileName: input.evidenceFileName?.trim() || undefined,
+    audit,
+  };
+  saveVm0007GapReportAudit(record);
+  return record;
+}

--- a/tests/components/quickCheckPanel.upload-regression.test.tsx
+++ b/tests/components/quickCheckPanel.upload-regression.test.tsx
@@ -392,6 +392,9 @@ describe("QuickCheckPanel upload regression", () => {
     expect(text).toContain("Validation Report");
     expect(text).toContain("Title and headers read “Validation Report”.");
     expect(text).toContain("VM0007");
+    expect(text).not.toContain("Internal VM0007 report");
+    expect(text).not.toContain("Generate Gap Report Preview");
+    expect(text).not.toContain("Generate the internal VM0007 gap report preview from the extracted PDD text.");
     expect(text).not.toContain("page 1 title");
     expect(text).not.toContain('body: "validation opinion"');
   });

--- a/tests/components/quickCheckPanel.vm0007GapReportEntry.test.tsx
+++ b/tests/components/quickCheckPanel.vm0007GapReportEntry.test.tsx
@@ -1,0 +1,182 @@
+/** @jest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import QuickCheckPanel, { resolveGapReportSourceAnalysis } from "@/components/chat/QuickCheckPanel";
+import type { QuickCheckEvidenceAnalysis } from "@/lib/chat/quickCheckEvidence";
+
+function seedVm0007Session(auditId?: string, documentType = "Project Description Document") {
+  window.localStorage.setItem(
+    "a6:quick-check:claim-first:v1",
+    JSON.stringify({
+      draft: {
+        id: "draft-vm0007",
+        claimText: "Does this PDD support the forest definition requirement?",
+        methodologyId: "VM0007",
+        methodologyVersion: "v1-8",
+        evidenceIds: ["upload-1"],
+        status: "checked",
+        matchedRequirementId: "R-1-0001",
+        matchedRequirementLabel: "R-1-0001 · Forest definition",
+        resultId: "result-vm0007",
+        sourceMode: "uploaded_file",
+        evidenceFileName: "envira-amazonia-vm0007.pdf",
+        createdAt: "2026-07-01T00:00:00Z",
+        updatedAt: "2026-07-01T00:00:00Z",
+      },
+      result: {
+        id: "result-vm0007",
+        claimText: "Does this PDD support the forest definition requirement?",
+        requirementId: "R-1-0001",
+        requirementLabel: "R-1-0001 · Forest definition",
+        verdict: "Supported",
+        explanation: "Project-specific evidence supports the forest-definition rule.",
+        citations: ["S-1"],
+        nextStepHint: "Open full review to preserve this check.",
+        extraction: {
+          documentType,
+          extractedFacts: ["Project area remained forest land before project start."],
+          methodologyMentions: ["VM0007"],
+          warnings: [],
+          signals: {
+            parsedEvidenceCount: 1,
+            factCount: 1,
+            relevantFactCount: 1,
+            methodologyMentionCount: 1,
+            warningCount: 0,
+          },
+        },
+        sourceMode: "uploaded_file",
+        evidenceFileName: "envira-amazonia-vm0007.pdf",
+        vm0007GapReportAuditId: auditId,
+      },
+      stagedUploads: [],
+    }),
+  );
+}
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+describe("QuickCheckPanel VM0007 gap report entry point", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    window.localStorage.clear();
+
+    (global.fetch as unknown as typeof fetch) = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/methods/inventory")) {
+        return new Response(
+          JSON.stringify({
+            methods: [{ code: "VM0007", latestVersion: "v1-8", versions: ["v1-8"] }],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/methods/VM0007/v/v1-8/rules")) {
+        return new Response(
+          JSON.stringify({
+            rules: [
+              {
+                id: "R-1-0001",
+                title: "Forest definition",
+                snippet: "Forest definition evidence.",
+                tags: ["vm0007", "eligibility"],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`Unhandled fetch ${url}`);
+    }) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+  });
+
+  test("renders an internal report section with an active View Gap Report link when audit id exists", async () => {
+    seedVm0007Session("audit-quickcheck-1");
+
+    await act(async () => {
+      root.render(<QuickCheckPanel initialMethod="VM0007" initialVersion="v1-8" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Internal report");
+    expect(text).toContain("View Gap Report");
+
+    const link = Array.from(container.querySelectorAll("a")).find((item) => item.textContent?.includes("View Gap Report"));
+    expect(link?.getAttribute("href")).toBe("/internal/reports/vm0007-gap/audit-quickcheck-1");
+  });
+
+  test("renders a disabled helper state when VM0007 result has no report id yet", async () => {
+    seedVm0007Session();
+
+    await act(async () => {
+      root.render(<QuickCheckPanel initialMethod="VM0007" initialVersion="v1-8" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Internal report");
+    expect(text).toContain("Gap report not available yet");
+    expect(text).toContain("Run a VM0007 evidence audit to generate the internal report preview.");
+    expect(text).not.toContain("View Gap Report");
+  });
+
+  test("does not render the internal report card for validation-report extraction results", async () => {
+    seedVm0007Session("audit-quickcheck-validation", "Validation Report");
+
+    await act(async () => {
+      root.render(<QuickCheckPanel initialMethod="VM0007" initialVersion="v1-8" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).not.toContain("Internal report");
+    expect(text).not.toContain("View Gap Report");
+    expect(text).not.toContain("Gap report not available yet");
+  });
+
+  test("manual match fallback reuses extracted PDD analysis when direct analysis is missing", async () => {
+    const analysisFromState: QuickCheckEvidenceAnalysis = {
+      rawPddText: "VM0007 PDD extracted text.",
+      facts: [],
+      parsedEvidenceLabels: [],
+      documentTypes: ["pdd"],
+      methodologyMentions: ["VM0007"],
+      extractionConfidence: 1,
+      warnings: [],
+      parserAdapterId: "test-parser",
+    };
+
+    expect(resolveGapReportSourceAnalysis(null, analysisFromState)).toBe(analysisFromState);
+    expect(resolveGapReportSourceAnalysis(undefined, analysisFromState)).toBe(analysisFromState);
+    expect(resolveGapReportSourceAnalysis(analysisFromState, null)).toBe(analysisFromState);
+  });
+});


### PR DESCRIPTION
This PR fixes a frontend display bug where the VM0007 Gap Report Preview card appeared whenever VM0007 was detected, even for non-PDD documents such as Validation Reports.

Expected behavior:

- Show VM0007 gap report card only for PDD / Project Description-like documents.
- Hide it for Validation Reports, Verification Reports, Monitoring Reports, deeds, and registry records.
- Do not create a Phase 7 fixture.
- Do not change extraction logic.
- Do not change report conclusions.

Validation:

- `tests/components/quickCheckPanel.upload-regression.test.tsx`
- `tests/components/quickCheckPanel.vm0007GapReportEntry.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `npm run lint`
