### PR TITLE
Fix methodology identity overcapture

### DIFF
--- a/src/lib/quickCheckV2/answers/index.ts
+++ b/src/lib/quickCheckV2/answers/index.ts
@@ -144,6 +144,28 @@ function summarizeStakeholderCommentActions(quote: string): string | null {
   return null;
 }
 
+function extractDisplayMethodologyAlias(quote: string): string | null {
+  const normalized = normalizeAnswerText(quote);
+  const rowBoundary = normalized.match(/\b(?:Module|Tool)\b/i);
+  const rowBody = rowBoundary?.index != null ? normalized.slice(0, rowBoundary.index).trim() : normalized;
+  const withoutLeadingCode = rowBody.replace(
+    /^(?:Applied(?:\s+Methodology)?|Methodology)\s+(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\s+/i,
+    "",
+  );
+  const withoutVersion = stripTrailingPunctuation(
+    withoutLeadingCode.replace(/\s*(?:,|\()?\s*(?:version|v)\s*\d+(?:[.-]\d+){0,2}.*$/i, "").trim(),
+  );
+
+  for (const match of withoutVersion.matchAll(/\(([^)]+)\)/g)) {
+    const candidate = normalizeWhitespace(match[1] ?? "");
+    if (candidate && !/[a-z]/.test(candidate) && /^[A-Z0-9][A-Z0-9+./\-\s]*$/.test(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
 function extractMethodologyTableDetails(evidence: RetrievedEvidence): MethodologyExtraction | null {
   const rowText = normalizeWhitespace(evidence.quote);
   const rowStart = rowText.match(
@@ -195,10 +217,11 @@ function formatMethodologyAnswer(
   methodology: MethodologyExtraction,
   evidence: RetrievedEvidence,
 ): string {
-  const aliasValue = evidence.sourceType === "exact_section"
-    ? methodology.methodologyAlias ?? buildQuickCheckMethodologyIdentity(evidence)?.methodologyAlias
+  const displayAlias = evidence.sourceType === "exact_section"
+    ? extractDisplayMethodologyAlias(evidence.quote) ?? methodology.methodologyAlias ?? buildQuickCheckMethodologyIdentity(evidence)?.methodologyAlias
     : methodology.methodologyAlias;
-  const alias = aliasValue && /\s/.test(aliasValue) ? ` (${aliasValue})` : "";
+  const aliasValue = displayAlias && /\s/.test(displayAlias) ? displayAlias : null;
+  const alias = aliasValue ? ` (${aliasValue})` : "";
   return `${methodology.methodologyId} ${methodology.methodologyName}${alias} ${methodology.pddDeclaredMethodologyVersion}`;
 }
 

--- a/src/lib/quickCheckV2/methodologyIdentity.ts
+++ b/src/lib/quickCheckV2/methodologyIdentity.ts
@@ -19,6 +19,8 @@ export type QuickCheckMethodologyIdentity = Readonly<{
 
 const PRIMARY_METHODOLOGY_CODE_RE =
   /\b(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\b/i;
+const METHODOLOGY_ROW_BOUNDARY_RE = /\b(?:Module|Tool)\b/i;
+const LIKELY_ALIAS_RE = /^[A-Z0-9][A-Z0-9+./-]*$/;
 
 function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
@@ -38,6 +40,34 @@ function stripTrailingVersionAndApproval(value: string): string {
     .replace(/\s*(?:,|\()?\s*(?:version|v)\s*\d+(?:[.-]\d+){0,2}.*$/i, "")
     .replace(/\s*approved.*$/i, "")
     .trim();
+}
+
+function stripLeadingMethodologyCode(value: string): string {
+  return normalizeDashCharacters(value).replace(
+    /^(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\s+/i,
+    "",
+  );
+}
+
+function isolateMethodologyRowBody(body: string): string {
+  const normalized = normalizeWhitespace(normalizeDashCharacters(body));
+  const boundary = normalized.match(METHODOLOGY_ROW_BOUNDARY_RE);
+  return boundary?.index != null ? normalized.slice(0, boundary.index).trim() : normalized;
+}
+
+function isLikelyMethodologyAlias(value: string): boolean {
+  return LIKELY_ALIAS_RE.test(value.trim());
+}
+
+function findLikelyAliasMatch(body: string): RegExpMatchArray | null {
+  const matches = body.matchAll(/\(([^)]+)\)/g);
+  for (const match of matches) {
+    const candidate = stripWrappingQuotes(normalizeWhitespace(normalizeDashCharacters(match[1] ?? "")));
+    if (candidate && isLikelyMethodologyAlias(candidate)) {
+      return match;
+    }
+  }
+  return null;
 }
 
 function extractMethodologyCode(quote: string): string | null {
@@ -77,20 +107,22 @@ function extractVersionFromQuote(quote: string): string | null {
 }
 
 function extractAlias(body: string): string | null {
-  const aliasMatch = normalizeDashCharacters(body).match(/\(([^)]+)\)(?:\s*(?:version|v\.?)\s*\d+(?:[.-]\d+){0,2}|\s*\d+(?:[.-]\d+){0,2})?\s*$/i);
+  const aliasMatch = findLikelyAliasMatch(
+    stripTrailingVersionAndApproval(stripLeadingMethodologyCode(isolateMethodologyRowBody(body))),
+  );
   if (!aliasMatch?.[1]) return null;
   const alias = stripWrappingQuotes(normalizeWhitespace(normalizeDashCharacters(aliasMatch[1])));
   return alias || null;
 }
 
 function extractMethodologyName(body: string): string {
-  const withoutLeadingDuplicateCode = normalizeDashCharacters(body).replace(
-    /^(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\s+/i,
-    "",
-  );
-  const withoutAlias = withoutLeadingDuplicateCode.replace(/\s*\([^)]+\)(?:\s*(?:version|v\.?)\s*\d+(?:[.-]\d+){0,2}|\s*\d+(?:[.-]\d+){0,2})?\s*$/i, "");
-  const cleaned = normalizeWhitespace(stripTrailingVersionAndApproval(withoutAlias))
-    .replace(/[.,;:]+$/g, "");
+  const withoutLeadingCode = stripLeadingMethodologyCode(isolateMethodologyRowBody(body));
+  const withoutVersion = stripTrailingVersionAndApproval(withoutLeadingCode);
+  const aliasMatch = findLikelyAliasMatch(withoutVersion);
+  const nameSource = aliasMatch?.index != null
+    ? withoutVersion.slice(0, aliasMatch.index)
+    : withoutVersion.replace(/\s*\([^()]*\)\s*$/g, "");
+  const cleaned = normalizeWhitespace(nameSource).replace(/[.,;:]+$/g, "");
   return stripWrappingQuotes(cleaned).replace(/[.,;:]+$/g, "").trim();
 }
 

--- a/tests/lib/quickCheckV2/methodologyIdentity.test.ts
+++ b/tests/lib/quickCheckV2/methodologyIdentity.test.ts
@@ -39,4 +39,27 @@ describe("buildQuickCheckMethodologyIdentity", () => {
       "Methodology VM0007 VM0007 REDD+ Methodology Framework (REDD+MF) 1.8",
     );
   });
+
+  it("stops generic methodology parsing before module text in a long methodology row", () => {
+    const identity = buildQuickCheckMethodologyIdentity({
+      sourceType: "fact_contract",
+      quote: "Applied Methodology VM0007 REDD+ Methodology Framework (REDD+MF) (Avoided Planned Deforestation) 1.8 Module VMD0001 Estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 Module VMD0011 Estimation of emissions from market leakage (LK- ME) 1.2",
+      page: 61,
+      sectionHeading: "Title and Reference of Methodology (VCS, 3.1)",
+      sectionPath: ["3", "3.1", "3.1.1"],
+      spanId: "synthetic:p61:b1",
+    });
+
+    expect(identity).not.toBeNull();
+    expect(identity).toStrictEqual({
+      methodologyId: "VM0007",
+      methodologyName: "REDD+ Methodology Framework",
+      methodologyAlias: "REDD+MF",
+      pddDeclaredMethodologyVersion: "v1.8",
+      versionStatus: "DECLARED",
+      evidencePage: 61,
+      evidenceSection: "Title and Reference of Methodology (VCS, 3.1)",
+      evidenceQuote: "Applied Methodology VM0007 REDD+ Methodology Framework (REDD+MF) (Avoided Planned Deforestation) 1.8 Module VMD0001 Estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 Module VMD0011 Estimation of emissions from market leakage (LK- ME) 1.2",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Fix the generic quick-check methodology identity parser so it stops overcapturing module/tool text from long methodology rows.

## What changed
- `buildQuickCheckMethodologyIdentity` now stops at the first `Module` / `Tool` boundary when parsing methodology metadata.
- Alias detection now prefers the first alias-like parenthetical before the module list instead of the last parenthetical in the row.
- The visible answer formatting keeps the human-readable alias display for existing cases, while the structured metadata is normalized.

## Root cause
The methodology row parser was treating the rest of the table row as part of the methodology name and then reading the final parenthetical as the alias. On Marcondes, that pulled in module/tool text and misread `LK- ME` as the alias.

## Marcondes before / after
Before:
- `methodologyId`: `VM0007`
- `methodologyName`: `REDD+ Methodology Framework (REDD+MF) (Avoided Planned Deforestation) 1.8 Module ...`
- `methodologyAlias`: `LK- ME`
- `pddDeclaredMethodologyVersion`: `v1.8`
- `versionStatus`: `DECLARED`
- `evidencePage`: `61`
- `evidenceSection`: `Title and Reference of Methodology (VCS, 3.1)`

After:
- `methodologyId`: `VM0007`
- `methodologyName`: `REDD+ Methodology Framework`
- `methodologyAlias`: `REDD+MF`
- `pddDeclaredMethodologyVersion`: `v1.8`
- `versionStatus`: `DECLARED`
- `evidencePage`: `61`
- `evidenceSection`: `Title and Reference of Methodology (VCS, 3.1)`

## Validation
- `npx jest tests/lib/quickCheckV2/methodologyIdentity.test.ts --runInBand` ✅
- `npx jest tests/lib/quickCheckV2/lisala-truth-mismatches.test.ts --runInBand` ✅
- `npx jest tests/lib/quickCheckV2/gold-fixtures.test.ts -t Marcondes --runInBand` ✅
- `npm run pr:gate` ✅
