### PR TITLE
[codex] VM0007 version cleanup roadmap

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -353,3 +353,8 @@ Not active now:
 4) RC3 — Full 58-Rule Audit Fixture Shape: Done — Completed via PR #911. Envira VM0007 now has a reviewed full 58-rule audit fixture with final split FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17. Review included FOUND red-team pass, UNCLEAR/MISSING rescue check, R-1-0003 carbon-rights fix, fixture/test-only scope confirmation, pr:gate, and blind rebuild validation.
 5) RC4 — Report Fixture Layer: Done — Completed via PR #914. Report summary expectations are fixture-driven, row grouping and summary sections are testable from fixtures, internal preview output is clearly distinguished from client-ready output. Local pr:gate passed, GitHub pr-gate passed, no production audit logic changed.
 6) RC5 — Client-Readiness Gate: Planned — Keep internal preview output separate from any later client-ready reporting work.
+
+## vm0007-version-cleanup
+
+Status SSOT: `docs/roadmaps/vm0007-version-cleanup/phase-status.json`
+

--- a/docs/roadmaps/vm0007-version-cleanup/phase-status.json
+++ b/docs/roadmaps/vm0007-version-cleanup/phase-status.json
@@ -1,0 +1,35 @@
+{
+  "roadmap": "vm0007-version-cleanup",
+  "phases": [
+    {
+      "title": "Phase 1: Version Lock",
+      "description": "Block VM0007 evidence audit unless PDD-declared methodology version matches the loaded contract/rulebook version.",
+      "status": "active"
+    },
+    {
+      "title": "Phase 2: Envira Quarantine",
+      "description": "Preserve Envira as a legacy v1.5 mismatch regression fixture, not validated truth.",
+      "status": "planned"
+    },
+    {
+      "title": "Phase 3: Report and PDF Blocking",
+      "description": "Prevent mismatched versions from producing normal evidence maps, reports, PDFs, or readiness claims.",
+      "status": "planned"
+    },
+    {
+      "title": "Phase 4: Gate Strengthening",
+      "description": "Add tests and gates so mismatches cannot produce judgments, reports, PDFs, or client-readiness output.",
+      "status": "planned"
+    },
+    {
+      "title": "Phase 5: Roadmap Correction",
+      "description": "Correct contaminated done states and mark VM0007 evidence-map work pending versioned re-audit.",
+      "status": "planned"
+    },
+    {
+      "title": "Phase 6: Forward Path",
+      "description": "Prepare a clean VM0007 v1.8 path such as Maya without building a full evidence map yet.",
+      "status": "planned"
+    }
+  ]
+}

--- a/docs/roadmaps/vm0007-version-cleanup/planned.md
+++ b/docs/roadmaps/vm0007-version-cleanup/planned.md
@@ -1,0 +1,136 @@
+# VM0007 Version Cleanup Roadmap
+
+## Goal
+
+Block VM0007 evidence audits unless the PDD-declared methodology version matches the loaded rulebook/contract version.
+
+## Non-Negotiable Invariant
+
+No VM0007 evidence judgment may produce FOUND, UNCLEAR, MISSING, N/A, report output, PDF output, or client-readiness output unless the system has verified:
+
+1. methodology ID match
+2. rulebook/contract version match
+3. PDD-declared methodology version match
+4. applicable module/version context where available
+
+## Phases
+
+### Phase 1: Version Lock
+
+Status: active
+
+Done when:
+
+* audit contracts/results include methodologyId
+* audit contracts/results include rulebookVersion
+* audit contracts/results include pddDeclaredMethodologyVersion
+* audit contracts/results include versionMatch
+* audit contracts/results include versionMismatchReason
+* generic evidenceAudit refuses to audit when versionMatch is false
+* Envira v1.5 + VM0007 v1.8 is blocked
+* matching VM0007 v1.8 + VM0007 v1.8 may proceed
+* blocked audits produce no FOUND, UNCLEAR, MISSING, or N/A judgments
+
+### Phase 2: Envira Quarantine
+
+Status: planned
+
+Done when:
+
+* Envira fixtures/routes/report labels clearly say legacy v1.5 mismatch
+* Envira is preserved as a regression fixture
+* old 30 FOUND / 8 UNCLEAR / 3 MISSING / 17 N/A counts are not treated as validated truth
+* false FOUND rows, wrong page anchors, module-list evidence, and flattened table evidence errors are preserved as failure examples
+
+### Phase 3: Report and PDF Blocking
+
+Status: planned
+
+Done when:
+
+* internal report route blocks mismatched versions
+* PDF export blocks mismatched versions
+* UI shows this message or equivalent:
+
+“Methodology version mismatch: PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.”
+
+* blocked output does not say client ready, ready for verification, verified, all clear, or similar
+
+### Phase 4: Gate Strengthening
+
+Status: planned
+
+Done when tests fail if:
+
+* a mismatched version produces FOUND rows
+* a mismatched version produces a report
+* a mismatched version produces a PDF export
+* a mismatched version passes client-readiness
+* old Envira counts are asserted as truth
+
+Also preserve:
+
+* exact quote integrity tests
+* page correctness tests
+* section correctness tests
+* cross-PDF leakage tests
+
+### Phase 5: Roadmap Correction
+
+Status: planned
+
+Done when:
+
+* docs/roadmaps/vm0007-judgement-fixtures and related summaries are corrected
+* old done states are changed to blocked, quarantined, or pending versioned re-audit
+* docs say VM0007 Evidence Map is not truth-complete until version lock and re-audit pass
+
+### Phase 6: Forward Path
+
+Status: planned
+
+Done when:
+
+* minimal fixture/test hook proves a clean VM0007 v1.8 PDD can pass the version lock
+* Envira remains blocked
+* no full Maya evidence map is built in this cleanup roadmap unless explicitly requested
+
+## Expected PR Split
+
+PR 1:
+`fix: require methodology version match before VM0007 evidence audit`
+
+Covers:
+
+* Phase 1
+* minimal Phase 6 proof
+
+PR 2:
+`fix: quarantine Envira VM0007 fixture as legacy v1.5`
+
+Covers:
+
+* Phase 2
+* Phase 3
+
+PR 3:
+`docs/test: mark VM0007 report fixture phases blocked pending versioned re-audit`
+
+Covers:
+
+* Phase 4
+* Phase 5
+* any remaining Phase 6 hook
+
+## Final Acceptance Criteria
+
+* Envira PDD declaring REDD-MF v1.5 cannot be judged using VM0007 v1.8 contracts
+* Envira mismatch produces an explicit blocked status
+* no normal Envira VM0007 evidence map, report, or PDF is produced from mismatched contracts
+* no tests assert 30 FOUND / 8 UNCLEAR / 3 MISSING / 17 N/A as validated truth
+* client-readiness gate fails on version mismatch
+* fixture quality gate checks methodology-version match
+* roadmap no longer says contaminated VM0007 report fixture work is truth-complete
+* existing Quick Check v2 fixtures still pass
+* existing quote integrity tests still pass
+* a future VM0007 v1.8 PDD can be audited only after version match is confirmed


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: vm0007-version-cleanup
- items:
  - PR922: in_progress

## What changed
- Added the VM0007 version cleanup roadmap docs under `docs/roadmaps/vm0007-version-cleanup/`.
- Added the generated roadmap summary entry in `docs/roadmaps/SUMMARY.md`.

## Why
- Document the cleanup needed to block VM0007 evidence audits when the PDD-declared methodology version does not match the loaded rulebook/contract version.
- Prevent mismatched-version Envira judgments from being treated as validated truth.

## Impact
- Docs only.
- No audit logic, fixtures, report rendering, PDF export, client-readiness gates, or tests were changed.
