### PR TITLE
Add reusable Evidence Stack support for multiple typed citations

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -78,6 +78,7 @@ import { FixtureReplayOverlay } from "@/components/dev/FixtureReplayOverlay";
 import type { FixtureContract } from "@/lib/dev/fixtureReplay";
 import { parseExtractedText, type StructuredCheckId } from "@/lib/quickCheckV2/evidence";
 import { extractAnswersForAllChecks, extractMethodologyDetailsFromEvidence, type MethodologyExtraction } from "@/lib/quickCheckV2/answers";
+import { buildQuickCheckEvidenceStackDisplay } from "@/lib/quickCheckV2/evidenceStackAdapter";
 import { validateAnswerResults, type StatusReason } from "@/lib/quickCheckV2/status";
 import Vm0007GapReportLaunchButton from "@/components/preverif/Vm0007GapReportLaunchButton";
 import { buildMethodologyVersionLock } from "@/lib/preverif/evidenceAudit";
@@ -138,6 +139,13 @@ type StructuredEvidenceCheckResult = {
   pages: number[];
   sections: string[];
   evidenceSpanIds: string[];
+  evidenceDetails: Array<{
+    role: string;
+    roleLabel: string;
+    page: number;
+    quote: string;
+    sectionLabel: string | null;
+  }>;
   methodology?: MethodologyExtraction | null;
 };
 
@@ -2100,6 +2108,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const results: StructuredEvidenceCheckResult[] = statusResults
         .map((statusResult) => {
           const evidence = statusResult.evidence;
+          const evidenceDetails = buildQuickCheckEvidenceStackDisplay(statusResult.evidenceStack ?? []);
           const status: StructuredEvidenceCheckResult["status"] =
             statusResult.status === "FOUND"
               ? "found"
@@ -2120,6 +2129,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                   ? evidence.sectionPath
                   : [],
             evidenceSpanIds: evidence?.spanId ? [evidence.spanId] : [],
+            evidenceDetails,
             methodology:
               statusResult.checkName === "methodology"
                 ? extractMethodologyDetailsFromEvidence(evidence)
@@ -2182,6 +2192,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         const results: StructuredEvidenceCheckResult[] = statusResults
           .map((statusResult) => {
             const evidence = statusResult.evidence;
+            const evidenceDetails = buildQuickCheckEvidenceStackDisplay(statusResult.evidenceStack ?? []);
             const status: StructuredEvidenceCheckResult["status"] =
               statusResult.status === "FOUND"
                 ? "found"
@@ -2202,6 +2213,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     ? evidence.sectionPath
                     : [],
               evidenceSpanIds: evidence?.spanId ? [evidence.spanId] : [],
+              evidenceDetails,
               methodology:
                 statusResult.checkName === "methodology"
                   ? extractMethodologyDetailsFromEvidence(evidence)
@@ -2783,6 +2795,28 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                                 {result.sections.length > 0 ? <span>{result.sections.join(" \u203a ")}</span> : null}
                                 {result.evidenceSpanIds.length > 0 ? <span>{result.evidenceSpanIds.length} span(s)</span> : null}
                               </div>
+                              {result.evidenceDetails.length > 1 ? (
+                                <div className="mt-2 rounded border border-slate-200 bg-slate-50 p-2 text-[10px] text-slate-600">
+                                  <div className="font-semibold uppercase tracking-wide text-slate-500">Evidence details</div>
+                                  <div className="mt-1 space-y-2">
+                                    {result.evidenceDetails.slice(1).map((detail, index) => (
+                                      <div
+                                        key={`${result.checkId}-${detail.role}-${detail.page}-${index}`}
+                                        className="rounded border border-slate-200 bg-white px-2 py-1"
+                                      >
+                                        <div className="flex flex-wrap gap-x-2 text-[10px] text-slate-500">
+                                          <span className="font-semibold text-slate-700">{detail.roleLabel}</span>
+                                          <span>p.{detail.page}</span>
+                                          {detail.sectionLabel ? <span>{detail.sectionLabel}</span> : null}
+                                        </div>
+                                        <div className="mt-1 italic text-slate-600">
+                                          &ldquo;{detail.quote.slice(0, 220)}{detail.quote.length > 220 ? "\u2026" : ""}&rdquo;
+                                        </div>
+                                      </div>
+                                    ))}
+                                  </div>
+                                </div>
+                              ) : null}
                             </>
                           ) : result.status === "missing" ? (
                             <div className="text-xs text-slate-500">{result.answerText}</div>

--- a/src/lib/evidence/evidenceStack.ts
+++ b/src/lib/evidence/evidenceStack.ts
@@ -1,0 +1,206 @@
+export const EVIDENCE_STACK_ROLES = [
+  "primary",
+  "supporting",
+  "caveat",
+  "blocker",
+] as const;
+
+export type EvidenceStackRole = (typeof EVIDENCE_STACK_ROLES)[number];
+
+export type EvidenceStackItem = {
+  role: EvidenceStackRole;
+  page: number;
+  quote: string;
+  sectionHeading?: string | null;
+  sectionPath?: string[];
+  spanId?: string | null;
+  sourceType?: string | null;
+  label?: string;
+  reason?: string;
+};
+
+type EvidenceLike = Partial<EvidenceStackItem> & {
+  role?: string | null;
+};
+
+export type EvidenceStackValidationOptions = {
+  requirePrimary?: boolean;
+  quoteValidator?: (
+    quote: string,
+    item: EvidenceStackItem,
+  ) => boolean | string | { valid: boolean; reason?: string };
+};
+
+export type EvidenceStackValidationResult = {
+  valid: boolean;
+  errors: string[];
+};
+
+const ROLE_ORDER: Record<EvidenceStackRole, number> = {
+  primary: 0,
+  supporting: 1,
+  caveat: 2,
+  blocker: 3,
+};
+
+function asTrimmedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const normalized = value
+    .map((entry) => asTrimmedString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return normalized.length > 0 ? normalized : [];
+}
+
+function asRole(value: unknown): EvidenceStackRole {
+  return EVIDENCE_STACK_ROLES.includes(value as EvidenceStackRole)
+    ? (value as EvidenceStackRole)
+    : "primary";
+}
+
+function normalizeEvidenceStackItem(
+  item: EvidenceLike,
+  fallbackRole: EvidenceStackRole = "primary",
+): EvidenceStackItem {
+  const quote = asTrimmedString(item.quote) ?? "";
+  const page = typeof item.page === "number" ? item.page : Number(item.page);
+
+  return {
+    role: EVIDENCE_STACK_ROLES.includes(item.role as EvidenceStackRole)
+      ? (item.role as EvidenceStackRole)
+      : fallbackRole,
+    page,
+    quote,
+    sectionHeading: asTrimmedString(item.sectionHeading),
+    sectionPath: asStringArray(item.sectionPath),
+    spanId: asTrimmedString(item.spanId),
+    sourceType: asTrimmedString(item.sourceType),
+    label: asTrimmedString(item.label) ?? undefined,
+    reason: asTrimmedString(item.reason) ?? undefined,
+  };
+}
+
+export function evidenceToStackItem(
+  evidence: EvidenceLike | null | undefined,
+  role: EvidenceStackRole = "primary",
+): EvidenceStackItem | null {
+  if (!evidence || typeof evidence !== "object") return null;
+  return normalizeEvidenceStackItem(evidence, role);
+}
+
+export function normalizeEvidenceStack(input: unknown): EvidenceStackItem[] {
+  if (!input) return [];
+
+  if (Array.isArray(input)) {
+    return input
+      .filter((item): item is EvidenceLike => Boolean(item) && typeof item === "object")
+      .map((item) => normalizeEvidenceStackItem(item, asRole(item.role)));
+  }
+
+  if (typeof input === "object") {
+    const item = evidenceToStackItem(input as EvidenceLike);
+    return item ? [item] : [];
+  }
+
+  return [];
+}
+
+export function sortEvidenceStack(stack: EvidenceStackItem[]): EvidenceStackItem[] {
+  return stack
+    .map((item, index) => ({ item, index }))
+    .sort((left, right) => {
+      const roleDelta = ROLE_ORDER[left.item.role] - ROLE_ORDER[right.item.role];
+      if (roleDelta !== 0) return roleDelta;
+      return left.index - right.index;
+    })
+    .map(({ item }) => item);
+}
+
+export function getPrimaryEvidence(
+  stack: EvidenceStackItem[] | null | undefined,
+): EvidenceStackItem | null {
+  return stack?.find((item) => item.role === "primary") ?? null;
+}
+
+export function hasPrimaryEvidence(stack: EvidenceStackItem[] | null | undefined): boolean {
+  return getPrimaryEvidence(stack) !== null;
+}
+
+export function groupEvidenceStackByRole(
+  stack: EvidenceStackItem[] | null | undefined,
+): Record<EvidenceStackRole, EvidenceStackItem[]> {
+  const grouped: Record<EvidenceStackRole, EvidenceStackItem[]> = {
+    primary: [],
+    supporting: [],
+    caveat: [],
+    blocker: [],
+  };
+
+  for (const item of sortEvidenceStack(stack ?? [])) {
+    grouped[item.role].push(item);
+  }
+
+  return grouped;
+}
+
+function validateQuote(
+  item: EvidenceStackItem,
+  quoteValidator?: EvidenceStackValidationOptions["quoteValidator"],
+): string | null {
+  if (!quoteValidator) return null;
+  const result = quoteValidator(item.quote, item);
+  if (typeof result === "boolean") return result ? null : "quote failed validation";
+  if (typeof result === "string") return result || "quote failed validation";
+  if (result && typeof result === "object") return result.valid ? null : (result.reason ?? "quote failed validation");
+  return null;
+}
+
+export function validateEvidenceStack(
+  stack: EvidenceStackItem[] | null | undefined,
+  options: EvidenceStackValidationOptions = {},
+): EvidenceStackValidationResult {
+  const errors: string[] = [];
+  const rawItems: EvidenceLike[] = Array.isArray(stack)
+    ? stack.filter(Boolean).map((item) => item as EvidenceLike)
+    : normalizeEvidenceStack(stack ?? []).map((item) => item as EvidenceLike);
+  const normalized = normalizeEvidenceStack(stack ?? []);
+
+  normalized.forEach((item, index) => {
+    const rawRole = rawItems[index]?.role;
+    if (rawRole != null && !EVIDENCE_STACK_ROLES.includes(rawRole as EvidenceStackRole)) {
+      errors.push(`stack[${index}] has an invalid role "${String(rawRole)}"`);
+    }
+    if (!Number.isFinite(item.page) || item.page <= 0) {
+      errors.push(`stack[${index}] must have a finite positive page number`);
+    }
+    if (!item.quote.trim()) {
+      errors.push(`stack[${index}] must have a non-empty quote`);
+    }
+    const quoteError = validateQuote(item, options.quoteValidator);
+    if (quoteError) {
+      errors.push(`stack[${index}] ${quoteError}`);
+    }
+  });
+
+  if (options.requirePrimary && !hasPrimaryEvidence(normalized)) {
+    errors.push("FOUND/answered evidence requires at least one primary citation");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+export function validateEvidenceStackForStatus(
+  status: string,
+  stack: EvidenceStackItem[] | null | undefined,
+): EvidenceStackValidationResult {
+  const normalizedStatus = status.trim().toUpperCase();
+  return validateEvidenceStack(stack, {
+    requirePrimary: normalizedStatus === "FOUND" || normalizedStatus === "ANSWERED",
+  });
+}

--- a/src/lib/quickCheckV2/answers/index.ts
+++ b/src/lib/quickCheckV2/answers/index.ts
@@ -34,11 +34,14 @@ import {
   type MethodologyReference,
 } from "@/lib/quickCheckV2/methodologyParsing";
 import { normalizeDeclaredMethodologyVersion } from "@/lib/chat/methodologyVersion";
+import type { EvidenceStackItem } from "@/lib/evidence/evidenceStack";
+import { buildQuickCheckEvidenceStack } from "@/lib/quickCheckV2/evidenceStackAdapter";
 
 export type AnswerResult = {
   checkName: StructuredCheckId;
   answer: string | null;
   evidence: RetrievedEvidence | null;
+  evidenceStack?: EvidenceStackItem[];
 };
 
 export type MethodologyExtraction = {
@@ -668,6 +671,7 @@ export function extractAnswerFromEvidence(
     checkName: selectedEvidence.checkName,
     answer: extractor(selectedEvidence.evidence),
     evidence: selectedEvidence.evidence,
+    evidenceStack: buildQuickCheckEvidenceStack(selectedEvidence.evidence),
   };
 }
 

--- a/src/lib/quickCheckV2/evidenceStackAdapter.ts
+++ b/src/lib/quickCheckV2/evidenceStackAdapter.ts
@@ -1,0 +1,105 @@
+import {
+  evidenceToStackItem,
+  getPrimaryEvidence,
+  normalizeEvidenceStack,
+  sortEvidenceStack,
+  type EvidenceStackItem,
+  type EvidenceStackRole,
+} from "@/lib/evidence/evidenceStack";
+import type { RetrievedEvidence } from "@/lib/quickCheckV2/evidence";
+
+type QuickCheckEvidenceCarrier = {
+  evidence: RetrievedEvidence | null;
+  evidenceStack?: EvidenceStackItem[] | null;
+};
+
+export type QuickCheckEvidenceStackDisplayItem = {
+  role: EvidenceStackRole;
+  roleLabel: string;
+  page: number;
+  quote: string;
+  sectionLabel: string | null;
+  spanId: string | null;
+  label: string | null;
+  reason: string | null;
+};
+
+const SOURCE_TYPES = new Set<RetrievedEvidence["sourceType"]>([
+  "fact_contract",
+  "exact_section",
+  "raw_text_fallback",
+]);
+
+function evidenceStackItemToRetrievedEvidence(
+  item: EvidenceStackItem | null,
+): RetrievedEvidence | null {
+  if (!item || !item.sourceType || !SOURCE_TYPES.has(item.sourceType as RetrievedEvidence["sourceType"])) {
+    return null;
+  }
+
+  return {
+    sourceType: item.sourceType as RetrievedEvidence["sourceType"],
+    quote: item.quote,
+    page: item.page,
+    sectionHeading: item.sectionHeading ?? null,
+    sectionPath: item.sectionPath ?? [],
+    spanId: item.spanId ?? "",
+  };
+}
+
+export function buildQuickCheckEvidenceStack(
+  evidence: RetrievedEvidence | null,
+  evidenceStack?: EvidenceStackItem[] | null,
+): EvidenceStackItem[] {
+  const normalized = normalizeEvidenceStack(
+    evidenceStack ?? (evidence ? [evidenceToStackItem(evidence, "primary")] : []),
+  );
+  return sortEvidenceStack(normalized);
+}
+
+export function normalizeQuickCheckEvidenceCarrier<T extends QuickCheckEvidenceCarrier>(
+  carrier: T,
+): T & { evidence: RetrievedEvidence | null; evidenceStack: EvidenceStackItem[] } {
+  const normalizedStack = buildQuickCheckEvidenceStack(carrier.evidence, carrier.evidenceStack);
+  const primaryEvidence = getPrimaryEvidence(normalizedStack);
+
+  return {
+    ...carrier,
+    evidence: carrier.evidence ?? evidenceStackItemToRetrievedEvidence(primaryEvidence),
+    evidenceStack: normalizedStack,
+  };
+}
+
+function buildSectionLabel(item: EvidenceStackItem): string | null {
+  if (item.sectionHeading?.trim()) return item.sectionHeading.trim();
+  if (item.sectionPath?.length) return item.sectionPath.join(" › ");
+  return null;
+}
+
+function roleLabel(role: EvidenceStackRole): string {
+  switch (role) {
+    case "primary":
+      return "Primary";
+    case "supporting":
+      return "Supporting";
+    case "caveat":
+      return "Caveat";
+    case "blocker":
+      return "Blocker";
+  }
+}
+
+export function buildQuickCheckEvidenceStackDisplay(
+  stack: EvidenceStackItem[] | null | undefined,
+): QuickCheckEvidenceStackDisplayItem[] {
+  return sortEvidenceStack(normalizeEvidenceStack(stack ?? [])).map((item) => ({
+    role: item.role,
+    roleLabel: roleLabel(item.role),
+    page: item.page,
+    quote: item.quote,
+    sectionLabel: buildSectionLabel(item),
+    spanId: item.spanId ?? null,
+    label: item.label ?? null,
+    reason: item.reason ?? null,
+  }));
+}

--- a/src/lib/quickCheckV2/status/index.ts
+++ b/src/lib/quickCheckV2/status/index.ts
@@ -22,9 +22,15 @@
 import type { AnswerResult } from "@/lib/quickCheckV2/answers";
 import type { RetrievedEvidence, StructuredCheckId } from "@/lib/quickCheckV2/evidence";
 import {
+  hasPrimaryEvidence,
+  validateEvidenceStackForStatus,
+  type EvidenceStackItem,
+} from "@/lib/evidence/evidenceStack";
+import {
   buildQuickCheckMethodologyIdentity,
   type QuickCheckMethodologyIdentity,
 } from "@/lib/quickCheckV2/methodologyIdentity";
+import { normalizeQuickCheckEvidenceCarrier } from "@/lib/quickCheckV2/evidenceStackAdapter";
 
 export type QuickCheckStatus = "FOUND" | "UNCLEAR" | "MISSING";
 
@@ -42,6 +48,7 @@ export type StatusResult = {
   status: QuickCheckStatus;
   answer: string | null;
   evidence: RetrievedEvidence | null;
+  evidenceStack?: EvidenceStackItem[];
   reason: StatusReason;
   methodology?: QuickCheckMethodologyIdentity | null;
 };
@@ -85,93 +92,108 @@ function hasWithoutProjectNarrative(evidence: RetrievedEvidence): boolean {
 }
 
 export function validateAnswerResult(result: AnswerResult): StatusResult {
-  const methodology = result.checkName === "methodology"
-    ? buildQuickCheckMethodologyIdentity(result.evidence)
+  const normalizedResult = normalizeQuickCheckEvidenceCarrier(result);
+  const methodology = normalizedResult.checkName === "methodology"
+    ? buildQuickCheckMethodologyIdentity(normalizedResult.evidence)
     : undefined;
+  const evidenceStackProps = normalizedResult.evidenceStack.length > 0
+    ? { evidenceStack: normalizedResult.evidenceStack }
+    : {};
 
-  if (!result.evidence) {
+  if (!normalizedResult.evidence) {
     return {
-      checkName: result.checkName,
+      checkName: normalizedResult.checkName,
       status: "MISSING",
-      answer: result.answer,
-      evidence: result.evidence,
+      answer: normalizedResult.answer,
+      evidence: normalizedResult.evidence,
       reason: "evidence_missing",
+      ...evidenceStackProps,
     };
   }
 
-  if (!hasText(result.answer)) {
+  if (!hasText(normalizedResult.answer)) {
     return {
-      checkName: result.checkName,
+      checkName: normalizedResult.checkName,
       status: "UNCLEAR",
-      answer: result.answer,
-      evidence: result.evidence,
+      answer: normalizedResult.answer,
+      evidence: normalizedResult.evidence,
       reason: "answer_missing",
       ...(methodology ? { methodology } : {}),
-    };
-  }
-
-  if (!hasCompleteProvenance(result.evidence)) {
-    return {
-      checkName: result.checkName,
-      status: "UNCLEAR",
-      answer: result.answer,
-      evidence: result.evidence,
-      reason: "provenance_incomplete",
-      ...(methodology ? { methodology } : {}),
+      ...evidenceStackProps,
     };
   }
 
   if (
-    result.checkName === "baseline_scenario" ||
-    result.checkName === "additionality" ||
-    result.checkName === "leakage" ||
-    result.checkName === "stakeholder_consultation"
+    !hasPrimaryEvidence(normalizedResult.evidenceStack) ||
+    !validateEvidenceStackForStatus("FOUND", normalizedResult.evidenceStack).valid ||
+    !hasCompleteProvenance(normalizedResult.evidence)
   ) {
-    if (hasUnderDevelopmentStub(result.evidence)) {
+    return {
+      checkName: normalizedResult.checkName,
+      status: "UNCLEAR",
+      answer: normalizedResult.answer,
+      evidence: normalizedResult.evidence,
+      reason: "provenance_incomplete",
+      ...(methodology ? { methodology } : {}),
+      ...evidenceStackProps,
+    };
+  }
+
+  if (
+    normalizedResult.checkName === "baseline_scenario" ||
+    normalizedResult.checkName === "additionality" ||
+    normalizedResult.checkName === "leakage" ||
+    normalizedResult.checkName === "stakeholder_consultation"
+  ) {
+    if (hasUnderDevelopmentStub(normalizedResult.evidence)) {
       return {
-        checkName: result.checkName,
+        checkName: normalizedResult.checkName,
         status: "UNCLEAR",
-        answer: result.answer,
-        evidence: result.evidence,
+        answer: normalizedResult.answer,
+        evidence: normalizedResult.evidence,
         reason: "under_development_stub",
         ...(methodology ? { methodology } : {}),
+        ...evidenceStackProps,
       };
     }
   }
 
   if (
-    result.checkName === "additionality" &&
-    !/additionality/i.test(result.evidence.sectionHeading ?? "") &&
-    hasWithoutProjectNarrative(result.evidence)
+    normalizedResult.checkName === "additionality" &&
+    !/additionality/i.test(normalizedResult.evidence.sectionHeading ?? "") &&
+    hasWithoutProjectNarrative(normalizedResult.evidence)
   ) {
     return {
-      checkName: result.checkName,
+      checkName: normalizedResult.checkName,
       status: "UNCLEAR",
-      answer: result.answer,
-      evidence: result.evidence,
+      answer: normalizedResult.answer,
+      evidence: normalizedResult.evidence,
       reason: "without_project_narrative_not_additionality_proof",
       ...(methodology ? { methodology } : {}),
+      ...evidenceStackProps,
     };
   }
 
-  if (result.evidence.sourceType === "raw_text_fallback") {
+  if (normalizedResult.evidence.sourceType === "raw_text_fallback") {
     return {
-      checkName: result.checkName,
+      checkName: normalizedResult.checkName,
       status: "UNCLEAR",
-      answer: result.answer,
-      evidence: result.evidence,
+      answer: normalizedResult.answer,
+      evidence: normalizedResult.evidence,
       reason: "fallback_evidence_only",
       ...(methodology ? { methodology } : {}),
+      ...evidenceStackProps,
     };
   }
 
   return {
-    checkName: result.checkName,
+    checkName: normalizedResult.checkName,
     status: "FOUND",
-    answer: result.answer,
-    evidence: result.evidence,
+    answer: normalizedResult.answer,
+    evidence: normalizedResult.evidence,
     reason: "answer_and_provenance_complete",
     ...(methodology ? { methodology } : {}),
+    ...evidenceStackProps,
   };
 }
 

--- a/tests/lib/evidence/evidenceStack.test.ts
+++ b/tests/lib/evidence/evidenceStack.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  evidenceToStackItem,
+  getPrimaryEvidence,
+  groupEvidenceStackByRole,
+  hasPrimaryEvidence,
+  normalizeEvidenceStack,
+  sortEvidenceStack,
+  validateEvidenceStack,
+  validateEvidenceStackForStatus,
+} from "@/lib/evidence/evidenceStack";
+
+describe("Evidence Stack", () => {
+  it("validates allowed roles", () => {
+    const result = validateEvidenceStack([
+      { role: "primary", page: 12, quote: "Primary quote." },
+      { role: "supporting", page: 13, quote: "Supporting quote." },
+      { role: "caveat", page: 14, quote: "Caveat quote." },
+      { role: "blocker", page: 15, quote: "Blocker quote." },
+    ]);
+
+    expect(result).toStrictEqual({ valid: true, errors: [] });
+  });
+
+  it("rejects unknown roles", () => {
+    const result = validateEvidenceStack([
+      { role: "unknown" as never, page: 12, quote: "Quote." },
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('stack[0] has an invalid role "unknown"');
+  });
+
+  it("rejects missing or invalid page values", () => {
+    const result = validateEvidenceStack([
+      { role: "primary", page: 0, quote: "Quote." },
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("stack[0] must have a finite positive page number");
+  });
+
+  it("rejects empty quotes", () => {
+    const result = validateEvidenceStack([
+      { role: "primary", page: 3, quote: "   " },
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("stack[0] must have a non-empty quote");
+  });
+
+  it("sorts primary, supporting, caveat, and blocker in that order", () => {
+    const sorted = sortEvidenceStack([
+      { role: "blocker", page: 4, quote: "Blocker." },
+      { role: "supporting", page: 2, quote: "Supporting." },
+      { role: "primary", page: 1, quote: "Primary." },
+      { role: "caveat", page: 3, quote: "Caveat." },
+    ]);
+
+    expect(sorted.map((item) => item.role)).toStrictEqual([
+      "primary",
+      "supporting",
+      "caveat",
+      "blocker",
+    ]);
+  });
+
+  it("preserves original order within each role", () => {
+    const sorted = sortEvidenceStack([
+      { role: "supporting", page: 2, quote: "Supporting A." },
+      { role: "supporting", page: 3, quote: "Supporting B." },
+      { role: "primary", page: 1, quote: "Primary." },
+      { role: "caveat", page: 4, quote: "Caveat A." },
+      { role: "caveat", page: 5, quote: "Caveat B." },
+    ]);
+
+    expect(sorted.map((item) => item.quote)).toStrictEqual([
+      "Primary.",
+      "Supporting A.",
+      "Supporting B.",
+      "Caveat A.",
+      "Caveat B.",
+    ]);
+  });
+
+  it("returns the first primary evidence item", () => {
+    const stack = normalizeEvidenceStack([
+      { role: "supporting", page: 2, quote: "Supporting." },
+      { role: "primary", page: 1, quote: "Primary A." },
+      { role: "primary", page: 3, quote: "Primary B." },
+    ]);
+
+    expect(getPrimaryEvidence(stack)?.quote).toBe("Primary A.");
+    expect(hasPrimaryEvidence(stack)).toBe(true);
+  });
+
+  it("groups items by role without dropping caveats or blockers", () => {
+    const grouped = groupEvidenceStackByRole([
+      { role: "primary", page: 1, quote: "Primary." },
+      { role: "caveat", page: 2, quote: "Caveat." },
+      { role: "blocker", page: 3, quote: "Blocker." },
+    ]);
+
+    expect(grouped.primary).toHaveLength(1);
+    expect(grouped.caveat).toHaveLength(1);
+    expect(grouped.blocker).toHaveLength(1);
+  });
+
+  it("rejects FOUND without primary evidence", () => {
+    const result = validateEvidenceStackForStatus("FOUND", [
+      { role: "supporting", page: 2, quote: "Supporting only." },
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("FOUND/answered evidence requires at least one primary citation");
+  });
+
+  it("builds a normalized stack item from legacy evidence", () => {
+    expect(
+      evidenceToStackItem({
+        page: 8,
+        quote: "Legacy quote.",
+        sectionHeading: "Section 2",
+        sectionPath: ["2"],
+        spanId: "doc:p8:b1",
+        sourceType: "exact_section",
+      }),
+    ).toStrictEqual({
+      role: "primary",
+      page: 8,
+      quote: "Legacy quote.",
+      sectionHeading: "Section 2",
+      sectionPath: ["2"],
+      spanId: "doc:p8:b1",
+      sourceType: "exact_section",
+      label: undefined,
+      reason: undefined,
+    });
+  });
+});

--- a/tests/lib/quickCheckV2/answer-extractors.test.ts
+++ b/tests/lib/quickCheckV2/answer-extractors.test.ts
@@ -209,6 +209,7 @@ describe("Quick Check v2 — Phase 4 tiny answer extractors", () => {
   it("keeps answers grounded in the selected Phase 3 evidence", () => {
     for (const result of answers) {
       expect(answerIsGroundedInEvidence(result.answer, result.evidence)).toBe(true);
+      expect(result.evidenceStack?.[0]?.role).toBe("primary");
     }
   });
 
@@ -296,6 +297,7 @@ describe("Quick Check v2 — Phase 4 tiny answer extractors", () => {
       checkName: "additionality",
       answer: null,
       evidence: null,
+      evidenceStack: [],
     });
   });
 
@@ -307,7 +309,7 @@ describe("Quick Check v2 — Phase 4 tiny answer extractors", () => {
 
   it("does not leak status, score, or router fields", () => {
     for (const result of answers) {
-      expect(Object.keys(result)).toStrictEqual(["checkName", "answer", "evidence"]);
+      expect(Object.keys(result)).toStrictEqual(["checkName", "answer", "evidence", "evidenceStack"]);
       expect(Object.keys(result)).not.toContain("status");
       expect(Object.keys(result)).not.toContain("score");
       expect(Object.keys(result)).not.toContain("router");

--- a/tests/lib/quickCheckV2/evidence-stack-adapter.test.ts
+++ b/tests/lib/quickCheckV2/evidence-stack-adapter.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "@jest/globals";
+import { extractAnswerFromEvidence } from "@/lib/quickCheckV2/answers";
+import {
+  buildQuickCheckEvidenceStackDisplay,
+  normalizeQuickCheckEvidenceCarrier,
+} from "@/lib/quickCheckV2/evidenceStackAdapter";
+import { buildComparableQuickCheckRecord } from "./goldComparison";
+
+describe("Quick Check v2 evidence stack adapter", () => {
+  const evidence = {
+    sourceType: "exact_section" as const,
+    quote: "Primary quote from the project description.",
+    page: 17,
+    sectionHeading: "Additionality",
+    sectionPath: ["3", "3.2"],
+    spanId: "synthetic-doc:p17:b1",
+  };
+
+  it("normalizes legacy single evidence into a primary evidence stack", () => {
+    const result = extractAnswerFromEvidence({
+      checkName: "additionality",
+      evidence,
+    });
+
+    expect(result.evidence).toStrictEqual(evidence);
+    expect(result.evidenceStack).toStrictEqual([
+      {
+        role: "primary",
+        page: 17,
+        quote: "Primary quote from the project description.",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.2"],
+        spanId: "synthetic-doc:p17:b1",
+        sourceType: "exact_section",
+        label: undefined,
+        reason: undefined,
+      },
+    ]);
+  });
+
+  it("keeps existing result.evidence usable for legacy consumers", () => {
+    const normalized = normalizeQuickCheckEvidenceCarrier({
+      evidence,
+      evidenceStack: [
+        {
+          role: "primary",
+          page: 17,
+          quote: "Primary quote from the project description.",
+          sectionHeading: "Additionality",
+          sectionPath: ["3", "3.2"],
+          spanId: "synthetic-doc:p17:b1",
+          sourceType: "exact_section",
+        },
+        {
+          role: "caveat",
+          page: 18,
+          quote: "Formal VCS section is still incomplete.",
+          sectionHeading: "Additionality caveat",
+          sectionPath: ["3", "3.3"],
+          spanId: "synthetic-doc:p18:b1",
+          sourceType: "exact_section",
+        },
+      ],
+    });
+
+    expect(normalized.evidence).toStrictEqual(evidence);
+    expect(normalized.evidenceStack).toHaveLength(2);
+  });
+
+  it("formats primary first and keeps caveat/blocker labels with page numbers", () => {
+    const display = buildQuickCheckEvidenceStackDisplay([
+      {
+        role: "blocker",
+        page: 22,
+        quote: "A blocker quote.",
+      },
+      {
+        role: "primary",
+        page: 17,
+        quote: "Primary quote from the project description.",
+        sectionHeading: "Additionality",
+      },
+      {
+        role: "caveat",
+        page: 19,
+        quote: "A caveat quote.",
+        sectionHeading: "Additionality caveat",
+      },
+    ]);
+
+    expect(display.map((item) => item.roleLabel)).toStrictEqual([
+      "Primary",
+      "Caveat",
+      "Blocker",
+    ]);
+    expect(display.map((item) => item.page)).toStrictEqual([17, 19, 22]);
+  });
+
+  it("compares legacy gold exactly when expected evidenceStack is absent", () => {
+    const comparable = buildComparableQuickCheckRecord(
+      {
+        checkName: "additionality",
+        status: "FOUND",
+        answer: "Additionality is demonstrated.",
+        evidence,
+        evidenceStack: [
+          {
+            role: "primary",
+            page: 17,
+            quote: "Primary quote from the project description.",
+            sectionHeading: "Additionality",
+            sectionPath: ["3", "3.2"],
+            spanId: "synthetic-doc:p17:b1",
+            sourceType: "exact_section",
+          },
+          {
+            role: "supporting",
+            page: 18,
+            quote: "Supporting quote.",
+            sectionHeading: "Additionality support",
+            sectionPath: ["3", "3.2.1"],
+            spanId: "synthetic-doc:p18:b1",
+            sourceType: "exact_section",
+          },
+        ],
+        reason: "answer_and_provenance_complete",
+      },
+      {
+        checkName: "additionality",
+        expectedStatus: "FOUND",
+        expectedAnswer: "Additionality is demonstrated.",
+        goldQuote: "Primary quote from the project description.",
+        page: 17,
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.2"],
+        spanId: "synthetic-doc:p17:b1",
+        sourceType: "exact_section",
+      },
+    );
+
+    expect("evidenceStack" in comparable).toBe(false);
+  });
+
+  it("includes evidenceStack comparison only when expected gold asks for it", () => {
+    const comparable = buildComparableQuickCheckRecord(
+      {
+        checkName: "additionality",
+        status: "UNCLEAR",
+        answer: "Additionality evidence exists but remains qualified.",
+        evidence,
+        evidenceStack: [
+          {
+            role: "primary",
+            page: 17,
+            quote: "Primary quote from the project description.",
+            sectionHeading: "Additionality",
+            sectionPath: ["3", "3.2"],
+            spanId: "synthetic-doc:p17:b1",
+            sourceType: "exact_section",
+          },
+          {
+            role: "caveat",
+            page: 18,
+            quote: "Formal VCS section is still incomplete.",
+            sectionHeading: "Additionality caveat",
+            sectionPath: ["3", "3.3"],
+            spanId: "synthetic-doc:p18:b1",
+            sourceType: "exact_section",
+            label: "Formal section gap",
+            reason: "Not required at this stage",
+          },
+        ],
+        reason: "provenance_incomplete",
+      },
+      {
+        checkName: "additionality",
+        expectedStatus: "UNCLEAR",
+        expectedAnswer: "Additionality evidence exists but remains qualified.",
+        goldQuote: "Primary quote from the project description.",
+        page: 17,
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.2"],
+        spanId: "synthetic-doc:p17:b1",
+        sourceType: "exact_section",
+        evidenceStack: [
+          {
+            role: "primary",
+            page: 17,
+            quote: "Primary quote from the project description.",
+            sectionHeading: "Additionality",
+            sectionPath: ["3", "3.2"],
+            spanId: "synthetic-doc:p17:b1",
+            sourceType: "exact_section",
+          },
+          {
+            role: "caveat",
+            page: 18,
+            quote: "Formal VCS section is still incomplete.",
+            sectionHeading: "Additionality caveat",
+            sectionPath: ["3", "3.3"],
+            spanId: "synthetic-doc:p18:b1",
+            sourceType: "exact_section",
+            label: "Formal section gap",
+            reason: "Not required at this stage",
+          },
+        ],
+      },
+    );
+
+    expect(comparable.evidenceStack).toStrictEqual([
+      {
+        role: "primary",
+        page: 17,
+        quote: "Primary quote from the project description.",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.2"],
+        spanId: "synthetic-doc:p17:b1",
+        sourceType: "exact_section",
+        label: undefined,
+        reason: undefined,
+      },
+      {
+        role: "caveat",
+        page: 18,
+        quote: "Formal VCS section is still incomplete.",
+        sectionHeading: "Additionality caveat",
+        sectionPath: ["3", "3.3"],
+        spanId: "synthetic-doc:p18:b1",
+        sourceType: "exact_section",
+        label: "Formal section gap",
+        reason: "Not required at this stage",
+      },
+    ]);
+  });
+});

--- a/tests/lib/quickCheckV2/gold-fixtures.test.ts
+++ b/tests/lib/quickCheckV2/gold-fixtures.test.ts
@@ -17,6 +17,11 @@ import {
   type QuickCheckMethodologyIdentity,
 } from "@/lib/quickCheckV2/methodologyIdentity";
 import { normalizeDeclaredMethodologyVersion } from "@/lib/chat/methodologyVersion";
+import type { EvidenceStackItem } from "@/lib/evidence/evidenceStack";
+import {
+  buildComparableQuickCheckRecord,
+  type QuickCheckGoldComparableRecord,
+} from "./goldComparison";
 
 const FIXTURE_ROOT = path.resolve("tests/fixtures/quick-check/v2");
 
@@ -43,17 +48,9 @@ type FixtureMeta = {
   adjudicationStatus?: "pending" | "reviewed";
 };
 
-type GoldRecord = {
-  checkName: StructuredCheckId;
-  expectedStatus: "FOUND" | "UNCLEAR" | "MISSING";
-  expectedAnswer: string | null;
-  goldQuote: string | null;
-  page: number | null;
-  sectionHeading: string | null;
-  sectionPath: string[];
-  spanId: string | null;
-  sourceType: "fact_contract" | "exact_section" | "raw_text_fallback" | null;
+type GoldRecord = QuickCheckGoldComparableRecord & {
   expectedMethodology?: Partial<QuickCheckMethodologyIdentity>;
+  evidenceStack?: EvidenceStackItem[];
 };
 
 type PendingGoldDraft = {
@@ -246,18 +243,7 @@ function toGoldComparableRecord(
   expected: GoldRecord,
 ): GoldRecord {
   const methodology = buildComparableMethodology(document, result);
-
-  const record: GoldRecord = {
-    checkName: result.checkName,
-    expectedStatus: result.status,
-    expectedAnswer: result.answer,
-    goldQuote: result.evidence?.quote ?? null,
-    page: result.evidence?.page ?? null,
-    sectionHeading: result.evidence?.sectionHeading ?? null,
-    sectionPath: result.evidence?.sectionPath ?? [],
-    spanId: result.evidence?.spanId ?? null,
-    sourceType: result.evidence?.sourceType ?? null,
-  };
+  const record: GoldRecord = buildComparableQuickCheckRecord(result, expected);
 
   if (methodology && expected.expectedMethodology) {
     record.expectedMethodology = pickComparableMethodology(methodology, expected.expectedMethodology);

--- a/tests/lib/quickCheckV2/goldComparison.ts
+++ b/tests/lib/quickCheckV2/goldComparison.ts
@@ -1,0 +1,42 @@
+import {
+  normalizeEvidenceStack,
+  type EvidenceStackItem,
+} from "@/lib/evidence/evidenceStack";
+import type { StatusResult } from "@/lib/quickCheckV2/status";
+import type { StructuredCheckId } from "@/lib/quickCheckV2/evidence";
+
+export type QuickCheckGoldComparableRecord = {
+  checkName: StructuredCheckId;
+  expectedStatus: "FOUND" | "UNCLEAR" | "MISSING";
+  expectedAnswer: string | null;
+  goldQuote: string | null;
+  page: number | null;
+  sectionHeading: string | null;
+  sectionPath: string[];
+  spanId: string | null;
+  sourceType: "fact_contract" | "exact_section" | "raw_text_fallback" | null;
+  evidenceStack?: EvidenceStackItem[];
+};
+
+export function buildComparableQuickCheckRecord(
+  result: Pick<StatusResult, "checkName" | "status" | "answer" | "evidence" | "evidenceStack">,
+  expected: Pick<QuickCheckGoldComparableRecord, "evidenceStack">,
+): QuickCheckGoldComparableRecord {
+  const record: QuickCheckGoldComparableRecord = {
+    checkName: result.checkName,
+    expectedStatus: result.status,
+    expectedAnswer: result.answer,
+    goldQuote: result.evidence?.quote ?? null,
+    page: result.evidence?.page ?? null,
+    sectionHeading: result.evidence?.sectionHeading ?? null,
+    sectionPath: result.evidence?.sectionPath ?? [],
+    spanId: result.evidence?.spanId ?? null,
+    sourceType: result.evidence?.sourceType ?? null,
+  };
+
+  if (expected.evidenceStack) {
+    record.evidenceStack = normalizeEvidenceStack(result.evidenceStack ?? []);
+  }
+
+  return record;
+}

--- a/tests/lib/quickCheckV2/status-validator.test.ts
+++ b/tests/lib/quickCheckV2/status-validator.test.ts
@@ -17,7 +17,7 @@ const STATUS_SOURCE_PATH = path.resolve("src/lib/quickCheckV2/status/index.ts");
 function makeAnswerResult(
   overrides: Partial<AnswerResult>,
 ): AnswerResult {
-  return {
+  const result: AnswerResult = {
     checkName: "additionality",
     answer: "Additionality is demonstrated.",
     evidence: {
@@ -28,8 +28,25 @@ function makeAnswerResult(
       sectionPath: ["3", "3.2"],
       spanId: "synthetic-doc:p38:b0:add",
     },
+    evidenceStack: [
+      {
+        role: "primary",
+        page: 38,
+        quote: "Additionality is demonstrated.",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.2"],
+        spanId: "synthetic-doc:p38:b0:add",
+        sourceType: "exact_section",
+      },
+    ],
     ...overrides,
   };
+
+  if (result.evidence === null && overrides.evidenceStack === undefined) {
+    result.evidenceStack = [];
+  }
+
+  return result;
 }
 
 describe("Quick Check v2 — Phase 5 deterministic status validator", () => {
@@ -136,6 +153,28 @@ describe("Quick Check v2 — Phase 5 deterministic status validator", () => {
 
     expect(result.status).toBe("FOUND");
     expect(result.reason).toBe("answer_and_provenance_complete");
+    expect(result.evidenceStack?.[0]?.role).toBe("primary");
+  });
+
+  it("returns UNCLEAR when the evidence stack has no primary citation", () => {
+    const result = validateAnswerResult(
+      makeAnswerResult({
+        evidenceStack: [
+          {
+            role: "supporting",
+            page: 38,
+            quote: "Supporting evidence only.",
+            sectionHeading: "Additionality",
+            sectionPath: ["3", "3.2"],
+            spanId: "synthetic-doc:p38:b0:add",
+            sourceType: "exact_section",
+          },
+        ],
+      }),
+    );
+
+    expect(result.status).toBe("UNCLEAR");
+    expect(result.reason).toBe("provenance_incomplete");
   });
 
   it("includes a structured methodology identity on methodology rows", () => {
@@ -193,8 +232,8 @@ describe("Quick Check v2 — Phase 5 deterministic status validator", () => {
       const keys = Object.keys(result).sort();
       expect(keys).toEqual(
         result.checkName === "methodology"
-          ? ["answer", "checkName", "evidence", "methodology", "reason", "status"]
-          : ["answer", "checkName", "evidence", "reason", "status"],
+          ? ["answer", "checkName", "evidence", "evidenceStack", "methodology", "reason", "status"]
+          : ["answer", "checkName", "evidence", "evidenceStack", "reason", "status"],
       );
       expect(Object.keys(result)).not.toContain("score");
       expect(Object.keys(result)).not.toContain("router");


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- - RC5: in_progress -->
  <!-- - PR12: done -->
  <!-- - PR13: in_progress -->

For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactors with no SSOT impact), leave `slug: N/A`. The roadmap gates will skip.

Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.

## Guardrails

- [ ] Confirmed source fixes are generic and not fixture-shaped.
- [ ] No project names, project IDs, exact page gates, or gold answer strings were added to source code.
- [ ] Methodology fixes extract IDs and versions generically instead of hardcoding one fixture pair.

## Summary

This PR adds a shared Evidence Stack module and wires Quick Check v2 as the first consumer while preserving the existing single-citation shape for backward compatibility.

- Shared evidence module for normalized multi-citation handling.
- Quick Check v2 adapter that mirrors legacy `result.evidence` to the primary stack item.
- Minimal UI support to surface additional supporting, caveat, and blocker evidence.
- Gold comparison stays opt-in for `evidenceStack`, so existing fixtures remain unchanged.

## Validation

- `npx jest --runInBand tests/lib/evidence/evidenceStack.test.ts tests/lib/quickCheckV2/evidence-stack-adapter.test.ts tests/lib/quickCheckV2/status-validator.test.ts tests/lib/quickCheckV2/answer-extractors.test.ts`
- `npx jest --runInBand tests/lib/quickCheckV2/gold-fixtures.test.ts tests/lib/quickCheckV2/evidence-stack-adapter.test.ts tests/lib/evidence/evidenceStack.test.ts`
- `npm run test:quickcheck:no-fixture-hardcoding`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run pr:gate`

## Notes

- `public/manifest/index.json` was restored and is not included.
- Evidence Map UI was not built in this PR.
