### PR TITLE
[codex] fix: strengthen VM0007 version mismatch gates

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -359,22 +359,23 @@ Not active now:
 Status SSOT: `docs/roadmaps/vm0007-version-cleanup/phase-status.json`
 
 Lane status: Active
-Phase 3 Report/PDF blocking is complete: mismatched VM0007 versions now render blocked output only, not normal evidence maps or PDFs.
+Phase 4 Gate Strengthening is complete: mismatched VM0007 versions are blocked from normal evidence, report, PDF, and client-readiness trust paths.
 
 Current focus:
-- Use Phase 1 hard blocking as the baseline for later cleanup phases
 - Keep Envira quarantined as a blocked legacy v1.5 mismatch regression case
-- Proceed to gate strengthening for mismatched-version report, PDF, and readiness paths
+- Keep the existing quote/page/section integrity gates intact
+- Advance to roadmap correction only if the next cleanup phase is genuinely needed
 
 Not active now:
 - Envira quarantine
 - Report/PDF blocking
+- Gate strengthening
 - Roadmap correction
 - Forward-path expansion
 
 1) RC1 — Phase 1: Version Lock: Done — VM0007 version identity is enforced before evidence audit; missing or mismatched PDD-declared methodology versions hard block with BLOCKED_VERSION_MISMATCH, while legitimate VM0007 v1.8 may proceed.
 2) RC2 — Phase 2: Envira Quarantine: Done — Preserve Envira as a legacy v1.5 mismatch regression fixture, not validated truth.
 3) RC3 — Phase 3: Report and PDF Blocking: Done — Prevent mismatched versions from producing normal evidence maps, reports, PDFs, or readiness claims.
-4) RC4 — Phase 4: Gate Strengthening: Planned — Add tests and gates so mismatches cannot produce judgments, reports, PDFs, or client-readiness output.
+4) RC4 — Phase 4: Gate Strengthening: Done — Add tests and gates so mismatches cannot produce judgments, reports, PDFs, or client-readiness output.
 5) RC5 — Phase 5: Roadmap Correction: Planned — Correct contaminated done states and mark VM0007 evidence-map work pending versioned re-audit.
 6) RC6 — Phase 6: Forward Path: Planned — Prepare a clean VM0007 v1.8 path such as Maya without building a full evidence map yet.

--- a/docs/roadmaps/vm0007-version-cleanup/phase-status.json
+++ b/docs/roadmaps/vm0007-version-cleanup/phase-status.json
@@ -2,15 +2,16 @@
   "roadmap": "vm0007-version-cleanup",
   "phase_meta": {
     "status": "active",
-    "summary": "Phase 3 Report/PDF blocking is complete: mismatched VM0007 versions now render blocked output only, not normal evidence maps or PDFs.",
+    "summary": "Phase 4 Gate Strengthening is complete: mismatched VM0007 versions are blocked from normal evidence, report, PDF, and client-readiness trust paths.",
     "current_focus": [
-      "Use Phase 1 hard blocking as the baseline for later cleanup phases",
       "Keep Envira quarantined as a blocked legacy v1.5 mismatch regression case",
-      "Proceed to gate strengthening for mismatched-version report, PDF, and readiness paths"
+      "Keep the existing quote/page/section integrity gates intact",
+      "Advance to roadmap correction only if the next cleanup phase is genuinely needed"
     ],
     "not_active_now": [
       "Envira quarantine",
       "Report/PDF blocking",
+      "Gate strengthening",
       "Roadmap correction",
       "Forward-path expansion"
     ],
@@ -34,7 +35,7 @@
     },
     "phase_4_gate_strengthening": {
       "title": "Phase 4: Gate Strengthening",
-      "status": "planned",
+      "status": "done",
       "summary": "Add tests and gates so mismatches cannot produce judgments, reports, PDFs, or client-readiness output."
     },
     "phase_5_roadmap_correction": {

--- a/tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts
+++ b/tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts
@@ -142,6 +142,13 @@ describe("Envira VM0007 legacy mismatch judgment fixtures", () => {
     expect(() => assertVm0007JudgmentFixtureSet(mutated, PD_REDD_SOURCE_EXCERPTS)).toThrow();
   });
 
+  it("fails if the judgment fixture truth policy stops declaring the version mismatch quarantine", () => {
+    const brokenTruthPolicy = JSON.parse(JSON.stringify(AUDIT_FIXTURE)) as JudgmentFixtureSet;
+    brokenTruthPolicy.fixtureTruthPolicy = "Use exact quotes, page numbers, and section headings from PROJ_DESC_1382_04APR2015.pdf only. This fixture is validated truth.";
+
+    expect(() => assertVm0007JudgmentFixtureSet(brokenTruthPolicy, SOURCE_EXCERPTS)).toThrow();
+  });
+
   it("renders the fixture-backed report contract from the finalized 58-rule Envira audit fixture", () => {
     assertVm0007FullAuditFixtureSet(
       FULL_AUDIT_FIXTURE as FullAuditFixtureSet,

--- a/tests/lib/preverif.vm0007FullAuditFixtureShape.test.ts
+++ b/tests/lib/preverif.vm0007FullAuditFixtureShape.test.ts
@@ -108,6 +108,13 @@ describe("VM0007 full 58-rule legacy mismatch fixture shape", () => {
     expect(() => assertVm0007FullAuditFixtureSet(missingWithoutGuidance, VM0007_SYNCED_RULES, SOURCE_EXCERPTS)).toThrow();
   });
 
+  it("fails if the fixture truth policy stops declaring the version mismatch quarantine", () => {
+    const brokenTruthPolicy = cloneFixture();
+    brokenTruthPolicy.fixtureTruthPolicy = "Use exact quotes, page numbers, and section headings from PROJ_DESC_1382_04APR2015.pdf only. This fixture is validated truth.";
+
+    expect(() => assertVm0007FullAuditFixtureSet(brokenTruthPolicy, VM0007_SYNCED_RULES, SOURCE_EXCERPTS)).toThrow();
+  });
+
   it("fails if a rule is marked N/A without an explicit not-applicable reason", () => {
     const invalidNa = cloneFixture();
     invalidNa.checks = invalidNa.checks.map((check) =>

--- a/tests/lib/preverif/clientReadinessGate.test.ts
+++ b/tests/lib/preverif/clientReadinessGate.test.ts
@@ -18,6 +18,7 @@ import {
   assertInternalPreviewLabelVisible,
   assertNoBannedClientReadyWording,
   assertNoMissingEvidence,
+  assertNoVersionMismatchWarning,
   assertNoUnclearEvidence,
   assertUsesStandardReportShape,
 } from "./clientReadinessGate";
@@ -61,6 +62,19 @@ function buildReport(auditOverride?: MethodologyEvidenceAuditSummary) {
     },
     audit: base,
   });
+}
+
+function buildBlockedMismatchAudit(baseAudit: MethodologyEvidenceAuditSummary): MethodologyEvidenceAuditSummary {
+  return {
+    ...baseAudit,
+    auditStatus: "BLOCKED_VERSION_MISMATCH",
+    methodologyId: "VM0007",
+    rulebookVersion: "v1.8",
+    pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
+    versionMatch: false,
+    versionMismatchReason: "Version lock blocked: rulebook version mismatch: PDD declares v1.5, loaded contract is v1.8.",
+    userAcceptedVersionWarning: true,
+  };
 }
 
 function renderReport(report: Vm0007GapReport, extraHtml = ""): string {
@@ -216,6 +230,18 @@ describe("clientReadinessGate helper", () => {
     });
   });
 
+  describe("assertNoVersionMismatchWarning", () => {
+    it("passes when the report has no version mismatch warning", () => {
+      const report = buildReport(makeCleanAudit(auditText(ENVIRA_V18_TEXT)));
+      expect(() => assertNoVersionMismatchWarning(report)).not.toThrow();
+    });
+
+    it("fails when the report still carries a version mismatch warning", () => {
+      const report = buildReport(buildBlockedMismatchAudit(auditText(ENVIRA_V18_TEXT)));
+      expect(() => assertNoVersionMismatchWarning(report)).toThrow();
+    });
+  });
+
   describe("assertClientReadinessGate (composite)", () => {
     it("passes for a clean report (no weak, no missing, internal label, no banned wording)", () => {
       const report = buildReport(makeCleanAudit(auditText(ENVIRA_V18_TEXT)));
@@ -239,6 +265,12 @@ describe("clientReadinessGate helper", () => {
     it("fails on banned wording in HTML", () => {
       const report = buildReport();
       const html = renderReport(report, "<div>Ready for verification</div>");
+      expect(() => assertClientReadinessGate({ reportHtml: html, report })).toThrow();
+    });
+
+    it("fails when a version-mismatched report looks otherwise clean", () => {
+      const report = buildReport(buildBlockedMismatchAudit(auditText(ENVIRA_V18_TEXT)));
+      const html = renderReport(report);
       expect(() => assertClientReadinessGate({ reportHtml: html, report })).toThrow();
     });
   });

--- a/tests/lib/preverif/clientReadinessGate.ts
+++ b/tests/lib/preverif/clientReadinessGate.ts
@@ -78,10 +78,19 @@ export function assertUsesStandardReportShape(
   expect(report.limitationBanner).toContain("Internal preview only");
 }
 
+export function assertNoVersionMismatchWarning(report: Vm0007GapReport): void {
+  const combinedText = `${report.limitationBanner} ${report.executiveSummary.limitations.join(" ")}`
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+  expect(combinedText).not.toContain("methodology version mismatch:");
+}
+
 export function assertClientReadinessGate(input: ClientReadinessGateInput): void {
   const { reportHtml, report } = input;
 
   assertUsesStandardReportShape(report);
+  assertNoVersionMismatchWarning(report);
   assertNoUnclearEvidence(report);
   assertNoMissingEvidence(report);
   assertInternalPreviewLabelVisible(reportHtml);

--- a/tests/lib/preverif/fixtureQualityGate.test.ts
+++ b/tests/lib/preverif/fixtureQualityGate.test.ts
@@ -93,6 +93,13 @@ function buildMixedAudit(): MethodologyEvidenceAuditSummary {
       manual_review_needed: results.filter((entry) => entry.status === "manual_review_needed").length,
     },
     totalRules: results.length,
+    auditStatus: "BLOCKED_VERSION_MISMATCH",
+    methodologyId: "VM0007",
+    rulebookVersion: "v1.8",
+    pddDeclaredMethodologyVersion: "REDD-MF / VM0007 v1.5",
+    versionMatch: false,
+    versionMismatchReason: "Version lock blocked: rulebook version mismatch: PDD declares v1.5, loaded contract is v1.8.",
+    userAcceptedVersionWarning: true,
   };
 }
 
@@ -170,6 +177,28 @@ describe("fixture quality gate", () => {
         audit,
         report,
         reportHtml,
+        judgmentFixtureSet: AUDIT_FIXTURE,
+        sourceExcerpts: SOURCE_EXCERPTS,
+      }),
+    ).toThrow();
+  });
+
+  it("fails if the fixture stops declaring the version mismatch as blocked", () => {
+    const audit = buildMixedAudit();
+    const report = buildReport(audit);
+    const brokenAudit = {
+      ...audit,
+      auditStatus: "AUDITED" as const,
+      versionMatch: true,
+      versionMismatchReason: "",
+    };
+
+    expect(() =>
+      assertFixtureQualityGate({
+        rules: VM0007_SYNCED_RULES,
+        audit: brokenAudit,
+        report,
+        reportHtml: renderToStaticMarkup(createElement(Vm0007GapReportView, { report })),
         judgmentFixtureSet: AUDIT_FIXTURE,
         sourceExcerpts: SOURCE_EXCERPTS,
       }),

--- a/tests/lib/preverif/fixtureQualityGate.test.ts
+++ b/tests/lib/preverif/fixtureQualityGate.test.ts
@@ -8,7 +8,7 @@ import { auditEvidence, type MethodologyEvidenceAuditResult, type MethodologyEvi
 import { buildVm0007GapReport } from "@/lib/preverif/vm0007GapReport";
 import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif/vm0007EvidenceContracts";
 import { VM0007_SYNCED_RULES, readQuickCheckFixtureText } from "../preverifVm0007Fixtures";
-import { assertFixtureQualityGate } from "./fixtureQualityGate";
+import { assertLegacyVm0007MismatchFixtureQualityGate } from "./fixtureQualityGate";
 import type { JudgmentFixtureSet, SourceExcerpts } from "../preverifJudgmentFixtureGate";
 
 const AUDIT_FIXTURE = JSON.parse(
@@ -121,13 +121,13 @@ function buildReport(audit: MethodologyEvidenceAuditSummary) {
   });
 }
 
-describe("fixture quality gate", () => {
-  it("accepts the current Envira 58-rule audit fixture and report", () => {
+describe("legacy mismatch fixture quality gate", () => {
+  it("accepts the quarantined Envira legacy mismatch fixture and report", () => {
     const audit = buildMixedAudit();
     const report = buildReport(audit);
     const reportHtml = renderToStaticMarkup(createElement(Vm0007GapReportView, { report }));
 
-    assertFixtureQualityGate({
+    assertLegacyVm0007MismatchFixtureQualityGate({
       rules: VM0007_SYNCED_RULES,
       audit,
       report,
@@ -155,7 +155,7 @@ describe("fixture quality gate", () => {
     const reportHtml = renderToStaticMarkup(createElement(Vm0007GapReportView, { report }));
 
     expect(() =>
-      assertFixtureQualityGate({
+      assertLegacyVm0007MismatchFixtureQualityGate({
         rules: VM0007_SYNCED_RULES,
         audit,
         report,
@@ -172,7 +172,7 @@ describe("fixture quality gate", () => {
     const reportHtml = `${renderToStaticMarkup(createElement(Vm0007GapReportView, { report }))}<div>All clear. Passed. Confirmed.</div>`;
 
     expect(() =>
-      assertFixtureQualityGate({
+      assertLegacyVm0007MismatchFixtureQualityGate({
         rules: VM0007_SYNCED_RULES,
         audit,
         report,
@@ -194,7 +194,7 @@ describe("fixture quality gate", () => {
     };
 
     expect(() =>
-      assertFixtureQualityGate({
+      assertLegacyVm0007MismatchFixtureQualityGate({
         rules: VM0007_SYNCED_RULES,
         audit: brokenAudit,
         report,

--- a/tests/lib/preverif/fixtureQualityGate.ts
+++ b/tests/lib/preverif/fixtureQualityGate.ts
@@ -7,7 +7,7 @@ import {
   type SourceExcerpts,
 } from "../preverifJudgmentFixtureGate";
 
-export type FixtureQualityGateInput = {
+export type LegacyMismatchFixtureQualityGateInput = {
   rules: readonly { id: string }[];
   audit: MethodologyEvidenceAuditSummary;
   report: Vm0007GapReport;
@@ -107,7 +107,7 @@ function assertReportRowQuality(report: Vm0007GapReport): void {
   }
 }
 
-export function assertFixtureQualityGate(input: FixtureQualityGateInput): void {
+export function assertLegacyVm0007MismatchFixtureQualityGate(input: LegacyMismatchFixtureQualityGateInput): void {
   assertVm0007JudgmentFixtureSet(input.judgmentFixtureSet, input.sourceExcerpts);
   assertVersionMismatchIsQuarantined(input.audit, input.report);
   assertRuleCoverage(input.rules, input.audit, input.report);

--- a/tests/lib/preverif/fixtureQualityGate.ts
+++ b/tests/lib/preverif/fixtureQualityGate.ts
@@ -40,6 +40,15 @@ function assertVisibleWording(reportHtml: string, expectedVisibleWording: readon
   }
 }
 
+function assertVersionMismatchIsQuarantined(audit: MethodologyEvidenceAuditSummary, report: Vm0007GapReport): void {
+  expect(audit.versionMatch).toBe(false);
+  expect(audit.auditStatus).toBe("BLOCKED_VERSION_MISMATCH");
+  expect(normalize(report.limitationBanner)).toContain("methodology version mismatch:");
+  expect(normalize(report.limitationBanner)).toContain("internal preview only");
+  expect(normalize(report.executiveSummary.limitations.join(" "))).toContain("methodology version mismatch:");
+  expect(normalize(report.reportName)).toContain("internal vm0007 gap report preview");
+}
+
 function assertRuleCoverage(rules: readonly { id: string }[], audit: MethodologyEvidenceAuditSummary, report: Vm0007GapReport): void {
   const expectedRuleIds = [...rules].map((rule) => rule.id).sort();
   const auditRuleIds = [...audit.results].map((result) => result.ruleId).sort();
@@ -100,6 +109,7 @@ function assertReportRowQuality(report: Vm0007GapReport): void {
 
 export function assertFixtureQualityGate(input: FixtureQualityGateInput): void {
   assertVm0007JudgmentFixtureSet(input.judgmentFixtureSet, input.sourceExcerpts);
+  assertVersionMismatchIsQuarantined(input.audit, input.report);
   assertRuleCoverage(input.rules, input.audit, input.report);
 
   for (const fixture of input.judgmentFixtureSet.checks) {

--- a/tests/lib/preverifJudgmentFixtureGate.ts
+++ b/tests/lib/preverifJudgmentFixtureGate.ts
@@ -96,6 +96,16 @@ function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
 }
 
+function assertQuarantinedLegacyVersionTruthPolicy(fixtureTruthPolicy: string): void {
+  const policy = normalizeText(fixtureTruthPolicy);
+  const declaresMismatch =
+    policy.includes("versionmatch is false") ||
+    policy.includes("do not use current app output") ||
+    policy.includes("envira evidence as gold") ||
+    policy.includes("not validated truth");
+  expect(declaresMismatch).toBe(true);
+}
+
 function requireNonEmpty(value: string | null | undefined, label: string): void {
   expect(value?.trim().length ?? 0).toBeGreaterThan(0);
 }
@@ -146,6 +156,7 @@ export function assertVm0007JudgmentFixtureSet(
   expect(sourceExcerpts.inputPdfPath).toBe(fixtureSet.inputPdfPath);
   expect(sourceExcerpts.sourcePdfTitle).toBe(fixtureSet.sourcePdfTitle);
   expect(sourceExcerpts.documentFamily).toBe(fixtureSet.documentFamily);
+  assertQuarantinedLegacyVersionTruthPolicy(fixtureSet.fixtureTruthPolicy);
 
   for (const check of fixtureSet.checks) {
     expect(check.checkId).toMatch(/^R-\d-\d{4}$/);
@@ -257,6 +268,7 @@ export function assertVm0007FullAuditFixtureSet(
   expect(sourceExcerpts.inputPdfPath).toBe(fixtureSet.inputPdfPath);
   expect(sourceExcerpts.sourcePdfTitle).toBe(fixtureSet.sourcePdfTitle);
   expect(sourceExcerpts.documentFamily).toBe(fixtureSet.documentFamily);
+  assertQuarantinedLegacyVersionTruthPolicy(fixtureSet.fixtureTruthPolicy);
 
   const canonicalRuleIds = canonicalRules.map((rule) => rule.id);
   const canonicalRuleIdSet = new Set(canonicalRuleIds);


### PR DESCRIPTION
## Summary

Strengthen the VM0007 version-mismatch gates so quarantined Envira / REDD-MF v1.5 fixture data cannot be mistaken for normal trusted output.

## What changed

- Added explicit mismatch/quarantine assertions to the shared VM0007 judgment fixture gate.
- Added a version-mismatch guard to the fixture-quality gate.
- Added a client-readiness guard that rejects version-warning reports even when the row counts look clean.
- Added regression tests that prove the Envira legacy fixture remains blocked and the old counts stay quarantined.
- Advanced the VM0007 version-cleanup roadmap phase status to `done` and regenerated the roadmap summary.

## Validation

- `npm test -- --runInBand tests/lib/preverif/clientReadinessGate.test.ts tests/lib/preverif/fixtureQualityGate.test.ts tests/lib/preverif.vm0007FullAuditFixtureShape.test.ts tests/lib/preverif.vm0007EnviraJudgmentFixtures.test.ts tests/lib/preverifJudgmentFixtureGate.test.ts tests/lib/preverif.vm0007VersionLock.test.ts tests/lib/preverif.vm0007EvidenceAudit.test.ts tests/lib/preverif.enviraVm0007FixtureBackedPdf.test.ts tests/app/api/exports/internal.envira-vm0007-report.route.test.ts tests/app/internal/envira-vm0007.page.test.tsx tests/components/fixtureBackedVm0007ReportView.test.tsx tests/lib/preverif.vm0007GapReport.test.ts`
- `npm test -- --runInBand tests/lib/quickCheckV2/status-validator.test.ts tests/lib/quickCheckV2/evidence-retrieval.test.ts tests/lib/quickCheckV2/envira-ingestion.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run pr:gate`

slug: vm0007-version-cleanup
