### PR TITLE
docs: add VVB finding presentation layer roadmap

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, quick-check-document-pipeline, quickcheck-v2, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp, vm0007-judgement-fixtures, vm0007-version-cleanup.
+Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, quick-check-document-pipeline, quickcheck-v2, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp, vm0007-judgement-fixtures, vm0007-version-cleanup, vvb-finding-presentation-layer.
 Frozen lanes: agentic-verification.
 
 
@@ -380,3 +380,31 @@ Not active now:
 4) RC4 — Phase 4: Gate Strengthening: Done — Add tests and gates so mismatches cannot produce judgments, reports, PDFs, or client-readiness output.
 5) RC5 — Phase 5: Roadmap Correction: Done — Correct contaminated done states, mark VM0007 evidence-map work pending versioned re-audit, and preserve the legacy Envira fixture as quarantined historical regression data rather than validated VM0007 v1.8 truth.
 6) RC6 — Phase 6: Forward Path: Done — A normalized VM0007 v1.8 PDD path can pass the version lock while the legacy Envira v1.5 mismatch fixture remains blocked, without building a full Maya evidence map.
+
+## vvb-finding-presentation-layer
+
+Status SSOT: `docs/roadmaps/vvb-finding-presentation-layer/phase-status.json`
+Details: `docs/roadmaps/vvb-finding-presentation-layer/PLAN.md`
+
+Lane status: Active
+Phase 1 CONFORMS Eligibility Contract is the next planned step. The roadmap is limited to status-consumer auditing and a strict eligibility contract before any mapper, presentation object, UI, report, or gap-report migration work.
+
+Current focus:
+- Audit current consumers of Quick Check v2 status output
+- Define the CONFORMS eligibility contract from the final validated StatusResult
+- Keep implementation, router, fixture, and gap report code untouched
+
+Not active now:
+- Mapper implementation
+- Presentation object migration
+- UI/report consumer changes
+- Gap report changes
+
+1) RC0 — Phase 0: Status Consumer Audit: Planned — Inventory the current consumers of Quick Check v2 status output and identify every FOUND -> CONFORMS touch point.
+2) RC1 — Phase 1: CONFORMS Eligibility Contract: Planned — CONFORMS may only be derived from the final validated Quick Check v2 StatusResult when all provenance and sufficiency gates are satisfied.
+3) RC2 — Phase 2: VVB Finding Mapper: Planned — Mapper code will derive VVB output from the eligibility contract without reading raw router or extractor output directly.
+4) RC3 — Phase 3: Evidence Presentation Object: Planned — Introduce a presentation object that carries the validated evidence fields needed by VVB consumers.
+5) RC4 — Phase 4: Presentation Gates: Planned — Add tests that fail if FOUND is upgraded to CONFORMS without the eligibility contract or if raw outputs are used directly.
+6) RC5 — Phase 5: Fixture Expectation Migration: Planned — Migrate fixture expectations to the new presentation contract.
+7) RC6 — Phase 6: UI, Report, and Gap Report Consumers: Planned — Move UI, report, and gap-report consumers onto the presentation object.
+8) RC7 — Phase 7: Deprecation Review: Planned — Deprecate or remove old ambiguous FOUND -> CONFORMS paths.

--- a/docs/roadmaps/vvb-finding-presentation-layer/PLAN.md
+++ b/docs/roadmaps/vvb-finding-presentation-layer/PLAN.md
@@ -1,0 +1,99 @@
+# VVB Finding Presentation Layer Roadmap
+
+## Goal
+
+Remove ambiguity around `FOUND -> CONFORMS` in the VVB finding presentation layer.
+
+## Non-Negotiable Invariant
+
+The deterministic router and Quick Check v2 status validator remain the truth gates. The VVB layer is not allowed to upgrade, rescue, reinterpret, or relabel weak evidence as `CONFORMS`.
+
+No `CONFORMS` output may be emitted merely because a lower-level router returned `"answered"` or an extractor found text.
+
+## Phases
+
+### Phase 0: Status Consumer Audit
+
+Status: planned
+
+Done when:
+
+* current consumers of Quick Check v2 status output are mapped
+* all `FOUND` -> `CONFORMS` touch points are identified
+* no implementation code is changed
+
+### Phase 1: CONFORMS Eligibility Contract
+
+Status: planned
+
+Done when:
+
+* `CONFORMS` may only be derived from the final Quick Check v2 validated `StatusResult`
+* `status/internalStatus` is `FOUND`
+* `reason` is `answer_and_provenance_complete`
+* `evidence.quote` is non-empty
+* `evidence.page` is a positive number
+* `evidence` has section provenance
+* `evidence.spanId` is non-empty
+* `evidenceStack` has primary evidence
+* `evidenceStack` validates for `FOUND`
+* no blocker downgrade rule applies
+* `evidence.sourceType` is not `raw_text_fallback`
+* the VVB mapper consumes only the final validated status result, not raw extractor output, not raw router output, and not unvalidated evidence
+
+### Phase 2: VVB Finding Mapper
+
+Status: planned
+
+Done when:
+
+* mapper code derives VVB output from the eligibility contract
+* mapper code does not read raw router or extractor output directly
+
+### Phase 3: Evidence Presentation Object
+
+Status: planned
+
+Done when:
+
+* the presentation object carries the validated evidence fields needed by VVB consumers
+
+### Phase 4: Presentation Gates
+
+Status: planned
+
+Done when:
+
+* tests fail if `FOUND` is upgraded to `CONFORMS` without the eligibility contract
+* tests fail if raw router or extractor output is used directly
+
+### Phase 5: Fixture Expectation Migration
+
+Status: planned
+
+Done when:
+
+* fixture expectations are migrated to the new presentation contract
+
+### Phase 6: UI, Report, and Gap Report Consumers
+
+Status: planned
+
+Done when:
+
+* UI consumers read the presentation object
+* report consumers read the presentation object
+* gap report consumers read the presentation object
+
+### Phase 7: Deprecation Review
+
+Status: planned
+
+Done when:
+
+* old ambiguous `FOUND -> CONFORMS` paths are deprecated or removed
+
+## Risks
+
+* Risk: FOUND is treated as a display synonym for CONFORMS before all provenance and sufficiency gates are checked.
+* Mitigation: add a CONFORMS eligibility contract and tests before any UI/report/gap report migration.

--- a/docs/roadmaps/vvb-finding-presentation-layer/phase-status.json
+++ b/docs/roadmaps/vvb-finding-presentation-layer/phase-status.json
@@ -1,0 +1,61 @@
+{
+  "roadmap": "vvb-finding-presentation-layer",
+  "phase_meta": {
+    "status": "active",
+    "summary": "Phase 1 CONFORMS Eligibility Contract is the next planned step. The roadmap is limited to status-consumer auditing and a strict eligibility contract before any mapper, presentation object, UI, report, or gap-report migration work.",
+    "current_focus": [
+      "Audit current consumers of Quick Check v2 status output",
+      "Define the CONFORMS eligibility contract from the final validated StatusResult",
+      "Keep implementation, router, fixture, and gap report code untouched"
+    ],
+    "not_active_now": [
+      "Mapper implementation",
+      "Presentation object migration",
+      "UI/report consumer changes",
+      "Gap report changes"
+    ],
+    "last_updated_at": "2026-07-09T00:00:00Z"
+  },
+  "phases": {
+    "phase_0_status_consumer_audit": {
+      "title": "Phase 0: Status Consumer Audit",
+      "status": "planned",
+      "summary": "Inventory the current consumers of Quick Check v2 status output and identify every FOUND -> CONFORMS touch point."
+    },
+    "phase_1_conforms_eligibility_contract": {
+      "title": "Phase 1: CONFORMS Eligibility Contract",
+      "status": "planned",
+      "summary": "CONFORMS may only be derived from the final validated Quick Check v2 StatusResult when all provenance and sufficiency gates are satisfied."
+    },
+    "phase_2_vvb_finding_mapper": {
+      "title": "Phase 2: VVB Finding Mapper",
+      "status": "planned",
+      "summary": "Mapper code will derive VVB output from the eligibility contract without reading raw router or extractor output directly."
+    },
+    "phase_3_evidence_presentation_object": {
+      "title": "Phase 3: Evidence Presentation Object",
+      "status": "planned",
+      "summary": "Introduce a presentation object that carries the validated evidence fields needed by VVB consumers."
+    },
+    "phase_4_presentation_gates": {
+      "title": "Phase 4: Presentation Gates",
+      "status": "planned",
+      "summary": "Add tests that fail if FOUND is upgraded to CONFORMS without the eligibility contract or if raw outputs are used directly."
+    },
+    "phase_5_fixture_expectation_migration": {
+      "title": "Phase 5: Fixture Expectation Migration",
+      "status": "planned",
+      "summary": "Migrate fixture expectations to the new presentation contract."
+    },
+    "phase_6_ui_report_and_gap_report_consumers": {
+      "title": "Phase 6: UI, Report, and Gap Report Consumers",
+      "status": "planned",
+      "summary": "Move UI, report, and gap-report consumers onto the presentation object."
+    },
+    "phase_7_deprecation_review": {
+      "title": "Phase 7: Deprecation Review",
+      "status": "planned",
+      "summary": "Deprecate or remove old ambiguous FOUND -> CONFORMS paths."
+    }
+  }
+}


### PR DESCRIPTION
Adds a roadmap for introducing VVB-style finding presentation as a derived layer after Quick Check status validation.

Scope:
- Adds roadmap only
- Does not change router logic
- Does not implement mapper code
- Does not migrate fixtures
- Does not touch gap report code

Key invariant:
Quick Check internal status remains the truth source. VVB finding types are derived presentation fields only.

Validation:
- npm run roadmap:check