### PR TITLE
ops: add pr:gate:fixtures fast validation gate for fixture-only PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "prebuild": "npm run fetch:methodologies-pack && npm run generate:manifest && npm run derive:all && npm run assert:derived && npm run check:golden",
     "generate:manifest": "node scripts/generate-manifest-from-pack.mjs",
     "determinism:audit-pack": "node scripts/determinism-audit-pack.mjs",
+    "pr:gate:fixtures": "node scripts/pr-gate-fixtures.mjs",
     "pr:gate": "node scripts/pr-gate.mjs",
     "ci:coverage": "node scripts/compute-coverage.mjs",
     "ci:ratchet": "node scripts/gate-coverage-ratchet.mjs",

--- a/scripts/pr-gate-fixtures.mjs
+++ b/scripts/pr-gate-fixtures.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * pr:gate:fixtures — Fast fixture-only validation gate.
+ *
+ * Runs only checks relevant to fixture correctness.
+ * Intentionally excludes heavy/irrelevant checks (PDF smoke, eval corpus, etc.).
+ *
+ * Full npm run pr:gate is still required before merge / in CI.
+ */
+import { execSync } from "node:child_process";
+
+function run(cmd) {
+  console.log(`\n> ${cmd}`);
+  execSync(cmd, { stdio: "inherit" });
+}
+
+function main() {
+  // 1. Fixture quality gate (the core contract checker)
+  run("npx jest tests/lib/preverif/fixtureQualityGate.test.ts --runInBand");
+
+  // 2. VM0007 judgment fixture tests
+  run("npx jest tests/lib/preverif.vm0007PdReddJudgmentFixtures.test.ts --runInBand");
+  run("npx jest tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts --runInBand");
+
+  // 3. Full 58-rule audit fixture shape test
+  run("npx jest tests/lib/preverif.vm0007FullAuditFixtureShape.test.ts --runInBand");
+
+  // 4. Report fixture layer tests
+  run("npx jest tests/lib/preverif.vm0007GapReport.test.ts --runInBand");
+  run("npx jest tests/lib/preverif.vm0007EvidenceAudit.test.ts --runInBand");
+  run("npx jest tests/lib/preverif.vm0007EvidenceContracts.test.ts --runInBand");
+
+  // 5. Lint (fast, always worth running)
+  run("npm run lint");
+
+  // 6. Typecheck (fast, always worth running)
+  run("npm run typecheck");
+
+  console.log("\n✓ pr:gate:fixtures passed");
+}
+
+main();


### PR DESCRIPTION
## New script: `npm run pr:gate:fixtures`

A fast validation gate for fixture-only PRs. Runs only fixture-relevant checks.

### What it runs (included):
1. Fixture quality gate (`fixtureQualityGate.test.ts`)
2. VM0007 judgment fixture tests (`PdReddJudgmentFixtures`, `EnviraJudgmentFixtures`)
3. Full 58-rule audit fixture shape test
4. Report fixture layer tests (GapReport, EvidenceAudit, EvidenceContracts)
5. `npm run lint`
6. `npm run typecheck`

### What it intentionally excludes:
- All PDF audit-pack smoke tests
- QuickCheck runtime smoke
- Python/docling extraction paths
- Full eval corpus
- Unrelated methodology/PDF regression tests

### Timing comparison:
| Gate | Time |
|---|---|
| `npm run pr:gate:fixtures` | **~10 seconds** |
| `npm run pr:gate` | ~90+ seconds |

### Recommended workflow:
| Phase | Command |
|---|---|
| During dev | `npm run pr:gate:fixtures` |
| Before handoff | `npm run pr:gate:fixtures` then `npm run pr:gate` once |
| Merge | GitHub CI green |

### Existing gate unchanged
`npm run pr:gate` is untouched. Still required before merge.