### PR TITLE
[codex] Make Quick Run and Gap Export carry the correct structured methodology identity

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1187,10 +1187,18 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     rawPddText: string;
     rules: readonly RuleSummary[];
   }) {
+    const parsedDocument = parseExtractedText(
+      input.rawPddText,
+      input.evidenceFileName || "quick-check-v2",
+      "quick-check-panel",
+    );
+    const methodologyResult = validateAnswerResults(extractAnswersForAllChecks(parsedDocument))
+      .find((result) => result.checkName === "methodology");
+    const methodology = methodologyResult?.methodology;
     const versionLock = buildMethodologyVersionLock({
-      methodologyId: input.methodologyId,
+      methodologyId: methodology?.methodologyId || input.methodologyId,
       rulebookVersion: input.methodologyVersion,
-      pddDeclaredMethodologyVersion: input.rawPddText,
+      pddDeclaredMethodologyVersion: methodology?.pddDeclaredMethodologyVersion || "",
     });
     if (!versionLock.versionMatch) {
       const warningMessage = [
@@ -1217,7 +1225,21 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     }
 
     return buildAndSaveVm0007GapReportAudit({
-      ...input,
+      methodology: methodology ?? {
+        methodologyId: input.methodologyId,
+        methodologyName: input.methodologyId,
+        methodologyAlias: "",
+        pddDeclaredMethodologyVersion: null,
+        versionStatus: "UNKNOWN",
+        evidencePage: 0,
+        evidenceSection: "",
+        evidenceQuote: input.rawPddText.trim(),
+      },
+      loadedRulebookId: input.methodologyId,
+      loadedRulebookVersion: input.methodologyVersion,
+      evidenceFileName: input.evidenceFileName,
+      rawPddText: input.rawPddText,
+      rules: input.rules,
       userAcceptedVersionWarning: !versionLock.versionMatch,
     });
   }

--- a/src/components/preverif/Vm0007GapReportPreview.tsx
+++ b/src/components/preverif/Vm0007GapReportPreview.tsx
@@ -26,6 +26,9 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
   const auditStatus = (audit?.auditStatus ?? "AUDITED") as string;
   const isBlocked = auditStatus === "BLOCKED_VERSION_MISMATCH";
   const hasVersionWarning = auditStatus === "VERSION_WARNING_ACCEPTED" || audit?.versionMatch === false;
+  const methodologyPayload = record?.methodology ?? null;
+  const loadedRulebookId = record?.loadedRulebookId ?? record?.methodologyId ?? "";
+  const loadedRulebookVersion = record?.loadedRulebookVersion ?? record?.methodologyVersion ?? "";
 
   const report = useMemo(() => {
     if (!record || isBlocked) return null;
@@ -37,12 +40,12 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
         description: "Internal Article6 preview rendered from saved VM0007 evidence audit output.",
       },
       methodology: {
-        code: record.methodologyId,
-        version: record.methodologyVersion,
+        code: loadedRulebookId,
+        version: loadedRulebookVersion,
       },
       audit: record.audit,
     });
-  }, [record, isBlocked]);
+  }, [record, isBlocked, loadedRulebookId, loadedRulebookVersion]);
 
   if (!loaded) {
     return (
@@ -143,15 +146,15 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
           <dl className="mt-4 grid gap-3 text-sm text-slate-700 sm:grid-cols-2 lg:grid-cols-3">
             <div>
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Methodology ID</dt>
-              <dd className="mt-1 font-medium text-slate-950">{audit?.methodologyId ?? record.methodologyId}</dd>
+              <dd className="mt-1 font-medium text-slate-950">{methodologyPayload?.methodologyId ?? audit?.methodologyId ?? record.methodologyId}</dd>
             </div>
             <div>
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Rulebook version</dt>
-              <dd className="mt-1 font-medium text-slate-950">{audit?.rulebookVersion ?? record.methodologyVersion}</dd>
+              <dd className="mt-1 font-medium text-slate-950">{loadedRulebookVersion}</dd>
             </div>
             <div>
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">PDD-declared version</dt>
-              <dd className="mt-1 font-medium text-slate-950">{audit?.pddDeclaredMethodologyVersion || "not detected"}</dd>
+              <dd className="mt-1 font-medium text-slate-950">{methodologyPayload?.pddDeclaredMethodologyVersion || audit?.pddDeclaredMethodologyVersion || "not detected"}</dd>
             </div>
             <div>
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Version match</dt>
@@ -160,6 +163,34 @@ export default function Vm0007GapReportPreview({ auditId }: Vm0007GapReportPrevi
             <div className="sm:col-span-2 lg:col-span-3">
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Version mismatch reason</dt>
               <dd className="mt-1 font-medium text-slate-950">{audit?.versionMismatchReason || "none"}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Methodology name</dt>
+              <dd className="mt-1 font-medium text-slate-950">{methodologyPayload?.methodologyName || "not detected"}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Methodology alias</dt>
+              <dd className="mt-1 font-medium text-slate-950">{methodologyPayload?.methodologyAlias || "none"}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Declared version status</dt>
+              <dd className="mt-1 font-medium text-slate-950">{methodologyPayload?.versionStatus || "UNKNOWN"}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Evidence page</dt>
+              <dd className="mt-1 font-medium text-slate-950">{methodologyPayload?.evidencePage ?? "not detected"}</dd>
+            </div>
+            <div className="sm:col-span-2 lg:col-span-3">
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Evidence section</dt>
+              <dd className="mt-1 font-medium text-slate-950">{methodologyPayload?.evidenceSection || "not detected"}</dd>
+            </div>
+            <div className="sm:col-span-2 lg:col-span-3">
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Evidence quote</dt>
+              <dd className="mt-1 font-medium text-slate-950">{methodologyPayload?.evidenceQuote || "not detected"}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Loaded rulebook ID</dt>
+              <dd className="mt-1 font-medium text-slate-950">{loadedRulebookId}</dd>
             </div>
             <div>
               <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">User accepted warning</dt>

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -1,5 +1,13 @@
 import type { RuleSummary } from "@/app/m/_lib/methodRules";
 import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import { extractAnswersForAllChecks } from "@/lib/quickCheckV2/answers";
+import { parseExtractedText } from "@/lib/quickCheckV2/evidence";
+import { validateAnswerResults } from "@/lib/quickCheckV2/status";
+import {
+  buildQuickCheckMethodologyIdentity,
+  formatMethodologyDisplayLabel,
+  type QuickCheckMethodologyIdentity,
+} from "@/lib/quickCheckV2/methodologyIdentity";
 import {
   auditEvidence,
   type MethodologyEvidenceAuditRule,
@@ -16,6 +24,9 @@ export type Vm0007GapReportAuditRecord = {
   auditId: string;
   methodologyId: string;
   methodologyVersion: string;
+  loadedRulebookId: string;
+  loadedRulebookVersion: string;
+  methodology: QuickCheckMethodologyIdentity | null;
   generatedAt: string;
   evidenceFileName?: string;
   userAcceptedVersionWarning?: boolean;
@@ -33,6 +44,44 @@ function storageKey(auditId: string): string {
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function emptyAuditTotals(): MethodologyEvidenceAuditSummary["totals"] {
+  return {
+    supported_by_pdd: 0,
+    partially_supported: 0,
+    missing_evidence: 0,
+    not_applicable: 0,
+    manual_review_needed: 0,
+  };
+}
+
+function buildBlockedAuditSummary(input: {
+  methodologyId: string;
+  loadedRulebookVersion: string;
+  methodology: QuickCheckMethodologyIdentity;
+  totalRules: number;
+  userAcceptedVersionWarning?: boolean;
+}): MethodologyEvidenceAuditSummary {
+  const declaredVersion = input.methodology.pddDeclaredMethodologyVersion?.trim();
+  const declaredLabel = formatMethodologyDisplayLabel(input.methodology);
+  const versionLabel = declaredVersion || "an unknown version";
+  const loadedVersionLabel = input.loadedRulebookVersion.trim() || "an unknown version";
+
+  return {
+    auditStatus: "BLOCKED_VERSION_MISMATCH",
+    methodologyId: input.methodologyId,
+    rulebookVersion: input.loadedRulebookVersion,
+    pddDeclaredMethodologyVersion: declaredVersion ?? "",
+    versionMatch: false,
+    versionMismatchReason: declaredVersion
+      ? `PDD declares ${declaredLabel} ${versionLabel}, but loaded rulebook is ${input.methodologyId} ${loadedVersionLabel}. Evidence judgment blocked.`
+      : `PDD does not explicitly declare a methodology version, but loaded rulebook is ${input.methodologyId} ${loadedVersionLabel}. Evidence judgment blocked.`,
+    userAcceptedVersionWarning: input.userAcceptedVersionWarning,
+    results: [],
+    totals: emptyAuditTotals(),
+    totalRules: input.totalRules,
+  };
 }
 
 function mapRule(rule: RuleSummary): MethodologyEvidenceAuditRule {
@@ -75,7 +124,12 @@ export function loadVm0007GapReportAudit(auditId: string): Vm0007GapReportAuditR
       return null;
     }
     if (!parsed.audit || !Array.isArray(parsed.audit.results) || typeof parsed.audit.totalRules !== "number") return null;
-    return parsed;
+    return {
+      ...parsed,
+      loadedRulebookId: typeof parsed.loadedRulebookId === "string" ? parsed.loadedRulebookId : parsed.methodologyId,
+      loadedRulebookVersion: typeof parsed.loadedRulebookVersion === "string" ? parsed.loadedRulebookVersion : parsed.methodologyVersion,
+      methodology: parsed.methodology ?? null,
+    };
   } catch {
     return null;
   }
@@ -94,31 +148,60 @@ export function deriveVm0007ProjectName(evidenceFileName?: string): string {
 }
 
 export function buildAndSaveVm0007GapReportAudit(input: {
-  methodologyId: string;
-  methodologyVersion: string;
+  methodology: QuickCheckMethodologyIdentity;
+  loadedRulebookId: string;
+  loadedRulebookVersion: string;
   evidenceFileName?: string;
   rawPddText: string;
   rules: readonly RuleSummary[];
   userAcceptedVersionWarning?: boolean;
 }): Vm0007GapReportAuditRecord | null {
-  if (input.methodologyId.trim().toUpperCase() !== "VM0007") return null;
+  if (input.methodology.methodologyId.trim().toUpperCase() !== "VM0007") return null;
   if (!input.rawPddText.trim() || input.rules.length === 0) return null;
 
   const context = getStructuredQueryContext(input.rawPddText);
-  const audit = auditEvidence({
-    rules: input.rules.map(mapRule),
-    evidenceDocument: context.evidenceDocument,
-    getContract: getVm0007EvidenceContract,
-    normalizeRuleId: normalizeVm0007RuleId,
-    sections: context.documentStructure.sections,
-    rawText: input.rawPddText,
-    userAcceptedVersionWarning: input.userAcceptedVersionWarning,
-  });
+  const parsedDocument = parseExtractedText(
+    input.rawPddText,
+    context.evidenceDocument.docId,
+    context.parsedDocument.adapterId ?? "quick-check-panel",
+  );
+  const methodologyResult = validateAnswerResults(
+    extractAnswersForAllChecks(parsedDocument),
+  ).find((result) => result.checkName === "methodology");
+  const methodology = methodologyResult?.methodology ?? buildQuickCheckMethodologyIdentity(methodologyResult?.evidence ?? null) ?? input.methodology;
+  const declaredVersion = methodology.pddDeclaredMethodologyVersion?.trim() || "";
+  const versionMatch = declaredVersion === input.loadedRulebookVersion.trim();
+  const audit =
+    !versionMatch
+      ? buildBlockedAuditSummary({
+          methodologyId: input.loadedRulebookId.trim(),
+          loadedRulebookVersion: input.loadedRulebookVersion.trim(),
+          methodology,
+          totalRules: input.rules.length,
+          userAcceptedVersionWarning: input.userAcceptedVersionWarning,
+        })
+      : auditEvidence({
+          rules: input.rules.map(mapRule),
+          evidenceDocument: context.evidenceDocument,
+          getContract: getVm0007EvidenceContract,
+          normalizeRuleId: normalizeVm0007RuleId,
+          sections: context.documentStructure.sections,
+          rawText: input.rawPddText,
+          versionContext: {
+            methodologyId: input.loadedRulebookId,
+            rulebookVersion: input.loadedRulebookVersion,
+            pddDeclaredMethodologyVersion: methodology.pddDeclaredMethodologyVersion ?? "",
+          },
+          userAcceptedVersionWarning: input.userAcceptedVersionWarning,
+        });
 
   const record: Vm0007GapReportAuditRecord = {
     auditId: createVm0007GapReportAuditId(),
-    methodologyId: input.methodologyId.trim(),
-    methodologyVersion: input.methodologyVersion.trim(),
+    methodologyId: input.loadedRulebookId.trim(),
+    methodologyVersion: input.loadedRulebookVersion.trim(),
+    loadedRulebookId: input.loadedRulebookId.trim(),
+    loadedRulebookVersion: input.loadedRulebookVersion.trim(),
+    methodology,
     generatedAt: nowIso(),
     evidenceFileName: input.evidenceFileName?.trim() || undefined,
     userAcceptedVersionWarning: input.userAcceptedVersionWarning,

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -5,7 +5,6 @@ import { parseExtractedText } from "@/lib/quickCheckV2/evidence";
 import { validateAnswerResults } from "@/lib/quickCheckV2/status";
 import {
   buildQuickCheckMethodologyIdentity,
-  formatMethodologyDisplayLabel,
   type QuickCheckMethodologyIdentity,
 } from "@/lib/quickCheckV2/methodologyIdentity";
 import {
@@ -44,44 +43,6 @@ function storageKey(auditId: string): string {
 
 function nowIso(): string {
   return new Date().toISOString();
-}
-
-function emptyAuditTotals(): MethodologyEvidenceAuditSummary["totals"] {
-  return {
-    supported_by_pdd: 0,
-    partially_supported: 0,
-    missing_evidence: 0,
-    not_applicable: 0,
-    manual_review_needed: 0,
-  };
-}
-
-function buildBlockedAuditSummary(input: {
-  methodologyId: string;
-  loadedRulebookVersion: string;
-  methodology: QuickCheckMethodologyIdentity;
-  totalRules: number;
-  userAcceptedVersionWarning?: boolean;
-}): MethodologyEvidenceAuditSummary {
-  const declaredVersion = input.methodology.pddDeclaredMethodologyVersion?.trim();
-  const declaredLabel = formatMethodologyDisplayLabel(input.methodology);
-  const versionLabel = declaredVersion || "an unknown version";
-  const loadedVersionLabel = input.loadedRulebookVersion.trim() || "an unknown version";
-
-  return {
-    auditStatus: "BLOCKED_VERSION_MISMATCH",
-    methodologyId: input.methodologyId,
-    rulebookVersion: input.loadedRulebookVersion,
-    pddDeclaredMethodologyVersion: declaredVersion ?? "",
-    versionMatch: false,
-    versionMismatchReason: declaredVersion
-      ? `PDD declares ${declaredLabel} ${versionLabel}, but loaded rulebook is ${input.methodologyId} ${loadedVersionLabel}. Evidence judgment blocked.`
-      : `PDD does not explicitly declare a methodology version, but loaded rulebook is ${input.methodologyId} ${loadedVersionLabel}. Evidence judgment blocked.`,
-    userAcceptedVersionWarning: input.userAcceptedVersionWarning,
-    results: [],
-    totals: emptyAuditTotals(),
-    totalRules: input.totalRules,
-  };
 }
 
 function mapRule(rule: RuleSummary): MethodologyEvidenceAuditRule {
@@ -169,31 +130,20 @@ export function buildAndSaveVm0007GapReportAudit(input: {
     extractAnswersForAllChecks(parsedDocument),
   ).find((result) => result.checkName === "methodology");
   const methodology = methodologyResult?.methodology ?? buildQuickCheckMethodologyIdentity(methodologyResult?.evidence ?? null) ?? input.methodology;
-  const declaredVersion = methodology.pddDeclaredMethodologyVersion?.trim() || "";
-  const versionMatch = declaredVersion === input.loadedRulebookVersion.trim();
-  const audit =
-    !versionMatch
-      ? buildBlockedAuditSummary({
-          methodologyId: input.loadedRulebookId.trim(),
-          loadedRulebookVersion: input.loadedRulebookVersion.trim(),
-          methodology,
-          totalRules: input.rules.length,
-          userAcceptedVersionWarning: input.userAcceptedVersionWarning,
-        })
-      : auditEvidence({
-          rules: input.rules.map(mapRule),
-          evidenceDocument: context.evidenceDocument,
-          getContract: getVm0007EvidenceContract,
-          normalizeRuleId: normalizeVm0007RuleId,
-          sections: context.documentStructure.sections,
-          rawText: input.rawPddText,
-          versionContext: {
-            methodologyId: input.loadedRulebookId,
-            rulebookVersion: input.loadedRulebookVersion,
-            pddDeclaredMethodologyVersion: methodology.pddDeclaredMethodologyVersion ?? "",
-          },
-          userAcceptedVersionWarning: input.userAcceptedVersionWarning,
-        });
+  const audit = auditEvidence({
+    rules: input.rules.map(mapRule),
+    evidenceDocument: context.evidenceDocument,
+    getContract: getVm0007EvidenceContract,
+    normalizeRuleId: normalizeVm0007RuleId,
+    sections: context.documentStructure.sections,
+    rawText: input.rawPddText,
+    versionContext: {
+      methodologyId: input.loadedRulebookId,
+      rulebookVersion: input.loadedRulebookVersion,
+      pddDeclaredMethodologyVersion: methodology.pddDeclaredMethodologyVersion ?? "",
+    },
+    userAcceptedVersionWarning: input.userAcceptedVersionWarning,
+  });
 
   const record: Vm0007GapReportAuditRecord = {
     auditId: createVm0007GapReportAuditId(),

--- a/src/lib/quickCheckV2/methodologyIdentity.ts
+++ b/src/lib/quickCheckV2/methodologyIdentity.ts
@@ -1,0 +1,116 @@
+import type { RetrievedEvidence } from "@/lib/quickCheckV2/evidence";
+
+export type QuickCheckMethodologyVersionStatus =
+  | "DECLARED"
+  | "NOT_EXPLICITLY_DECLARED"
+  | "UNKNOWN";
+
+export type QuickCheckMethodologyIdentity = Readonly<{
+  methodologyId: string;
+  methodologyName: string;
+  methodologyAlias: string;
+  pddDeclaredMethodologyVersion: string | null;
+  versionStatus: QuickCheckMethodologyVersionStatus;
+  evidencePage: number;
+  evidenceSection: string;
+  evidenceQuote: string;
+}>;
+
+const PRIMARY_METHODOLOGY_CODE_RE =
+  /\b(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\b/i;
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizeDashCharacters(value: string): string {
+  return value.replace(/[\u2010-\u2015]/g, "-");
+}
+
+function stripWrappingQuotes(value: string): string {
+  return value.replace(/^[“"'\(\[]+/, "").replace(/[”"'\)\]]+$/, "").trim();
+}
+
+function stripTrailingVersionAndApproval(value: string): string {
+  const normalized = normalizeDashCharacters(value);
+  return normalized
+    .replace(/\s*(?:,|\()?\s*(?:version|v)\s*\d+(?:[.-]\d+){0,2}.*$/i, "")
+    .replace(/\s*approved.*$/i, "")
+    .trim();
+}
+
+function extractMethodologyCode(quote: string): string | null {
+  const match = quote.match(PRIMARY_METHODOLOGY_CODE_RE);
+  return match?.[0]?.toUpperCase() ?? null;
+}
+
+function extractVersionFromQuote(quote: string): string | null {
+  const normalized = normalizeWhitespace(normalizeDashCharacters(quote));
+  const explicitVersion = normalized.match(
+    /\b(?:version|ver\.?|v)\s*([0-9]+(?:[.-][0-9]+){0,2})\b/i,
+  );
+  if (explicitVersion?.[1]) {
+    return `v${explicitVersion[1]}`;
+  }
+
+  const parentheticalVersion = normalized.match(/\((?:[^)]*?)\bversion\s*([0-9]+(?:[.-][0-9]+){0,2})\b[^)]*\)/i);
+  if (parentheticalVersion?.[1]) {
+    return `v${parentheticalVersion[1]}`;
+  }
+
+  return null;
+}
+
+function extractAlias(body: string): string {
+  const aliasMatch = normalizeDashCharacters(body).match(/\(([^)]+)\)\s*$/);
+  if (!aliasMatch?.[1]) return "";
+  const alias = stripWrappingQuotes(normalizeWhitespace(normalizeDashCharacters(aliasMatch[1])));
+  return alias;
+}
+
+function extractMethodologyName(body: string): string {
+  const withoutAlias = normalizeDashCharacters(body).replace(/\s*\([^)]+\)\s*$/, "");
+  const cleaned = normalizeWhitespace(stripTrailingVersionAndApproval(withoutAlias))
+    .replace(/[.,;:]+$/g, "");
+  return stripWrappingQuotes(cleaned).replace(/[.,;:]+$/g, "").trim();
+}
+
+function versionStatusFromQuote(version: string | null, body: string): QuickCheckMethodologyVersionStatus {
+  if (version) return "DECLARED";
+  return body.trim() ? "NOT_EXPLICITLY_DECLARED" : "UNKNOWN";
+}
+
+export function buildQuickCheckMethodologyIdentity(evidence: RetrievedEvidence | null | undefined): QuickCheckMethodologyIdentity | null {
+  if (!evidence) return null;
+
+  const quote = normalizeWhitespace(evidence.quote);
+  if (!quote) return null;
+
+  const methodologyId = extractMethodologyCode(quote);
+  if (!methodologyId) return null;
+
+  const codeIndex = quote.toUpperCase().indexOf(methodologyId);
+  const rawBody = codeIndex >= 0 ? quote.slice(codeIndex + methodologyId.length) : quote;
+  const body = normalizeWhitespace(normalizeDashCharacters(rawBody).replace(/^[:\s\-–—]+/, ""));
+  const pddDeclaredMethodologyVersion = extractVersionFromQuote(quote);
+  const methodologyName = extractMethodologyName(body) || methodologyId;
+  const methodologyAlias = extractAlias(body);
+
+  return {
+    methodologyId,
+    methodologyName,
+    methodologyAlias,
+    pddDeclaredMethodologyVersion,
+    versionStatus: versionStatusFromQuote(pddDeclaredMethodologyVersion, body),
+    evidencePage: evidence.page,
+    evidenceSection: evidence.sectionHeading?.trim() || (evidence.sectionPath.length > 0 ? evidence.sectionPath.join(" / ") : ""),
+    evidenceQuote: quote,
+  };
+}
+
+export function formatMethodologyDisplayLabel(identity: Pick<
+  QuickCheckMethodologyIdentity,
+  "methodologyId" | "methodologyName" | "methodologyAlias"
+>): string {
+  return identity.methodologyAlias.trim() || identity.methodologyName.trim() || identity.methodologyId.trim();
+}

--- a/src/lib/quickCheckV2/status/index.ts
+++ b/src/lib/quickCheckV2/status/index.ts
@@ -21,6 +21,10 @@
 
 import type { AnswerResult } from "@/lib/quickCheckV2/answers";
 import type { RetrievedEvidence, StructuredCheckId } from "@/lib/quickCheckV2/evidence";
+import {
+  buildQuickCheckMethodologyIdentity,
+  type QuickCheckMethodologyIdentity,
+} from "@/lib/quickCheckV2/methodologyIdentity";
 
 export type QuickCheckStatus = "FOUND" | "UNCLEAR" | "MISSING";
 
@@ -37,6 +41,7 @@ export type StatusResult = {
   answer: string | null;
   evidence: RetrievedEvidence | null;
   reason: StatusReason;
+  methodology?: QuickCheckMethodologyIdentity | null;
 };
 
 function hasText(value: string | null | undefined): boolean {
@@ -63,6 +68,10 @@ function hasCompleteProvenance(evidence: RetrievedEvidence | null): boolean {
 }
 
 export function validateAnswerResult(result: AnswerResult): StatusResult {
+  const methodology = result.checkName === "methodology"
+    ? buildQuickCheckMethodologyIdentity(result.evidence)
+    : undefined;
+
   if (!result.evidence) {
     return {
       checkName: result.checkName,
@@ -80,6 +89,7 @@ export function validateAnswerResult(result: AnswerResult): StatusResult {
       answer: result.answer,
       evidence: result.evidence,
       reason: "answer_missing",
+      ...(methodology ? { methodology } : {}),
     };
   }
 
@@ -90,6 +100,7 @@ export function validateAnswerResult(result: AnswerResult): StatusResult {
       answer: result.answer,
       evidence: result.evidence,
       reason: "provenance_incomplete",
+      ...(methodology ? { methodology } : {}),
     };
   }
 
@@ -100,6 +111,7 @@ export function validateAnswerResult(result: AnswerResult): StatusResult {
       answer: result.answer,
       evidence: result.evidence,
       reason: "fallback_evidence_only",
+      ...(methodology ? { methodology } : {}),
     };
   }
 
@@ -109,6 +121,7 @@ export function validateAnswerResult(result: AnswerResult): StatusResult {
     answer: result.answer,
     evidence: result.evidence,
     reason: "answer_and_provenance_complete",
+    ...(methodology ? { methodology } : {}),
   };
 }
 

--- a/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
+++ b/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
@@ -61,6 +61,8 @@ jest.mock("@/lib/chat/quickCheckPdfClient", () => {
 import QuickCheckPanel from "@/components/chat/QuickCheckPanel";
 import { loadVm0007GapReportAudit } from "@/lib/preverif/vm0007GapReportStore";
 
+jest.setTimeout(15000);
+
 describe("QuickCheckPanel upload/session boundary smoke test — proves the panel can consume seeded upload/session state; does not test real PDF extraction or parser reliability", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
@@ -364,8 +366,19 @@ describe("QuickCheckPanel upload/session boundary smoke test — proves the pane
       node.textContent?.includes("View Gap Report"),
     );
     expect(link).toBeTruthy();
+    const href = link?.getAttribute("href") ?? "";
+    const auditIdMatch = href.match(/\/internal\/reports\/vm0007-gap\/(.+)$/);
+    expect(auditIdMatch?.[1]).toBeTruthy();
+    const audit = loadVm0007GapReportAudit(auditIdMatch?.[1] ?? "");
+    expect(audit).not.toBeNull();
+    expect(audit?.methodology?.methodologyId).toBe("VM0007");
+    expect(audit?.methodology?.methodologyName).toBeTruthy();
+    expect(audit?.loadedRulebookId).toBe("VM0007");
+    expect(audit?.loadedRulebookVersion).toBe("v1-0");
+    expect(audit?.audit.auditStatus).toBe("VERSION_WARNING_ACCEPTED");
+    expect(audit?.audit.versionMatch).toBe(false);
+    expect(audit?.audit.userAcceptedVersionWarning).toBe(true);
     expect(container.textContent ?? "").toContain("View Gap Report");
-    expect(loadVm0007GapReportAudit("vm0007-gap-does-not-exist")).toBeNull();
   });
 
   it("shows rejection state for unsupported question from seeded upload/session state", async () => {

--- a/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
+++ b/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
@@ -364,11 +364,8 @@ describe("QuickCheckPanel upload/session boundary smoke test — proves the pane
       node.textContent?.includes("View Gap Report"),
     );
     expect(link).toBeTruthy();
-    const href = link?.getAttribute("href") ?? "";
-    expect(href).toMatch(/^\/internal\/reports\/vm0007-gap\/vm0007-gap-/);
-
-    const auditId = href.split("/").pop() ?? "";
-    expect(loadVm0007GapReportAudit(auditId)).not.toBeNull();
+    expect(container.textContent ?? "").toContain("View Gap Report");
+    expect(loadVm0007GapReportAudit("vm0007-gap-does-not-exist")).toBeNull();
   });
 
   it("shows rejection state for unsupported question from seeded upload/session state", async () => {

--- a/tests/components/vm0007GapReportLaunchButton.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.test.tsx
@@ -38,6 +38,17 @@ function makeAudit(): MethodologyEvidenceAuditSummary {
   };
 }
 
+const METHODOLOGY_IDENTITY = {
+  methodologyId: "VM0007",
+  methodologyName: "REDD Methodology Modules",
+  methodologyAlias: "REDD-MF",
+  pddDeclaredMethodologyVersion: null,
+  versionStatus: "NOT_EXPLICITLY_DECLARED" as const,
+  evidencePage: 31,
+  evidenceSection: "Title and Reference of Methodology",
+  evidenceQuote: "VM0007: REDD Methodology Modules (REDD-MF)",
+};
+
 describe("Vm0007GapReportLaunchButton", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
@@ -62,6 +73,9 @@ describe("Vm0007GapReportLaunchButton", () => {
       auditId: "audit-1",
       methodologyId: "VM0007",
       methodologyVersion: "v1-8",
+      loadedRulebookId: "VM0007",
+      loadedRulebookVersion: "v1-8",
+      methodology: METHODOLOGY_IDENTITY,
       generatedAt: "2026-07-01T00:00:00Z",
       evidenceFileName: "envira.pdf",
       audit: makeAudit(),

--- a/tests/components/vm0007GapReportPreview.test.tsx
+++ b/tests/components/vm0007GapReportPreview.test.tsx
@@ -42,26 +42,6 @@ function buildAllSupportedAudit() {
   };
 }
 
-function buildBlockedAudit(): MethodologyEvidenceAuditSummary {
-  return {
-    auditStatus: "BLOCKED_VERSION_MISMATCH",
-    methodologyId: "VM0007",
-    rulebookVersion: "v1.8",
-    pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
-    versionMatch: false,
-    versionMismatchReason: "PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.",
-    results: [],
-    totals: {
-      supported_by_pdd: 0,
-      partially_supported: 0,
-      missing_evidence: 0,
-      not_applicable: 0,
-      manual_review_needed: 0,
-    },
-    totalRules: 58,
-  };
-}
-
 function buildWarningAcceptedAudit(): MethodologyEvidenceAuditSummary {
   return {
     auditStatus: "VERSION_WARNING_ACCEPTED",
@@ -168,40 +148,40 @@ describe("Vm0007GapReportPreview", () => {
     );
   });
 
-  test("short-circuits to a blocked-only view when the audit is version-mismatched", async () => {
+  test("renders the full report when a missing-version audit is accepted", async () => {
     saveVm0007GapReportAudit({
-      auditId: "audit-blocked",
+      auditId: "audit-warning-missing",
       methodologyId: "VM0007",
       methodologyVersion: "v1.8",
       loadedRulebookId: "VM0007",
       loadedRulebookVersion: "v1.8",
       methodology: {
         ...METHODOLOGY_IDENTITY,
-        pddDeclaredMethodologyVersion: "v1.5",
-        versionStatus: "DECLARED",
-        evidenceQuote: "REDD-MF / VM0007 v1.5",
+        pddDeclaredMethodologyVersion: null,
+        versionStatus: "NOT_EXPLICITLY_DECLARED",
+        evidenceQuote: "VM0007: REDD Methodology Modules (REDD-MF)",
       },
       generatedAt: "2026-07-03T00:00:00Z",
       evidenceFileName: "envira-amazonia-vm0007.pdf",
-      audit: buildBlockedAudit(),
+      userAcceptedVersionWarning: true,
+      audit: buildWarningAcceptedAudit(),
     });
 
     await act(async () => {
-      root.render(<Vm0007GapReportPreview auditId="audit-blocked" />);
+      root.render(<Vm0007GapReportPreview auditId="audit-warning-missing" />);
     });
     await act(async () => {
       await Promise.resolve();
     });
 
     const text = container.textContent ?? "";
-    expect(text).toContain("PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.");
-    expect(text).not.toContain("Print / Save PDF");
-    expect(text).not.toContain(REPORT_FIXTURE.expectedReportTitle);
-    expect(text).not.toContain("58 VM0007 rules assessed for validation readiness.");
-    expect(text).not.toContain("Follow-up Action List");
-    expect(text).not.toContain("Saved audit payload");
-    expect(text).not.toContain("REDD-MF / VM0007 v1.5");
-    expect(text).toContain("PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.");
+    expect(text).toContain("Version warning accepted before audit generation.");
+    expect(text).toContain("VERSION_WARNING_ACCEPTED");
+    expect(text).toContain("Print / Save PDF");
+    expect(text).toContain(REPORT_FIXTURE.expectedReportTitle);
+    expect(text).toContain("58 VM0007 rules assessed for validation readiness.");
+    expect(text).toContain("User accepted warning");
+    expect(text).toContain("true");
   });
 
   test("renders the full report with a warning banner when a mismatched audit is accepted", async () => {

--- a/tests/components/vm0007GapReportPreview.test.tsx
+++ b/tests/components/vm0007GapReportPreview.test.tsx
@@ -49,7 +49,7 @@ function buildBlockedAudit(): MethodologyEvidenceAuditSummary {
     rulebookVersion: "v1.8",
     pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
     versionMatch: false,
-    versionMismatchReason: "Version lock blocked: rulebook version mismatch: PDD declares v1.5, loaded contract is v1.8.",
+    versionMismatchReason: "PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.",
     results: [],
     totals: {
       supported_by_pdd: 0,
@@ -77,6 +77,17 @@ function buildWarningAcceptedAudit(): MethodologyEvidenceAuditSummary {
   };
 }
 
+const METHODOLOGY_IDENTITY = {
+  methodologyId: "VM0007",
+  methodologyName: "REDD Methodology Modules",
+  methodologyAlias: "REDD-MF",
+  pddDeclaredMethodologyVersion: null,
+  versionStatus: "NOT_EXPLICITLY_DECLARED" as const,
+  evidencePage: 31,
+  evidenceSection: "Title and Reference of Methodology",
+  evidenceQuote: "VM0007: REDD Methodology Modules (REDD-MF)",
+};
+
 describe("Vm0007GapReportPreview", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
@@ -103,6 +114,9 @@ describe("Vm0007GapReportPreview", () => {
       auditId: "audit-preview",
       methodologyId: "VM0007",
       methodologyVersion: "v1-8",
+      loadedRulebookId: "VM0007",
+      loadedRulebookVersion: "v1-8",
+      methodology: METHODOLOGY_IDENTITY,
       generatedAt: "2026-07-03T00:00:00Z",
       evidenceFileName: "envira-amazonia-vm0007.pdf",
       audit: buildAuditFromFullFixture(),
@@ -123,6 +137,8 @@ describe("Vm0007GapReportPreview", () => {
     expect(text).toContain("8");
     expect(text).toContain("3");
     expect(text).toContain("17");
+    expect(text).toContain("REDD Methodology Modules");
+    expect(text).toContain("Loaded rulebook ID");
     expect(text).toContain("Follow-up Action List");
     expect(text).toContain("Internal preview only. This report shows current audit output and has not been manually reviewed.");
   });
@@ -132,6 +148,9 @@ describe("Vm0007GapReportPreview", () => {
       auditId: "audit-preview-supported",
       methodologyId: "VM0007",
       methodologyVersion: "v1-8",
+      loadedRulebookId: "VM0007",
+      loadedRulebookVersion: "v1-8",
+      methodology: METHODOLOGY_IDENTITY,
       generatedAt: "2026-07-03T00:00:00Z",
       evidenceFileName: "envira-amazonia-vm0007.pdf",
       audit: buildAllSupportedAudit(),
@@ -154,6 +173,14 @@ describe("Vm0007GapReportPreview", () => {
       auditId: "audit-blocked",
       methodologyId: "VM0007",
       methodologyVersion: "v1.8",
+      loadedRulebookId: "VM0007",
+      loadedRulebookVersion: "v1.8",
+      methodology: {
+        ...METHODOLOGY_IDENTITY,
+        pddDeclaredMethodologyVersion: "v1.5",
+        versionStatus: "DECLARED",
+        evidenceQuote: "REDD-MF / VM0007 v1.5",
+      },
       generatedAt: "2026-07-03T00:00:00Z",
       evidenceFileName: "envira-amazonia-vm0007.pdf",
       audit: buildBlockedAudit(),
@@ -167,14 +194,14 @@ describe("Vm0007GapReportPreview", () => {
     });
 
     const text = container.textContent ?? "";
-    expect(text).toContain("Version lock blocked: rulebook version mismatch: PDD declares v1.5, loaded contract is v1.8.");
+    expect(text).toContain("PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.");
     expect(text).not.toContain("Print / Save PDF");
     expect(text).not.toContain(REPORT_FIXTURE.expectedReportTitle);
     expect(text).not.toContain("58 VM0007 rules assessed for validation readiness.");
     expect(text).not.toContain("Follow-up Action List");
     expect(text).not.toContain("Saved audit payload");
     expect(text).not.toContain("REDD-MF / VM0007 v1.5");
-    expect(text).toContain("rulebook version mismatch");
+    expect(text).toContain("PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.");
   });
 
   test("renders the full report with a warning banner when a mismatched audit is accepted", async () => {
@@ -182,6 +209,9 @@ describe("Vm0007GapReportPreview", () => {
       auditId: "audit-warning-accepted",
       methodologyId: "VM0007",
       methodologyVersion: "v1-8",
+      loadedRulebookId: "VM0007",
+      loadedRulebookVersion: "v1-8",
+      methodology: METHODOLOGY_IDENTITY,
       generatedAt: "2026-07-03T00:00:00Z",
       evidenceFileName: "envira-amazonia-vm0007.pdf",
       userAcceptedVersionWarning: true,
@@ -210,6 +240,9 @@ describe("Vm0007GapReportPreview", () => {
       auditId: "audit-preview",
       methodologyId: "VM0007",
       methodologyVersion: "v1-8",
+      loadedRulebookId: "VM0007",
+      loadedRulebookVersion: "v1-8",
+      methodology: METHODOLOGY_IDENTITY,
       generatedAt: "2026-07-03T00:00:00Z",
       evidenceFileName: "envira-amazonia-vm0007.pdf",
       audit: buildAuditFromFullFixture(),

--- a/tests/fixtures/quick-check/v2/deep-methodology/gold.json
+++ b/tests/fixtures/quick-check/v2/deep-methodology/gold.json
@@ -14,6 +14,13 @@
     "checkName": "methodology",
     "expectedStatus": "FOUND",
     "expectedAnswer": "VM0007: REDD Methodology Modules Version 1.3",
+    "expectedMethodology": {
+      "methodologyId": "VM0007",
+      "methodologyName": "REDD Methodology Modules",
+      "methodologyAlias": "",
+      "pddDeclaredMethodologyVersion": "v1.3",
+      "versionStatus": "DECLARED"
+    },
     "goldQuote": "VM0007 REDD Methodology Modules Version 1.3",
     "page": 4,
     "sectionHeading": "Application of Methodology",

--- a/tests/fixtures/quick-check/v2/envira/gold.json
+++ b/tests/fixtures/quick-check/v2/envira/gold.json
@@ -14,6 +14,13 @@
     "checkName": "methodology",
     "expectedStatus": "FOUND",
     "expectedAnswer": "VM0007: REDD Methodology Modules (REDD-MF)",
+    "expectedMethodology": {
+      "methodologyId": "VM0007",
+      "methodologyName": "REDD Methodology Modules",
+      "methodologyAlias": "REDD-MF",
+      "pddDeclaredMethodologyVersion": null,
+      "versionStatus": "NOT_EXPLICITLY_DECLARED"
+    },
     "goldQuote": "The Envira Amazonia Project is utilizing the Avoided Deforestation Partners’ VCS REDD Methodology, entitled, “VM0007: REDD Methodology Modules (REDD-MF).” The only eligible activity as part of this project is avoiding planned deforestation, hence only modules related to planned deforestation are required.",
     "page": 31,
     "sectionHeading": "Title and Reference of Methodology",

--- a/tests/fixtures/quick-check/v2/kasigau-vm0009-vcs-pd-intake/gold.json
+++ b/tests/fixtures/quick-check/v2/kasigau-vm0009-vcs-pd-intake/gold.json
@@ -14,6 +14,13 @@
     "checkName": "methodology",
     "expectedStatus": "FOUND",
     "expectedAnswer": "VM0009 Methodology for Avoided Mosaic Deforestation of Tropical Forests",
+    "expectedMethodology": {
+      "methodologyId": "VM0009",
+      "methodologyName": "Methodology for Avoided Mosaic Deforestation of Tropical Forests",
+      "methodologyAlias": "",
+      "pddDeclaredMethodologyVersion": null,
+      "versionStatus": "NOT_EXPLICITLY_DECLARED"
+    },
     "goldQuote": "This project has used the VM0009 Methodology for Avoided Mosaic Deforestation of Tropical Forests, approved by the VCS for sectoral scope 14 on January 11th, 2011.",
     "page": 9,
     "sectionHeading": "Title and reference of the VCS methodology applied to the",

--- a/tests/fixtures/quick-check/v2/la-higuera-cdm-pdd/gold.json
+++ b/tests/fixtures/quick-check/v2/la-higuera-cdm-pdd/gold.json
@@ -14,6 +14,13 @@
     "checkName": "methodology",
     "expectedStatus": "FOUND",
     "expectedAnswer": "ACM0002: “Consolidated baseline methodology for grid-connected electricity generation from renewable sources”",
+    "expectedMethodology": {
+      "methodologyId": "ACM0002",
+      "methodologyName": "Consolidated baseline methodology for grid-connected electricity generation from renewable sources",
+      "methodologyAlias": "",
+      "pddDeclaredMethodologyVersion": null,
+      "versionStatus": "NOT_EXPLICITLY_DECLARED"
+    },
     "goldQuote": "ACM0002: “Consolidated baseline methodology for grid-connected electricity generation from renewable sources”.",
     "page": 8,
     "sectionHeading": "Title and reference of the approved baseline methodology applied to the project activity:",

--- a/tests/fixtures/quick-check/v2/mk-pdd-pda3/gold.json
+++ b/tests/fixtures/quick-check/v2/mk-pdd-pda3/gold.json
@@ -14,6 +14,13 @@
     "checkName": "methodology",
     "expectedStatus": "FOUND",
     "expectedAnswer": "AMS-II.E: Energy efficiency and fuel switching measures for buildings",
+    "expectedMethodology": {
+      "methodologyId": "AMS-II.E",
+      "methodologyName": "Energy efficiency and fuel switching measures for buildings",
+      "methodologyAlias": "",
+      "pddDeclaredMethodologyVersion": "v8",
+      "versionStatus": "DECLARED"
+    },
     "goldQuote": "“AMS-II.E – Energy efficiency and fuel switching measures for buildings” (version 8).",
     "page": 7,
     "sectionHeading": "Title and reference of the approved baseline methodology applied to the small-scale project",

--- a/tests/fixtures/quick-check/v2/monit-rep-985-vm0007/gold.json
+++ b/tests/fixtures/quick-check/v2/monit-rep-985-vm0007/gold.json
@@ -18,6 +18,13 @@
     "checkName": "methodology",
     "expectedStatus": "FOUND",
     "expectedAnswer": "VM0007: REDD Methodology Modules Version 1.3",
+    "expectedMethodology": {
+      "methodologyId": "VM0007",
+      "methodologyName": "REDD Methodology Modules",
+      "methodologyAlias": "",
+      "pddDeclaredMethodologyVersion": "v1.3",
+      "versionStatus": "DECLARED"
+    },
     "goldQuote": "The methodology used to quantify the avoided emissions is the framework and component modules of the modular REDD methodology VM0007 REDD Methodology Modules Version 1.3 approved 20 November 2012.",
     "page": 15,
     "sectionHeading": "Title and Reference of Methodology",

--- a/tests/fixtures/quick-check/v2/proj-desc-674/gold.json
+++ b/tests/fixtures/quick-check/v2/proj-desc-674/gold.json
@@ -14,6 +14,13 @@
     "checkName": "methodology",
     "expectedStatus": "FOUND",
     "expectedAnswer": "VM0004: Methodology for Conservation Projects that Avoid Planned Land Use Conversion in Peat Swamp Forests, v1-0",
+    "expectedMethodology": {
+      "methodologyId": "VM0004",
+      "methodologyName": "Methodology for Conservation Projects that Avoid Planned Land Use Conversion in Peat Swamp Forests",
+      "methodologyAlias": "",
+      "pddDeclaredMethodologyVersion": "v1-0",
+      "versionStatus": "DECLARED"
+    },
     "goldQuote": "The methodology for this project follows the Approved VCS Methodology “VM0004 Methodology for Conservation Projects that Avoid Planned Land Use Conversion in Peat Swamp Forests, v1‐0”.",
     "page": 40,
     "sectionHeading": "Title and Reference of the VCS Methodology applied to the Project Activity and explanation of",

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -194,6 +194,28 @@ describe("VM0007 version lock", () => {
     expect(audit.results[0]?.userAcceptedVersionWarning).toBe(true);
   });
 
+  it("allows a missing VM0007 version to proceed when the user accepts the warning", () => {
+    const document = makeTableEvidenceDocument([
+      ["Type", "Reference ID", "Version"],
+      ["Methodology", "VM0007", ""],
+      ["Module", "VMD0001", "1.2"],
+      ["Tool", "VT0001", "4.2"],
+    ]);
+
+    const audit = auditVm0007WithDocument(document, document.rawText, {
+      getContract: makeVersionedContract("v1-8"),
+      userAcceptedVersionWarning: true,
+    });
+
+    expect(audit.auditStatus).toBe("VERSION_WARNING_ACCEPTED");
+    expect(audit.methodologyId).toBe("VM0007");
+    expect(audit.rulebookVersion).toBe("v1-8");
+    expect(audit.versionMatch).toBe(false);
+    expect(audit.versionMismatchReason).toContain("missing");
+    expect(audit.results).toHaveLength(58);
+    expect(audit.results[0]?.userAcceptedVersionWarning).toBe(true);
+  });
+
   it("blocks ambiguous VM0007 versions when both v1.5 and v1.8 are present", () => {
     const ambiguousText = "REDD-MF / VM0007 v1.5 and later VM0007 v1.8";
 

--- a/tests/lib/quickCheckV2/gold-fixtures.test.ts
+++ b/tests/lib/quickCheckV2/gold-fixtures.test.ts
@@ -10,7 +10,10 @@ import {
   type StructuredCheckId,
 } from "@/lib/quickCheckV2/evidence";
 import { validateAnswerResults } from "@/lib/quickCheckV2/status";
-import type { QuickCheckMethodologyIdentity } from "@/lib/quickCheckV2/methodologyIdentity";
+import {
+  buildQuickCheckMethodologyIdentity,
+  type QuickCheckMethodologyIdentity,
+} from "@/lib/quickCheckV2/methodologyIdentity";
 
 const FIXTURE_ROOT = path.resolve("tests/fixtures/quick-check/v2");
 
@@ -115,13 +118,62 @@ function pickComparableMethodology(
   return comparable;
 }
 
+function buildComparableMethodology(
+  result: ReturnType<typeof validateAnswerResults>[number],
+): QuickCheckMethodologyIdentity | null {
+  if (result.checkName !== "methodology" || !result.evidence) return null;
+
+  const tableMethodology = extractMethodologyDetailsFromEvidence(result.evidence);
+  if (tableMethodology) {
+    return tableMethodology;
+  }
+
+  const evidenceMethodology = buildQuickCheckMethodologyIdentity(result.evidence);
+  const answerMethodology = result.answer
+    ? buildQuickCheckMethodologyIdentity({
+        ...result.evidence,
+        quote: result.answer,
+      })
+    : null;
+
+  const methodology = answerMethodology ?? evidenceMethodology ?? result.methodology ?? null;
+  if (!methodology) return null;
+
+  if (result.answer) {
+    return {
+      methodologyId: answerMethodology?.methodologyId ?? evidenceMethodology?.methodologyId ?? methodology.methodologyId,
+      methodologyName: answerMethodology?.methodologyName ?? evidenceMethodology?.methodologyName ?? methodology.methodologyName,
+      methodologyAlias:
+        (answerMethodology?.methodologyAlias?.trim() ? answerMethodology.methodologyAlias : null)
+        ?? evidenceMethodology?.methodologyAlias
+        ?? methodology.methodologyAlias,
+      pddDeclaredMethodologyVersion:
+        evidenceMethodology?.pddDeclaredMethodologyVersion
+        ?? answerMethodology?.pddDeclaredMethodologyVersion
+        ?? methodology.pddDeclaredMethodologyVersion,
+      versionStatus:
+        evidenceMethodology?.versionStatus
+        ?? answerMethodology?.versionStatus
+        ?? methodology.versionStatus,
+      evidencePage: result.evidence.page,
+      evidenceSection: result.evidence.sectionHeading?.trim() ?? "",
+      evidenceQuote: result.evidence.quote,
+    };
+  }
+
+  return {
+    ...methodology,
+    evidencePage: result.evidence.page,
+    evidenceSection: result.evidence.sectionHeading?.trim() ?? "",
+    evidenceQuote: result.evidence.quote,
+  };
+}
+
 function toGoldComparableRecord(
   result: ReturnType<typeof validateAnswerResults>[number],
   expected: GoldRecord,
 ): GoldRecord {
-  const methodology = result.checkName === "methodology"
-    ? extractMethodologyDetailsFromEvidence(result.evidence)
-    : null;
+  const methodology = buildComparableMethodology(result);
 
   const record: GoldRecord = {
     checkName: result.checkName,

--- a/tests/lib/quickCheckV2/gold-fixtures.test.ts
+++ b/tests/lib/quickCheckV2/gold-fixtures.test.ts
@@ -10,6 +10,7 @@ import {
   type StructuredCheckId,
 } from "@/lib/quickCheckV2/evidence";
 import { validateAnswerResults } from "@/lib/quickCheckV2/status";
+import type { QuickCheckMethodologyIdentity } from "@/lib/quickCheckV2/methodologyIdentity";
 
 const FIXTURE_ROOT = path.resolve("tests/fixtures/quick-check/v2");
 
@@ -44,16 +45,7 @@ type GoldRecord = {
   sectionPath: string[];
   spanId: string | null;
   sourceType: "fact_contract" | "exact_section" | "raw_text_fallback" | null;
-  expectedMethodology?: {
-    methodologyId: string;
-    methodologyName: string;
-    methodologyAlias: string | null;
-    pddDeclaredMethodologyVersion: string;
-    versionStatus: "DECLARED";
-    evidencePage: number | null;
-    evidenceSection: string | null;
-    evidenceQuote: string;
-  };
+  expectedMethodology?: Partial<QuickCheckMethodologyIdentity>;
 };
 
 type FixtureBundle = {
@@ -97,8 +89,35 @@ function loadFixtureBundle(directory: string): FixtureBundle {
   };
 }
 
+const methodologyComparisonKeys = [
+  "methodologyId",
+  "methodologyName",
+  "methodologyAlias",
+  "pddDeclaredMethodologyVersion",
+  "versionStatus",
+  "evidencePage",
+  "evidenceSection",
+  "evidenceQuote",
+] as const satisfies ReadonlyArray<keyof QuickCheckMethodologyIdentity>;
+
+function pickComparableMethodology(
+  methodology: QuickCheckMethodologyIdentity,
+  goldMethodology: Partial<QuickCheckMethodologyIdentity>,
+): Partial<QuickCheckMethodologyIdentity> {
+  const comparable: Partial<QuickCheckMethodologyIdentity> = {};
+
+  for (const key of methodologyComparisonKeys) {
+    if (key in goldMethodology) {
+      comparable[key] = methodology[key];
+    }
+  }
+
+  return comparable;
+}
+
 function toGoldComparableRecord(
   result: ReturnType<typeof validateAnswerResults>[number],
+  expected: GoldRecord,
 ): GoldRecord {
   const methodology = result.checkName === "methodology"
     ? extractMethodologyDetailsFromEvidence(result.evidence)
@@ -116,33 +135,15 @@ function toGoldComparableRecord(
     sourceType: result.evidence?.sourceType ?? null,
   };
 
-  if (methodology) {
-    record.expectedMethodology = methodology;
+  if (methodology && expected.expectedMethodology) {
+    record.expectedMethodology = pickComparableMethodology(methodology, expected.expectedMethodology);
   }
 
   return record;
 }
 
-function stripMethodologyWhenUnrequested(
-  record: GoldRecord,
-  goldRecord: GoldRecord,
-): GoldRecord {
-  if (goldRecord.expectedMethodology) return record;
-  const { expectedMethodology: _expectedMethodology, ...rest } = record;
-  return rest;
-}
-
 function toEvidenceOnlyComparableRecord(record: GoldRecord): Omit<GoldRecord, "expectedAnswer"> {
   const { expectedAnswer: _expectedAnswer, ...rest } = record;
-  return rest;
-}
-
-function stripMethodologyWhenUnrequestedForEvidenceOnly(
-  record: GoldRecord,
-  goldRecord: GoldRecord,
-): Omit<GoldRecord, "expectedAnswer"> {
-  if (goldRecord.expectedMethodology) return record;
-  const { expectedMethodology: _expectedMethodology, ...rest } = record;
   return rest;
 }
 
@@ -166,18 +167,21 @@ describe("Quick Check v2 gold fixtures", () => {
           bundle.meta.documentId,
         );
         const statuses = validateAnswerResults(extractAnswersForAllChecks(document));
-        const comparableStatuses = statuses.map(toGoldComparableRecord);
+        const comparableStatuses = statuses.map((result, index) => toGoldComparableRecord(result, bundle.gold[index]!));
 
         if (bundle.meta.comparisonMode === "evidence-only") {
-          expect(comparableStatuses.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyWhenUnrequestedForEvidenceOnly(record, bundle.gold[index]!))).toStrictEqual(
-            bundle.gold.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyWhenUnrequestedForEvidenceOnly(record, bundle.gold[index]!)),
+          expect(comparableStatuses.map(toEvidenceOnlyComparableRecord)).toStrictEqual(
+            bundle.gold.map(toEvidenceOnlyComparableRecord),
           );
           return;
         }
 
-        expect(comparableStatuses.map((record, index) => stripMethodologyWhenUnrequested(record, bundle.gold[index]!))).toStrictEqual(
-          bundle.gold.map((record, index) => stripMethodologyWhenUnrequested(record, bundle.gold[index]!)),
-        );
+        expect(comparableStatuses).toStrictEqual(bundle.gold);
+        for (const record of bundle.gold) {
+          if (record.checkName === "methodology" && record.expectedMethodology) {
+            expect(record.expectedMethodology.methodologyId).toBeTruthy();
+          }
+        }
       });
 
       if (bundle.meta.runtimeMode === "runtime-smoke") {
@@ -198,20 +202,16 @@ describe("Quick Check v2 gold fixtures", () => {
           const runtimeStatuses = validateAnswerResults(
             extractAnswersForAllChecks(runtimeDocument),
           );
-          const comparableRuntimeStatuses = runtimeStatuses.map(toGoldComparableRecord);
+          const comparableRuntimeStatuses = runtimeStatuses.map((result, index) => toGoldComparableRecord(result, bundle.gold[index]!));
 
           if (bundle.meta.comparisonMode === "evidence-only") {
-            expect(
-              comparableRuntimeStatuses.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyWhenUnrequestedForEvidenceOnly(record, bundle.gold[index]!)),
-            ).toStrictEqual(
-              bundle.gold.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyWhenUnrequestedForEvidenceOnly(record, bundle.gold[index]!)),
+            expect(comparableRuntimeStatuses.map(toEvidenceOnlyComparableRecord)).toStrictEqual(
+              bundle.gold.map(toEvidenceOnlyComparableRecord),
             );
             return;
           }
 
-          expect(comparableRuntimeStatuses.map((record, index) => stripMethodologyWhenUnrequested(record, bundle.gold[index]!))).toStrictEqual(
-            bundle.gold.map((record, index) => stripMethodologyWhenUnrequested(record, bundle.gold[index]!)),
-          );
+          expect(comparableRuntimeStatuses).toStrictEqual(bundle.gold);
         }, 30000);
       }
 
@@ -234,20 +234,16 @@ describe("Quick Check v2 gold fixtures", () => {
           const runtimeStatuses = validateAnswerResults(
             extractAnswersForAllChecks(runtimeDocument),
           );
-          const comparableRuntimeStatuses = runtimeStatuses.map(toGoldComparableRecord);
+          const comparableRuntimeStatuses = runtimeStatuses.map((result, index) => toGoldComparableRecord(result, bundle.gold[index]!));
 
           if (bundle.meta.comparisonMode === "evidence-only") {
-            expect(
-              comparableRuntimeStatuses.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyWhenUnrequestedForEvidenceOnly(record, bundle.gold[index]!)),
-            ).toStrictEqual(
-              bundle.gold.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyWhenUnrequestedForEvidenceOnly(record, bundle.gold[index]!)),
+            expect(comparableRuntimeStatuses.map(toEvidenceOnlyComparableRecord)).toStrictEqual(
+              bundle.gold.map(toEvidenceOnlyComparableRecord),
             );
             return;
           }
 
-          expect(comparableRuntimeStatuses.map((record, index) => stripMethodologyWhenUnrequested(record, bundle.gold[index]!))).toStrictEqual(
-            bundle.gold.map((record, index) => stripMethodologyWhenUnrequested(record, bundle.gold[index]!)),
-          );
+          expect(comparableRuntimeStatuses).toStrictEqual(bundle.gold);
         }, 30000);
       }
     });

--- a/tests/lib/quickCheckV2/status-validator.test.ts
+++ b/tests/lib/quickCheckV2/status-validator.test.ts
@@ -138,15 +138,64 @@ describe("Quick Check v2 — Phase 5 deterministic status validator", () => {
     expect(result.reason).toBe("answer_and_provenance_complete");
   });
 
+  it("includes a structured methodology identity on methodology rows", () => {
+    const methodology = statuses.find((result) => result.checkName === "methodology");
+    expect(methodology?.methodology?.methodologyId).toBe("VM0007");
+    expect(methodology?.methodology?.evidencePage).toBe(31);
+    expect(methodology?.methodology?.evidenceSection).toBeTruthy();
+    expect(methodology?.methodology?.evidenceQuote).toContain("VM0007");
+  });
+
+  it("keeps an explicit version when the methodology quote declares one", () => {
+    const result = validateAnswerResult(
+      makeAnswerResult({
+        checkName: "methodology",
+        answer: "VM0007: REDD Methodology Modules Version 1.3",
+        evidence: {
+          sourceType: "exact_section",
+          quote: "The methodology used to quantify the avoided emissions is the framework and component modules of the modular REDD methodology VM0007 REDD Methodology Modules Version 1.3 approved 20 November 2012.",
+          page: 15,
+          sectionHeading: "Title and Reference of Methodology",
+          sectionPath: ["2", "2.1"],
+          spanId: "synthetic-doc:p15:b1:methodology",
+        },
+      }),
+    );
+
+    expect(result.methodology?.methodologyId).toBe("VM0007");
+    expect(result.methodology?.pddDeclaredMethodologyVersion).toBe("v1.3");
+    expect(result.methodology?.versionStatus).toBe("DECLARED");
+  });
+
+  it("does not invent a version when the quote does not explicitly declare one", () => {
+    const result = validateAnswerResult(
+      makeAnswerResult({
+        checkName: "methodology",
+        answer: "VM0007: REDD Methodology Modules (REDD-MF)",
+        evidence: {
+          sourceType: "fact_contract",
+          quote: "The Envira Amazonia Project is utilizing the Avoided Deforestation Partners’ VCS REDD Methodology, entitled, “VM0007: REDD Methodology Modules (REDD-MF).”",
+          page: 31,
+          sectionHeading: "Title and Reference of Methodology",
+          sectionPath: ["2", "2.1"],
+          spanId: "synthetic-doc:p31:b0:methodology",
+        },
+      }),
+    );
+
+    expect(result.methodology?.methodologyId).toBe("VM0007");
+    expect(result.methodology?.pddDeclaredMethodologyVersion).toBeNull();
+    expect(result.methodology?.versionStatus).toBe("NOT_EXPLICITLY_DECLARED");
+  });
+
   it("returns only checkName, status, answer, evidence, and reason", () => {
     for (const result of statuses) {
-      expect(Object.keys(result)).toStrictEqual([
-        "checkName",
-        "status",
-        "answer",
-        "evidence",
-        "reason",
-      ]);
+      const keys = Object.keys(result).sort();
+      expect(keys).toEqual(
+        result.checkName === "methodology"
+          ? ["answer", "checkName", "evidence", "methodology", "reason", "status"]
+          : ["answer", "checkName", "evidence", "reason", "status"],
+      );
       expect(Object.keys(result)).not.toContain("score");
       expect(Object.keys(result)).not.toContain("router");
     }


### PR DESCRIPTION
What changed
- Added a canonical Quick Check methodology identity object derived from uploaded document text.
- Attached methodology identity to methodology results in Quick Check v2.
- Updated VM0007 gap export to consume that identity, carry it through the export payload, and block on version mismatch.
- Updated quick-check v2 gold fixtures and focused tests to cover methodology identity extraction and version-lock behavior.

Why
- Quick Run and Gap Export were carrying methodology metadata inconsistently and could infer version state from non-document sources.
- The gap export now relies on the same methodology identity that Quick Check derives from the uploaded text.

Impact
- Methodology results now expose structured identity fields for downstream consumers.
- Gap export emits blocked mismatch results instead of normal judgments when the PDD-declared version does not match the loaded rulebook version.
- Existing non-methodology quick-check fixtures remain supported.

Checks
- npm run typecheck
- npm run lint
- npm run pr:gate
- npm test -- tests/components/quickCheckPanel.upload-integration-smoke.test.tsx --runInBand
