### PR TITLE
test: add VM0007 client-readiness gate

### DIFF
--- a/tests/lib/preverif/clientReadinessGate.test.ts
+++ b/tests/lib/preverif/clientReadinessGate.test.ts
@@ -9,9 +9,17 @@ import {
   type MethodologyEvidenceAuditResult,
   type MethodologyEvidenceAuditSummary,
 } from "@/lib/preverif/evidenceAudit";
-import { buildVm0007GapReport } from "@/lib/preverif/vm0007GapReport";
+import { buildVm0007GapReport, type Vm0007GapReport } from "@/lib/preverif/vm0007GapReport";
 import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif/vm0007EvidenceContracts";
 import { VM0007_SYNCED_RULES, readQuickCheckFixtureText } from "../preverifVm0007Fixtures";
+import {
+  assertClientReadinessGate,
+  assertNoUnclearEvidence,
+  assertNoMissingEvidence,
+  assertInternalPreviewLabelVisible,
+  assertNoBannedClientReadyWording,
+  assertUsesStandardReportShape,
+} from "./clientReadinessGate";
 
 const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
 
@@ -34,8 +42,8 @@ function withStatus(
   return { ...result, ...overrides };
 }
 
-function buildReport(reportOverrides?: Partial<Parameters<typeof buildVm0007GapReport>[0]>) {
-  const base = auditText(ENVIRA_TEXT);
+function buildReport(auditOverride?: MethodologyEvidenceAuditSummary) {
+  const base = auditOverride ?? auditText(ENVIRA_TEXT);
   return buildVm0007GapReport({
     reportId: "VRGR-VM0007-CRG-001",
     generatedAt: "2026-07-03T00:00:00Z",
@@ -50,164 +58,187 @@ function buildReport(reportOverrides?: Partial<Parameters<typeof buildVm0007GapR
       name: "VM0007: REDD Methodology Modules (REDD-MF)",
     },
     audit: base,
-    ...reportOverrides,
   });
 }
 
-function renderReport(
-  report: ReturnType<typeof buildReport>,
-  extraHtml = "",
-): string {
+function renderReport(report: Vm0007GapReport, extraHtml = ""): string {
   const baseHtml = renderToStaticMarkup(createElement(Vm0007GapReportView, { report }));
   return `${baseHtml}${extraHtml}`;
 }
 
-/**
- * Client-readiness gate.
- *
- * Enforces:
- * - Reports with UNCLEAR ("weak") evidence cannot be marked client-ready.
- * - Reports with MISSING evidence cannot be marked client-ready.
- * - Internal previews must stay explicitly labeled as internal preview / not client ready.
- * - Misleading wording fails tests unless evidence truly supports it.
- * - Client-readiness stays separate from production audit logic and report UI.
- */
-
-function assertInternalPreviewLabel(reportHtml: string): void {
-  const text = reportHtml.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim().toLowerCase();
-  const hasInternalLabel = text.includes("internal preview") || text.includes("internal vm0007 gap report preview");
-  expect(hasInternalLabel).toBe(true);
-}
-
-function assertNoBannedWording(reportHtml: string, report: ReturnType<typeof buildReport>): void {
-  const bannedPhrases = ["all clear", "fully verified", "ready for verification"];
-  const combinedText = `${reportHtml} ${JSON.stringify(report)}`.toLowerCase().replace(/\s+/g, " ");
-  for (const phrase of bannedPhrases) {
-    expect(combinedText).not.toContain(phrase);
-  }
-}
-
-function countStatusRows(report: ReturnType<typeof buildReport>, status: string): number {
-  return report.fullRuleAuditTable.filter((row) => row.status === status).length;
-}
-
-describe("VM0007 client-readiness gate", () => {
-  it("flags reports with UNCLEAR (weak) evidence as not client-ready", () => {
-    const audit = auditText(ENVIRA_TEXT);
-    const results = audit.results.map((result) => {
-      if (result.ruleId === "R-1-0002") {
-        return withStatus(result, {
-          status: "partially_supported" as const,
-          gap: "The current PDD names the baseline category but does not explain why that category fits the project area.",
-          clientAction: "Add the project-specific baseline deforestation category rationale and the supporting land-use evidence.",
-        });
-      }
-      return result;
-    });
-    const weakAudit: MethodologyEvidenceAuditSummary = {
-      results,
-      totals: {
-        supported_by_pdd: results.filter((r) => r.status === "supported_by_pdd").length,
-        partially_supported: results.filter((r) => r.status === "partially_supported").length,
-        missing_evidence: results.filter((r) => r.status === "missing_evidence").length,
-        not_applicable: results.filter((r) => r.status === "not_applicable").length,
-        manual_review_needed: results.filter((r) => r.status === "manual_review_needed").length,
-      },
-      totalRules: results.length,
-    };
-    const report = buildReport({ audit: weakAudit });
-
-    const weakCount = countStatusRows(report, "weak");
-    expect(weakCount).toBeGreaterThan(0);
-
-    const text = renderReport(report).toLowerCase();
-    const noOverstated = !text.includes("all clear") && !text.includes("fully verified") && !text.includes("ready for verification");
-    expect(noOverstated).toBe(true);
-  });
-
-  it("flags reports with MISSING evidence as not client-ready", () => {
-    const audit = auditText(ENVIRA_TEXT);
-    const results = audit.results.map((result) => {
-      if (result.ruleId === "R-1-0003") {
-        return withStatus(result, {
-          status: "missing_evidence" as const,
-          bestEvidenceQuote: null,
-          section: null,
-          page: null,
-          span: null,
-          gap: "The current PDD does not show the AUDef agent evidence required for this rule.",
-          clientAction: "Add the project-specific evidence for the relevant deforestation agents and explain how they drive baseline pressure.",
-          assessmentReason: "The current PDD does not yet show project-specific evidence for this rule.",
-          reasonSelected: "No reliable project-specific span was selected for this rule.",
-        });
-      }
-      return result;
-    });
-    const missingAudit: MethodologyEvidenceAuditSummary = {
-      results,
-      totals: {
-        supported_by_pdd: results.filter((r) => r.status === "supported_by_pdd").length,
-        partially_supported: results.filter((r) => r.status === "partially_supported").length,
-        missing_evidence: results.filter((r) => r.status === "missing_evidence").length,
-        not_applicable: results.filter((r) => r.status === "not_applicable").length,
-        manual_review_needed: results.filter((r) => r.status === "manual_review_needed").length,
-      },
-      totalRules: results.length,
-    };
-    const report = buildReport({ audit: missingAudit });
-
-    const missingCount = countStatusRows(report, "missing");
-    expect(missingCount).toBeGreaterThan(0);
-
-    const text = renderReport(report).toLowerCase();
-    const noOverstated = !text.includes("all clear") && !text.includes("fully verified") && !text.includes("ready for verification");
-    expect(noOverstated).toBe(true);
-  });
-
-  it("labels report as internal preview, not client-ready", () => {
-    const audit = auditText(ENVIRA_TEXT);
-    const report = buildReport({ audit });
-    const reportHtml = renderReport(report);
-
-    assertInternalPreviewLabel(reportHtml);
-    assertNoBannedWording(reportHtml, report);
-  });
-
-  it("rejects misleading 'all clear' or 'fully verified' wording", () => {
-    const audit = auditText(ENVIRA_TEXT);
-    const report = buildReport({ audit });
-    const reportHtml = renderReport(report, "<div>All clear. Fully verified.</div>");
-
-    expect(() => {
-      assertNoBannedWording(reportHtml, report);
-    }).toThrow();
-  });
-
-  it("rejects 'ready for verification' misleading wording", () => {
-    const audit = auditText(ENVIRA_TEXT);
-    const report = buildReport({ audit });
-    const reportHtml = renderReport(report, "<div>Ready for verification.</div>");
-
-    expect(() => {
-      assertNoBannedWording(reportHtml, report);
-    }).toThrow();
-  });
-
-  it("does not modify production audit logic or report UI types", () => {
-    // Verify the gate uses existing Vm0007GapReport types and buildVm0007GapReport
-    // rather than altering them. This test is structural.
-    const audit = auditText(ENVIRA_TEXT);
-    const report = buildReport({ audit });
-
-    // The report should use the standard internal preview naming
-    expect(report.reportName).toBe("Internal VM0007 Gap Report Preview");
-
-    // All statuses should be from the existing display status type
-    for (const row of report.fullRuleAuditTable) {
-      expect(["supported", "weak", "missing", "not applicable"]).toContain(row.status);
+function makeWeakAudit(baseAudit: MethodologyEvidenceAuditSummary): MethodologyEvidenceAuditSummary {
+  const results = baseAudit.results.map((result) => {
+    if (result.ruleId === "R-1-0002") {
+      return withStatus(result, {
+        status: "partially_supported" as const,
+        gap: "The current PDD names the baseline category but does not explain why that category fits the project area.",
+        clientAction: "Add the project-specific baseline deforestation category rationale and the supporting land-use evidence.",
+      });
     }
+    return result;
+  });
+  return {
+    results,
+    totals: {
+      supported_by_pdd: results.filter((r) => r.status === "supported_by_pdd").length,
+      partially_supported: results.filter((r) => r.status === "partially_supported").length,
+      missing_evidence: results.filter((r) => r.status === "missing_evidence").length,
+      not_applicable: results.filter((r) => r.status === "not_applicable").length,
+      manual_review_needed: results.filter((r) => r.status === "manual_review_needed").length,
+    },
+    totalRules: results.length,
+  };
+}
 
-    // The existing limitation banner should be present
-    expect(report.limitationBanner).toContain("Internal preview only");
+function makeMissingAudit(baseAudit: MethodologyEvidenceAuditSummary): MethodologyEvidenceAuditSummary {
+  const results = baseAudit.results.map((result) => {
+    if (result.ruleId === "R-1-0003") {
+      return withStatus(result, {
+        status: "missing_evidence" as const,
+        bestEvidenceQuote: null,
+        section: null,
+        page: null,
+        span: null,
+        gap: "The current PDD does not show the AUDef agent evidence required for this rule.",
+        clientAction: "Add the project-specific evidence for the relevant deforestation agents and explain how they drive baseline pressure.",
+        assessmentReason: "The current PDD does not yet show project-specific evidence for this rule.",
+        reasonSelected: "No reliable project-specific span was selected for this rule.",
+      });
+    }
+    return result;
+  });
+  return {
+    results,
+    totals: {
+      supported_by_pdd: results.filter((r) => r.status === "supported_by_pdd").length,
+      partially_supported: results.filter((r) => r.status === "partially_supported").length,
+      missing_evidence: results.filter((r) => r.status === "missing_evidence").length,
+      not_applicable: results.filter((r) => r.status === "not_applicable").length,
+      manual_review_needed: results.filter((r) => r.status === "manual_review_needed").length,
+    },
+    totalRules: results.length,
+  };
+}
+
+/** Build a report where every row is treated as supported or not applicable — no weak/missing. */
+function makeCleanAudit(baseAudit: MethodologyEvidenceAuditSummary): MethodologyEvidenceAuditSummary {
+  const results = baseAudit.results.map((result) => {
+    if (result.status === "missing_evidence" || result.status === "partially_supported" || result.status === "manual_review_needed") {
+      return withStatus(result, {
+        status: "supported_by_pdd" as const,
+        bestEvidenceQuote: "Evidence found in the PDD.",
+      });
+    }
+    return result;
+  });
+  return {
+    results,
+    totals: {
+      supported_by_pdd: results.filter((r) => r.status === "supported_by_pdd").length,
+      partially_supported: 0,
+      missing_evidence: 0,
+      not_applicable: results.filter((r) => r.status === "not_applicable").length,
+      manual_review_needed: 0,
+    },
+    totalRules: results.length,
+  };
+}
+
+describe("clientReadinessGate helper", () => {
+  describe("assertNoUnclearEvidence", () => {
+    it("passes when report has zero weak rows", () => {
+      const report = buildReport(makeCleanAudit(auditText(ENVIRA_TEXT)));
+      expect(() => assertNoUnclearEvidence(report)).not.toThrow();
+    });
+
+    it("fails when report has weak rows", () => {
+      const report = buildReport(makeWeakAudit(auditText(ENVIRA_TEXT)));
+      expect(() => assertNoUnclearEvidence(report)).toThrow();
+    });
+  });
+
+  describe("assertNoMissingEvidence", () => {
+    it("passes when report has zero missing rows", () => {
+      const report = buildReport(makeCleanAudit(auditText(ENVIRA_TEXT)));
+      expect(() => assertNoMissingEvidence(report)).not.toThrow();
+    });
+
+    it("fails when report has missing rows", () => {
+      const report = buildReport(makeMissingAudit(auditText(ENVIRA_TEXT)));
+      expect(() => assertNoMissingEvidence(report)).toThrow();
+    });
+  });
+
+  describe("assertInternalPreviewLabelVisible", () => {
+    it("passes when internal preview label is present", () => {
+      const report = buildReport();
+      const html = renderReport(report);
+      expect(() => assertInternalPreviewLabelVisible(html)).not.toThrow();
+    });
+
+    it("fails when internal preview label is stripped", () => {
+      const html = "<div>Client-ready report</div>";
+      expect(() => assertInternalPreviewLabelVisible(html)).toThrow();
+    });
+  });
+
+  describe("assertNoBannedClientReadyWording", () => {
+    it("passes when no banned wording is present", () => {
+      const report = buildReport();
+      const html = renderReport(report);
+      expect(() => assertNoBannedClientReadyWording(html, report)).not.toThrow();
+    });
+
+    it("fails when 'all clear' is injected into HTML", () => {
+      const report = buildReport();
+      const html = renderReport(report, "<div>All clear.</div>");
+      expect(() => assertNoBannedClientReadyWording(html, report)).toThrow();
+    });
+
+    it("fails when 'fully verified' is injected into HTML", () => {
+      const report = buildReport();
+      const html = renderReport(report, "<div>Fully verified.</div>");
+      expect(() => assertNoBannedClientReadyWording(html, report)).toThrow();
+    });
+
+    it("fails when 'ready for verification' is injected into HTML", () => {
+      const report = buildReport();
+      const html = renderReport(report, "<div>Ready for verification.</div>");
+      expect(() => assertNoBannedClientReadyWording(html, report)).toThrow();
+    });
+  });
+
+  describe("assertUsesStandardReportShape", () => {
+    it("passes for a standard Vm0007GapReport", () => {
+      const report = buildReport();
+      expect(() => assertUsesStandardReportShape(report)).not.toThrow();
+    });
+  });
+
+  describe("assertClientReadinessGate (composite)", () => {
+    it("passes for a clean report (no weak, no missing, internal label, no banned wording)", () => {
+      const report = buildReport(makeCleanAudit(auditText(ENVIRA_TEXT)));
+      const html = renderReport(report);
+
+      expect(() => assertClientReadinessGate({ reportHtml: html, report })).not.toThrow();
+    });
+
+    it("fails on UNCLEAR evidence", () => {
+      const report = buildReport(makeWeakAudit(auditText(ENVIRA_TEXT)));
+      const html = renderReport(report);
+      expect(() => assertClientReadinessGate({ reportHtml: html, report })).toThrow();
+    });
+
+    it("fails on MISSING evidence", () => {
+      const report = buildReport(makeMissingAudit(auditText(ENVIRA_TEXT)));
+      const html = renderReport(report);
+      expect(() => assertClientReadinessGate({ reportHtml: html, report })).toThrow();
+    });
+
+    it("fails on banned wording in HTML", () => {
+      const report = buildReport();
+      const html = renderReport(report, "<div>Ready for verification</div>");
+      expect(() => assertClientReadinessGate({ reportHtml: html, report })).toThrow();
+    });
   });
 });

--- a/tests/lib/preverif/clientReadinessGate.test.ts
+++ b/tests/lib/preverif/clientReadinessGate.test.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs";
+import { describe, expect, it } from "@jest/globals";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import Vm0007GapReportView from "@/components/preverif/Vm0007GapReportView";
+import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import {
+  auditEvidence,
+  type MethodologyEvidenceAuditResult,
+  type MethodologyEvidenceAuditSummary,
+} from "@/lib/preverif/evidenceAudit";
+import { buildVm0007GapReport } from "@/lib/preverif/vm0007GapReport";
+import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif/vm0007EvidenceContracts";
+import { VM0007_SYNCED_RULES, readQuickCheckFixtureText } from "../preverifVm0007Fixtures";
+
+const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
+
+function auditText(rawText: string): MethodologyEvidenceAuditSummary {
+  const context = getStructuredQueryContext(rawText);
+  return auditEvidence({
+    rules: VM0007_SYNCED_RULES,
+    evidenceDocument: context.evidenceDocument,
+    getContract: getVm0007EvidenceContract,
+    normalizeRuleId: normalizeVm0007RuleId,
+    sections: context.documentStructure.sections,
+    rawText,
+  });
+}
+
+function withStatus(
+  result: MethodologyEvidenceAuditResult,
+  overrides: Partial<MethodologyEvidenceAuditResult>,
+): MethodologyEvidenceAuditResult {
+  return { ...result, ...overrides };
+}
+
+function buildReport(reportOverrides?: Partial<Parameters<typeof buildVm0007GapReport>[0]>) {
+  const base = auditText(ENVIRA_TEXT);
+  return buildVm0007GapReport({
+    reportId: "VRGR-VM0007-CRG-001",
+    generatedAt: "2026-07-03T00:00:00Z",
+    project: {
+      name: "The Envira Amazonia Project",
+      projectId: "envira-fixture",
+      region: "Acre, Brazil",
+    },
+    methodology: {
+      code: "VM0007",
+      version: "4.2",
+      name: "VM0007: REDD Methodology Modules (REDD-MF)",
+    },
+    audit: base,
+    ...reportOverrides,
+  });
+}
+
+function renderReport(
+  report: ReturnType<typeof buildReport>,
+  extraHtml = "",
+): string {
+  const baseHtml = renderToStaticMarkup(createElement(Vm0007GapReportView, { report }));
+  return `${baseHtml}${extraHtml}`;
+}
+
+/**
+ * Client-readiness gate.
+ *
+ * Enforces:
+ * - Reports with UNCLEAR ("weak") evidence cannot be marked client-ready.
+ * - Reports with MISSING evidence cannot be marked client-ready.
+ * - Internal previews must stay explicitly labeled as internal preview / not client ready.
+ * - Misleading wording fails tests unless evidence truly supports it.
+ * - Client-readiness stays separate from production audit logic and report UI.
+ */
+
+function assertInternalPreviewLabel(reportHtml: string): void {
+  const text = reportHtml.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim().toLowerCase();
+  const hasInternalLabel = text.includes("internal preview") || text.includes("internal vm0007 gap report preview");
+  expect(hasInternalLabel).toBe(true);
+}
+
+function assertNoBannedWording(reportHtml: string, report: ReturnType<typeof buildReport>): void {
+  const bannedPhrases = ["all clear", "fully verified", "ready for verification"];
+  const combinedText = `${reportHtml} ${JSON.stringify(report)}`.toLowerCase().replace(/\s+/g, " ");
+  for (const phrase of bannedPhrases) {
+    expect(combinedText).not.toContain(phrase);
+  }
+}
+
+function countStatusRows(report: ReturnType<typeof buildReport>, status: string): number {
+  return report.fullRuleAuditTable.filter((row) => row.status === status).length;
+}
+
+describe("VM0007 client-readiness gate", () => {
+  it("flags reports with UNCLEAR (weak) evidence as not client-ready", () => {
+    const audit = auditText(ENVIRA_TEXT);
+    const results = audit.results.map((result) => {
+      if (result.ruleId === "R-1-0002") {
+        return withStatus(result, {
+          status: "partially_supported" as const,
+          gap: "The current PDD names the baseline category but does not explain why that category fits the project area.",
+          clientAction: "Add the project-specific baseline deforestation category rationale and the supporting land-use evidence.",
+        });
+      }
+      return result;
+    });
+    const weakAudit: MethodologyEvidenceAuditSummary = {
+      results,
+      totals: {
+        supported_by_pdd: results.filter((r) => r.status === "supported_by_pdd").length,
+        partially_supported: results.filter((r) => r.status === "partially_supported").length,
+        missing_evidence: results.filter((r) => r.status === "missing_evidence").length,
+        not_applicable: results.filter((r) => r.status === "not_applicable").length,
+        manual_review_needed: results.filter((r) => r.status === "manual_review_needed").length,
+      },
+      totalRules: results.length,
+    };
+    const report = buildReport({ audit: weakAudit });
+
+    const weakCount = countStatusRows(report, "weak");
+    expect(weakCount).toBeGreaterThan(0);
+
+    const text = renderReport(report).toLowerCase();
+    const noOverstated = !text.includes("all clear") && !text.includes("fully verified") && !text.includes("ready for verification");
+    expect(noOverstated).toBe(true);
+  });
+
+  it("flags reports with MISSING evidence as not client-ready", () => {
+    const audit = auditText(ENVIRA_TEXT);
+    const results = audit.results.map((result) => {
+      if (result.ruleId === "R-1-0003") {
+        return withStatus(result, {
+          status: "missing_evidence" as const,
+          bestEvidenceQuote: null,
+          section: null,
+          page: null,
+          span: null,
+          gap: "The current PDD does not show the AUDef agent evidence required for this rule.",
+          clientAction: "Add the project-specific evidence for the relevant deforestation agents and explain how they drive baseline pressure.",
+          assessmentReason: "The current PDD does not yet show project-specific evidence for this rule.",
+          reasonSelected: "No reliable project-specific span was selected for this rule.",
+        });
+      }
+      return result;
+    });
+    const missingAudit: MethodologyEvidenceAuditSummary = {
+      results,
+      totals: {
+        supported_by_pdd: results.filter((r) => r.status === "supported_by_pdd").length,
+        partially_supported: results.filter((r) => r.status === "partially_supported").length,
+        missing_evidence: results.filter((r) => r.status === "missing_evidence").length,
+        not_applicable: results.filter((r) => r.status === "not_applicable").length,
+        manual_review_needed: results.filter((r) => r.status === "manual_review_needed").length,
+      },
+      totalRules: results.length,
+    };
+    const report = buildReport({ audit: missingAudit });
+
+    const missingCount = countStatusRows(report, "missing");
+    expect(missingCount).toBeGreaterThan(0);
+
+    const text = renderReport(report).toLowerCase();
+    const noOverstated = !text.includes("all clear") && !text.includes("fully verified") && !text.includes("ready for verification");
+    expect(noOverstated).toBe(true);
+  });
+
+  it("labels report as internal preview, not client-ready", () => {
+    const audit = auditText(ENVIRA_TEXT);
+    const report = buildReport({ audit });
+    const reportHtml = renderReport(report);
+
+    assertInternalPreviewLabel(reportHtml);
+    assertNoBannedWording(reportHtml, report);
+  });
+
+  it("rejects misleading 'all clear' or 'fully verified' wording", () => {
+    const audit = auditText(ENVIRA_TEXT);
+    const report = buildReport({ audit });
+    const reportHtml = renderReport(report, "<div>All clear. Fully verified.</div>");
+
+    expect(() => {
+      assertNoBannedWording(reportHtml, report);
+    }).toThrow();
+  });
+
+  it("rejects 'ready for verification' misleading wording", () => {
+    const audit = auditText(ENVIRA_TEXT);
+    const report = buildReport({ audit });
+    const reportHtml = renderReport(report, "<div>Ready for verification.</div>");
+
+    expect(() => {
+      assertNoBannedWording(reportHtml, report);
+    }).toThrow();
+  });
+
+  it("does not modify production audit logic or report UI types", () => {
+    // Verify the gate uses existing Vm0007GapReport types and buildVm0007GapReport
+    // rather than altering them. This test is structural.
+    const audit = auditText(ENVIRA_TEXT);
+    const report = buildReport({ audit });
+
+    // The report should use the standard internal preview naming
+    expect(report.reportName).toBe("Internal VM0007 Gap Report Preview");
+
+    // All statuses should be from the existing display status type
+    for (const row of report.fullRuleAuditTable) {
+      expect(["supported", "weak", "missing", "not applicable"]).toContain(row.status);
+    }
+
+    // The existing limitation banner should be present
+    expect(report.limitationBanner).toContain("Internal preview only");
+  });
+});

--- a/tests/lib/preverif/clientReadinessGate.ts
+++ b/tests/lib/preverif/clientReadinessGate.ts
@@ -1,0 +1,117 @@
+import { expect } from "@jest/globals";
+import type { Vm0007GapReport } from "@/lib/preverif/vm0007GapReport";
+
+/**
+ * Client-readiness gate for VM0007 gap reports.
+ *
+ * Enforces:
+ * 1. Reports with UNCLEAR ("weak") evidence cannot be marked client-ready.
+ * 2. Reports with MISSING evidence cannot be marked client-ready.
+ * 3. Internal preview labels must be visibly present.
+ * 4. Banned global wording ("all clear", "fully verified", "ready for verification") is rejected.
+ * 5. Client-readiness stays separate from production audit logic and report UI.
+ */
+
+export const BANNED_CLIENT_READY_PHRASES = [
+  "all clear",
+  "fully verified",
+  "ready for verification",
+] as const;
+
+export const INTERNAL_PREVIEW_LABELS = [
+  "internal preview",
+  "internal vm0007 gap report preview",
+] as const;
+
+export type ClientReadinessGateInput = {
+  /** The rendered HTML of the gap report. */
+  reportHtml: string;
+  /** The Vm0007GapReport object (used for data checks and banned-wording scan). */
+  report: Vm0007GapReport;
+};
+
+/**
+ * Asserts that the report has no UNCLEAR ("weak") rows.
+ * Throws if any weak rows are present.
+ */
+export function assertNoUnclearEvidence(report: Vm0007GapReport): void {
+  const unclearCount = report.fullRuleAuditTable.filter(
+    (row) => row.status === "weak",
+  ).length;
+  expect(unclearCount).toBe(0);
+}
+
+/**
+ * Asserts that the report has no MISSING rows.
+ * Throws if any missing rows are present.
+ */
+export function assertNoMissingEvidence(report: Vm0007GapReport): void {
+  const missingCount = report.fullRuleAuditTable.filter(
+    (row) => row.status === "missing",
+  ).length;
+  expect(missingCount).toBe(0);
+}
+
+/**
+ * Asserts that the report HTML contains an internal preview label.
+ */
+export function assertInternalPreviewLabelVisible(reportHtml: string): void {
+  const text = reportHtml
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+  const hasLabel = INTERNAL_PREVIEW_LABELS.some((label) =>
+    text.includes(label),
+  );
+  expect(hasLabel).toBe(true);
+}
+
+/**
+ * Asserts that neither the rendered HTML nor the report data
+ * contain any banned client-ready phrasing.
+ */
+export function assertNoBannedClientReadyWording(
+  reportHtml: string,
+  report: Vm0007GapReport,
+): void {
+  const combinedText = `${reportHtml} ${JSON.stringify(report)}`
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+  for (const phrase of BANNED_CLIENT_READY_PHRASES) {
+    expect(combinedText).not.toContain(phrase);
+  }
+}
+
+/**
+ * Asserts that the report uses only standard VM0007 display statuses
+ * and carries an internal preview name and limitation banner.
+ * This guard prevents the gate from being bypassed by type changes.
+ */
+export function assertUsesStandardReportShape(
+  report: Vm0007GapReport,
+): void {
+  expect(report.reportName).toBe("Internal VM0007 Gap Report Preview");
+  for (const row of report.fullRuleAuditTable) {
+    expect(["supported", "weak", "missing", "not applicable"]).toContain(
+      row.status,
+    );
+  }
+  expect(report.limitationBanner).toContain("Internal preview only");
+}
+
+/**
+ * Full client-readiness gate assertion.
+ *
+ * Runs all checks and throws on the first failure.
+ * Use this for convenience when you want all enforcement in one call.
+ */
+export function assertClientReadinessGate(input: ClientReadinessGateInput): void {
+  const { reportHtml, report } = input;
+
+  assertUsesStandardReportShape(report);
+  assertNoUnclearEvidence(report);
+  assertNoMissingEvidence(report);
+  assertInternalPreviewLabelVisible(reportHtml);
+  assertNoBannedClientReadyWording(reportHtml, report);
+}


### PR DESCRIPTION
## What

Adds the Phase 5 VM0007 client-readiness gate.

This gate prevents internal fixture/report preview output from being mistaken for client-ready output.

## Enforces

- Reports with UNCLEAR evidence cannot be marked client-ready.
- Reports with MISSING evidence cannot be marked client-ready.
- Internal previews must stay explicitly labeled as internal preview / not client ready.
- Misleading wording such as "all clear," "fully verified," or "ready for verification" fails tests unless evidence truly supports it.
- Client-readiness remains separate from production audit logic and report UI.

## Validation

- [x] npm test -- tests/lib/preverif/clientReadinessGate.test.ts --runInBand — 15/15 passed
- [x] npm run pr:gate:fixtures — n/a (not on main yet; auto-picked up by jest default glob)
- [x] npm run lint — 0 warnings, 0 errors
- [x] npm run typecheck — clean

## Scope

Fixture/test gate only.

No production audit logic changes.
No report UI redesign.
No parser/router changes.