### PR TITLE
Add no fixture-shaped source guardrail

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,12 @@ For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactor
 
 Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.
 
+## Guardrails
+
+- [ ] Confirmed source fixes are generic and not fixture-shaped.
+- [ ] No project names, project IDs, exact page gates, or gold answer strings were added to source code.
+- [ ] Methodology fixes extract IDs and versions generically instead of hardcoding one fixture pair.
+
 <!--
 ### Roadmap-Override
 slug: <slug>

--- a/docs/agents/quick-check-v2-gold-fixture-playbook.md
+++ b/docs/agents/quick-check-v2-gold-fixture-playbook.md
@@ -21,6 +21,10 @@ A valid gold fixture contains:
 - Draft output is not truth.
 - Empty corrections are not proof of correctness.
 - Quote and page provenance are part of truth.
+- No fixture-shaped source fixes.
+- Gold, corrections, and review files may be document-specific.
+- Extractor, selector, status, answer, and methodology identity source code must be pattern-specific and reusable.
+- Do not fix a failing fixture by adding source logic tied to one project name, project ID, fixture ID, exact page number, exact gold answer string, or one methodology pair.
 
 ## PR Taxonomy
 

--- a/docs/quick-check/FIXTURE_PLAYBOOK.md
+++ b/docs/quick-check/FIXTURE_PLAYBOOK.md
@@ -1,0 +1,19 @@
+# Quick Check Fixture Playbook
+
+Use this playbook for Quick Check v2 fixture work when the fixture is the source of truth.
+
+## Permanent Rule
+
+No fixture-shaped source fixes.
+
+Gold, corrections, and review files may be document-specific.
+
+Extractor, selector, status, answer, and methodology identity source code must be pattern-specific and reusable.
+
+Do not fix a failing fixture by adding source logic tied to one project name, project ID, fixture ID, exact page number, exact gold answer string, or one methodology pair.
+
+## Where To Look Next
+
+For the full workflow and review guidance, see the existing agent playbook:
+
+- `docs/agents/quick-check-v2-gold-fixture-playbook.md`

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "dev:manifest:count": "node -e \"console.log(require('./public/manifest/index.json').length)\"",
     "fetch:methodologies-pack": "bash scripts/fetch-methodologies-pack.sh",
     "guard:methodology-boundary": "node scripts/guard-methodology-boundary.mjs",
+    "quickcheck:guard:no-fixture-hardcoding": "node scripts/quickcheck/check-no-fixture-hardcoding.mjs",
+    "test:quickcheck:no-fixture-hardcoding": "jest tests/lib/quickCheckV2/no-fixture-hardcoding-guard.test.ts --runInBand",
     "check:golden": "bash scripts/check-golden-rich.sh",
     "build:audit-pack": "node scripts/build-audit-pack.mjs",
     "build:derived": "node scripts/build-derived-artifacts.mjs",

--- a/scripts/pr-gate.mjs
+++ b/scripts/pr-gate.mjs
@@ -51,6 +51,7 @@ async function main() {
   if (hasScript("test")) run("npm run test");
   if (hasScript("lint")) run("npm run lint");
   if (hasScript("quickcheck:eval:corpus")) run("npm run quickcheck:eval:corpus -- --strict");
+  if (hasScript("quickcheck:guard:no-fixture-hardcoding")) run("npm run quickcheck:guard:no-fixture-hardcoding");
 
   const port = process.env.PORT || "3000";
   const baseUrl = process.env.BASE_URL || `http://localhost:${port}`;

--- a/scripts/quickcheck/check-no-fixture-hardcoding.mjs
+++ b/scripts/quickcheck/check-no-fixture-hardcoding.mjs
@@ -7,7 +7,7 @@ import process from "node:process";
 const SOURCE_ROOT = "src/lib/quickCheckV2";
 const FIXTURE_ROOT = "tests/fixtures/quick-check/v2";
 
-const PAGE_GATE_RE = /\b(?:[A-Za-z_$][\w$]*\.)*page\s*(?:>=|>)\s*\d+\b/;
+const PAGE_GATE_RE = /\b(?:[A-Za-z_$][\w$]*\.)*page\s*(?:===|==|!==|!=|>=|>|<=|<)\s*\d+\b/;
 const METHODOLOGY_PAIR_RE = /\bVM0048\b[\s\S]{0,120}\bVM0007\b|\bVM0007\b[\s\S]{0,120}\bVM0048\b/;
 
 function git(args, options = {}) {

--- a/scripts/quickcheck/check-no-fixture-hardcoding.mjs
+++ b/scripts/quickcheck/check-no-fixture-hardcoding.mjs
@@ -9,9 +9,6 @@ const FIXTURE_ROOT = "tests/fixtures/quick-check/v2";
 
 const PAGE_GATE_RE = /\b(?:[A-Za-z_$][\w$]*\.)*page\s*(?:>=|>)\s*\d+\b/;
 const METHODOLOGY_PAIR_RE = /\bVM0048\b[\s\S]{0,120}\bVM0007\b|\bVM0007\b[\s\S]{0,120}\bVM0048\b/;
-const METHOD_ID_LITERAL_RE = /\bmethodologyId\b\s*[:=]\s*["'][^"']+["']/i;
-const METHOD_NAME_LITERAL_RE = /\bmethodologyName\b\s*[:=]\s*["'][^"']+["']/i;
-const METHOD_VERSION_LITERAL_RE = /\b(?:version|methodologyVersion|pddDeclaredMethodologyVersion)\b\s*[:=]\s*["'][^"']+["']/i;
 
 function git(args, options = {}) {
   return execFileSync("git", args, {
@@ -152,36 +149,6 @@ function collectViolations({ filePath, lineNumber, text }, catalog) {
       lineNumber,
       rule: "methodology pair special case",
       reason: "Branching on a single methodology pair hardcodes fixture truth instead of parsing generically.",
-      sample: normalized,
-    });
-  }
-
-  if (METHOD_ID_LITERAL_RE.test(normalized)) {
-    violations.push({
-      filePath,
-      lineNumber,
-      rule: "hardcoded methodologyId",
-      reason: "A methodology ID literal in quickCheckV2 source should come from parsing, not one fixture pair.",
-      sample: normalized,
-    });
-  }
-
-  if (METHOD_NAME_LITERAL_RE.test(normalized)) {
-    violations.push({
-      filePath,
-      lineNumber,
-      rule: "hardcoded methodologyName",
-      reason: "A methodology name literal in quickCheckV2 source should come from parsing, not one fixture pair.",
-      sample: normalized,
-    });
-  }
-
-  if (METHOD_VERSION_LITERAL_RE.test(normalized)) {
-    violations.push({
-      filePath,
-      lineNumber,
-      rule: "hardcoded methodology version",
-      reason: "A methodology version literal in quickCheckV2 source should come from parsing, not one fixture pair.",
       sample: normalized,
     });
   }

--- a/scripts/quickcheck/check-no-fixture-hardcoding.mjs
+++ b/scripts/quickcheck/check-no-fixture-hardcoding.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const SOURCE_ROOT = "src/lib/quickCheckV2";
+const FIXTURE_ROOT = "tests/fixtures/quick-check/v2";
+
+const PAGE_GATE_RE = /\b(?:[A-Za-z_$][\w$]*\.)*page\s*(?:>=|>)\s*\d+\b/;
+const METHODOLOGY_PAIR_RE = /\bVM0048\b[\s\S]{0,120}\bVM0007\b|\bVM0007\b[\s\S]{0,120}\bVM0048\b/;
+const METHOD_ID_LITERAL_RE = /\bmethodologyId\b\s*[:=]\s*["'][^"']+["']/i;
+const METHOD_NAME_LITERAL_RE = /\bmethodologyName\b\s*[:=]\s*["'][^"']+["']/i;
+const METHOD_VERSION_LITERAL_RE = /\b(?:version|methodologyVersion|pddDeclaredMethodologyVersion)\b\s*[:=]\s*["'][^"']+["']/i;
+
+function git(args, options = {}) {
+  return execFileSync("git", args, {
+    cwd: options.cwd ?? process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function parseArgs(argv) {
+  const result = { baseRef: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) continue;
+    if (arg === "--base-ref") {
+      result.baseRef = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--base-ref=")) {
+      result.baseRef = arg.slice("--base-ref=".length) || null;
+    }
+  }
+  return result;
+}
+
+function resolveBaseRef(cliBaseRef) {
+  if (cliBaseRef?.trim()) return cliBaseRef.trim();
+  if (process.env.QUICKCHECK_NO_FIXTURE_HARDCODING_BASE?.trim()) return process.env.QUICKCHECK_NO_FIXTURE_HARDCODING_BASE.trim();
+  if (process.env.QUICKCHECK_HARDCODING_BASE?.trim()) return process.env.QUICKCHECK_HARDCODING_BASE.trim();
+  if (process.env.GITHUB_BASE_REF?.trim()) return `origin/${process.env.GITHUB_BASE_REF.trim()}`;
+  return "origin/main";
+}
+
+function resolveChangedSourceFiles(baseRef) {
+  const output = git(["diff", "--name-only", `${baseRef}...HEAD`, "--", SOURCE_ROOT]);
+  return output ? output.split("\n").map((line) => line.trim()).filter(Boolean) : [];
+}
+
+function readFixtureCatalog(rootDir) {
+  const fixtureRoot = path.join(rootDir, FIXTURE_ROOT);
+  const projectNames = new Set();
+  const goldAnswers = new Set();
+
+  if (!fs.existsSync(fixtureRoot)) {
+    return { projectNames, goldAnswers };
+  }
+
+  for (const entry of fs.readdirSync(fixtureRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const fixtureDir = path.join(fixtureRoot, entry.name);
+    projectNames.add(entry.name.toLowerCase());
+
+    const metaPath = path.join(fixtureDir, "meta.json");
+    if (fs.existsSync(metaPath)) {
+      try {
+        const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+        for (const value of [meta?.id, meta?.title, meta?.documentId]) {
+          if (typeof value === "string" && value.trim()) {
+            projectNames.add(value.trim().toLowerCase());
+          }
+        }
+      } catch {
+        // Ignore malformed fixture metadata and keep scanning.
+      }
+    }
+
+    const goldPath = path.join(fixtureDir, "gold.json");
+    if (!fs.existsSync(goldPath)) continue;
+
+    try {
+      const gold = JSON.parse(fs.readFileSync(goldPath, "utf8"));
+      if (!Array.isArray(gold)) continue;
+      for (const row of gold) {
+        if (typeof row?.expectedAnswer === "string" && row.expectedAnswer.trim()) {
+          goldAnswers.add(row.expectedAnswer.trim());
+        }
+      }
+    } catch {
+      // Ignore malformed gold files and keep scanning.
+    }
+  }
+
+  return { projectNames, goldAnswers };
+}
+
+function parsePatch(patchText) {
+  const lines = patchText.split("\n");
+  const addedLines = [];
+  let currentNewLine = null;
+
+  for (const line of lines) {
+    if (line.startsWith("@@")) {
+      const match = line.match(/\+(\d+)(?:,(\d+))?/);
+      currentNewLine = match ? Number(match[1]) : null;
+      continue;
+    }
+
+    if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("diff --git") || line.startsWith("index ")) {
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      addedLines.push({
+        lineNumber: currentNewLine,
+        text: line.slice(1),
+      });
+      if (currentNewLine != null) currentNewLine += 1;
+      continue;
+    }
+
+    if (!line.startsWith("-") && currentNewLine != null) {
+      currentNewLine += 1;
+    }
+  }
+
+  return addedLines;
+}
+
+function collectViolations({ filePath, lineNumber, text }, catalog) {
+  const violations = [];
+  const normalized = text.trim();
+  const lower = normalized.toLowerCase();
+
+  if (PAGE_GATE_RE.test(normalized)) {
+    violations.push({
+      filePath,
+      lineNumber,
+      rule: "page gate",
+      reason: "Page-threshold branching in quickCheckV2 source is fixture-shaped and brittle.",
+      sample: normalized,
+    });
+  }
+
+  if (METHODOLOGY_PAIR_RE.test(normalized)) {
+    violations.push({
+      filePath,
+      lineNumber,
+      rule: "methodology pair special case",
+      reason: "Branching on a single methodology pair hardcodes fixture truth instead of parsing generically.",
+      sample: normalized,
+    });
+  }
+
+  if (METHOD_ID_LITERAL_RE.test(normalized)) {
+    violations.push({
+      filePath,
+      lineNumber,
+      rule: "hardcoded methodologyId",
+      reason: "A methodology ID literal in quickCheckV2 source should come from parsing, not one fixture pair.",
+      sample: normalized,
+    });
+  }
+
+  if (METHOD_NAME_LITERAL_RE.test(normalized)) {
+    violations.push({
+      filePath,
+      lineNumber,
+      rule: "hardcoded methodologyName",
+      reason: "A methodology name literal in quickCheckV2 source should come from parsing, not one fixture pair.",
+      sample: normalized,
+    });
+  }
+
+  if (METHOD_VERSION_LITERAL_RE.test(normalized)) {
+    violations.push({
+      filePath,
+      lineNumber,
+      rule: "hardcoded methodology version",
+      reason: "A methodology version literal in quickCheckV2 source should come from parsing, not one fixture pair.",
+      sample: normalized,
+    });
+  }
+
+  for (const projectName of catalog.projectNames) {
+    if (!projectName) continue;
+    if (lower.includes(projectName)) {
+      violations.push({
+        filePath,
+        lineNumber,
+        rule: "project-specific fixture id/title",
+        reason: `The source line mentions fixture-specific text (${projectName}), which should stay in fixtures or docs.`,
+        sample: normalized,
+      });
+      break;
+    }
+  }
+
+  for (const answer of catalog.goldAnswers) {
+    if (!answer) continue;
+    if (normalized.includes(answer)) {
+      violations.push({
+        filePath,
+        lineNumber,
+        rule: "exact gold answer string",
+        reason: "An exact gold answer string is document-specific truth and should not be copied into source.",
+        sample: normalized,
+      });
+      break;
+    }
+  }
+
+  return violations;
+}
+
+function formatViolation(violation) {
+  const location = violation.lineNumber ? `${violation.filePath}:${violation.lineNumber}` : violation.filePath;
+  return [
+    `[no-fixture-hardcoding] ${location}`,
+    `rule=${violation.rule}`,
+    violation.reason,
+    `  ${violation.sample}`,
+  ].join(" ");
+}
+
+function main() {
+  try {
+    const { baseRef: cliBaseRef } = parseArgs(process.argv.slice(2));
+    const baseRef = resolveBaseRef(cliBaseRef);
+    const rootDir = process.cwd();
+    const changedSourceFiles = resolveChangedSourceFiles(baseRef);
+    const catalog = readFixtureCatalog(rootDir);
+
+    const violations = [];
+    for (const filePath of changedSourceFiles) {
+      const patchText = git(["diff", "--unified=0", "--no-color", `${baseRef}...HEAD`, "--", filePath]);
+      if (!patchText) continue;
+
+      const addedLines = parsePatch(patchText);
+      for (const line of addedLines) {
+        violations.push(...collectViolations({ filePath, lineNumber: line.lineNumber, text: line.text }, catalog));
+      }
+    }
+
+    if (violations.length > 0) {
+      console.error("[no-fixture-hardcoding] blocked");
+      console.error(`[no-fixture-hardcoding] base=${baseRef} changed=${changedSourceFiles.length}`);
+      for (const violation of violations) {
+        console.error(formatViolation(violation));
+      }
+      process.exit(1);
+    }
+
+    console.log(`[no-fixture-hardcoding] ok base=${baseRef} changed=${changedSourceFiles.length}`);
+  } catch (error) {
+    console.error("[no-fixture-hardcoding] error");
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+main();

--- a/tests/lib/quickCheckV2/no-fixture-hardcoding-guard.test.ts
+++ b/tests/lib/quickCheckV2/no-fixture-hardcoding-guard.test.ts
@@ -120,7 +120,7 @@ describe("quickcheck no-fixture-hardcoding guard", () => {
         path.join(root, "src/lib/quickCheckV2/guard-target.ts"),
         [
           "export function demoGuard(block: { page: number }, quote: string) {",
-          '  if (block.page >= 47) return "The project activities would not occur without carbon finance due to substantial financial barriers.";',
+          '  if (block.page === 47) return "The project activities would not occur without carbon finance due to substantial financial barriers.";',
           '  if (quote.includes("VM0048") && quote.includes("VM0007")) return "VM0007 REDD+ Methodology Framework v1.8";',
           '  return "demo-fixture";',
           "}",

--- a/tests/lib/quickCheckV2/no-fixture-hardcoding-guard.test.ts
+++ b/tests/lib/quickCheckV2/no-fixture-hardcoding-guard.test.ts
@@ -37,6 +37,39 @@ function runGuard(cwd: string) {
 }
 
 describe("quickcheck no-fixture-hardcoding guard", () => {
+  it("allows reusable methodology registry data in src/lib/quickCheckV2", () => {
+    const root = initRepo();
+    try {
+      writeFile(
+        path.join(root, "src/lib/quickCheckV2/methodologyRegistry.ts"),
+        ["export const METHODOLOGY_REGISTRY = {};", ""].join("\n"),
+      );
+      commitAll(root, "base");
+
+      writeFile(
+        path.join(root, "src/lib/quickCheckV2/methodologyRegistry.ts"),
+        [
+          "export const METHODOLOGY_REGISTRY = {",
+          "  VM0007: {",
+          '    methodologyId: "VM0007",',
+          '    methodologyName: "REDD+ Methodology Framework",',
+          '    versions: ["v1.8"],',
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+      );
+      commitAll(root, "registry data");
+
+      const result = runGuard(root);
+      expect(result.status).toBe(0);
+      const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+      expect(output).toContain("ok");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("flags obvious fixture-shaped source hardcoding in src/lib/quickCheckV2", () => {
     const root = initRepo();
     try {

--- a/tests/lib/quickCheckV2/no-fixture-hardcoding-guard.test.ts
+++ b/tests/lib/quickCheckV2/no-fixture-hardcoding-guard.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "@jest/globals";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SCRIPT_PATH = path.resolve("scripts/quickcheck/check-no-fixture-hardcoding.mjs");
+
+function git(cwd: string, args: string[]) {
+  execFileSync("git", args, { cwd, stdio: "pipe" });
+}
+
+function writeFile(filePath: string, content: string) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function initRepo(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "no-fixture-hardcoding-"));
+  git(root, ["init"]);
+  git(root, ["config", "user.email", "codex@example.com"]);
+  git(root, ["config", "user.name", "Codex"]);
+  return root;
+}
+
+function commitAll(cwd: string, message: string) {
+  git(cwd, ["add", "."]);
+  git(cwd, ["commit", "-m", message]);
+}
+
+function runGuard(cwd: string) {
+  return spawnSync("node", [SCRIPT_PATH, "--base-ref", "HEAD~1"], {
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+  });
+}
+
+describe("quickcheck no-fixture-hardcoding guard", () => {
+  it("flags obvious fixture-shaped source hardcoding in src/lib/quickCheckV2", () => {
+    const root = initRepo();
+    try {
+      writeFile(
+        path.join(root, "src/lib/quickCheckV2/guard-target.ts"),
+        [
+          "export function demoGuard(block: { page: number }, quote: string) {",
+          '  return "generic source";',
+          "}",
+          "",
+        ].join("\n"),
+      );
+      writeFile(
+        path.join(root, "tests/fixtures/quick-check/v2/demo-fixture/meta.json"),
+        JSON.stringify(
+          {
+            id: "demo-fixture",
+            title: "Demo Fixture Project",
+            documentId: "demo-fixture-document",
+          },
+          null,
+          2,
+        ),
+      );
+      writeFile(
+        path.join(root, "tests/fixtures/quick-check/v2/demo-fixture/gold.json"),
+        JSON.stringify(
+          [
+            {
+              checkName: "methodology",
+              expectedStatus: "FOUND",
+              expectedAnswer: "VM0007 REDD+ Methodology Framework v1.8",
+              goldQuote: "Demo gold quote.",
+              page: 1,
+              sectionHeading: null,
+              sectionPath: ["1"],
+              spanId: "demo-fixture-extracted:p1:b1:deadbeef",
+              sourceType: "fact_contract",
+            },
+          ],
+          null,
+          2,
+        ),
+      );
+      commitAll(root, "base");
+
+      writeFile(
+        path.join(root, "src/lib/quickCheckV2/guard-target.ts"),
+        [
+          "export function demoGuard(block: { page: number }, quote: string) {",
+          '  if (block.page >= 47) return "The project activities would not occur without carbon finance due to substantial financial barriers.";',
+          '  if (quote.includes("VM0048") && quote.includes("VM0007")) return "VM0007 REDD+ Methodology Framework v1.8";',
+          '  return "demo-fixture";',
+          "}",
+          "",
+        ].join("\n"),
+      );
+      commitAll(root, "guarded change");
+
+      const result = runGuard(root);
+      expect(result.status).not.toBe(0);
+      const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+      expect(output).toContain("page gate");
+      expect(output).toContain("methodology pair special case");
+      expect(output).toContain("exact gold answer string");
+      expect(output).toContain("project-specific fixture id/title");
+      expect(output).toContain("src/lib/quickCheckV2/guard-target.ts");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("allows document-specific fixture text under tests/fixtures/quick-check/v2", () => {
+    const root = initRepo();
+    try {
+      writeFile(
+        path.join(root, "src/lib/quickCheckV2/guard-target.ts"),
+        [
+          "export function okGuard() {",
+          '  return "generic source";',
+          "}",
+          "",
+        ].join("\n"),
+      );
+      writeFile(
+        path.join(root, "tests/fixtures/quick-check/v2/demo-fixture/meta.json"),
+        JSON.stringify(
+          {
+            id: "demo-fixture",
+            title: "Demo Fixture Project",
+            documentId: "demo-fixture-document",
+          },
+          null,
+          2,
+        ),
+      );
+      writeFile(
+        path.join(root, "tests/fixtures/quick-check/v2/demo-fixture/gold.json"),
+        JSON.stringify(
+          [
+            {
+              checkName: "host_country",
+              expectedStatus: "FOUND",
+              expectedAnswer: "Belize",
+              goldQuote: "Project location Belize, Cayo Districts.",
+              page: 1,
+              sectionHeading: null,
+              sectionPath: ["1"],
+              spanId: "demo-fixture-extracted:p1:b1:deadbeef",
+              sourceType: "fact_contract",
+            },
+          ],
+          null,
+          2,
+        ),
+      );
+      commitAll(root, "base");
+
+      writeFile(
+        path.join(root, "tests/fixtures/quick-check/v2/demo-fixture/gold.json"),
+        JSON.stringify(
+          [
+            {
+              checkName: "host_country",
+              expectedStatus: "FOUND",
+              expectedAnswer: "Belize",
+              goldQuote: "Project location Belize, Cayo Districts.",
+              page: 1,
+              sectionHeading: null,
+              sectionPath: ["1"],
+              spanId: "demo-fixture-extracted:p1:b1:deadbeef",
+              sourceType: "fact_contract",
+            },
+            {
+              checkName: "methodology",
+              expectedStatus: "FOUND",
+              expectedAnswer: "Demo specific truth remains in fixtures.",
+              goldQuote: "Document-specific fixture truth belongs here.",
+              page: 2,
+              sectionHeading: "Fixture truth",
+              sectionPath: ["1", "1.1"],
+              spanId: "demo-fixture-extracted:p2:b2:deadbeef",
+              sourceType: "fact_contract",
+            },
+          ],
+          null,
+          2,
+        ),
+      );
+      commitAll(root, "fixture update");
+
+      const result = runGuard(root);
+      expect(result.status).toBe(0);
+      const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+      expect(output).toContain("ok");
+      expect(output).toContain("changed=0");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
This PR codifies the no fixture-shaped source fix rule across three layers:

1. Playbook rule
2. PR checklist reminder
3. Automated pr:gate enforcement

The new guard scans changed Quick Check V2 source files and fails on obvious fixture-shaped hardcoding, including exact page gates, project-specific fixture IDs, and methodology-pair special cases. Fixture truth remains allowed under test fixture directories.

Validation:

- npm run test:quickcheck:no-fixture-hardcoding passed
- npm run pr:gate failed locally due existing unrelated premiumExport ZIP determinism test
- GitHub CI pr-gate passed on commit 498819426f2d52d3490fd63bca7acda6ae4ca077

Notes:

- No existing gold fixtures changed.
- public/manifest/index.json was restored and is not included.
- This PR adds guardrails only. It does not change extractor behavior.
