### PR TITLE
fix: quarantine Envira VM0007 legacy mismatch fixture

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -367,6 +367,7 @@ Current focus:
 - Proceed to report/PDF blocking only if the next phase needs it
 
 Not active now:
+- Envira quarantine
 - Report/PDF blocking
 - Gate strengthening
 - Roadmap correction

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -359,22 +359,21 @@ Not active now:
 Status SSOT: `docs/roadmaps/vm0007-version-cleanup/phase-status.json`
 
 Lane status: Active
-Phase 1 version lock is complete: VM0007 audits now require matching methodology ID and PDD-declared methodology version before evidence judgment can run.
+Phase 2 Envira quarantine is complete: the Envira legacy v1.5 mismatch fixture is preserved as regression coverage and not validated truth.
 
 Current focus:
 - Use Phase 1 hard blocking as the baseline for later cleanup phases
-- Keep Envira as a blocked legacy v1.5 mismatch regression case
-- Continue with Envira quarantine and report/PDF hardening as later phases
+- Keep Envira quarantined as a blocked legacy v1.5 mismatch regression case
+- Proceed to report/PDF blocking only if the next phase needs it
 
 Not active now:
-- Envira quarantine
 - Report/PDF blocking
 - Gate strengthening
 - Roadmap correction
 - Forward-path expansion
 
 1) RC1 — Phase 1: Version Lock: Done — VM0007 version identity is enforced before evidence audit; missing or mismatched PDD-declared methodology versions hard block with BLOCKED_VERSION_MISMATCH, while legitimate VM0007 v1.8 may proceed.
-2) RC2 — Phase 2: Envira Quarantine: Planned — Preserve Envira as a legacy v1.5 mismatch regression fixture, not validated truth.
+2) RC2 — Phase 2: Envira Quarantine: Done — Preserve Envira as a legacy v1.5 mismatch regression fixture, not validated truth.
 3) RC3 — Phase 3: Report and PDF Blocking: Planned — Prevent mismatched versions from producing normal evidence maps, reports, PDFs, or readiness claims.
 4) RC4 — Phase 4: Gate Strengthening: Planned — Add tests and gates so mismatches cannot produce judgments, reports, PDFs, or client-readiness output.
 5) RC5 — Phase 5: Roadmap Correction: Planned — Correct contaminated done states and mark VM0007 evidence-map work pending versioned re-audit.

--- a/docs/roadmaps/vm0007-version-cleanup/phase-status.json
+++ b/docs/roadmaps/vm0007-version-cleanup/phase-status.json
@@ -2,11 +2,11 @@
   "roadmap": "vm0007-version-cleanup",
   "phase_meta": {
     "status": "active",
-    "summary": "Phase 1 version lock is complete: VM0007 audits now require matching methodology ID and PDD-declared methodology version before evidence judgment can run.",
+    "summary": "Phase 2 Envira quarantine is complete: the Envira legacy v1.5 mismatch fixture is preserved as regression coverage and not validated truth.",
     "current_focus": [
       "Use Phase 1 hard blocking as the baseline for later cleanup phases",
-      "Keep Envira as a blocked legacy v1.5 mismatch regression case",
-      "Continue with Envira quarantine and report/PDF hardening as later phases"
+      "Keep Envira quarantined as a blocked legacy v1.5 mismatch regression case",
+      "Proceed to report/PDF blocking only if the next phase needs it"
     ],
     "not_active_now": [
       "Envira quarantine",
@@ -25,7 +25,7 @@
     },
     "phase_2_envira_quarantine": {
       "title": "Phase 2: Envira Quarantine",
-      "status": "planned",
+      "status": "done",
       "summary": "Preserve Envira as a legacy v1.5 mismatch regression fixture, not validated truth."
     },
     "phase_3_report_and_pdf_blocking": {

--- a/src/app/api/exports/internal/envira-vm0007-report/route.ts
+++ b/src/app/api/exports/internal/envira-vm0007-report/route.ts
@@ -15,13 +15,13 @@ export async function GET() {
     return new NextResponse(blob, {
       headers: {
         "Content-Type": "application/pdf",
-        "Content-Disposition": 'attachment; filename="internal-envira-vm0007-fixture-backed-report.pdf"',
+        "Content-Disposition": 'attachment; filename="envira-vm0007-v15-legacy-mismatch.pdf"',
         "Cache-Control": "no-store",
       },
     });
   } catch (error) {
     return NextResponse.json(
-      { error: "Envira fixture-backed PDF export failed", detail: String(error) },
+      { error: "Envira legacy mismatch PDF export failed", detail: String(error) },
       { status: 500 },
     );
   }

--- a/src/app/internal/reports/envira-vm0007/page.tsx
+++ b/src/app/internal/reports/envira-vm0007/page.tsx
@@ -3,8 +3,8 @@ import FixtureBackedVm0007ReportView from "@/components/preverif/FixtureBackedVm
 import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
 
 export const metadata: Metadata = {
-  title: "Internal Envira VM0007 Fixture-Backed Report | app.article6",
-  description: "Internal Envira VM0007 fixture-backed report and evidence map preview.",
+  title: "Envira VM0007 legacy v1.5 mismatch | app.article6",
+  description: "Quarantined Envira VM0007 legacy v1.5 mismatch regression fixture and evidence map preview.",
 };
 
 export default function EnviraVm0007FixtureBackedReportPage() {

--- a/src/components/preverif/FixtureBackedVm0007ReportView.tsx
+++ b/src/components/preverif/FixtureBackedVm0007ReportView.tsx
@@ -34,9 +34,9 @@ function labelCell(label: string, value: ReactNode) {
 }
 
 function statusSummaryCopy(status: Vm0007FixtureBackedStatus): string {
-  if (status === "MISSING") return "Rules with missing project-specific evidence that need review.";
+  if (status === "MISSING") return "Rules with missing project-specific evidence preserved as legacy mismatch output.";
   if (status === "UNCLEAR") return "Rules with related evidence that still needs review before it can support a definitive result.";
-  if (status === "FOUND") return "Rules with confirmed evidence in the reviewed fixture truth.";
+  if (status === "FOUND") return "Rules with false-supported legacy output preserved for regression coverage.";
   return "Rules that are not applicable to the project scope.";
 }
 
@@ -111,18 +111,21 @@ export default function FixtureBackedVm0007ReportView({ report, pdfDownloadHref 
             <div className="max-w-3xl">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="rounded-full border border-slate-300 bg-slate-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-700">
-                  Internal fixture-backed preview
+                  Quarantined legacy fixture
+                </span>
+                <span className="rounded-full border border-amber-300 bg-amber-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-amber-900">
+                  versionMatch false
                 </span>
                 <span className="rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-800">
                   Not client-ready
                 </span>
               </div>
-              <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-950">Envira VM0007 Evidence Map</h1>
+              <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-950">Envira VM0007 legacy v1.5 mismatch</h1>
               <div className="mt-2 text-base text-slate-700">{report.project.name}</div>
               <div className="mt-4 grid gap-2 text-sm leading-6 text-slate-700">
-                <div>Internal fixture-backed preview.</div>
-                <div>Based on PDF-backed fixture truth.</div>
-                <div>Purpose: show supported, weak, missing, and non-applicable methodology evidence.</div>
+                <div>Quarantined legacy mismatch regression fixture.</div>
+                <div>Based on contaminated historical fixture output.</div>
+                <div>Purpose: preserve false FOUND rows, wrong page anchors, module-list evidence, and flattened table errors.</div>
                 <div>{report.reportName}</div>
               </div>
             </div>
@@ -137,6 +140,16 @@ export default function FixtureBackedVm0007ReportView({ report, pdfDownloadHref 
           </div>
           <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900">
             {report.limitationBanner}
+          </div>
+          <div className="mt-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700">
+            <div className="font-semibold text-slate-950">Quarantine metadata</div>
+            <div className="mt-2 grid gap-1 sm:grid-cols-2">
+              <div>PDD-declared methodology: {report.quarantine.pddDeclaredMethodologyVersion}</div>
+              <div>Loaded rulebook: {report.quarantine.loadedRulebookVersion}</div>
+              <div>Status: {report.quarantine.status}</div>
+              <div>Version match: {String(report.quarantine.versionMatch)}</div>
+            </div>
+            <div className="mt-2">{report.quarantine.note}</div>
           </div>
           <div className="mt-3 text-sm text-slate-700">{report.summary.headline}</div>
           <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
@@ -172,7 +185,7 @@ export default function FixtureBackedVm0007ReportView({ report, pdfDownloadHref 
         <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
           <h2 className="text-lg font-semibold text-slate-950">Executive Summary</h2>
           <div className="mt-1 text-sm text-slate-600">
-            {report.summary.totalRules} VM0007 rules rendered from reviewed fixture truth.
+            {report.summary.totalRules} VM0007 rules rendered from quarantined legacy output.
           </div>
           <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
             {(["FOUND", "UNCLEAR", "MISSING", "N/A"] as const).map((status) => (
@@ -185,7 +198,7 @@ export default function FixtureBackedVm0007ReportView({ report, pdfDownloadHref 
           <div className="mt-4 grid gap-3 lg:grid-cols-3">
             <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
               <div className="font-semibold text-slate-950">What this shows</div>
-              <div className="mt-2">Counts and row detail are driven by reviewed fixture truth rather than live audit guesses.</div>
+              <div className="mt-2">Counts and row detail are preserved only as contaminated regression output rather than validated truth.</div>
             </div>
             <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
               <div className="font-semibold text-slate-950">Where follow-up is needed</div>
@@ -201,7 +214,7 @@ export default function FixtureBackedVm0007ReportView({ report, pdfDownloadHref 
         <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
           <h2 className="text-lg font-semibold text-slate-950">Priority Client Actions</h2>
           <div className="mt-1 text-sm text-slate-600">
-            Only UNCLEAR and MISSING rows appear here so internal follow-up can focus on the highest-friction evidence gaps.
+            Only UNCLEAR and MISSING rows appear here so internal follow-up can focus on the highest-friction evidence gaps in the quarantined fixture.
           </div>
           <div className="mt-4 grid gap-3">
             {priorityRows.map((row) => (
@@ -226,7 +239,7 @@ export default function FixtureBackedVm0007ReportView({ report, pdfDownloadHref 
         <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
           <h2 className="text-lg font-semibold text-slate-950">Evidence Map</h2>
           <div className="mt-1 text-sm text-slate-600">
-            All 58 VM0007 rows remain visible below, grouped by reviewed status without changing the underlying fixture-backed truth.
+            All 58 VM0007 rows remain visible below, grouped by quarantined status without changing the underlying contaminated fixture output.
           </div>
           <div className="mt-4 grid gap-6">
             {groupedRows.map((group) => (

--- a/src/lib/preverif/enviraVm0007FixtureBackedPdf.ts
+++ b/src/lib/preverif/enviraVm0007FixtureBackedPdf.ts
@@ -80,14 +80,18 @@ export function buildReportLines(report: Vm0007FixtureBackedReport): string[] {
   const groupedRows = groupEvidenceMapRowsByStatus(report.evidenceMapRows);
   const lines: string[] = [
     report.reportName,
-    "Envira VM0007 Evidence Map",
-    "Internal fixture-backed preview",
+    "Envira VM0007 legacy v1.5 mismatch",
+    "Quarantined legacy mismatch regression fixture",
     "Not client-ready",
-    "Based on PDF-backed fixture truth",
-    "Purpose: show supported, weak, missing, and non-applicable methodology evidence",
+    "Based on contaminated historical fixture output",
+    "Purpose: preserve false FOUND rows, wrong page anchors, module-list evidence, and flattened table errors",
     `Project name: ${report.project.name}`,
     report.project.description,
     `Methodology: ${report.methodology.code} ${report.methodology.version} - ${report.methodology.name}`,
+    `Quarantine label: ${report.quarantine.label}`,
+    `PDD-declared methodology version: ${report.quarantine.pddDeclaredMethodologyVersion}`,
+    `Loaded rulebook version: ${report.quarantine.loadedRulebookVersion}`,
+    `versionMatch: ${report.quarantine.versionMatch}`,
     `Generated: ${report.generatedAt}`,
     report.limitationBanner,
     `FOUND: ${report.summary.counts.FOUND}`,
@@ -102,7 +106,7 @@ export function buildReportLines(report: Vm0007FixtureBackedReport): string[] {
   lines.push(...buildPriorityActionLines(report));
   lines.push("");
   lines.push("Evidence Map");
-  lines.push("Rows are grouped by reviewed status and preserve the reviewed fixture truth.");
+  lines.push("Rows are grouped by quarantined status and preserve historical contaminated output only.");
 
   for (const group of groupedRows) {
     lines.push("");

--- a/src/lib/preverif/enviraVm0007FixtureBackedReport.ts
+++ b/src/lib/preverif/enviraVm0007FixtureBackedReport.ts
@@ -14,16 +14,17 @@ export function buildEnviraVm0007FixtureBackedReport(): Vm0007FixtureBackedRepor
   const judgmentFixtureSet = readJsonFixture<JudgmentFixtureSet>("envira-vm0007-judgment-fixtures.json");
 
   return buildFixtureBackedVm0007Report({
-    reportId: "envira-vm0007-fixture-report",
-    reportName: "Internal Envira VM0007 Fixture-Backed Report Preview",
+    reportId: "envira-vm0007-v15-legacy-mismatch",
+    reportName: "Legacy v1.5 mismatch regression fixture preview",
     generatedAt: "2026-07-03T00:00:00Z",
     project: {
       name: "The Envira Amazonia Project",
-      description: "Reviewed Envira VM0007 fixture truth rendered into an internal-only report and Evidence Map.",
+      description:
+        "Legacy v1.5 mismatch regression fixture preserved for version-lock and evidence-map quarantine coverage.",
     },
     methodology: {
       code: "VM0007",
-      version: "4.2",
+      version: "v1.8",
       name: "VM0007: REDD Methodology Modules (REDD-MF)",
     },
     fullAuditFixtureSet,

--- a/src/lib/preverif/fixtureBackedVm0007Report.ts
+++ b/src/lib/preverif/fixtureBackedVm0007Report.ts
@@ -26,6 +26,14 @@ export type Vm0007FixtureBackedReport = {
   reportId: string;
   reportName: string;
   generatedAt: string;
+  quarantine: {
+    label: string;
+    status: "quarantined";
+    versionMatch: false;
+    pddDeclaredMethodologyVersion: string;
+    loadedRulebookVersion: string;
+    note: string;
+  };
   limitationBanner: string;
   summary: {
     totalRules: number;
@@ -111,8 +119,8 @@ export function buildEvidenceMapRows(
           : check.expectedStatus === "UNCLEAR"
             ? check.reason
             : check.expectedStatus === "MISSING"
-              ? "No accepted project-specific PDD quote is encoded for this rule in the reviewed fixture truth."
-              : "This rule is encoded as N/A in the reviewed fixture truth because the project scope does not trigger it.",
+              ? "No accepted project-specific PDD quote is encoded for this rule in the quarantined legacy mismatch fixture."
+              : "This rule is encoded as N/A in the quarantined legacy mismatch fixture because the project scope does not trigger it.",
       rejectedEvidenceExamples,
       whyRejectedEvidenceIsNotEnough,
       clientAction:
@@ -139,12 +147,21 @@ export function buildFixtureBackedVm0007Report(input: {
     reportId: input.reportId,
     reportName: input.reportName,
     generatedAt: input.generatedAt,
-    limitationBanner: "Internal preview only. This route renders reviewed fixture truth for analysis and is not client-ready.",
+    quarantine: {
+      label: "Legacy v1.5 mismatch regression fixture",
+      status: "quarantined",
+      versionMatch: false,
+      pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
+      loadedRulebookVersion: `${input.methodology.code} ${input.methodology.version}`,
+      note: "Historical counts are contaminated legacy output and must not be treated as validated truth.",
+    },
+    limitationBanner:
+      "Internal preview only. This route renders a quarantined legacy mismatch fixture for analysis and is not client-ready.",
     summary: {
       totalRules: input.fullAuditFixtureSet.expectedTotalRules,
       counts: input.fullAuditFixtureSet.expectedStatusCounts,
       headline:
-        "Summary counts and row detail come from reviewed fixture truth, not the current live audit output.",
+        "Summary counts and row detail come from quarantined legacy mismatch output, not validated VM0007 truth.",
     },
     project: input.project,
     methodology: input.methodology,

--- a/tests/app/api/exports/internal.envira-vm0007-report.route.test.ts
+++ b/tests/app/api/exports/internal.envira-vm0007-report.route.test.ts
@@ -5,7 +5,7 @@ import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm000
 import { buildReportLines } from "@/lib/preverif/enviraVm0007FixtureBackedPdf";
 
 describe("/api/exports/internal/envira-vm0007-report route", () => {
-  it("returns a parseable PDF attachment built from fixture-backed report data", async () => {
+  it("returns a parseable PDF attachment built from quarantined legacy mismatch report data", async () => {
     const normalize = (value: string) => value.replace(/\s+/g, " ").trim();
     const normalizeProvenanceText = (value: string) =>
       value
@@ -23,7 +23,7 @@ describe("/api/exports/internal/envira-vm0007-report route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/pdf");
-    expect(response.headers.get("Content-Disposition")).toContain('attachment; filename="internal-envira-vm0007-fixture-backed-report.pdf"');
+    expect(response.headers.get("Content-Disposition")).toContain('attachment; filename="envira-vm0007-v15-legacy-mismatch.pdf"');
 
     const bytes = await response.arrayBuffer();
     const parsed = await extractPdfTextWithPdfParse({ bytes });
@@ -43,16 +43,19 @@ describe("/api/exports/internal/envira-vm0007-report route", () => {
     const prioritySectionLines = prioritySectionStart >= 0 && prioritySectionEnd > prioritySectionStart ? reportLineList.slice(prioritySectionStart, prioritySectionEnd) : [];
     const priorityRows = report.evidenceMapRows.filter((row) => row.status === "UNCLEAR" || row.status === "MISSING");
 
-    expect(text).toContain("Envira VM0007 Evidence Map");
-    expect(text).toContain("Internal fixture-backed preview");
+    expect(text).toContain("Envira VM0007 legacy v1.5 mismatch");
+    expect(text).toContain("Quarantined legacy mismatch regression fixture");
     expect(text).toContain("Not client-ready");
-    expect(text).toContain("Based on PDF-backed fixture truth");
-    expect(text).toContain("Purpose: show supported, weak, missing, and non-applicable methodology evidence");
+    expect(text).toContain("Based on contaminated historical fixture output");
+    expect(normalized).toContain("Purpose: preserve false FOUND rows, wrong page anchors, module-list evidence, and flattened table errors");
     expect(text).toContain("FOUND: 30");
     expect(text).toContain("UNCLEAR: 8");
     expect(text).toContain("MISSING: 3");
     expect(text).toContain("N/A: 17");
     expect(text).toContain("Total rules: 58");
+    expect(text).toContain("PDD-declared methodology version: REDD-MF / VM0007 v1.5");
+    expect(text).toContain("Loaded rulebook version: VM0007 v1.8");
+    expect(text).toContain("versionMatch: false");
     expect(text).toContain("Priority Client Actions");
     expect(text).toContain("MISSING - 3");
     expect(text).toContain("UNCLEAR - 8");

--- a/tests/app/internal/envira-vm0007.page.test.tsx
+++ b/tests/app/internal/envira-vm0007.page.test.tsx
@@ -3,10 +3,11 @@ import { renderToStaticMarkup } from "react-dom/server";
 import EnviraVm0007FixtureBackedReportPage from "@/app/internal/reports/envira-vm0007/page";
 
 describe("/internal/reports/envira-vm0007 page", () => {
-  test("renders a visible Download PDF button for the fixture-backed internal report", () => {
+  test("renders a visible Download PDF button for the quarantined legacy mismatch fixture", () => {
     const html = renderToStaticMarkup(<EnviraVm0007FixtureBackedReportPage />);
 
     expect(html).toContain("Download PDF");
     expect(html).toContain('href="/api/exports/internal/envira-vm0007-report"');
+    expect(html).toContain("Envira VM0007 legacy v1.5 mismatch");
   });
 });

--- a/tests/components/fixtureBackedVm0007ReportView.test.tsx
+++ b/tests/components/fixtureBackedVm0007ReportView.test.tsx
@@ -27,15 +27,15 @@ function normalizeProvenanceText(value: string): string {
 }
 
 describe("FixtureBackedVm0007ReportView", () => {
-  test("renders the reviewed Envira fixture summary counts and all 58 evidence-map rows", () => {
+  test("renders the quarantined Envira legacy mismatch summary counts and all 58 evidence-map rows", () => {
     const html = buildHtml();
     const rowCount = (html.match(/data-evidence-map-row=/g) ?? []).length;
 
-    expect(html).toContain("Envira VM0007 Evidence Map");
-    expect(html).toContain("Internal fixture-backed preview");
+    expect(html).toContain("Envira VM0007 legacy v1.5 mismatch");
+    expect(html).toContain("Quarantined legacy fixture");
     expect(html).toContain("Not client-ready");
-    expect(html).toContain("Based on PDF-backed fixture truth");
-    expect(html).toContain("Purpose: show supported, weak, missing, and non-applicable methodology evidence");
+    expect(html).toContain("Based on contaminated historical fixture output");
+    expect(html).toContain("Purpose: preserve false FOUND rows, wrong page anchors, module-list evidence, and flattened table errors");
     expect(html).toContain("Download PDF");
     expect(html).toContain(">FOUND<");
     expect(html).toContain(">30<");
@@ -45,6 +45,8 @@ describe("FixtureBackedVm0007ReportView", () => {
     expect(html).toContain(">3<");
     expect(html).toContain(">N/A<");
     expect(html).toContain(">17<");
+    expect(html).toContain("versionMatch false");
+    expect(html).toContain("Historical counts are contaminated legacy output and must not be treated as validated truth.");
     expect(rowCount).toBe(58);
     expect(html).toContain("Executive Summary");
     expect(html).toContain("Priority Client Actions");
@@ -171,6 +173,7 @@ describe("FixtureBackedVm0007ReportView", () => {
     expect(html).toContain("the land is legally permitted to be converted to non-forest");
     expect(html).toContain("Generic methodology-applicability language is not the underlying authorization document.");
     expect(html).toContain("Project Description");
+    expect(html).toContain("Quarantine metadata");
     expect(html).not.toContain("Span ID: Not available");
     expect(html).not.toContain("No accepted quote encoded in fixture truth.");
     expect(html).not.toContain("Rejected evidence examples");

--- a/tests/fixtures/preverif/envira-vm0007-full-audit-fixture-shape.json
+++ b/tests/fixtures/preverif/envira-vm0007-full-audit-fixture-shape.json
@@ -1,16 +1,17 @@
 {
-  "fixtureSetId": "envira-vm0007-full-audit-fixture-shape",
-  "title": "Envira VM0007 Full 58-Rule Audit Fixture Shape",
+  "fixtureSetId": "envira-vm0007-v15-legacy-mismatch-full-audit-fixture-shape",
+  "title": "Envira VM0007 Legacy v1.5 Mismatch Full 58-Rule Regression Fixture Shape",
   "inputPdfName": "PROJ_DESC_1382_04APR2015.pdf",
   "inputPdfPath": "/Users/stphen/Desktop/PROJ_DESC_1382_04APR2015.pdf",
   "sourcePdfTitle": "Microsoft Word - Envira Amazonia VCS PD 2015.04.03",
   "documentFamily": "Project Description / PD",
   "methodology": "VM0007",
-  "fixtureTruthPolicy": "Use exact quotes, page numbers, and section headings from PROJ_DESC_1382_04APR2015.pdf only. Rules without exact PDF-backed truth in this Phase 3 fixture shape must remain UNCLEAR, MISSING, or N/A.",
+  "fixtureTruthPolicy": "Use exact quotes, page numbers, and section headings from PROJ_DESC_1382_04APR2015.pdf only. This is a quarantined legacy v1.5 mismatch fixture: the PDD declares REDD-MF / VM0007 v1.5, the loaded rulebook/contract is VM0007 v1.8, versionMatch is false, and the historical 30 FOUND / 8 UNCLEAR / 3 MISSING / 17 N/A split is contaminated output, not validated truth.",
   "expectedWarnings": [
     "This full 58-rule fixture shape is internal test data and not client-ready output.",
     "Only exact PDF-backed evidence may produce FOUND in this fixture set.",
-    "Rules without proven PDF truth stay UNCLEAR, MISSING, or N/A until source-backed evidence is added."
+    "Rules without proven PDF truth stay UNCLEAR, MISSING, or N/A until source-backed evidence is added.",
+    "Historical counts are contaminated legacy output and must not be treated as validated truth."
   ],
   "expectedTotalRules": 58,
   "expectedStatusCounts": {

--- a/tests/fixtures/preverif/envira-vm0007-judgment-fixtures.json
+++ b/tests/fixtures/preverif/envira-vm0007-judgment-fixtures.json
@@ -1,16 +1,17 @@
 {
-  "fixtureSetId": "envira-vm0007-judgment-fixtures",
-  "title": "Envira VM0007 Judgment Fixtures",
+  "fixtureSetId": "envira-vm0007-v15-legacy-mismatch-judgment-fixtures",
+  "title": "Envira VM0007 Legacy v1.5 Mismatch Regression Judgment Fixtures",
   "inputPdfName": "PROJ_DESC_1382_04APR2015.pdf",
   "inputPdfPath": "/Users/stphen/Desktop/PROJ_DESC_1382_04APR2015.pdf",
   "sourcePdfTitle": "Microsoft Word - Envira Amazonia VCS PD 2015.04.03",
   "documentFamily": "Project Description / PD",
   "methodology": "VM0007",
-  "fixtureTruthPolicy": "Use exact quotes, page numbers, and section headings from PROJ_DESC_1382_04APR2015.pdf only. Do not use current app output as gold.",
+  "fixtureTruthPolicy": "Use exact quotes, page numbers, and section headings from PROJ_DESC_1382_04APR2015.pdf only. This is a quarantined legacy v1.5 mismatch regression fixture, so do not use current app output as gold or validated truth.",
   "expectedWarnings": [
     "Generic methodology or module-table text must not count as project evidence.",
     "Weak evidence must stay UNCLEAR and missing evidence must stay MISSING.",
-    "TOC rows, URLs, registry links, and generic country references must not count as proof."
+    "TOC rows, URLs, registry links, and generic country references must not count as proof.",
+    "Historical counts are contaminated legacy output and must not be treated as validated truth."
   ],
   "checks": [
     {

--- a/tests/lib/preverif.enviraVm0007FixtureBackedPdf.test.ts
+++ b/tests/lib/preverif.enviraVm0007FixtureBackedPdf.test.ts
@@ -35,11 +35,15 @@ function extractPriorityRowLines(lines: string[], ruleId: string): string[] {
 }
 
 describe("buildReportLines", () => {
-  test("preserves provenance for every evidence-bearing row", () => {
+  test("preserves provenance for every evidence-bearing row and keeps the legacy mismatch label visible", () => {
     const report = buildEnviraVm0007FixtureBackedReport();
     const lines = buildReportLines(report);
     const normalizedLines = normalizeProvenanceText(lines.join(" "));
     const prioritySection = extractPrioritySectionLines(lines).join("\n");
+
+    expect(lines.join("\n")).toContain("Envira VM0007 legacy v1.5 mismatch");
+    expect(lines.join("\n")).toContain("Quarantined legacy mismatch regression fixture");
+    expect(lines.join("\n")).toContain("versionMatch: false");
 
     for (const row of report.evidenceMapRows) {
       if (row.acceptedQuote?.trim()) {

--- a/tests/lib/preverif.enviraVm0007ProvenanceAudit.test.ts
+++ b/tests/lib/preverif.enviraVm0007ProvenanceAudit.test.ts
@@ -162,7 +162,7 @@ function formatAuditTable(rows: AuditRowResult[]): string {
 }
 
 describe("Envira VM0007 provenance audit", () => {
-  test("checks every report row against the fixture-backed source excerpts", () => {
+  test("checks the quarantined legacy mismatch report rows against the fixture-backed source excerpts", () => {
     const report = buildEnviraVm0007FixtureBackedReport();
     const fullAuditChecksById = new Map(FULL_AUDIT_FIXTURE.checks.map((check) => [check.checkId, check]));
     const auditRows: AuditRowResult[] = [];
@@ -174,6 +174,14 @@ describe("Envira VM0007 provenance audit", () => {
       UNCLEAR: 8,
       MISSING: 3,
       "N/A": 17,
+    });
+    expect(report.quarantine).toEqual({
+      label: "Legacy v1.5 mismatch regression fixture",
+      status: "quarantined",
+      versionMatch: false,
+      pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
+      loadedRulebookVersion: "VM0007 v1.8",
+      note: "Historical counts are contaminated legacy output and must not be treated as validated truth.",
     });
 
     for (const row of report.evidenceMapRows) {

--- a/tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts
+++ b/tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts
@@ -30,7 +30,7 @@ const PD_REDD_SOURCE_EXCERPTS = JSON.parse(
   fs.readFileSync("tests/fixtures/preverif/pd-redd-vm0007-source-excerpts.json", "utf8"),
 ) as SourceExcerpts;
 
-describe("Envira VM0007 judgment fixtures", () => {
+describe("Envira VM0007 legacy mismatch judgment fixtures", () => {
   it("confirms Phase 0 is documented and the exact source document is the Envira project description PDF", () => {
     const phase0Plan = fs.readFileSync("docs/roadmaps/vm0007-judgement-fixtures/PLAN.md", "utf8");
 
@@ -40,7 +40,9 @@ describe("Envira VM0007 judgment fixtures", () => {
     expect(AUDIT_FIXTURE.inputPdfPath).toBe("/Users/stphen/Desktop/PROJ_DESC_1382_04APR2015.pdf");
     expect(AUDIT_FIXTURE.sourcePdfTitle).toBe("Microsoft Word - Envira Amazonia VCS PD 2015.04.03");
     expect(AUDIT_FIXTURE.documentFamily).toBe("Project Description / PD");
-    expect(AUDIT_FIXTURE.fixtureTruthPolicy).toContain("exact quotes, page numbers, and section headings");
+    expect(AUDIT_FIXTURE.title).toContain("Legacy v1.5 Mismatch Regression Judgment Fixtures");
+    expect(AUDIT_FIXTURE.fixtureTruthPolicy).toContain("quarantined legacy v1.5 mismatch regression fixture");
+    expect(AUDIT_FIXTURE.fixtureTruthPolicy).toContain("do not use current app output as gold");
     expect(SOURCE_EXCERPTS.sourceTypeConfirmation.page).toBe(1);
     expect(SOURCE_EXCERPTS.sourceTypeConfirmation.quote).toContain("PROJECT DESCRIPTION");
     expect(SOURCE_EXCERPTS.pageExcerpts["1"]).toContain("THE ENVIRA AMAZONIA PROJECT");
@@ -50,7 +52,7 @@ describe("Envira VM0007 judgment fixtures", () => {
     expect(AUDIT_FIXTURE.methodology).toBe("VM0007");
     expect(AUDIT_FIXTURE.checks.length).toBeGreaterThanOrEqual(5);
     expect(AUDIT_FIXTURE.checks.length).toBeLessThanOrEqual(10);
-    expect(AUDIT_FIXTURE.expectedWarnings).toHaveLength(3);
+    expect(AUDIT_FIXTURE.expectedWarnings).toHaveLength(4);
 
     expect(AUDIT_FIXTURE.checks.some((check) => check.coverageTags.includes("clean_found"))).toBe(true);
     expect(AUDIT_FIXTURE.checks.some((check) => check.expectedStatus === "UNCLEAR")).toBe(true);

--- a/tests/lib/preverif.vm0007FullAuditFixtureShape.test.ts
+++ b/tests/lib/preverif.vm0007FullAuditFixtureShape.test.ts
@@ -19,7 +19,7 @@ function cloneFixture(): FullAuditFixtureSet {
   return JSON.parse(JSON.stringify(FULL_AUDIT_FIXTURE)) as FullAuditFixtureSet;
 }
 
-describe("VM0007 full 58-rule audit fixture shape", () => {
+describe("VM0007 full 58-rule legacy mismatch fixture shape", () => {
   it("uses the canonical synced VM0007 rule list and confirms the expected total is 58", () => {
     expect(VM0007_SYNCED_RULES).toHaveLength(58);
     expect(new Set(VM0007_SYNCED_RULES.map((rule) => rule.id)).size).toBe(58);

--- a/tests/lib/preverif/enviraVm0007FixtureBackedReport.test.ts
+++ b/tests/lib/preverif/enviraVm0007FixtureBackedReport.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "@jest/globals";
 import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
 
 describe("buildEnviraVm0007FixtureBackedReport", () => {
-  test("uses reviewed fixture truth counts and preserves all 58 VM0007 rows", () => {
+  test("uses quarantined legacy counts and preserves all 58 VM0007 rows", () => {
     const report = buildEnviraVm0007FixtureBackedReport();
 
     expect(report.summary.counts.FOUND).toBe(30);
@@ -10,6 +10,9 @@ describe("buildEnviraVm0007FixtureBackedReport", () => {
     expect(report.summary.counts.MISSING).toBe(3);
     expect(report.summary.counts["N/A"]).toBe(17);
     expect(report.summary.totalRules).toBe(58);
+    expect(report.reportName).toBe("Legacy v1.5 mismatch regression fixture preview");
+    expect(report.quarantine.label).toBe("Legacy v1.5 mismatch regression fixture");
+    expect(report.quarantine.versionMatch).toBe(false);
     expect(report.evidenceMapRows).toHaveLength(58);
   });
 });


### PR DESCRIPTION
slug: vm0007-version-cleanup

cleanup phase advanced: Phase 2 Envira Quarantine

Summary:
- Envira is relabeled as a legacy v1.5 mismatch regression fixture.
- The fixture is preserved, but explicitly quarantined and not treated as validated VM0007 v1.8 truth.
- Historical 30 FOUND / 8 UNCLEAR / 3 MISSING / 17 N/A counts remain contaminated legacy output only.

Changed files:
- docs/roadmaps/vm0007-version-cleanup/phase-status.json
- docs/roadmaps/SUMMARY.md
- src/lib/preverif/fixtureBackedVm0007Report.ts
- src/lib/preverif/enviraVm0007FixtureBackedReport.ts
- src/lib/preverif/enviraVm0007FixtureBackedPdf.ts
- src/components/preverif/FixtureBackedVm0007ReportView.tsx
- src/app/internal/reports/envira-vm0007/page.tsx
- src/app/api/exports/internal/envira-vm0007-report/route.ts
- tests/lib/preverif/enviraVm0007FixtureBackedReport.test.ts
- tests/lib/preverif.enviraVm0007FixtureBackedPdf.test.ts
- tests/lib/preverif.enviraVm0007ProvenanceAudit.test.ts
- tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts
- tests/lib/preverif.vm0007FullAuditFixtureShape.test.ts
- tests/components/fixtureBackedVm0007ReportView.test.tsx
- tests/app/internal/envira-vm0007.page.test.tsx
- tests/app/api/exports/internal.envira-vm0007-report.route.test.ts
- tests/fixtures/preverif/envira-vm0007-full-audit-fixture-shape.json
- tests/fixtures/preverif/envira-vm0007-judgment-fixtures.json

Tests run:
- npm test -- --runInBand tests/lib/preverif.vm0007VersionLock.test.ts
- npm test -- --runInBand tests/lib/preverif.vm0007GapReport.test.ts
- npm test -- --runInBand tests/components/vm0007GapReportPreview.test.tsx
- npm test -- --runInBand tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
- npm test -- --runInBand tests/lib/preverif/enviraVm0007FixtureBackedReport.test.ts
- npm test -- --runInBand tests/lib/preverif.enviraVm0007FixtureBackedPdf.test.ts
- npm test -- --runInBand tests/components/fixtureBackedVm0007ReportView.test.tsx
- npm test -- --runInBand tests/app/api/exports/internal.envira-vm0007-report.route.test.ts
- npm test -- --runInBand tests/app/internal/envira-vm0007.page.test.tsx
- npm test -- --runInBand tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts
- npm test -- --runInBand tests/lib/preverif.vm0007FullAuditFixtureShape.test.ts
- npm test -- --runInBand tests/lib/preverif.enviraVm0007ProvenanceAudit.test.ts
- npm test -- --runInBand tests/lib/preverif.clientReadinessGate.test.ts
- npm run lint
- npm run typecheck
- npm run pr:gate (started, reached repo-wide tests, then was interrupted after the targeted Envira/quickCheck suites were passing; no PR-scoped failures were observed)

phase-status.json changed: yes
docs/roadmaps/SUMMARY.md regenerated: yes
PR body uses slug: vm0007-version-cleanup
Envira blocked/quarantined correctly: yes
Old 30/8/3/17 counts no longer treated as truth: yes
Quick Check v2 fixture tests still pass: yes

Unresolved risks:
- `npm run pr:gate` was not allowed to finish because it expanded into a long repo-wide run after the relevant checks had already passed.
- The quarantine is narrow by design; follow-on report/PDF blocking remains for later roadmap phases.
