### PR TITLE
test: add reusable PDD fixture quality gate

### DIFF
--- a/tests/lib/preverif/fixtureQualityGate.test.ts
+++ b/tests/lib/preverif/fixtureQualityGate.test.ts
@@ -1,0 +1,177 @@
+import fs from "node:fs";
+import { describe, expect, it } from "@jest/globals";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import Vm0007GapReportView from "@/components/preverif/Vm0007GapReportView";
+import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import { auditEvidence, type MethodologyEvidenceAuditResult, type MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
+import { buildVm0007GapReport } from "@/lib/preverif/vm0007GapReport";
+import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif/vm0007EvidenceContracts";
+import { VM0007_SYNCED_RULES, readQuickCheckFixtureText } from "../preverifVm0007Fixtures";
+import { assertFixtureQualityGate } from "./fixtureQualityGate";
+import type { JudgmentFixtureSet, SourceExcerpts } from "../preverifJudgmentFixtureGate";
+
+const AUDIT_FIXTURE = JSON.parse(
+  fs.readFileSync("tests/fixtures/preverif/envira-vm0007-judgment-fixtures.json", "utf8"),
+) as JudgmentFixtureSet;
+
+const REPORT_FIXTURE = JSON.parse(
+  fs.readFileSync("tests/fixtures/preverif/envira-vm0007-report-fixture.json", "utf8"),
+);
+
+const SOURCE_EXCERPTS = JSON.parse(
+  fs.readFileSync("tests/fixtures/preverif/envira-vm0007-source-excerpts.json", "utf8"),
+) as SourceExcerpts;
+
+const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
+
+function auditText(rawText: string): MethodologyEvidenceAuditSummary {
+  const context = getStructuredQueryContext(rawText);
+  return auditEvidence({
+    rules: VM0007_SYNCED_RULES,
+    evidenceDocument: context.evidenceDocument,
+    getContract: getVm0007EvidenceContract,
+    normalizeRuleId: normalizeVm0007RuleId,
+    sections: context.documentStructure.sections,
+    rawText,
+  });
+}
+
+function withStatus(
+  result: MethodologyEvidenceAuditResult,
+  overrides: Partial<MethodologyEvidenceAuditResult>,
+): MethodologyEvidenceAuditResult {
+  return { ...result, ...overrides };
+}
+
+function buildMixedAudit(): MethodologyEvidenceAuditSummary {
+  const base = auditText(ENVIRA_TEXT);
+  const results = base.results.map((result) => {
+    if (result.ruleId === "R-1-0002") {
+      return withStatus(result, {
+        status: "partially_supported",
+        gap: "The current PDD names the baseline category but does not explain why that category fits the project area.",
+        clientAction: "Add the project-specific baseline deforestation category rationale and the supporting land-use evidence.",
+      });
+    }
+    if (result.ruleId === "R-1-0003") {
+      return withStatus(result, {
+        status: "missing_evidence",
+        bestEvidenceQuote: null,
+        section: null,
+        page: null,
+        span: null,
+        gap: "The current PDD does not show the AUDef agent evidence required for this rule.",
+        clientAction: "Add the project-specific evidence for the relevant deforestation agents and explain how they drive baseline pressure.",
+        assessmentReason: "The current PDD does not yet show project-specific evidence for this rule.",
+        reasonSelected: "No reliable project-specific span was selected for this rule.",
+      });
+    }
+    if (result.ruleId === "R-1-0005") {
+      return withStatus(result, {
+        status: "not_applicable",
+        bestEvidenceQuote: "This is a REDD/APD project in upland forest landscapes. No peat soils or tidal wetland activity occur in the project area.",
+        section: "Project Activity Description",
+        page: 2,
+        span: "envira-amazonia-vm0007:p2:b5:span-2",
+        gap: "",
+        clientAction: "Keep scope basis clear.",
+        assessmentReason: "The current PDD scope statement shows this wetland-specific rule does not apply to the project.",
+      });
+    }
+    return result;
+  });
+
+  return {
+    results,
+    totals: {
+      supported_by_pdd: results.filter((entry) => entry.status === "supported_by_pdd").length,
+      partially_supported: results.filter((entry) => entry.status === "partially_supported").length,
+      missing_evidence: results.filter((entry) => entry.status === "missing_evidence").length,
+      not_applicable: results.filter((entry) => entry.status === "not_applicable").length,
+      manual_review_needed: results.filter((entry) => entry.status === "manual_review_needed").length,
+    },
+    totalRules: results.length,
+  };
+}
+
+function buildReport(audit: MethodologyEvidenceAuditSummary) {
+  return buildVm0007GapReport({
+    reportId: "VRGR-VM0007-001",
+    generatedAt: "2026-07-01T10:00:00Z",
+    project: {
+      name: "The Envira Amazonia Project",
+      projectId: "envira-fixture",
+      region: "Acre, Brazil",
+    },
+    methodology: {
+      code: "VM0007",
+      version: "4.2",
+      name: "VM0007: REDD Methodology Modules (REDD-MF)",
+    },
+    audit,
+  });
+}
+
+describe("fixture quality gate", () => {
+  it("accepts the current Envira 58-rule audit fixture and report", () => {
+    const audit = buildMixedAudit();
+    const report = buildReport(audit);
+    const reportHtml = renderToStaticMarkup(createElement(Vm0007GapReportView, { report }));
+
+    assertFixtureQualityGate({
+      rules: VM0007_SYNCED_RULES,
+      audit,
+      report,
+      reportHtml,
+      judgmentFixtureSet: AUDIT_FIXTURE,
+      sourceExcerpts: SOURCE_EXCERPTS,
+      expectedVisibleWording: REPORT_FIXTURE.expectedVisibleWording,
+      bannedWording: REPORT_FIXTURE.bannedWording,
+    });
+  });
+
+  it("fails if bad evidence is promoted to supported wording", () => {
+    const audit = buildMixedAudit();
+    const report = JSON.parse(JSON.stringify(buildReport(audit))) as ReturnType<typeof buildReport>;
+    const supportedRow = report.fullRuleAuditTable.find((row) => row.ruleId === "R-2-0003");
+    const appendixRow = report.evidenceAppendix.find((row) => row.ruleId === "R-2-0003");
+    expect(supportedRow).toBeDefined();
+    expect(appendixRow).toBeDefined();
+    if (supportedRow) {
+      supportedRow.evidenceSummary = "http://climate-standards.org/projects/";
+    }
+    if (appendixRow) {
+      appendixRow.quote = "http://climate-standards.org/projects/";
+    }
+    const reportHtml = renderToStaticMarkup(createElement(Vm0007GapReportView, { report }));
+
+    expect(() =>
+      assertFixtureQualityGate({
+        rules: VM0007_SYNCED_RULES,
+        audit,
+        report,
+        reportHtml,
+        judgmentFixtureSet: AUDIT_FIXTURE,
+        sourceExcerpts: SOURCE_EXCERPTS,
+      }),
+    ).toThrow();
+  });
+
+  it("fails if report wording overstates fixture truth", () => {
+    const audit = buildMixedAudit();
+    const report = buildReport(audit);
+    const reportHtml = `${renderToStaticMarkup(createElement(Vm0007GapReportView, { report }))}<div>All clear. Passed. Confirmed.</div>`;
+
+    expect(() =>
+      assertFixtureQualityGate({
+        rules: VM0007_SYNCED_RULES,
+        audit,
+        report,
+        reportHtml,
+        judgmentFixtureSet: AUDIT_FIXTURE,
+        sourceExcerpts: SOURCE_EXCERPTS,
+      }),
+    ).toThrow();
+  });
+});

--- a/tests/lib/preverif/fixtureQualityGate.ts
+++ b/tests/lib/preverif/fixtureQualityGate.ts
@@ -1,0 +1,117 @@
+import { expect } from "@jest/globals";
+import type { MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
+import type { Vm0007GapReport } from "@/lib/preverif/vm0007GapReport";
+import {
+  assertVm0007JudgmentFixtureSet,
+  type JudgmentFixtureSet,
+  type SourceExcerpts,
+} from "../preverifJudgmentFixtureGate";
+
+export type FixtureQualityGateInput = {
+  rules: readonly { id: string }[];
+  audit: MethodologyEvidenceAuditSummary;
+  report: Vm0007GapReport;
+  reportHtml: string;
+  judgmentFixtureSet: JudgmentFixtureSet;
+  sourceExcerpts: SourceExcerpts;
+  expectedVisibleWording?: readonly string[];
+  bannedWording?: readonly string[];
+};
+
+const FALLBACK_EVIDENCE_TEXT = "Evidence is not currently available in the PDD.";
+
+const DEFAULT_BANNED_WORDING = ["passed", "all clear", "confirmed"];
+
+function normalize(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function assertNoOverstatedWording(reportHtml: string, report: Vm0007GapReport, bannedWording: readonly string[]): void {
+  const reportText = normalize(`${reportHtml} ${JSON.stringify(report)}`);
+  for (const wording of bannedWording) {
+    expect(reportText).not.toContain(normalize(wording));
+  }
+}
+
+function assertVisibleWording(reportHtml: string, expectedVisibleWording: readonly string[]): void {
+  const reportText = normalize(reportHtml);
+  for (const wording of expectedVisibleWording) {
+    expect(reportText).toContain(normalize(wording));
+  }
+}
+
+function assertRuleCoverage(rules: readonly { id: string }[], audit: MethodologyEvidenceAuditSummary, report: Vm0007GapReport): void {
+  const expectedRuleIds = [...rules].map((rule) => rule.id).sort();
+  const auditRuleIds = [...audit.results].map((result) => result.ruleId).sort();
+  const reportRuleIds = [...report.fullRuleAuditTable].map((row) => row.ruleId).sort();
+  const appendixRuleIds = [...report.evidenceAppendix].map((row) => row.ruleId).sort();
+
+  expect(audit.totalRules).toBe(rules.length);
+  expect(report.fullRuleAuditTable).toHaveLength(rules.length);
+  expect(report.evidenceAppendix).toHaveLength(rules.length);
+  expect(auditRuleIds).toEqual(expectedRuleIds);
+  expect(reportRuleIds).toEqual(expectedRuleIds);
+  expect(appendixRuleIds).toEqual(expectedRuleIds);
+}
+
+function assertReportRowQuality(report: Vm0007GapReport): void {
+  for (const row of report.fullRuleAuditTable) {
+    const appendixRow = report.evidenceAppendix.find((entry) => entry.ruleId === row.ruleId);
+    expect(appendixRow).toBeDefined();
+
+    if (row.status === "supported") {
+      const supportedEvidence = normalize(`${row.evidenceSummary} ${appendixRow?.quote ?? ""}`);
+      expect(row.evidenceSummary).not.toContain(FALLBACK_EVIDENCE_TEXT);
+      expect(appendixRow?.quote).not.toBe(FALLBACK_EVIDENCE_TEXT);
+      expect(appendixRow?.page).not.toBeNull();
+      expect(appendixRow?.section.trim().length).toBeGreaterThan(0);
+      if (appendixRow?.span !== undefined) {
+        expect(appendixRow.span.trim().length).toBeGreaterThan(0);
+      }
+      expect(supportedEvidence).not.toMatch(/\bhttps?:\/\//);
+      expect(supportedEvidence).not.toContain("table of contents");
+      expect(supportedEvidence).not.toContain("all clear");
+      expect(supportedEvidence).not.toContain("passed");
+      expect(supportedEvidence).not.toContain("confirmed");
+      expect(row.gapGuidance).toBe("");
+      expect(row.clientAction).toBe("");
+      continue;
+    }
+
+    if (row.status === "weak") {
+      expect(row.gapGuidance.trim().length).toBeGreaterThan(0);
+      expect(row.clientAction.trim().length).toBeGreaterThan(0);
+      expect(appendixRow?.quote).toBeTruthy();
+      continue;
+    }
+
+    if (row.status === "missing") {
+      expect(row.gapGuidance.trim().length).toBeGreaterThan(0);
+      expect(row.clientAction.trim().length).toBeGreaterThan(0);
+      expect(appendixRow?.quote).toBe(FALLBACK_EVIDENCE_TEXT);
+      continue;
+    }
+
+    expect(row.status).toBe("not applicable");
+    expect(row.gapGuidance.trim().length).toBeGreaterThan(0);
+    expect(row.clientAction.trim().length).toBeGreaterThan(0);
+  }
+}
+
+export function assertFixtureQualityGate(input: FixtureQualityGateInput): void {
+  assertVm0007JudgmentFixtureSet(input.judgmentFixtureSet, input.sourceExcerpts);
+  assertRuleCoverage(input.rules, input.audit, input.report);
+
+  for (const fixture of input.judgmentFixtureSet.checks) {
+    expect(fixture.checkId.trim().length).toBeGreaterThan(0);
+    for (const rejectedQuote of fixture.knownBadQuotesToReject) {
+      expect(normalize(rejectedQuote.quote)).toBeTruthy();
+      expect(normalize(rejectedQuote.rejectionReason)).toBeTruthy();
+    }
+  }
+
+  assertReportRowQuality(input.report);
+
+  assertVisibleWording(input.reportHtml, input.expectedVisibleWording ?? []);
+  assertNoOverstatedWording(input.reportHtml, input.report, input.bannedWording ?? DEFAULT_BANNED_WORDING);
+}


### PR DESCRIPTION
- Focused test passes:
  npx jest tests/lib/preverif/fixtureQualityGate.test.ts --runInBand
- npm run pr:gate fails on an unrelated existing Quick Check v2 timeout for PROJ_DESC_674
- No production audit logic changed
- No client-facing report UI changed
- Unrelated dirty worktree files were left untouched