### PR TITLE
test: add VM0007 quote integrity gate

### DIFF
--- a/tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts
+++ b/tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts
@@ -5,41 +5,14 @@ import { renderToStaticMarkup } from "react-dom/server";
 import Vm0007GapReportView from "@/components/preverif/Vm0007GapReportView";
 import { buildVm0007GapReport } from "@/lib/preverif/vm0007GapReport";
 import type { EvidenceAuditStatus, MethodologyEvidenceAuditResult, MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
-
-type FixtureStatus = "FOUND" | "UNCLEAR" | "MISSING" | "N/A";
-
-type RejectedQuote = {
-  quote: string;
-  rejectionReason: string;
-};
-
-type JudgmentFixture = {
-  checkId: string;
-  checkName: string;
-  expectedStatus: FixtureStatus;
-  expectedAnswer: string;
-  goldQuote: string | null;
-  page: number | null;
-  sectionHeading: string | null;
-  spanId: string | null;
-  whyQuoteIsSufficientOrInsufficient: string;
-  knownBadQuotesToReject: RejectedQuote[];
-  expectedClientAction: string | null;
-  coverageTags: string[];
-};
-
-type JudgmentFixtureSet = {
-  fixtureSetId: string;
-  title: string;
-  inputPdfName: string;
-  inputPdfPath: string;
-  sourcePdfTitle: string;
-  documentFamily: string;
-  methodology: string;
-  fixtureTruthPolicy: string;
-  expectedWarnings: string[];
-  checks: JudgmentFixture[];
-};
+import {
+  assertQuoteDoesNotAppearInSourceExcerpts,
+  assertVm0007JudgmentFixtureSet,
+  type FixtureStatus,
+  type JudgmentFixture,
+  type JudgmentFixtureSet,
+  type SourceExcerpts,
+} from "./preverifJudgmentFixtureGate";
 
 type ReportFixture = {
   fixtureSetId: string;
@@ -59,21 +32,12 @@ type ReportFixture = {
   expectedClientActionWording: string[];
 };
 
-type SourceExcerpts = {
-  inputPdfName: string;
-  inputPdfPath: string;
-  sourcePdfTitle: string;
-  documentFamily: string;
-  sourceTypeConfirmation: {
-    page: number;
-    sectionHeading: string;
-    quote: string;
-  };
-  pageExcerpts: Record<string, string>;
-};
-
 const AUDIT_FIXTURE = JSON.parse(
   fs.readFileSync("tests/fixtures/preverif/envira-vm0007-judgment-fixtures.json", "utf8"),
+) as JudgmentFixtureSet;
+
+const PD_REDD_FIXTURE = JSON.parse(
+  fs.readFileSync("tests/fixtures/preverif/pd-redd-vm0007-judgment-fixtures.json", "utf8"),
 ) as JudgmentFixtureSet;
 
 const REPORT_FIXTURE = JSON.parse(
@@ -84,9 +48,9 @@ const SOURCE_EXCERPTS = JSON.parse(
   fs.readFileSync("tests/fixtures/preverif/envira-vm0007-source-excerpts.json", "utf8"),
 ) as SourceExcerpts;
 
-function normalizeText(value: string | null | undefined): string {
-  return (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
-}
+const PD_REDD_SOURCE_EXCERPTS = JSON.parse(
+  fs.readFileSync("tests/fixtures/preverif/pd-redd-vm0007-source-excerpts.json", "utf8"),
+) as SourceExcerpts;
 
 function toAuditStatus(status: FixtureStatus): EvidenceAuditStatus {
   switch (status) {
@@ -190,27 +154,67 @@ describe("Envira VM0007 judgment fixtures", () => {
   });
 
   it("anchors every gold quote and section heading to exact excerpts from the specified PDF", () => {
-    expect(SOURCE_EXCERPTS.inputPdfName).toBe(AUDIT_FIXTURE.inputPdfName);
-    expect(SOURCE_EXCERPTS.inputPdfPath).toBe(AUDIT_FIXTURE.inputPdfPath);
-    expect(SOURCE_EXCERPTS.sourcePdfTitle).toBe(AUDIT_FIXTURE.sourcePdfTitle);
-    expect(SOURCE_EXCERPTS.documentFamily).toBe(AUDIT_FIXTURE.documentFamily);
+    assertVm0007JudgmentFixtureSet(AUDIT_FIXTURE, SOURCE_EXCERPTS);
+  });
 
-    for (const check of AUDIT_FIXTURE.checks) {
-      if (check.page == null) {
-        expect(check.goldQuote).toBeNull();
-        expect(check.sectionHeading).toBeNull();
-        continue;
-      }
+  it("keeps Envira quotes out of the PD_REDD source excerpts", () => {
+    const enviraQuote = AUDIT_FIXTURE.checks.find((check) => check.checkId === "R-1-0002")?.goldQuote;
+    expect(enviraQuote).toBeTruthy();
+    assertQuoteDoesNotAppearInSourceExcerpts(enviraQuote!, PD_REDD_SOURCE_EXCERPTS);
+  });
 
-      const excerpt = SOURCE_EXCERPTS.pageExcerpts[String(check.page)];
-      expect(excerpt).toBeTruthy();
-      expect(normalizeText(excerpt)).toContain(normalizeText(check.sectionHeading));
-      expect(normalizeText(excerpt)).toContain(normalizeText(check.goldQuote));
+  it("fails when a gold quote is stitched, paraphrased, on the wrong page, or on the wrong section", () => {
+    const stitched = JSON.parse(JSON.stringify(AUDIT_FIXTURE)) as JudgmentFixtureSet;
+    stitched.checks = stitched.checks.map((check) =>
+      check.checkId === "R-5-0003"
+        ? {
+            ...check,
+            goldQuote: "Leakage emissions from displacement of planned deforestation are estimated in conformance with the VCS modular REDD methodology VM0007, specifically the LK-ASP and LK-ME modules. The initial PRA indicated that the agents of deforestation comprise in majority the local population",
+          }
+        : check,
+    );
 
-      for (const rejected of check.knownBadQuotesToReject) {
-        expect(rejected.rejectionReason.trim().length).toBeGreaterThan(0);
-      }
-    }
+    const paraphrased = JSON.parse(JSON.stringify(AUDIT_FIXTURE)) as JudgmentFixtureSet;
+    paraphrased.checks = paraphrased.checks.map((check) =>
+      check.checkId === "R-2-0014"
+        ? { ...check, goldQuote: "The crediting period lasts 30 years from August 2, 2012 until August 1, 2042." }
+        : check,
+    );
+
+    const wrongPage = JSON.parse(JSON.stringify(AUDIT_FIXTURE)) as JudgmentFixtureSet;
+    wrongPage.checks = wrongPage.checks.map((check) =>
+      check.checkId === "R-3-0001"
+        ? { ...check, page: 29 }
+        : check,
+    );
+
+    const wrongSection = JSON.parse(JSON.stringify(AUDIT_FIXTURE)) as JudgmentFixtureSet;
+    wrongSection.checks = wrongSection.checks.map((check) =>
+      check.checkId === "R-6-0002"
+        ? { ...check, sectionHeading: "3.3 Leakage" }
+        : check,
+    );
+
+    expect(() => assertVm0007JudgmentFixtureSet(stitched, SOURCE_EXCERPTS)).toThrow();
+    expect(() => assertVm0007JudgmentFixtureSet(paraphrased, SOURCE_EXCERPTS)).toThrow();
+    expect(() => assertVm0007JudgmentFixtureSet(wrongPage, SOURCE_EXCERPTS)).toThrow();
+    expect(() => assertVm0007JudgmentFixtureSet(wrongSection, SOURCE_EXCERPTS)).toThrow();
+  });
+
+  it("fails when Envira evidence is injected into PD_REDD fixtures", () => {
+    const mutated = JSON.parse(JSON.stringify(PD_REDD_FIXTURE)) as JudgmentFixtureSet;
+    mutated.checks = mutated.checks.map((check) =>
+      check.checkId === "R-3-0001"
+        ? {
+            ...check,
+            goldQuote: "Baseline deforestation in the project area falls within the planned deforestation category, as the agents of deforestation is the project proponent.",
+            page: 32,
+            sectionHeading: "2.2 Applicability of Methodology",
+          }
+        : check,
+    );
+
+    expect(() => assertVm0007JudgmentFixtureSet(mutated, PD_REDD_SOURCE_EXCERPTS)).toThrow();
   });
 
   it("renders the fixture-backed report contract without misleading wording", () => {

--- a/tests/lib/preverif.vm0007PdReddJudgmentFixtures.test.ts
+++ b/tests/lib/preverif.vm0007PdReddJudgmentFixtures.test.ts
@@ -23,6 +23,13 @@ const ENVIRA_SOURCE_EXCERPTS = JSON.parse(
   fs.readFileSync("tests/fixtures/preverif/envira-vm0007-source-excerpts.json", "utf8"),
 ) as SourceExcerpts;
 
+const PHASE_STATUS = JSON.parse(
+  fs.readFileSync("docs/roadmaps/vm0007-judgement-fixtures/phase-status.json", "utf8"),
+) as {
+  goals: Array<{ id: string; status: string }>;
+  phases: Record<string, { status: string; summary: string }>;
+};
+
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
 }
@@ -38,6 +45,44 @@ describe("PD_REDD VM0007 judgment fixtures", () => {
     expect(SOURCE_EXCERPTS.sourceTypeConfirmation.page).toBe(1);
     expect(SOURCE_EXCERPTS.sourceTypeConfirmation.quote).toContain("PROJECT DESCRIPTION: VCS");
     expect(SOURCE_EXCERPTS.sourceTypeConfirmation.quote).toContain("COMMUNITY BASED AVOIDED DEFORESTATION PROJECT");
+    expect(PHASE_STATUS.goals.find((goal) => goal.id === "phase_1_envira_vm0007_judgment_fixtures")?.status).toBe("done");
+    expect(PHASE_STATUS.goals.find((goal) => goal.id === "phase_2_pd_redd_vm0007_judgment_fixtures")?.status).toBe("done");
+    expect(PHASE_STATUS.phases.phase_2_pd_redd_vm0007_judgment_fixtures.status).toBe("done");
+    expect(PHASE_STATUS.phases.phase_2_pd_redd_vm0007_judgment_fixtures.summary).toContain("PD_REDD");
+  });
+
+  it("defines a complete 5-10 check fixture contract with PD_REDD-specific rejection coverage", () => {
+    expect(AUDIT_FIXTURE.methodology).toBe("VM0007");
+    expect(AUDIT_FIXTURE.checks.length).toBeGreaterThanOrEqual(5);
+    expect(AUDIT_FIXTURE.checks.length).toBeLessThanOrEqual(10);
+    expect(AUDIT_FIXTURE.expectedWarnings).toHaveLength(3);
+
+    expect(AUDIT_FIXTURE.checks.some((check) => check.expectedStatus === "FOUND")).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.expectedStatus === "UNCLEAR")).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.expectedStatus === "MISSING")).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.expectedStatus === "N/A")).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.coverageTags.includes("reject_generic_methodology_text"))).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.coverageTags.includes("reject_module_table_text"))).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.coverageTags.includes("reject_envira_specific_evidence"))).toBe(true);
+    expect(AUDIT_FIXTURE.checks.some((check) => check.coverageTags.includes("same_rule_different_pdf_different_judgment"))).toBe(true);
+
+    for (const check of AUDIT_FIXTURE.checks) {
+      expect(check.checkId).toMatch(/^R-\d-\d{4}$/);
+      expect(check.checkName.trim().length).toBeGreaterThan(0);
+      expect(check.expectedAnswer.trim().length).toBeGreaterThan(0);
+      expect(check.whyQuoteIsSufficientOrInsufficient.trim().length).toBeGreaterThan(0);
+      expect(check.knownBadQuotesToReject.length).toBeGreaterThan(0);
+
+      if (check.expectedStatus === "FOUND" || check.expectedStatus === "UNCLEAR" || check.expectedStatus === "N/A") {
+        expect(check.goldQuote).not.toBeNull();
+        expect(check.page).not.toBeNull();
+        expect(check.sectionHeading).not.toBeNull();
+      }
+
+      if (check.expectedStatus === "UNCLEAR" || check.expectedStatus === "MISSING" || check.expectedStatus === "N/A") {
+        expect(check.expectedClientAction?.trim().length).toBeGreaterThan(0);
+      }
+    }
   });
 
   it("anchors every gold quote and section heading to exact excerpts from the specified PDF", () => {
@@ -91,7 +136,7 @@ describe("PD_REDD VM0007 judgment fixtures", () => {
     expect(() => assertVm0007JudgmentFixtureSet(wrongSection, SOURCE_EXCERPTS)).toThrow();
   });
 
-  it("fails when Envira evidence is injected into PD_REDD fixtures", () => {
+  it("fails when PD_REDD evidence is injected into Envira fixtures", () => {
     const mutated = JSON.parse(JSON.stringify(ENVIRA_FIXTURE)) as JudgmentFixtureSet;
     mutated.checks = mutated.checks.map((check) =>
       check.checkId === "R-2-0003"

--- a/tests/lib/preverif.vm0007PdReddJudgmentFixtures.test.ts
+++ b/tests/lib/preverif.vm0007PdReddJudgmentFixtures.test.ts
@@ -1,169 +1,116 @@
 import fs from "node:fs";
 import { describe, expect, it } from "@jest/globals";
+import {
+  assertQuoteDoesNotAppearInSourceExcerpts,
+  assertVm0007JudgmentFixtureSet,
+  type JudgmentFixtureSet,
+  type SourceExcerpts,
+} from "./preverifJudgmentFixtureGate";
 
-type FixtureStatus = "FOUND" | "UNCLEAR" | "MISSING" | "N/A";
-
-type RejectedQuote = {
-  quote: string;
-  rejectionReason: string;
-};
-
-type JudgmentFixture = {
-  checkId: string;
-  checkName: string;
-  expectedStatus: FixtureStatus;
-  expectedAnswer: string;
-  goldQuote: string | null;
-  page: number | null;
-  sectionHeading: string | null;
-  spanId: string | null;
-  whyQuoteIsSufficientOrInsufficient: string;
-  knownBadQuotesToReject: RejectedQuote[];
-  expectedClientAction: string | null;
-  coverageTags: string[];
-};
-
-type JudgmentFixtureSet = {
-  fixtureSetId: string;
-  title: string;
-  inputPdfName: string;
-  inputPdfPath: string;
-  sourcePdfTitle: string;
-  documentFamily: string;
-  methodology: string;
-  fixtureTruthPolicy: string;
-  expectedWarnings: string[];
-  checks: JudgmentFixture[];
-};
-
-type SourceExcerpts = {
-  inputPdfName: string;
-  inputPdfPath: string;
-  sourcePdfTitle: string;
-  documentFamily: string;
-  sourceTypeConfirmation: {
-    page: number;
-    sectionHeading: string;
-    quote: string;
-  };
-  pageExcerpts: Record<string, string>;
-};
-
-type PhaseStatus = {
-  goals: Array<{
-    id: string;
-    status: string;
-  }>;
-  phases: Record<string, {
-    status: string;
-    summary: string;
-  }>;
-};
-
-const PD_REDD_FIXTURE = JSON.parse(
+const AUDIT_FIXTURE = JSON.parse(
   fs.readFileSync("tests/fixtures/preverif/pd-redd-vm0007-judgment-fixtures.json", "utf8"),
 ) as JudgmentFixtureSet;
-
-const PD_REDD_SOURCE_EXCERPTS = JSON.parse(
-  fs.readFileSync("tests/fixtures/preverif/pd-redd-vm0007-source-excerpts.json", "utf8"),
-) as SourceExcerpts;
 
 const ENVIRA_FIXTURE = JSON.parse(
   fs.readFileSync("tests/fixtures/preverif/envira-vm0007-judgment-fixtures.json", "utf8"),
 ) as JudgmentFixtureSet;
 
-const PHASE_STATUS = JSON.parse(
-  fs.readFileSync("docs/roadmaps/vm0007-judgement-fixtures/phase-status.json", "utf8"),
-) as PhaseStatus;
+const SOURCE_EXCERPTS = JSON.parse(
+  fs.readFileSync("tests/fixtures/preverif/pd-redd-vm0007-source-excerpts.json", "utf8"),
+) as SourceExcerpts;
+
+const ENVIRA_SOURCE_EXCERPTS = JSON.parse(
+  fs.readFileSync("tests/fixtures/preverif/envira-vm0007-source-excerpts.json", "utf8"),
+) as SourceExcerpts;
 
 function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
 }
 
 describe("PD_REDD VM0007 judgment fixtures", () => {
-  it("confirms the exact source document is the PD_REDD project description PDF and Phase 2 is marked done", () => {
-    expect(PD_REDD_FIXTURE.inputPdfName).toBe("PD_REDD_v1_130.pdf");
-    expect(PD_REDD_FIXTURE.inputPdfPath).toBe("/Users/stphen/Desktop/test folder/VCS:2324/PD_REDD_v1_130.pdf");
-    expect(PD_REDD_FIXTURE.sourcePdfTitle).toBe(
+  it("confirms the exact source document is the PD_REDD project description PDF", () => {
+    expect(AUDIT_FIXTURE.inputPdfName).toBe("PD_REDD_v1_130.pdf");
+    expect(AUDIT_FIXTURE.inputPdfPath).toBe("/Users/stphen/Desktop/test folder/VCS:2324/PD_REDD_v1_130.pdf");
+    expect(AUDIT_FIXTURE.sourcePdfTitle).toBe(
       "PROJECT DESCRIPTION: VCS Version 3 — Community Based Avoided Deforestation Project in Guinea-Bissau",
     );
-    expect(PD_REDD_FIXTURE.documentFamily).toBe("Project Description / PD");
-    expect(PD_REDD_SOURCE_EXCERPTS.sourceTypeConfirmation.page).toBe(1);
-    expect(PD_REDD_SOURCE_EXCERPTS.sourceTypeConfirmation.quote).toContain("PROJECT DESCRIPTION: VCS");
-    expect(PD_REDD_SOURCE_EXCERPTS.sourceTypeConfirmation.quote).toContain("COMMUNITY BASED AVOIDED DEFORESTATION PROJECT");
-
-    expect(
-      PHASE_STATUS.goals.find((goal) => goal.id === "phase_1_envira_vm0007_judgment_fixtures")?.status,
-    ).toBe("done");
-    expect(
-      PHASE_STATUS.goals.find((goal) => goal.id === "phase_2_pd_redd_vm0007_judgment_fixtures")?.status,
-    ).toBe("done");
-    expect(PHASE_STATUS.phases.phase_2_pd_redd_vm0007_judgment_fixtures.status).toBe("done");
-    expect(PHASE_STATUS.phases.phase_2_pd_redd_vm0007_judgment_fixtures.summary).toContain("PD_REDD");
+    expect(AUDIT_FIXTURE.documentFamily).toBe("Project Description / PD");
+    expect(SOURCE_EXCERPTS.sourceTypeConfirmation.page).toBe(1);
+    expect(SOURCE_EXCERPTS.sourceTypeConfirmation.quote).toContain("PROJECT DESCRIPTION: VCS");
+    expect(SOURCE_EXCERPTS.sourceTypeConfirmation.quote).toContain("COMMUNITY BASED AVOIDED DEFORESTATION PROJECT");
   });
 
-  it("defines a complete 5-10 check fixture contract with PD_REDD-specific rejection coverage", () => {
-    expect(PD_REDD_FIXTURE.methodology).toBe("VM0007");
-    expect(PD_REDD_FIXTURE.checks.length).toBeGreaterThanOrEqual(5);
-    expect(PD_REDD_FIXTURE.checks.length).toBeLessThanOrEqual(10);
-    expect(PD_REDD_FIXTURE.expectedWarnings).toHaveLength(3);
-
-    expect(PD_REDD_FIXTURE.checks.some((check) => check.expectedStatus === "FOUND")).toBe(true);
-    expect(PD_REDD_FIXTURE.checks.some((check) => check.expectedStatus === "UNCLEAR")).toBe(true);
-    expect(PD_REDD_FIXTURE.checks.some((check) => check.expectedStatus === "MISSING")).toBe(true);
-    expect(PD_REDD_FIXTURE.checks.some((check) => check.expectedStatus === "N/A")).toBe(true);
-    expect(PD_REDD_FIXTURE.checks.some((check) => check.coverageTags.includes("reject_generic_methodology_text"))).toBe(true);
-    expect(PD_REDD_FIXTURE.checks.some((check) => check.coverageTags.includes("reject_module_table_text"))).toBe(true);
-    expect(PD_REDD_FIXTURE.checks.some((check) => check.coverageTags.includes("reject_envira_specific_evidence"))).toBe(true);
-    expect(PD_REDD_FIXTURE.checks.some((check) => check.coverageTags.includes("same_rule_different_pdf_different_judgment"))).toBe(true);
-
-    for (const check of PD_REDD_FIXTURE.checks) {
-      expect(check.checkId).toMatch(/^R-\d-\d{4}$/);
-      expect(check.checkName.trim().length).toBeGreaterThan(0);
-      expect(check.expectedAnswer.trim().length).toBeGreaterThan(0);
-      expect(check.whyQuoteIsSufficientOrInsufficient.trim().length).toBeGreaterThan(0);
-      expect(check.knownBadQuotesToReject.length).toBeGreaterThan(0);
-
-      if (check.expectedStatus === "FOUND" || check.expectedStatus === "UNCLEAR" || check.expectedStatus === "N/A") {
-        expect(check.goldQuote).not.toBeNull();
-        expect(check.page).not.toBeNull();
-        expect(check.sectionHeading).not.toBeNull();
-      }
-
-      if (check.expectedStatus === "UNCLEAR" || check.expectedStatus === "MISSING" || check.expectedStatus === "N/A") {
-        expect(check.expectedClientAction?.trim().length).toBeGreaterThan(0);
-      }
-    }
+  it("anchors every gold quote and section heading to exact excerpts from the specified PDF", () => {
+    assertVm0007JudgmentFixtureSet(AUDIT_FIXTURE, SOURCE_EXCERPTS);
   });
 
-  it("anchors every gold quote and section heading to exact excerpts from the specified PD_REDD PDF", () => {
-    expect(PD_REDD_SOURCE_EXCERPTS.inputPdfName).toBe(PD_REDD_FIXTURE.inputPdfName);
-    expect(PD_REDD_SOURCE_EXCERPTS.inputPdfPath).toBe(PD_REDD_FIXTURE.inputPdfPath);
-    expect(PD_REDD_SOURCE_EXCERPTS.sourcePdfTitle).toBe(PD_REDD_FIXTURE.sourcePdfTitle);
-    expect(PD_REDD_SOURCE_EXCERPTS.documentFamily).toBe(PD_REDD_FIXTURE.documentFamily);
+  it("keeps PD_REDD quotes out of the Envira source excerpts", () => {
+    const pdrQuote = AUDIT_FIXTURE.checks.find((check) => check.checkId === "R-2-0014")?.goldQuote;
+    expect(pdrQuote).toBeTruthy();
+    assertQuoteDoesNotAppearInSourceExcerpts(pdrQuote!, ENVIRA_SOURCE_EXCERPTS);
+  });
 
-    for (const check of PD_REDD_FIXTURE.checks) {
-      if (check.page == null) {
-        expect(check.goldQuote).toBeNull();
-        expect(check.sectionHeading).toBeNull();
-        continue;
-      }
+  it("fails when a PD_REDD quote is stitched, paraphrased, on the wrong page, or on the wrong section", () => {
+    const stitched = JSON.parse(JSON.stringify(AUDIT_FIXTURE)) as JudgmentFixtureSet;
+    stitched.checks = stitched.checks.map((check) =>
+      check.checkId === "R-5-0003"
+        ? {
+            ...check,
+            goldQuote: "Leakage emissions accounted for are entirely from displacement of unplanned deforestation and were estimated applying the LK-ASU (v1.0) module. The initial PRA indicated that the agents of deforestation comprise in majority the local population",
+          }
+        : check,
+    );
 
-      const excerpt = PD_REDD_SOURCE_EXCERPTS.pageExcerpts[String(check.page)];
-      expect(excerpt).toBeTruthy();
-      expect(normalizeText(excerpt)).toContain(normalizeText(check.sectionHeading));
-      expect(normalizeText(excerpt)).toContain(normalizeText(check.goldQuote));
+    const paraphrased = JSON.parse(JSON.stringify(AUDIT_FIXTURE)) as JudgmentFixtureSet;
+    paraphrased.checks = paraphrased.checks.map((check) =>
+      check.checkId === "R-4-0001"
+        ? {
+            ...check,
+            goldQuote: "The project uses VT0001 and has financial, institutional, and first-of-its-kind barriers.",
+          }
+        : check,
+    );
 
-      for (const rejected of check.knownBadQuotesToReject) {
-        expect(rejected.rejectionReason.trim().length).toBeGreaterThan(0);
-      }
-    }
+    const wrongPage = JSON.parse(JSON.stringify(AUDIT_FIXTURE)) as JudgmentFixtureSet;
+    wrongPage.checks = wrongPage.checks.map((check) =>
+      check.checkId === "R-3-0001"
+        ? { ...check, page: 22 }
+        : check,
+    );
+
+    const wrongSection = JSON.parse(JSON.stringify(AUDIT_FIXTURE)) as JudgmentFixtureSet;
+    wrongSection.checks = wrongSection.checks.map((check) =>
+      check.checkId === "R-6-0002"
+        ? { ...check, sectionHeading: "1.12.4 Participation under Other GHG Programs" }
+        : check,
+    );
+
+    expect(() => assertVm0007JudgmentFixtureSet(stitched, SOURCE_EXCERPTS)).toThrow();
+    expect(() => assertVm0007JudgmentFixtureSet(paraphrased, SOURCE_EXCERPTS)).toThrow();
+    expect(() => assertVm0007JudgmentFixtureSet(wrongPage, SOURCE_EXCERPTS)).toThrow();
+    expect(() => assertVm0007JudgmentFixtureSet(wrongSection, SOURCE_EXCERPTS)).toThrow();
+  });
+
+  it("fails when Envira evidence is injected into PD_REDD fixtures", () => {
+    const mutated = JSON.parse(JSON.stringify(ENVIRA_FIXTURE)) as JudgmentFixtureSet;
+    mutated.checks = mutated.checks.map((check) =>
+      check.checkId === "R-2-0003"
+        ? {
+            ...check,
+            goldQuote: "The project is not registered or seeking registration under any other GHG Program.",
+            page: 22,
+            sectionHeading: "1.12.4 Participation under Other GHG Programs",
+          }
+        : check,
+    );
+
+    expect(() => assertVm0007JudgmentFixtureSet(mutated, ENVIRA_SOURCE_EXCERPTS)).toThrow();
   });
 
   it("does not let Envira evidence or answers leak into the PD_REDD fixture set", () => {
     let enviraLeakageGuardCount = 0;
 
-    for (const check of PD_REDD_FIXTURE.checks) {
+    for (const check of AUDIT_FIXTURE.checks) {
       expect(normalizeText(check.expectedAnswer)).not.toContain("envira");
 
       if (check.coverageTags.includes("reject_envira_specific_evidence")) {
@@ -179,13 +126,13 @@ describe("PD_REDD VM0007 judgment fixtures", () => {
 
   it("uses at least one overlapping rule with a different judgment than Envira", () => {
     const enviraByRule = new Map(ENVIRA_FIXTURE.checks.map((check) => [check.checkId, check]));
-    const pdReddWithDifferentStatus = PD_REDD_FIXTURE.checks.find((check) => {
+    const pdReddWithDifferentStatus = AUDIT_FIXTURE.checks.find((check) => {
       const envira = enviraByRule.get(check.checkId);
       return envira && envira.expectedStatus !== check.expectedStatus;
     });
 
     expect(pdReddWithDifferentStatus?.checkId).toBe("R-1-0004");
     expect(enviraByRule.get("R-1-0004")?.expectedStatus).toBe("UNCLEAR");
-    expect(PD_REDD_FIXTURE.checks.find((check) => check.checkId === "R-1-0004")?.expectedStatus).toBe("N/A");
+    expect(AUDIT_FIXTURE.checks.find((check) => check.checkId === "R-1-0004")?.expectedStatus).toBe("N/A");
   });
 });

--- a/tests/lib/preverifJudgmentFixtureGate.ts
+++ b/tests/lib/preverifJudgmentFixtureGate.ts
@@ -1,0 +1,124 @@
+import { expect } from "@jest/globals";
+
+export type FixtureStatus = "FOUND" | "UNCLEAR" | "MISSING" | "N/A";
+
+export type RejectedQuote = {
+  quote: string;
+  rejectionReason: string;
+};
+
+export type JudgmentFixture = {
+  checkId: string;
+  checkName: string;
+  expectedStatus: FixtureStatus;
+  expectedAnswer: string;
+  goldQuote: string | null;
+  page: number | null;
+  sectionHeading: string | null;
+  spanId: string | null;
+  whyQuoteIsSufficientOrInsufficient: string;
+  knownBadQuotesToReject: RejectedQuote[];
+  expectedClientAction: string | null;
+  coverageTags: string[];
+};
+
+export type JudgmentFixtureSet = {
+  fixtureSetId: string;
+  title: string;
+  inputPdfName: string;
+  inputPdfPath: string;
+  sourcePdfTitle: string;
+  documentFamily: string;
+  methodology: string;
+  fixtureTruthPolicy: string;
+  expectedWarnings: string[];
+  checks: JudgmentFixture[];
+};
+
+export type SourceExcerpts = {
+  inputPdfName: string;
+  inputPdfPath: string;
+  sourcePdfTitle: string;
+  documentFamily: string;
+  sourceTypeConfirmation: {
+    page: number;
+    sectionHeading: string;
+    quote: string;
+  };
+  pageExcerpts: Record<string, string>;
+};
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function requireNonEmpty(value: string | null | undefined, label: string): void {
+  expect(value?.trim().length ?? 0).toBeGreaterThan(0);
+}
+
+function assertQuoteAnchored(check: JudgmentFixture, excerpt: string): void {
+  requireNonEmpty(check.goldQuote, `${check.checkId} goldQuote`);
+  requireNonEmpty(check.sectionHeading, `${check.checkId} sectionHeading`);
+  expect(normalizeText(excerpt)).toContain(normalizeText(check.sectionHeading));
+  expect(normalizeText(excerpt)).toContain(normalizeText(check.goldQuote));
+}
+
+export function assertVm0007JudgmentFixtureSet(
+  fixtureSet: JudgmentFixtureSet,
+  sourceExcerpts: SourceExcerpts,
+): void {
+  expect(sourceExcerpts.inputPdfName).toBe(fixtureSet.inputPdfName);
+  expect(sourceExcerpts.inputPdfPath).toBe(fixtureSet.inputPdfPath);
+  expect(sourceExcerpts.sourcePdfTitle).toBe(fixtureSet.sourcePdfTitle);
+  expect(sourceExcerpts.documentFamily).toBe(fixtureSet.documentFamily);
+
+  for (const check of fixtureSet.checks) {
+    expect(check.checkId).toMatch(/^R-\d-\d{4}$/);
+    requireNonEmpty(check.checkName, `${check.checkId} checkName`);
+    requireNonEmpty(check.expectedAnswer, `${check.checkId} expectedAnswer`);
+    requireNonEmpty(check.whyQuoteIsSufficientOrInsufficient, `${check.checkId} whyQuoteIsSufficientOrInsufficient`);
+    expect(check.knownBadQuotesToReject.length).toBeGreaterThan(0);
+
+    for (const rejected of check.knownBadQuotesToReject) {
+      requireNonEmpty(rejected.quote, `${check.checkId} rejected quote`);
+      requireNonEmpty(rejected.rejectionReason, `${check.checkId} rejection reason`);
+    }
+
+    if (check.expectedStatus === "FOUND" || check.expectedStatus === "N/A") {
+      requireNonEmpty(check.goldQuote, `${check.checkId} goldQuote`);
+      expect(check.page).not.toBeNull();
+      expect(check.sectionHeading).not.toBeNull();
+    }
+
+    if (check.expectedStatus === "MISSING") {
+      expect(check.goldQuote).toBeNull();
+      expect(check.page).toBeNull();
+      expect(check.sectionHeading).toBeNull();
+      requireNonEmpty(check.expectedClientAction, `${check.checkId} expectedClientAction`);
+    }
+
+    if (check.expectedStatus === "UNCLEAR") {
+      if (check.goldQuote != null) {
+        expect(check.page).not.toBeNull();
+        expect(check.sectionHeading).not.toBeNull();
+      }
+      requireNonEmpty(check.expectedClientAction, `${check.checkId} expectedClientAction`);
+    }
+
+    if (check.goldQuote != null) {
+      const excerpt = sourceExcerpts.pageExcerpts[String(check.page)];
+      expect(excerpt).toBeTruthy();
+      assertQuoteAnchored(check, excerpt);
+    }
+  }
+}
+
+export function assertQuoteDoesNotAppearInSourceExcerpts(
+  quote: string,
+  sourceExcerpts: SourceExcerpts,
+): void {
+  const normalizedQuote = normalizeText(quote);
+  for (const excerpt of Object.values(sourceExcerpts.pageExcerpts)) {
+    expect(normalizeText(excerpt)).not.toContain(normalizedQuote);
+  }
+}


### PR DESCRIPTION
## What
- Add a shared VM0007 judgment-fixture quote-integrity gate.
- Apply it to the Envira and PD_REDD VM0007 fixture suites.
- Add negative coverage for stitched, paraphrased, wrong-page, wrong-section, and cross-PDF evidence leakage.

## Why
- PR #899 exposed that a fixture can have the right judgment while still carrying a bad goldQuote.
- This gate makes the fixture contract verify that each goldQuote is exact, contiguous, page-anchored, and from the right PDF.

## Validation
- `npx jest tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts --runInBand`
- `npx jest tests/lib/preverif.vm0007PdReddJudgmentFixtures.test.ts --runInBand`
