### PR TITLE
fixture: add Envira VM0007 fixture-backed report route

### DIFF
--- a/src/app/api/exports/internal/envira-vm0007-report/route.ts
+++ b/src/app/api/exports/internal/envira-vm0007-report/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
+import { buildEnviraVm0007FixtureBackedPdf } from "@/lib/preverif/enviraVm0007FixtureBackedPdf";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const report = buildEnviraVm0007FixtureBackedReport();
+    const pdf = buildEnviraVm0007FixtureBackedPdf(report);
+    const bytes = new Uint8Array(pdf);
+    const blob = new Blob([bytes], { type: "application/pdf" });
+
+    return new NextResponse(blob, {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": 'attachment; filename="internal-envira-vm0007-fixture-backed-report.pdf"',
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Envira fixture-backed PDF export failed", detail: String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/internal/reports/envira-vm0007/page.tsx
+++ b/src/app/internal/reports/envira-vm0007/page.tsx
@@ -9,5 +9,10 @@ export const metadata: Metadata = {
 
 export default function EnviraVm0007FixtureBackedReportPage() {
   const report = buildEnviraVm0007FixtureBackedReport();
-  return <FixtureBackedVm0007ReportView report={report} />;
+  return (
+    <FixtureBackedVm0007ReportView
+      report={report}
+      pdfDownloadHref="/api/exports/internal/envira-vm0007-report"
+    />
+  );
 }

--- a/src/app/internal/reports/envira-vm0007/page.tsx
+++ b/src/app/internal/reports/envira-vm0007/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import FixtureBackedVm0007ReportView from "@/components/preverif/FixtureBackedVm0007ReportView";
+import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
+
+export const metadata: Metadata = {
+  title: "Internal Envira VM0007 Fixture-Backed Report | app.article6",
+  description: "Internal Envira VM0007 fixture-backed report and evidence map preview.",
+};
+
+export default function EnviraVm0007FixtureBackedReportPage() {
+  const report = buildEnviraVm0007FixtureBackedReport();
+  return <FixtureBackedVm0007ReportView report={report} />;
+}

--- a/src/components/preverif/FixtureBackedVm0007ReportView.tsx
+++ b/src/components/preverif/FixtureBackedVm0007ReportView.tsx
@@ -1,0 +1,139 @@
+import type { ReactNode } from "react";
+import type { Vm0007EvidenceMapRow, Vm0007FixtureBackedReport, Vm0007FixtureBackedStatus } from "@/lib/preverif/fixtureBackedVm0007Report";
+
+type FixtureBackedVm0007ReportViewProps = {
+  report: Vm0007FixtureBackedReport;
+};
+
+function statusTone(status: Vm0007FixtureBackedStatus): string {
+  if (status === "FOUND") return "border-emerald-200 bg-emerald-50 text-emerald-900";
+  if (status === "UNCLEAR") return "border-amber-200 bg-amber-50 text-amber-900";
+  if (status === "MISSING") return "border-rose-200 bg-rose-50 text-rose-900";
+  return "border-sky-200 bg-sky-50 text-sky-900";
+}
+
+function labelCell(label: string, value: ReactNode) {
+  return (
+    <div className="mt-2">
+      <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">{label}</div>
+      <div className="mt-1 text-sm text-slate-700">{value}</div>
+    </div>
+  );
+}
+
+function rejectedEvidenceBlock(row: Vm0007EvidenceMapRow) {
+  if (row.rejectedEvidenceExamples.length === 0) {
+    return <span className="text-slate-500">No rejected evidence examples encoded for this row.</span>;
+  }
+
+  return (
+    <div className="grid gap-2">
+      {row.rejectedEvidenceExamples.map((entry) => (
+        <div key={`${row.ruleId}-${entry.quote}`} className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+          <div className="text-sm text-slate-800">{entry.quote}</div>
+          <div className="mt-1 text-xs text-slate-500">{entry.rejectionReason}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function FixtureBackedVm0007ReportView({ report }: FixtureBackedVm0007ReportViewProps) {
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-8">
+      <div className="mx-auto grid max-w-7xl gap-4">
+        <section className="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full border border-slate-300 bg-slate-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-700">
+              Internal only
+            </span>
+            <span className="rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-800">
+              Fixture-backed VM0007 report
+            </span>
+          </div>
+          <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-950">{report.reportName}</h1>
+          <div className="mt-2 text-base text-slate-700">{report.project.name}</div>
+          <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900">
+            {report.limitationBanner}
+          </div>
+          <div className="mt-3 text-sm text-slate-700">{report.summary.headline}</div>
+          <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+              <div className="font-semibold text-slate-950">Project</div>
+              <div className="mt-2">{report.project.description}</div>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+              <div><span className="font-semibold text-slate-950">Methodology:</span> {report.methodology.code} {report.methodology.version}</div>
+              <div className="mt-2"><span className="font-semibold text-slate-950">Name:</span> {report.methodology.name}</div>
+              <div className="mt-2"><span className="font-semibold text-slate-950">Report ID:</span> {report.reportId}</div>
+              <div className="mt-2"><span className="font-semibold text-slate-950">Generated:</span> {report.generatedAt}</div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-950">Summary</h2>
+          <div className="mt-1 text-sm text-slate-600">
+            {report.summary.totalRules} VM0007 rules rendered from reviewed fixture truth.
+          </div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {(["FOUND", "UNCLEAR", "MISSING", "N/A"] as const).map((status) => (
+              <div key={status} className={`rounded-2xl border p-4 ${statusTone(status)}`}>
+                <div className="text-[11px] font-semibold uppercase tracking-wide">{status}</div>
+                <div className="mt-1 text-2xl font-semibold">{report.summary.counts[status]}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-950">Evidence Map</h2>
+          <div className="mt-1 text-sm text-slate-600">
+            Each row reflects reviewed fixture truth for a single VM0007 rule. UNCLEAR and MISSING rows remain visible for internal follow-up.
+          </div>
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full border-separate border-spacing-0 text-left text-sm">
+              <thead>
+                <tr>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Rule</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Rule name</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Status</th>
+                  <th className="border-b border-slate-200 px-3 py-2 font-semibold text-slate-900">Evidence Map details</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.evidenceMapRows.map((row) => (
+                  <tr key={row.ruleId} className="align-top" data-evidence-map-row={row.ruleId} data-status={row.status}>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-950">{row.ruleId}</td>
+                    <td className="border-b border-slate-100 px-3 py-3 text-slate-700">{row.ruleName}</td>
+                    <td className="border-b border-slate-100 px-3 py-3">
+                      <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusTone(row.status)}`}>
+                        {row.status}
+                      </span>
+                    </td>
+                    <td className="border-b border-slate-100 px-3 py-3">
+                      <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                        {labelCell("Accepted PDD quote", row.acceptedQuote ?? "No accepted quote encoded in fixture truth.")}
+                        {labelCell("Page number", row.page ?? "Not available")}
+                        {labelCell("Section heading", row.sectionHeading ?? "Not available")}
+                        {labelCell("Span ID", row.spanId ?? "Not available")}
+                        {labelCell("Why the evidence is accepted", row.whyEvidenceIsAccepted)}
+                        {labelCell("Rejected evidence examples", rejectedEvidenceBlock(row))}
+                        {labelCell(
+                          "Why rejected evidence is not enough",
+                          row.whyRejectedEvidenceIsNotEnough ?? "No rejected evidence explanation encoded for this row.",
+                        )}
+                        {labelCell("Client action", row.clientAction ?? "No client action required for this row.")}
+                        {labelCell("N/A reason", row.naReason ?? "This row is not marked N/A.")}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/preverif/FixtureBackedVm0007ReportView.tsx
+++ b/src/components/preverif/FixtureBackedVm0007ReportView.tsx
@@ -3,6 +3,7 @@ import type { Vm0007EvidenceMapRow, Vm0007FixtureBackedReport, Vm0007FixtureBack
 
 type FixtureBackedVm0007ReportViewProps = {
   report: Vm0007FixtureBackedReport;
+  pdfDownloadHref?: string | null;
 };
 
 function statusTone(status: Vm0007FixtureBackedStatus): string {
@@ -38,18 +39,28 @@ function rejectedEvidenceBlock(row: Vm0007EvidenceMapRow) {
   );
 }
 
-export default function FixtureBackedVm0007ReportView({ report }: FixtureBackedVm0007ReportViewProps) {
+export default function FixtureBackedVm0007ReportView({ report, pdfDownloadHref = null }: FixtureBackedVm0007ReportViewProps) {
   return (
     <main className="min-h-screen bg-slate-50 px-4 py-8">
       <div className="mx-auto grid max-w-7xl gap-4">
         <section className="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-slate-300 bg-slate-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-700">
-              Internal only
-            </span>
-            <span className="rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-800">
-              Fixture-backed VM0007 report
-            </span>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded-full border border-slate-300 bg-slate-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-700">
+                Internal only
+              </span>
+              <span className="rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-800">
+                Fixture-backed VM0007 report
+              </span>
+            </div>
+            {pdfDownloadHref ? (
+              <a
+                href={pdfDownloadHref}
+                className="rounded-full border border-slate-900 bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slate-800"
+              >
+                Download PDF
+              </a>
+            ) : null}
           </div>
           <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-950">{report.reportName}</h1>
           <div className="mt-2 text-base text-slate-700">{report.project.name}</div>

--- a/src/lib/preverif/enviraVm0007FixtureBackedPdf.ts
+++ b/src/lib/preverif/enviraVm0007FixtureBackedPdf.ts
@@ -1,0 +1,134 @@
+import type { Vm0007FixtureBackedReport } from "@/lib/preverif/fixtureBackedVm0007Report";
+
+function esc(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+}
+
+function asciiSafeText(input: string): string {
+  return input
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/[\u2013\u2014]/g, "-")
+    .replace(/\u2022/g, "-")
+    .replace(/\u00B7/g, "-")
+    .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, "");
+}
+
+function wrapText(text: string, max = 96): string[] {
+  const words = asciiSafeText(text).split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [""];
+
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= max) {
+      current = next;
+      continue;
+    }
+    if (current) lines.push(current);
+    current = word;
+  }
+  if (current) lines.push(current);
+  return lines;
+}
+
+function buildReportLines(report: Vm0007FixtureBackedReport): string[] {
+  const lines: string[] = [
+    report.reportName,
+    `Project: ${report.project.name}`,
+    `Methodology: ${report.methodology.code} ${report.methodology.version} - ${report.methodology.name}`,
+    `Generated: ${report.generatedAt}`,
+    report.limitationBanner,
+    report.summary.headline,
+    "Summary counts",
+    `FOUND: ${report.summary.counts.FOUND}`,
+    `UNCLEAR: ${report.summary.counts.UNCLEAR}`,
+    `MISSING: ${report.summary.counts.MISSING}`,
+    `N/A: ${report.summary.counts["N/A"]}`,
+    `Total rules: ${report.summary.totalRules}`,
+    "Evidence Map",
+    "Each row reflects reviewed fixture truth for a single VM0007 rule. UNCLEAR and MISSING rows remain visible for internal follow-up.",
+  ];
+
+  for (const row of report.evidenceMapRows) {
+    lines.push("");
+    lines.push(`Rule ID: ${row.ruleId}`);
+    lines.push(`Rule name: ${row.ruleName}`);
+    lines.push(`Status: ${row.status}`);
+    lines.push(`Accepted quote: ${row.acceptedQuote ?? "No accepted quote encoded in fixture truth."}`);
+    lines.push(`Page number: ${row.page ?? "Not available"}`);
+    lines.push(`Section heading: ${row.sectionHeading ?? "Not available"}`);
+    lines.push(`Span ID: ${row.spanId ?? "Not available"}`);
+    lines.push(`Accepted reason: ${row.whyEvidenceIsAccepted}`);
+    if (row.rejectedEvidenceExamples.length === 0) {
+      lines.push("Rejected evidence examples: No rejected evidence examples encoded for this row.");
+    } else {
+      lines.push("Rejected evidence examples:");
+      for (const rejected of row.rejectedEvidenceExamples) {
+        lines.push(`Rejected evidence quote: ${rejected.quote}`);
+        lines.push(`Rejection reason: ${rejected.rejectionReason}`);
+      }
+    }
+    lines.push(`Why rejected evidence is not enough: ${row.whyRejectedEvidenceIsNotEnough ?? "No rejected evidence explanation encoded for this row."}`);
+    lines.push(`Client action: ${row.clientAction ?? "No client action required for this row."}`);
+    lines.push(`N/A reason: ${row.naReason ?? "This row is not marked N/A."}`);
+  }
+
+  return lines.flatMap((line) => wrapText(line));
+}
+
+function buildPages(lines: string[], linesPerPage = 56): string[][] {
+  const pages: string[][] = [];
+  for (let index = 0; index < lines.length; index += linesPerPage) {
+    pages.push(lines.slice(index, index + linesPerPage));
+  }
+  return pages;
+}
+
+function buildContentStream(lines: string[]): string {
+  const commands = ["BT", "/F1 9 Tf", "50 770 Td"];
+  lines.forEach((line, index) => {
+    if (index > 0) commands.push("0 -12 Td");
+    commands.push(`(${esc(line)}) Tj`);
+  });
+  commands.push("ET");
+  return commands.join("\n");
+}
+
+export function buildEnviraVm0007FixtureBackedPdf(report: Vm0007FixtureBackedReport): Buffer {
+  const pageLines = buildPages(buildReportLines(report));
+  const objects: string[] = [];
+
+  objects.push("<< /Type /Catalog /Pages 2 0 R >>");
+  const pageObjectNumbers = pageLines.map((_, index) => 4 + index * 2);
+  objects.push(`<< /Type /Pages /Kids [${pageObjectNumbers.map((num) => `${num} 0 R`).join(" ")}] /Count ${pageLines.length} >>`);
+  objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+  pageLines.forEach((lines, index) => {
+    const pageObjectNumber = 4 + index * 2;
+    const contentObjectNumber = pageObjectNumber + 1;
+    const stream = buildContentStream(lines);
+    objects.push(
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents ${contentObjectNumber} 0 R >>`,
+    );
+    objects.push(`<< /Length ${Buffer.byteLength(stream, "utf8")} >>\nstream\n${stream}\nendstream`);
+  });
+
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+  objects.forEach((object, index) => {
+    offsets.push(Buffer.byteLength(pdf, "utf8"));
+    pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+
+  const xrefOffset = Buffer.byteLength(pdf, "utf8");
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += "0000000000 65535 f \n";
+  for (let index = 1; index < offsets.length; index += 1) {
+    pdf += `${String(offsets[index]).padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer << /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
+
+  return Buffer.from(pdf, "utf8");
+}

--- a/src/lib/preverif/enviraVm0007FixtureBackedReport.ts
+++ b/src/lib/preverif/enviraVm0007FixtureBackedReport.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { FullAuditFixtureSet, JudgmentFixtureSet } from "../../../tests/lib/preverifJudgmentFixtureGate";
+import { buildFixtureBackedVm0007Report, type Vm0007FixtureBackedReport } from "@/lib/preverif/fixtureBackedVm0007Report";
+
+const FIXTURE_DIR = path.join(process.cwd(), "tests/fixtures/preverif");
+
+function readJsonFixture<T>(fileName: string): T {
+  return JSON.parse(fs.readFileSync(path.join(FIXTURE_DIR, fileName), "utf8")) as T;
+}
+
+export function buildEnviraVm0007FixtureBackedReport(): Vm0007FixtureBackedReport {
+  const fullAuditFixtureSet = readJsonFixture<FullAuditFixtureSet>("envira-vm0007-full-audit-fixture-shape.json");
+  const judgmentFixtureSet = readJsonFixture<JudgmentFixtureSet>("envira-vm0007-judgment-fixtures.json");
+
+  return buildFixtureBackedVm0007Report({
+    reportId: "envira-vm0007-fixture-report",
+    reportName: "Internal Envira VM0007 Fixture-Backed Report Preview",
+    generatedAt: "2026-07-03T00:00:00Z",
+    project: {
+      name: "The Envira Amazonia Project",
+      description: "Reviewed Envira VM0007 fixture truth rendered into an internal-only report and Evidence Map.",
+    },
+    methodology: {
+      code: "VM0007",
+      version: "4.2",
+      name: "VM0007: REDD Methodology Modules (REDD-MF)",
+    },
+    fullAuditFixtureSet,
+    judgmentFixtureSet,
+  });
+}

--- a/src/lib/preverif/fixtureBackedVm0007Report.ts
+++ b/src/lib/preverif/fixtureBackedVm0007Report.ts
@@ -1,0 +1,118 @@
+import type { FixtureStatus, FullAuditFixtureSet, JudgmentFixtureSet } from "../../../tests/lib/preverifJudgmentFixtureGate";
+
+export type Vm0007FixtureBackedStatus = FixtureStatus;
+
+export type Vm0007EvidenceMapRejectedEvidence = {
+  quote: string;
+  rejectionReason: string;
+};
+
+export type Vm0007EvidenceMapRow = {
+  ruleId: string;
+  ruleName: string;
+  status: Vm0007FixtureBackedStatus;
+  acceptedQuote: string | null;
+  page: number | null;
+  sectionHeading: string | null;
+  spanId: string | null;
+  whyEvidenceIsAccepted: string;
+  rejectedEvidenceExamples: Vm0007EvidenceMapRejectedEvidence[];
+  whyRejectedEvidenceIsNotEnough: string | null;
+  clientAction: string | null;
+  naReason: string | null;
+};
+
+export type Vm0007FixtureBackedReport = {
+  reportId: string;
+  reportName: string;
+  generatedAt: string;
+  limitationBanner: string;
+  summary: {
+    totalRules: number;
+    counts: Record<Vm0007FixtureBackedStatus, number>;
+    headline: string;
+  };
+  project: {
+    name: string;
+    description: string;
+  };
+  methodology: {
+    code: string;
+    version: string;
+    name: string;
+  };
+  evidenceMapRows: Vm0007EvidenceMapRow[];
+};
+
+function buildJudgmentIndex(judgmentFixtureSet?: JudgmentFixtureSet): Map<string, JudgmentFixtureSet["checks"][number]> {
+  return new Map((judgmentFixtureSet?.checks ?? []).map((check) => [check.checkId, check]));
+}
+
+export function buildEvidenceMapRows(
+  fullAuditFixtureSet: FullAuditFixtureSet,
+  judgmentFixtureSet?: JudgmentFixtureSet,
+): Vm0007EvidenceMapRow[] {
+  const judgmentIndex = buildJudgmentIndex(judgmentFixtureSet);
+
+  return fullAuditFixtureSet.checks.map((check) => {
+    const judgmentCheck = judgmentIndex.get(check.checkId);
+    const rejectedEvidenceExamples = judgmentCheck?.knownBadQuotesToReject ?? [];
+    const whyRejectedEvidenceIsNotEnough =
+      rejectedEvidenceExamples.length > 0
+        ? judgmentCheck?.whyQuoteIsSufficientOrInsufficient ?? check.reason
+        : null;
+
+    return {
+      ruleId: check.checkId,
+      ruleName: check.checkName,
+      status: check.expectedStatus,
+      acceptedQuote: check.evidence?.quote ?? null,
+      page: check.page,
+      sectionHeading: check.sectionHeading,
+      spanId: check.spanId,
+      whyEvidenceIsAccepted:
+        check.expectedStatus === "FOUND"
+          ? check.reason
+          : check.expectedStatus === "UNCLEAR"
+            ? check.reason
+            : check.expectedStatus === "MISSING"
+              ? "No accepted project-specific PDD quote is encoded for this rule in the reviewed fixture truth."
+              : "This rule is encoded as N/A in the reviewed fixture truth because the project scope does not trigger it.",
+      rejectedEvidenceExamples,
+      whyRejectedEvidenceIsNotEnough,
+      clientAction:
+        check.expectedStatus === "UNCLEAR" || check.expectedStatus === "MISSING"
+          ? check.clientAction
+          : null,
+      naReason: check.expectedStatus === "N/A" ? check.reason : null,
+    };
+  });
+}
+
+export function buildFixtureBackedVm0007Report(input: {
+  reportId: string;
+  reportName: string;
+  generatedAt: string;
+  project: Vm0007FixtureBackedReport["project"];
+  methodology: Vm0007FixtureBackedReport["methodology"];
+  fullAuditFixtureSet: FullAuditFixtureSet;
+  judgmentFixtureSet?: JudgmentFixtureSet;
+}): Vm0007FixtureBackedReport {
+  const evidenceMapRows = buildEvidenceMapRows(input.fullAuditFixtureSet, input.judgmentFixtureSet);
+
+  return {
+    reportId: input.reportId,
+    reportName: input.reportName,
+    generatedAt: input.generatedAt,
+    limitationBanner: "Internal preview only. This route renders reviewed fixture truth for analysis and is not client-ready.",
+    summary: {
+      totalRules: input.fullAuditFixtureSet.expectedTotalRules,
+      counts: input.fullAuditFixtureSet.expectedStatusCounts,
+      headline:
+        "Summary counts and row detail come from reviewed fixture truth, not the current live audit output.",
+    },
+    project: input.project,
+    methodology: input.methodology,
+    evidenceMapRows,
+  };
+}

--- a/tests/app/api/exports/internal.envira-vm0007-report.route.test.ts
+++ b/tests/app/api/exports/internal.envira-vm0007-report.route.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "@jest/globals";
+import { GET } from "@/app/api/exports/internal/envira-vm0007-report/route";
+import { extractPdfTextWithPdfParse } from "@/lib/chat/quickCheckPdfExtractor";
+import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
+
+describe("/api/exports/internal/envira-vm0007-report route", () => {
+  it("returns a parseable PDF attachment built from fixture-backed report data", async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+    expect(response.headers.get("Content-Disposition")).toContain('attachment; filename="internal-envira-vm0007-fixture-backed-report.pdf"');
+
+    const bytes = await response.arrayBuffer();
+    const parsed = await extractPdfTextWithPdfParse({ bytes });
+    const text = parsed.text;
+    const lower = text.toLowerCase();
+    const normalized = text.replace(/\s+/g, " ").trim();
+    const report = buildEnviraVm0007FixtureBackedReport();
+
+    expect(text).toContain("Internal Envira VM0007 Fixture-Backed Report Preview");
+    expect(text).toContain("FOUND: 30");
+    expect(text).toContain("UNCLEAR: 8");
+    expect(text).toContain("MISSING: 3");
+    expect(text).toContain("N/A: 17");
+    expect(text).toContain("Total rules: 58");
+    expect(normalized).toContain(
+      "Internal preview only. This route renders reviewed fixture truth for analysis and is not client-ready.",
+    );
+
+    for (const row of report.evidenceMapRows) {
+      expect(text).toContain(`Rule ID: ${row.ruleId}`);
+      expect(text).toContain(`Rule name: ${row.ruleName}`);
+    }
+
+    expect((text.match(/Rule ID:/g) ?? []).length).toBe(58);
+    expect(normalized).toContain("Rejected evidence quote: the land is legally permitted to be converted to non-forest");
+    expect(normalized).toContain(
+      "Rejection reason: Generic methodology-applicability language is not the underlying authorization document.",
+    );
+
+    for (const banned of [
+      "all clear",
+      "passed",
+      "fully verified",
+      "ready for verification",
+      "58 supported",
+      "all rules supported",
+      "client-ready claim",
+    ]) {
+      expect(lower).not.toContain(banned);
+    }
+  }, 20000);
+});

--- a/tests/app/internal/envira-vm0007.page.test.tsx
+++ b/tests/app/internal/envira-vm0007.page.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "@jest/globals";
+import { renderToStaticMarkup } from "react-dom/server";
+import EnviraVm0007FixtureBackedReportPage from "@/app/internal/reports/envira-vm0007/page";
+
+describe("/internal/reports/envira-vm0007 page", () => {
+  test("renders a visible Download PDF button for the fixture-backed internal report", () => {
+    const html = renderToStaticMarkup(<EnviraVm0007FixtureBackedReportPage />);
+
+    expect(html).toContain("Download PDF");
+    expect(html).toContain('href="/api/exports/internal/envira-vm0007-report"');
+  });
+});

--- a/tests/components/fixtureBackedVm0007ReportView.test.tsx
+++ b/tests/components/fixtureBackedVm0007ReportView.test.tsx
@@ -4,7 +4,12 @@ import FixtureBackedVm0007ReportView from "@/components/preverif/FixtureBackedVm
 import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
 
 function buildHtml() {
-  return renderToStaticMarkup(<FixtureBackedVm0007ReportView report={buildEnviraVm0007FixtureBackedReport()} />);
+  return renderToStaticMarkup(
+    <FixtureBackedVm0007ReportView
+      report={buildEnviraVm0007FixtureBackedReport()}
+      pdfDownloadHref="/api/exports/internal/envira-vm0007-report"
+    />,
+  );
 }
 
 describe("FixtureBackedVm0007ReportView", () => {
@@ -13,6 +18,7 @@ describe("FixtureBackedVm0007ReportView", () => {
     const rowCount = (html.match(/data-evidence-map-row=/g) ?? []).length;
 
     expect(html).toContain("Internal Envira VM0007 Fixture-Backed Report Preview");
+    expect(html).toContain("Download PDF");
     expect(html).toContain(">FOUND<");
     expect(html).toContain(">30<");
     expect(html).toContain(">UNCLEAR<");

--- a/tests/components/fixtureBackedVm0007ReportView.test.tsx
+++ b/tests/components/fixtureBackedVm0007ReportView.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "@jest/globals";
+import { renderToStaticMarkup } from "react-dom/server";
+import FixtureBackedVm0007ReportView from "@/components/preverif/FixtureBackedVm0007ReportView";
+import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
+
+function buildHtml() {
+  return renderToStaticMarkup(<FixtureBackedVm0007ReportView report={buildEnviraVm0007FixtureBackedReport()} />);
+}
+
+describe("FixtureBackedVm0007ReportView", () => {
+  test("renders the reviewed Envira fixture summary counts and all 58 evidence-map rows", () => {
+    const html = buildHtml();
+    const rowCount = (html.match(/data-evidence-map-row=/g) ?? []).length;
+
+    expect(html).toContain("Internal Envira VM0007 Fixture-Backed Report Preview");
+    expect(html).toContain(">FOUND<");
+    expect(html).toContain(">30<");
+    expect(html).toContain(">UNCLEAR<");
+    expect(html).toContain(">8<");
+    expect(html).toContain(">MISSING<");
+    expect(html).toContain(">3<");
+    expect(html).toContain(">N/A<");
+    expect(html).toContain(">17<");
+    expect(rowCount).toBe(58);
+  });
+
+  test("renders UNCLEAR, MISSING, and N/A rows with the required explanations", () => {
+    const html = buildHtml();
+
+    expect(html).toContain('data-status="UNCLEAR"');
+    expect(html).toContain("still an inference");
+    expect(html).toContain("Add the conversion authorization document");
+
+    expect(html).toContain('data-status="MISSING"');
+    expect(html).toContain("No accepted quote encoded in fixture truth.");
+    expect(html).toContain("Add the project-specific eligibility analysis");
+
+    expect(html).toContain('data-status="N/A"');
+    expect(html).toContain("does not apply because the Envira Amazonia Project is a REDD forest-conservation project");
+  });
+
+  test("renders rejected evidence examples where the fixture encodes them and avoids banned wording", () => {
+    const html = buildHtml();
+    const lower = html.toLowerCase();
+
+    expect(html).toContain("the land is legally permitted to be converted to non-forest");
+    expect(html).toContain("Generic methodology-applicability language is not the underlying authorization document.");
+    expect(html).toContain("Project Description");
+
+    for (const banned of [
+      "all clear",
+      "fully verified",
+      "ready for verification",
+      "58 supported",
+      "all rules supported",
+      "passed",
+    ]) {
+      expect(lower).not.toContain(banned);
+    }
+  });
+});

--- a/tests/lib/preverif/clientReadinessGate.test.ts
+++ b/tests/lib/preverif/clientReadinessGate.test.ts
@@ -1,9 +1,10 @@
-import fs from "node:fs";
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, test } from "@jest/globals";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import FixtureBackedVm0007ReportView from "@/components/preverif/FixtureBackedVm0007ReportView";
 import Vm0007GapReportView from "@/components/preverif/Vm0007GapReportView";
 import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
 import {
   auditEvidence,
   type MethodologyEvidenceAuditResult,
@@ -14,10 +15,11 @@ import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif
 import { VM0007_SYNCED_RULES, readQuickCheckFixtureText } from "../preverifVm0007Fixtures";
 import {
   assertClientReadinessGate,
-  assertNoUnclearEvidence,
-  assertNoMissingEvidence,
+  assertInternalPreviewBoundaries,
   assertInternalPreviewLabelVisible,
   assertNoBannedClientReadyWording,
+  assertNoMissingEvidence,
+  assertNoUnclearEvidence,
   assertUsesStandardReportShape,
 } from "./clientReadinessGate";
 
@@ -120,7 +122,6 @@ function makeMissingAudit(baseAudit: MethodologyEvidenceAuditSummary): Methodolo
   };
 }
 
-/** Build a report where every row is treated as supported or not applicable — no weak/missing. */
 function makeCleanAudit(baseAudit: MethodologyEvidenceAuditSummary): MethodologyEvidenceAuditSummary {
   const results = baseAudit.results.map((result) => {
     if (result.status === "missing_evidence" || result.status === "partially_supported" || result.status === "manual_review_needed") {
@@ -240,5 +241,15 @@ describe("clientReadinessGate helper", () => {
       const html = renderReport(report, "<div>Ready for verification</div>");
       expect(() => assertClientReadinessGate({ reportHtml: html, report })).toThrow();
     });
+  });
+});
+
+describe("clientReadinessGate", () => {
+  test("internal Envira fixture-backed preview stays inside internal-only wording boundaries", () => {
+    const html = renderToStaticMarkup(
+      createElement(FixtureBackedVm0007ReportView, { report: buildEnviraVm0007FixtureBackedReport() }),
+    );
+
+    assertInternalPreviewBoundaries(html);
   });
 });

--- a/tests/lib/preverif/clientReadinessGate.ts
+++ b/tests/lib/preverif/clientReadinessGate.ts
@@ -24,16 +24,10 @@ export const INTERNAL_PREVIEW_LABELS = [
 ] as const;
 
 export type ClientReadinessGateInput = {
-  /** The rendered HTML of the gap report. */
   reportHtml: string;
-  /** The Vm0007GapReport object (used for data checks and banned-wording scan). */
   report: Vm0007GapReport;
 };
 
-/**
- * Asserts that the report has no UNCLEAR ("weak") rows.
- * Throws if any weak rows are present.
- */
 export function assertNoUnclearEvidence(report: Vm0007GapReport): void {
   const unclearCount = report.fullRuleAuditTable.filter(
     (row) => row.status === "weak",
@@ -41,10 +35,6 @@ export function assertNoUnclearEvidence(report: Vm0007GapReport): void {
   expect(unclearCount).toBe(0);
 }
 
-/**
- * Asserts that the report has no MISSING rows.
- * Throws if any missing rows are present.
- */
 export function assertNoMissingEvidence(report: Vm0007GapReport): void {
   const missingCount = report.fullRuleAuditTable.filter(
     (row) => row.status === "missing",
@@ -52,9 +42,6 @@ export function assertNoMissingEvidence(report: Vm0007GapReport): void {
   expect(missingCount).toBe(0);
 }
 
-/**
- * Asserts that the report HTML contains an internal preview label.
- */
 export function assertInternalPreviewLabelVisible(reportHtml: string): void {
   const text = reportHtml
     .replace(/<[^>]+>/g, " ")
@@ -67,10 +54,6 @@ export function assertInternalPreviewLabelVisible(reportHtml: string): void {
   expect(hasLabel).toBe(true);
 }
 
-/**
- * Asserts that neither the rendered HTML nor the report data
- * contain any banned client-ready phrasing.
- */
 export function assertNoBannedClientReadyWording(
   reportHtml: string,
   report: Vm0007GapReport,
@@ -83,11 +66,6 @@ export function assertNoBannedClientReadyWording(
   }
 }
 
-/**
- * Asserts that the report uses only standard VM0007 display statuses
- * and carries an internal preview name and limitation banner.
- * This guard prevents the gate from being bypassed by type changes.
- */
 export function assertUsesStandardReportShape(
   report: Vm0007GapReport,
 ): void {
@@ -100,12 +78,6 @@ export function assertUsesStandardReportShape(
   expect(report.limitationBanner).toContain("Internal preview only");
 }
 
-/**
- * Full client-readiness gate assertion.
- *
- * Runs all checks and throws on the first failure.
- * Use this for convenience when you want all enforcement in one call.
- */
 export function assertClientReadinessGate(input: ClientReadinessGateInput): void {
   const { reportHtml, report } = input;
 
@@ -114,4 +86,22 @@ export function assertClientReadinessGate(input: ClientReadinessGateInput): void
   assertNoMissingEvidence(report);
   assertInternalPreviewLabelVisible(reportHtml);
   assertNoBannedClientReadyWording(reportHtml, report);
+}
+
+export function assertInternalPreviewBoundaries(text: string): void {
+  const normalized = text.toLowerCase();
+
+  expect(normalized).toContain("internal preview only");
+  expect(normalized).toContain("not client-ready");
+
+  for (const banned of [
+    "all clear",
+    "fully verified",
+    "ready for verification",
+    "58 supported",
+    "all rules supported",
+    "passed",
+  ]) {
+    expect(normalized).not.toContain(banned);
+  }
 }

--- a/tests/lib/preverif/enviraVm0007FixtureBackedReport.test.ts
+++ b/tests/lib/preverif/enviraVm0007FixtureBackedReport.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "@jest/globals";
+import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
+
+describe("buildEnviraVm0007FixtureBackedReport", () => {
+  test("uses reviewed fixture truth counts and preserves all 58 VM0007 rows", () => {
+    const report = buildEnviraVm0007FixtureBackedReport();
+
+    expect(report.summary.counts.FOUND).toBe(30);
+    expect(report.summary.counts.UNCLEAR).toBe(8);
+    expect(report.summary.counts.MISSING).toBe(3);
+    expect(report.summary.counts["N/A"]).toBe(17);
+    expect(report.summary.totalRules).toBe(58);
+    expect(report.evidenceMapRows).toHaveLength(58);
+  });
+});


### PR DESCRIPTION
## What

Adds an internal fixture-backed Envira VM0007 report route/evidence-map path.

This route renders reviewed Envira fixture truth instead of current live audit output.

## Why

The old internal report can still show 58 supported / 0 weak / 0 missing / 0 N/A.

Reviewed fixture truth is 30 FOUND / 8 UNCLEAR / 3 MISSING / 17 N/A.

## Enforces

- Summary counts come from fixture truth.
- Evidence map renders all 58 VM0007 rows.
- Weak and missing evidence remain visible.
- Internal preview is not client-ready.
- Banned confidence wording is rejected.

## Validation

- [ ] npm test -- tests/lib/preverif/clientReadinessGate.test.ts --runInBand
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm run pr:gate
- [ ] npm run pr:gate:fixtures, if available

## Scope

Internal fixture-backed report route only.

No production audit logic changes.
No parser/router changes.
No generic upload behavior changes.
No client-ready report claim.
