### PR TITLE
[codex] PR1 fixture intake pending adjudication

### DIFF
--- a/scripts/lib/quickcheck-fixture-intake.ts
+++ b/scripts/lib/quickcheck-fixture-intake.ts
@@ -26,6 +26,7 @@ type FixtureMeta = {
   phase: string;
   registry: string;
   documentType: string;
+  adjudicationStatus?: "pending" | "reviewed";
 };
 
 type Manifest = {
@@ -33,6 +34,7 @@ type Manifest = {
   fixtures: Array<{
     id: string;
     directory: string;
+    adjudicationStatus?: "pending" | "reviewed";
   }>;
 };
 
@@ -49,18 +51,9 @@ type GoldRecord = {
   expectedMethodology?: Partial<QuickCheckMethodologyIdentity>;
 };
 
-type CorrectionRecord = {
-  checkName: StructuredCheckId;
-  currentStatus: "FOUND" | "UNCLEAR" | "MISSING";
-  currentAnswer: string | null;
-  currentQuote: string | null;
-  page: number | null;
-  sectionHeading: string | null;
-  sectionPath: string[];
-  spanId: string | null;
-  sourceType: EvidenceSourceType | null;
-  reason: StatusResult["reason"];
-  methodology?: Partial<QuickCheckMethodologyIdentity>;
+type PendingCorrections = {
+  status: "PENDING_ADJUDICATION";
+  corrections: [];
 };
 
 type PdfPageExtractionResult = {
@@ -172,81 +165,37 @@ function toGoldRecord(result: StatusResult): GoldRecord {
   return record;
 }
 
-function toCorrectionRecord(result: StatusResult): CorrectionRecord {
-  const record: CorrectionRecord = {
-    checkName: result.checkName,
-    currentStatus: result.status,
-    currentAnswer: result.answer,
-    currentQuote: result.evidence?.quote ?? null,
-    page: result.evidence?.page ?? null,
-    sectionHeading: result.evidence?.sectionHeading ?? null,
-    sectionPath: result.evidence?.sectionPath ?? [],
-    spanId: result.evidence?.spanId ?? null,
-    sourceType: result.evidence?.sourceType ?? null,
-    reason: result.reason,
-  };
-  const methodology = buildMethodologyExpectation(result);
-  if (methodology) {
-    record.methodology = methodology;
-  }
-  return record;
-}
-
-function strengthLabel(result: StatusResult): string {
-  if (result.status === "FOUND" && result.evidence?.sourceType !== "raw_text_fallback") {
-    return "possibly strong, but still requires PDF truth review";
-  }
-  if (result.status === "MISSING") {
-    return "missing or not detected; requires PDF truth review";
-  }
-  return "weak/unclear; requires PDF truth review";
-}
-
 function buildReviewMarkdown(input: {
   id: string;
   title: string;
   pdfPath: string;
-  results: StatusResult[];
 }): string {
-  const lines = [
-    `# Quick Check v2 fixture review: ${input.title}`,
+  return [
+    `# Quick Check v2 fixture intake: ${input.title}`,
     "",
     "This fixture was created by the intake command.",
-    "",
-    "Do not merge until `gold.json` has been reviewed against the source PDF. Draft gold is current Quick Run output, not verified truth.",
+    "Adjudication not done.",
     "",
     `- Fixture id: ${input.id}`,
     `- Source PDF: ${input.pdfPath}`,
     "",
-    "## Review checklist",
+    "## Later review checklist",
     "",
-  ];
+    "- compare `gold.draft.json` against the PDF",
+    "- verify each answer",
+    "- verify page numbers",
+    "- verify quotes",
+    "- write final `gold.json`",
+    "- write `corrections.json` only for real corrections",
+    "",
+  ].join("\n");
+}
 
-  for (const result of input.results) {
-    const methodology = buildMethodologyExpectation(result);
-    lines.push(
-      `### ${result.checkName}`,
-      "",
-      `- current answer: ${result.answer ?? "null"}`,
-      `- current status: ${result.status}`,
-      `- current quote: ${result.evidence?.quote ?? "null"}`,
-      `- page: ${result.evidence?.page ?? "null"}`,
-      `- section: ${result.evidence?.sectionHeading ?? result.evidence?.sectionPath.join(" > ") ?? "null"}`,
-      `- spanId: ${result.evidence?.spanId ?? "null"}`,
-      `- source type: ${result.evidence?.sourceType ?? "null"}`,
-      `- strength: ${strengthLabel(result)}`,
-      `- suggested gold answer: ${result.answer ?? "null"}`,
-      `- suggested gold quote: ${result.evidence?.quote ?? "null"}`,
-      `- suggested expected status: ${result.status}`,
-      "- weak evidence to reject: TODO: add related-but-insufficient PDF text that must not pass",
-      methodology
-        ? `- notes for method ID/version: ${methodology.methodologyId ?? "UNKNOWN"} ${methodology.pddDeclaredMethodologyVersion ?? "UNKNOWN"} (${methodology.versionStatus ?? "UNKNOWN"})`
-        : "- notes for method ID/version: N/A",
-      "",
-    );
-  }
-
-  return `${lines.join("\n").trim()}\n`;
+function buildPendingCorrections(): PendingCorrections {
+  return {
+    status: "PENDING_ADJUDICATION",
+    corrections: [],
+  };
 }
 
 async function loadManifest(manifestPath: string): Promise<Manifest> {
@@ -258,7 +207,7 @@ async function loadManifest(manifestPath: string): Promise<Manifest> {
 
 async function writeManifest(manifestPath: string, manifest: Manifest, id: string): Promise<void> {
   const fixtures = manifest.fixtures.filter((fixture) => fixture.id !== id && fixture.directory !== id);
-  fixtures.push({ id, directory: id });
+  fixtures.push({ id, directory: id, adjudicationStatus: "pending" });
   await fs.writeFile(manifestPath, toJson({ ...manifest, fixtures }));
 }
 
@@ -294,7 +243,6 @@ export async function addQuickCheckV2Fixture(args: FixtureIntakeArgs): Promise<F
     const document = parseExtractedText(extractedText, documentId, "pdf-parse");
     const results = validateAnswerResults(extractAnswersForAllChecks(document));
     const gold = results.map(toGoldRecord);
-    const corrections = results.map(toCorrectionRecord);
     const meta: FixtureMeta = {
       id,
       title: args.title.trim(),
@@ -304,15 +252,15 @@ export async function addQuickCheckV2Fixture(args: FixtureIntakeArgs): Promise<F
       phase: "fixture_intake",
       registry: "UNKNOWN",
       documentType: "PDD / Project Description",
+      adjudicationStatus: "pending",
     };
 
     await fs.writeFile(path.join(tempDir, "meta.json"), toJson(meta));
     await fs.writeFile(path.join(tempDir, "gold.draft.json"), toJson(gold));
-    await fs.writeFile(path.join(tempDir, "gold.json"), toJson(gold));
-    await fs.writeFile(path.join(tempDir, "corrections.json"), toJson(corrections));
+    await fs.writeFile(path.join(tempDir, "corrections.json"), toJson(buildPendingCorrections()));
     await fs.writeFile(
       path.join(tempDir, "REVIEW.md"),
-      buildReviewMarkdown({ id, title: args.title.trim(), pdfPath, results }),
+      buildReviewMarkdown({ id, title: args.title.trim(), pdfPath }),
     );
 
     if (args.force) {
@@ -329,7 +277,6 @@ export async function addQuickCheckV2Fixture(args: FixtureIntakeArgs): Promise<F
         "source.pdf",
         "extracted.txt",
         "gold.draft.json",
-        "gold.json",
         "meta.json",
         "corrections.json",
         "REVIEW.md",

--- a/tests/lib/quickCheckV2/fixture-intake-cli.test.ts
+++ b/tests/lib/quickCheckV2/fixture-intake-cli.test.ts
@@ -79,7 +79,6 @@ describe("quickcheck fixture intake command", () => {
       "source.pdf",
       "extracted.txt",
       "gold.draft.json",
-      "gold.json",
       "meta.json",
       "corrections.json",
       "REVIEW.md",
@@ -90,10 +89,10 @@ describe("quickcheck fixture intake command", () => {
     await expect(fs.stat(path.join(fixtureDir, "source.pdf"))).resolves.toBeTruthy();
     await expect(fs.stat(path.join(fixtureDir, "extracted.txt"))).resolves.toBeTruthy();
     await expect(fs.stat(path.join(fixtureDir, "gold.draft.json"))).resolves.toBeTruthy();
-    await expect(fs.stat(path.join(fixtureDir, "gold.json"))).resolves.toBeTruthy();
     await expect(fs.stat(path.join(fixtureDir, "meta.json"))).resolves.toBeTruthy();
     await expect(fs.stat(path.join(fixtureDir, "corrections.json"))).resolves.toBeTruthy();
     await expect(fs.stat(path.join(fixtureDir, "REVIEW.md"))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(fixtureDir, "gold.json"))).rejects.toThrow();
 
     await expect(fs.readFile(path.join(fixtureDir, "source.pdf"), "utf-8")).resolves.toBe("%PDF-1.4\nfixture\n");
     const extractedText = await fs.readFile(path.join(fixtureDir, "extracted.txt"), "utf-8");
@@ -109,13 +108,12 @@ describe("quickcheck fixture intake command", () => {
       phase: "fixture_intake",
       registry: "UNKNOWN",
       documentType: "PDD / Project Description",
+      adjudicationStatus: "pending",
     });
 
-    const gold = await readJson<Array<Record<string, unknown>>>(path.join(fixtureDir, "gold.json"));
     const draftGold = await readJson<Array<Record<string, unknown>>>(path.join(fixtureDir, "gold.draft.json"));
-    expect(draftGold).toStrictEqual(gold);
-    expect(gold).toHaveLength(6);
-    for (const record of gold) {
+    expect(draftGold).toHaveLength(6);
+    for (const record of draftGold) {
       expect(record).toEqual(expect.objectContaining({
         checkName: expect.any(String),
         expectedStatus: expect.stringMatching(/^(FOUND|UNCLEAR|MISSING)$/),
@@ -123,7 +121,7 @@ describe("quickcheck fixture intake command", () => {
       }));
     }
 
-    expect(gold.find((record) => record.checkName === "methodology")).toEqual(expect.objectContaining({
+    expect(draftGold.find((record) => record.checkName === "methodology")).toEqual(expect.objectContaining({
       expectedStatus: "FOUND",
       expectedAnswer: "VM0007 REDD+ Methodology Framework v1.8",
       expectedMethodology: expect.objectContaining({
@@ -135,22 +133,21 @@ describe("quickcheck fixture intake command", () => {
       }),
     }));
 
-    const corrections = await readJson<Array<Record<string, unknown>>>(path.join(fixtureDir, "corrections.json"));
-    expect(corrections).toHaveLength(6);
-    expect(corrections[0]).toEqual(expect.objectContaining({
-      checkName: expect.any(String),
-      currentStatus: expect.stringMatching(/^(FOUND|UNCLEAR|MISSING)$/),
-      reason: expect.any(String),
-    }));
+    const corrections = await readJson<{ status: string; corrections: [] }>(path.join(fixtureDir, "corrections.json"));
+    expect(corrections).toStrictEqual({
+      status: "PENDING_ADJUDICATION",
+      corrections: [],
+    });
 
     const review = await fs.readFile(path.join(fixtureDir, "REVIEW.md"), "utf-8");
-    expect(review).toContain("Do not merge until `gold.json` has been reviewed against the source PDF");
-    expect(review).toContain("weak evidence to reject");
-    expect(review).toContain("notes for method ID/version: VM0007 v1.8 (DECLARED)");
+    expect(review).toContain("Adjudication not done.");
+    expect(review).toContain("compare `gold.draft.json` against the PDF");
+    expect(review).toContain("verify quotes");
+    expect(review).toContain("write `corrections.json` only for real corrections");
 
     await expect(readJson(path.join(fixtureRoot, "manifest.json"))).resolves.toStrictEqual({
       version: 1,
-      fixtures: [{ id: "example-pdd", directory: "example-pdd" }],
+      fixtures: [{ id: "example-pdd", directory: "example-pdd", adjudicationStatus: "pending" }],
     });
   });
 
@@ -191,7 +188,7 @@ describe("quickcheck fixture intake command", () => {
     await expect(readJson(path.join(fixtureDir, "meta.json"))).resolves.toMatchObject({ title: "Second Title" });
     await expect(readJson(path.join(fixtureRoot, "manifest.json"))).resolves.toStrictEqual({
       version: 1,
-      fixtures: [{ id: "example-pdd", directory: "example-pdd" }],
+      fixtures: [{ id: "example-pdd", directory: "example-pdd", adjudicationStatus: "pending" }],
     });
   });
 

--- a/tests/lib/quickCheckV2/gold-fixtures.test.ts
+++ b/tests/lib/quickCheckV2/gold-fixtures.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "@jest/globals";
 import { extractAnswersForAllChecks, extractMethodologyDetailsFromEvidence } from "@/lib/quickCheckV2/answers";
@@ -26,6 +27,7 @@ type Manifest = {
   fixtures: Array<{
     id: string;
     directory: string;
+    adjudicationStatus?: "pending" | "reviewed";
   }>;
 };
 
@@ -38,6 +40,7 @@ type FixtureMeta = {
   phase: string;
   registry: string;
   documentType: string;
+  adjudicationStatus?: "pending" | "reviewed";
 };
 
 type GoldRecord = {
@@ -53,6 +56,11 @@ type GoldRecord = {
   expectedMethodology?: Partial<QuickCheckMethodologyIdentity>;
 };
 
+type PendingGoldDraft = {
+  status: "PENDING_ADJUDICATION";
+  message: string;
+};
+
 type FixtureBundle = {
   directory: string;
   extractedPath: string;
@@ -61,7 +69,8 @@ type FixtureBundle = {
   correctionsPath: string;
   sourcePdfPath: string;
   meta: FixtureMeta;
-  gold: GoldRecord[];
+  gold: GoldRecord[] | PendingGoldDraft | null;
+  pending: boolean;
 };
 
 function loadManifest(): Manifest {
@@ -74,13 +83,25 @@ function loadJsonFile<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
 }
 
-function loadFixtureBundle(directory: string): FixtureBundle {
-  const fixtureDir = path.join(FIXTURE_ROOT, directory);
+function isPendingGoldDraft(value: unknown): value is PendingGoldDraft {
+  return Boolean(
+    value
+    && typeof value === "object"
+    && (value as PendingGoldDraft).status === "PENDING_ADJUDICATION",
+  );
+}
+
+function loadFixtureBundle(directory: string, fixtureRoot = FIXTURE_ROOT): FixtureBundle {
+  const fixtureDir = path.join(fixtureRoot, directory);
   const extractedPath = path.join(fixtureDir, "extracted.txt");
   const goldPath = path.join(fixtureDir, "gold.json");
   const metaPath = path.join(fixtureDir, "meta.json");
   const correctionsPath = path.join(fixtureDir, "corrections.json");
   const sourcePdfPath = path.join(fixtureDir, "source.pdf");
+  const meta = loadJsonFile<FixtureMeta>(metaPath);
+  const goldExists = fs.existsSync(goldPath);
+  const gold = goldExists ? loadJsonFile<GoldRecord[] | PendingGoldDraft>(goldPath) : null;
+  const pending = meta.adjudicationStatus === "pending" || !goldExists || isPendingGoldDraft(gold);
 
   return {
     directory,
@@ -89,8 +110,9 @@ function loadFixtureBundle(directory: string): FixtureBundle {
     metaPath,
     correctionsPath,
     sourcePdfPath,
-    meta: loadJsonFile<FixtureMeta>(metaPath),
-    gold: loadJsonFile<GoldRecord[]>(goldPath),
+    meta,
+    gold: pending ? null : (gold as GoldRecord[]),
+    pending,
   };
 }
 
@@ -293,6 +315,61 @@ function toEvidenceOnlyComparableRecord(record: GoldRecord): Omit<GoldRecord, "e
   return rest;
 }
 
+it("blocks pending adjudication fixtures from strict gold truth loading", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "qcv2-pending-"));
+  try {
+    const fixtureRoot = path.join(root, "tests/fixtures/quick-check/v2");
+    const fixtureDir = path.join(fixtureRoot, "pending-fixture");
+    fs.mkdirSync(fixtureDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(fixtureRoot, "manifest.json"),
+      JSON.stringify({
+        version: 1,
+        fixtures: [
+          {
+            id: "pending-fixture",
+            directory: "pending-fixture",
+            adjudicationStatus: "pending",
+          },
+        ],
+      }, null, 2),
+    );
+    fs.writeFileSync(
+      path.join(fixtureDir, "meta.json"),
+      JSON.stringify({
+        id: "pending-fixture",
+        title: "Pending Fixture",
+        documentId: "pending-fixture-extracted",
+        runtimeMode: "static",
+        comparisonMode: "full",
+        phase: "fixture_intake",
+        registry: "UNKNOWN",
+        documentType: "PDD / Project Description",
+        adjudicationStatus: "pending",
+      }, null, 2),
+    );
+    fs.writeFileSync(path.join(fixtureDir, "gold.draft.json"), JSON.stringify([], null, 2));
+    fs.writeFileSync(
+      path.join(fixtureDir, "corrections.json"),
+      JSON.stringify({ status: "PENDING_ADJUDICATION", corrections: [] }, null, 2),
+    );
+    fs.writeFileSync(
+      path.join(fixtureDir, "REVIEW.md"),
+      "# Quick Check v2 fixture intake: Pending Fixture\n\nAdjudication not done.\n",
+    );
+    fs.writeFileSync(path.join(fixtureDir, "extracted.txt"), "Page 1\nPending fixture\n");
+    fs.writeFileSync(path.join(fixtureDir, "source.pdf"), "%PDF-1.4\npending\n");
+
+    const bundle = loadFixtureBundle("pending-fixture", fixtureRoot);
+    expect(bundle.pending).toBe(true);
+    expect(bundle.gold).toBeNull();
+    expect(bundle.meta.adjudicationStatus).toBe("pending");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 const manifest = loadManifest();
 
 describe("Quick Check v2 gold fixtures", () => {
@@ -300,6 +377,20 @@ describe("Quick Check v2 gold fixtures", () => {
     const bundle = loadFixtureBundle(fixtureRef.directory);
 
     describe(bundle.meta.title, () => {
+      if (bundle.pending) {
+        it("remains pending adjudication and is skipped from strict gold truth", () => {
+          expect(bundle.meta.adjudicationStatus).toBe("pending");
+          expect(bundle.gold).toBeNull();
+          expect(fs.existsSync(bundle.goldPath)).toBe(false);
+        });
+        return;
+      }
+
+      const gold = bundle.gold;
+      if (!gold) {
+        throw new Error(`Expected reviewed gold for fixture ${bundle.directory}`);
+      }
+
       it("keeps fixture files in the v2 layout", () => {
         expect(fs.statSync(bundle.extractedPath).isFile()).toBe(true);
         expect(fs.statSync(bundle.goldPath).isFile()).toBe(true);
@@ -308,7 +399,7 @@ describe("Quick Check v2 gold fixtures", () => {
       });
 
       it("normalizes methodology gold shape", () => {
-        for (const record of bundle.gold) {
+        for (const record of gold) {
           validateMethodologyGoldRecord(record);
         }
       });
@@ -319,20 +410,20 @@ describe("Quick Check v2 gold fixtures", () => {
           bundle.meta.documentId,
         );
         const statuses = validateAnswerResults(extractAnswersForAllChecks(document));
-        const comparableStatuses = statuses.map((result, index) => toGoldComparableRecord(document, result, bundle.gold[index]!));
+        const comparableStatuses = statuses.map((result, index) => toGoldComparableRecord(document, result, gold[index]!));
         const methodologyComparisonFlags = comparableStatuses.map((record, index) =>
-          shouldCompareMethodology(record, bundle.gold[index]!),
+          shouldCompareMethodology(record, gold[index]!),
         );
 
         if (bundle.meta.comparisonMode === "evidence-only") {
           expect(comparableStatuses.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!))).toStrictEqual(
-            bundle.gold.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
+            gold.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
           );
           return;
         }
 
         expect(comparableStatuses.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!))).toStrictEqual(
-          bundle.gold.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
+          gold.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
         );
       });
 
@@ -354,22 +445,22 @@ describe("Quick Check v2 gold fixtures", () => {
           const runtimeStatuses = validateAnswerResults(
             extractAnswersForAllChecks(runtimeDocument),
           );
-          const comparableRuntimeStatuses = runtimeStatuses.map((result, index) => toGoldComparableRecord(runtimeDocument, result, bundle.gold[index]!));
+          const comparableRuntimeStatuses = runtimeStatuses.map((result, index) => toGoldComparableRecord(runtimeDocument, result, gold[index]!));
           const methodologyComparisonFlags = comparableRuntimeStatuses.map((record, index) =>
-            shouldCompareMethodology(record, bundle.gold[index]!),
+            shouldCompareMethodology(record, gold[index]!),
           );
 
           if (bundle.meta.comparisonMode === "evidence-only") {
             expect(
               comparableRuntimeStatuses.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
             ).toStrictEqual(
-              bundle.gold.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
+              gold.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
             );
             return;
           }
 
           expect(comparableRuntimeStatuses.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!))).toStrictEqual(
-            bundle.gold.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
+            gold.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
           );
         }, 120000);
       }
@@ -393,22 +484,22 @@ describe("Quick Check v2 gold fixtures", () => {
           const runtimeStatuses = validateAnswerResults(
             extractAnswersForAllChecks(runtimeDocument),
           );
-          const comparableRuntimeStatuses = runtimeStatuses.map((result, index) => toGoldComparableRecord(runtimeDocument, result, bundle.gold[index]!));
+          const comparableRuntimeStatuses = runtimeStatuses.map((result, index) => toGoldComparableRecord(runtimeDocument, result, gold[index]!));
           const methodologyComparisonFlags = comparableRuntimeStatuses.map((record, index) =>
-            shouldCompareMethodology(record, bundle.gold[index]!),
+            shouldCompareMethodology(record, gold[index]!),
           );
 
           if (bundle.meta.comparisonMode === "evidence-only") {
             expect(
               comparableRuntimeStatuses.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
             ).toStrictEqual(
-              bundle.gold.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
+              gold.map(toEvidenceOnlyComparableRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
             );
             return;
           }
 
           expect(comparableRuntimeStatuses.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!))).toStrictEqual(
-            bundle.gold.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
+            gold.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
           );
         }, 30000);
       }


### PR DESCRIPTION
This PR separates machine fixture intake from human adjudication for Quick Check v2 fixtures.

What changed:
- `npm run quickcheck:fixture:add` now writes `gold.draft.json` only and leaves `gold.json` absent.
- The intake metadata and manifest entry are marked `adjudicationStatus: "pending"`.
- `corrections.json` is now a pending sentinel instead of reviewed corrections.
- `REVIEW.md` now says `Adjudication not done.` and gives the later review checklist.
- Fixture loader tests treat missing or pending gold as non-truth and skip strict eval for pending fixtures.

Why:
- PR1 intake should store raw machine output without implying human-reviewed gold truth.
- Pending fixtures must not be consumed by strict eval as if they were adjudicated.

Checks:
- `npx jest tests/lib/quickCheckV2/fixture-intake-cli.test.ts --runInBand`
- `npx jest tests/lib/quickCheckV2/gold-fixtures.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`
- `npm run pr:gate`
