### PR TITLE
fix: block VM0007 reports and PDF exports on version mismatch

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -359,23 +359,22 @@ Not active now:
 Status SSOT: `docs/roadmaps/vm0007-version-cleanup/phase-status.json`
 
 Lane status: Active
-Phase 2 Envira quarantine is complete: the Envira legacy v1.5 mismatch fixture is preserved as regression coverage and not validated truth.
+Phase 3 Report/PDF blocking is complete: mismatched VM0007 versions now render blocked output only, not normal evidence maps or PDFs.
 
 Current focus:
 - Use Phase 1 hard blocking as the baseline for later cleanup phases
 - Keep Envira quarantined as a blocked legacy v1.5 mismatch regression case
-- Proceed to report/PDF blocking only if the next phase needs it
+- Proceed to gate strengthening for mismatched-version report, PDF, and readiness paths
 
 Not active now:
 - Envira quarantine
 - Report/PDF blocking
-- Gate strengthening
 - Roadmap correction
 - Forward-path expansion
 
 1) RC1 — Phase 1: Version Lock: Done — VM0007 version identity is enforced before evidence audit; missing or mismatched PDD-declared methodology versions hard block with BLOCKED_VERSION_MISMATCH, while legitimate VM0007 v1.8 may proceed.
 2) RC2 — Phase 2: Envira Quarantine: Done — Preserve Envira as a legacy v1.5 mismatch regression fixture, not validated truth.
-3) RC3 — Phase 3: Report and PDF Blocking: Planned — Prevent mismatched versions from producing normal evidence maps, reports, PDFs, or readiness claims.
+3) RC3 — Phase 3: Report and PDF Blocking: Done — Prevent mismatched versions from producing normal evidence maps, reports, PDFs, or readiness claims.
 4) RC4 — Phase 4: Gate Strengthening: Planned — Add tests and gates so mismatches cannot produce judgments, reports, PDFs, or client-readiness output.
 5) RC5 — Phase 5: Roadmap Correction: Planned — Correct contaminated done states and mark VM0007 evidence-map work pending versioned re-audit.
 6) RC6 — Phase 6: Forward Path: Planned — Prepare a clean VM0007 v1.8 path such as Maya without building a full evidence map yet.

--- a/docs/roadmaps/vm0007-version-cleanup/phase-status.json
+++ b/docs/roadmaps/vm0007-version-cleanup/phase-status.json
@@ -2,16 +2,15 @@
   "roadmap": "vm0007-version-cleanup",
   "phase_meta": {
     "status": "active",
-    "summary": "Phase 2 Envira quarantine is complete: the Envira legacy v1.5 mismatch fixture is preserved as regression coverage and not validated truth.",
+    "summary": "Phase 3 Report/PDF blocking is complete: mismatched VM0007 versions now render blocked output only, not normal evidence maps or PDFs.",
     "current_focus": [
       "Use Phase 1 hard blocking as the baseline for later cleanup phases",
       "Keep Envira quarantined as a blocked legacy v1.5 mismatch regression case",
-      "Proceed to report/PDF blocking only if the next phase needs it"
+      "Proceed to gate strengthening for mismatched-version report, PDF, and readiness paths"
     ],
     "not_active_now": [
       "Envira quarantine",
       "Report/PDF blocking",
-      "Gate strengthening",
       "Roadmap correction",
       "Forward-path expansion"
     ],
@@ -30,7 +29,7 @@
     },
     "phase_3_report_and_pdf_blocking": {
       "title": "Phase 3: Report and PDF Blocking",
-      "status": "planned",
+      "status": "done",
       "summary": "Prevent mismatched versions from producing normal evidence maps, reports, PDFs, or readiness claims."
     },
     "phase_4_gate_strengthening": {

--- a/src/app/api/exports/internal/envira-vm0007-report/route.ts
+++ b/src/app/api/exports/internal/envira-vm0007-report/route.ts
@@ -15,7 +15,7 @@ export async function GET() {
     return new NextResponse(blob, {
       headers: {
         "Content-Type": "application/pdf",
-        "Content-Disposition": 'attachment; filename="envira-vm0007-v15-legacy-mismatch.pdf"',
+        "Content-Disposition": 'attachment; filename="envira-vm0007-v15-legacy-mismatch-blocked.pdf"',
         "Cache-Control": "no-store",
       },
     });

--- a/src/app/internal/reports/envira-vm0007/page.tsx
+++ b/src/app/internal/reports/envira-vm0007/page.tsx
@@ -4,7 +4,7 @@ import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm000
 
 export const metadata: Metadata = {
   title: "Envira VM0007 legacy v1.5 mismatch | app.article6",
-  description: "Quarantined Envira VM0007 legacy v1.5 mismatch regression fixture and evidence map preview.",
+  description: "Quarantined Envira VM0007 legacy v1.5 mismatch regression fixture with blocked report preview.",
 };
 
 export default function EnviraVm0007FixtureBackedReportPage() {

--- a/src/components/preverif/FixtureBackedVm0007ReportView.tsx
+++ b/src/components/preverif/FixtureBackedVm0007ReportView.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 import {
+  isVm0007VersionMismatchBlocked,
+  VM0007_VERSION_MISMATCH_BLOCK_MESSAGE,
   getPriorityClientActionRows,
   groupEvidenceMapRowsByStatus,
   type Vm0007EvidenceMapRow,
@@ -70,6 +72,62 @@ function renderBlocks(blocks: Vm0007DisplayBlock[]) {
   );
 }
 
+function renderVersionMismatchBlock(report: Vm0007FixtureBackedReport, pdfDownloadHref: string | null) {
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-8">
+      <div className="mx-auto grid max-w-5xl gap-4">
+        <section className="rounded-[28px] border border-amber-200 bg-[linear-gradient(135deg,#fffaf0_0%,#fff4e6_100%)] p-6 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="max-w-3xl">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-amber-300 bg-amber-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-amber-900">
+                  Report blocked
+                </span>
+                <span className="rounded-full border border-slate-300 bg-slate-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-700">
+                  Quarantined legacy fixture
+                </span>
+              </div>
+              <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-950">Envira VM0007 legacy v1.5 mismatch</h1>
+              <div className="mt-2 text-base text-slate-700">{report.project.name}</div>
+              <div className="mt-4 text-sm font-medium text-amber-900">{VM0007_VERSION_MISMATCH_BLOCK_MESSAGE}</div>
+              <div className="mt-3 grid gap-2 text-sm leading-6 text-slate-700">
+                <div>Quarantined legacy mismatch regression fixture.</div>
+                <div>Historical counts remain contaminated output only.</div>
+                <div>PDD-declared methodology: {report.quarantine.pddDeclaredMethodologyVersion}</div>
+                <div>Loaded rulebook: {report.quarantine.loadedRulebookVersion}</div>
+              </div>
+            </div>
+            {pdfDownloadHref ? (
+              <a
+                href={pdfDownloadHref}
+                className="inline-flex items-center justify-center rounded-full border border-amber-900 bg-amber-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-amber-800"
+              >
+                Download blocked PDF
+              </a>
+            ) : null}
+          </div>
+          <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900">
+            Evidence judgment blocked by methodology version mismatch.
+          </div>
+          <div className="mt-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700">
+            <div className="font-semibold text-slate-950">Quarantine metadata</div>
+            <div className="mt-2 grid gap-1 sm:grid-cols-2">
+              <div>PDD-declared methodology: {report.quarantine.pddDeclaredMethodologyVersion}</div>
+              <div>Loaded rulebook: {report.quarantine.loadedRulebookVersion}</div>
+              <div>Status: {report.quarantine.status}</div>
+              <div>Version match: {String(report.quarantine.versionMatch)}</div>
+            </div>
+            <div className="mt-2">{report.quarantine.note}</div>
+          </div>
+          <div className="mt-4 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700">
+            Internal-only blocked output. No evidence map is rendered.
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
 function renderEvidenceMapRow(row: Vm0007EvidenceMapRow) {
   const supportingBlocks = buildEvidenceMapDisplayBlocks(row);
 
@@ -93,6 +151,10 @@ function renderEvidenceMapRow(row: Vm0007EvidenceMapRow) {
 }
 
 export default function FixtureBackedVm0007ReportView({ report, pdfDownloadHref = null }: FixtureBackedVm0007ReportViewProps) {
+  if (isVm0007VersionMismatchBlocked(report)) {
+    return renderVersionMismatchBlock(report, pdfDownloadHref);
+  }
+
   const groupedRows = groupEvidenceMapRowsByStatus(report.evidenceMapRows);
   const priorityRows = getPriorityClientActionRows(report.evidenceMapRows);
   const summaryCards = [

--- a/src/lib/preverif/enviraVm0007FixtureBackedPdf.ts
+++ b/src/lib/preverif/enviraVm0007FixtureBackedPdf.ts
@@ -1,6 +1,8 @@
 import {
   getPriorityClientActionRows,
   groupEvidenceMapRowsByStatus,
+  isVm0007VersionMismatchBlocked,
+  VM0007_VERSION_MISMATCH_BLOCK_MESSAGE,
   type Vm0007EvidenceMapRow,
   type Vm0007FixtureBackedReport,
 } from "@/lib/preverif/fixtureBackedVm0007Report";
@@ -57,6 +59,22 @@ function buildPriorityActionLines(report: Vm0007FixtureBackedReport): string[] {
   return lines;
 }
 
+function buildBlockedReportLines(report: Vm0007FixtureBackedReport): string[] {
+  return [
+    report.reportName,
+    "Version mismatch blocked",
+    VM0007_VERSION_MISMATCH_BLOCK_MESSAGE,
+    `Project name: ${report.project.name}`,
+    `Methodology: ${report.methodology.code} ${report.methodology.version} - ${report.methodology.name}`,
+    `Quarantine label: ${report.quarantine.label}`,
+    `PDD-declared methodology version: ${report.quarantine.pddDeclaredMethodologyVersion}`,
+    `Loaded rulebook version: ${report.quarantine.loadedRulebookVersion}`,
+    `versionMatch: ${report.quarantine.versionMatch}`,
+    `Generated: ${report.generatedAt}`,
+    "Blocked output only. No evidence map or summary counts are rendered.",
+  ].flatMap((line) => wrapText(line));
+}
+
 function wrapText(text: string, max = 96): string[] {
   const words = asciiSafeText(text).split(/\s+/).filter(Boolean);
   if (words.length === 0) return [""];
@@ -77,6 +95,10 @@ function wrapText(text: string, max = 96): string[] {
 }
 
 export function buildReportLines(report: Vm0007FixtureBackedReport): string[] {
+  if (isVm0007VersionMismatchBlocked(report)) {
+    return buildBlockedReportLines(report);
+  }
+
   const groupedRows = groupEvidenceMapRowsByStatus(report.evidenceMapRows);
   const lines: string[] = [
     report.reportName,

--- a/src/lib/preverif/enviraVm0007FixtureBackedReport.ts
+++ b/src/lib/preverif/enviraVm0007FixtureBackedReport.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { FullAuditFixtureSet, JudgmentFixtureSet } from "../../../tests/lib/preverifJudgmentFixtureGate";
 import { buildFixtureBackedVm0007Report, type Vm0007FixtureBackedReport } from "@/lib/preverif/fixtureBackedVm0007Report";
+export { VM0007_VERSION_MISMATCH_BLOCK_MESSAGE } from "@/lib/preverif/fixtureBackedVm0007Report";
 
 const FIXTURE_DIR = path.join(process.cwd(), "tests/fixtures/preverif");
 

--- a/src/lib/preverif/fixtureBackedVm0007Report.ts
+++ b/src/lib/preverif/fixtureBackedVm0007Report.ts
@@ -52,6 +52,9 @@ export type Vm0007FixtureBackedReport = {
   evidenceMapRows: Vm0007EvidenceMapRow[];
 };
 
+export const VM0007_VERSION_MISMATCH_BLOCK_MESSAGE =
+  "Methodology version mismatch: PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.";
+
 export const VM0007_FIXTURE_BACKED_STATUS_ORDER: Vm0007FixtureBackedStatus[] = [
   "MISSING",
   "UNCLEAR",
@@ -85,6 +88,10 @@ export function groupEvidenceMapRowsByStatus(rows: Vm0007EvidenceMapRow[]): Arra
 
 export function getPriorityClientActionRows(rows: Vm0007EvidenceMapRow[]): Vm0007EvidenceMapRow[] {
   return sortEvidenceMapRows(rows).filter((row) => row.status === "MISSING" || row.status === "UNCLEAR");
+}
+
+export function isVm0007VersionMismatchBlocked(report: Pick<Vm0007FixtureBackedReport, "quarantine">): boolean {
+  return report.quarantine.versionMatch === false;
 }
 
 function buildJudgmentIndex(judgmentFixtureSet?: JudgmentFixtureSet): Map<string, JudgmentFixtureSet["checks"][number]> {

--- a/tests/app/api/exports/internal.envira-vm0007-report.route.test.ts
+++ b/tests/app/api/exports/internal.envira-vm0007-report.route.test.ts
@@ -1,164 +1,29 @@
 import { describe, expect, it } from "@jest/globals";
 import { GET } from "@/app/api/exports/internal/envira-vm0007-report/route";
 import { extractPdfTextWithPdfParse } from "@/lib/chat/quickCheckPdfExtractor";
-import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
-import { buildReportLines } from "@/lib/preverif/enviraVm0007FixtureBackedPdf";
 
 describe("/api/exports/internal/envira-vm0007-report route", () => {
-  it("returns a parseable PDF attachment built from quarantined legacy mismatch report data", async () => {
-    const normalize = (value: string) => value.replace(/\s+/g, " ").trim();
-    const normalizeProvenanceText = (value: string) =>
-      value
-        .replace(/[\u2018\u2019]/g, "'")
-        .replace(/[\u201C\u201D]/g, '"')
-        .replace(/[\u2013\u2014]/g, "-")
-        .replace(/\s+/g, " ")
-        .trim();
-    const normalizePdfProvenanceText = (value: string) =>
-      normalizeProvenanceText(value)
-        .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, "")
-        .replace(/\s+/g, " ")
-        .trim();
+  it("returns a blocked PDF attachment instead of a normal evidence report", async () => {
     const response = await GET();
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toBe("application/pdf");
-    expect(response.headers.get("Content-Disposition")).toContain('attachment; filename="envira-vm0007-v15-legacy-mismatch.pdf"');
-
     const bytes = await response.arrayBuffer();
     const parsed = await extractPdfTextWithPdfParse({ bytes });
     const text = parsed.text;
     const lower = text.toLowerCase();
-    const normalized = normalize(text);
-    const report = buildEnviraVm0007FixtureBackedReport();
-    const reportLines = buildReportLines(report).join("\n");
-    const reportLinesNormalized = normalize(reportLines);
-    const textNormalized = normalize(text);
-    const rowsWithQuotes = report.evidenceMapRows.filter((row) => row.acceptedQuote?.trim());
-    const rowsWithPages = report.evidenceMapRows.filter((row) => row.page != null);
-    const rowsWithSections = report.evidenceMapRows.filter((row) => row.sectionHeading?.trim());
-    const reportLineList = reportLines.split("\n");
-    const prioritySectionStart = reportLineList.indexOf("Priority Client Actions");
-    const prioritySectionEnd = reportLineList.indexOf("Evidence Map");
-    const prioritySectionLines = prioritySectionStart >= 0 && prioritySectionEnd > prioritySectionStart ? reportLineList.slice(prioritySectionStart, prioritySectionEnd) : [];
-    const priorityRows = report.evidenceMapRows.filter((row) => row.status === "UNCLEAR" || row.status === "MISSING");
+    const collapsedText = text.replace(/\s+/g, " ").trim();
 
-    expect(text).toContain("Envira VM0007 legacy v1.5 mismatch");
-    expect(text).toContain("Quarantined legacy mismatch regression fixture");
-    expect(text).toContain("Not client-ready");
-    expect(text).toContain("Based on contaminated historical fixture output");
-    expect(normalized).toContain("Purpose: preserve false FOUND rows, wrong page anchors, module-list evidence, and flattened table errors");
-    expect(text).toContain("FOUND: 30");
-    expect(text).toContain("UNCLEAR: 8");
-    expect(text).toContain("MISSING: 3");
-    expect(text).toContain("N/A: 17");
-    expect(text).toContain("Total rules: 58");
-    expect(text).toContain("PDD-declared methodology version: REDD-MF / VM0007 v1.5");
-    expect(text).toContain("Loaded rulebook version: VM0007 v1.8");
-    expect(text).toContain("versionMatch: false");
-    expect(text).toContain("Priority Client Actions");
-    expect(text).toContain("MISSING - 3");
-    expect(text).toContain("UNCLEAR - 8");
-    expect(text).toContain("FOUND - 30");
-    expect(text).toContain("N/A - 17");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+    expect(response.headers.get("Content-Disposition")).toContain('attachment; filename="envira-vm0007-v15-legacy-mismatch-blocked.pdf"');
+    expect(text).toContain("Version mismatch blocked");
+    expect(collapsedText).toContain("Methodology version mismatch: PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.");
+    expect(text).not.toContain("FOUND: 30");
+    expect(text).not.toContain("UNCLEAR: 8");
+    expect(text).not.toContain("MISSING: 3");
+    expect(text).not.toContain("N/A: 17");
+    expect(text).not.toContain("Priority Client Actions");
+    expect(text).not.toContain("Evidence Map");
 
-    expect(rowsWithQuotes.length).toBeGreaterThan(0);
-    expect(rowsWithPages.length).toBeGreaterThan(0);
-    expect(rowsWithSections.length).toBeGreaterThan(0);
-
-    for (const row of report.evidenceMapRows) {
-      expect(reportLinesNormalized).toContain(`Rule ID: ${row.ruleId}`);
-      expect(reportLinesNormalized).toContain(`Rule name: ${row.ruleName}`);
-
-      if (row.acceptedQuote?.trim()) {
-        const expectedQuoteLabel = row.status === "UNCLEAR" ? "Weak quote" : "Accepted quote";
-        const quotePrefix = row.acceptedQuote.trim().slice(0, 60);
-        expect(normalizePdfProvenanceText(reportLinesNormalized)).toContain(
-          normalizePdfProvenanceText(`${expectedQuoteLabel}: ${quotePrefix}`),
-        );
-        expect(normalizePdfProvenanceText(textNormalized)).toContain(
-          normalizePdfProvenanceText(`${expectedQuoteLabel}: ${quotePrefix}`),
-        );
-      }
-
-      if (row.page != null) {
-        expect(reportLinesNormalized).toContain(`Page: ${row.page}`);
-        expect(textNormalized).toContain(`Page: ${row.page}`);
-      }
-
-      if (row.sectionHeading?.trim()) {
-        expect(normalizePdfProvenanceText(reportLinesNormalized)).toContain(
-          normalizePdfProvenanceText(`Section: ${row.sectionHeading.trim()}`),
-        );
-        expect(normalizePdfProvenanceText(textNormalized)).toContain(
-          normalizePdfProvenanceText(`Section: ${row.sectionHeading.trim()}`),
-        );
-      }
-    }
-
-    for (const row of priorityRows) {
-      const startIndex = prioritySectionLines.indexOf(`Rule ID: ${row.ruleId}`);
-      expect(startIndex).toBeGreaterThanOrEqual(0);
-
-      let endIndex = prioritySectionLines.length;
-      for (let index = startIndex + 1; index < prioritySectionLines.length; index += 1) {
-        if (prioritySectionLines[index].startsWith("Rule ID: ")) {
-          endIndex = index;
-          break;
-        }
-      }
-
-      const rowText = normalizePdfProvenanceText(prioritySectionLines.slice(startIndex, endIndex).join(" "));
-      expect(rowText).toContain(row.ruleId);
-      expect(rowText).toContain(row.ruleName);
-
-      if (row.status === "UNCLEAR") {
-        if (row.acceptedQuote?.trim()) {
-          expect(rowText).toContain(normalizePdfProvenanceText(row.acceptedQuote.trim()));
-          expect(rowText).toContain("Weak quote");
-        }
-
-        if (row.page != null) {
-          expect(rowText).toContain(`Page: ${row.page}`);
-        }
-
-        if (row.sectionHeading?.trim()) {
-          expect(rowText).toContain(normalizePdfProvenanceText(`Section: ${row.sectionHeading.trim()}`));
-        }
-
-        if (row.clientAction?.trim()) {
-          expect(rowText).toContain(normalizePdfProvenanceText(row.clientAction.trim()));
-        }
-      }
-
-      if (row.status === "MISSING") {
-        expect(rowText).toContain(normalizePdfProvenanceText(row.whyEvidenceIsAccepted.trim()));
-        if (row.clientAction?.trim()) {
-          expect(rowText).toContain(normalizePdfProvenanceText(row.clientAction.trim()));
-        }
-        expect(rowText).not.toContain("No accepted quote encoded");
-        expect(rowText).not.toContain("Page: Not available");
-        expect(rowText).not.toContain("Section: Not available");
-        expect(rowText).not.toContain("Span ID: Not available");
-      }
-    }
-
-    expect(normalized).toContain("Rejected evidence:");
-    expect(normalized).toContain("the land is legally permitted to be converted to non-forest");
-    expect(normalized).toContain("Generic methodology-applicability language is not the underlying authorization document.");
-    expect(text).not.toContain("Span ID: Not available");
-    expect(text).not.toContain("No accepted quote encoded in fixture truth.");
-    expect(text).not.toContain("Page: Not available");
-    expect(text).not.toContain("Section: Not available");
-
-    for (const banned of [
-      "all clear",
-      "passed",
-      "fully verified",
-      "ready for verification",
-      "58 supported",
-      "all rules supported",
-    ]) {
+    for (const banned of ["client ready", "ready for verification", "verified", "all clear"]) {
       expect(lower).not.toContain(banned);
     }
   }, 20000);

--- a/tests/app/internal/envira-vm0007.page.test.tsx
+++ b/tests/app/internal/envira-vm0007.page.test.tsx
@@ -3,11 +3,15 @@ import { renderToStaticMarkup } from "react-dom/server";
 import EnviraVm0007FixtureBackedReportPage from "@/app/internal/reports/envira-vm0007/page";
 
 describe("/internal/reports/envira-vm0007 page", () => {
-  test("renders a visible Download PDF button for the quarantined legacy mismatch fixture", () => {
+  test("renders the blocked legacy mismatch message and blocked PDF download link", () => {
     const html = renderToStaticMarkup(<EnviraVm0007FixtureBackedReportPage />);
 
-    expect(html).toContain("Download PDF");
-    expect(html).toContain('href="/api/exports/internal/envira-vm0007-report"');
+    expect(html).toContain("Report blocked");
     expect(html).toContain("Envira VM0007 legacy v1.5 mismatch");
+    expect(html).toContain("Methodology version mismatch: PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.");
+    expect(html).toContain('href="/api/exports/internal/envira-vm0007-report"');
+    expect(html).toContain("Download blocked PDF");
+    expect(html).not.toContain("Executive Summary");
+    expect(html).not.toContain("Evidence Map");
   });
 });

--- a/tests/components/fixtureBackedVm0007ReportView.test.tsx
+++ b/tests/components/fixtureBackedVm0007ReportView.test.tsx
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
-import { JSDOM } from "jsdom";
 import { renderToStaticMarkup } from "react-dom/server";
 import FixtureBackedVm0007ReportView from "@/components/preverif/FixtureBackedVm0007ReportView";
-import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
+import { VM0007_VERSION_MISMATCH_BLOCK_MESSAGE, buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
 
 function buildHtml() {
   return renderToStaticMarkup(
@@ -13,179 +12,34 @@ function buildHtml() {
   );
 }
 
-function buildDocument() {
-  return new JSDOM(buildHtml()).window.document;
-}
-
-function normalizeProvenanceText(value: string): string {
-  return value
-    .replace(/[\u2018\u2019]/g, "'")
-    .replace(/[\u201C\u201D]/g, '"')
-    .replace(/[\u2013\u2014]/g, "-")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
 describe("FixtureBackedVm0007ReportView", () => {
-  test("renders the quarantined Envira legacy mismatch summary counts and all 58 evidence-map rows", () => {
+  test("renders the blocked legacy mismatch panel instead of a normal evidence map", () => {
     const html = buildHtml();
     const rowCount = (html.match(/data-evidence-map-row=/g) ?? []).length;
 
+    expect(html).toContain("Report blocked");
     expect(html).toContain("Envira VM0007 legacy v1.5 mismatch");
-    expect(html).toContain("Quarantined legacy fixture");
-    expect(html).toContain("Not client-ready");
-    expect(html).toContain("Based on contaminated historical fixture output");
-    expect(html).toContain("Purpose: preserve false FOUND rows, wrong page anchors, module-list evidence, and flattened table errors");
-    expect(html).toContain("Download PDF");
-    expect(html).toContain(">FOUND<");
-    expect(html).toContain(">30<");
-    expect(html).toContain(">UNCLEAR<");
-    expect(html).toContain(">8<");
-    expect(html).toContain(">MISSING<");
-    expect(html).toContain(">3<");
-    expect(html).toContain(">N/A<");
-    expect(html).toContain(">17<");
-    expect(html).toContain("versionMatch false");
-    expect(html).toContain("Historical counts are contaminated legacy output and must not be treated as validated truth.");
-    expect(rowCount).toBe(58);
-    expect(html).toContain("Executive Summary");
-    expect(html).toContain("Priority Client Actions");
-  });
-
-  test("renders row-scoped provenance for every evidence-bearing row and keeps missing rows honest", () => {
-    const document = buildDocument();
-    const report = buildEnviraVm0007FixtureBackedReport();
-
-    const rowsWithQuotes = report.evidenceMapRows.filter((row) => row.acceptedQuote?.trim());
-    const rowsWithPages = report.evidenceMapRows.filter((row) => row.page != null);
-    const rowsWithSections = report.evidenceMapRows.filter((row) => row.sectionHeading?.trim());
-
-    expect(rowsWithQuotes.length).toBeGreaterThan(0);
-    expect(rowsWithPages.length).toBeGreaterThan(0);
-    expect(rowsWithSections.length).toBeGreaterThan(0);
-
-    for (const row of report.evidenceMapRows) {
-      const rowEl = document.querySelector(`[data-evidence-map-row="${row.ruleId}"]`);
-      expect(rowEl).not.toBeNull();
-      const rowText = rowEl?.textContent?.replace(/\s+/g, " ").trim() ?? "";
-      const normalizedRowText = normalizeProvenanceText(rowText);
-
-      if (row.acceptedQuote?.trim()) {
-        expect(normalizedRowText).toContain(normalizeProvenanceText(row.acceptedQuote.trim()));
-        expect(normalizedRowText).toContain(row.status === "UNCLEAR" ? "Weak quote" : "Accepted quote");
-      }
-
-      if (row.page != null) {
-        expect(normalizedRowText).toContain(String(row.page));
-      }
-
-      if (row.sectionHeading?.trim()) {
-        expect(normalizedRowText).toContain(normalizeProvenanceText(row.sectionHeading.trim()));
-      }
-    }
-
-    for (const row of report.evidenceMapRows.filter((entry) => entry.status === "MISSING")) {
-      const rowEl = document.querySelector(`[data-evidence-map-row="${row.ruleId}"]`);
-      const rowText = rowEl?.textContent?.replace(/\s+/g, " ").trim() ?? "";
-
-      expect(rowText).not.toContain("No accepted quote encoded");
-      expect(rowText).not.toContain("Page: Not available");
-      expect(rowText).not.toContain("Section: Not available");
-      expect(rowText).not.toContain("Span ID: Not available");
-    }
-  });
-
-  test("renders grouped evidence-map sections in the expected order", () => {
-    const html = buildHtml();
-
-    expect(html).toContain("MISSING — 3");
-    expect(html).toContain("UNCLEAR — 8");
-    expect(html).toContain("FOUND — 30");
-    expect(html).toContain("N/A — 17");
-    expect(html).toContain('data-status="UNCLEAR"');
-    expect(html).toContain('data-status="MISSING"');
-    expect(html).toContain('data-status="N/A"');
-  });
-
-  test("renders row-scoped priority client actions with provenance for UNCLEAR rows", () => {
-    const document = buildDocument();
-    const report = buildEnviraVm0007FixtureBackedReport();
-    const priorityRows = report.evidenceMapRows.filter((row) => row.status === "UNCLEAR" || row.status === "MISSING");
-
-    expect(priorityRows.length).toBeGreaterThan(0);
-
-    for (const row of priorityRows) {
-      const rowEl = document.querySelector(`[data-priority-action-row="${row.ruleId}"]`);
-      expect(rowEl).not.toBeNull();
-
-      const rowText = rowEl?.textContent?.replace(/\s+/g, " ").trim() ?? "";
-      const normalizedRowText = normalizeProvenanceText(rowText);
-
-      if (row.status === "UNCLEAR") {
-        if (row.acceptedQuote?.trim()) {
-          expect(normalizedRowText).toContain(normalizeProvenanceText(row.acceptedQuote.trim()));
-          expect(normalizedRowText).toContain("Weak quote");
-        }
-
-        if (row.page != null) {
-          expect(normalizedRowText).toContain(String(row.page));
-        }
-
-        if (row.sectionHeading?.trim()) {
-          expect(normalizedRowText).toContain(normalizeProvenanceText(row.sectionHeading.trim()));
-        }
-
-        expect(normalizedRowText).toContain(normalizeProvenanceText(row.whyEvidenceIsAccepted));
-
-        if (row.whyRejectedEvidenceIsNotEnough?.trim()) {
-          expect(normalizedRowText).toContain(normalizeProvenanceText(row.whyRejectedEvidenceIsNotEnough.trim()));
-        }
-
-        for (const rejected of row.rejectedEvidenceExamples) {
-          expect(normalizedRowText).toContain(normalizeProvenanceText(rejected.quote));
-          expect(normalizedRowText).toContain(normalizeProvenanceText(rejected.rejectionReason));
-        }
-
-        if (row.clientAction?.trim()) {
-          expect(normalizedRowText).toContain(normalizeProvenanceText(row.clientAction.trim()));
-        }
-      }
-
-      if (row.status === "MISSING") {
-        expect(rowText).toContain("Missing reason");
-        expect(normalizedRowText).toContain(normalizeProvenanceText(row.whyEvidenceIsAccepted));
-
-        if (row.clientAction?.trim()) {
-          expect(normalizedRowText).toContain(normalizeProvenanceText(row.clientAction.trim()));
-        }
-
-        for (const placeholder of ["No accepted quote encoded", "Page: Not available", "Section: Not available", "Span ID: Not available"]) {
-          expect(rowText).not.toContain(placeholder);
-        }
-      }
-    }
-  });
-
-  test("hides placeholder clutter while preserving rejected evidence where encoded and avoids banned wording", () => {
-    const html = buildHtml();
-    const lower = html.toLowerCase();
-
-    expect(html).toContain("the land is legally permitted to be converted to non-forest");
-    expect(html).toContain("Generic methodology-applicability language is not the underlying authorization document.");
-    expect(html).toContain("Project Description");
+    expect(html).toContain(VM0007_VERSION_MISMATCH_BLOCK_MESSAGE);
+    expect(html).toContain("Download blocked PDF");
     expect(html).toContain("Quarantine metadata");
-    expect(html).not.toContain("Span ID: Not available");
-    expect(html).not.toContain("No accepted quote encoded in fixture truth.");
-    expect(html).not.toContain("Rejected evidence examples");
+    expect(html).toContain("PDD-declared methodology: REDD-MF / VM0007 v1.5");
+    expect(html).toContain("Loaded rulebook: VM0007 v1.8");
+    expect(html).toContain("Version match: false");
+    expect(html).toContain("Internal-only blocked output. No evidence map is rendered.");
+    expect(rowCount).toBe(0);
+    expect(html).not.toContain("Executive Summary");
+    expect(html).not.toContain("Priority Client Actions");
+    expect(html).not.toContain("Evidence Map");
+    expect(html).not.toContain(">30<");
+    expect(html).not.toContain(">8<");
+    expect(html).not.toContain(">3<");
+    expect(html).not.toContain(">17<");
+  });
 
-    for (const banned of [
-      "all clear",
-      "fully verified",
-      "ready for verification",
-      "58 supported",
-      "all rules supported",
-      "passed",
-    ]) {
+  test("avoids readiness language in the blocked report view", () => {
+    const lower = buildHtml().toLowerCase();
+
+    for (const banned of ["client ready", "ready for verification", "verified", "all clear"]) {
       expect(lower).not.toContain(banned);
     }
   });

--- a/tests/lib/preverif.enviraVm0007FixtureBackedPdf.test.ts
+++ b/tests/lib/preverif.enviraVm0007FixtureBackedPdf.test.ts
@@ -1,115 +1,41 @@
-import { describe, expect, test } from "@jest/globals";
+import { describe, expect, it } from "@jest/globals";
+import { extractPdfTextWithPdfParse } from "@/lib/chat/quickCheckPdfExtractor";
 import { buildEnviraVm0007FixtureBackedReport } from "@/lib/preverif/enviraVm0007FixtureBackedReport";
-import { buildReportLines } from "@/lib/preverif/enviraVm0007FixtureBackedPdf";
+import { buildEnviraVm0007FixtureBackedPdf, buildReportLines } from "@/lib/preverif/enviraVm0007FixtureBackedPdf";
 
-function normalizeProvenanceText(value: string): string {
-  return value
-    .replace(/[\u2018\u2019]/g, "'")
-    .replace(/[\u201C\u201D]/g, '"')
-    .replace(/[\u2013\u2014]/g, "-")
-    .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function extractPrioritySectionLines(lines: string[]): string[] {
-  const startIndex = lines.indexOf("Priority Client Actions");
-  const endIndex = lines.indexOf("Evidence Map");
-  return startIndex >= 0 && endIndex > startIndex ? lines.slice(startIndex, endIndex) : [];
-}
-
-function extractPriorityRowLines(lines: string[], ruleId: string): string[] {
-  const sectionLines = extractPrioritySectionLines(lines);
-  const startIndex = sectionLines.indexOf(`Rule ID: ${ruleId}`);
-  if (startIndex < 0) return [];
-
-  let endIndex = sectionLines.length;
-  for (let index = startIndex + 1; index < sectionLines.length; index += 1) {
-    if (sectionLines[index] === "Priority Client Actions" || sectionLines[index].startsWith("Rule ID: ")) {
-      endIndex = index;
-      break;
-    }
-  }
-
-  return sectionLines.slice(startIndex, endIndex);
-}
-
-describe("buildReportLines", () => {
-  test("preserves provenance for every evidence-bearing row and keeps the legacy mismatch label visible", () => {
+describe("buildEnviraVm0007FixtureBackedPdf", () => {
+  it("returns a blocked-only PDF when the legacy mismatch report is version-blocked", async () => {
     const report = buildEnviraVm0007FixtureBackedReport();
+    const pdf = buildEnviraVm0007FixtureBackedPdf(report);
+    const parsed = await extractPdfTextWithPdfParse({ bytes: pdf });
+    const text = parsed.text;
+    const lower = text.toLowerCase();
     const lines = buildReportLines(report);
-    const normalizedLines = normalizeProvenanceText(lines.join(" "));
-    const prioritySection = extractPrioritySectionLines(lines).join("\n");
+    const collapsedLines = lines.join(" ").replace(/\s+/g, " ").trim();
+    const collapsedText = text.replace(/\s+/g, " ").trim();
 
-    expect(lines.join("\n")).toContain("Envira VM0007 legacy v1.5 mismatch");
-    expect(lines.join("\n")).toContain("Quarantined legacy mismatch regression fixture");
-    expect(lines.join("\n")).toContain("versionMatch: false");
+    expect(lines.join("\n")).toContain("Version mismatch blocked");
+    expect(collapsedLines).toContain("Methodology version mismatch: PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.");
+    expect(lines.join("\n")).toContain("Blocked output only. No evidence map or summary counts are rendered.");
+    expect(lines.join("\n")).not.toContain("FOUND: 30");
+    expect(lines.join("\n")).not.toContain("Priority Client Actions");
+    expect(lines.join("\n")).not.toContain("Evidence Map");
 
-    for (const row of report.evidenceMapRows) {
-      if (row.acceptedQuote?.trim()) {
-        const expectedQuoteLabel = row.status === "UNCLEAR" ? "Weak quote" : "Accepted quote";
-        expect(normalizedLines).toContain(
-          normalizeProvenanceText(`${expectedQuoteLabel}: ${row.acceptedQuote.trim().slice(0, 60)}`),
-        );
-      }
+    expect(text).toContain("Version mismatch blocked");
+    expect(collapsedText).toContain("Methodology version mismatch: PDD declares REDD-MF v1.5, but loaded rulebook is VM0007 v1.8. Evidence judgment blocked.");
+    expect(text).toContain("Quarantine label: Legacy v1.5 mismatch regression fixture");
+    expect(text).toContain("PDD-declared methodology version: REDD-MF / VM0007 v1.5");
+    expect(text).toContain("Loaded rulebook version: VM0007 v1.8");
+    expect(text).toContain("versionMatch: false");
+    expect(text).not.toContain("FOUND: 30");
+    expect(text).not.toContain("UNCLEAR: 8");
+    expect(text).not.toContain("MISSING: 3");
+    expect(text).not.toContain("N/A: 17");
+    expect(text).not.toContain("Priority Client Actions");
+    expect(text).not.toContain("Evidence Map");
 
-      if (row.page != null) {
-        expect(normalizedLines).toContain(`Page: ${row.page}`);
-      }
-
-      if (row.sectionHeading?.trim()) {
-        expect(normalizedLines).toContain(normalizeProvenanceText(`Section: ${row.sectionHeading.trim()}`));
-      }
+    for (const banned of ["client ready", "ready for verification", "verified", "all clear"]) {
+      expect(lower).not.toContain(banned);
     }
-
-    const priorityRows = report.evidenceMapRows.filter((row) => row.status === "UNCLEAR" || row.status === "MISSING");
-    expect(prioritySection).toContain("Priority Client Actions");
-
-    for (const row of priorityRows) {
-      const rowLines = extractPriorityRowLines(lines, row.ruleId);
-      const rowText = normalizeProvenanceText(rowLines.join(" "));
-
-      expect(rowText).toContain(row.ruleId);
-      expect(rowText).toContain(row.ruleName);
-
-      if (row.status === "UNCLEAR") {
-        if (row.acceptedQuote?.trim()) {
-          expect(rowText).toContain(normalizeProvenanceText(row.acceptedQuote.trim()));
-          expect(rowText).toContain("Weak quote");
-        }
-
-        if (row.page != null) {
-          expect(rowText).toContain(`Page: ${row.page}`);
-        }
-
-        if (row.sectionHeading?.trim()) {
-          expect(rowText).toContain(normalizeProvenanceText(`Section: ${row.sectionHeading.trim()}`));
-        }
-
-        if (row.whyEvidenceIsAccepted?.trim()) {
-          expect(rowText).toContain(normalizeProvenanceText(row.whyEvidenceIsAccepted.trim()));
-        }
-
-        if (row.whyRejectedEvidenceIsNotEnough?.trim()) {
-          expect(rowText).toContain(normalizeProvenanceText(row.whyRejectedEvidenceIsNotEnough.trim()));
-        }
-
-        for (const rejected of row.rejectedEvidenceExamples) {
-          expect(rowText).toContain(normalizeProvenanceText(rejected.quote));
-          expect(rowText).toContain(normalizeProvenanceText(rejected.rejectionReason));
-        }
-      }
-
-      if (row.status === "MISSING") {
-        expect(rowText).toContain(normalizeProvenanceText(row.whyEvidenceIsAccepted.trim()));
-        if (row.clientAction?.trim()) {
-          expect(rowText).toContain(normalizeProvenanceText(row.clientAction.trim()));
-        }
-        expect(rowText).not.toContain("No accepted quote encoded");
-        expect(rowText).not.toContain("Page: Not available");
-        expect(rowText).not.toContain("Section: Not available");
-        expect(rowText).not.toContain("Span ID: Not available");
-      }
-    }
-  });
+  }, 20000);
 });

--- a/tests/lib/preverif/clientReadinessGate.test.ts
+++ b/tests/lib/preverif/clientReadinessGate.test.ts
@@ -15,7 +15,6 @@ import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif
 import { VM0007_SYNCED_RULES, readQuickCheckFixtureText } from "../preverifVm0007Fixtures";
 import {
   assertClientReadinessGate,
-  assertInternalPreviewBoundaries,
   assertInternalPreviewLabelVisible,
   assertNoBannedClientReadyWording,
   assertNoMissingEvidence,
@@ -246,11 +245,24 @@ describe("clientReadinessGate helper", () => {
 });
 
 describe("clientReadinessGate", () => {
-  test("internal Envira fixture-backed preview stays inside internal-only wording boundaries", () => {
+  test("blocked Envira fixture-backed preview uses mismatch wording instead of preview wording", () => {
     const html = renderToStaticMarkup(
-      createElement(FixtureBackedVm0007ReportView, { report: buildEnviraVm0007FixtureBackedReport() }),
+      createElement(FixtureBackedVm0007ReportView, {
+        report: buildEnviraVm0007FixtureBackedReport(),
+        pdfDownloadHref: "/api/exports/internal/envira-vm0007-report",
+      }),
     );
 
-    assertInternalPreviewBoundaries(html);
+    const normalized = html.toLowerCase();
+
+    expect(normalized).toContain("report blocked");
+    expect(normalized).toContain("methodology version mismatch: pdd declares redd-mf v1.5, but loaded rulebook is vm0007 v1.8. evidence judgment blocked.");
+    expect(normalized).toContain("download blocked pdf");
+    expect(normalized).not.toContain("internal preview only");
+    expect(normalized).not.toContain("not client-ready");
+
+    for (const banned of ["all clear", "fully verified", "ready for verification"]) {
+      expect(normalized).not.toContain(banned);
+    }
   });
 });


### PR DESCRIPTION
slug: vm0007-version-cleanup

- cleanup phase advanced: Phase 3 Report and PDF blocking
- changed files: docs/roadmaps/vm0007-version-cleanup/phase-status.json, docs/roadmaps/SUMMARY.md, src/lib/preverif/fixtureBackedVm0007Report.ts, src/lib/preverif/enviraVm0007FixtureBackedReport.ts, src/lib/preverif/enviraVm0007FixtureBackedPdf.ts, src/components/preverif/FixtureBackedVm0007ReportView.tsx, src/app/internal/reports/envira-vm0007/page.tsx, src/app/api/exports/internal/envira-vm0007-report/route.ts, tests/components/fixtureBackedVm0007ReportView.test.tsx, tests/lib/preverif.enviraVm0007FixtureBackedPdf.test.ts, tests/app/api/exports/internal.envira-vm0007-report.route.test.ts, tests/app/internal/envira-vm0007.page.test.tsx, tests/lib/preverif/clientReadinessGate.test.ts
- tests run: npm test -- --runInBand tests/lib/preverif.vm0007VersionLock.test.ts; npm test -- --runInBand tests/lib/preverif.vm0007GapReport.test.ts; npm test -- --runInBand tests/components/vm0007GapReportPreview.test.tsx; npm test -- --runInBand tests/components/quickCheckPanel.upload-integration-smoke.test.tsx; npm test -- --runInBand tests/components/fixtureBackedVm0007ReportView.test.tsx; npm test -- --runInBand tests/lib/preverif.enviraVm0007FixtureBackedPdf.test.ts; npm test -- --runInBand tests/app/api/exports/internal.envira-vm0007-report.route.test.ts; npm test -- --runInBand tests/app/internal/envira-vm0007.page.test.tsx; npm test -- --runInBand tests/lib/preverif.enviraVm0007ProvenanceAudit.test.ts; npm test -- --runInBand tests/lib/preverif/clientReadinessGate.test.ts; npm run roadmap:check; npm run lint; npm run typecheck; npm run pr:gate
- phase-status.json changed: yes
- docs/roadmaps/SUMMARY.md regenerated: yes
- envira blocked correctly: yes
- old 30 FOUND / 8 UNCLEAR / 3 MISSING / 17 N/A counts treated as truth: no
- Quick Check v2 fixture tests still pass: yes
- unresolved risks: npm run pr:gate still hits an unrelated tests/lib/preverif/pymupdfHelperSmoke.test.ts circular-JSON failure in the repo-wide gate
