### PR TITLE
docs: define VVB report terminology contract

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -3,7 +3,7 @@
 This file is generated from roadmap SSOT JSON. Do not edit manually.
 
 Roadmap reset: only explicitly active items drive what's next; historical PR numbers stay preserved for context.
-Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, quick-check-document-pipeline, quickcheck-v2, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp, vm0007-judgement-fixtures, vm0007-version-cleanup.
+Active lanes: verification-factory, project-readiness-verification-output, review-grade-quick-check, project-verification, quick-check-document-pipeline, quickcheck-v2, requirement-coverage, review-grade-evidence-intelligence, safe-learning-intake-pipeline, standard-registry-wiring, traceable-rule-review-mvp, vm0007-judgement-fixtures, vm0007-version-cleanup, vvb-report-presentation-layer.
 Frozen lanes: agentic-verification.
 
 
@@ -386,13 +386,13 @@ Not active now:
 Status SSOT: `docs/roadmaps/vvb-report-presentation-layer/phase-status.json`
 Details: `docs/roadmaps/vvb-report-presentation-layer/PLAN.md`
 
-Lane status: Planned
+Lane status: Active
 Add a generic pre-validation presentation layer downstream of finalized Evidence Map rows, without changing Quick Check router semantics or claiming formal VVB authority.
 
 Current focus:
+- Phase 0 terminology and compatibility contract is complete
+- Phase 1 status consumer audit is next
 - Keep the Evidence Map upstream and canonical
-- Consume only finalized Evidence Map rows with accepted and rejected evidence
-- Use draft finding language with the GENERIC_PRE_VALIDATION profile
 - Keep the Pre-Validation Readiness Report and UI downstream
 
 Not active now:
@@ -402,7 +402,7 @@ Not active now:
 - Organization-specific report profiles
 - Formal verifier authority claims
 
-1) RC0 — Phase 0: Report Terminology Contract: Planned — Define pre-validation language, draft finding terminology, and the boundary against formal VVB authority.
+1) RC0 — Phase 0: Report Terminology Contract: Done — Define additive pre-validation language, draft finding terminology, prohibited formal-authority claims, and preservation of existing statuses without mappings.
 2) RC1 — Phase 1: Status Consumer Audit: Planned — Inventory every consumer of FOUND, UNCLEAR, MISSING, answered, unclear, and no_evidence before adding presentation fields.
 3) RC2 — Phase 2: Evidence Map Dependency Contract: Planned — Require finalized Evidence Map rows, accepted and rejected evidence retention, client actions, assessment reasons, and full provenance before presentation.
 4) RC3 — Phase 3: Conformance Conclusion Contract: Planned — Define when finalized Evidence Map support may produce CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or NOT_ASSESSED.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_0_TERMINOLOGY_CONTRACT.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_0_TERMINOLOGY_CONTRACT.md
@@ -1,0 +1,100 @@
+# Phase 0: Report Terminology Contract
+
+This document is the authoritative terminology and backward-compatibility contract for the future generic pre-validation presentation layer.
+
+## Presentation profile
+
+The only generic presentation profile is:
+
+`GENERIC_PRE_VALIDATION`
+
+Organization-specific profiles are not part of this contract.
+
+## Presentation conclusions
+
+The allowed downstream presentation conclusions are:
+
+- `CONFORMS`
+- `ACTION_REQUIRED`
+- `NOT_APPLICABLE`
+- `NOT_ASSESSED`
+
+These are presentation vocabulary only. Phase 0 does not define or implement mappings from existing statuses to these conclusions. Mapping requires the Phase 1 consumer audit and later presentation contracts.
+
+## Draft finding terminology
+
+The allowed draft finding terminology is:
+
+- `NCR_RISK`
+- `NIR`
+- `NONE`
+
+These terms describe readiness-oriented draft output. They do not represent findings issued by a validator, verifier, registry, or other formal authority.
+
+## User-facing language
+
+The presentation layer may use:
+
+- Draft finding
+- Draft action
+- Finding candidate
+- Pre-validation conclusion
+- Readiness assessment
+- Client action required
+
+The language must make clear that the output is preparatory and subject to professional review.
+
+## Prohibited authority claims
+
+The application must not claim that it:
+
+- issued a finding
+- closed a finding
+- validated a finding or project
+- verified a finding or project
+- formally approved a finding
+- issued a formal VVB finding
+- granted registry approval
+
+The application may describe a draft finding, finding candidate, draft action, or readiness assessment. It must not present those as completed formal authority decisions.
+
+## Backward compatibility
+
+The existing statuses and semantics remain unchanged:
+
+```text
+FOUND
+UNCLEAR
+MISSING
+answered
+unclear
+no_evidence
+```
+
+They must not be renamed, replaced, reinterpreted, migrated, or deprecated by the presentation layer. No existing consumer is switched to the new terms by this contract.
+
+The boundary is:
+
+```text
+Existing status → preserved upstream value
+New terminology → additive downstream presentation value
+```
+
+The new terminology coexists with the existing system until the explicit Phase 10 deprecation review approves any change. Phase 0 creates no compatibility adapter because no runtime consumer requires one.
+
+## Explicit non-goals
+
+This contract does not change or implement:
+
+- Quick Check routing or status semantics
+- Evidence Map behavior
+- Existing report output
+- PDF generation
+- UI labels
+- fixtures or gold truth
+- gap reports
+- finding mapping logic
+- applicability logic
+- organization-specific profiles
+- runtime consumers
+

--- a/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
@@ -4,6 +4,10 @@
 
 Build a generic pre-validation report presentation layer downstream of the Evidence Map. The layer formats and interprets finalized Evidence Map rows for client-facing readiness output without changing router semantics or claiming formal VVB authority.
 
+## Phase 0 contract
+
+The authoritative terminology and backward-compatibility contract is [Phase 0: Report Terminology Contract](./PHASE_0_TERMINOLOGY_CONTRACT.md). It defines additive downstream vocabulary only. It does not map existing statuses to presentation conclusions or change any runtime consumer.
+
 ## Product architecture
 
 Article6 has one core paid asset:

--- a/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
+++ b/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
@@ -1,12 +1,12 @@
 {
   "roadmap": "vvb-report-presentation-layer",
   "phase_meta": {
-    "status": "planned",
+    "status": "active",
     "summary": "Add a generic pre-validation presentation layer downstream of finalized Evidence Map rows, without changing Quick Check router semantics or claiming formal VVB authority.",
     "current_focus": [
+      "Phase 0 terminology and compatibility contract is complete",
+      "Phase 1 status consumer audit is next",
       "Keep the Evidence Map upstream and canonical",
-      "Consume only finalized Evidence Map rows with accepted and rejected evidence",
-      "Use draft finding language with the GENERIC_PRE_VALIDATION profile",
       "Keep the Pre-Validation Readiness Report and UI downstream"
     ],
     "not_active_now": [
@@ -16,13 +16,13 @@
       "Organization-specific report profiles",
       "Formal verifier authority claims"
     ],
-    "last_updated_at": "2026-07-09T00:00:00Z"
+    "last_updated_at": "2026-07-10T00:00:00Z"
   },
   "phases": {
     "phase_0_report_terminology_contract": {
       "title": "Phase 0: Report Terminology Contract",
-      "status": "planned",
-      "summary": "Define pre-validation language, draft finding terminology, and the boundary against formal VVB authority."
+      "status": "done",
+      "summary": "Define additive pre-validation language, draft finding terminology, prohibited formal-authority claims, and preservation of existing statuses without mappings."
     },
     "phase_1_status_consumer_audit": {
       "title": "Phase 1: Status Consumer Audit",


### PR DESCRIPTION
## Summary
- add the authoritative Phase 0 terminology and backward-compatibility contract
- preserve existing Quick Check statuses and semantics as upstream values
- mark only Phase 0 done in the roadmap SSOT and regenerate the summary

## Scope
Documentation and roadmap metadata only. No runtime consumers, mappings, UI labels, report output, fixtures, or gold truth changed.

### Roadmap-Update
- slug: vvb-report-presentation-layer
- items:
  - RC0: done