### PR TITLE
ui: make VM0007 gap report launch button green

### DIFF
--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -36,7 +36,7 @@ export default function Vm0007GapReportLaunchButton({
           <div className="mt-3">
             <Link
               href={buildVm0007GapReportHref(auditId)}
-              className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700"
+              className="inline-flex items-center gap-2 rounded-full border border-green-600 bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:border-green-700 hover:bg-green-700"
             >
               <ArrowUpRight className="h-4 w-4" />
               View Gap Report

--- a/tests/components/vm0007GapReportLaunchButton.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.test.tsx
@@ -89,6 +89,8 @@ describe("Vm0007GapReportLaunchButton", () => {
     expect(container.textContent).toContain("Internal report");
     expect(link?.textContent).toContain("View Gap Report");
     expect(link?.getAttribute("href")).toBe("/internal/reports/vm0007-gap/audit-1");
+    expect(link?.className).toContain("bg-green-600");
+    expect(link?.className).toContain("text-white");
   });
 
   test("shows a disabled helper state when VM0007 result has no audit id yet", async () => {
@@ -120,6 +122,7 @@ describe("Vm0007GapReportLaunchButton", () => {
     const button = container.querySelector("button");
     expect(container.textContent).toContain("Internal VM0007 report");
     expect(button?.textContent).toContain("Generate Gap Report Preview");
+    expect(button?.className).not.toContain("bg-green-600");
 
     button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onGenerate).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Roadmap-Update
slug: none

Summary:
- UI-only polish: make “View Gap Report” green after a VM0007 gap report exists.
- No roadmap status changes.
- No audit/report/version-lock behavior changes.