### PR TITLE
feat: Phase 2 Evidence Map dependency contract

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -392,7 +392,8 @@ Add a generic pre-validation presentation layer downstream of finalized Evidence
 Current focus:
 - Phase 0 terminology and compatibility contract is complete
 - Phase 1 status consumer audit is complete
-- Phase 2 Evidence Map dependency contract is next
+- Phase 2 Evidence Map dependency contract is complete
+- Phase 3 Conformance Conclusion Contract is next
 - Keep the Evidence Map upstream and canonical
 - Keep the Pre-Validation Readiness Report and UI downstream
 
@@ -405,8 +406,8 @@ Not active now:
 
 1) RC0 — Phase 0: Report Terminology Contract: Done — Define additive pre-validation language, draft finding terminology, prohibited formal-authority claims, and preservation of existing statuses without mappings.
 2) RC1 — Phase 1: Status Consumer Audit: Done — Audit every producer, storage boundary, transformation, comparison, filter, display, fixture, analytics, and test consumer of FOUND, UNCLEAR, MISSING, answered, unclear, and no_evidence without changing runtime semantics.
-3) RC2 — Phase 2: Evidence Map Dependency Contract: Next — Require finalized Evidence Map rows, accepted and rejected evidence retention, client actions, assessment reasons, and full provenance before presentation.
-4) RC3 — Phase 3: Conformance Conclusion Contract: Planned — Define when finalized Evidence Map support may produce CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or NOT_ASSESSED.
+3) RC2 — Phase 2: Evidence Map Dependency Contract: Done — Add a generic pure dependency gate requiring finalized Evidence Map row identity, requirement and methodology identity, upstream status, applicability state, accepted and rejected evidence, assessment reason, client action, search coverage, source-document identity, and evidence provenance without mapping or judging them.
+4) RC3 — Phase 3: Conformance Conclusion Contract: Next — Define when finalized Evidence Map support may produce CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or NOT_ASSESSED.
 5) RC4 — Phase 4: Draft Action/Finding Contract: Planned — Define draftFindingType and draftFindingRecord mappings for unclear, missing, and weak non-blocking Evidence Map rows.
 6) RC5 — Phase 5: Applicability Contract: Planned — Ensure NOT_APPLICABLE is derived only from an explicit applicability decision, not from missing or unclear evidence.
 7) RC6 — Phase 6: Report Presentation Object: Planned — Define the generic presentation object with Evidence Map row identity, provenance, conformance conclusion, and draft finding fields.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_2_EVIDENCE_MAP_DEPENDENCY_CONTRACT.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_2_EVIDENCE_MAP_DEPENDENCY_CONTRACT.md
@@ -1,0 +1,73 @@
+# Phase 2: Evidence Map Dependency Contract
+
+## Scope
+
+This contract defines the minimum structural dependency surface for a finalized Evidence Map row to enter the future presentation layer. The Evidence Map remains the canonical source of evidence truth. This module does not create a report-specific evidence model, choose evidence, or map statuses to presentation conclusions.
+
+Implementation: `src/lib/evidence/evidenceMapDependencyContract.ts`
+
+Focused contract test: `tests/lib/evidence/evidenceMapDependencyContract.test.ts`
+
+## Minimum row contract
+
+`EvidenceMapRow` requires these fields. Required absence is represented explicitly: accepted/rejected evidence and provenance are arrays, methodology may be explicit `null` when it is not applicable to the row, and client action may be explicit `null` when no action is required.
+
+| Field | Required shape | Phase 2 meaning |
+| --- | --- | --- |
+| `rowId` | non-empty string | Stable Evidence Map row identity. |
+| `requirement` | `requirementId`, `requirementReference`, `requirementText`, all non-empty strings | Requirement identity and source requirement text. |
+| `methodology` | `{ methodologyId, rulebookVersion }` or explicit `null` | Methodology identity/version when applicable; `null` is an explicit not-required value. No version matching is judged here. |
+| `upstreamStatus` | non-empty string | Preserved upstream value. The contract does not rename, normalize, or reinterpret it. |
+| `applicabilityState` | `APPLICABLE`, `NOT_APPLICABLE`, or `UNKNOWN` | Explicit applicability state representation only. Phase 2 does not decide whether the state is correct. |
+| `acceptedEvidence` | array of evidence records | Accepted evidence is retained exactly. `[]` is valid. |
+| `rejectedEvidence` | array of evidence records | Rejected evidence and rejection reasons are retained exactly. `[]` is valid. |
+| `assessmentReason` | non-empty string | Existing upstream explanation for the row assessment. |
+| `clientAction` | non-empty string or explicit `null` | Existing upstream client action. `null` is valid; omission is not. |
+| `searchCoverage` | `{ searched, searchedDocumentIds, notes }` | Explicit search-coverage carrier. The validator checks shape only; it does not judge coverage adequacy. |
+| `sourceDocument` | `{ documentId, documentName, contentSha256 }` | Source-document identity. Name and hash may be explicit `null`; document ID may not be absent. |
+| `evidenceProvenance` | array of provenance records | Provenance records reuse canonical `EvidenceSpan` coordinates (`docId`, `page`, `sectionPath`, `spanId`) and carry section/source labels. `[]` is structurally explicit. |
+| `finalizationState` | `draft`, `finalized`, or `unknown` | Only `finalized` is eligible for the presentation dependency boundary. |
+
+Accepted evidence records contain an `evidenceId`, exact `quote`, and provenance. Rejected records contain the same fields plus a non-empty `rejectionReason`. The validator preserves these records and their arrays without mutation or copying.
+
+## Dependency gate
+
+```ts
+validateEvidenceMapDependency(candidate: unknown):
+  | { ready: true; row: EvidenceMapRow }
+  | { ready: false; blockedBy: EvidenceMapDependencyBlockReason[] }
+```
+
+The ready result returns the validated row unchanged. The blocked result returns one or more typed reasons. The reason union is exhaustive:
+
+```text
+row_not_finalized
+missing_row_identity
+missing_requirement_identity
+missing_methodology_identity
+missing_methodology_version
+missing_upstream_status
+missing_applicability_state
+missing_accepted_evidence_field
+missing_rejected_evidence_field
+missing_assessment_reason
+missing_client_action_field
+missing_search_coverage_field
+missing_source_document_identity
+missing_provenance
+```
+
+Malformed evidence records, partial methodology identity, incomplete search coverage, incomplete source identity, and incomplete provenance are blocked under their corresponding dependency reason. The validator does not infer omitted values or turn malformed values into `null`, empty arrays, or unknown states.
+
+## Explicit Phase 2 boundary
+
+The gate checks dependency completeness only. It does not:
+
+- map `FOUND`, `UNCLEAR`, `MISSING`, `answered`, `unclear`, or `no_evidence`;
+- produce `CONFORMS`, `ACTION_REQUIRED`, `NOT_APPLICABLE`, or `NOT_ASSESSED`;
+- produce `NCR_RISK`, `NIR`, or draft finding records;
+- judge evidence sufficiency, applicability correctness, search coverage adequacy, or methodology version matching;
+- select, discard, rewrite, or downgrade evidence;
+- change Quick Check, Evidence Map, report, PDF, UI, fixture, gold-truth, parser, router, or existing status behavior.
+
+Those concerns remain dependencies for later roadmap phases. Phase 3 may define presentation conclusions only after this structural dependency boundary is available.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_2_EVIDENCE_MAP_DEPENDENCY_CONTRACT.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_2_EVIDENCE_MAP_DEPENDENCY_CONTRACT.md
@@ -27,6 +27,12 @@ Focused contract test: `tests/lib/evidence/evidenceMapDependencyContract.test.ts
 | `sourceDocument` | `{ documentId, documentName, contentSha256 }` | Source-document identity. Name and hash may be explicit `null`; document ID may not be absent. |
 | `evidenceProvenance` | array of provenance records | Provenance records reuse canonical `EvidenceSpan` coordinates (`docId`, `page`, `sectionPath`, `spanId`) and carry section/source labels. `[]` is structurally explicit. |
 | `finalizationState` | `draft`, `finalized`, or `unknown` | Only `finalized` is eligible for the presentation dependency boundary. |
+| `finalizationActorRef` | non-empty string | Explicit reference for the actor associated with finalization. The contract does not assess permissions. |
+| `finalizedAt` | non-empty string | Explicit finalization timestamp value. The contract does not parse or validate lifecycle timing. |
+| `finalizationBasis` | non-empty string | Explicit basis/reference for the finalization decision. |
+| `reviewHistoryRef` | non-empty string | Explicit reference to the upstream review history. The contract does not create or inspect review events. |
+| `evidenceMapContractVersion` | non-empty string | Version of the Evidence Map contract used by the row. |
+| `reviewPolicyVersion` | non-empty string | Version of the upstream review policy used by the row. |
 
 Accepted evidence records contain an `evidenceId`, exact `quote`, and provenance. Rejected records contain the same fields plus a non-empty `rejectionReason`. The validator preserves these records and their arrays without mutation or copying.
 
@@ -55,11 +61,22 @@ missing_client_action_field
 missing_search_coverage_field
 missing_source_document_identity
 missing_provenance
+missing_finalization_actor_ref
+missing_finalized_at
+missing_finalization_basis
+missing_review_history_ref
+missing_evidence_map_contract_version
+missing_review_policy_version
 ```
 
 Malformed evidence records, partial methodology identity, incomplete search coverage, incomplete source identity, and incomplete provenance are blocked under their corresponding dependency reason. The validator does not infer omitted values or turn malformed values into `null`, empty arrays, or unknown states.
 
 ## Explicit Phase 2 boundary
+
+All six finalized-row metadata fields are required and non-empty when
+`finalizationState` is `finalized`. The gate checks presence and string shape
+only; it does not determine reviewer permissions, parse timestamps, enforce
+lifecycle transitions, create audit events, or render reviewer UI.
 
 The gate checks dependency completeness only. It does not:
 

--- a/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
@@ -10,6 +10,8 @@ The authoritative terminology and backward-compatibility contract is [Phase 0: R
 
 The Phase 1 status inventory is [Phase 1: Status Consumer Audit](./PHASE_1_STATUS_CONSUMER_AUDIT.md). It records every repository consumer of the existing status families and introduces no runtime mapping or semantic change.
 
+The Phase 2 structural dependency contract is [Phase 2: Evidence Map Dependency Contract](./PHASE_2_EVIDENCE_MAP_DEPENDENCY_CONTRACT.md). It validates only that finalized Evidence Map rows carry the explicit upstream dependencies required downstream; it does not map statuses or judge evidence, applicability, or search quality.
+
 ## Product architecture
 
 Article6 has one core paid asset:
@@ -200,10 +202,13 @@ Do not mark placeholder text as FOUND. MISSING means no relevant document eviden
 
 ## Validation
 
-For this roadmap-only change, run:
+For this contract-only change, run:
 
 ```bash
+npx jest tests/lib/evidence/evidenceMapDependencyContract.test.ts --runInBand
+npm run lint
+npm run typecheck
 npm run roadmap:check
 ```
 
-No implementation code, parser/router logic, or client-facing report UI should change as part of this roadmap update.
+No parser/router logic, client-facing report UI, report output, PDF output, fixture, or gold truth should change as part of this phase.

--- a/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
+++ b/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
@@ -6,7 +6,8 @@
     "current_focus": [
       "Phase 0 terminology and compatibility contract is complete",
       "Phase 1 status consumer audit is complete",
-      "Phase 2 Evidence Map dependency contract is next",
+      "Phase 2 Evidence Map dependency contract is complete",
+      "Phase 3 Conformance Conclusion Contract is next",
       "Keep the Evidence Map upstream and canonical",
       "Keep the Pre-Validation Readiness Report and UI downstream"
     ],
@@ -32,12 +33,12 @@
     },
     "phase_2_evidence_map_dependency_contract": {
       "title": "Phase 2: Evidence Map Dependency Contract",
-      "status": "next",
-      "summary": "Require finalized Evidence Map rows, accepted and rejected evidence retention, client actions, assessment reasons, and full provenance before presentation."
+      "status": "done",
+      "summary": "Add a generic pure dependency gate requiring finalized Evidence Map row identity, requirement and methodology identity, upstream status, applicability state, accepted and rejected evidence, assessment reason, client action, search coverage, source-document identity, and evidence provenance without mapping or judging them."
     },
     "phase_3_conformance_conclusion_contract": {
       "title": "Phase 3: Conformance Conclusion Contract",
-      "status": "planned",
+      "status": "next",
       "summary": "Define when finalized Evidence Map support may produce CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or NOT_ASSESSED."
     },
     "phase_4_draft_action_finding_contract": {

--- a/src/lib/evidence/evidenceMapDependencyContract.ts
+++ b/src/lib/evidence/evidenceMapDependencyContract.ts
@@ -1,0 +1,245 @@
+import type { EvidenceSpan } from "@/lib/quickCheck/evidence/evidenceTypes";
+
+/**
+ * Phase 2 dependency contract for the future presentation layer.
+ *
+ * This module checks only that a finalized Evidence Map row carries the
+ * upstream dependencies required by downstream presentation. It does not
+ * judge evidence sufficiency, applicability, search quality, or status.
+ */
+
+export type EvidenceMapFinalizationState = "draft" | "finalized" | "unknown";
+
+export type EvidenceMapApplicabilityState =
+  | "APPLICABLE"
+  | "NOT_APPLICABLE"
+  | "UNKNOWN";
+
+export type EvidenceMapMethodologyIdentity = Readonly<{
+  methodologyId: string;
+  rulebookVersion: string;
+}>;
+
+export type EvidenceMapRequirementIdentity = Readonly<{
+  requirementId: string;
+  requirementReference: string;
+  requirementText: string;
+}>;
+
+export type EvidenceMapSourceDocumentIdentity = Readonly<{
+  documentId: string;
+  documentName: string | null;
+  contentSha256: string | null;
+}>;
+
+export type EvidenceMapSearchCoverage = Readonly<{
+  searched: boolean;
+  searchedDocumentIds: readonly string[];
+  notes: string | null;
+}>;
+
+/** Provenance reuses the canonical EvidenceSpan coordinates and span ID. */
+export type EvidenceMapEvidenceProvenance = Readonly<
+  Pick<EvidenceSpan, "docId" | "page" | "sectionPath" | "spanId">
+> & {
+  sectionHeading: string | null;
+  sourceType: string | null;
+};
+
+export type EvidenceMapAcceptedEvidence = Readonly<{
+  evidenceId: string;
+  quote: string;
+  provenance: EvidenceMapEvidenceProvenance;
+}>;
+
+export type EvidenceMapRejectedEvidence = Readonly<{
+  evidenceId: string;
+  quote: string;
+  rejectionReason: string;
+  provenance: EvidenceMapEvidenceProvenance;
+}>;
+
+export type EvidenceMapRow = Readonly<{
+  rowId: string;
+  requirement: EvidenceMapRequirementIdentity;
+  methodology: EvidenceMapMethodologyIdentity | null;
+  upstreamStatus: string;
+  applicabilityState: EvidenceMapApplicabilityState;
+  acceptedEvidence: readonly EvidenceMapAcceptedEvidence[];
+  rejectedEvidence: readonly EvidenceMapRejectedEvidence[];
+  assessmentReason: string;
+  clientAction: string | null;
+  searchCoverage: EvidenceMapSearchCoverage;
+  sourceDocument: EvidenceMapSourceDocumentIdentity;
+  evidenceProvenance: readonly EvidenceMapEvidenceProvenance[];
+  finalizationState: EvidenceMapFinalizationState;
+}>;
+
+export type EvidenceMapDependencyBlockReason =
+  | "row_not_finalized"
+  | "missing_row_identity"
+  | "missing_requirement_identity"
+  | "missing_methodology_identity"
+  | "missing_methodology_version"
+  | "missing_upstream_status"
+  | "missing_applicability_state"
+  | "missing_accepted_evidence_field"
+  | "missing_rejected_evidence_field"
+  | "missing_assessment_reason"
+  | "missing_client_action_field"
+  | "missing_search_coverage_field"
+  | "missing_source_document_identity"
+  | "missing_provenance";
+
+export type EvidenceMapDependencyValidationResult =
+  | Readonly<{
+      ready: true;
+      row: EvidenceMapRow;
+    }>
+  | Readonly<{
+      ready: false;
+      blockedBy: readonly EvidenceMapDependencyBlockReason[];
+    }>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasNullableText(value: unknown): value is string | null {
+  return value === null || hasText(value);
+}
+
+function isEvidenceProvenance(value: unknown): value is EvidenceMapEvidenceProvenance {
+  if (!isRecord(value)) return false;
+  return (
+    hasText(value.docId) &&
+    (value.page === null || (typeof value.page === "number" && Number.isFinite(value.page))) &&
+    Array.isArray(value.sectionPath) &&
+    value.sectionPath.every((entry) => typeof entry === "string") &&
+    hasText(value.spanId) &&
+    hasNullableText(value.sectionHeading) &&
+    hasNullableText(value.sourceType)
+  );
+}
+
+function areAcceptedEvidenceItems(value: unknown): value is readonly EvidenceMapAcceptedEvidence[] {
+  return Array.isArray(value) && value.every((item) => {
+    if (!isRecord(item)) return false;
+    return hasText(item.evidenceId) && hasText(item.quote) && isEvidenceProvenance(item.provenance);
+  });
+}
+
+function areRejectedEvidenceItems(value: unknown): value is readonly EvidenceMapRejectedEvidence[] {
+  return Array.isArray(value) && value.every((item) => {
+    if (!isRecord(item)) return false;
+    return (
+      hasText(item.evidenceId) &&
+      hasText(item.quote) &&
+      hasText(item.rejectionReason) &&
+      isEvidenceProvenance(item.provenance)
+    );
+  });
+}
+
+function isRequirementIdentity(value: unknown): value is EvidenceMapRequirementIdentity {
+  if (!isRecord(value)) return false;
+  return hasText(value.requirementId) && hasText(value.requirementReference) && hasText(value.requirementText);
+}
+
+function isMethodologyIdentity(value: unknown): value is EvidenceMapMethodologyIdentity {
+  if (!isRecord(value)) return false;
+  return hasText(value.methodologyId) && hasText(value.rulebookVersion);
+}
+
+function isSearchCoverage(value: unknown): value is EvidenceMapSearchCoverage {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.searched === "boolean" &&
+    Array.isArray(value.searchedDocumentIds) &&
+    value.searchedDocumentIds.every((entry) => hasText(entry)) &&
+    hasNullableText(value.notes)
+  );
+}
+
+function isSourceDocumentIdentity(value: unknown): value is EvidenceMapSourceDocumentIdentity {
+  if (!isRecord(value)) return false;
+  return hasText(value.documentId) && hasNullableText(value.documentName) && hasNullableText(value.contentSha256);
+}
+
+function isApplicabilityState(value: unknown): value is EvidenceMapApplicabilityState {
+  return value === "APPLICABLE" || value === "NOT_APPLICABLE" || value === "UNKNOWN";
+}
+
+/**
+ * Validate dependency completeness without changing or copying the candidate.
+ * Explicit empty arrays and null values are retained as valid representations
+ * of absence where the contract permits them.
+ */
+export function validateEvidenceMapDependency(
+  candidate: unknown,
+): EvidenceMapDependencyValidationResult {
+  const blockedBy: EvidenceMapDependencyBlockReason[] = [];
+
+  if (!isRecord(candidate) || candidate.finalizationState !== "finalized") {
+    blockedBy.push("row_not_finalized");
+  }
+
+  if (!isRecord(candidate)) {
+    return { ready: false, blockedBy };
+  }
+
+  if (!hasText(candidate.rowId)) blockedBy.push("missing_row_identity");
+
+  if (!isRequirementIdentity(candidate.requirement)) {
+    blockedBy.push("missing_requirement_identity");
+  }
+
+  if (candidate.methodology === undefined) {
+    blockedBy.push("missing_methodology_identity");
+  } else if (candidate.methodology !== null && !isMethodologyIdentity(candidate.methodology)) {
+    blockedBy.push(
+      isRecord(candidate.methodology) && !hasText(candidate.methodology.methodologyId)
+        ? "missing_methodology_identity"
+        : "missing_methodology_version",
+    );
+  }
+
+  if (!hasText(candidate.upstreamStatus)) blockedBy.push("missing_upstream_status");
+  if (!isApplicabilityState(candidate.applicabilityState)) blockedBy.push("missing_applicability_state");
+
+  if (!hasOwn(candidate, "acceptedEvidence") || !areAcceptedEvidenceItems(candidate.acceptedEvidence)) {
+    blockedBy.push("missing_accepted_evidence_field");
+  }
+
+  if (!hasOwn(candidate, "rejectedEvidence") || !areRejectedEvidenceItems(candidate.rejectedEvidence)) {
+    blockedBy.push("missing_rejected_evidence_field");
+  }
+
+  if (!hasText(candidate.assessmentReason)) blockedBy.push("missing_assessment_reason");
+
+  if (!hasOwn(candidate, "clientAction") || !hasNullableText(candidate.clientAction)) {
+    blockedBy.push("missing_client_action_field");
+  }
+
+  if (!isSearchCoverage(candidate.searchCoverage)) blockedBy.push("missing_search_coverage_field");
+  if (!isSourceDocumentIdentity(candidate.sourceDocument)) {
+    blockedBy.push("missing_source_document_identity");
+  }
+  if (
+    !Array.isArray(candidate.evidenceProvenance) ||
+    !candidate.evidenceProvenance.every((item) => isEvidenceProvenance(item))
+  ) {
+    blockedBy.push("missing_provenance");
+  }
+
+  if (blockedBy.length > 0) return { ready: false, blockedBy };
+  return { ready: true, row: candidate as EvidenceMapRow };
+}

--- a/src/lib/evidence/evidenceMapDependencyContract.ts
+++ b/src/lib/evidence/evidenceMapDependencyContract.ts
@@ -73,6 +73,12 @@ export type EvidenceMapRow = Readonly<{
   sourceDocument: EvidenceMapSourceDocumentIdentity;
   evidenceProvenance: readonly EvidenceMapEvidenceProvenance[];
   finalizationState: EvidenceMapFinalizationState;
+  finalizationActorRef: string;
+  finalizedAt: string;
+  finalizationBasis: string;
+  reviewHistoryRef: string;
+  evidenceMapContractVersion: string;
+  reviewPolicyVersion: string;
 }>;
 
 export type EvidenceMapDependencyBlockReason =
@@ -89,7 +95,13 @@ export type EvidenceMapDependencyBlockReason =
   | "missing_client_action_field"
   | "missing_search_coverage_field"
   | "missing_source_document_identity"
-  | "missing_provenance";
+  | "missing_provenance"
+  | "missing_finalization_actor_ref"
+  | "missing_finalized_at"
+  | "missing_finalization_basis"
+  | "missing_review_history_ref"
+  | "missing_evidence_map_contract_version"
+  | "missing_review_policy_version";
 
 export type EvidenceMapDependencyValidationResult =
   | Readonly<{
@@ -239,6 +251,15 @@ export function validateEvidenceMapDependency(
   ) {
     blockedBy.push("missing_provenance");
   }
+
+  if (!hasText(candidate.finalizationActorRef)) blockedBy.push("missing_finalization_actor_ref");
+  if (!hasText(candidate.finalizedAt)) blockedBy.push("missing_finalized_at");
+  if (!hasText(candidate.finalizationBasis)) blockedBy.push("missing_finalization_basis");
+  if (!hasText(candidate.reviewHistoryRef)) blockedBy.push("missing_review_history_ref");
+  if (!hasText(candidate.evidenceMapContractVersion)) {
+    blockedBy.push("missing_evidence_map_contract_version");
+  }
+  if (!hasText(candidate.reviewPolicyVersion)) blockedBy.push("missing_review_policy_version");
 
   if (blockedBy.length > 0) return { ready: false, blockedBy };
   return { ready: true, row: candidate as EvidenceMapRow };

--- a/tests/lib/evidence/evidenceMapDependencyContract.test.ts
+++ b/tests/lib/evidence/evidenceMapDependencyContract.test.ts
@@ -1,0 +1,198 @@
+import {
+  validateEvidenceMapDependency,
+  type EvidenceMapAcceptedEvidence,
+  type EvidenceMapRejectedEvidence,
+  type EvidenceMapRow,
+} from "@/lib/evidence/evidenceMapDependencyContract";
+
+const acceptedEvidence: EvidenceMapAcceptedEvidence = {
+  evidenceId: "accepted-1",
+  quote: "The requirement is addressed in the source document.",
+  provenance: {
+    docId: "document-1",
+    page: 4,
+    sectionPath: ["4", "4.1"],
+    spanId: "span-1",
+    sectionHeading: "Requirement evidence",
+    sourceType: "uploaded-document",
+  },
+};
+
+const rejectedEvidence: EvidenceMapRejectedEvidence = {
+  evidenceId: "rejected-1",
+  quote: "A related but insufficient statement.",
+  rejectionReason: "Does not establish the requirement for the reviewed source.",
+  provenance: {
+    docId: "document-1",
+    page: 5,
+    sectionPath: ["5"],
+    spanId: "span-2",
+    sectionHeading: "Related material",
+    sourceType: "uploaded-document",
+  },
+};
+
+function makeRow(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
+  return {
+    rowId: "row-1",
+    requirement: {
+      requirementId: "requirement-1",
+      requirementReference: "REQ-1",
+      requirementText: "The project must document the requirement.",
+    },
+    methodology: {
+      methodologyId: "METHOD-1",
+      rulebookVersion: "v1.0",
+    },
+    upstreamStatus: "UNCLEAR",
+    applicabilityState: "UNKNOWN",
+    acceptedEvidence: [acceptedEvidence],
+    rejectedEvidence: [rejectedEvidence],
+    assessmentReason: "The row has been assessed against the available source.",
+    clientAction: null,
+    searchCoverage: {
+      searched: true,
+      searchedDocumentIds: ["document-1"],
+      notes: null,
+    },
+    sourceDocument: {
+      documentId: "document-1",
+      documentName: "source-document.pdf",
+      contentSha256: null,
+    },
+    evidenceProvenance: [acceptedEvidence.provenance, rejectedEvidence.provenance],
+    finalizationState: "finalized",
+    ...overrides,
+  };
+}
+
+function without(row: EvidenceMapRow, field: string): Record<string, unknown> {
+  const candidate = { ...row } as Record<string, unknown>;
+  delete candidate[field];
+  return candidate;
+}
+
+describe("validateEvidenceMapDependency", () => {
+  it("accepts a complete finalized row", () => {
+    const row = makeRow();
+
+    expect(validateEvidenceMapDependency(row)).toEqual({ ready: true, row });
+  });
+
+  it("blocks a non-finalized row", () => {
+    const result = validateEvidenceMapDependency(makeRow({ finalizationState: "draft" }));
+
+    expect(result).toEqual({ ready: false, blockedBy: ["row_not_finalized"] });
+  });
+
+  it.each([
+    ["acceptedEvidence", "missing_accepted_evidence_field"],
+    ["rejectedEvidence", "missing_rejected_evidence_field"],
+  ])("blocks an omitted %s field", (field, reason) => {
+    const result = validateEvidenceMapDependency(without(makeRow(), field));
+
+    expect(result.ready).toBe(false);
+    if (!result.ready) expect(result.blockedBy).toContain(reason);
+  });
+
+  it("retains explicit empty evidence arrays", () => {
+    const row = makeRow({ acceptedEvidence: [], rejectedEvidence: [] });
+    const result = validateEvidenceMapDependency(row);
+
+    expect(result).toEqual({ ready: true, row });
+    if (result.ready) {
+      expect(result.row.acceptedEvidence).toBe(row.acceptedEvidence);
+      expect(result.row.rejectedEvidence).toBe(row.rejectedEvidence);
+    }
+  });
+
+  it("blocks a missing assessment reason", () => {
+    const result = validateEvidenceMapDependency(without(makeRow(), "assessmentReason"));
+
+    expect(result).toEqual({ ready: false, blockedBy: ["missing_assessment_reason"] });
+  });
+
+  it("requires the client-action field but allows explicit null", () => {
+    const allowed = validateEvidenceMapDependency(makeRow({ clientAction: null }));
+    const blocked = validateEvidenceMapDependency(without(makeRow(), "clientAction"));
+
+    expect(allowed.ready).toBe(true);
+    expect(blocked).toEqual({ ready: false, blockedBy: ["missing_client_action_field"] });
+  });
+
+  it("blocks missing search coverage information", () => {
+    const result = validateEvidenceMapDependency(without(makeRow(), "searchCoverage"));
+
+    expect(result).toEqual({ ready: false, blockedBy: ["missing_search_coverage_field"] });
+  });
+
+  it("blocks missing source-document identity and provenance", () => {
+    const row = without(makeRow(), "sourceDocument");
+    delete row.evidenceProvenance;
+    const result = validateEvidenceMapDependency(row);
+
+    expect(result.ready).toBe(false);
+    if (!result.ready) {
+      expect(result.blockedBy).toEqual([
+        "missing_source_document_identity",
+        "missing_provenance",
+      ]);
+    }
+  });
+
+  it("returns accepted and rejected evidence unchanged", () => {
+    const row = makeRow();
+    const result = validateEvidenceMapDependency(row);
+
+    expect(result.ready).toBe(true);
+    if (result.ready) {
+      expect(result.row.acceptedEvidence).toEqual(row.acceptedEvidence);
+      expect(result.row.rejectedEvidence).toEqual(row.rejectedEvidence);
+      expect(result.row.evidenceProvenance).toEqual(row.evidenceProvenance);
+    }
+  });
+
+  it("does not rename or reinterpret the upstream status", () => {
+    const row = makeRow({ upstreamStatus: "no_evidence" });
+    const result = validateEvidenceMapDependency(row);
+
+    expect(result.ready).toBe(true);
+    if (result.ready) expect(result.row.upstreamStatus).toBe("no_evidence");
+  });
+
+  it("does not mutate its input", () => {
+    const row = makeRow();
+    const before = structuredClone(row);
+
+    validateEvidenceMapDependency(row);
+
+    expect(row).toEqual(before);
+  });
+
+  it("blocks incomplete methodology identity without judging applicability", () => {
+    const missingId = validateEvidenceMapDependency(makeRow({
+      methodology: { methodologyId: "", rulebookVersion: "v1.0" },
+    }));
+    const missingVersion = validateEvidenceMapDependency(makeRow({
+      methodology: { methodologyId: "METHOD-1", rulebookVersion: "" },
+    }));
+    const explicitlyNotRequired = validateEvidenceMapDependency(makeRow({ methodology: null }));
+
+    expect(missingId).toEqual({ ready: false, blockedBy: ["missing_methodology_identity"] });
+    expect(missingVersion).toEqual({ ready: false, blockedBy: ["missing_methodology_version"] });
+    expect(explicitlyNotRequired.ready).toBe(true);
+  });
+
+  it("is generic and accepts ordinary non-fixture row identities", () => {
+    const result = validateEvidenceMapDependency(makeRow({
+      rowId: "generic-row",
+      requirement: {
+        requirementId: "generic-requirement",
+        requirementReference: "STANDARD-1",
+        requirementText: "A generic requirement.",
+      },
+    }));
+
+    expect(result.ready).toBe(true);
+  });
+});

--- a/tests/lib/evidence/evidenceMapDependencyContract.test.ts
+++ b/tests/lib/evidence/evidenceMapDependencyContract.test.ts
@@ -62,6 +62,12 @@ function makeRow(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
     },
     evidenceProvenance: [acceptedEvidence.provenance, rejectedEvidence.provenance],
     finalizationState: "finalized",
+    finalizationActorRef: "actor-1",
+    finalizedAt: "2026-07-10T00:00:00.000Z",
+    finalizationBasis: "review-complete",
+    reviewHistoryRef: "review-history-1",
+    evidenceMapContractVersion: "evidence-map-contract-1",
+    reviewPolicyVersion: "review-policy-1",
     ...overrides,
   };
 }
@@ -83,6 +89,19 @@ describe("validateEvidenceMapDependency", () => {
     const result = validateEvidenceMapDependency(makeRow({ finalizationState: "draft" }));
 
     expect(result).toEqual({ ready: false, blockedBy: ["row_not_finalized"] });
+  });
+
+  it.each([
+    ["finalizationActorRef", "missing_finalization_actor_ref"],
+    ["finalizedAt", "missing_finalized_at"],
+    ["finalizationBasis", "missing_finalization_basis"],
+    ["reviewHistoryRef", "missing_review_history_ref"],
+    ["evidenceMapContractVersion", "missing_evidence_map_contract_version"],
+    ["reviewPolicyVersion", "missing_review_policy_version"],
+  ])("blocks missing finalized-row metadata: %s", (field, reason) => {
+    const result = validateEvidenceMapDependency(without(makeRow(), field));
+
+    expect(result).toEqual({ ready: false, blockedBy: [reason] });
   });
 
   it.each([


### PR DESCRIPTION
## Roadmap

- Roadmap: `vvb-report-presentation-layer`
- Phase: Phase 2 Evidence Map Dependency Contract
- `RC2: done`
- This PR update remains Phase 2 only; Phase 3 remains next.

## Contract introduced

Added a generic `EvidenceMapRow` contract and pure `validateEvidenceMapDependency` gate. It requires finalized row identity, requirement identity, methodology/version where applicable, opaque upstream status, explicit applicability state, accepted/rejected evidence, assessment reason, client action, search coverage, source-document identity, evidence provenance, and explicit finalized-row trace metadata. Evidence provenance reuses canonical `EvidenceSpan` coordinates. Explicit empty arrays and `null` values remain valid where documented.

For `finalizationState: "finalized"`, the contract now also requires non-empty:

- `finalizationActorRef`
- `finalizedAt`
- `finalizationBasis`
- `reviewHistoryRef`
- `evidenceMapContractVersion`
- `reviewPolicyVersion`

These are structural traceability fields only.

## Typed blocked dependency behavior

The exhaustive blocked-reason union includes:

- `row_not_finalized`
- `missing_row_identity`
- `missing_requirement_identity`
- `missing_methodology_identity`
- `missing_methodology_version`
- `missing_upstream_status`
- `missing_applicability_state`
- `missing_accepted_evidence_field`
- `missing_rejected_evidence_field`
- `missing_assessment_reason`
- `missing_client_action_field`
- `missing_search_coverage_field`
- `missing_source_document_identity`
- `missing_provenance`
- `missing_finalization_actor_ref`
- `missing_finalized_at`
- `missing_finalization_basis`
- `missing_review_history_ref`
- `missing_evidence_map_contract_version`
- `missing_review_policy_version`

## Files changed

- `src/lib/evidence/evidenceMapDependencyContract.ts`
- `tests/lib/evidence/evidenceMapDependencyContract.test.ts`
- `docs/roadmaps/vvb-report-presentation-layer/PHASE_2_EVIDENCE_MAP_DEPENDENCY_CONTRACT.md`
- `docs/roadmaps/vvb-report-presentation-layer/PLAN.md`
- `docs/roadmaps/vvb-report-presentation-layer/phase-status.json`
- `docs/roadmaps/SUMMARY.md` (generated)

## Focused tests added

20 pure contract tests cover complete finalized rows, finalization blocking, all six finalized-row metadata dependencies, omitted evidence fields, explicit empty arrays, assessment reason, nullable client action, search coverage, source identity/provenance, evidence preservation, status preservation, input immutability, methodology identity, and genericity.

## Validation run

- `npx jest tests/lib/evidence/evidenceMapDependencyContract.test.ts --runInBand` — 20 passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run roadmap:check` — passed
- `npm run pr:gate` — passed: 211 suites, 2,241 tests passed, 54 skipped; strict corpus thresholds passed; build/start and audit-pack smoke checks passed
- `git diff --check` — passed
- Pre-push lint/typecheck — passed

The existing optional `fitz`/`docling` parser warnings and expected diagnostic logs were non-failing environment/test output. Generated `public/manifest/index.json` changes were restored and are not part of this PR.

## Explicit non-goals

No reviewer permissions, lifecycle transitions, audit events, reviewer UI, status semantics, status mappings, router logic, Quick Check behavior, report conclusions, draft findings, applicability judgments, evidence-sufficiency judgments, search-quality judgments, version matching, reports, PDFs, UI, fixtures, or gold truth changed. The validator does not mutate or reinterpret upstream Evidence Map data.

## Risk assessment

Low runtime risk: this update strengthens an unused pure dependency contract and focused tests. The six new metadata fields are required only for structurally finalized rows and are not interpreted as governance decisions.