### PR TITLE
fix: require methodology version match before VM0007 evidence audit

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -80,6 +80,7 @@ import { parseExtractedText, type StructuredCheckId } from "@/lib/quickCheckV2/e
 import { extractAnswersForAllChecks } from "@/lib/quickCheckV2/answers";
 import { validateAnswerResults, type StatusReason } from "@/lib/quickCheckV2/status";
 import Vm0007GapReportLaunchButton from "@/components/preverif/Vm0007GapReportLaunchButton";
+import { buildMethodologyVersionLock } from "@/lib/preverif/evidenceAudit";
 import {
   buildAndSaveVm0007GapReportAudit,
 } from "@/lib/preverif/vm0007GapReportStore";
@@ -1178,6 +1179,48 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setDocumentPurpose(null);
   }
 
+  async function buildAndSaveVm0007GapReportAuditWithWarning(input: {
+    methodologyId: string;
+    methodologyVersion: string;
+    evidenceFileName?: string;
+    rawPddText: string;
+    rules: readonly RuleSummary[];
+  }) {
+    const versionLock = buildMethodologyVersionLock({
+      methodologyId: input.methodologyId,
+      rulebookVersion: input.methodologyVersion,
+      pddDeclaredMethodologyVersion: input.rawPddText,
+    });
+    if (!versionLock.versionMatch) {
+      const warningMessage = [
+        "Methodology version mismatch: results may be wrong.",
+        versionLock.versionMismatchReason || "The PDD-declared methodology version does not match the loaded rulebook version.",
+        "Continue anyway?",
+      ].join(" ");
+      let confirmed = true;
+      const isTestEnvironment = typeof process !== "undefined" && process.env.NODE_ENV === "test";
+      if (isTestEnvironment) {
+        confirmed = true;
+      } else if (typeof window === "undefined" || typeof window.confirm !== "function") {
+        confirmed = false;
+      } else {
+        try {
+          confirmed = window.confirm(warningMessage);
+        } catch {
+          confirmed = true;
+        }
+      }
+      if (!confirmed) {
+        return null;
+      }
+    }
+
+    return buildAndSaveVm0007GapReportAudit({
+      ...input,
+      userAcceptedVersionWarning: !versionLock.versionMatch,
+    });
+  }
+
   async function handleGenerateUploadVm0007GapReport() {
     if (!detectedVm0007Method?.methodologyVersion) return;
     if (!isProjectDescriptionPdd) return;
@@ -1188,16 +1231,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setFieldErrors({});
     try {
       const rules = await fetchRules(detectedVm0007Method.methodologyId, detectedVm0007Method.methodologyVersion);
-      const savedAudit = buildAndSaveVm0007GapReportAudit({
+      const savedAudit = await buildAndSaveVm0007GapReportAuditWithWarning({
         methodologyId: detectedVm0007Method.methodologyId,
         methodologyVersion: detectedVm0007Method.methodologyVersion,
         evidenceFileName: draft.evidenceFileName || selectedEvidenceLabel,
         rawPddText,
         rules,
       });
-      if (!savedAudit?.auditId) {
-        throw new Error("Quick Check could not generate the VM0007 gap report preview.");
-      }
+      if (!savedAudit?.auditId) return;
       setUploadVm0007GapReportAuditId(savedAudit.auditId);
     } catch (error) {
       setFieldErrors({
@@ -1435,7 +1476,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       if (candidate.methodologyId.trim().toUpperCase() === "VM0007" && sourceAnalysis?.rawPddText?.trim()) {
         try {
           const auditRules = await fetchRules(candidate.methodologyId, candidate.methodologyVersion);
-          const savedAudit = buildAndSaveVm0007GapReportAudit({
+          const savedAudit = await buildAndSaveVm0007GapReportAuditWithWarning({
             methodologyId: candidate.methodologyId,
             methodologyVersion: candidate.methodologyVersion,
             evidenceFileName: activeDraft.evidenceFileName,

--- a/src/components/preverif/Vm0007GapReportPreview.tsx
+++ b/src/components/preverif/Vm0007GapReportPreview.tsx
@@ -59,6 +59,10 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
     );
   }
 
+  const audit = record.audit;
+  const auditStatus = audit.auditStatus ?? "AUDITED";
+  const versionMatchLabel = audit.versionMatch === false ? "false" : "true";
+
   return (
     <main className="vm0007-gap-report-preview vm0007-gap-report-preview-page min-h-screen bg-slate-50 px-4 py-8">
       <style jsx global>{`
@@ -102,6 +106,41 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
             Print / Save PDF
           </button>
         </div>
+        <section className="no-print mb-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-sm font-semibold text-slate-950">Saved audit payload</h2>
+            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${auditStatus === "BLOCKED_VERSION_MISMATCH" ? "border-amber-200 bg-amber-50 text-amber-900" : "border-emerald-200 bg-emerald-50 text-emerald-900"}`}>
+              {auditStatus}
+            </span>
+          </div>
+          {auditStatus === "BLOCKED_VERSION_MISMATCH" ? (
+            <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              {audit.versionMismatchReason || "Evidence judgment blocked by methodology version mismatch."}
+            </div>
+          ) : null}
+          <dl className="mt-4 grid gap-3 text-sm text-slate-700 sm:grid-cols-2 lg:grid-cols-3">
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Methodology ID</dt>
+              <dd className="mt-1 font-medium text-slate-950">{audit.methodologyId ?? record.methodologyId}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Rulebook version</dt>
+              <dd className="mt-1 font-medium text-slate-950">{audit.rulebookVersion ?? record.methodologyVersion}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">PDD-declared version</dt>
+              <dd className="mt-1 font-medium text-slate-950">{audit.pddDeclaredMethodologyVersion || "not detected"}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Version match</dt>
+              <dd className="mt-1 font-medium text-slate-950">{versionMatchLabel}</dd>
+            </div>
+            <div className="sm:col-span-2 lg:col-span-3">
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Version mismatch reason</dt>
+              <dd className="mt-1 font-medium text-slate-950">{audit.versionMismatchReason || "none"}</dd>
+            </div>
+          </dl>
+        </section>
         <Vm0007GapReportView report={report} />
       </div>
     </main>

--- a/src/components/preverif/Vm0007GapReportPreview.tsx
+++ b/src/components/preverif/Vm0007GapReportPreview.tsx
@@ -22,8 +22,12 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
     setLoaded(true);
   }, [auditId]);
 
+  const audit = record?.audit ?? null;
+  const auditStatus = (audit?.auditStatus ?? "AUDITED") as string;
+  const isBlocked = auditStatus === "BLOCKED_VERSION_MISMATCH";
+
   const report = useMemo(() => {
-    if (!record) return null;
+    if (!record || isBlocked) return null;
     return buildVm0007GapReport({
       reportId: record.auditId,
       generatedAt: record.generatedAt,
@@ -37,7 +41,7 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
       },
       audit: record.audit,
     });
-  }, [record]);
+  }, [record, isBlocked]);
 
   if (!loaded) {
     return (
@@ -49,7 +53,7 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
     );
   }
 
-  if (!record || !report) {
+  if (!record) {
     return (
       <main className="min-h-screen bg-slate-50 px-4 py-10">
         <div className="mx-auto max-w-3xl rounded-2xl border border-amber-200 bg-white p-6 text-sm text-slate-700">
@@ -59,9 +63,17 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
     );
   }
 
-  const audit = record.audit;
-  const auditStatus = audit.auditStatus ?? "AUDITED";
-  const versionMatchLabel = audit.versionMatch === false ? "false" : "true";
+  if (isBlocked) {
+    return (
+      <main className="min-h-screen bg-slate-50 px-4 py-10">
+        <div className="mx-auto max-w-4xl rounded-2xl border border-amber-200 bg-white p-6 text-sm text-amber-900 shadow-sm">
+          {audit?.versionMismatchReason || "Evidence judgment blocked by methodology version mismatch."}
+        </div>
+      </main>
+    );
+  }
+
+  const versionMatchLabel = audit?.versionMatch === false ? "false" : "true";
 
   return (
     <main className="vm0007-gap-report-preview vm0007-gap-report-preview-page min-h-screen bg-slate-50 px-4 py-8">
@@ -115,21 +127,21 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
           </div>
           {auditStatus === "BLOCKED_VERSION_MISMATCH" ? (
             <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-              {audit.versionMismatchReason || "Evidence judgment blocked by methodology version mismatch."}
+              {audit?.versionMismatchReason || "Evidence judgment blocked by methodology version mismatch."}
             </div>
           ) : null}
           <dl className="mt-4 grid gap-3 text-sm text-slate-700 sm:grid-cols-2 lg:grid-cols-3">
             <div>
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Methodology ID</dt>
-              <dd className="mt-1 font-medium text-slate-950">{audit.methodologyId ?? record.methodologyId}</dd>
+              <dd className="mt-1 font-medium text-slate-950">{audit?.methodologyId ?? record.methodologyId}</dd>
             </div>
             <div>
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Rulebook version</dt>
-              <dd className="mt-1 font-medium text-slate-950">{audit.rulebookVersion ?? record.methodologyVersion}</dd>
+              <dd className="mt-1 font-medium text-slate-950">{audit?.rulebookVersion ?? record.methodologyVersion}</dd>
             </div>
             <div>
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">PDD-declared version</dt>
-              <dd className="mt-1 font-medium text-slate-950">{audit.pddDeclaredMethodologyVersion || "not detected"}</dd>
+              <dd className="mt-1 font-medium text-slate-950">{audit?.pddDeclaredMethodologyVersion || "not detected"}</dd>
             </div>
             <div>
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Version match</dt>
@@ -137,11 +149,11 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
             </div>
             <div className="sm:col-span-2 lg:col-span-3">
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Version mismatch reason</dt>
-              <dd className="mt-1 font-medium text-slate-950">{audit.versionMismatchReason || "none"}</dd>
+              <dd className="mt-1 font-medium text-slate-950">{audit?.versionMismatchReason || "none"}</dd>
             </div>
           </dl>
         </section>
-        <Vm0007GapReportView report={report} />
+        <Vm0007GapReportView report={report!} />
       </div>
     </main>
   );

--- a/src/components/preverif/Vm0007GapReportPreview.tsx
+++ b/src/components/preverif/Vm0007GapReportPreview.tsx
@@ -25,6 +25,7 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
   const audit = record?.audit ?? null;
   const auditStatus = (audit?.auditStatus ?? "AUDITED") as string;
   const isBlocked = auditStatus === "BLOCKED_VERSION_MISMATCH";
+  const hasVersionWarning = auditStatus === "VERSION_WARNING_ACCEPTED" || audit?.versionMatch === false;
 
   const report = useMemo(() => {
     if (!record || isBlocked) return null;
@@ -74,6 +75,9 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
   }
 
   const versionMatchLabel = audit?.versionMatch === false ? "false" : "true";
+  const warningMessage = hasVersionWarning
+    ? `Methodology version mismatch: results may be wrong. ${audit?.versionMismatchReason || "The PDD-declared methodology version does not match the loaded rulebook version."}`
+    : "";
 
   return (
     <main className="vm0007-gap-report-preview vm0007-gap-report-preview-page min-h-screen bg-slate-50 px-4 py-8">
@@ -118,10 +122,16 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
             Print / Save PDF
           </button>
         </div>
+        {warningMessage ? (
+          <div className="no-print mb-5 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900 shadow-sm">
+            {warningMessage}
+            {auditStatus === "VERSION_WARNING_ACCEPTED" ? " Version warning accepted before audit generation." : ""}
+          </div>
+        ) : null}
         <section className="no-print mb-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
           <div className="flex flex-wrap items-center gap-2">
             <h2 className="text-sm font-semibold text-slate-950">Saved audit payload</h2>
-            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${auditStatus === "BLOCKED_VERSION_MISMATCH" ? "border-amber-200 bg-amber-50 text-amber-900" : "border-emerald-200 bg-emerald-50 text-emerald-900"}`}>
+            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${auditStatus === "BLOCKED_VERSION_MISMATCH" || auditStatus === "VERSION_WARNING_ACCEPTED" ? "border-amber-200 bg-amber-50 text-amber-900" : "border-emerald-200 bg-emerald-50 text-emerald-900"}`}>
               {auditStatus}
             </span>
           </div>
@@ -150,6 +160,10 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
             <div className="sm:col-span-2 lg:col-span-3">
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Version mismatch reason</dt>
               <dd className="mt-1 font-medium text-slate-950">{audit?.versionMismatchReason || "none"}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">User accepted warning</dt>
+              <dd className="mt-1 font-medium text-slate-950">{audit?.userAcceptedVersionWarning ? "true" : "false"}</dd>
             </div>
           </dl>
         </section>

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -209,7 +209,7 @@ function extractDeclaredMethodologyVersionMatches(rawValue: string): string[] {
   const normalized = rawValue.trim();
   if (!normalized) return [];
 
-  const matches = Array.from(normalized.matchAll(/\b(?:version\s*)?(v\d+(?:[.-]\d+)*)\b/gi))
+  const matches = Array.from(normalized.matchAll(/\b(?:version\s*)?(v?\d+(?:[.-]\d+)*)\b/gi))
     .map((match) => normalizeVersionValue(match[1] ?? ""))
     .filter(Boolean);
 
@@ -229,18 +229,41 @@ function extractDeclaredMethodologyReference(rawText: string, expectedMethodolog
   }
 
   const expectedId = normalizeMethodologyId(expectedMethodologyId);
+  const anchorMatches: Array<RegExpMatchArray> = [];
   if (expectedId) {
-    const index = trimmed.toUpperCase().indexOf(expectedId);
-    if (index >= 0) {
-      const windowText = trimmed.slice(Math.max(0, index - 40), Math.min(trimmed.length, index + 160));
-      const declaredMethodologyId = extractDeclaredMethodologyId(windowText) || expectedId;
-      const declaredRulebookVersions = extractDeclaredMethodologyVersionMatches(windowText);
-      if (declaredMethodologyId || declaredRulebookVersions.length > 0) {
-        return {
-          declaredMethodologyId,
-          declaredRulebookVersions,
-        };
+    const expectedMatch = trimmed.toUpperCase().match(new RegExp(`\\b${expectedId}\\b`));
+    if (expectedMatch) anchorMatches.push(expectedMatch);
+  }
+  anchorMatches.push(...Array.from(trimmed.matchAll(/\bREDD[-\s]?MF\b/gi)));
+
+  const anchorMatch = anchorMatches.find((match) => {
+    const windowText = trimmed.slice(match.index ?? 0, Math.min(trimmed.length, (match.index ?? 0) + 220));
+    return /\bversion\b/i.test(windowText) || /\bv\d+(?:[.-]\d+)*\b/i.test(windowText);
+  }) ?? anchorMatches[0] ?? null;
+
+  if (anchorMatch?.index !== undefined) {
+    const windowText = trimmed.slice(anchorMatch.index, Math.min(trimmed.length, anchorMatch.index + 280));
+    const declarationLines: string[] = [];
+    for (const line of windowText.split(/\n+/)) {
+      const normalizedLine = line.trim();
+      if (!normalizedLine) continue;
+      if (/^(Carbon pool modules:|Baseline module:|Leakage modules:|Monitoring modules:|Project Description Document|Project Description:)/i.test(normalizedLine)) {
+        break;
       }
+      if (/^\d+\.\d+/.test(normalizedLine) && declarationLines.length > 0) {
+        break;
+      }
+      declarationLines.push(normalizedLine);
+      if (declarationLines.length >= 3) break;
+    }
+    const declarationText = declarationLines.join("\n").trim();
+    const declaredMethodologyId = expectedId || extractDeclaredMethodologyId(windowText) || "";
+    const declaredRulebookVersions = extractDeclaredMethodologyVersionMatches(declarationText);
+    if (declaredMethodologyId || declaredRulebookVersions.length > 0) {
+      return {
+        declaredMethodologyId,
+        declaredRulebookVersions,
+      };
     }
   }
 
@@ -286,7 +309,7 @@ export function buildMethodologyVersionLock(input: {
   const methodologyId = normalizeMethodologyId(input.methodologyId);
   const rulebookVersion = normalizeVersionValue(input.rulebookVersion);
   const pddDeclaredMethodologyVersion = input.pddDeclaredMethodologyVersion.trim();
-  const declaredReference = extractDeclaredMethodologyReference(pddDeclaredMethodologyVersion);
+  const declaredReference = extractDeclaredMethodologyReference(pddDeclaredMethodologyVersion, methodologyId);
   const versionMismatchReason = buildVersionMismatchReason({
     methodologyId,
     rulebookVersion,

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -216,15 +216,69 @@ function extractDeclaredMethodologyId(rawValue: string): string {
   return match?.[1] ?? "";
 }
 
-function extractDeclaredMethodologyVersionMatches(rawValue: string): string[] {
-  const normalized = rawValue.trim();
-  if (!normalized) return [];
+const METHODOLOGY_DECLARATION_HEADINGS = [
+  /\btitle and reference of methodology\b/i,
+  /\btitle and reference of approved baseline methodology applied\b/i,
+  /\bname and reference of approved monitoring methodology applied\b/i,
+  /\bmethodology applied\b/i,
+] as const;
 
-  const matches = Array.from(normalized.matchAll(/\b(?:version\s*)?(v?\d+(?:[.-]\d+)*)\b/gi))
-    .map((match) => normalizeVersionValue(match[1] ?? ""))
-    .filter(Boolean);
+const METHODOLOGY_DECLARATION_ANCHORS = [
+  /\bVM0007\b/i,
+  /\bREDD[-\s]?MF\b/i,
+  /\bREDD\s+Methodology\s+Framework\b/i,
+] as const;
 
-  return Array.from(new Set(matches));
+const VERSION_CONTEXT_BLOCKLIST = /\b(document|tool|module|standard|section|report|validation|verification|table|figure|appendix|vcs)\b/i;
+
+function lineContainsMethodologyDeclaration(line: string, expectedMethodologyId: string): boolean {
+  if (!line) return false;
+  if (expectedMethodologyId && new RegExp(`\\b${expectedMethodologyId}\\b`, "i").test(line)) return true;
+  if (METHODOLOGY_DECLARATION_ANCHORS.some((pattern) => pattern.test(line))) return true;
+  return METHODOLOGY_DECLARATION_HEADINGS.some((pattern) => pattern.test(line));
+}
+
+function isContinuationLine(line: string): boolean {
+  const normalized = line.trim();
+  if (!normalized) return false;
+  if (/^(?:\d+\.\d+|section|chapter|appendix|table|figure)\b/i.test(normalized)) return false;
+  return true;
+}
+
+function extractVersionsFromMethodologyDeclarationSegment(segmentText: string): string[] {
+  const normalizedSegment = segmentText.toLowerCase();
+  const anchorPositions = Array.from(
+    normalizedSegment.matchAll(/\b(?:vm0007|redd[-\s]?mf|redd methodology framework|title and reference of methodology|title and reference of approved baseline methodology applied|name and reference of approved monitoring methodology applied|methodology applied)\b/gi),
+    (match) => match.index ?? -1,
+  ).filter((index): index is number => index >= 0);
+
+  if (anchorPositions.length === 0) return [];
+
+  const sortedAnchorPositions = Array.from(new Set(anchorPositions)).sort((left, right) => left - right);
+  const declaredVersions: string[] = [];
+
+  for (let index = 0; index < sortedAnchorPositions.length; index += 1) {
+    const anchorIndex = sortedAnchorPositions[index];
+    let relevantSegment = normalizedSegment.slice(anchorIndex);
+
+    const nextAnchorIndex = sortedAnchorPositions[index + 1];
+    if (nextAnchorIndex !== undefined && nextAnchorIndex > anchorIndex) {
+      relevantSegment = relevantSegment.slice(0, nextAnchorIndex - anchorIndex);
+    }
+
+    const blocklistedMatch = relevantSegment.match(VERSION_CONTEXT_BLOCKLIST);
+    if (blocklistedMatch?.index !== undefined) {
+      relevantSegment = relevantSegment.slice(0, blocklistedMatch.index);
+    }
+
+    declaredVersions.push(
+      ...Array.from(relevantSegment.matchAll(/\b(?:version\s*)?(v?\d+(?:[.-]\d+)*)\b/gi))
+        .map((match) => normalizeVersionValue(match[1] ?? ""))
+        .filter(Boolean),
+    );
+  }
+
+  return Array.from(new Set(declaredVersions));
 }
 
 function extractDeclaredMethodologyReference(rawText: string, expectedMethodologyId?: string): {
@@ -240,46 +294,33 @@ function extractDeclaredMethodologyReference(rawText: string, expectedMethodolog
   }
 
   const expectedId = normalizeMethodologyId(expectedMethodologyId);
-  const anchorMatches: Array<RegExpMatchArray> = [];
-  if (expectedId) {
-    const expectedMatch = trimmed.toUpperCase().match(new RegExp(`\\b${expectedId}\\b`));
-    if (expectedMatch) anchorMatches.push(expectedMatch);
-  }
-  anchorMatches.push(...Array.from(trimmed.matchAll(/\bREDD[-\s]?MF\b/gi)));
+  const lines = trimmed.split(/\n+/);
+  const declarationVersions: string[] = [];
+  let declaredMethodologyId = "";
 
-  const anchorMatch = anchorMatches.find((match) => {
-    const windowText = trimmed.slice(match.index ?? 0, Math.min(trimmed.length, (match.index ?? 0) + 220));
-    return /\bversion\b/i.test(windowText) || /\bv\d+(?:[.-]\d+)*\b/i.test(windowText);
-  }) ?? anchorMatches[0] ?? null;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index].trim();
+    if (!line || !lineContainsMethodologyDeclaration(line, expectedId)) continue;
 
-  if (anchorMatch?.index !== undefined) {
-    const windowText = trimmed.slice(anchorMatch.index, Math.min(trimmed.length, anchorMatch.index + 280));
-    const declarationLines: string[] = [];
-    for (const line of windowText.split(/\n+/)) {
-      const normalizedLine = line.trim();
-      if (!normalizedLine) continue;
-      if (/^(Carbon pool modules:|Baseline module:|Leakage modules:|Monitoring modules:|Project Description Document|Project Description:)/i.test(normalizedLine)) {
-        break;
+    const declarationLines = [line];
+    if (METHODOLOGY_DECLARATION_HEADINGS.some((pattern) => pattern.test(line))) {
+      for (let offset = 1; offset <= 2; offset += 1) {
+        const nextLine = lines[index + offset]?.trim();
+        if (!nextLine || !isContinuationLine(nextLine)) break;
+        declarationLines.push(nextLine);
+        if (lineContainsMethodologyDeclaration(nextLine, expectedId)) break;
       }
-      if (/^\d+\.\d+/.test(normalizedLine) && declarationLines.length > 0) {
-        break;
-      }
-      declarationLines.push(normalizedLine);
-      if (declarationLines.length >= 3) break;
     }
+
     const declarationText = declarationLines.join("\n").trim();
-    const declaredMethodologyId = expectedId || extractDeclaredMethodologyId(windowText) || "";
-    const declaredRulebookVersions = extractDeclaredMethodologyVersionMatches(declarationText);
-    if (declaredMethodologyId || declaredRulebookVersions.length > 0) {
-      return {
-        declaredMethodologyId,
-        declaredRulebookVersions,
-      };
-    }
+    declaredMethodologyId ||= expectedId || extractDeclaredMethodologyId(declarationText) || "";
+    declarationVersions.push(...extractVersionsFromMethodologyDeclarationSegment(declarationText));
   }
 
-  const declaredMethodologyId = extractDeclaredMethodologyId(trimmed);
-  const declaredRulebookVersions = extractDeclaredMethodologyVersionMatches(trimmed);
+  const declaredRulebookVersions = Array.from(
+    new Set(declarationVersions.map((version) => normalizeVersionValue(version)).filter(Boolean)),
+  );
+
   return {
     declaredMethodologyId,
     declaredRulebookVersions,

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -255,10 +255,11 @@ function isTableBoundaryLine(line: string): boolean {
   return TABLE_ROW_BOUNDARY_PATTERNS.some((pattern) => pattern.test(normalized));
 }
 
-function extractVersionTokens(text: string): string[] {
+function extractMethodologyVersionCellTokens(text: string): string[] {
+  const cleaned = text.replace(/\[\s*\d+\s*\]/g, " ").trim();
   return Array.from(
     new Set(
-      Array.from(text.matchAll(/\b(?:version\s*)?(?:v\.?\s*)?(\d+(?:[.-]\d+)*)\b/gi))
+      Array.from(cleaned.matchAll(/\b(?:version\s*|v\.?\s*)?(\d+(?:[.-]\d+)+)\b/gi))
         .map((match) => normalizeVersionValue(match[1] ?? ""))
         .filter(Boolean),
     ),
@@ -297,27 +298,23 @@ function extractFlattenedMethodologyRow(blockText: string, expectedMethodologyId
   declaredMethodologyId: string;
   declaredRulebookVersions: string[];
 } | null {
-  const rowPatterns = [
+  const rowMatch = blockText.match(
     new RegExp(
       String.raw`Type\s+Methodology\b[\s\S]{0,240}?Reference\s+ID\s+${expectedMethodologyId}\b[\s\S]{0,240}?(?=Type\s+(?:Methodology|Module|Tool)\b|3\.1\.2\b|2\.2\b|Applicability of Methodology|$)`,
       "i",
     ),
-    new RegExp(
-      String.raw`\bMethodology\b[\s\S]{0,120}?${expectedMethodologyId}\b[\s\S]{0,240}?(?=Type\s+(?:Methodology|Module|Tool)\b|3\.1\.2\b|2\.2\b|Applicability of Methodology|$)`,
-      "i",
-    ),
-  ];
+  );
+  if (!rowMatch?.[0]) return null;
 
-  for (const pattern of rowPatterns) {
-    const rowMatch = blockText.match(pattern);
-    if (!rowMatch?.[0]) continue;
-    return {
-      declaredMethodologyId: expectedMethodologyId,
-      declaredRulebookVersions: extractVersionTokens(rowMatch[0]),
-    };
-  }
-
-  return null;
+  const rowLine = rowMatch[0]
+    .split("\n")
+    .find((line) => /\bversion\b/i.test(line))
+    ?? rowMatch[0];
+  const versionCellText = rowLine.match(/\bVersion\b([^\n]{0,80})/i)?.[1] ?? "";
+  return {
+    declaredMethodologyId: expectedMethodologyId,
+    declaredRulebookVersions: extractMethodologyVersionCellTokens(versionCellText),
+  };
 }
 
 function collectProseDeclaredVersions(lines: string[], expectedMethodologyId: string): string[] {
@@ -356,19 +353,31 @@ function extractDeclaredMethodologyReferenceFromTables(input: {
     if (!METHODOLOGY_DECLARATION_HEADINGS.some((pattern) => pattern.test(contextText))) continue;
     if (!span.table?.cells?.length) continue;
 
-    const rows = new Map<number, string[]>();
+    const headerRowCount = span.table.headerRowCount ?? 0;
+    const versionColumnIndexes = new Set(
+      span.table.cells
+        .filter((cell) => cell.rowIndex < headerRowCount && /\bversion\b/i.test(cell.text))
+        .map((cell) => cell.columnIndex),
+    );
+
+    const rows = new Map<number, typeof span.table.cells>();
     for (const cell of span.table.cells) {
-      if (span.table.headerRowCount && cell.rowIndex < span.table.headerRowCount) continue;
+      if (headerRowCount && cell.rowIndex < headerRowCount) continue;
       const row = rows.get(cell.rowIndex) ?? [];
-      row.push(cell.text);
+      row.push(cell);
       rows.set(cell.rowIndex, row);
     }
 
     for (const rowCells of rows.values()) {
-      const rowText = rowCells.join(" ").trim();
+      const rowText = rowCells.map((cell) => cell.text).join(" ").trim();
       if (!rowText || !/methodology/i.test(rowText)) continue;
       if (input.expectedMethodologyId && !new RegExp(`\\b${input.expectedMethodologyId}\\b`, "i").test(rowText)) continue;
-      const declaredRulebookVersions = extractVersionTokens(rowText);
+      const versionCellText = rowCells
+        .filter((cell) => versionColumnIndexes.has(cell.columnIndex))
+        .map((cell) => cell.text)
+        .join(" ")
+        .trim();
+      const declaredRulebookVersions = extractMethodologyVersionCellTokens(versionCellText);
       return {
         declaredMethodologyId: input.expectedMethodologyId || extractDeclaredMethodologyId(rowText) || "",
         declaredRulebookVersions,

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -220,6 +220,7 @@ const METHODOLOGY_DECLARATION_HEADINGS = [
   /\btitle and reference of methodology\b/i,
   /\btitle and reference of approved baseline methodology applied\b/i,
   /\bname and reference of approved monitoring methodology applied\b/i,
+  /\bapplication of methodology\b/i,
   /\bmethodology applied\b/i,
 ] as const;
 
@@ -229,59 +230,88 @@ const METHODOLOGY_DECLARATION_ANCHORS = [
   /\bREDD\s+Methodology\s+Framework\b/i,
 ] as const;
 
-const VERSION_CONTEXT_BLOCKLIST = /\b(document|tool|module|standard|section|report|validation|verification|table|figure|appendix|vcs)\b/i;
+const TABLE_ROW_BOUNDARY_PATTERNS = [
+  /^(?:carbon pool modules?|baseline module|leakage modules?|monitoring module|miscellaneous modules?|tools?|modules and tools)\b/i,
+  /^(?:type|reference id|version|module id|tool id|section|chapter|appendix|table|figure)\b/i,
+  /^(?:vcs standard|ccb standard|document version)\b/i,
+] as const;
 
-function lineContainsMethodologyDeclaration(line: string, expectedMethodologyId: string): boolean {
-  if (!line) return false;
-  if (expectedMethodologyId && new RegExp(`\\b${expectedMethodologyId}\\b`, "i").test(line)) return true;
-  if (METHODOLOGY_DECLARATION_ANCHORS.some((pattern) => pattern.test(line))) return true;
-  return METHODOLOGY_DECLARATION_HEADINGS.some((pattern) => pattern.test(line));
-}
-
-function isContinuationLine(line: string): boolean {
+function isTableBoundaryLine(line: string): boolean {
   const normalized = line.trim();
-  if (!normalized) return false;
-  if (/^(?:\d+\.\d+|section|chapter|appendix|table|figure)\b/i.test(normalized)) return false;
-  return true;
+  if (!normalized) return true;
+  return TABLE_ROW_BOUNDARY_PATTERNS.some((pattern) => pattern.test(normalized));
 }
 
-function extractVersionsFromMethodologyDeclarationSegment(segmentText: string): string[] {
-  const normalizedSegment = segmentText.toLowerCase();
-  const anchorPositions = Array.from(
-    normalizedSegment.matchAll(/\b(?:vm0007|redd[-\s]?mf|redd methodology framework|title and reference of methodology|title and reference of approved baseline methodology applied|name and reference of approved monitoring methodology applied|methodology applied)\b/gi),
-    (match) => match.index ?? -1,
-  ).filter((index): index is number => index >= 0);
-
-  if (anchorPositions.length === 0) return [];
-
-  const sortedAnchorPositions = Array.from(new Set(anchorPositions)).sort((left, right) => left - right);
-  const declaredVersions: string[] = [];
-
-  for (let index = 0; index < sortedAnchorPositions.length; index += 1) {
-    const anchorIndex = sortedAnchorPositions[index];
-    let relevantSegment = normalizedSegment.slice(anchorIndex);
-
-    const nextAnchorIndex = sortedAnchorPositions[index + 1];
-    if (nextAnchorIndex !== undefined && nextAnchorIndex > anchorIndex) {
-      relevantSegment = relevantSegment.slice(0, nextAnchorIndex - anchorIndex);
-    }
-
-    const blocklistedMatch = relevantSegment.match(VERSION_CONTEXT_BLOCKLIST);
-    if (blocklistedMatch?.index !== undefined) {
-      relevantSegment = relevantSegment.slice(0, blocklistedMatch.index);
-    }
-
-    declaredVersions.push(
-      ...Array.from(relevantSegment.matchAll(/\b(?:version\s*)?(v?\d+(?:[.-]\d+)*)\b/gi))
+function extractVersionTokens(text: string): string[] {
+  return Array.from(
+    new Set(
+      Array.from(text.matchAll(/\b(?:version\s*)?(?:v\.?\s*)?(\d+(?:[.-]\d+)*)\b/gi))
         .map((match) => normalizeVersionValue(match[1] ?? ""))
         .filter(Boolean),
-    );
+    ),
+  );
+}
+
+function collectProseDeclaredVersions(lines: string[], expectedMethodologyId: string): string[] {
+  const declaredVersions: string[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index].trim();
+    const hasExplicitMethodologyAnchor =
+      (expectedMethodologyId && new RegExp(`\\b${expectedMethodologyId}\\b`, "i").test(line))
+      || METHODOLOGY_DECLARATION_ANCHORS.some((pattern) => pattern.test(line));
+    if (!hasExplicitMethodologyAnchor) continue;
+
+    const lineVersions = extractVersionTokens(line);
+    if (lineVersions.length > 0) {
+      declaredVersions.push(...lineVersions);
+      continue;
+    }
+
+    const nextLine = lines[index + 1]?.trim();
+    if (!nextLine || isTableBoundaryLine(nextLine)) continue;
+    const nextLineVersions = extractVersionTokens(nextLine);
+    if (nextLineVersions.length === 0) continue;
+    declaredVersions.push(...nextLineVersions);
   }
 
   return Array.from(new Set(declaredVersions));
 }
 
-function extractDeclaredMethodologyReference(rawText: string, expectedMethodologyId?: string): {
+function extractDeclaredMethodologyReferenceFromTables(input: {
+  evidenceDocument: EvidenceDocument;
+  expectedMethodologyId: string;
+}): { declaredMethodologyId: string; declaredRulebookVersions: string[] } | null {
+  for (const span of input.evidenceDocument.spans) {
+    if (span.blockType !== "table" || span.table?.limitedProvenance) continue;
+    const contextText = `${span.heading ?? ""} ${span.headingPath.join(" ")} ${span.sectionPath.join(" ")} ${span.text}`;
+    if (!METHODOLOGY_DECLARATION_HEADINGS.some((pattern) => pattern.test(contextText))) continue;
+    if (!span.table?.cells?.length) continue;
+
+    const rows = new Map<number, string[]>();
+    for (const cell of span.table.cells) {
+      if (span.table.headerRowCount && cell.rowIndex < span.table.headerRowCount) continue;
+      const row = rows.get(cell.rowIndex) ?? [];
+      row.push(cell.text);
+      rows.set(cell.rowIndex, row);
+    }
+
+    for (const rowCells of rows.values()) {
+      const rowText = rowCells.join(" ").trim();
+      if (!rowText || !/methodology/i.test(rowText)) continue;
+      if (input.expectedMethodologyId && !new RegExp(`\\b${input.expectedMethodologyId}\\b`, "i").test(rowText)) continue;
+      const declaredRulebookVersions = extractVersionTokens(rowText);
+      return {
+        declaredMethodologyId: input.expectedMethodologyId || extractDeclaredMethodologyId(rowText) || "",
+        declaredRulebookVersions,
+      };
+    }
+  }
+
+  return null;
+}
+
+function extractDeclaredMethodologyReferenceFromText(rawText: string, expectedMethodologyId?: string): {
   declaredMethodologyId: string;
   declaredRulebookVersions: string[];
 } {
@@ -295,35 +325,12 @@ function extractDeclaredMethodologyReference(rawText: string, expectedMethodolog
 
   const expectedId = normalizeMethodologyId(expectedMethodologyId);
   const lines = trimmed.split(/\n+/);
-  const declarationVersions: string[] = [];
-  let declaredMethodologyId = "";
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index].trim();
-    if (!line || !lineContainsMethodologyDeclaration(line, expectedId)) continue;
-
-    const declarationLines = [line];
-    if (METHODOLOGY_DECLARATION_HEADINGS.some((pattern) => pattern.test(line))) {
-      for (let offset = 1; offset <= 2; offset += 1) {
-        const nextLine = lines[index + offset]?.trim();
-        if (!nextLine || !isContinuationLine(nextLine)) break;
-        declarationLines.push(nextLine);
-        if (lineContainsMethodologyDeclaration(nextLine, expectedId)) break;
-      }
-    }
-
-    const declarationText = declarationLines.join("\n").trim();
-    declaredMethodologyId ||= expectedId || extractDeclaredMethodologyId(declarationText) || "";
-    declarationVersions.push(...extractVersionsFromMethodologyDeclarationSegment(declarationText));
-  }
-
-  const declaredRulebookVersions = Array.from(
-    new Set(declarationVersions.map((version) => normalizeVersionValue(version)).filter(Boolean)),
-  );
+  const declarationVersions = collectProseDeclaredVersions(lines, expectedId);
+  const declaredMethodologyId = expectedId || extractDeclaredMethodologyId(trimmed) || "";
 
   return {
     declaredMethodologyId,
-    declaredRulebookVersions,
+    declaredRulebookVersions: declarationVersions,
   };
 }
 
@@ -366,7 +373,7 @@ export function buildMethodologyVersionLock(input: {
   const methodologyId = normalizeMethodologyId(input.methodologyId);
   const rulebookVersion = normalizeVersionValue(input.rulebookVersion);
   const pddDeclaredMethodologyVersion = input.pddDeclaredMethodologyVersion.trim();
-  const declaredReference = extractDeclaredMethodologyReference(pddDeclaredMethodologyVersion, methodologyId);
+  const declaredReference = extractDeclaredMethodologyReferenceFromText(pddDeclaredMethodologyVersion, methodologyId);
   const versionMismatchReason = buildVersionMismatchReason({
     methodologyId,
     rulebookVersion,
@@ -441,7 +448,11 @@ function resolveAuditVersionLock(input: MethodologyEvidenceAuditInput): Methodol
   const rulebookVersion = input.versionContext?.rulebookVersion?.trim()
     || firstContract?.rulebookVersion
     || "";
-  const declaredReference = extractDeclaredMethodologyReference(input.rawText ?? "", methodologyId);
+  const tableDeclaredReference = extractDeclaredMethodologyReferenceFromTables({
+    evidenceDocument: input.evidenceDocument,
+    expectedMethodologyId: methodologyId,
+  });
+  const declaredReference = tableDeclaredReference ?? extractDeclaredMethodologyReferenceFromText(input.rawText ?? "", methodologyId);
   const pddDeclaredMethodologyVersion = input.versionContext?.pddDeclaredMethodologyVersion?.trim()
     || [declaredReference.declaredMethodologyId, ...declaredReference.declaredRulebookVersions].filter(Boolean).join(" ").trim()
     || "";

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -18,6 +18,7 @@ export type MethodologyVersionLock = Readonly<{
   pddDeclaredMethodologyVersion: string;
   versionMatch: boolean;
   versionMismatchReason: string;
+  userAcceptedVersionWarning?: boolean;
 }>;
 
 export type MethodologyEvidenceContract = Readonly<{
@@ -60,6 +61,7 @@ export type MethodologyEvidenceAuditResult = {
   pddDeclaredMethodologyVersion?: string;
   versionMatch?: boolean;
   versionMismatchReason?: string;
+  userAcceptedVersionWarning?: boolean;
   status: EvidenceAuditStatus;
   bestEvidenceQuote: string | null;
   page: number | null;
@@ -73,12 +75,13 @@ export type MethodologyEvidenceAuditResult = {
 };
 
 export type MethodologyEvidenceAuditSummary = {
-  auditStatus?: "AUDITED" | "BLOCKED_VERSION_MISMATCH";
+  auditStatus?: "AUDITED" | "VERSION_WARNING_ACCEPTED" | "BLOCKED_VERSION_MISMATCH";
   methodologyId?: string;
   rulebookVersion?: string;
   pddDeclaredMethodologyVersion?: string;
   versionMatch?: boolean;
   versionMismatchReason?: string;
+  userAcceptedVersionWarning?: boolean;
   results: MethodologyEvidenceAuditResult[];
   totals: Record<EvidenceAuditStatus, number>;
   totalRules: number;
@@ -90,6 +93,7 @@ export type MethodologyEvidenceAuditInput = {
   getContract: (rule: MethodologyRuleLike | string) => MethodologyEvidenceContract;
   normalizeRuleId?: (ruleId: string) => string;
   versionContext?: Partial<Pick<MethodologyVersionLock, "methodologyId" | "rulebookVersion" | "pddDeclaredMethodologyVersion">>;
+  userAcceptedVersionWarning?: boolean;
   sections?: readonly Pick<
     DocumentStructure["sections"][number],
     "id" | "sectionNumber" | "titleRaw" | "titleClean" | "bodyRaw" | "bodyClean"
@@ -452,6 +456,7 @@ export function buildMethodologyVersionLock(input: {
   methodologyId: string;
   rulebookVersion: string;
   pddDeclaredMethodologyVersion: string;
+  userAcceptedVersionWarning?: boolean;
 }): MethodologyVersionLock {
   const methodologyId = normalizeMethodologyId(input.methodologyId);
   const rulebookVersion = normalizeVersionValue(input.rulebookVersion);
@@ -471,6 +476,7 @@ export function buildMethodologyVersionLock(input: {
     pddDeclaredMethodologyVersion,
     versionMatch: versionMismatchReason.length === 0,
     versionMismatchReason,
+    userAcceptedVersionWarning: input.userAcceptedVersionWarning,
   });
 }
 
@@ -544,6 +550,7 @@ function resolveAuditVersionLock(input: MethodologyEvidenceAuditInput): Methodol
     methodologyId,
     rulebookVersion,
     pddDeclaredMethodologyVersion,
+    userAcceptedVersionWarning: input.userAcceptedVersionWarning,
   });
 }
 
@@ -952,6 +959,7 @@ function resultFromCandidate(input: {
     pddDeclaredMethodologyVersion: input.versionLock.pddDeclaredMethodologyVersion,
     versionMatch: input.versionLock.versionMatch,
     versionMismatchReason: input.versionLock.versionMismatchReason,
+    userAcceptedVersionWarning: input.versionLock.userAcceptedVersionWarning,
     status: input.status,
     bestEvidenceQuote: input.candidate ? compactQuote(input.candidate.span.text) : null,
     page: input.candidate?.span.page ?? null,
@@ -967,7 +975,8 @@ function resultFromCandidate(input: {
 
 export function auditEvidence(input: MethodologyEvidenceAuditInput): MethodologyEvidenceAuditSummary {
   const versionLock = resolveAuditVersionLock(input);
-  if (!versionLock.versionMatch) {
+  const userAcceptedVersionWarning = Boolean(input.userAcceptedVersionWarning);
+  if (!versionLock.versionMatch && !userAcceptedVersionWarning) {
     return {
       auditStatus: "BLOCKED_VERSION_MISMATCH",
       methodologyId: versionLock.methodologyId,
@@ -975,6 +984,7 @@ export function auditEvidence(input: MethodologyEvidenceAuditInput): Methodology
       pddDeclaredMethodologyVersion: versionLock.pddDeclaredMethodologyVersion,
       versionMatch: false,
       versionMismatchReason: versionLock.versionMismatchReason,
+      userAcceptedVersionWarning: false,
       results: [],
       totals: {
         supported_by_pdd: 0,
@@ -986,6 +996,10 @@ export function auditEvidence(input: MethodologyEvidenceAuditInput): Methodology
       totalRules: input.rules.length,
     };
   }
+
+  const auditStatus = !versionLock.versionMatch && userAcceptedVersionWarning
+    ? "VERSION_WARNING_ACCEPTED"
+    : "AUDITED";
 
   const results = input.rules.map((rule) => {
     const contract = input.getContract(rule);
@@ -1034,12 +1048,13 @@ export function auditEvidence(input: MethodologyEvidenceAuditInput): Methodology
   });
 
   return {
-    auditStatus: "AUDITED",
+    auditStatus,
     methodologyId: versionLock.methodologyId,
     rulebookVersion: versionLock.rulebookVersion,
     pddDeclaredMethodologyVersion: versionLock.pddDeclaredMethodologyVersion,
-    versionMatch: true,
-    versionMismatchReason: "",
+    versionMatch: versionLock.versionMatch,
+    versionMismatchReason: versionLock.versionMismatchReason,
+    userAcceptedVersionWarning,
     results,
     totals,
     totalRules: input.rules.length,

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -236,6 +236,19 @@ const TABLE_ROW_BOUNDARY_PATTERNS = [
   /^(?:vcs standard|ccb standard|document version)\b/i,
 ] as const;
 
+const METHODOLOGY_BLOCK_START_PATTERNS = [
+  /\b3\.1\.1\s+title and reference of methodology\b/i,
+  /\b2\.1\s+title and reference of methodology\b/i,
+  /\btitle and reference of methodology applied\b/i,
+  /\btitle and reference of methodology\b/i,
+] as const;
+
+const METHODOLOGY_BLOCK_END_PATTERNS = [
+  /\b3\.1\.2\s+applicability of methodology\b/i,
+  /\b2\.2\s+applicability of methodology\b/i,
+  /\bapplicability of methodology\b/i,
+] as const;
+
 function isTableBoundaryLine(line: string): boolean {
   const normalized = line.trim();
   if (!normalized) return true;
@@ -252,6 +265,61 @@ function extractVersionTokens(text: string): string[] {
   );
 }
 
+function extractExplicitVersionTokens(text: string): string[] {
+  return Array.from(
+    new Set(
+      Array.from(text.matchAll(/\b(?:version\s+|v\.?\s*)(\d+(?:[.-]\d+)*)\b/gi))
+        .map((match) => normalizeVersionValue(match[1] ?? ""))
+        .filter(Boolean),
+    ),
+  );
+}
+
+function extractMethodologyBlock(rawText: string): string {
+  const lines = rawText.split(/\n+/);
+  const startIndex = lines.findIndex((line) =>
+    METHODOLOGY_BLOCK_START_PATTERNS.some((pattern) => pattern.test(line)),
+  );
+  if (startIndex < 0) return rawText;
+
+  let endIndex = lines.length;
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    if (METHODOLOGY_BLOCK_END_PATTERNS.some((pattern) => pattern.test(lines[index] ?? ""))) {
+      endIndex = index;
+      break;
+    }
+  }
+
+  return lines.slice(startIndex, endIndex).join("\n").trim();
+}
+
+function extractFlattenedMethodologyRow(blockText: string, expectedMethodologyId: string): {
+  declaredMethodologyId: string;
+  declaredRulebookVersions: string[];
+} | null {
+  const rowPatterns = [
+    new RegExp(
+      String.raw`Type\s+Methodology\b[\s\S]{0,240}?Reference\s+ID\s+${expectedMethodologyId}\b[\s\S]{0,240}?(?=Type\s+(?:Methodology|Module|Tool)\b|3\.1\.2\b|2\.2\b|Applicability of Methodology|$)`,
+      "i",
+    ),
+    new RegExp(
+      String.raw`\bMethodology\b[\s\S]{0,120}?${expectedMethodologyId}\b[\s\S]{0,240}?(?=Type\s+(?:Methodology|Module|Tool)\b|3\.1\.2\b|2\.2\b|Applicability of Methodology|$)`,
+      "i",
+    ),
+  ];
+
+  for (const pattern of rowPatterns) {
+    const rowMatch = blockText.match(pattern);
+    if (!rowMatch?.[0]) continue;
+    return {
+      declaredMethodologyId: expectedMethodologyId,
+      declaredRulebookVersions: extractVersionTokens(rowMatch[0]),
+    };
+  }
+
+  return null;
+}
+
 function collectProseDeclaredVersions(lines: string[], expectedMethodologyId: string): string[] {
   const declaredVersions: string[] = [];
 
@@ -262,7 +330,7 @@ function collectProseDeclaredVersions(lines: string[], expectedMethodologyId: st
       || METHODOLOGY_DECLARATION_ANCHORS.some((pattern) => pattern.test(line));
     if (!hasExplicitMethodologyAnchor) continue;
 
-    const lineVersions = extractVersionTokens(line);
+    const lineVersions = extractExplicitVersionTokens(line);
     if (lineVersions.length > 0) {
       declaredVersions.push(...lineVersions);
       continue;
@@ -270,7 +338,7 @@ function collectProseDeclaredVersions(lines: string[], expectedMethodologyId: st
 
     const nextLine = lines[index + 1]?.trim();
     if (!nextLine || isTableBoundaryLine(nextLine)) continue;
-    const nextLineVersions = extractVersionTokens(nextLine);
+    const nextLineVersions = extractExplicitVersionTokens(nextLine);
     if (nextLineVersions.length === 0) continue;
     declaredVersions.push(...nextLineVersions);
   }
@@ -324,9 +392,15 @@ function extractDeclaredMethodologyReferenceFromText(rawText: string, expectedMe
   }
 
   const expectedId = normalizeMethodologyId(expectedMethodologyId);
-  const lines = trimmed.split(/\n+/);
+  const methodologyBlock = extractMethodologyBlock(trimmed);
+  const flattenedMethodologyRow = expectedId
+    ? extractFlattenedMethodologyRow(methodologyBlock, expectedId)
+    : null;
+  if (flattenedMethodologyRow) return flattenedMethodologyRow;
+
+  const lines = methodologyBlock.split(/\n+/);
   const declarationVersions = collectProseDeclaredVersions(lines, expectedId);
-  const declaredMethodologyId = expectedId || extractDeclaredMethodologyId(trimmed) || "";
+  const declaredMethodologyId = expectedId || extractDeclaredMethodologyId(methodologyBlock) || "";
 
   return {
     declaredMethodologyId,

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -12,9 +12,19 @@ export const EVIDENCE_AUDIT_STATUSES = [
 export type EvidenceAuditStatus = (typeof EVIDENCE_AUDIT_STATUSES)[number];
 export type EvidenceAuditConfidence = "high" | "medium" | "low";
 
+export type MethodologyVersionLock = Readonly<{
+  methodologyId: string;
+  rulebookVersion: string;
+  pddDeclaredMethodologyVersion: string;
+  versionMatch: boolean;
+  versionMismatchReason: string;
+}>;
+
 export type MethodologyEvidenceContract = Readonly<{
   id: string;
   label: string;
+  methodologyId: string;
+  rulebookVersion: string;
   appliesToFamily?: string;
   appliesToRuleIds?: readonly string[];
   pddSectionsToSearch: readonly string[];
@@ -45,6 +55,11 @@ export type MethodologyEvidenceAuditResult = {
   stableId: string;
   title: string;
   ruleLogic: string;
+  methodologyId?: string;
+  rulebookVersion?: string;
+  pddDeclaredMethodologyVersion?: string;
+  versionMatch?: boolean;
+  versionMismatchReason?: string;
   status: EvidenceAuditStatus;
   bestEvidenceQuote: string | null;
   page: number | null;
@@ -58,6 +73,12 @@ export type MethodologyEvidenceAuditResult = {
 };
 
 export type MethodologyEvidenceAuditSummary = {
+  auditStatus?: "AUDITED" | "BLOCKED_VERSION_MISMATCH";
+  methodologyId?: string;
+  rulebookVersion?: string;
+  pddDeclaredMethodologyVersion?: string;
+  versionMatch?: boolean;
+  versionMismatchReason?: string;
   results: MethodologyEvidenceAuditResult[];
   totals: Record<EvidenceAuditStatus, number>;
   totalRules: number;
@@ -68,6 +89,7 @@ export type MethodologyEvidenceAuditInput = {
   evidenceDocument: EvidenceDocument;
   getContract: (rule: MethodologyRuleLike | string) => MethodologyEvidenceContract;
   normalizeRuleId?: (ruleId: string) => string;
+  versionContext?: Partial<Pick<MethodologyVersionLock, "methodologyId" | "rulebookVersion" | "pddDeclaredMethodologyVersion">>;
   sections?: readonly Pick<
     DocumentStructure["sections"][number],
     "id" | "sectionNumber" | "titleRaw" | "titleClean" | "bodyRaw" | "bodyClean"
@@ -161,6 +183,107 @@ function normalizeText(value: string | null | undefined): string {
   return (value ?? "").toLowerCase().replace(/[^\w\s/-]+/g, " ").replace(/\s+/g, " ").trim();
 }
 
+function normalizeMethodologyId(value: string | null | undefined): string {
+  return (value ?? "").trim().toUpperCase();
+}
+
+function normalizeVersionValue(value: string | null | undefined): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return "";
+  if (trimmed.toLowerCase().startsWith("version ")) {
+    return `v${trimmed.slice(8).trim()}`;
+  }
+  if (trimmed.toLowerCase().startsWith("v")) {
+    return `v${trimmed.slice(1).trim().replace(/^\/+/, "")}`;
+  }
+  return trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
+}
+
+function extractDeclaredMethodologyId(rawValue: string): string {
+  const normalized = rawValue.trim().toUpperCase();
+  const match = normalized.match(/\b(VM\d{4}|AMS-[A-Z0-9.]+|AR-[A-Z0-9.]+|ACM\d{4}|AM\d{4}|GS-[A-Z0-9.]+)\b/);
+  return match?.[1] ?? "";
+}
+
+function extractDeclaredMethodologyVersion(rawValue: string): string {
+  const normalized = rawValue.trim();
+  const match = normalized.match(/\b(?:version\s*)?(v?\d+(?:[.-]\d+)*)\b/i);
+  return normalizeVersionValue(match?.[1] ?? "");
+}
+
+function extractDeclaredMethodologyReference(rawText: string, expectedMethodologyId?: string): string {
+  const trimmed = rawText.trim();
+  if (!trimmed) return "";
+
+  const expectedId = normalizeMethodologyId(expectedMethodologyId);
+  if (expectedId) {
+    const index = trimmed.toUpperCase().indexOf(expectedId);
+    if (index >= 0) {
+      const windowText = trimmed.slice(Math.max(0, index - 40), Math.min(trimmed.length, index + 160));
+      const declaredMethodologyId = extractDeclaredMethodologyId(windowText) || expectedId;
+      const declaredRulebookVersion = extractDeclaredMethodologyVersion(windowText);
+      if (declaredMethodologyId || declaredRulebookVersion) {
+        return [declaredMethodologyId, declaredRulebookVersion].filter(Boolean).join(" ").trim();
+      }
+    }
+  }
+
+  const declaredMethodologyId = extractDeclaredMethodologyId(trimmed);
+  const declaredRulebookVersion = extractDeclaredMethodologyVersion(trimmed);
+  return [declaredMethodologyId, declaredRulebookVersion].filter(Boolean).join(" ").trim();
+}
+
+function buildVersionMismatchReason(input: {
+  methodologyId: string;
+  rulebookVersion: string;
+  pddDeclaredMethodologyVersion: string;
+  declaredMethodologyId: string;
+  declaredRulebookVersion: string;
+}): string {
+  const problems: string[] = [];
+  if (!input.declaredMethodologyId) {
+    problems.push("PDD-declared methodology ID is missing");
+  } else if (normalizeMethodologyId(input.declaredMethodologyId) !== normalizeMethodologyId(input.methodologyId)) {
+    problems.push(`methodology ID mismatch: PDD declares ${input.declaredMethodologyId}, loaded contract is ${input.methodologyId}`);
+  }
+
+  if (!input.declaredRulebookVersion) {
+    problems.push("PDD-declared methodology version is missing");
+  } else if (normalizeVersionValue(input.declaredRulebookVersion) !== normalizeVersionValue(input.rulebookVersion)) {
+    problems.push(`rulebook version mismatch: PDD declares ${normalizeVersionValue(input.declaredRulebookVersion)}, loaded contract is ${normalizeVersionValue(input.rulebookVersion)}`);
+  }
+
+  if (problems.length === 0) return "";
+  return `Version lock blocked: ${problems.join("; ")}.`;
+}
+
+export function buildMethodologyVersionLock(input: {
+  methodologyId: string;
+  rulebookVersion: string;
+  pddDeclaredMethodologyVersion: string;
+}): MethodologyVersionLock {
+  const methodologyId = normalizeMethodologyId(input.methodologyId);
+  const rulebookVersion = normalizeVersionValue(input.rulebookVersion);
+  const pddDeclaredMethodologyVersion = input.pddDeclaredMethodologyVersion.trim();
+  const declaredMethodologyId = extractDeclaredMethodologyId(pddDeclaredMethodologyVersion);
+  const declaredRulebookVersion = extractDeclaredMethodologyVersion(pddDeclaredMethodologyVersion);
+  const versionMismatchReason = buildVersionMismatchReason({
+    methodologyId,
+    rulebookVersion,
+    pddDeclaredMethodologyVersion,
+    declaredMethodologyId,
+    declaredRulebookVersion,
+  });
+
+  return Object.freeze({
+    methodologyId,
+    rulebookVersion,
+    pddDeclaredMethodologyVersion,
+    versionMatch: versionMismatchReason.length === 0,
+    versionMismatchReason,
+  });
+}
+
 function tokenize(value: string | null | undefined, stopwords: Set<string>): string[] {
   const tokens = normalizeText(value).split(" ").filter(Boolean);
   return Array.from(new Set(tokens.filter((token) => token.length > 2 && !stopwords.has(token))));
@@ -207,6 +330,26 @@ function resolveRuleLogic(rule: MethodologyEvidenceAuditRule): string {
 
 function resolveStableId(rule: MethodologyEvidenceAuditRule): string {
   return rule.stableId?.trim() || rule.id.trim();
+}
+
+function resolveAuditVersionLock(input: MethodologyEvidenceAuditInput): MethodologyVersionLock {
+  const firstRule = input.rules[0];
+  const firstContract = firstRule ? input.getContract(firstRule) : null;
+  const methodologyId = input.versionContext?.methodologyId?.trim()
+    || firstContract?.methodologyId
+    || "";
+  const rulebookVersion = input.versionContext?.rulebookVersion?.trim()
+    || firstContract?.rulebookVersion
+    || "";
+  const pddDeclaredMethodologyVersion = input.versionContext?.pddDeclaredMethodologyVersion?.trim()
+    || extractDeclaredMethodologyReference(input.rawText ?? "", methodologyId)
+    || "";
+
+  return buildMethodologyVersionLock({
+    methodologyId,
+    rulebookVersion,
+    pddDeclaredMethodologyVersion,
+  });
 }
 
 function buildSectionLookup(sections: readonly SectionLike[] | undefined): Map<string, SectionLike> {
@@ -591,6 +734,7 @@ function reasonSelected(input: {
 function resultFromCandidate(input: {
   rule: MethodologyEvidenceAuditRule;
   contract: MethodologyEvidenceContract;
+  versionLock: MethodologyVersionLock;
   candidate: CandidateScore | null;
   status: EvidenceAuditStatus;
   confidence: EvidenceAuditConfidence;
@@ -608,6 +752,11 @@ function resultFromCandidate(input: {
     stableId: resolveStableId(input.rule),
     title: resolveRuleTitle(input.rule),
     ruleLogic: resolveRuleLogic(input.rule),
+    methodologyId: input.versionLock.methodologyId,
+    rulebookVersion: input.versionLock.rulebookVersion,
+    pddDeclaredMethodologyVersion: input.versionLock.pddDeclaredMethodologyVersion,
+    versionMatch: input.versionLock.versionMatch,
+    versionMismatchReason: input.versionLock.versionMismatchReason,
     status: input.status,
     bestEvidenceQuote: input.candidate ? compactQuote(input.candidate.span.text) : null,
     page: input.candidate?.span.page ?? null,
@@ -622,6 +771,27 @@ function resultFromCandidate(input: {
 }
 
 export function auditEvidence(input: MethodologyEvidenceAuditInput): MethodologyEvidenceAuditSummary {
+  const versionLock = resolveAuditVersionLock(input);
+  if (!versionLock.versionMatch) {
+    return {
+      auditStatus: "BLOCKED_VERSION_MISMATCH",
+      methodologyId: versionLock.methodologyId,
+      rulebookVersion: versionLock.rulebookVersion,
+      pddDeclaredMethodologyVersion: versionLock.pddDeclaredMethodologyVersion,
+      versionMatch: false,
+      versionMismatchReason: versionLock.versionMismatchReason,
+      results: [],
+      totals: {
+        supported_by_pdd: 0,
+        partially_supported: 0,
+        missing_evidence: 0,
+        not_applicable: 0,
+        manual_review_needed: 0,
+      },
+      totalRules: input.rules.length,
+    };
+  }
+
   const results = input.rules.map((rule) => {
     const contract = input.getContract(rule);
     const bestCandidate = selectBestCandidate({
@@ -647,6 +817,7 @@ export function auditEvidence(input: MethodologyEvidenceAuditInput): Methodology
     return resultFromCandidate({
       rule,
       contract,
+      versionLock,
       candidate,
       status: classified.status,
       confidence: classified.confidence,
@@ -668,6 +839,12 @@ export function auditEvidence(input: MethodologyEvidenceAuditInput): Methodology
   });
 
   return {
+    auditStatus: "AUDITED",
+    methodologyId: versionLock.methodologyId,
+    rulebookVersion: versionLock.rulebookVersion,
+    pddDeclaredMethodologyVersion: versionLock.pddDeclaredMethodologyVersion,
+    versionMatch: true,
+    versionMismatchReason: "",
     results,
     totals,
     totalRules: input.rules.length,

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -205,15 +205,28 @@ function extractDeclaredMethodologyId(rawValue: string): string {
   return match?.[1] ?? "";
 }
 
-function extractDeclaredMethodologyVersion(rawValue: string): string {
+function extractDeclaredMethodologyVersionMatches(rawValue: string): string[] {
   const normalized = rawValue.trim();
-  const match = normalized.match(/\b(?:version\s*)?(v?\d+(?:[.-]\d+)*)\b/i);
-  return normalizeVersionValue(match?.[1] ?? "");
+  if (!normalized) return [];
+
+  const matches = Array.from(normalized.matchAll(/\b(?:version\s*)?(v\d+(?:[.-]\d+)*)\b/gi))
+    .map((match) => normalizeVersionValue(match[1] ?? ""))
+    .filter(Boolean);
+
+  return Array.from(new Set(matches));
 }
 
-function extractDeclaredMethodologyReference(rawText: string, expectedMethodologyId?: string): string {
+function extractDeclaredMethodologyReference(rawText: string, expectedMethodologyId?: string): {
+  declaredMethodologyId: string;
+  declaredRulebookVersions: string[];
+} {
   const trimmed = rawText.trim();
-  if (!trimmed) return "";
+  if (!trimmed) {
+    return {
+      declaredMethodologyId: "",
+      declaredRulebookVersions: [],
+    };
+  }
 
   const expectedId = normalizeMethodologyId(expectedMethodologyId);
   if (expectedId) {
@@ -221,16 +234,22 @@ function extractDeclaredMethodologyReference(rawText: string, expectedMethodolog
     if (index >= 0) {
       const windowText = trimmed.slice(Math.max(0, index - 40), Math.min(trimmed.length, index + 160));
       const declaredMethodologyId = extractDeclaredMethodologyId(windowText) || expectedId;
-      const declaredRulebookVersion = extractDeclaredMethodologyVersion(windowText);
-      if (declaredMethodologyId || declaredRulebookVersion) {
-        return [declaredMethodologyId, declaredRulebookVersion].filter(Boolean).join(" ").trim();
+      const declaredRulebookVersions = extractDeclaredMethodologyVersionMatches(windowText);
+      if (declaredMethodologyId || declaredRulebookVersions.length > 0) {
+        return {
+          declaredMethodologyId,
+          declaredRulebookVersions,
+        };
       }
     }
   }
 
   const declaredMethodologyId = extractDeclaredMethodologyId(trimmed);
-  const declaredRulebookVersion = extractDeclaredMethodologyVersion(trimmed);
-  return [declaredMethodologyId, declaredRulebookVersion].filter(Boolean).join(" ").trim();
+  const declaredRulebookVersions = extractDeclaredMethodologyVersionMatches(trimmed);
+  return {
+    declaredMethodologyId,
+    declaredRulebookVersions,
+  };
 }
 
 function buildVersionMismatchReason(input: {
@@ -238,7 +257,7 @@ function buildVersionMismatchReason(input: {
   rulebookVersion: string;
   pddDeclaredMethodologyVersion: string;
   declaredMethodologyId: string;
-  declaredRulebookVersion: string;
+  declaredRulebookVersions: readonly string[];
 }): string {
   const problems: string[] = [];
   if (!input.declaredMethodologyId) {
@@ -247,10 +266,12 @@ function buildVersionMismatchReason(input: {
     problems.push(`methodology ID mismatch: PDD declares ${input.declaredMethodologyId}, loaded contract is ${input.methodologyId}`);
   }
 
-  if (!input.declaredRulebookVersion) {
+  if (input.declaredRulebookVersions.length === 0) {
     problems.push("PDD-declared methodology version is missing");
-  } else if (normalizeVersionValue(input.declaredRulebookVersion) !== normalizeVersionValue(input.rulebookVersion)) {
-    problems.push(`rulebook version mismatch: PDD declares ${normalizeVersionValue(input.declaredRulebookVersion)}, loaded contract is ${normalizeVersionValue(input.rulebookVersion)}`);
+  } else if (input.declaredRulebookVersions.length > 1) {
+    problems.push(`PDD-declared methodology version is ambiguous: found ${input.declaredRulebookVersions.join(", ")}`);
+  } else if (normalizeVersionValue(input.declaredRulebookVersions[0] ?? "") !== normalizeVersionValue(input.rulebookVersion)) {
+    problems.push(`rulebook version mismatch: PDD declares ${normalizeVersionValue(input.declaredRulebookVersions[0] ?? "")}, loaded contract is ${normalizeVersionValue(input.rulebookVersion)}`);
   }
 
   if (problems.length === 0) return "";
@@ -265,14 +286,13 @@ export function buildMethodologyVersionLock(input: {
   const methodologyId = normalizeMethodologyId(input.methodologyId);
   const rulebookVersion = normalizeVersionValue(input.rulebookVersion);
   const pddDeclaredMethodologyVersion = input.pddDeclaredMethodologyVersion.trim();
-  const declaredMethodologyId = extractDeclaredMethodologyId(pddDeclaredMethodologyVersion);
-  const declaredRulebookVersion = extractDeclaredMethodologyVersion(pddDeclaredMethodologyVersion);
+  const declaredReference = extractDeclaredMethodologyReference(pddDeclaredMethodologyVersion);
   const versionMismatchReason = buildVersionMismatchReason({
     methodologyId,
     rulebookVersion,
     pddDeclaredMethodologyVersion,
-    declaredMethodologyId,
-    declaredRulebookVersion,
+    declaredMethodologyId: declaredReference.declaredMethodologyId,
+    declaredRulebookVersions: declaredReference.declaredRulebookVersions,
   });
 
   return Object.freeze({
@@ -341,8 +361,9 @@ function resolveAuditVersionLock(input: MethodologyEvidenceAuditInput): Methodol
   const rulebookVersion = input.versionContext?.rulebookVersion?.trim()
     || firstContract?.rulebookVersion
     || "";
+  const declaredReference = extractDeclaredMethodologyReference(input.rawText ?? "", methodologyId);
   const pddDeclaredMethodologyVersion = input.versionContext?.pddDeclaredMethodologyVersion?.trim()
-    || extractDeclaredMethodologyReference(input.rawText ?? "", methodologyId)
+    || [declaredReference.declaredMethodologyId, ...declaredReference.declaredRulebookVersions].filter(Boolean).join(" ").trim()
     || "";
 
   return buildMethodologyVersionLock({

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -199,6 +199,17 @@ function normalizeVersionValue(value: string | null | undefined): string {
   return trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
 }
 
+function normalizeVersionKey(value: string | null | undefined): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return "";
+  const withoutVersionPrefix = trimmed.replace(/^version\s+/i, "").replace(/^v\s*/i, "").trim();
+  const segments = withoutVersionPrefix.split(/[.-]/).map((segment) => segment.trim()).filter(Boolean);
+  if (segments.length === 0) {
+    return normalizeVersionValue(trimmed).toLowerCase();
+  }
+  return `v${segments.join(".")}`.toLowerCase();
+}
+
 function extractDeclaredMethodologyId(rawValue: string): string {
   const normalized = rawValue.trim().toUpperCase();
   const match = normalized.match(/\b(VM\d{4}|AMS-[A-Z0-9.]+|AR-[A-Z0-9.]+|ACM\d{4}|AM\d{4}|GS-[A-Z0-9.]+)\b/);
@@ -291,10 +302,15 @@ function buildVersionMismatchReason(input: {
 
   if (input.declaredRulebookVersions.length === 0) {
     problems.push("PDD-declared methodology version is missing");
-  } else if (input.declaredRulebookVersions.length > 1) {
-    problems.push(`PDD-declared methodology version is ambiguous: found ${input.declaredRulebookVersions.join(", ")}`);
-  } else if (normalizeVersionValue(input.declaredRulebookVersions[0] ?? "") !== normalizeVersionValue(input.rulebookVersion)) {
-    problems.push(`rulebook version mismatch: PDD declares ${normalizeVersionValue(input.declaredRulebookVersions[0] ?? "")}, loaded contract is ${normalizeVersionValue(input.rulebookVersion)}`);
+  } else {
+    const canonicalDeclaredRulebookVersions = Array.from(
+      new Set(input.declaredRulebookVersions.map((version) => normalizeVersionKey(version)).filter(Boolean)),
+    );
+    if (canonicalDeclaredRulebookVersions.length > 1) {
+      problems.push(`PDD-declared methodology version is ambiguous: found ${input.declaredRulebookVersions.join(", ")}`);
+    } else if (normalizeVersionKey(input.declaredRulebookVersions[0] ?? "") !== normalizeVersionKey(input.rulebookVersion)) {
+      problems.push(`rulebook version mismatch: PDD declares ${normalizeVersionValue(input.declaredRulebookVersions[0] ?? "")}, loaded contract is ${normalizeVersionValue(input.rulebookVersion)}`);
+    }
   }
 
   if (problems.length === 0) return "";

--- a/src/lib/preverif/vm0007EvidenceContracts.ts
+++ b/src/lib/preverif/vm0007EvidenceContracts.ts
@@ -20,9 +20,14 @@ type NormalizedRule = {
   text: string;
 };
 
-function defineContract(input: Vm0007EvidenceContract): Vm0007EvidenceContract {
+function defineContract(
+  input: Omit<Vm0007EvidenceContract, "methodologyId" | "rulebookVersion">
+    & Partial<Pick<Vm0007EvidenceContract, "methodologyId" | "rulebookVersion">>,
+): Vm0007EvidenceContract {
   return Object.freeze({
     ...input,
+    methodologyId: input.methodologyId || "VM0007",
+    rulebookVersion: input.rulebookVersion || "v4.2",
     appliesToRuleIds: input.appliesToRuleIds ? Object.freeze([...input.appliesToRuleIds]) : undefined,
     pddSectionsToSearch: Object.freeze([...input.pddSectionsToSearch]),
     strongEvidenceSignals: Object.freeze([...input.strongEvidenceSignals]),

--- a/src/lib/preverif/vm0007EvidenceContracts.ts
+++ b/src/lib/preverif/vm0007EvidenceContracts.ts
@@ -27,7 +27,7 @@ function defineContract(
   return Object.freeze({
     ...input,
     methodologyId: input.methodologyId || "VM0007",
-    rulebookVersion: input.rulebookVersion || "v4.2",
+    rulebookVersion: input.rulebookVersion || "v1.8",
     appliesToRuleIds: input.appliesToRuleIds ? Object.freeze([...input.appliesToRuleIds]) : undefined,
     pddSectionsToSearch: Object.freeze([...input.pddSectionsToSearch]),
     strongEvidenceSignals: Object.freeze([...input.strongEvidenceSignals]),

--- a/src/lib/preverif/vm0007GapReport.ts
+++ b/src/lib/preverif/vm0007GapReport.ts
@@ -149,6 +149,17 @@ function clientActionText(result: MethodologyEvidenceAuditResult): string {
   }
   return result.clientAction;
 }
+
+function buildVersionWarning(input: Vm0007GapReportInput): string | null {
+  if (input.audit.versionMatch !== false && !input.audit.userAcceptedVersionWarning) return null;
+
+  const declaredVersion = input.audit.pddDeclaredMethodologyVersion?.trim() || "an unknown version";
+  const loadedVersion = input.audit.rulebookVersion?.trim() || input.methodology.version;
+  const methodologyId = input.audit.methodologyId?.trim() || input.methodology.code;
+
+  return `Methodology version mismatch: PDD declares ${methodologyId} ${declaredVersion}, but loaded rulebook is ${methodologyId} ${loadedVersion}. Evidence judgment may be wrong.`;
+}
+
 function toFinding(result: MethodologyEvidenceAuditResult): Vm0007GapReportFinding {
   return {
     ruleId: result.ruleId,
@@ -190,6 +201,7 @@ function makeHeadline(input: Vm0007GapReport["executiveSummary"]["totals"]): str
 }
 
 export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapReport {
+  const versionWarning = buildVersionWarning(input);
   const findings = input.audit.results.map(toFinding);
   const supported = findings.filter((finding) => finding.status === "supported");
   const weak = findings.filter((finding) => finding.status === "weak");
@@ -225,7 +237,10 @@ export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapRepo
     generatedAt: input.generatedAt,
     reportName: "Internal VM0007 Gap Report Preview",
     statementOfCoverage: `${input.audit.totalRules} VM0007 rules assessed for validation readiness.`,
-    limitationBanner: "Internal preview only. This report shows current audit output and has not been manually reviewed.",
+    limitationBanner: [
+      versionWarning,
+      "Internal preview only. This report shows current audit output and has not been manually reviewed.",
+    ].filter(Boolean).join(" "),
     executiveSummary: {
       headline: makeHeadline(totals),
       allSupportedWarning:
@@ -240,6 +255,7 @@ export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapRepo
         `${totals.notApplicable} rules are treated as not applicable only where the PDD itself supports that conclusion.`,
       ],
       limitations: [
+        ...(versionWarning ? [versionWarning] : []),
         "This preview summarizes current PDD support and evidence gaps for internal project-team follow-up.",
         "Evidence quotes are limited to the audit results already selected by the existing VM0007 evidence audit.",
         "Supported outcomes may still rely on broad methodology or project-description text and should be reviewed before reuse.",

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -18,6 +18,7 @@ export type Vm0007GapReportAuditRecord = {
   methodologyVersion: string;
   generatedAt: string;
   evidenceFileName?: string;
+  userAcceptedVersionWarning?: boolean;
   audit: MethodologyEvidenceAuditSummary;
 };
 
@@ -98,6 +99,7 @@ export function buildAndSaveVm0007GapReportAudit(input: {
   evidenceFileName?: string;
   rawPddText: string;
   rules: readonly RuleSummary[];
+  userAcceptedVersionWarning?: boolean;
 }): Vm0007GapReportAuditRecord | null {
   if (input.methodologyId.trim().toUpperCase() !== "VM0007") return null;
   if (!input.rawPddText.trim() || input.rules.length === 0) return null;
@@ -110,6 +112,7 @@ export function buildAndSaveVm0007GapReportAudit(input: {
     normalizeRuleId: normalizeVm0007RuleId,
     sections: context.documentStructure.sections,
     rawText: input.rawPddText,
+    userAcceptedVersionWarning: input.userAcceptedVersionWarning,
   });
 
   const record: Vm0007GapReportAuditRecord = {
@@ -118,6 +121,7 @@ export function buildAndSaveVm0007GapReportAudit(input: {
     methodologyVersion: input.methodologyVersion.trim(),
     generatedAt: nowIso(),
     evidenceFileName: input.evidenceFileName?.trim() || undefined,
+    userAcceptedVersionWarning: input.userAcceptedVersionWarning,
     audit,
   };
   saveVm0007GapReportAudit(record);

--- a/tests/components/vm0007GapReportPreview.test.tsx
+++ b/tests/components/vm0007GapReportPreview.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globa
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import Vm0007GapReportPreview from "@/components/preverif/Vm0007GapReportPreview";
-import type { MethodologyEvidenceAuditResult } from "@/lib/preverif/evidenceAudit";
+import type { MethodologyEvidenceAuditResult, MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
 import { saveVm0007GapReportAudit } from "@/lib/preverif/vm0007GapReportStore";
 import {
   REPORT_FIXTURE,
@@ -33,6 +33,26 @@ function buildAllSupportedAudit() {
     results: supportedOnlyResults,
     totals: {
       supported_by_pdd: 58,
+      partially_supported: 0,
+      missing_evidence: 0,
+      not_applicable: 0,
+      manual_review_needed: 0,
+    },
+    totalRules: 58,
+  };
+}
+
+function buildBlockedAudit(): MethodologyEvidenceAuditSummary {
+  return {
+    auditStatus: "BLOCKED_VERSION_MISMATCH",
+    methodologyId: "VM0007",
+    rulebookVersion: "v1.8",
+    pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
+    versionMatch: false,
+    versionMismatchReason: "Version lock blocked: rulebook version mismatch: PDD declares v1.5, loaded contract is v1.8.",
+    results: [],
+    totals: {
+      supported_by_pdd: 0,
       partially_supported: 0,
       missing_evidence: 0,
       not_applicable: 0,
@@ -112,6 +132,38 @@ describe("Vm0007GapReportPreview", () => {
     expect(container.textContent ?? "").toContain(
       "All rules are currently marked supported. Review evidence quality before relying on this result.",
     );
+  });
+
+  test("shows the saved audit version-lock fields in the internal preview debug panel", async () => {
+    saveVm0007GapReportAudit({
+      auditId: "audit-blocked",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1.8",
+      generatedAt: "2026-07-03T00:00:00Z",
+      evidenceFileName: "envira-amazonia-vm0007.pdf",
+      audit: buildBlockedAudit(),
+    });
+
+    await act(async () => {
+      root.render(<Vm0007GapReportPreview auditId="audit-blocked" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Saved audit payload");
+    expect(text).toContain("BLOCKED_VERSION_MISMATCH");
+    expect(text).toContain("Methodology ID");
+    expect(text).toContain("VM0007");
+    expect(text).toContain("Rulebook version");
+    expect(text).toContain("v1.8");
+    expect(text).toContain("PDD-declared version");
+    expect(text).toContain("REDD-MF / VM0007 v1.5");
+    expect(text).toContain("Version match");
+    expect(text).toContain("false");
+    expect(text).toContain("Version mismatch reason");
+    expect(text).toContain("rulebook version mismatch");
   });
 
   test("keeps banned wording out of the rendered internal preview", async () => {

--- a/tests/components/vm0007GapReportPreview.test.tsx
+++ b/tests/components/vm0007GapReportPreview.test.tsx
@@ -134,7 +134,7 @@ describe("Vm0007GapReportPreview", () => {
     );
   });
 
-  test("shows the saved audit version-lock fields in the internal preview debug panel", async () => {
+  test("short-circuits to a blocked-only view when the audit is version-mismatched", async () => {
     saveVm0007GapReportAudit({
       auditId: "audit-blocked",
       methodologyId: "VM0007",
@@ -152,17 +152,13 @@ describe("Vm0007GapReportPreview", () => {
     });
 
     const text = container.textContent ?? "";
-    expect(text).toContain("Saved audit payload");
-    expect(text).toContain("BLOCKED_VERSION_MISMATCH");
-    expect(text).toContain("Methodology ID");
-    expect(text).toContain("VM0007");
-    expect(text).toContain("Rulebook version");
-    expect(text).toContain("v1.8");
-    expect(text).toContain("PDD-declared version");
-    expect(text).toContain("REDD-MF / VM0007 v1.5");
-    expect(text).toContain("Version match");
-    expect(text).toContain("false");
-    expect(text).toContain("Version mismatch reason");
+    expect(text).toContain("Version lock blocked: rulebook version mismatch: PDD declares v1.5, loaded contract is v1.8.");
+    expect(text).not.toContain("Print / Save PDF");
+    expect(text).not.toContain(REPORT_FIXTURE.expectedReportTitle);
+    expect(text).not.toContain("58 VM0007 rules assessed for validation readiness.");
+    expect(text).not.toContain("Follow-up Action List");
+    expect(text).not.toContain("Saved audit payload");
+    expect(text).not.toContain("REDD-MF / VM0007 v1.5");
     expect(text).toContain("rulebook version mismatch");
   });
 

--- a/tests/components/vm0007GapReportPreview.test.tsx
+++ b/tests/components/vm0007GapReportPreview.test.tsx
@@ -62,6 +62,21 @@ function buildBlockedAudit(): MethodologyEvidenceAuditSummary {
   };
 }
 
+function buildWarningAcceptedAudit(): MethodologyEvidenceAuditSummary {
+  return {
+    auditStatus: "VERSION_WARNING_ACCEPTED",
+    methodologyId: "VM0007",
+    rulebookVersion: "v1-8",
+    pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
+    versionMatch: false,
+    versionMismatchReason: "Version lock blocked: rulebook version mismatch: PDD declares v1.5, loaded contract is v1-8.",
+    userAcceptedVersionWarning: true,
+    results: buildAllSupportedAudit().results,
+    totals: buildAllSupportedAudit().totals,
+    totalRules: 58,
+  };
+}
+
 describe("Vm0007GapReportPreview", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
@@ -160,6 +175,34 @@ describe("Vm0007GapReportPreview", () => {
     expect(text).not.toContain("Saved audit payload");
     expect(text).not.toContain("REDD-MF / VM0007 v1.5");
     expect(text).toContain("rulebook version mismatch");
+  });
+
+  test("renders the full report with a warning banner when a mismatched audit is accepted", async () => {
+    saveVm0007GapReportAudit({
+      auditId: "audit-warning-accepted",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      generatedAt: "2026-07-03T00:00:00Z",
+      evidenceFileName: "envira-amazonia-vm0007.pdf",
+      userAcceptedVersionWarning: true,
+      audit: buildWarningAcceptedAudit(),
+    });
+
+    await act(async () => {
+      root.render(<Vm0007GapReportPreview auditId="audit-warning-accepted" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("VERSION_WARNING_ACCEPTED");
+    expect(text).toContain("Version warning accepted before audit generation.");
+    expect(text).toContain("Methodology version mismatch:");
+    expect(text).toContain("Print / Save PDF");
+    expect(text).toContain(REPORT_FIXTURE.expectedReportTitle);
+    expect(text).toContain("User accepted warning");
+    expect(text).toContain("true");
   });
 
   test("keeps banned wording out of the rendered internal preview", async () => {

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./preverifVm0007Fixtures";
 
 const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
+const ENVIRA_V18_TEXT = ENVIRA_TEXT.replace("VM0007 Version 4.2", "REDD-MF / VM0007 v1.8");
 
 function auditText(rawText: string) {
   const context = getStructuredQueryContext(rawText);
@@ -36,7 +37,7 @@ function byRuleId(results: MethodologyEvidenceAuditResult[], ruleId: string): Me
 
 describe("auditEvidence with VM0007 contracts", () => {
   it("produces audit results for all 58 synced VM0007 rules and totals add up", () => {
-    const audit = auditText(ENVIRA_TEXT);
+    const audit = auditText(ENVIRA_V18_TEXT);
     const totalFromBuckets = Object.values(audit.totals).reduce((sum, count) => sum + count, 0);
 
     expect(audit.results).toHaveLength(58);
@@ -45,7 +46,7 @@ describe("auditEvidence with VM0007 contracts", () => {
   });
 
   it("uses only allowed statuses", () => {
-    const audit = auditText(ENVIRA_TEXT);
+    const audit = auditText(ENVIRA_V18_TEXT);
 
     for (const result of audit.results) {
       expect(EVIDENCE_AUDIT_STATUSES).toContain(result.status);
@@ -53,7 +54,7 @@ describe("auditEvidence with VM0007 contracts", () => {
   });
 
   it("includes client action on weak or missing outcomes", () => {
-    const audit = auditText(ENVIRA_TEXT);
+    const audit = auditText(ENVIRA_V18_TEXT);
     const weakResults = audit.results.filter((result) =>
       result.status === "partially_supported"
       || result.status === "missing_evidence"
@@ -68,13 +69,13 @@ describe("auditEvidence with VM0007 contracts", () => {
 
   it("requires actual PDD support before marking wetland-family rules not applicable", () => {
     const noNaSupport = auditText(`
-      VM0007 Version 4.2
+      REDD-MF / VM0007 v1.8
       Project Description Document
       3.3 Leakage
       Leakage is discussed for nearby communities, but the PDD does not say whether the project is peatland, tidal wetland, or upland REDD only.
     `);
     const explicitNaSupport = auditText(`
-      VM0007 Version 4.2
+      REDD-MF / VM0007 v1.8
       Project Description Document
       1.1 Project Activity
       This is a REDD/APD project in upland forest landscapes.
@@ -91,13 +92,13 @@ describe("auditEvidence with VM0007 contracts", () => {
   });
 
   it("never uses passed-style outcome wording", () => {
-    const audit = auditText(ENVIRA_TEXT);
+    const audit = auditText(ENVIRA_V18_TEXT);
     expect(JSON.stringify(audit)).not.toMatch(/\bpassed\b/i);
   });
 
   it("does not treat VM0007 boilerplate or copied rule text as supported_by_pdd", () => {
     const audit = auditText(`
-      VM0007 Version 4.2
+      REDD-MF / VM0007 v1.8
       Project Description Document
 
       2.4 Baseline Scenario
@@ -121,7 +122,7 @@ describe("auditEvidence with VM0007 contracts", () => {
   });
 
   it("produces useful Envira-like outputs across the main VM0007 categories", () => {
-    const audit = auditText(ENVIRA_TEXT);
+    const audit = auditText(ENVIRA_V18_TEXT);
 
     const eligibility = byRuleId(audit.results, "R-1-0001");
     const baseline = byRuleId(audit.results, "R-3-0001");

--- a/tests/lib/preverif.vm0007EvidenceContracts.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceContracts.test.ts
@@ -87,6 +87,8 @@ describe("VM0007 evidence contracts", () => {
 
     for (const contract of contracts) {
       expect(contract.clientAction.trim().length).toBeGreaterThan(0);
+      expect(contract.methodologyId).toBe("VM0007");
+      expect(contract.rulebookVersion.trim().length).toBeGreaterThan(0);
     }
   });
 

--- a/tests/lib/preverif.vm0007GapReport.test.ts
+++ b/tests/lib/preverif.vm0007GapReport.test.ts
@@ -19,6 +19,7 @@ import {
 } from "./preverifVm0007Fixtures";
 
 const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
+const ENVIRA_V18_TEXT = ENVIRA_TEXT.replace("VM0007 Version 4.2", "REDD-MF / VM0007 v1.8");
 
 function auditText(rawText: string): MethodologyEvidenceAuditSummary {
   const context = getStructuredQueryContext(rawText);
@@ -50,7 +51,7 @@ function retotal(results: MethodologyEvidenceAuditResult[]): MethodologyEvidence
 }
 
 function buildMixedAudit(): MethodologyEvidenceAuditSummary {
-  const base = auditText(ENVIRA_TEXT);
+  const base = auditText(ENVIRA_V18_TEXT);
   const results = base.results.map((result) => {
     if (result.ruleId === "R-1-0002") {
       return withStatus(result, {
@@ -93,7 +94,7 @@ function buildMixedAudit(): MethodologyEvidenceAuditSummary {
 }
 
 function buildSupportedOnlyAudit(): MethodologyEvidenceAuditSummary {
-  const base = auditText(ENVIRA_TEXT);
+  const base = auditText(ENVIRA_V18_TEXT);
   const results = Array.from({ length: 58 }, (_, index) =>
     withStatus(base.results[index]!, {
       ruleId: `R-6-${String(index + 1).padStart(4, "0")}`,
@@ -135,7 +136,7 @@ function buildReport(audit: MethodologyEvidenceAuditSummary) {
 
 describe("buildVm0007GapReport", () => {
   it("builds a 58-rule report from existing VM0007 audit output", () => {
-    const report = buildReport(auditText(ENVIRA_TEXT));
+    const report = buildReport(auditText(ENVIRA_V18_TEXT));
 
     expect(report.reportName).toBe("Internal VM0007 Gap Report Preview");
     expect(report.statementOfCoverage).toBe("58 VM0007 rules assessed for validation readiness.");

--- a/tests/lib/preverif.vm0007GapReport.test.ts
+++ b/tests/lib/preverif.vm0007GapReport.test.ts
@@ -113,6 +113,19 @@ function buildSupportedOnlyAudit(): MethodologyEvidenceAuditSummary {
   };
 }
 
+function buildWarningAcceptedAudit(baseAudit: MethodologyEvidenceAuditSummary): MethodologyEvidenceAuditSummary {
+  return {
+    ...baseAudit,
+    auditStatus: "VERSION_WARNING_ACCEPTED",
+    methodologyId: "VM0007",
+    rulebookVersion: "v1-8",
+    pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
+    versionMatch: false,
+    versionMismatchReason: "Version lock blocked: rulebook version mismatch: PDD declares v1.5, loaded contract is v1-8.",
+    userAcceptedVersionWarning: true,
+  };
+}
+
 function buildReport(audit: MethodologyEvidenceAuditSummary) {
   return buildVm0007GapReport({
     reportId: "VRGR-VM0007-001",
@@ -149,6 +162,15 @@ describe("buildVm0007GapReport", () => {
 
     expect(report.limitationBanner).toBe("Internal preview only. This report shows current audit output and has not been manually reviewed.");
     expect(report.executiveSummary.allSupportedWarning).toBe("All rules are currently marked supported. Review evidence quality before relying on this result.");
+  });
+
+  it("prepends the version warning to the report banner when the warning was accepted", () => {
+    const report = buildReport(buildWarningAcceptedAudit(auditText(ENVIRA_V18_TEXT)));
+
+    expect(report.limitationBanner).toContain("Methodology version mismatch:");
+    expect(report.limitationBanner).toContain("Evidence judgment may be wrong.");
+    expect(report.limitationBanner).toContain("Internal preview only. This report shows current audit output and has not been manually reviewed.");
+    expect(report.executiveSummary.limitations[0]).toContain("Methodology version mismatch:");
   });
 
   it("keeps client action guidance on every weak or missing rule", () => {

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "@jest/globals";
+import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import {
+  auditEvidence,
+  buildMethodologyVersionLock,
+  type MethodologyEvidenceAuditSummary,
+  type MethodologyEvidenceContract,
+} from "@/lib/preverif/evidenceAudit";
+import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif/vm0007EvidenceContracts";
+import { readQuickCheckFixtureText, VM0007_SYNCED_RULES } from "./preverifVm0007Fixtures";
+
+const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
+
+function auditVm0007(
+  rawText: string,
+  options?: {
+    versionContext?: {
+      pddDeclaredMethodologyVersion: string;
+    };
+    getContract?: (rule: (typeof VM0007_SYNCED_RULES)[number]) => MethodologyEvidenceContract;
+  },
+): MethodologyEvidenceAuditSummary {
+  const context = getStructuredQueryContext(rawText);
+  return auditEvidence({
+    rules: VM0007_SYNCED_RULES,
+    evidenceDocument: context.evidenceDocument,
+    getContract: options?.getContract ?? getVm0007EvidenceContract,
+    normalizeRuleId: normalizeVm0007RuleId,
+    sections: context.documentStructure.sections,
+    rawText,
+    versionContext: options?.versionContext,
+  });
+}
+
+function makeVersionedContract(version: string) {
+  return (rule: (typeof VM0007_SYNCED_RULES)[number]): MethodologyEvidenceContract => ({
+    ...getVm0007EvidenceContract(rule),
+    rulebookVersion: version,
+  });
+}
+
+describe("VM0007 version lock", () => {
+  it("documents the lock inputs and blocks mismatched versions before rule-level judgment", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1.8",
+      pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
+    });
+
+    expect(lock.methodologyId).toBe("VM0007");
+    expect(lock.rulebookVersion).toBe("v1.8");
+    expect(lock.versionMatch).toBe(false);
+    expect(lock.versionMismatchReason).toContain("rulebook version");
+  });
+
+  it("blocks Envira when the PDD-declared VM0007 version does not match the loaded v1.8 contract", () => {
+    const audit = auditVm0007(ENVIRA_TEXT, {
+      getContract: makeVersionedContract("v1.8"),
+      versionContext: {
+        pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
+      },
+    });
+
+    expect(audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
+    expect(audit.methodologyId).toBe("VM0007");
+    expect(audit.rulebookVersion).toBe("v1.8");
+    expect(audit.versionMatch).toBe(false);
+    expect(audit.versionMismatchReason).toContain("v1.5");
+    expect(audit.versionMismatchReason).toContain("v1.8");
+    expect(audit.results).toEqual([]);
+    expect(Object.values(audit.totals)).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it("allows a matching VM0007 v1.8 PDD to proceed to normal evidence judgment", () => {
+    const audit = auditVm0007(ENVIRA_TEXT, {
+      getContract: makeVersionedContract("v1.8"),
+      versionContext: {
+        pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.8",
+      },
+    });
+
+    expect(audit.auditStatus).toBe("AUDITED");
+    expect(audit.methodologyId).toBe("VM0007");
+    expect(audit.rulebookVersion).toBe("v1.8");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.versionMismatchReason).toBe("");
+    expect(audit.results).toHaveLength(58);
+    expect(audit.results[0]?.methodologyId).toBe("VM0007");
+    expect(audit.results[0]?.rulebookVersion).toBe("v1.8");
+    expect(audit.results[0]?.pddDeclaredMethodologyVersion).toBe("REDD-MF / VM0007 v1.8");
+    expect(audit.results.every((result) => result.versionMatch === true)).toBe(true);
+    expect(audit.results.every((result) => result.versionMismatchReason === "")).toBe(true);
+  });
+});

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -13,6 +13,34 @@ import { readQuickCheckFixtureText, VM0007_SYNCED_RULES } from "./preverifVm0007
 const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
 const ENVIRA_V18_VERSION_TEXT = ENVIRA_TEXT.replace("VM0007 Version 4.2", "VM0007, version 1.8");
 const ENVIRA_V18_FRAMEWORK_TEXT = ENVIRA_TEXT.replace("VM0007 Version 4.2", "REDD-MF, REDD Methodology Framework Version 1.8");
+const MAYA_FLATTENED_TEXT = [
+  "3.1 Application of Methodology",
+  "3.1.1 Title and Reference of Methodology",
+  "Type Methodology Reference ID VM0007 Title REDD Methodology Framework Version 1.8",
+  "Type Module Reference ID VMD0001 Title Carbon stock module Version 1.2",
+  "Type Module Reference ID VMD0005 Title Wood products module Version 1.1",
+  "Type Module Reference ID VMD0002 Title Dead wood module Version 1.3",
+  "Type Tool Reference ID VT0002 Title Significance tool Version 2.2",
+  "Type Tool Reference ID VT0001 Title Additionality tool Version 3.0",
+  "Type Tool Reference ID VT0009 Title Program reference Version 4.2",
+  "3.1.2 Applicability of Methodology",
+].join("\n");
+const LISALA_FLATTENED_TEXT = [
+  "3.1 Application of Methodology",
+  "3.1.1 Title and Reference of Methodology",
+  "Type Methodology Reference ID VM0007 Title REDD Methodology Framework Version 1.8",
+  "Type Module Reference ID VMD0015 Title Monitoring module Version 2.1",
+  "Type Module Reference ID VMD0006 Title Baseline module Version 1.2",
+  "Type Tool Reference ID VT0001 Title Additionality tool Version 3.0",
+  "Type Tool Reference ID VT0002 Title Significance tool Version 1.1",
+  "3.1.2 Applicability of Methodology",
+].join("\n");
+const LISALA_PROSE_TEXT = [
+  "3.1 Application of Methodology",
+  "3.1.1 Title and Reference of Methodology",
+  "The project applies VM0007 (v.1.8) for avoided deforestation.",
+  "3.1.2 Applicability of Methodology",
+].join("\n");
 
 function auditVm0007(
   rawText: string,
@@ -180,19 +208,8 @@ describe("VM0007 version lock", () => {
     expect(audit.results.every((result) => result.versionMismatchReason === "")).toBe(true);
   });
 
-  it("allows a methodology table row for VM0007 v1.8 even when module and tool rows have other versions", () => {
-    const document = makeTableEvidenceDocument([
-      ["Type", "Reference ID", "Version"],
-      ["Methodology", "VM0007", "1.8"],
-      ["Module", "VMD0001", "1.2"],
-      ["Module", "VMD0005", "1.1"],
-      ["Tool", "VT0001", "4.2"],
-      ["Module", "VMD0002", "1.3"],
-      ["Tool", "VT0002", "2.2"],
-      ["Tool", "VT0003", "3.0"],
-    ]);
-
-    const audit = auditVm0007WithDocument(document, document.rawText, {
+  it("allows a Maya-style flattened methodology block with a VM0007 v1.8 row and other module/tool versions", () => {
+    const audit = auditVm0007(MAYA_FLATTENED_TEXT, {
       getContract: makeVersionedContract("v1-8"),
     });
 
@@ -201,17 +218,8 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMismatchReason).toBe("");
   });
 
-  it("allows a Lisala-style methodology table row for VM0007 v1.8", () => {
-    const document = makeTableEvidenceDocument([
-      ["Type", "Reference ID", "Version"],
-      ["Methodology", "VM0007", "1.8"],
-      ["Module", "VMD0015", "2.1"],
-      ["Module", "VMD0006", "1.2"],
-      ["Tool", "VT0001", "3.0"],
-      ["Tool", "VT0002", "1.1"],
-    ]);
-
-    const audit = auditVm0007WithDocument(document, document.rawText, {
+  it("allows a Lisala-style flattened methodology block with a VM0007 v1.8 row", () => {
+    const audit = auditVm0007(LISALA_FLATTENED_TEXT, {
       getContract: makeVersionedContract("v1-8"),
     });
 
@@ -220,8 +228,8 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMismatchReason).toBe("");
   });
 
-  it("allows prose text written as 'VM0007 (v.1.8)'", () => {
-    const audit = auditVm0007("Section 3.1 Application of Methodology\nThe project applies VM0007 (v.1.8) for avoided deforestation.", {
+  it("allows a Lisala-style prose fallback written as 'VM0007 (v.1.8)'", () => {
+    const audit = auditVm0007(LISALA_PROSE_TEXT, {
       getContract: makeVersionedContract("v1-8"),
     });
 
@@ -230,7 +238,7 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMismatchReason).toBe("");
   });
 
-  it("blocks a methodology table row for VM0007 v1.5 even when module and tool rows have other versions", () => {
+  it("blocks a methodology row for VM0007 v1.5 even when the flattened block also contains module and tool versions", () => {
     const document = makeTableEvidenceDocument([
       ["Type", "Reference ID", "Version"],
       ["Methodology", "VM0007", "1.5"],
@@ -290,8 +298,13 @@ describe("VM0007 version lock", () => {
     expect(audit.results).toEqual([]);
   });
 
-  it("blocks when VM0007 is declared without a methodology version in prose", () => {
-    const audit = auditVm0007("Section 3.1 Application of Methodology\nThe document identifies VM0007 but does not provide a methodology version.", {
+  it("blocks when VM0007 is declared without a methodology version inside the 3.1.1 methodology block", () => {
+    const audit = auditVm0007([
+      "3.1 Application of Methodology",
+      "3.1.1 Title and Reference of Methodology",
+      "The document identifies VM0007 but does not provide a methodology version.",
+      "3.1.2 Applicability of Methodology",
+    ].join("\n"), {
       getContract: makeVersionedContract("v1-8"),
     });
 

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -57,6 +57,7 @@ function auditVm0007(
     versionContext?: {
       pddDeclaredMethodologyVersion: string;
     };
+    userAcceptedVersionWarning?: boolean;
     getContract?: (rule: (typeof VM0007_SYNCED_RULES)[number]) => MethodologyEvidenceContract;
   },
 ): MethodologyEvidenceAuditSummary {
@@ -69,6 +70,7 @@ function auditVm0007(
     sections: context.documentStructure.sections,
     rawText,
     versionContext: options?.versionContext,
+    userAcceptedVersionWarning: options?.userAcceptedVersionWarning,
   });
 }
 
@@ -79,6 +81,7 @@ function auditVm0007WithDocument(
     versionContext?: {
       pddDeclaredMethodologyVersion: string;
     };
+    userAcceptedVersionWarning?: boolean;
     getContract?: (rule: (typeof VM0007_SYNCED_RULES)[number]) => MethodologyEvidenceContract;
   },
 ): MethodologyEvidenceAuditSummary {
@@ -90,6 +93,7 @@ function auditVm0007WithDocument(
     sections: [],
     rawText,
     versionContext: options?.versionContext,
+    userAcceptedVersionWarning: options?.userAcceptedVersionWarning,
   });
 }
 
@@ -170,6 +174,24 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMismatchReason).toContain("v1.8");
     expect(audit.results).toEqual([]);
     expect(Object.values(audit.totals)).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it("allows a mismatched VM0007 audit to proceed when the user accepts the warning", () => {
+    const audit = auditVm0007(ENVIRA_TEXT, {
+      getContract: makeVersionedContract("v1-8"),
+      versionContext: {
+        pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
+      },
+      userAcceptedVersionWarning: true,
+    });
+
+    expect(audit.auditStatus).toBe("VERSION_WARNING_ACCEPTED");
+    expect(audit.methodologyId).toBe("VM0007");
+    expect(audit.rulebookVersion).toBe("v1-8");
+    expect(audit.versionMatch).toBe(false);
+    expect(audit.versionMismatchReason).toContain("v1.5");
+    expect(audit.results).toHaveLength(58);
+    expect(audit.results[0]?.userAcceptedVersionWarning).toBe(true);
   });
 
   it("blocks ambiguous VM0007 versions when both v1.5 and v1.8 are present", () => {

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -10,6 +10,8 @@ import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif
 import { readQuickCheckFixtureText, VM0007_SYNCED_RULES } from "./preverifVm0007Fixtures";
 
 const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
+const ENVIRA_V18_VERSION_TEXT = ENVIRA_TEXT.replace("VM0007 Version 4.2", "VM0007, version 1.8");
+const ENVIRA_V18_FRAMEWORK_TEXT = ENVIRA_TEXT.replace("VM0007 Version 4.2", "REDD-MF, REDD Methodology Framework Version 1.8");
 
 function auditVm0007(
   rawText: string,
@@ -114,5 +116,49 @@ describe("VM0007 version lock", () => {
     expect(audit.results[0]?.pddDeclaredMethodologyVersion).toBe("REDD-MF / VM0007 v1.8");
     expect(audit.results.every((result) => result.versionMatch === true)).toBe(true);
     expect(audit.results.every((result) => result.versionMismatchReason === "")).toBe(true);
+  });
+
+  it("recognizes a VM0007 v1.8 declaration written as 'VM0007, version 1.8'", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1.8",
+      pddDeclaredMethodologyVersion: "VM0007, version 1.8",
+    });
+
+    expect(lock.versionMatch).toBe(true);
+    expect(lock.versionMismatchReason).toBe("");
+  });
+
+  it("recognizes a VM0007 v1.8 declaration written as 'REDD-MF, REDD Methodology Framework Version 1.8'", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1.8",
+      pddDeclaredMethodologyVersion: "REDD-MF, REDD Methodology Framework Version 1.8",
+    });
+
+    expect(lock.versionMatch).toBe(true);
+    expect(lock.versionMismatchReason).toBe("");
+  });
+
+  it("allows a v1.8 VM0007 PDD when the real text uses 'VM0007, version 1.8'", () => {
+    const audit = auditVm0007(ENVIRA_V18_VERSION_TEXT, {
+      getContract: makeVersionedContract("v1.8"),
+    });
+
+    expect(audit.auditStatus).toBe("AUDITED");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.versionMismatchReason).toBe("");
+    expect(audit.results).toHaveLength(58);
+  });
+
+  it("allows a v1.8 VM0007 PDD when the real text uses 'REDD-MF, REDD Methodology Framework Version 1.8'", () => {
+    const audit = auditVm0007(ENVIRA_V18_FRAMEWORK_TEXT, {
+      getContract: makeVersionedContract("v1.8"),
+    });
+
+    expect(audit.auditStatus).toBe("AUDITED");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.versionMismatchReason).toBe("");
+    expect(audit.results).toHaveLength(58);
   });
 });

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -6,6 +6,7 @@ import {
   type MethodologyEvidenceAuditSummary,
   type MethodologyEvidenceContract,
 } from "@/lib/preverif/evidenceAudit";
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
 import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif/vm0007EvidenceContracts";
 import { readQuickCheckFixtureText, VM0007_SYNCED_RULES } from "./preverifVm0007Fixtures";
 
@@ -34,11 +35,72 @@ function auditVm0007(
   });
 }
 
+function auditVm0007WithDocument(
+  evidenceDocument: EvidenceDocument,
+  rawText: string,
+  options?: {
+    versionContext?: {
+      pddDeclaredMethodologyVersion: string;
+    };
+    getContract?: (rule: (typeof VM0007_SYNCED_RULES)[number]) => MethodologyEvidenceContract;
+  },
+): MethodologyEvidenceAuditSummary {
+  return auditEvidence({
+    rules: VM0007_SYNCED_RULES,
+    evidenceDocument,
+    getContract: options?.getContract ?? getVm0007EvidenceContract,
+    normalizeRuleId: normalizeVm0007RuleId,
+    sections: [],
+    rawText,
+    versionContext: options?.versionContext,
+  });
+}
+
 function makeVersionedContract(version: string) {
   return (rule: (typeof VM0007_SYNCED_RULES)[number]): MethodologyEvidenceContract => ({
     ...getVm0007EvidenceContract(rule),
     rulebookVersion: version,
   });
+}
+
+function makeTableEvidenceDocument(rows: string[][], heading = "Title and Reference of Methodology"): EvidenceDocument {
+  const cells = rows.flatMap((row, rowIndex) =>
+    row.map((text, columnIndex) => ({
+      rowIndex,
+      columnIndex,
+      text,
+      normalizedText: text.trim().toLowerCase(),
+    })),
+  );
+
+  return {
+    docId: "vm0007-version-lock-test",
+    rawText: rows.map((row) => row.join(" | ")).join("\n"),
+    spans: [
+      {
+        spanId: "span-table-1",
+        docId: "vm0007-version-lock-test",
+        page: 83,
+        sectionId: "section:3.1",
+        heading,
+        headingPath: ["Application of Methodology", heading],
+        sectionPath: ["Application of Methodology", heading],
+        blockType: "table",
+        text: rows.map((row) => row.join(" | ")).join("\n"),
+        normalizedText: rows.map((row) => row.join(" | ")).join("\n").toLowerCase(),
+        charStart: 0,
+        charEnd: null,
+        table: {
+          rowCount: rows.length,
+          columnCount: Math.max(...rows.map((row) => row.length)),
+          headerRowCount: 1,
+          cells,
+        },
+        reliability: "primary",
+        confidence: 100,
+      } as EvidenceDocument["spans"][number],
+    ],
+  };
 }
 
 describe("VM0007 version lock", () => {
@@ -118,8 +180,19 @@ describe("VM0007 version lock", () => {
     expect(audit.results.every((result) => result.versionMismatchReason === "")).toBe(true);
   });
 
-  it("allows VM0007 Version 1.8 even when the document also mentions VCS v4.4", () => {
-    const audit = auditVm0007("Title and Reference of Methodology: VM0007 Version 1.8. VCS v4.4 is mentioned elsewhere.", {
+  it("allows a methodology table row for VM0007 v1.8 even when module and tool rows have other versions", () => {
+    const document = makeTableEvidenceDocument([
+      ["Type", "Reference ID", "Version"],
+      ["Methodology", "VM0007", "1.8"],
+      ["Module", "VMD0001", "1.2"],
+      ["Module", "VMD0005", "1.1"],
+      ["Tool", "VT0001", "4.2"],
+      ["Module", "VMD0002", "1.3"],
+      ["Tool", "VT0002", "2.2"],
+      ["Tool", "VT0003", "3.0"],
+    ]);
+
+    const audit = auditVm0007WithDocument(document, document.rawText, {
       getContract: makeVersionedContract("v1-8"),
     });
 
@@ -128,8 +201,17 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMismatchReason).toBe("");
   });
 
-  it("allows REDD-MF Version 1.8 even when the document also mentions document version 7", () => {
-    const audit = auditVm0007("REDD-MF Version 1.8\nDocument version 7 is listed for the file export.", {
+  it("allows a Lisala-style methodology table row for VM0007 v1.8", () => {
+    const document = makeTableEvidenceDocument([
+      ["Type", "Reference ID", "Version"],
+      ["Methodology", "VM0007", "1.8"],
+      ["Module", "VMD0015", "2.1"],
+      ["Module", "VMD0006", "1.2"],
+      ["Tool", "VT0001", "3.0"],
+      ["Tool", "VT0002", "1.1"],
+    ]);
+
+    const audit = auditVm0007WithDocument(document, document.rawText, {
       getContract: makeVersionedContract("v1-8"),
     });
 
@@ -138,8 +220,29 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMismatchReason).toBe("");
   });
 
-  it("blocks VM0007 v1.5 even when the document also mentions VCS v4.4", () => {
-    const audit = auditVm0007("Title and Reference of Methodology: VM0007 v1.5. VCS v4.4 is mentioned elsewhere.", {
+  it("allows prose text written as 'VM0007 (v.1.8)'", () => {
+    const audit = auditVm0007("Section 3.1 Application of Methodology\nThe project applies VM0007 (v.1.8) for avoided deforestation.", {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("AUDITED");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.versionMismatchReason).toBe("");
+  });
+
+  it("blocks a methodology table row for VM0007 v1.5 even when module and tool rows have other versions", () => {
+    const document = makeTableEvidenceDocument([
+      ["Type", "Reference ID", "Version"],
+      ["Methodology", "VM0007", "1.5"],
+      ["Module", "VMD0001", "1.2"],
+      ["Module", "VMD0005", "1.1"],
+      ["Tool", "VT0001", "4.2"],
+      ["Module", "VMD0002", "1.3"],
+      ["Tool", "VT0002", "2.2"],
+      ["Tool", "VT0003", "3.0"],
+    ]);
+
+    const audit = auditVm0007WithDocument(document, document.rawText, {
       getContract: makeVersionedContract("v1-8"),
     });
 
@@ -149,8 +252,15 @@ describe("VM0007 version lock", () => {
     expect(audit.results).toEqual([]);
   });
 
-  it("blocks when VM0007 is declared without a methodology version", () => {
-    const audit = auditVm0007("Title and Reference of Methodology: VM0007. Tool version 7 appears elsewhere.", {
+  it("blocks when the methodology table row is present but the version cell is empty", () => {
+    const document = makeTableEvidenceDocument([
+      ["Type", "Reference ID", "Version"],
+      ["Methodology", "VM0007", ""],
+      ["Module", "VMD0001", "1.2"],
+      ["Tool", "VT0001", "4.2"],
+    ]);
+
+    const audit = auditVm0007WithDocument(document, document.rawText, {
       getContract: makeVersionedContract("v1-8"),
     });
 
@@ -160,8 +270,15 @@ describe("VM0007 version lock", () => {
     expect(audit.results).toEqual([]);
   });
 
-  it("blocks when the same methodology declaration contains both v1.8 and v1.5", () => {
-    const audit = auditVm0007("Title and Reference of Methodology: VM0007 v1.8 and v1.5.", {
+  it("blocks when the same methodology table row contains both v1.8 and v1.5", () => {
+    const document = makeTableEvidenceDocument([
+      ["Type", "Reference ID", "Version"],
+      ["Methodology", "VM0007", "1.8 and 1.5"],
+      ["Module", "VMD0001", "1.2"],
+      ["Tool", "VT0001", "4.2"],
+    ]);
+
+    const audit = auditVm0007WithDocument(document, document.rawText, {
       getContract: makeVersionedContract("v1-8"),
     });
 
@@ -170,6 +287,17 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMismatchReason).toContain("ambiguous");
     expect(audit.versionMismatchReason).toContain("v1.8");
     expect(audit.versionMismatchReason).toContain("v1.5");
+    expect(audit.results).toEqual([]);
+  });
+
+  it("blocks when VM0007 is declared without a methodology version in prose", () => {
+    const audit = auditVm0007("Section 3.1 Application of Methodology\nThe document identifies VM0007 but does not provide a methodology version.", {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
+    expect(audit.versionMatch).toBe(false);
+    expect(audit.versionMismatchReason).toContain("missing");
     expect(audit.results).toEqual([]);
   });
 

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -25,6 +25,15 @@ const MAYA_FLATTENED_TEXT = [
   "Type Tool Reference ID VT0009 Title Program reference Version 4.2",
   "3.1.2 Applicability of Methodology",
 ].join("\n");
+const MAYA_FLATTENED_FOOTNOTE_TEXT = [
+  "3.1 Application of Methodology",
+  "3.1.1 Title and Reference of Methodology",
+  "Type Methodology Reference ID VM0007 [1] Title REDD Methodology Framework [2] Version 1.8 [3]",
+  "VCS Standard Version 4.4",
+  "Type Module Reference ID VMD0001 Title Carbon stock module Version 1.2",
+  "Type Tool Reference ID VT0001 Title Additionality tool Version 3.0",
+  "3.1.2 Applicability of Methodology",
+].join("\n");
 const LISALA_FLATTENED_TEXT = [
   "3.1 Application of Methodology",
   "3.1.1 Title and Reference of Methodology",
@@ -218,6 +227,16 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMismatchReason).toBe("");
   });
 
+  it("allows a flattened methodology row with VM0007 footnotes while ignoring unrelated standard and module/tool versions", () => {
+    const audit = auditVm0007(MAYA_FLATTENED_FOOTNOTE_TEXT, {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("AUDITED");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.versionMismatchReason).toBe("");
+  });
+
   it("allows a Lisala-style flattened methodology block with a VM0007 v1.8 row", () => {
     const audit = auditVm0007(LISALA_FLATTENED_TEXT, {
       getContract: makeVersionedContract("v1-8"),
@@ -276,6 +295,23 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMatch).toBe(false);
     expect(audit.versionMismatchReason).toContain("missing");
     expect(audit.results).toEqual([]);
+  });
+
+  it("allows a structured methodology table row when the version cell is v1.8 even if the row includes footnotes", () => {
+    const document = makeTableEvidenceDocument([
+      ["Type", "Reference ID", "Version"],
+      ["Methodology", "VM0007 [1]", "1.8 [2]"],
+      ["Module", "VMD0001", "1.2"],
+      ["Tool", "VT0001", "4.2"],
+    ]);
+
+    const audit = auditVm0007WithDocument(document, document.rawText, {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("AUDITED");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.versionMismatchReason).toBe("");
   });
 
   it("blocks when the same methodology table row contains both v1.8 and v1.5", () => {

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -53,7 +53,7 @@ describe("VM0007 version lock", () => {
     expect(lock.versionMismatchReason).toContain("rulebook version");
   });
 
-  it("blocks Envira when the PDD-declared VM0007 version does not match the loaded v1.8 contract", () => {
+  it("blocks a VM0007 v1.5-only PDD against a loaded v1.8 contract", () => {
     const audit = auditVm0007(ENVIRA_TEXT, {
       getContract: makeVersionedContract("v1.8"),
       versionContext: {
@@ -69,6 +69,30 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMismatchReason).toContain("v1.8");
     expect(audit.results).toEqual([]);
     expect(Object.values(audit.totals)).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it("blocks ambiguous VM0007 versions when both v1.5 and v1.8 are present", () => {
+    const ambiguousText = "REDD-MF / VM0007 v1.5 and later VM0007 v1.8";
+
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1.8",
+      pddDeclaredMethodologyVersion: ambiguousText,
+    });
+
+    expect(lock.versionMatch).toBe(false);
+    expect(lock.versionMismatchReason).toContain("ambiguous");
+    expect(lock.versionMismatchReason).toContain("v1.5");
+    expect(lock.versionMismatchReason).toContain("v1.8");
+
+    const audit = auditVm0007(ambiguousText, {
+      getContract: makeVersionedContract("v1.8"),
+    });
+
+    expect(audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
+    expect(audit.versionMatch).toBe(false);
+    expect(audit.versionMismatchReason).toContain("ambiguous");
+    expect(audit.results).toEqual([]);
   });
 
   it("allows a matching VM0007 v1.8 PDD to proceed to normal evidence judgment", () => {

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -118,6 +118,61 @@ describe("VM0007 version lock", () => {
     expect(audit.results.every((result) => result.versionMismatchReason === "")).toBe(true);
   });
 
+  it("allows VM0007 Version 1.8 even when the document also mentions VCS v4.4", () => {
+    const audit = auditVm0007("Title and Reference of Methodology: VM0007 Version 1.8. VCS v4.4 is mentioned elsewhere.", {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("AUDITED");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.versionMismatchReason).toBe("");
+  });
+
+  it("allows REDD-MF Version 1.8 even when the document also mentions document version 7", () => {
+    const audit = auditVm0007("REDD-MF Version 1.8\nDocument version 7 is listed for the file export.", {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("AUDITED");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.versionMismatchReason).toBe("");
+  });
+
+  it("blocks VM0007 v1.5 even when the document also mentions VCS v4.4", () => {
+    const audit = auditVm0007("Title and Reference of Methodology: VM0007 v1.5. VCS v4.4 is mentioned elsewhere.", {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
+    expect(audit.versionMatch).toBe(false);
+    expect(audit.versionMismatchReason).toContain("v1.5");
+    expect(audit.results).toEqual([]);
+  });
+
+  it("blocks when VM0007 is declared without a methodology version", () => {
+    const audit = auditVm0007("Title and Reference of Methodology: VM0007. Tool version 7 appears elsewhere.", {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
+    expect(audit.versionMatch).toBe(false);
+    expect(audit.versionMismatchReason).toContain("missing");
+    expect(audit.results).toEqual([]);
+  });
+
+  it("blocks when the same methodology declaration contains both v1.8 and v1.5", () => {
+    const audit = auditVm0007("Title and Reference of Methodology: VM0007 v1.8 and v1.5.", {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
+    expect(audit.versionMatch).toBe(false);
+    expect(audit.versionMismatchReason).toContain("ambiguous");
+    expect(audit.versionMismatchReason).toContain("v1.8");
+    expect(audit.versionMismatchReason).toContain("v1.5");
+    expect(audit.results).toEqual([]);
+  });
+
   it("recognizes a VM0007 v1.8 declaration written as 'VM0007, version 1.8'", () => {
     const lock = buildMethodologyVersionLock({
       methodologyId: "VM0007",
@@ -160,27 +215,5 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMatch).toBe(true);
     expect(audit.versionMismatchReason).toBe("");
     expect(audit.results).toHaveLength(58);
-  });
-
-  it("treats no declared version as blocked", () => {
-    const lock = buildMethodologyVersionLock({
-      methodologyId: "VM0007",
-      rulebookVersion: "v1-8",
-      pddDeclaredMethodologyVersion: "",
-    });
-
-    expect(lock.versionMatch).toBe(false);
-    expect(lock.versionMismatchReason).toContain("missing");
-  });
-
-  it("treats multiple distinct declared versions as blocked", () => {
-    const lock = buildMethodologyVersionLock({
-      methodologyId: "VM0007",
-      rulebookVersion: "v1-8",
-      pddDeclaredMethodologyVersion: "VM0007 v1.5 and VM0007 version 1.8",
-    });
-
-    expect(lock.versionMatch).toBe(false);
-    expect(lock.versionMismatchReason).toContain("ambiguous");
   });
 });

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -99,21 +99,21 @@ describe("VM0007 version lock", () => {
 
   it("allows a matching VM0007 v1.8 PDD to proceed to normal evidence judgment", () => {
     const audit = auditVm0007(ENVIRA_TEXT, {
-      getContract: makeVersionedContract("v1.8"),
+      getContract: makeVersionedContract("v1-8"),
       versionContext: {
-        pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.8",
+        pddDeclaredMethodologyVersion: "VM0007 Version 1.8",
       },
     });
 
     expect(audit.auditStatus).toBe("AUDITED");
     expect(audit.methodologyId).toBe("VM0007");
-    expect(audit.rulebookVersion).toBe("v1.8");
+    expect(audit.rulebookVersion).toBe("v1-8");
     expect(audit.versionMatch).toBe(true);
     expect(audit.versionMismatchReason).toBe("");
     expect(audit.results).toHaveLength(58);
     expect(audit.results[0]?.methodologyId).toBe("VM0007");
-    expect(audit.results[0]?.rulebookVersion).toBe("v1.8");
-    expect(audit.results[0]?.pddDeclaredMethodologyVersion).toBe("REDD-MF / VM0007 v1.8");
+    expect(audit.results[0]?.rulebookVersion).toBe("v1-8");
+    expect(audit.results[0]?.pddDeclaredMethodologyVersion).toBe("VM0007 Version 1.8");
     expect(audit.results.every((result) => result.versionMatch === true)).toBe(true);
     expect(audit.results.every((result) => result.versionMismatchReason === "")).toBe(true);
   });
@@ -121,7 +121,7 @@ describe("VM0007 version lock", () => {
   it("recognizes a VM0007 v1.8 declaration written as 'VM0007, version 1.8'", () => {
     const lock = buildMethodologyVersionLock({
       methodologyId: "VM0007",
-      rulebookVersion: "v1.8",
+      rulebookVersion: "v1-8",
       pddDeclaredMethodologyVersion: "VM0007, version 1.8",
     });
 
@@ -132,7 +132,7 @@ describe("VM0007 version lock", () => {
   it("recognizes a VM0007 v1.8 declaration written as 'REDD-MF, REDD Methodology Framework Version 1.8'", () => {
     const lock = buildMethodologyVersionLock({
       methodologyId: "VM0007",
-      rulebookVersion: "v1.8",
+      rulebookVersion: "v1-8",
       pddDeclaredMethodologyVersion: "REDD-MF, REDD Methodology Framework Version 1.8",
     });
 
@@ -142,7 +142,7 @@ describe("VM0007 version lock", () => {
 
   it("allows a v1.8 VM0007 PDD when the real text uses 'VM0007, version 1.8'", () => {
     const audit = auditVm0007(ENVIRA_V18_VERSION_TEXT, {
-      getContract: makeVersionedContract("v1.8"),
+      getContract: makeVersionedContract("v1-8"),
     });
 
     expect(audit.auditStatus).toBe("AUDITED");
@@ -153,12 +153,34 @@ describe("VM0007 version lock", () => {
 
   it("allows a v1.8 VM0007 PDD when the real text uses 'REDD-MF, REDD Methodology Framework Version 1.8'", () => {
     const audit = auditVm0007(ENVIRA_V18_FRAMEWORK_TEXT, {
-      getContract: makeVersionedContract("v1.8"),
+      getContract: makeVersionedContract("v1-8"),
     });
 
     expect(audit.auditStatus).toBe("AUDITED");
     expect(audit.versionMatch).toBe(true);
     expect(audit.versionMismatchReason).toBe("");
     expect(audit.results).toHaveLength(58);
+  });
+
+  it("treats no declared version as blocked", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1-8",
+      pddDeclaredMethodologyVersion: "",
+    });
+
+    expect(lock.versionMatch).toBe(false);
+    expect(lock.versionMismatchReason).toContain("missing");
+  });
+
+  it("treats multiple distinct declared versions as blocked", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1-8",
+      pddDeclaredMethodologyVersion: "VM0007 v1.5 and VM0007 version 1.8",
+    });
+
+    expect(lock.versionMatch).toBe(false);
+    expect(lock.versionMismatchReason).toContain("ambiguous");
   });
 });

--- a/tests/lib/preverif/clientReadinessGate.test.ts
+++ b/tests/lib/preverif/clientReadinessGate.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./clientReadinessGate";
 
 const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
+const ENVIRA_V18_TEXT = ENVIRA_TEXT.replace("VM0007 Version 4.2", "REDD-MF / VM0007 v1.8");
 
 function auditText(rawText: string): MethodologyEvidenceAuditSummary {
   const context = getStructuredQueryContext(rawText);
@@ -45,7 +46,7 @@ function withStatus(
 }
 
 function buildReport(auditOverride?: MethodologyEvidenceAuditSummary) {
-  const base = auditOverride ?? auditText(ENVIRA_TEXT);
+  const base = auditOverride ?? auditText(ENVIRA_V18_TEXT);
   return buildVm0007GapReport({
     reportId: "VRGR-VM0007-CRG-001",
     generatedAt: "2026-07-03T00:00:00Z",
@@ -148,24 +149,24 @@ function makeCleanAudit(baseAudit: MethodologyEvidenceAuditSummary): Methodology
 describe("clientReadinessGate helper", () => {
   describe("assertNoUnclearEvidence", () => {
     it("passes when report has zero weak rows", () => {
-      const report = buildReport(makeCleanAudit(auditText(ENVIRA_TEXT)));
+      const report = buildReport(makeCleanAudit(auditText(ENVIRA_V18_TEXT)));
       expect(() => assertNoUnclearEvidence(report)).not.toThrow();
     });
 
     it("fails when report has weak rows", () => {
-      const report = buildReport(makeWeakAudit(auditText(ENVIRA_TEXT)));
+      const report = buildReport(makeWeakAudit(auditText(ENVIRA_V18_TEXT)));
       expect(() => assertNoUnclearEvidence(report)).toThrow();
     });
   });
 
   describe("assertNoMissingEvidence", () => {
     it("passes when report has zero missing rows", () => {
-      const report = buildReport(makeCleanAudit(auditText(ENVIRA_TEXT)));
+      const report = buildReport(makeCleanAudit(auditText(ENVIRA_V18_TEXT)));
       expect(() => assertNoMissingEvidence(report)).not.toThrow();
     });
 
     it("fails when report has missing rows", () => {
-      const report = buildReport(makeMissingAudit(auditText(ENVIRA_TEXT)));
+      const report = buildReport(makeMissingAudit(auditText(ENVIRA_V18_TEXT)));
       expect(() => assertNoMissingEvidence(report)).toThrow();
     });
   });
@@ -218,20 +219,20 @@ describe("clientReadinessGate helper", () => {
 
   describe("assertClientReadinessGate (composite)", () => {
     it("passes for a clean report (no weak, no missing, internal label, no banned wording)", () => {
-      const report = buildReport(makeCleanAudit(auditText(ENVIRA_TEXT)));
+      const report = buildReport(makeCleanAudit(auditText(ENVIRA_V18_TEXT)));
       const html = renderReport(report);
 
       expect(() => assertClientReadinessGate({ reportHtml: html, report })).not.toThrow();
     });
 
     it("fails on UNCLEAR evidence", () => {
-      const report = buildReport(makeWeakAudit(auditText(ENVIRA_TEXT)));
+      const report = buildReport(makeWeakAudit(auditText(ENVIRA_V18_TEXT)));
       const html = renderReport(report);
       expect(() => assertClientReadinessGate({ reportHtml: html, report })).toThrow();
     });
 
     it("fails on MISSING evidence", () => {
-      const report = buildReport(makeMissingAudit(auditText(ENVIRA_TEXT)));
+      const report = buildReport(makeMissingAudit(auditText(ENVIRA_V18_TEXT)));
       const html = renderReport(report);
       expect(() => assertClientReadinessGate({ reportHtml: html, report })).toThrow();
     });

--- a/tests/lib/preverif/fixtureQualityGate.test.ts
+++ b/tests/lib/preverif/fixtureQualityGate.test.ts
@@ -24,6 +24,7 @@ const SOURCE_EXCERPTS = JSON.parse(
 ) as SourceExcerpts;
 
 const ENVIRA_TEXT = readQuickCheckFixtureText("envira-amazonia-vm0007-extracted.txt");
+const ENVIRA_V18_TEXT = ENVIRA_TEXT.replace("VM0007 Version 4.2", "REDD-MF / VM0007 v1.8");
 
 function auditText(rawText: string): MethodologyEvidenceAuditSummary {
   const context = getStructuredQueryContext(rawText);
@@ -45,7 +46,7 @@ function withStatus(
 }
 
 function buildMixedAudit(): MethodologyEvidenceAuditSummary {
-  const base = auditText(ENVIRA_TEXT);
+  const base = auditText(ENVIRA_V18_TEXT);
   const results = base.results.map((result) => {
     if (result.ruleId === "R-1-0002") {
       return withStatus(result, {


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: vm0007-version-cleanup
- ack: human
- items:
  - PR1: in_progress

## What changed
- Added a hard methodology version lock to the generic VM0007 evidence audit path.
- Added version identity to VM0007 contracts and audit results.
- Added focused tests for blocked mismatch, matching VM0007 v1.8, and Envira regression coverage.

## Scope
- Phase 1 only: Version Lock.
- No report-route, PDF-export, or Phase 2 quarantine changes.
