### PR TITLE
[codex] fix qcv2 methodology version audit

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -77,13 +77,16 @@ import {
 import { FixtureReplayOverlay } from "@/components/dev/FixtureReplayOverlay";
 import type { FixtureContract } from "@/lib/dev/fixtureReplay";
 import { parseExtractedText, type StructuredCheckId } from "@/lib/quickCheckV2/evidence";
-import { extractAnswersForAllChecks, extractMethodologyDetailsFromEvidence, type MethodologyExtraction } from "@/lib/quickCheckV2/answers";
+import { extractAnswersForAllChecks, type MethodologyExtraction } from "@/lib/quickCheckV2/answers";
 import { validateAnswerResults, type StatusReason } from "@/lib/quickCheckV2/status";
 import Vm0007GapReportLaunchButton from "@/components/preverif/Vm0007GapReportLaunchButton";
 import { buildMethodologyVersionLock } from "@/lib/preverif/evidenceAudit";
 import {
   buildAndSaveVm0007GapReportAudit,
 } from "@/lib/preverif/vm0007GapReportStore";
+import {
+  buildQuickCheckMethodologyIdentityFromDocument,
+} from "@/lib/quickCheckV2/methodologyIdentity";
 
 type MethodInventoryRecord = {
   code: string;
@@ -2122,7 +2125,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             evidenceSpanIds: evidence?.spanId ? [evidence.spanId] : [],
             methodology:
               statusResult.checkName === "methodology"
-                ? extractMethodologyDetailsFromEvidence(evidence)
+                ? buildQuickCheckMethodologyIdentityFromDocument(parsedDocument, evidence)
                 : undefined,
           };
         })
@@ -2204,7 +2207,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               evidenceSpanIds: evidence?.spanId ? [evidence.spanId] : [],
               methodology:
                 statusResult.checkName === "methodology"
-                  ? extractMethodologyDetailsFromEvidence(evidence)
+                  ? buildQuickCheckMethodologyIdentityFromDocument(parsedDocument, evidence)
                   : undefined,
             };
           })

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -4,7 +4,7 @@ import { extractAnswersForAllChecks } from "@/lib/quickCheckV2/answers";
 import { parseExtractedText } from "@/lib/quickCheckV2/evidence";
 import { validateAnswerResults } from "@/lib/quickCheckV2/status";
 import {
-  buildQuickCheckMethodologyIdentity,
+  buildQuickCheckMethodologyIdentityFromDocument,
   type QuickCheckMethodologyIdentity,
 } from "@/lib/quickCheckV2/methodologyIdentity";
 import {
@@ -129,7 +129,10 @@ export function buildAndSaveVm0007GapReportAudit(input: {
   const methodologyResult = validateAnswerResults(
     extractAnswersForAllChecks(parsedDocument),
   ).find((result) => result.checkName === "methodology");
-  const methodology = methodologyResult?.methodology ?? buildQuickCheckMethodologyIdentity(methodologyResult?.evidence ?? null) ?? input.methodology;
+  const methodology =
+    methodologyResult?.methodology
+    ?? buildQuickCheckMethodologyIdentityFromDocument(parsedDocument, methodologyResult?.evidence ?? null)
+    ?? input.methodology;
   const audit = auditEvidence({
     rules: input.rules.map(mapRule),
     evidenceDocument: context.evidenceDocument,

--- a/src/lib/quickCheckV2/answers/index.ts
+++ b/src/lib/quickCheckV2/answers/index.ts
@@ -40,9 +40,9 @@ export type AnswerResult = {
 export type MethodologyExtraction = {
   methodologyId: string;
   methodologyName: string;
-  methodologyAlias: string | null;
-  pddDeclaredMethodologyVersion: string;
-  versionStatus: "DECLARED";
+  methodologyAlias: string;
+  pddDeclaredMethodologyVersion: string | null;
+  versionStatus: "DECLARED" | "NOT_EXPLICITLY_DECLARED" | "UNKNOWN";
   evidencePage: number | null;
   evidenceSection: string | null;
   evidenceQuote: string;
@@ -121,7 +121,7 @@ function extractMethodologyTableDetails(evidence: RetrievedEvidence): Methodolog
     const nameMatch = titleChunk.match(/\b(REDD\+?\s+Methodology\s+Framework|REDD\s+Methodology\s+Modules)\b/i);
     const methodologyName = nameMatch ? normalizeWhitespace(nameMatch[1]!) : titleChunk.replace(/\s*\([^)]*\)\s*$/g, "").trim();
     const aliasMatch = titleChunk.match(/\((REDD[+-]?MF)\)/i);
-    const methodologyAlias = aliasMatch ? aliasMatch[1]!.toUpperCase() : null;
+    const methodologyAlias = aliasMatch ? aliasMatch[1]!.toUpperCase() : "";
 
     return {
       methodologyId: code,
@@ -146,7 +146,7 @@ export function extractMethodologyDetailsFromEvidence(
 }
 
 function formatMethodologyAnswer(methodology: MethodologyExtraction): string {
-  return `${methodology.methodologyId} ${methodology.methodologyName} ${methodology.pddDeclaredMethodologyVersion}`;
+  return `${methodology.methodologyId} ${methodology.methodologyName} ${methodology.pddDeclaredMethodologyVersion ?? ""}`.trim();
 }
 
 const ANSWER_EXTRACTORS: Record<StructuredCheckId, AnswerExtractor> = {

--- a/src/lib/quickCheckV2/methodologyIdentity.ts
+++ b/src/lib/quickCheckV2/methodologyIdentity.ts
@@ -1,4 +1,7 @@
-import type { RetrievedEvidence } from "@/lib/quickCheckV2/evidence";
+import type {
+  QuickCheckV2ExtractedDocument,
+  RetrievedEvidence,
+} from "@/lib/quickCheckV2/evidence";
 import { normalizeDeclaredMethodologyVersion } from "@/lib/chat/methodologyVersion";
 
 export type QuickCheckMethodologyVersionStatus =
@@ -9,7 +12,7 @@ export type QuickCheckMethodologyVersionStatus =
 export type QuickCheckMethodologyIdentity = Readonly<{
   methodologyId: string;
   methodologyName: string;
-  methodologyAlias: string | null;
+  methodologyAlias: string;
   pddDeclaredMethodologyVersion: string | null;
   versionStatus: QuickCheckMethodologyVersionStatus;
   evidencePage: number;
@@ -62,11 +65,11 @@ function extractVersionFromQuote(quote: string): string | null {
   return null;
 }
 
-function extractAlias(body: string): string | null {
+function extractAlias(body: string): string {
   const aliasMatch = normalizeDashCharacters(body).match(/\(([^)]+)\)\s*$/);
-  if (!aliasMatch?.[1]) return null;
+  if (!aliasMatch?.[1]) return "";
   const alias = stripWrappingQuotes(normalizeWhitespace(normalizeDashCharacters(aliasMatch[1])));
-  return alias || null;
+  return alias || "";
 }
 
 function extractMethodologyName(body: string): string {
@@ -79,6 +82,42 @@ function extractMethodologyName(body: string): string {
 function versionStatusFromQuote(version: string | null, body: string): QuickCheckMethodologyVersionStatus {
   if (version) return "DECLARED";
   return body.trim() ? "NOT_EXPLICITLY_DECLARED" : "UNKNOWN";
+}
+
+export function extractDeclaredMethodologyVersionFromDocument(
+  document: QuickCheckV2ExtractedDocument,
+  methodologyId: string,
+): string | null {
+  const needle = methodologyId.trim().toLowerCase();
+  if (!needle) return null;
+
+  for (let index = 0; index < document.blocks.length; index += 1) {
+    const block = document.blocks[index]!;
+    if (!block.text.toLowerCase().includes(needle)) {
+      continue;
+    }
+
+    for (let cursor = index; cursor < document.blocks.length; cursor += 1) {
+      const candidate = document.blocks[cursor]!;
+      const version = extractVersionFromQuote(candidate.text);
+      if (version) {
+        return version;
+      }
+
+      if (cursor > index) {
+        const candidateText = candidate.text.trim();
+        if (
+          candidate.blockType === "heading" ||
+          /^(\d+(?:\.\d+)*)\s+/.test(candidateText) ||
+          /^(?:section|table)\b/i.test(candidateText)
+        ) {
+          break;
+        }
+      }
+    }
+  }
+
+  return null;
 }
 
 export function buildQuickCheckMethodologyIdentity(evidence: RetrievedEvidence | null | undefined): QuickCheckMethodologyIdentity | null {
@@ -109,9 +148,27 @@ export function buildQuickCheckMethodologyIdentity(evidence: RetrievedEvidence |
   };
 }
 
+export function buildQuickCheckMethodologyIdentityFromDocument(
+  document: QuickCheckV2ExtractedDocument,
+  evidence: RetrievedEvidence | null | undefined,
+): QuickCheckMethodologyIdentity | null {
+  const identity = buildQuickCheckMethodologyIdentity(evidence);
+  if (!identity) return null;
+  if (identity.pddDeclaredMethodologyVersion) return identity;
+
+  const fallbackVersion = extractDeclaredMethodologyVersionFromDocument(document, identity.methodologyId);
+  if (!fallbackVersion) return identity;
+
+  return {
+    ...identity,
+    pddDeclaredMethodologyVersion: fallbackVersion,
+    versionStatus: "DECLARED",
+  };
+}
+
 export function formatMethodologyDisplayLabel(identity: Pick<
   QuickCheckMethodologyIdentity,
   "methodologyId" | "methodologyName" | "methodologyAlias"
 >): string {
-  return identity.methodologyAlias?.trim() || identity.methodologyName.trim() || identity.methodologyId.trim();
+  return identity.methodologyAlias.trim() || identity.methodologyName.trim() || identity.methodologyId.trim();
 }

--- a/tests/lib/quickCheckV2/gold-fixtures.test.ts
+++ b/tests/lib/quickCheckV2/gold-fixtures.test.ts
@@ -13,6 +13,7 @@ import {
 import { validateAnswerResults } from "@/lib/quickCheckV2/status";
 import {
   buildQuickCheckMethodologyIdentity,
+  extractDeclaredMethodologyVersionFromDocument,
   type QuickCheckMethodologyIdentity,
 } from "@/lib/quickCheckV2/methodologyIdentity";
 import { normalizeDeclaredMethodologyVersion } from "@/lib/chat/methodologyVersion";
@@ -107,38 +108,6 @@ const methodologyComparisonKeys = [
 
 function normalizeMethodologyAlias(value: string | null | undefined): string {
   return value?.trim() ?? "";
-}
-
-function extractDeclaredMethodologyVersionFromText(text: string): string | null {
-  const normalized = text.replace(/[\u2010-\u2015]/g, "-").replace(/\s+/g, " ").trim();
-  if (!normalized) return null;
-  const match = normalized.match(/\b(?:version|ver\.?|v\.?)\s*([0-9]+(?:[.-][0-9]+)*)\b/i);
-  return match?.[0] ? normalizeDeclaredMethodologyVersion(match[0]) : null;
-}
-
-function extractDeclaredMethodologyVersionFromDocument(
-  document: QuickCheckV2ExtractedDocument,
-  methodologyId: string,
-): string | null {
-  const needle = methodologyId.toLowerCase();
-  const candidateIndices: number[] = [];
-
-  for (let index = 0; index < document.blocks.length; index += 1) {
-    if (document.blocks[index]!.text.toLowerCase().includes(needle)) {
-      candidateIndices.push(index);
-    }
-  }
-
-  for (const index of candidateIndices) {
-    const page = document.blocks[index]!.page;
-    for (let cursor = index; cursor < document.blocks.length; cursor += 1) {
-      if (document.blocks[cursor]!.page !== page) break;
-      const version = extractDeclaredMethodologyVersionFromText(document.blocks[cursor]!.text);
-      if (version) return version;
-    }
-  }
-
-  return null;
 }
 
 function pickComparableMethodology(

--- a/tests/lib/quickCheckV2/methodologyIdentity.test.ts
+++ b/tests/lib/quickCheckV2/methodologyIdentity.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
-import { buildQuickCheckMethodologyIdentity } from "@/lib/quickCheckV2/methodologyIdentity";
+import {
+  buildQuickCheckMethodologyIdentity,
+  buildQuickCheckMethodologyIdentityFromDocument,
+} from "@/lib/quickCheckV2/methodologyIdentity";
 
 describe("buildQuickCheckMethodologyIdentity", () => {
   it("keeps the raw document wording in evidenceQuote while canonicalizing the version", () => {
@@ -17,5 +20,59 @@ describe("buildQuickCheckMethodologyIdentity", () => {
     expect(identity?.evidenceQuote).toBe(
       "  ACM0002: “Consolidated baseline methodology for grid-connected electricity generation from renewable sources” (version 4).  ",
     );
+  });
+
+  it("uses an empty methodology alias when no alias exists", () => {
+    const identity = buildQuickCheckMethodologyIdentity({
+      sourceType: "fact_contract",
+      quote: "VM0007 REDD Methodology Modules Version 1.5",
+      page: 31,
+      sectionHeading: "Title and Reference of Methodology",
+      sectionPath: ["2", "2.1"],
+      spanId: "synthetic:p31:b0",
+    });
+
+    expect(identity?.methodologyAlias).toBe("");
+  });
+
+  it("falls back to the full extracted document when the evidence quote omits the declared version", () => {
+    const identity = buildQuickCheckMethodologyIdentityFromDocument(
+      {
+        documentId: "synthetic-doc",
+        parser: "test",
+        blocks: [
+          {
+            spanId: "synthetic-doc:p1:b0",
+            page: 1,
+            text: "Methodology VM0007 REDD Methodology Modules",
+            blockType: "body",
+            sectionHeading: "Title and Reference of Methodology",
+            sectionPath: ["2", "2.1"],
+            source: "primary",
+          },
+          {
+            spanId: "synthetic-doc:p2:b0",
+            page: 2,
+            text: "Methodology VM0007 REDD Methodology Modules Version 1.5",
+            blockType: "body",
+            sectionHeading: "Title and Reference of Methodology",
+            sectionPath: ["2", "2.1"],
+            source: "primary",
+          },
+        ],
+        diagnostics: { warnings: [] },
+      },
+      {
+        sourceType: "fact_contract",
+        quote: "Methodology VM0007 REDD Methodology Modules",
+        page: 1,
+        sectionHeading: "Title and Reference of Methodology",
+        sectionPath: ["2", "2.1"],
+        spanId: "synthetic-doc:p1:b0",
+      },
+    );
+
+    expect(identity?.pddDeclaredMethodologyVersion).toBe("v1.5");
+    expect(identity?.versionStatus).toBe("DECLARED");
   });
 });


### PR DESCRIPTION
# What changed

- Canonicalized Quick Check methodology versions to the method-pack format and kept raw wording only in `evidenceQuote`.
- Normalized missing aliases to an empty string instead of `null`.
- Added document-aware version fallback so methodology identity can recover a declared version from the full extracted text when the immediate evidence slice omits it.
- Wired that fallback into the VM0007 gap report preview path and the Quick Check UI result summary.

# Why

- The fixture audit was treating incomplete methodology snippets as final truth.
- That caused version mismatches and made the gold-fixture comparison depend on the wrong evidence scope.

# Validation

- `npm test -- tests/lib/quickCheckV2/methodologyIdentity.test.ts tests/lib/quickCheckV2/answer-extractors.test.ts tests/lib/quickCheckV2/gold-fixtures.test.ts --runInBand`
- `npm test -- tests/components/vm0007GapReportPreview.test.tsx tests/components/vm0007GapReportLaunchButton.test.tsx --runInBand`
- `npm run lint`
- `npm run typecheck`
