### PR TITLE
feat: Phase 3 conformance conclusion contract

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -393,7 +393,8 @@ Current focus:
 - Phase 0 terminology and compatibility contract is complete
 - Phase 1 status consumer audit is complete
 - Phase 2 Evidence Map dependency contract is complete
-- Phase 3 Conformance Conclusion Contract is next
+- Phase 3 Conformance Conclusion Contract is complete
+- Phase 4 Draft Action/Finding Contract is next
 - Review traceability and release controls are explicit downstream requirements
 - Keep the Evidence Map upstream and canonical
 - Keep the Pre-Validation Readiness Report and UI downstream
@@ -408,8 +409,8 @@ Not active now:
 1) RC0 — Phase 0: Report Terminology Contract: Done — Define additive pre-validation language, canonical NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, and null draft-finding values, prohibited formal-authority claims, and preservation of existing statuses without mappings.
 2) RC1 — Phase 1: Status Consumer Audit: Done — Audit every producer, storage boundary, transformation, comparison, filter, display, fixture, analytics, and test consumer of FOUND, UNCLEAR, MISSING, answered, unclear, and no_evidence without changing runtime semantics.
 3) RC2 — Phase 2: Evidence Map Dependency Contract: Done — Add a generic pure dependency gate requiring finalized Evidence Map row identity, requirement and methodology identity, upstream status, applicability state, accepted and rejected evidence, assessment reason, client action, search coverage, source-document identity, and evidence provenance without mapping or judging them.
-4) RC3 — Phase 3: Conformance Conclusion Contract: Next — Define when finalized Evidence Map support may produce CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or NOT_ASSESSED.
-5) RC4 — Phase 4: Draft Action/Finding Contract: Planned — Define draftFindingType and draftFindingRecord mappings using only NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, or null for unclear, missing, and weak non-blocking Evidence Map rows.
+4) RC3 — Phase 3: Conformance Conclusion Contract: Done — Consume explicit assessment inputs after the Phase 2 dependency gate to derive CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or fail-closed NOT_ASSESSED without creating draft findings.
+5) RC4 — Phase 4: Draft Action/Finding Contract: Next — Define draftFindingType and draftFindingRecord mappings using only NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, or null for unclear, missing, and weak non-blocking Evidence Map rows.
 6) RC5 — Phase 5: Applicability Contract: Planned — Ensure NOT_APPLICABLE is derived only from an explicit applicability decision, not from missing or unclear evidence.
 7) RC6 — Phase 6: Report Presentation Object: Planned — Define the generic presentation object with Evidence Map row identity, provenance, conformance conclusion, draft finding fields, machine-proposal traceability, reviewer finalization metadata, review history, and contract versions without replacing the canonical Evidence Map decision.
 8) RC7 — Phase 7: Presentation Gates: Planned — Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_3_CONFORMANCE_CONCLUSION_CONTRACT.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_3_CONFORMANCE_CONCLUSION_CONTRACT.md
@@ -1,0 +1,78 @@
+# Phase 3: Conformance Conclusion Contract
+
+## Scope
+
+`deriveConformanceConclusion` is a pure, centralized contract downstream of the
+Phase 2 Evidence Map dependency gate. It consumes a candidate row and explicit
+assessment inputs and derives only `CONFORMS`, `ACTION_REQUIRED`,
+`NOT_APPLICABLE`, or `NOT_ASSESSED`.
+
+It does not calculate assessments from evidence counts, quotes, search flags,
+reason text, client actions, or upstream status alone. It does not create draft
+findings or choose a finding type; those are Phase 4 concerns.
+
+## Input contract
+
+The row input is `unknown` and is first passed to
+`validateEvidenceMapDependency`. A row must therefore be a complete finalized
+Evidence Map row. The assessment input is:
+
+```ts
+type ConformanceAssessmentInput = Readonly<{
+  requirementSupport: "SUPPORTED" | "NOT_SUPPORTED" | "NOT_EVALUATED";
+  searchCoverageAssessment:
+    | "ADEQUATE" | "INADEQUATE" | "NOT_REQUIRED" | "NOT_EVALUATED";
+  provenanceAssessment: "COMPLETE" | "INCOMPLETE" | "NOT_EVALUATED";
+  versionIdentityAssessment:
+    | "MATCHED" | "NOT_REQUIRED" | "MISMATCHED" | "UNRESOLVED";
+  contradictionAssessment: "NONE" | "BLOCKING" | "NOT_EVALUATED";
+}>;
+```
+
+These are explicit decision inputs. Later gates may calculate them; Phase 3
+only consumes them.
+
+## Output contract
+
+The result is a discriminated union. Positive results contain the Evidence Map
+row ID and a fixed basis. `NOT_ASSESSED` contains a deterministic ordered list
+of typed block records. Dependency blocks retain the exact Phase 2 reason.
+No result contains `draftFindingType` or a draft finding record.
+
+```ts
+type ConformanceConclusionResult =
+  | { conclusion: "CONFORMS"; evidenceMapRowId: string;
+      basis: "supported_applicable_requirement" }
+  | { conclusion: "ACTION_REQUIRED"; evidenceMapRowId: string;
+      basis: "applicable_requirement_not_supported" }
+  | { conclusion: "NOT_APPLICABLE"; evidenceMapRowId: string;
+      basis: "explicit_upstream_not_applicable" }
+  | { conclusion: "NOT_ASSESSED"; evidenceMapRowId: string | null;
+      blockedBy: readonly ConformanceConclusionBlock[] };
+```
+
+## Decision table
+
+| Conditions after the Phase 2 gate | Conclusion |
+| --- | --- |
+| Dependency blocked, malformed assessments, unsupported status, unknown applicability, unevaluated support, unsafe version/provenance/contradiction, conflicting support/status, or inadequate/unevaluated required search | `NOT_ASSESSED` |
+| Explicit `applicabilityState: NOT_APPLICABLE`, safe version identity, complete provenance, and no blocking contradiction | `NOT_APPLICABLE` |
+| `APPLICABLE`, `SUPPORTED`, adequate or not-required search, complete provenance, safe version, no contradiction, and upstream `FOUND` or `answered` | `CONFORMS` |
+| `APPLICABLE`, `NOT_SUPPORTED`, the same safe gates, and upstream `FOUND`, `UNCLEAR`, `MISSING`, `answered`, `unclear`, or `no_evidence` | `ACTION_REQUIRED` |
+
+`FOUND` or `answered` alone never conforms. Supported `UNCLEAR`, `MISSING`,
+`unclear`, or `no_evidence` fails closed because the explicit inputs conflict.
+Missing or unclear evidence never means `NOT_APPLICABLE`.
+
+## Fail-closed behavior and boundaries
+
+Malformed assessment values, unknown upstream statuses, incomplete or
+unevaluated provenance, mismatched or unresolved version identity, blocking or
+unevaluated contradiction review, unknown applicability, and insufficient
+search coverage produce `NOT_ASSESSED`. Dependency validation always runs first;
+its reasons are preserved in validator order. Inputs are not mutated.
+
+Phase 4 may define `NIR_CANDIDATE`, `NCR_CANDIDATE`, `OFI_CANDIDATE`, and null
+draft-finding outputs. Phase 3 does not implement those records, an
+applicability decision engine, report/PDF/UI consumers, runtime wiring, or any
+status renaming.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_3_CONFORMANCE_CONCLUSION_CONTRACT.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_3_CONFORMANCE_CONCLUSION_CONTRACT.md
@@ -32,6 +32,11 @@ type ConformanceAssessmentInput = Readonly<{
 These are explicit decision inputs. Later gates may calculate them; Phase 3
 only consumes them.
 
+Version identity is coupled to the row's methodology identity: a non-null
+methodology requires `MATCHED`, while a null methodology permits
+`NOT_REQUIRED`. `NOT_REQUIRED` for a non-null methodology and `MATCHED` for a
+null methodology are inconsistent and fail closed with typed blockers.
+
 ## Output contract
 
 The result is a discriminated union. Positive results contain the Evidence Map
@@ -59,6 +64,9 @@ type ConformanceConclusionResult =
 | Explicit `applicabilityState: NOT_APPLICABLE`, safe version identity, complete provenance, and no blocking contradiction | `NOT_APPLICABLE` |
 | `APPLICABLE`, `SUPPORTED`, adequate or not-required search, complete provenance, safe version, no contradiction, and upstream `FOUND` or `answered` | `CONFORMS` |
 | `APPLICABLE`, `NOT_SUPPORTED`, the same safe gates, and upstream `FOUND`, `UNCLEAR`, `MISSING`, `answered`, `unclear`, or `no_evidence` | `ACTION_REQUIRED` |
+
+For rows with a methodology identity, “safe version” means `MATCHED`. For rows
+whose methodology is explicitly null, “safe version” means `NOT_REQUIRED`.
 
 `FOUND` or `answered` alone never conforms. Supported `UNCLEAR`, `MISSING`,
 `unclear`, or `no_evidence` fails closed because the explicit inputs conflict.

--- a/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
@@ -12,6 +12,8 @@ The Phase 1 status inventory is [Phase 1: Status Consumer Audit](./PHASE_1_STATU
 
 The Phase 2 structural dependency contract is [Phase 2: Evidence Map Dependency Contract](./PHASE_2_EVIDENCE_MAP_DEPENDENCY_CONTRACT.md). It validates only that finalized Evidence Map rows carry the explicit upstream dependencies required downstream; it does not map statuses or judge evidence, applicability, or search quality.
 
+The Phase 3 conclusion contract is [Phase 3: Conformance Conclusion Contract](./PHASE_3_CONFORMANCE_CONCLUSION_CONTRACT.md). It consumes explicit assessment inputs after the Phase 2 gate and fails closed to the four canonical presentation conclusions; it does not create draft findings.
+
 ## Product architecture
 
 Article6 has one core paid asset:
@@ -322,8 +324,8 @@ Do not mark placeholder text as FOUND. MISSING means no relevant document eviden
 - Phase 0: Report Terminology Contract — done
 - Phase 1: Status Consumer Audit — done
 - Phase 2: Evidence Map Dependency Contract — done
-- Phase 3: Conformance Conclusion Contract — next
-- Phase 4: Draft Action/Finding Contract — planned
+- Phase 3: Conformance Conclusion Contract — done
+- Phase 4: Draft Action/Finding Contract — next
 - Phase 5: Applicability Contract — planned
 - Phase 6: Report Presentation Object — planned
 - Phase 7: Presentation Gates — planned

--- a/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
+++ b/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
@@ -7,7 +7,8 @@
       "Phase 0 terminology and compatibility contract is complete",
       "Phase 1 status consumer audit is complete",
       "Phase 2 Evidence Map dependency contract is complete",
-      "Phase 3 Conformance Conclusion Contract is next",
+      "Phase 3 Conformance Conclusion Contract is complete",
+      "Phase 4 Draft Action/Finding Contract is next",
       "Review traceability and release controls are explicit downstream requirements",
       "Keep the Evidence Map upstream and canonical",
       "Keep the Pre-Validation Readiness Report and UI downstream"
@@ -39,12 +40,12 @@
     },
     "phase_3_conformance_conclusion_contract": {
       "title": "Phase 3: Conformance Conclusion Contract",
-      "status": "next",
-      "summary": "Define when finalized Evidence Map support may produce CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or NOT_ASSESSED."
+      "status": "done",
+      "summary": "Consume explicit assessment inputs after the Phase 2 dependency gate to derive CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or fail-closed NOT_ASSESSED without creating draft findings."
     },
     "phase_4_draft_action_finding_contract": {
       "title": "Phase 4: Draft Action/Finding Contract",
-      "status": "planned",
+      "status": "next",
       "summary": "Define draftFindingType and draftFindingRecord mappings using only NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, or null for unclear, missing, and weak non-blocking Evidence Map rows."
     },
     "phase_5_applicability_contract": {

--- a/src/lib/evidence/conformanceConclusionContract.ts
+++ b/src/lib/evidence/conformanceConclusionContract.ts
@@ -1,0 +1,180 @@
+import {
+  validateEvidenceMapDependency,
+  type EvidenceMapDependencyBlockReason,
+  type EvidenceMapRow,
+} from "@/lib/evidence/evidenceMapDependencyContract";
+
+export type ConformanceConclusion =
+  | "CONFORMS"
+  | "ACTION_REQUIRED"
+  | "NOT_APPLICABLE"
+  | "NOT_ASSESSED";
+
+export type ConformanceAssessmentInput = Readonly<{
+  requirementSupport: "SUPPORTED" | "NOT_SUPPORTED" | "NOT_EVALUATED";
+  searchCoverageAssessment:
+    | "ADEQUATE"
+    | "INADEQUATE"
+    | "NOT_REQUIRED"
+    | "NOT_EVALUATED";
+  provenanceAssessment: "COMPLETE" | "INCOMPLETE" | "NOT_EVALUATED";
+  versionIdentityAssessment:
+    | "MATCHED"
+    | "NOT_REQUIRED"
+    | "MISMATCHED"
+    | "UNRESOLVED";
+  contradictionAssessment: "NONE" | "BLOCKING" | "NOT_EVALUATED";
+}>;
+
+export type ConformanceConclusionBlockCategory =
+  | "evidence_map_dependency_blocked"
+  | "invalid_assessment_input"
+  | "unsupported_upstream_status"
+  | "applicability_unknown"
+  | "requirement_support_not_evaluated"
+  | "upstream_status_conflicts_with_support"
+  | "search_coverage_inadequate"
+  | "search_coverage_not_evaluated"
+  | "provenance_incomplete"
+  | "provenance_not_evaluated"
+  | "version_identity_mismatch"
+  | "version_identity_unresolved"
+  | "blocking_contradiction"
+  | "contradiction_not_evaluated";
+
+export type ConformanceConclusionBlock =
+  | Readonly<{
+      category: "evidence_map_dependency_blocked";
+      reason: EvidenceMapDependencyBlockReason;
+    }>
+  | Readonly<{
+      category: Exclude<ConformanceConclusionBlockCategory, "evidence_map_dependency_blocked">;
+    }>;
+
+export type ConformanceConclusionResult =
+  | Readonly<{
+      conclusion: "CONFORMS";
+      evidenceMapRowId: string;
+      basis: "supported_applicable_requirement";
+    }>
+  | Readonly<{
+      conclusion: "ACTION_REQUIRED";
+      evidenceMapRowId: string;
+      basis: "applicable_requirement_not_supported";
+    }>
+  | Readonly<{
+      conclusion: "NOT_APPLICABLE";
+      evidenceMapRowId: string;
+      basis: "explicit_upstream_not_applicable";
+    }>
+  | Readonly<{
+      conclusion: "NOT_ASSESSED";
+      evidenceMapRowId: string | null;
+      blockedBy: readonly ConformanceConclusionBlock[];
+    }>;
+
+const assessmentValues = {
+  requirementSupport: ["SUPPORTED", "NOT_SUPPORTED", "NOT_EVALUATED"],
+  searchCoverageAssessment: ["ADEQUATE", "INADEQUATE", "NOT_REQUIRED", "NOT_EVALUATED"],
+  provenanceAssessment: ["COMPLETE", "INCOMPLETE", "NOT_EVALUATED"],
+  versionIdentityAssessment: ["MATCHED", "NOT_REQUIRED", "MISMATCHED", "UNRESOLVED"],
+  contradictionAssessment: ["NONE", "BLOCKING", "NOT_EVALUATED"],
+} as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isAssessment(value: unknown): value is ConformanceAssessmentInput {
+  if (!isRecord(value)) return false;
+  return (Object.keys(assessmentValues) as (keyof ConformanceAssessmentInput)[]).every((key) =>
+    (assessmentValues[key] as readonly unknown[]).includes(value[key]),
+  );
+}
+
+function block(category: Exclude<ConformanceConclusionBlockCategory, "evidence_map_dependency_blocked">): ConformanceConclusionBlock {
+  return { category };
+}
+
+function notAssessed(
+  row: EvidenceMapRow | null,
+  blockedBy: readonly ConformanceConclusionBlock[],
+): ConformanceConclusionResult {
+  return { conclusion: "NOT_ASSESSED", evidenceMapRowId: row?.rowId ?? null, blockedBy };
+}
+
+const supportedUpstreamStatuses = new Set(["FOUND", "answered"]);
+const unsupportedUpstreamStatuses = new Set(["UNCLEAR", "MISSING", "unclear", "no_evidence"]);
+
+/** Derive a conclusion from a finalized Evidence Map row and explicit assessments. */
+export function deriveConformanceConclusion(
+  candidate: unknown,
+  assessmentInput: unknown,
+): ConformanceConclusionResult {
+  const dependency = validateEvidenceMapDependency(candidate);
+  if (!dependency.ready) {
+    return notAssessed(
+      isRecord(candidate) && typeof candidate.rowId === "string" && candidate.rowId.trim()
+        ? (candidate as EvidenceMapRow)
+        : null,
+      dependency.blockedBy.map((reason) => ({
+        category: "evidence_map_dependency_blocked" as const,
+        reason,
+      })),
+    );
+  }
+
+  const row = dependency.row;
+  if (!isAssessment(assessmentInput)) return notAssessed(row, [block("invalid_assessment_input")]);
+
+  const assessment = assessmentInput;
+  const blockedBy: ConformanceConclusionBlock[] = [];
+
+  if (!supportedUpstreamStatuses.has(row.upstreamStatus) && !unsupportedUpstreamStatuses.has(row.upstreamStatus)) {
+    blockedBy.push(block("unsupported_upstream_status"));
+  }
+  if (row.applicabilityState === "UNKNOWN") blockedBy.push(block("applicability_unknown"));
+  if (assessment.requirementSupport === "NOT_EVALUATED") {
+    blockedBy.push(block("requirement_support_not_evaluated"));
+  }
+  if (assessment.requirementSupport === "SUPPORTED" && unsupportedUpstreamStatuses.has(row.upstreamStatus)) {
+    blockedBy.push(block("upstream_status_conflicts_with_support"));
+  }
+  if (assessment.versionIdentityAssessment === "MISMATCHED") blockAndPush(blockedBy, "version_identity_mismatch");
+  if (assessment.versionIdentityAssessment === "UNRESOLVED") blockAndPush(blockedBy, "version_identity_unresolved");
+  if (assessment.provenanceAssessment === "INCOMPLETE") blockAndPush(blockedBy, "provenance_incomplete");
+  if (assessment.provenanceAssessment === "NOT_EVALUATED") blockAndPush(blockedBy, "provenance_not_evaluated");
+  if (assessment.contradictionAssessment === "BLOCKING") blockAndPush(blockedBy, "blocking_contradiction");
+  if (assessment.contradictionAssessment === "NOT_EVALUATED") blockAndPush(blockedBy, "contradiction_not_evaluated");
+  if (row.applicabilityState === "APPLICABLE") {
+    if (assessment.searchCoverageAssessment === "INADEQUATE") blockAndPush(blockedBy, "search_coverage_inadequate");
+    if (assessment.searchCoverageAssessment === "NOT_EVALUATED") blockAndPush(blockedBy, "search_coverage_not_evaluated");
+  }
+
+  if (blockedBy.length > 0) return notAssessed(row, blockedBy);
+
+  const safeVersion = assessment.versionIdentityAssessment === "MATCHED" || assessment.versionIdentityAssessment === "NOT_REQUIRED";
+  const safeProvenance = assessment.provenanceAssessment === "COMPLETE";
+  const safeContradiction = assessment.contradictionAssessment === "NONE";
+  if (row.applicabilityState === "NOT_APPLICABLE" && safeVersion && safeProvenance && safeContradiction) {
+    return { conclusion: "NOT_APPLICABLE", evidenceMapRowId: row.rowId, basis: "explicit_upstream_not_applicable" };
+  }
+
+  const adequateSearch = assessment.searchCoverageAssessment === "ADEQUATE" || assessment.searchCoverageAssessment === "NOT_REQUIRED";
+  if (row.applicabilityState !== "APPLICABLE" || !adequateSearch || !safeVersion || !safeProvenance || !safeContradiction) {
+    return notAssessed(row, [block("invalid_assessment_input")]);
+  }
+  if (assessment.requirementSupport === "SUPPORTED") {
+    return { conclusion: "CONFORMS", evidenceMapRowId: row.rowId, basis: "supported_applicable_requirement" };
+  }
+  return { conclusion: "ACTION_REQUIRED", evidenceMapRowId: row.rowId, basis: "applicable_requirement_not_supported" };
+}
+
+function blockAndPush(
+  blockedBy: ConformanceConclusionBlock[],
+  category: Exclude<ConformanceConclusionBlockCategory, "evidence_map_dependency_blocked">,
+): void {
+  blockedBy.push(block(category));
+}
+
+export const evaluateConformanceConclusion = deriveConformanceConclusion;

--- a/src/lib/evidence/conformanceConclusionContract.ts
+++ b/src/lib/evidence/conformanceConclusionContract.ts
@@ -37,6 +37,8 @@ export type ConformanceConclusionBlockCategory =
   | "search_coverage_not_evaluated"
   | "provenance_incomplete"
   | "provenance_not_evaluated"
+  | "version_identity_not_required_for_methodology"
+  | "version_identity_matched_without_methodology"
   | "version_identity_mismatch"
   | "version_identity_unresolved"
   | "blocking_contradiction"
@@ -139,6 +141,12 @@ export function deriveConformanceConclusion(
   }
   if (assessment.requirementSupport === "SUPPORTED" && unsupportedUpstreamStatuses.has(row.upstreamStatus)) {
     blockedBy.push(block("upstream_status_conflicts_with_support"));
+  }
+  if (row.methodology !== null && assessment.versionIdentityAssessment === "NOT_REQUIRED") {
+    blockAndPush(blockedBy, "version_identity_not_required_for_methodology");
+  }
+  if (row.methodology === null && assessment.versionIdentityAssessment === "MATCHED") {
+    blockAndPush(blockedBy, "version_identity_matched_without_methodology");
   }
   if (assessment.versionIdentityAssessment === "MISMATCHED") blockAndPush(blockedBy, "version_identity_mismatch");
   if (assessment.versionIdentityAssessment === "UNRESOLVED") blockAndPush(blockedBy, "version_identity_unresolved");

--- a/tests/lib/evidence/conformanceConclusionContract.test.ts
+++ b/tests/lib/evidence/conformanceConclusionContract.test.ts
@@ -1,0 +1,76 @@
+import {
+  deriveConformanceConclusion,
+  type ConformanceAssessmentInput,
+  type ConformanceConclusionResult,
+} from "@/lib/evidence/conformanceConclusionContract";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+
+const provenance = { docId: "doc-1", page: 1, sectionPath: ["1"], spanId: "span-1", sectionHeading: "Heading", sourceType: "PDD" };
+function row(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
+  return {
+    rowId: "row-1", requirement: { requirementId: "req-1", requirementReference: "REQ-1", requirementText: "A requirement." },
+    methodology: null, upstreamStatus: "FOUND", applicabilityState: "APPLICABLE", acceptedEvidence: [], rejectedEvidence: [],
+    assessmentReason: "Reviewed.", clientAction: null, searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null },
+    sourceDocument: { documentId: "doc-1", documentName: "source.pdf", contentSha256: null }, evidenceProvenance: [provenance],
+    finalizationState: "finalized", finalizationActorRef: "actor-1", finalizedAt: "now", finalizationBasis: "review",
+    reviewHistoryRef: "history-1", evidenceMapContractVersion: "v1", reviewPolicyVersion: "v1", ...overrides,
+  };
+}
+const complete: ConformanceAssessmentInput = {
+  requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE",
+  versionIdentityAssessment: "NOT_REQUIRED", contradictionAssessment: "NONE",
+};
+function assess(overrides: Partial<ConformanceAssessmentInput> = {}): ConformanceAssessmentInput { return { ...complete, ...overrides }; }
+function conclusion(result: ConformanceConclusionResult): string { return result.conclusion; }
+
+describe("deriveConformanceConclusion", () => {
+  it.each(["FOUND", "answered"]) ("allows complete supported %s to conform", (upstreamStatus) => {
+    expect(conclusion(deriveConformanceConclusion(row({ upstreamStatus }), complete))).toBe("CONFORMS");
+  });
+  it("does not conform from FOUND alone", () => expect(conclusion(deriveConformanceConclusion(row(), assess({ requirementSupport: "NOT_EVALUATED" })))).toBe("NOT_ASSESSED"));
+  it.each(["FOUND", "UNCLEAR", "MISSING", "unclear", "no_evidence"]) ("requires explicit support for %s", (upstreamStatus) => {
+    const result = deriveConformanceConclusion(row({ upstreamStatus }), assess({ requirementSupport: "NOT_SUPPORTED" }));
+    expect(conclusion(result)).toBe("ACTION_REQUIRED");
+  });
+  it.each(["UNCLEAR", "MISSING", "unclear", "no_evidence"]) ("fails closed for supported %s", (upstreamStatus) => {
+    expect(conclusion(deriveConformanceConclusion(row({ upstreamStatus }), complete))).toBe("NOT_ASSESSED");
+  });
+  it("requires explicit not-applicable applicability", () => {
+    expect(conclusion(deriveConformanceConclusion(row({ applicabilityState: "NOT_APPLICABLE" }), complete))).toBe("NOT_APPLICABLE");
+    expect(conclusion(deriveConformanceConclusion(row({ applicabilityState: "UNKNOWN" }), complete))).toBe("NOT_ASSESSED");
+  });
+  it.each(["UNCLEAR", "MISSING", "unclear", "no_evidence"]) ("does not treat %s as not applicable", (upstreamStatus) => {
+    expect(conclusion(deriveConformanceConclusion(row({ upstreamStatus }), complete))).toBe("NOT_ASSESSED");
+  });
+  it.each([
+    ["INADEQUATE", "search_coverage_inadequate"], ["NOT_EVALUATED", "search_coverage_not_evaluated"],
+    ["INCOMPLETE", "provenance_incomplete"], ["MISMATCHED", "version_identity_mismatch"],
+    ["UNRESOLVED", "version_identity_unresolved"], ["BLOCKING", "blocking_contradiction"], ["NOT_EVALUATED", "contradiction_not_evaluated"],
+  ])("blocks unsafe assessment %s", (value, reason) => {
+    const key = reason.startsWith("search") ? "searchCoverageAssessment" : reason.startsWith("provenance") ? "provenanceAssessment" : reason.startsWith("version") ? "versionIdentityAssessment" : "contradictionAssessment";
+    const result = deriveConformanceConclusion(row(), assess({ [key]: value } as Partial<ConformanceAssessmentInput>));
+    expect(conclusion(result)).toBe("NOT_ASSESSED");
+    expect(result).toMatchObject({ blockedBy: [{ category: reason }] });
+  });
+  it("preserves dependency reasons for incomplete rows", () => {
+    const result = deriveConformanceConclusion({ finalizationState: "draft" }, complete);
+    expect(result.conclusion).toBe("NOT_ASSESSED");
+    expect(result.evidenceMapRowId).toBeNull();
+    expect(result.blockedBy).toContainEqual({ category: "evidence_map_dependency_blocked", reason: "row_not_finalized" });
+  });
+  it("rejects malformed assessments and unsupported statuses", () => {
+    expect(conclusion(deriveConformanceConclusion(row(), {}))).toBe("NOT_ASSESSED");
+    const result = deriveConformanceConclusion(row({ upstreamStatus: "UNKNOWN" }), complete);
+    expect(result).toMatchObject({ conclusion: "NOT_ASSESSED", blockedBy: [{ category: "unsupported_upstream_status" }] });
+  });
+  it("does not mutate inputs, includes deterministic blocks, and has no finding fields", () => {
+    const candidate = row({ upstreamStatus: "UNCLEAR" }); const before = structuredClone(candidate);
+    const result = deriveConformanceConclusion(candidate, assess({ requirementSupport: "SUPPORTED", provenanceAssessment: "NOT_EVALUATED", versionIdentityAssessment: "MISMATCHED" }));
+    expect(candidate).toEqual(before);
+    expect((result as Record<string, unknown>).draftFindingType).toBeUndefined();
+    expect((result as Record<string, unknown>).draftFindingRecord).toBeUndefined();
+    expect(result).toMatchObject({ blockedBy: [
+      { category: "upstream_status_conflicts_with_support" }, { category: "version_identity_mismatch" }, { category: "provenance_not_evaluated" },
+    ] });
+  });
+});

--- a/tests/lib/evidence/conformanceConclusionContract.test.ts
+++ b/tests/lib/evidence/conformanceConclusionContract.test.ts
@@ -20,6 +20,7 @@ const complete: ConformanceAssessmentInput = {
   requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE",
   versionIdentityAssessment: "NOT_REQUIRED", contradictionAssessment: "NONE",
 };
+const methodology = { methodologyId: "method-1", rulebookVersion: "v1.0" };
 function assess(overrides: Partial<ConformanceAssessmentInput> = {}): ConformanceAssessmentInput { return { ...complete, ...overrides }; }
 function conclusion(result: ConformanceConclusionResult): string { return result.conclusion; }
 
@@ -38,6 +39,22 @@ describe("deriveConformanceConclusion", () => {
   it("requires explicit not-applicable applicability", () => {
     expect(conclusion(deriveConformanceConclusion(row({ applicabilityState: "NOT_APPLICABLE" }), complete))).toBe("NOT_APPLICABLE");
     expect(conclusion(deriveConformanceConclusion(row({ applicabilityState: "UNKNOWN" }), complete))).toBe("NOT_ASSESSED");
+  });
+  it.each(["CONFORMS", "ACTION_REQUIRED", "NOT_APPLICABLE"]) ("allows %s with methodology only when version identity is matched", (expected) => {
+    const assessment = assess({
+      versionIdentityAssessment: "MATCHED",
+      requirementSupport: expected === "ACTION_REQUIRED" ? "NOT_SUPPORTED" : "SUPPORTED",
+    });
+    const candidate = row({ methodology, applicabilityState: expected === "NOT_APPLICABLE" ? "NOT_APPLICABLE" : "APPLICABLE" });
+    const result = deriveConformanceConclusion(candidate, assessment);
+    expect(conclusion(result)).toBe(expected);
+  });
+  it.each([
+    [null, "MATCHED", "version_identity_matched_without_methodology"],
+    [methodology, "NOT_REQUIRED", "version_identity_not_required_for_methodology"],
+  ])("blocks inconsistent methodology/version identity combinations", (rowMethodology, versionIdentityAssessment, reason) => {
+    const result = deriveConformanceConclusion(row({ methodology: rowMethodology }), assess({ versionIdentityAssessment }));
+    expect(result).toMatchObject({ conclusion: "NOT_ASSESSED", blockedBy: [{ category: reason }] });
   });
   it.each(["UNCLEAR", "MISSING", "unclear", "no_evidence"]) ("does not treat %s as not applicable", (upstreamStatus) => {
     expect(conclusion(deriveConformanceConclusion(row({ upstreamStatus }), complete))).toBe("NOT_ASSESSED");


### PR DESCRIPTION
## Roadmap slug and Phase 3

`vvb-report-presentation-layer`, Phase 3: Conformance Conclusion Contract.

## Problem being solved

Create one centralized pure contract that derives only `CONFORMS`, `ACTION_REQUIRED`, `NOT_APPLICABLE`, or fail-closed `NOT_ASSESSED` from finalized Evidence Map rows and explicit assessment inputs.

## Contract and decision table introduced

- Reuses `validateEvidenceMapDependency` and preserves its typed dependency reasons.
- Validates explicit requirement support, search coverage, provenance, version identity, and contradiction assessments without inferring them from evidence counts, quotes, search flags, reason text, client actions, or upstream status alone.
- Allows `CONFORMS` only for a complete applicable supported row with safe assessments and upstream `FOUND` or `answered`.
- Allows `ACTION_REQUIRED` only for applicable, explicitly unsupported rows with safe assessments and supported upstream statuses.
- Allows `NOT_APPLICABLE` only for an explicit upstream `applicabilityState: NOT_APPLICABLE` with safe assessments.
- Fails closed with typed, deterministically ordered blockers in all unsafe or malformed cases.

## Files changed

- `src/lib/evidence/conformanceConclusionContract.ts`
- `tests/lib/evidence/conformanceConclusionContract.test.ts`
- `docs/roadmaps/vvb-report-presentation-layer/PHASE_3_CONFORMANCE_CONCLUSION_CONTRACT.md`
- `docs/roadmaps/vvb-report-presentation-layer/PLAN.md`
- `docs/roadmaps/vvb-report-presentation-layer/phase-status.json`
- `docs/roadmaps/SUMMARY.md`

## Focused tests added

The focused tests cover conformance, action-required statuses, explicit not-applicable behavior, fail-closed gates, malformed inputs, dependency reason preservation, immutability, deterministic block ordering, and the absence of draft finding fields.

## Validation run

- `npx jest tests/lib/evidence/conformanceConclusionContract.test.ts tests/lib/evidence/evidenceMapDependencyContract.test.ts --runInBand` — 47 passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run roadmap:check` — passed
- `npm run pr:gate` — passed: build, 212 suites / 2,264 tests, strict eval corpus, dev-server health, and audit-pack smoke checks
- `git diff --check` — passed

## Explicit non-goals

- No draft finding types or records
- No Phase 4 implementation
- No applicability decision engine
- No Phase 5 or Phase 7 implementation
- No report or PDF generation
- No UI consumers or runtime consumers switched
- No fixture migration or gold-truth changes
- No router, Quick Check, parser, or status changes
- No organization-specific profiles or formal VVB authority language
- No methodology-specific or project-specific conditions
- No changes to the Phase 2 row schema

## Risk assessment

Low. This is a pure additive contract with focused tests and no runtime consumers. It reuses the existing Phase 2 validator and fails closed when dependencies or explicit assessments are unsafe.

Phase 3 done.
Phase 4 next.
No draft findings implemented.
No runtime consumers switched.