### PR TITLE
roadmap: mark Phase 4 (Report Fixture Layer) done via PR #914

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -335,9 +335,10 @@ Tighten VM0007 gap report accuracy by improving rule-level judgment fixtures and
 Current focus:
 - Phase 0 done: boundary-only fixture contract is documented and enforced.
 - Phase 1 done: Envira VM0007 judgment fixtures were delivered by PR #897
-- Phase 2 done: PD_REDD VM0007 judgment fixtures are established with PDF-backed accepted and rejected evidence coverage.
-- Next focus: expand from targeted fixture sets to the full 58-rule audit fixture shape.
-- Keep audit-summary and report-summary expectations fixture-driven
+- Phase 2 done: PD_REDD VM0007 judgment fixtures established with PDF-backed accepted and rejected evidence coverage.
+- Phase 3 done: Envira VM0007 now has a reviewed full 58-rule audit fixture with final split FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17. Review included FOUND red-team pass, UNCLEAR/MISSING rescue check, R-1-0003 carbon-rights fix, fixture/test-only scope confirmation, pr:gate, and blind rebuild validation.
+- Phase 4 done: Report fixture layer delivered by PR #914. Report summary expectations are fixture-driven, row grouping and summary sections are testable from fixtures, internal preview output is clearly distinguished from client-ready output.
+- Next focus: Phase 5 — Client-Readiness Gate to prevent fixture drift from being mistaken for client-ready output.
 
 Not active now:
 - Production audit logic changes
@@ -350,5 +351,5 @@ Not active now:
 2) RC1 — Envira VM0007 Judgment Fixtures: Done — Added 5-10 Envira VM0007 judgment fixtures with explicit accepted evidence, rejected generic evidence examples, false-supported coverage, and expected statuses plus client actions where weak or missing. Delivered by PR #897.
 3) RC2 — PD_REDD VM0007 Judgment Fixtures: Done — Added PD_REDD VM0007 fixture coverage using the same judgment contract discipline, including accepted evidence, rejected weak or generic evidence, and explicit FOUND / UNCLEAR / MISSING / N/A expectations.
 4) RC3 — Full 58-Rule Audit Fixture Shape: Done — Completed via PR #911. Envira VM0007 now has a reviewed full 58-rule audit fixture with final split FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17. Review included FOUND red-team pass, UNCLEAR/MISSING rescue check, R-1-0003 carbon-rights fix, fixture/test-only scope confirmation, pr:gate, and blind rebuild validation.
-5) RC4 — Report Fixture Layer: Planned — Add internal preview report expectations for summary sections and row grouping.
+5) RC4 — Report Fixture Layer: Done — Completed via PR #914. Report summary expectations are fixture-driven, row grouping and summary sections are testable from fixtures, internal preview output is clearly distinguished from client-ready output. Local pr:gate passed, GitHub pr-gate passed, no production audit logic changed.
 6) RC5 — Client-Readiness Gate: Planned — Keep internal preview output separate from any later client-ready reporting work.

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -7,9 +7,10 @@
     "current_focus": [
       "Phase 0 done: boundary-only fixture contract is documented and enforced.",
       "Phase 1 done: Envira VM0007 judgment fixtures were delivered by PR #897",
-      "Phase 2 done: PD_REDD VM0007 judgment fixtures are established with PDF-backed accepted and rejected evidence coverage.",
-      "Next focus: expand from targeted fixture sets to the full 58-rule audit fixture shape.",
-      "Keep audit-summary and report-summary expectations fixture-driven"
+      "Phase 2 done: PD_REDD VM0007 judgment fixtures established with PDF-backed accepted and rejected evidence coverage.",
+      "Phase 3 done: Envira VM0007 now has a reviewed full 58-rule audit fixture with final split FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17. Review included FOUND red-team pass, UNCLEAR/MISSING rescue check, R-1-0003 carbon-rights fix, fixture/test-only scope confirmation, pr:gate, and blind rebuild validation.",
+      "Phase 4 done: Report fixture layer delivered by PR #914. Report summary expectations are fixture-driven, row grouping and summary sections are testable from fixtures, internal preview output is clearly distinguished from client-ready output.",
+      "Next focus: Phase 5 — Client-Readiness Gate to prevent fixture drift from being mistaken for client-ready output."
     ],
     "not_active_now": [
       "Production audit logic changes",
@@ -18,7 +19,7 @@
       "LLM final judgment",
       "Quick Check v2 Phase 7 work"
     ],
-    "last_updated_at": "2026-07-01T13:31:04Z"
+    "last_updated_at": "2026-07-02T17:30:00Z"
   },
   "goals": [
     {
@@ -88,10 +89,12 @@
     {
       "id": "phase_4_report_fixture_layer",
       "title": "Report Fixture Layer",
-      "status": "planned",
+      "status": "done",
       "dependsOn": [
         "phase_3_full_58_rule_audit_fixture_shape"
       ],
+      "branch": "test/vm0007-report-fixture-layer",
+      "pr": 914,
       "doneCriteria": [
         "Report summary expectations are fixture-driven",
         "Row grouping and summary sections are testable from fixtures",
@@ -134,8 +137,8 @@
     },
     "phase_4_report_fixture_layer": {
       "title": "Report Fixture Layer",
-      "status": "planned",
-      "summary": "Add internal preview report expectations for summary sections and row grouping."
+      "status": "done",
+      "summary": "Completed via PR #914. Report summary expectations are fixture-driven, row grouping and summary sections are testable from fixtures, internal preview output is clearly distinguished from client-ready output. Local pr:gate passed, GitHub pr-gate passed, no production audit logic changed."
     },
     "phase_5_client_readiness_gate": {
       "title": "Client-Readiness Gate",


### PR DESCRIPTION
Updates vm0007-judgement-fixtures phase-status.json and regenerates SUMMARY.md.

**Phase 4 status change:** planned → done

Changes:
- phase_4 phase-status.json entry: status=done, branch, pr, summary updated
- current_focus updated with Phase 4 completion and Phase 5 next focus
- SUMMARY.md regenerated via roadmap:check
- No production code, fixtures, or tests changed