### PR TITLE
Fix/vm0007 v18 declaration extraction from pr956

### DIFF
--- a/src/lib/chat/methodologyVersion.ts
+++ b/src/lib/chat/methodologyVersion.ts
@@ -2,8 +2,8 @@ function normalizeDashCharacters(value: string): string {
   return value.replace(/[\u2010-\u2015]/g, "-");
 }
 
-const METHODOLOGY_VERSION_CONTEXT_RE =
-  /\b(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-[A-Z0-9.-]+|GS-[A-Z0-9.-]+|VT\d{4}|methodology|framework|redd(?:\+\s*|[-\s]+)?mf)\b/i;
+const METHODOLOGY_DECLARATION_SUFFIX_RE =
+  /(?:\bmethodology\s+)?(?:\bVM\d{4}\b(?:\s+REDD\+?\s+Methodology\s+Framework)?|\bREDD(?:\+\s*|[-\s]+)?MF\b|\bREDD\+?\s+Methodology\s+Framework\b)(?:\s*\([^)]*\))?\s+([0-9]+(?:[.-][0-9]+)+)\s*$/i;
 
 function canonicalizeVersionSegments(rawSegments: string[]): string | null {
   const normalizedSegments: string[] = [];
@@ -47,9 +47,9 @@ export function normalizeMethodologyVersion(rawVersion: string | null | undefine
     return canonicalizeVersionSegments(bareMatch[1].split(/[.-]/));
   }
 
-  const contextualTrailingMatch = normalized.match(/([0-9]+(?:[.-][0-9]+)+)\s*$/);
-  if (contextualTrailingMatch?.[1] && METHODOLOGY_VERSION_CONTEXT_RE.test(normalized)) {
-    return canonicalizeVersionSegments(contextualTrailingMatch[1].split(/[.-]/));
+  const methodologyDeclarationSuffixMatch = normalized.match(METHODOLOGY_DECLARATION_SUFFIX_RE);
+  if (methodologyDeclarationSuffixMatch?.[1]) {
+    return canonicalizeVersionSegments(methodologyDeclarationSuffixMatch[1].split(/[.-]/));
   }
 
   return null;

--- a/src/lib/chat/methodologyVersion.ts
+++ b/src/lib/chat/methodologyVersion.ts
@@ -2,6 +2,9 @@ function normalizeDashCharacters(value: string): string {
   return value.replace(/[\u2010-\u2015]/g, "-");
 }
 
+const METHODOLOGY_VERSION_CONTEXT_RE =
+  /\b(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-[A-Z0-9.-]+|GS-[A-Z0-9.-]+|VT\d{4}|methodology|framework|redd(?:\+\s*|[-\s]+)?mf)\b/i;
+
 function canonicalizeVersionSegments(rawSegments: string[]): string | null {
   const normalizedSegments: string[] = [];
 
@@ -24,7 +27,7 @@ function canonicalizeVersionSegments(rawSegments: string[]): string | null {
   return `v${normalizedSegments.join(".")}`;
 }
 
-export function normalizeDeclaredMethodologyVersion(rawVersion: string | null | undefined): string | null {
+export function normalizeMethodologyVersion(rawVersion: string | null | undefined): string | null {
   if (typeof rawVersion !== "string") return null;
 
   const normalized = normalizeDashCharacters(rawVersion)
@@ -44,5 +47,12 @@ export function normalizeDeclaredMethodologyVersion(rawVersion: string | null | 
     return canonicalizeVersionSegments(bareMatch[1].split(/[.-]/));
   }
 
+  const contextualTrailingMatch = normalized.match(/([0-9]+(?:[.-][0-9]+)+)\s*$/);
+  if (contextualTrailingMatch?.[1] && METHODOLOGY_VERSION_CONTEXT_RE.test(normalized)) {
+    return canonicalizeVersionSegments(contextualTrailingMatch[1].split(/[.-]/));
+  }
+
   return null;
 }
+
+export const normalizeDeclaredMethodologyVersion = normalizeMethodologyVersion;

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -285,6 +285,22 @@ function extractDeclaredVersionTokens(text: string): string[] {
   return contextualVersion ? [contextualVersion] : [];
 }
 
+function extractDeclaredVersionTokensFromContinuation(input: {
+  line: string;
+  nextLine?: string;
+}): string[] {
+  const currentLineVersions = extractDeclaredVersionTokens(input.line);
+  if (currentLineVersions.length > 0) return currentLineVersions;
+
+  const nextLine = input.nextLine?.trim() ?? "";
+  if (!nextLine || isTableBoundaryLine(nextLine)) return [];
+
+  const combinedVersions = extractDeclaredVersionTokens(`${input.line} ${nextLine}`.trim());
+  if (combinedVersions.length > 0) return combinedVersions;
+
+  return extractDeclaredVersionTokens(nextLine);
+}
+
 function extractMethodologyBlock(rawText: string): string {
   const lines = rawText.split(/\n+/);
   const startIndex = lines.findIndex((line) =>
@@ -336,17 +352,15 @@ function collectProseDeclaredVersions(lines: string[], expectedMethodologyId: st
       || METHODOLOGY_DECLARATION_ANCHORS.some((pattern) => pattern.test(line));
     if (!hasExplicitMethodologyAnchor) continue;
 
-    const lineVersions = extractDeclaredVersionTokens(line);
+    const nextLine = lines[index + 1]?.trim();
+    const lineVersions = extractDeclaredVersionTokensFromContinuation({
+      line,
+      nextLine,
+    });
     if (lineVersions.length > 0) {
       declaredVersions.push(...lineVersions);
       continue;
     }
-
-    const nextLine = lines[index + 1]?.trim();
-    if (!nextLine || isTableBoundaryLine(nextLine)) continue;
-    const nextLineVersions = extractDeclaredVersionTokens(nextLine);
-    if (nextLineVersions.length === 0) continue;
-    declaredVersions.push(...nextLineVersions);
   }
 
   return Array.from(new Set(declaredVersions));

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -1,5 +1,5 @@
 import type { DocumentStructure } from "@/lib/documentModel";
-import { normalizeDeclaredMethodologyVersion } from "@/lib/chat/methodologyVersion";
+import { normalizeMethodologyVersion } from "@/lib/chat/methodologyVersion";
 import type { EvidenceDocument, EvidenceSpan } from "@/lib/quickCheck/evidence/evidenceTypes";
 
 export const EVIDENCE_AUDIT_STATUSES = [
@@ -15,7 +15,10 @@ export type EvidenceAuditConfidence = "high" | "medium" | "low";
 
 export type MethodologyVersionLock = Readonly<{
   methodologyId: string;
+  rulebookVersionRaw: string;
+  rulebookVersionKey: string;
   rulebookVersion: string;
+  pddDeclaredMethodologyVersionRaw: string;
   pddDeclaredMethodologyVersion: string;
   versionMatch: boolean;
   versionMismatchReason: string;
@@ -58,7 +61,10 @@ export type MethodologyEvidenceAuditResult = {
   title: string;
   ruleLogic: string;
   methodologyId?: string;
+  rulebookVersionRaw?: string;
+  rulebookVersionKey?: string;
   rulebookVersion?: string;
+  pddDeclaredMethodologyVersionRaw?: string;
   pddDeclaredMethodologyVersion?: string;
   versionMatch?: boolean;
   versionMismatchReason?: string;
@@ -78,7 +84,10 @@ export type MethodologyEvidenceAuditResult = {
 export type MethodologyEvidenceAuditSummary = {
   auditStatus?: "AUDITED" | "VERSION_WARNING_ACCEPTED" | "BLOCKED_VERSION_MISMATCH";
   methodologyId?: string;
+  rulebookVersionRaw?: string;
+  rulebookVersionKey?: string;
   rulebookVersion?: string;
+  pddDeclaredMethodologyVersionRaw?: string;
   pddDeclaredMethodologyVersion?: string;
   versionMatch?: boolean;
   versionMismatchReason?: string;
@@ -195,7 +204,7 @@ function normalizeMethodologyId(value: string | null | undefined): string {
 function normalizeVersionValue(value: string | null | undefined): string {
   const trimmed = (value ?? "").trim();
   if (!trimmed) return "";
-  return normalizeDeclaredMethodologyVersion(trimmed) ?? (trimmed.startsWith("v") ? trimmed : `v${trimmed}`);
+  return normalizeMethodologyVersion(trimmed) ?? (trimmed.startsWith("v") ? trimmed : `v${trimmed}`);
 }
 
 function normalizeVersionKey(value: string | null | undefined): string {
@@ -268,6 +277,14 @@ function extractExplicitVersionTokens(text: string): string[] {
   );
 }
 
+function extractDeclaredVersionTokens(text: string): string[] {
+  const explicitVersions = extractExplicitVersionTokens(text);
+  if (explicitVersions.length > 0) return explicitVersions;
+
+  const contextualVersion = normalizeMethodologyVersion(text);
+  return contextualVersion ? [contextualVersion] : [];
+}
+
 function extractMethodologyBlock(rawText: string): string {
   const lines = rawText.split(/\n+/);
   const startIndex = lines.findIndex((line) =>
@@ -319,7 +336,7 @@ function collectProseDeclaredVersions(lines: string[], expectedMethodologyId: st
       || METHODOLOGY_DECLARATION_ANCHORS.some((pattern) => pattern.test(line));
     if (!hasExplicitMethodologyAnchor) continue;
 
-    const lineVersions = extractExplicitVersionTokens(line);
+    const lineVersions = extractDeclaredVersionTokens(line);
     if (lineVersions.length > 0) {
       declaredVersions.push(...lineVersions);
       continue;
@@ -327,7 +344,7 @@ function collectProseDeclaredVersions(lines: string[], expectedMethodologyId: st
 
     const nextLine = lines[index + 1]?.trim();
     if (!nextLine || isTableBoundaryLine(nextLine)) continue;
-    const nextLineVersions = extractExplicitVersionTokens(nextLine);
+    const nextLineVersions = extractDeclaredVersionTokens(nextLine);
     if (nextLineVersions.length === 0) continue;
     declaredVersions.push(...nextLineVersions);
   }
@@ -447,20 +464,27 @@ export function buildMethodologyVersionLock(input: {
   userAcceptedVersionWarning?: boolean;
 }): MethodologyVersionLock {
   const methodologyId = normalizeMethodologyId(input.methodologyId);
-  const rulebookVersion = normalizeVersionValue(input.rulebookVersion);
-  const pddDeclaredMethodologyVersion = input.pddDeclaredMethodologyVersion.trim();
-  const declaredReference = extractDeclaredMethodologyReferenceFromText(pddDeclaredMethodologyVersion, methodologyId);
+  const rulebookVersionRaw = input.rulebookVersion.trim();
+  const rulebookVersion = normalizeVersionValue(rulebookVersionRaw);
+  const pddDeclaredMethodologyVersionRaw = input.pddDeclaredMethodologyVersion.trim();
+  const declaredReference = extractDeclaredMethodologyReferenceFromText(pddDeclaredMethodologyVersionRaw, methodologyId);
+  const pddDeclaredMethodologyVersion = declaredReference.declaredRulebookVersions.length === 1
+    ? normalizeVersionValue(declaredReference.declaredRulebookVersions[0] ?? "")
+    : normalizeMethodologyVersion(pddDeclaredMethodologyVersionRaw) ?? pddDeclaredMethodologyVersionRaw;
   const versionMismatchReason = buildVersionMismatchReason({
     methodologyId,
     rulebookVersion,
-    pddDeclaredMethodologyVersion,
+    pddDeclaredMethodologyVersion: pddDeclaredMethodologyVersionRaw,
     declaredMethodologyId: declaredReference.declaredMethodologyId,
     declaredRulebookVersions: declaredReference.declaredRulebookVersions,
   });
 
   return Object.freeze({
     methodologyId,
+    rulebookVersionRaw,
+    rulebookVersionKey: rulebookVersionRaw,
     rulebookVersion,
+    pddDeclaredMethodologyVersionRaw,
     pddDeclaredMethodologyVersion,
     versionMatch: versionMismatchReason.length === 0,
     versionMismatchReason,
@@ -943,7 +967,10 @@ function resultFromCandidate(input: {
     title: resolveRuleTitle(input.rule),
     ruleLogic: resolveRuleLogic(input.rule),
     methodologyId: input.versionLock.methodologyId,
+    rulebookVersionRaw: input.versionLock.rulebookVersionRaw,
+    rulebookVersionKey: input.versionLock.rulebookVersionKey,
     rulebookVersion: input.versionLock.rulebookVersion,
+    pddDeclaredMethodologyVersionRaw: input.versionLock.pddDeclaredMethodologyVersionRaw,
     pddDeclaredMethodologyVersion: input.versionLock.pddDeclaredMethodologyVersion,
     versionMatch: input.versionLock.versionMatch,
     versionMismatchReason: input.versionLock.versionMismatchReason,
@@ -964,15 +991,18 @@ function resultFromCandidate(input: {
 export function auditEvidence(input: MethodologyEvidenceAuditInput): MethodologyEvidenceAuditSummary {
   const versionLock = resolveAuditVersionLock(input);
   const userAcceptedVersionWarning = Boolean(input.userAcceptedVersionWarning);
-  if (!versionLock.versionMatch && !userAcceptedVersionWarning) {
+  if (!versionLock.versionMatch) {
     return {
       auditStatus: "BLOCKED_VERSION_MISMATCH",
       methodologyId: versionLock.methodologyId,
+      rulebookVersionRaw: versionLock.rulebookVersionRaw,
+      rulebookVersionKey: versionLock.rulebookVersionKey,
       rulebookVersion: versionLock.rulebookVersion,
+      pddDeclaredMethodologyVersionRaw: versionLock.pddDeclaredMethodologyVersionRaw,
       pddDeclaredMethodologyVersion: versionLock.pddDeclaredMethodologyVersion,
       versionMatch: false,
       versionMismatchReason: versionLock.versionMismatchReason,
-      userAcceptedVersionWarning: false,
+      userAcceptedVersionWarning,
       results: [],
       totals: {
         supported_by_pdd: 0,
@@ -985,9 +1015,7 @@ export function auditEvidence(input: MethodologyEvidenceAuditInput): Methodology
     };
   }
 
-  const auditStatus = !versionLock.versionMatch && userAcceptedVersionWarning
-    ? "VERSION_WARNING_ACCEPTED"
-    : "AUDITED";
+  const auditStatus = "AUDITED";
 
   const results = input.rules.map((rule) => {
     const contract = input.getContract(rule);
@@ -1038,7 +1066,10 @@ export function auditEvidence(input: MethodologyEvidenceAuditInput): Methodology
   return {
     auditStatus,
     methodologyId: versionLock.methodologyId,
+    rulebookVersionRaw: versionLock.rulebookVersionRaw,
+    rulebookVersionKey: versionLock.rulebookVersionKey,
     rulebookVersion: versionLock.rulebookVersion,
+    pddDeclaredMethodologyVersionRaw: versionLock.pddDeclaredMethodologyVersionRaw,
     pddDeclaredMethodologyVersion: versionLock.pddDeclaredMethodologyVersion,
     versionMatch: versionLock.versionMatch,
     versionMismatchReason: versionLock.versionMismatchReason,

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -211,6 +211,13 @@ function normalizeVersionKey(value: string | null | undefined): string {
   return normalizeVersionValue(value).toLowerCase();
 }
 
+function isStandaloneDeclaredVersion(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return normalizeMethodologyVersion(trimmed) !== null
+    && /^(?:version\s+|ver\.?\s*|v\.?\s*)?\d+(?:[.-]\d+)*$/i.test(trimmed);
+}
+
 function extractDeclaredMethodologyId(rawValue: string): string {
   const normalized = rawValue.trim().toUpperCase();
   const match = normalized.match(/\b(VM\d{4}|AMS-[A-Z0-9.]+|AR-[A-Z0-9.]+|ACM\d{4}|AM\d{4}|GS-[A-Z0-9.]+)\b/);
@@ -481,10 +488,18 @@ export function buildMethodologyVersionLock(input: {
   const rulebookVersionRaw = input.rulebookVersion.trim();
   const rulebookVersion = normalizeVersionValue(rulebookVersionRaw);
   const pddDeclaredMethodologyVersionRaw = input.pddDeclaredMethodologyVersion.trim();
-  const declaredReference = extractDeclaredMethodologyReferenceFromText(pddDeclaredMethodologyVersionRaw, methodologyId);
+  const standaloneDeclaredVersion = isStandaloneDeclaredVersion(pddDeclaredMethodologyVersionRaw)
+    ? normalizeMethodologyVersion(pddDeclaredMethodologyVersionRaw)
+    : null;
+  const declaredReference = standaloneDeclaredVersion
+    ? {
+      declaredMethodologyId: methodologyId,
+      declaredRulebookVersions: [standaloneDeclaredVersion],
+    }
+    : extractDeclaredMethodologyReferenceFromText(pddDeclaredMethodologyVersionRaw, methodologyId);
   const pddDeclaredMethodologyVersion = declaredReference.declaredRulebookVersions.length === 1
     ? normalizeVersionValue(declaredReference.declaredRulebookVersions[0] ?? "")
-    : normalizeMethodologyVersion(pddDeclaredMethodologyVersionRaw) ?? pddDeclaredMethodologyVersionRaw;
+    : standaloneDeclaredVersion ?? pddDeclaredMethodologyVersionRaw;
   const versionMismatchReason = buildVersionMismatchReason({
     methodologyId,
     rulebookVersion,

--- a/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
+++ b/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
@@ -375,7 +375,7 @@ describe("QuickCheckPanel upload/session boundary smoke test — proves the pane
     expect(audit?.methodology?.methodologyName).toBeTruthy();
     expect(audit?.loadedRulebookId).toBe("VM0007");
     expect(audit?.loadedRulebookVersion).toBe("v1-0");
-    expect(audit?.audit.auditStatus).toBe("VERSION_WARNING_ACCEPTED");
+    expect(audit?.audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
     expect(audit?.audit.versionMatch).toBe(false);
     expect(audit?.audit.userAcceptedVersionWarning).toBe(true);
     expect(container.textContent ?? "").toContain("View Gap Report");

--- a/tests/components/vm0007GapReportPreview.test.tsx
+++ b/tests/components/vm0007GapReportPreview.test.tsx
@@ -42,9 +42,9 @@ function buildAllSupportedAudit() {
   };
 }
 
-function buildWarningAcceptedAudit(): MethodologyEvidenceAuditSummary {
+function buildBlockedMismatchAudit(): MethodologyEvidenceAuditSummary {
   return {
-    auditStatus: "VERSION_WARNING_ACCEPTED",
+    auditStatus: "BLOCKED_VERSION_MISMATCH",
     methodologyId: "VM0007",
     rulebookVersion: "v1-8",
     pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
@@ -148,7 +148,7 @@ describe("Vm0007GapReportPreview", () => {
     );
   });
 
-  test("renders the full report when a missing-version audit is accepted", async () => {
+  test("renders only the blocked mismatch message when a missing-version audit was accepted", async () => {
     saveVm0007GapReportAudit({
       auditId: "audit-warning-missing",
       methodologyId: "VM0007",
@@ -164,7 +164,7 @@ describe("Vm0007GapReportPreview", () => {
       generatedAt: "2026-07-03T00:00:00Z",
       evidenceFileName: "envira-amazonia-vm0007.pdf",
       userAcceptedVersionWarning: true,
-      audit: buildWarningAcceptedAudit(),
+      audit: buildBlockedMismatchAudit(),
     });
 
     await act(async () => {
@@ -175,16 +175,12 @@ describe("Vm0007GapReportPreview", () => {
     });
 
     const text = container.textContent ?? "";
-    expect(text).toContain("Version warning accepted before audit generation.");
-    expect(text).toContain("VERSION_WARNING_ACCEPTED");
-    expect(text).toContain("Print / Save PDF");
-    expect(text).toContain(REPORT_FIXTURE.expectedReportTitle);
-    expect(text).toContain("58 VM0007 rules assessed for validation readiness.");
-    expect(text).toContain("User accepted warning");
-    expect(text).toContain("true");
+    expect(text).toContain("Version lock blocked:");
+    expect(text).not.toContain("Print / Save PDF");
+    expect(text).not.toContain(REPORT_FIXTURE.expectedReportTitle);
   });
 
-  test("renders the full report with a warning banner when a mismatched audit is accepted", async () => {
+  test("renders only the blocked mismatch message when a mismatched audit was accepted", async () => {
     saveVm0007GapReportAudit({
       auditId: "audit-warning-accepted",
       methodologyId: "VM0007",
@@ -195,7 +191,7 @@ describe("Vm0007GapReportPreview", () => {
       generatedAt: "2026-07-03T00:00:00Z",
       evidenceFileName: "envira-amazonia-vm0007.pdf",
       userAcceptedVersionWarning: true,
-      audit: buildWarningAcceptedAudit(),
+      audit: buildBlockedMismatchAudit(),
     });
 
     await act(async () => {
@@ -206,13 +202,9 @@ describe("Vm0007GapReportPreview", () => {
     });
 
     const text = container.textContent ?? "";
-    expect(text).toContain("VERSION_WARNING_ACCEPTED");
-    expect(text).toContain("Version warning accepted before audit generation.");
-    expect(text).toContain("Methodology version mismatch:");
-    expect(text).toContain("Print / Save PDF");
-    expect(text).toContain(REPORT_FIXTURE.expectedReportTitle);
-    expect(text).toContain("User accepted warning");
-    expect(text).toContain("true");
+    expect(text).toContain("Version lock blocked:");
+    expect(text).not.toContain("Print / Save PDF");
+    expect(text).not.toContain(REPORT_FIXTURE.expectedReportTitle);
   });
 
   test("keeps banned wording out of the rendered internal preview", async () => {

--- a/tests/lib/chat/methodologyVersion.test.ts
+++ b/tests/lib/chat/methodologyVersion.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { normalizeDeclaredMethodologyVersion } from "@/lib/chat/methodologyVersion";
+import { normalizeDeclaredMethodologyVersion, normalizeMethodologyVersion } from "@/lib/chat/methodologyVersion";
 
 describe("normalizeDeclaredMethodologyVersion", () => {
   it("canonicalizes equivalent document forms to the same internal key", () => {
@@ -11,5 +11,15 @@ describe("normalizeDeclaredMethodologyVersion", () => {
     expect(normalizeDeclaredMethodologyVersion("version 4")).toBe("v4.0");
     expect(normalizeDeclaredMethodologyVersion("version 8")).toBe("v8.0");
     expect(normalizeDeclaredMethodologyVersion("v8")).toBe("v8.0");
+  });
+
+  it("canonicalizes VM0007 methodology version variants to v1.8", () => {
+    expect(normalizeMethodologyVersion("v1-8")).toBe("v1.8");
+    expect(normalizeMethodologyVersion("v1.8")).toBe("v1.8");
+    expect(normalizeMethodologyVersion("1.8")).toBe("v1.8");
+    expect(normalizeMethodologyVersion("Version 1.8")).toBe("v1.8");
+    expect(normalizeMethodologyVersion("VM0007 v1.8")).toBe("v1.8");
+    expect(normalizeMethodologyVersion("REDD+ MF 1.8")).toBe("v1.8");
+    expect(normalizeMethodologyVersion("Methodology VM0007 REDD+ Methodology Framework (REDD+ MF) 1.8")).toBe("v1.8");
   });
 });

--- a/tests/lib/chat/methodologyVersion.test.ts
+++ b/tests/lib/chat/methodologyVersion.test.ts
@@ -22,4 +22,9 @@ describe("normalizeDeclaredMethodologyVersion", () => {
     expect(normalizeMethodologyVersion("REDD+ MF 1.8")).toBe("v1.8");
     expect(normalizeMethodologyVersion("Methodology VM0007 REDD+ Methodology Framework (REDD+ MF) 1.8")).toBe("v1.8");
   });
+
+  it("does not treat trailing module or tool versions as methodology versions", () => {
+    expect(normalizeMethodologyVersion("The project applies VM0007 and module VMD0001 1.8")).toBeNull();
+    expect(normalizeMethodologyVersion("The project applies REDD+ MF and tool VT0001 1.8")).toBeNull();
+  });
 });

--- a/tests/lib/preverif.vm0007GapReport.test.ts
+++ b/tests/lib/preverif.vm0007GapReport.test.ts
@@ -113,10 +113,10 @@ function buildSupportedOnlyAudit(): MethodologyEvidenceAuditSummary {
   };
 }
 
-function buildWarningAcceptedAudit(baseAudit: MethodologyEvidenceAuditSummary): MethodologyEvidenceAuditSummary {
+function buildBlockedMismatchAudit(baseAudit: MethodologyEvidenceAuditSummary): MethodologyEvidenceAuditSummary {
   return {
     ...baseAudit,
-    auditStatus: "VERSION_WARNING_ACCEPTED",
+    auditStatus: "BLOCKED_VERSION_MISMATCH",
     methodologyId: "VM0007",
     rulebookVersion: "v1.8",
     pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
@@ -164,8 +164,8 @@ describe("buildVm0007GapReport", () => {
     expect(report.executiveSummary.allSupportedWarning).toBe("All rules are currently marked supported. Review evidence quality before relying on this result.");
   });
 
-  it("prepends the version warning to the report banner when the warning was accepted", () => {
-    const report = buildReport(buildWarningAcceptedAudit(auditText(ENVIRA_V18_TEXT)));
+  it("prepends the version warning to the report banner when the audit is blocked for a mismatch", () => {
+    const report = buildReport(buildBlockedMismatchAudit(auditText(ENVIRA_V18_TEXT)));
 
     expect(report.limitationBanner).toContain("Methodology version mismatch:");
     expect(report.limitationBanner).toContain("Evidence judgment may be wrong.");

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -281,6 +281,21 @@ describe("VM0007 version lock", () => {
     expect(audit.results.every((result) => result.versionMismatchReason === "")).toBe(true);
   });
 
+  it("allows a matching VM0007 v1.8 audit when versionContext already provides 'v1.8'", () => {
+    const audit = auditVm0007(ENVIRA_TEXT, {
+      getContract: makeVersionedContract("v1-8"),
+      versionContext: {
+        pddDeclaredMethodologyVersion: "v1.8",
+      },
+    });
+
+    expect(audit.auditStatus).toBe("AUDITED");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(audit.versionMismatchReason).toBe("");
+    expect(audit.results).toHaveLength(58);
+  });
+
   it("allows a Maya-style flattened methodology block with a VM0007 v1.8 row and other module/tool versions", () => {
     const audit = auditVm0007(MAYA_FLATTENED_TEXT, {
       getContract: makeVersionedContract("v1-8"),
@@ -430,6 +445,42 @@ describe("VM0007 version lock", () => {
       methodologyId: "VM0007",
       rulebookVersion: "v1-8",
       pddDeclaredMethodologyVersion: "VM0007, version 1.8",
+    });
+
+    expect(lock.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(lock.versionMatch).toBe(true);
+    expect(lock.versionMismatchReason).toBe("");
+  });
+
+  it("accepts a standalone declared version written as 'v1.8'", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1-8",
+      pddDeclaredMethodologyVersion: "v1.8",
+    });
+
+    expect(lock.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(lock.versionMatch).toBe(true);
+    expect(lock.versionMismatchReason).toBe("");
+  });
+
+  it("accepts a standalone declared version written as 'v1-8'", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1-8",
+      pddDeclaredMethodologyVersion: "v1-8",
+    });
+
+    expect(lock.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(lock.versionMatch).toBe(true);
+    expect(lock.versionMismatchReason).toBe("");
+  });
+
+  it("accepts a standalone declared version written as '1.8'", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1-8",
+      pddDeclaredMethodologyVersion: "1.8",
     });
 
     expect(lock.pddDeclaredMethodologyVersion).toBe("v1.8");

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -441,6 +441,34 @@ describe("VM0007 version lock", () => {
     expect(lock.versionMismatchReason).toBe("");
   });
 
+  it("does not accept a trailing module version as the VM0007 methodology declaration", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1-8",
+      pddDeclaredMethodologyVersion: "The project applies VM0007 and module VMD0001 1.8",
+    });
+
+    expect(lock.pddDeclaredMethodologyVersion).toBe("The project applies VM0007 and module VMD0001 1.8");
+    expect(lock.versionMatch).toBe(false);
+    expect(lock.versionMismatchReason).toContain("missing");
+  });
+
+  it("blocks a line where VM0007 is present but only a module version trails at the end", () => {
+    const audit = auditVm0007([
+      "3.1 Application of Methodology",
+      "3.1.1 Title and Reference of Methodology",
+      "The project applies VM0007 and module VMD0001 1.8",
+      "3.1.2 Applicability of Methodology",
+    ].join("\n"), {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
+    expect(audit.versionMatch).toBe(false);
+    expect(audit.versionMismatchReason).toContain("missing");
+    expect(audit.results).toEqual([]);
+  });
+
   it("allows a v1.8 VM0007 PDD when the real text uses 'VM0007, version 1.8'", () => {
     const audit = auditVm0007(ENVIRA_V18_VERSION_TEXT, {
       getContract: makeVersionedContract("v1-8"),

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -153,7 +153,11 @@ describe("VM0007 version lock", () => {
     });
 
     expect(lock.methodologyId).toBe("VM0007");
+    expect(lock.rulebookVersionRaw).toBe("v1.8");
+    expect(lock.rulebookVersionKey).toBe("v1.8");
     expect(lock.rulebookVersion).toBe("v1.8");
+    expect(lock.pddDeclaredMethodologyVersionRaw).toBe("REDD-MF / VM0007 v1.5");
+    expect(lock.pddDeclaredMethodologyVersion).toBe("v1.5");
     expect(lock.versionMatch).toBe(false);
     expect(lock.versionMismatchReason).toContain("rulebook version");
   });
@@ -176,7 +180,7 @@ describe("VM0007 version lock", () => {
     expect(Object.values(audit.totals)).toEqual([0, 0, 0, 0, 0]);
   });
 
-  it("allows a mismatched VM0007 audit to proceed when the user accepts the warning", () => {
+  it("keeps a mismatched VM0007 audit blocked even when the user accepts the warning", () => {
     const audit = auditVm0007(ENVIRA_TEXT, {
       getContract: makeVersionedContract("v1-8"),
       versionContext: {
@@ -185,16 +189,16 @@ describe("VM0007 version lock", () => {
       userAcceptedVersionWarning: true,
     });
 
-    expect(audit.auditStatus).toBe("VERSION_WARNING_ACCEPTED");
+    expect(audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
     expect(audit.methodologyId).toBe("VM0007");
     expect(audit.rulebookVersion).toBe("v1.8");
     expect(audit.versionMatch).toBe(false);
     expect(audit.versionMismatchReason).toContain("v1.5");
-    expect(audit.results).toHaveLength(58);
-    expect(audit.results[0]?.userAcceptedVersionWarning).toBe(true);
+    expect(audit.userAcceptedVersionWarning).toBe(true);
+    expect(audit.results).toEqual([]);
   });
 
-  it("allows a missing VM0007 version to proceed when the user accepts the warning", () => {
+  it("keeps a missing VM0007 version blocked even when the user accepts the warning", () => {
     const document = makeTableEvidenceDocument([
       ["Type", "Reference ID", "Version"],
       ["Methodology", "VM0007", ""],
@@ -207,13 +211,13 @@ describe("VM0007 version lock", () => {
       userAcceptedVersionWarning: true,
     });
 
-    expect(audit.auditStatus).toBe("VERSION_WARNING_ACCEPTED");
+    expect(audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
     expect(audit.methodologyId).toBe("VM0007");
     expect(audit.rulebookVersion).toBe("v1.8");
     expect(audit.versionMatch).toBe(false);
     expect(audit.versionMismatchReason).toContain("missing");
-    expect(audit.results).toHaveLength(58);
-    expect(audit.results[0]?.userAcceptedVersionWarning).toBe(true);
+    expect(audit.userAcceptedVersionWarning).toBe(true);
+    expect(audit.results).toEqual([]);
   });
 
   it("blocks ambiguous VM0007 versions when both v1.5 and v1.8 are present", () => {
@@ -250,13 +254,20 @@ describe("VM0007 version lock", () => {
 
     expect(audit.auditStatus).toBe("AUDITED");
     expect(audit.methodologyId).toBe("VM0007");
+    expect(audit.rulebookVersionRaw).toBe("v1-8");
+    expect(audit.rulebookVersionKey).toBe("v1-8");
     expect(audit.rulebookVersion).toBe("v1.8");
+    expect(audit.pddDeclaredMethodologyVersionRaw).toBe("VM0007 Version 1.8");
+    expect(audit.pddDeclaredMethodologyVersion).toBe("v1.8");
     expect(audit.versionMatch).toBe(true);
     expect(audit.versionMismatchReason).toBe("");
     expect(audit.results).toHaveLength(58);
     expect(audit.results[0]?.methodologyId).toBe("VM0007");
+    expect(audit.results[0]?.rulebookVersionRaw).toBe("v1-8");
+    expect(audit.results[0]?.rulebookVersionKey).toBe("v1-8");
     expect(audit.results[0]?.rulebookVersion).toBe("v1.8");
-    expect(audit.results[0]?.pddDeclaredMethodologyVersion).toBe("VM0007 Version 1.8");
+    expect(audit.results[0]?.pddDeclaredMethodologyVersionRaw).toBe("VM0007 Version 1.8");
+    expect(audit.results[0]?.pddDeclaredMethodologyVersion).toBe("v1.8");
     expect(audit.results.every((result) => result.versionMatch === true)).toBe(true);
     expect(audit.results.every((result) => result.versionMismatchReason === "")).toBe(true);
   });
@@ -401,6 +412,7 @@ describe("VM0007 version lock", () => {
       pddDeclaredMethodologyVersion: "VM0007, version 1.8",
     });
 
+    expect(lock.pddDeclaredMethodologyVersion).toBe("v1.8");
     expect(lock.versionMatch).toBe(true);
     expect(lock.versionMismatchReason).toBe("");
   });
@@ -412,6 +424,19 @@ describe("VM0007 version lock", () => {
       pddDeclaredMethodologyVersion: "REDD-MF, REDD Methodology Framework Version 1.8",
     });
 
+    expect(lock.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(lock.versionMatch).toBe(true);
+    expect(lock.versionMismatchReason).toBe("");
+  });
+
+  it("normalizes a trailing methodology declaration to v1.8 instead of reporting it missing", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1-8",
+      pddDeclaredMethodologyVersion: "Methodology VM0007 REDD+ Methodology Framework (REDD+ MF) 1.8",
+    });
+
+    expect(lock.pddDeclaredMethodologyVersion).toBe("v1.8");
     expect(lock.versionMatch).toBe(true);
     expect(lock.versionMismatchReason).toBe("");
   });

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -50,6 +50,15 @@ const LISALA_PROSE_TEXT = [
   "The project applies VM0007 (v.1.8) for avoided deforestation.",
   "3.1.2 Applicability of Methodology",
 ].join("\n");
+const SPLIT_DECLARATION_TEXT = [
+  "3.1 Application of Methodology",
+  "3.1.1 Title and Reference of Methodology",
+  "Methodology VM0007 REDD+ Methodology Framework (REDD+",
+  "MF) 1.8",
+  "Tool VT0001",
+  "Additionality Tool 3.0",
+  "3.1.2 Applicability of Methodology",
+].join("\n");
 
 function auditVm0007(
   rawText: string,
@@ -312,6 +321,17 @@ describe("VM0007 version lock", () => {
     expect(audit.versionMismatchReason).toBe("");
   });
 
+  it("allows a real-like split VM0007 v1.8 declaration from upload text", () => {
+    const audit = auditVm0007(SPLIT_DECLARATION_TEXT, {
+      getContract: makeVersionedContract("v1-8"),
+    });
+
+    expect(audit.auditStatus).toBe("AUDITED");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(audit.versionMismatchReason).toBe("");
+  });
+
   it("blocks a methodology row for VM0007 v1.5 even when the flattened block also contains module and tool versions", () => {
     const document = makeTableEvidenceDocument([
       ["Type", "Reference ID", "Version"],
@@ -434,6 +454,18 @@ describe("VM0007 version lock", () => {
       methodologyId: "VM0007",
       rulebookVersion: "v1-8",
       pddDeclaredMethodologyVersion: "Methodology VM0007 REDD+ Methodology Framework (REDD+ MF) 1.8",
+    });
+
+    expect(lock.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(lock.versionMatch).toBe(true);
+    expect(lock.versionMismatchReason).toBe("");
+  });
+
+  it("normalizes a split methodology declaration to v1.8 instead of reporting it missing", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0007",
+      rulebookVersion: "v1-8",
+      pddDeclaredMethodologyVersion: "Methodology VM0007 REDD+ Methodology Framework (REDD+\nMF) 1.8",
     });
 
     expect(lock.pddDeclaredMethodologyVersion).toBe("v1.8");


### PR DESCRIPTION
## Roadmap

### Roadmap-Update
- slug: N/A
- ack: human
- items:
  <!-- - RC5: in_progress -->
  <!-- - PR12: done -->
  <!-- - PR13: in_progress -->

For PRs that do not advance any roadmap item (e.g. chores, dev tooling, refactors with no SSOT impact), leave `slug: N/A`. The roadmap gates will skip.

Allowed statuses: planned | next | in_progress | done | blocked | merged | etc.

## Guardrails

- [ ] Confirmed source fixes are generic and not fixture-shaped.
- [ ] No project names, project IDs, exact page gates, or gold answer strings were added to source code.
- [ ] Methodology fixes extract IDs and versions generically instead of hardcoding one fixture pair.

<!--
### Roadmap-Override
slug: <slug>
pr: PRxx
from_status: <old_status>
to_status: <new_status>
revert_of: <PR_NUMBER>
reason: <why>
-->

Visible UI changes to look for:
