### PR TITLE
feat: Phase 4 draft action/finding contract

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -394,7 +394,8 @@ Current focus:
 - Phase 1 status consumer audit is complete
 - Phase 2 Evidence Map dependency contract is complete
 - Phase 3 Conformance Conclusion Contract is complete
-- Phase 4 Draft Action/Finding Contract is next
+- Phase 4 Draft Action/Finding Contract is complete
+- Phase 5 Applicability Contract is next
 - Review traceability and release controls are explicit downstream requirements
 - Keep the Evidence Map upstream and canonical
 - Keep the Pre-Validation Readiness Report and UI downstream
@@ -410,8 +411,8 @@ Not active now:
 2) RC1 — Phase 1: Status Consumer Audit: Done — Audit every producer, storage boundary, transformation, comparison, filter, display, fixture, analytics, and test consumer of FOUND, UNCLEAR, MISSING, answered, unclear, and no_evidence without changing runtime semantics.
 3) RC2 — Phase 2: Evidence Map Dependency Contract: Done — Add a generic pure dependency gate requiring finalized Evidence Map row identity, requirement and methodology identity, upstream status, applicability state, accepted and rejected evidence, assessment reason, client action, search coverage, source-document identity, and evidence provenance without mapping or judging them.
 4) RC3 — Phase 3: Conformance Conclusion Contract: Done — Consume explicit assessment inputs after the Phase 2 dependency gate to derive CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or fail-closed NOT_ASSESSED without creating draft findings.
-5) RC4 — Phase 4: Draft Action/Finding Contract: Next — Define draftFindingType and draftFindingRecord mappings using only NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, or null for unclear, missing, and weak non-blocking Evidence Map rows.
-6) RC5 — Phase 5: Applicability Contract: Planned — Ensure NOT_APPLICABLE is derived only from an explicit applicability decision, not from missing or unclear evidence.
+5) RC4 — Phase 4: Draft Action/Finding Contract: Done — Consume a Phase 3 conclusion and explicit classification to produce only generic NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, or null without selecting evidence or claiming formal authority.
+6) RC5 — Phase 5: Applicability Contract: Next — Ensure NOT_APPLICABLE is derived only from an explicit applicability decision, not from missing or unclear evidence.
 7) RC6 — Phase 6: Report Presentation Object: Planned — Define the generic presentation object with Evidence Map row identity, provenance, conformance conclusion, draft finding fields, machine-proposal traceability, reviewer finalization metadata, review history, and contract versions without replacing the canonical Evidence Map decision.
 8) RC7 — Phase 7: Presentation Gates: Planned — Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates.
 9) RC8 — Phase 8: Fixture Expectation Migration: Planned — Migrate fixtures to preserve accepted and rejected evidence and use the Evidence Map-backed draft presentation expectations.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_4_DRAFT_ACTION_FINDING_CONTRACT.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_4_DRAFT_ACTION_FINDING_CONTRACT.md
@@ -1,0 +1,92 @@
+# Phase 4: Draft Action/Finding Contract
+
+## Scope
+
+`deriveDraftFinding` is a pure contract downstream of a finalized Evidence Map
+row and a Phase 3 `ConformanceConclusionResult`. It consumes an explicit draft
+classification and produces either no candidate or one generic pre-validation
+candidate. It never creates a formally issued finding and does not select,
+copy, or rewrite evidence.
+
+## Input contract
+
+The row is validated with `validateEvidenceMapDependency`. The Phase 3 result
+must be structurally valid and, when it carries a row ID, must identify the
+same row. The explicit assessment input is:
+
+```ts
+type DraftFindingAssessmentInput = Readonly<{
+  draftFindingType:
+    | "NIR_CANDIDATE"
+    | "NCR_CANDIDATE"
+    | "OFI_CANDIDATE"
+    | null;
+  findingBasis: string | null;
+  reviewerAssessment: string | null;
+}>;
+```
+
+`null` is an explicit decision that no candidate is proposed. A candidate
+requires non-empty basis and reviewer-assessment text. The contract does not
+derive classification from `FOUND`, `UNCLEAR`, `MISSING`, `answered`,
+`unclear`, or `no_evidence`.
+
+## Output contract
+
+Valid non-candidate output is exactly:
+
+```ts
+{
+  draftFindingType: null;
+  draftFindingRecord: null;
+}
+```
+
+Valid candidate output contains an immutable generic record:
+
+```ts
+{
+  findingId: string;
+  profile: "GENERIC_PRE_VALIDATION";
+  evidenceMapRowId: string;
+  requirementId: string;
+  conformanceConclusion: "ACTION_REQUIRED";
+  draftFindingType: "NIR_CANDIDATE" | "NCR_CANDIDATE" | "OFI_CANDIDATE";
+  findingBasis: string;
+  clientResponse: null;
+  reviewerAssessment: string;
+  closingRemarks: null;
+}
+```
+
+The record preserves row and requirement identity but contains no accepted
+evidence, rejected evidence, or provenance. The Evidence Map remains the one
+evidence truth model.
+
+## Decision table
+
+| Phase 3 conclusion and explicit classification | Result |
+| --- | --- |
+| `CONFORMS`, `NOT_APPLICABLE`, or `NOT_ASSESSED` with a valid explicit assessment | Null candidate |
+| `ACTION_REQUIRED` with explicit `null` classification | Null candidate |
+| `ACTION_REQUIRED` with explicit `NIR_CANDIDATE` | NIR candidate record |
+| `ACTION_REQUIRED` with explicit `NCR_CANDIDATE` | NCR candidate record |
+| `ACTION_REQUIRED` with explicit `OFI_CANDIDATE` | OFI candidate record |
+| Invalid, contradictory, incomplete, unsafe, or mismatched inputs | Null candidate plus typed blockers |
+
+The contract does not decide whether a case is missing mandatory evidence,
+requires clarification, or is a weak non-blocking issue. Those judgments must
+arrive through the explicit classification input. In particular, status alone
+never chooses NCR, NIR, or OFI.
+
+## Fail-closed behavior and boundaries
+
+Dependency failures preserve the exact Phase 2 reasons. Invalid Phase 3
+results, row-ID mismatches, invalid or missing classification data, missing
+basis or reviewer assessment, and formal authority language return null with
+deterministically ordered typed blockers. Inputs are not mutated.
+
+`NIR_CANDIDATE`, `NCR_CANDIDATE`, and `OFI_CANDIDATE` are generic draft
+candidate vocabulary only; they are not formally issued VVB findings. Phase 4
+does not implement runtime consumers, UI, reports, PDFs, fixtures, routing,
+Quick Check changes, applicability, or Phase 5 logic.

--- a/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
@@ -14,6 +14,8 @@ The Phase 2 structural dependency contract is [Phase 2: Evidence Map Dependency 
 
 The Phase 3 conclusion contract is [Phase 3: Conformance Conclusion Contract](./PHASE_3_CONFORMANCE_CONCLUSION_CONTRACT.md). It consumes explicit assessment inputs after the Phase 2 gate and fails closed to the four canonical presentation conclusions; it does not create draft findings.
 
+The Phase 4 draft action/finding contract is [Phase 4: Draft Action/Finding Contract](./PHASE_4_DRAFT_ACTION_FINDING_CONTRACT.md). It consumes a Phase 3 conclusion and explicit candidate classification to produce only generic NIR, NCR, or OFI candidates, or null, without selecting evidence or claiming formal authority.
+
 ## Product architecture
 
 Article6 has one core paid asset:
@@ -325,8 +327,8 @@ Do not mark placeholder text as FOUND. MISSING means no relevant document eviden
 - Phase 1: Status Consumer Audit — done
 - Phase 2: Evidence Map Dependency Contract — done
 - Phase 3: Conformance Conclusion Contract — done
-- Phase 4: Draft Action/Finding Contract — next
-- Phase 5: Applicability Contract — planned
+- Phase 4: Draft Action/Finding Contract — done
+- Phase 5: Applicability Contract — next
 - Phase 6: Report Presentation Object — planned
 - Phase 7: Presentation Gates — planned
 - Phase 8: Fixture Expectation Migration — planned

--- a/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
+++ b/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
@@ -8,7 +8,8 @@
       "Phase 1 status consumer audit is complete",
       "Phase 2 Evidence Map dependency contract is complete",
       "Phase 3 Conformance Conclusion Contract is complete",
-      "Phase 4 Draft Action/Finding Contract is next",
+      "Phase 4 Draft Action/Finding Contract is complete",
+      "Phase 5 Applicability Contract is next",
       "Review traceability and release controls are explicit downstream requirements",
       "Keep the Evidence Map upstream and canonical",
       "Keep the Pre-Validation Readiness Report and UI downstream"
@@ -45,12 +46,12 @@
     },
     "phase_4_draft_action_finding_contract": {
       "title": "Phase 4: Draft Action/Finding Contract",
-      "status": "next",
-      "summary": "Define draftFindingType and draftFindingRecord mappings using only NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, or null for unclear, missing, and weak non-blocking Evidence Map rows."
+      "status": "done",
+      "summary": "Consume a Phase 3 conclusion and explicit classification to produce only generic NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, or null without selecting evidence or claiming formal authority."
     },
     "phase_5_applicability_contract": {
       "title": "Phase 5: Applicability Contract",
-      "status": "planned",
+      "status": "next",
       "summary": "Ensure NOT_APPLICABLE is derived only from an explicit applicability decision, not from missing or unclear evidence."
     },
     "phase_6_report_presentation_object": {

--- a/src/lib/evidence/draftFindingContract.ts
+++ b/src/lib/evidence/draftFindingContract.ts
@@ -1,0 +1,184 @@
+import {
+  validateEvidenceMapDependency,
+  type EvidenceMapDependencyBlockReason,
+} from "@/lib/evidence/evidenceMapDependencyContract";
+import type {
+  ConformanceConclusion,
+  ConformanceConclusionResult,
+} from "@/lib/evidence/conformanceConclusionContract";
+
+export type DraftFindingType = "NIR_CANDIDATE" | "NCR_CANDIDATE" | "OFI_CANDIDATE" | null;
+
+export type DraftFindingAssessmentInput = Readonly<{
+  draftFindingType: DraftFindingType;
+  findingBasis: string | null;
+  reviewerAssessment: string | null;
+}>;
+
+export type DraftFindingRecord = Readonly<{
+  findingId: string;
+  profile: "GENERIC_PRE_VALIDATION";
+  evidenceMapRowId: string;
+  requirementId: string;
+  conformanceConclusion: "ACTION_REQUIRED";
+  draftFindingType: Exclude<DraftFindingType, null>;
+  findingBasis: string;
+  clientResponse: null;
+  reviewerAssessment: string;
+  closingRemarks: null;
+}>;
+
+export type DraftFindingBlockCategory =
+  | "evidence_map_dependency_blocked"
+  | "invalid_conformance_result"
+  | "conformance_row_id_mismatch"
+  | "invalid_draft_finding_assessment"
+  | "classification_not_explicit"
+  | "classification_not_allowed_for_conclusion"
+  | "finding_basis_missing"
+  | "reviewer_assessment_missing"
+  | "formal_authority_language";
+
+export type DraftFindingBlock =
+  | Readonly<{
+      category: "evidence_map_dependency_blocked";
+      reason: EvidenceMapDependencyBlockReason;
+    }>
+  | Readonly<{
+      category: Exclude<DraftFindingBlockCategory, "evidence_map_dependency_blocked">;
+    }>;
+
+export type DraftFindingResult =
+  | Readonly<{
+      draftFindingType: null;
+      draftFindingRecord: null;
+      blockedBy?: readonly DraftFindingBlock[];
+    }>
+  | Readonly<{
+      draftFindingType: Exclude<DraftFindingType, null>;
+      draftFindingRecord: DraftFindingRecord;
+    }>;
+
+const draftFindingTypes = ["NIR_CANDIDATE", "NCR_CANDIDATE", "OFI_CANDIDATE"] as const;
+const conclusions: readonly ConformanceConclusion[] = [
+  "CONFORMS",
+  "ACTION_REQUIRED",
+  "NOT_APPLICABLE",
+  "NOT_ASSESSED",
+];
+const authorityLanguage = /\b(?:issued|formally\s+issued|validated|verified|approved\s+by\s+(?:a\s+)?vvb|closed\s+(?:a\s+)?finding|formal\s+finding)\b/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isDraftFindingType(value: unknown): value is DraftFindingType {
+  return value === null || (typeof value === "string" && draftFindingTypes.includes(value as (typeof draftFindingTypes)[number]));
+}
+
+function isConformanceResult(value: unknown): value is ConformanceConclusionResult {
+  if (!isRecord(value) || !conclusions.includes(value.conclusion as ConformanceConclusion)) return false;
+  if (value.conclusion === "NOT_ASSESSED") {
+    return (value.evidenceMapRowId === null || typeof value.evidenceMapRowId === "string") && Array.isArray(value.blockedBy);
+  }
+  const basis = value.conclusion === "CONFORMS"
+    ? "supported_applicable_requirement"
+    : value.conclusion === "ACTION_REQUIRED"
+      ? "applicable_requirement_not_supported"
+      : "explicit_upstream_not_applicable";
+  return typeof value.evidenceMapRowId === "string" && value.basis === basis;
+}
+
+function isAssessment(value: unknown): value is DraftFindingAssessmentInput {
+  if (!isRecord(value) || !Object.prototype.hasOwnProperty.call(value, "draftFindingType")) return false;
+  return (
+    isDraftFindingType(value.draftFindingType) &&
+    (value.findingBasis === null || typeof value.findingBasis === "string") &&
+    (value.reviewerAssessment === null || typeof value.reviewerAssessment === "string")
+  );
+}
+
+function block(category: Exclude<DraftFindingBlockCategory, "evidence_map_dependency_blocked">): DraftFindingBlock {
+  return { category };
+}
+
+function nullFinding(blockedBy?: readonly DraftFindingBlock[]): DraftFindingResult {
+  return blockedBy === undefined
+    ? { draftFindingType: null, draftFindingRecord: null }
+    : { draftFindingType: null, draftFindingRecord: null, blockedBy };
+}
+
+function nonEmptyText(value: string | null): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Map an explicit Phase 4 classification to a generic draft candidate. */
+export function deriveDraftFinding(
+  candidate: unknown,
+  conformanceResult: unknown,
+  assessmentInput: unknown,
+): DraftFindingResult {
+  const dependency = validateEvidenceMapDependency(candidate);
+  if (!dependency.ready) {
+    return nullFinding(
+      dependency.blockedBy.map((reason) => ({
+        category: "evidence_map_dependency_blocked" as const,
+        reason,
+      })),
+    );
+  }
+
+  const row = dependency.row;
+  const blockedBy: DraftFindingBlock[] = [];
+  if (!isConformanceResult(conformanceResult)) {
+    blockedBy.push(block("invalid_conformance_result"));
+  } else if (conformanceResult.evidenceMapRowId !== null && conformanceResult.evidenceMapRowId !== row.rowId) {
+    blockedBy.push(block("conformance_row_id_mismatch"));
+  }
+
+  if (!isAssessment(assessmentInput)) {
+    blockedBy.push(block("invalid_draft_finding_assessment"));
+  } else {
+    if (assessmentInput.draftFindingType === null) {
+      if (assessmentInput.findingBasis !== null || assessmentInput.reviewerAssessment !== null) {
+        blockedBy.push(block("classification_not_explicit"));
+      }
+    } else {
+      if (!nonEmptyText(assessmentInput.findingBasis)) blockedBy.push(block("finding_basis_missing"));
+      if (!nonEmptyText(assessmentInput.reviewerAssessment)) blockedBy.push(block("reviewer_assessment_missing"));
+      if (nonEmptyText(assessmentInput.findingBasis) && authorityLanguage.test(assessmentInput.findingBasis)) {
+        blockedBy.push(block("formal_authority_language"));
+      }
+      if (nonEmptyText(assessmentInput.reviewerAssessment) && authorityLanguage.test(assessmentInput.reviewerAssessment)) {
+        blockedBy.push(block("formal_authority_language"));
+      }
+    }
+  }
+
+  const conclusion = isConformanceResult(conformanceResult) ? conformanceResult.conclusion : null;
+  if (conclusion !== "ACTION_REQUIRED" && isAssessment(assessmentInput) && assessmentInput.draftFindingType !== null) {
+    blockedBy.push(block("classification_not_allowed_for_conclusion"));
+  }
+
+  if (blockedBy.length > 0) return nullFinding(blockedBy);
+  if (!isConformanceResult(conformanceResult) || !isAssessment(assessmentInput)) return nullFinding();
+  if (conformanceResult.conclusion !== "ACTION_REQUIRED" || assessmentInput.draftFindingType === null) return nullFinding();
+
+  const findingBasis = assessmentInput.findingBasis as string;
+  const reviewerAssessment = assessmentInput.reviewerAssessment as string;
+  const record: DraftFindingRecord = {
+    findingId: `draft:${row.rowId}:${assessmentInput.draftFindingType}`,
+    profile: "GENERIC_PRE_VALIDATION",
+    evidenceMapRowId: row.rowId,
+    requirementId: row.requirement.requirementId,
+    conformanceConclusion: "ACTION_REQUIRED",
+    draftFindingType: assessmentInput.draftFindingType,
+    findingBasis,
+    clientResponse: null,
+    reviewerAssessment,
+    closingRemarks: null,
+  };
+  return { draftFindingType: assessmentInput.draftFindingType, draftFindingRecord: record };
+}
+
+export const evaluateDraftFinding = deriveDraftFinding;

--- a/src/lib/evidence/draftFindingContract.ts
+++ b/src/lib/evidence/draftFindingContract.ts
@@ -167,7 +167,7 @@ export function deriveDraftFinding(
   const findingBasis = assessmentInput.findingBasis as string;
   const reviewerAssessment = assessmentInput.reviewerAssessment as string;
   const record: DraftFindingRecord = {
-    findingId: `draft:${row.rowId}:${assessmentInput.draftFindingType}`,
+    findingId: `draft:${row.rowId}`,
     profile: "GENERIC_PRE_VALIDATION",
     evidenceMapRowId: row.rowId,
     requirementId: row.requirement.requirementId,

--- a/tests/lib/evidence/draftFindingContract.test.ts
+++ b/tests/lib/evidence/draftFindingContract.test.ts
@@ -34,6 +34,17 @@ describe("deriveDraftFinding", () => {
     expect(findingType(result)).toBe(draftFindingType);
     expect(result).toMatchObject({ draftFindingRecord: { profile: "GENERIC_PRE_VALIDATION", evidenceMapRowId: "row-1", requirementId: "req-1", conformanceConclusion: "ACTION_REQUIRED", clientResponse: null, closingRemarks: null } });
   });
+  it("keeps one stable record identity when classification changes", () => {
+    const findingIds = ["NIR_CANDIDATE", "NCR_CANDIDATE", "OFI_CANDIDATE"].map((draftFindingType) => {
+      const result = deriveDraftFinding(row(), actionRequired, assessment(draftFindingType as DraftFindingAssessmentInput["draftFindingType"], "Explicit classification basis.", "Reviewer assessment."));
+      if (result.draftFindingRecord === null) throw new Error("Expected a draft finding record");
+      return result.draftFindingRecord.findingId;
+    });
+
+    expect(new Set(findingIds)).toEqual(new Set(["draft:row-1"]));
+    expect(findingIds[0]).toBe(findingIds[1]);
+    expect(findingIds[1]).toBe(findingIds[2]);
+  });
   it.each([
     ["CONFORMS", deriveConformanceConclusion(row({ upstreamStatus: "FOUND" }), { ...conformanceAssessment, requirementSupport: "SUPPORTED" })],
     ["NOT_APPLICABLE", deriveConformanceConclusion(row({ applicabilityState: "NOT_APPLICABLE" }), { ...conformanceAssessment, requirementSupport: "SUPPORTED" })],

--- a/tests/lib/evidence/draftFindingContract.test.ts
+++ b/tests/lib/evidence/draftFindingContract.test.ts
@@ -1,0 +1,70 @@
+import {
+  deriveDraftFinding,
+  type DraftFindingAssessmentInput,
+  type DraftFindingResult,
+} from "@/lib/evidence/draftFindingContract";
+import {
+  deriveConformanceConclusion,
+  type ConformanceAssessmentInput,
+} from "@/lib/evidence/conformanceConclusionContract";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+
+const provenance = { docId: "doc-1", page: 1, sectionPath: ["1"], spanId: "span-1", sectionHeading: "Heading", sourceType: "PDD" };
+function row(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
+  return {
+    rowId: "row-1", requirement: { requirementId: "req-1", requirementReference: "REQ-1", requirementText: "A requirement." },
+    methodology: null, upstreamStatus: "UNCLEAR", applicabilityState: "APPLICABLE", acceptedEvidence: [], rejectedEvidence: [],
+    assessmentReason: "Reviewed.", clientAction: null, searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null },
+    sourceDocument: { documentId: "doc-1", documentName: "source.pdf", contentSha256: null }, evidenceProvenance: [provenance],
+    finalizationState: "finalized", finalizationActorRef: "actor-1", finalizedAt: "now", finalizationBasis: "review",
+    reviewHistoryRef: "history-1", evidenceMapContractVersion: "v1", reviewPolicyVersion: "v1", ...overrides,
+  };
+}
+const conformanceAssessment: ConformanceAssessmentInput = {
+  requirementSupport: "NOT_SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE",
+  versionIdentityAssessment: "NOT_REQUIRED", contradictionAssessment: "NONE",
+};
+const actionRequired = deriveConformanceConclusion(row(), conformanceAssessment);
+const assessment = (draftFindingType: DraftFindingAssessmentInput["draftFindingType"], findingBasis: string | null = null, reviewerAssessment: string | null = null): DraftFindingAssessmentInput => ({ draftFindingType, findingBasis, reviewerAssessment });
+function findingType(result: DraftFindingResult): string | null { return result.draftFindingType; }
+
+describe("deriveDraftFinding", () => {
+  it.each(["NIR_CANDIDATE", "NCR_CANDIDATE", "OFI_CANDIDATE"]) ("returns an immutable %s candidate only from explicit classification", (draftFindingType) => {
+    const result = deriveDraftFinding(row(), actionRequired, assessment(draftFindingType as DraftFindingAssessmentInput["draftFindingType"], "Explicit classification basis.", "Reviewer assessment."));
+    expect(findingType(result)).toBe(draftFindingType);
+    expect(result).toMatchObject({ draftFindingRecord: { profile: "GENERIC_PRE_VALIDATION", evidenceMapRowId: "row-1", requirementId: "req-1", conformanceConclusion: "ACTION_REQUIRED", clientResponse: null, closingRemarks: null } });
+  });
+  it.each([
+    ["CONFORMS", deriveConformanceConclusion(row({ upstreamStatus: "FOUND" }), { ...conformanceAssessment, requirementSupport: "SUPPORTED" })],
+    ["NOT_APPLICABLE", deriveConformanceConclusion(row({ applicabilityState: "NOT_APPLICABLE" }), { ...conformanceAssessment, requirementSupport: "SUPPORTED" })],
+    ["NOT_ASSESSED", deriveConformanceConclusion(row(), { ...conformanceAssessment, requirementSupport: "NOT_EVALUATED" })],
+  ])("returns null for %s", (_label, conformance) => {
+    expect(deriveDraftFinding(row(), conformance, assessment("NIR_CANDIDATE", "Basis.", "Assessment."))).toMatchObject({ draftFindingType: null, draftFindingRecord: null });
+  });
+  it("allows ACTION_REQUIRED to have no candidate", () => {
+    expect(deriveDraftFinding(row(), actionRequired, assessment(null))).toEqual({ draftFindingType: null, draftFindingRecord: null });
+  });
+  it.each(["FOUND", "UNCLEAR", "MISSING", "answered", "unclear", "no_evidence"]) ("does not infer a candidate from upstream status %s", (upstreamStatus) => {
+    const candidate = row({ upstreamStatus });
+    const conformance = deriveConformanceConclusion(candidate, conformanceAssessment);
+    expect(deriveDraftFinding(candidate, conformance, assessment(null))).toEqual({ draftFindingType: null, draftFindingRecord: null });
+  });
+  it("fails closed for invalid classification and mismatched row identity", () => {
+    expect(deriveDraftFinding(row(), actionRequired, { draftFindingType: "NCR" })).toMatchObject({ draftFindingType: null, blockedBy: [{ category: "invalid_draft_finding_assessment" }] });
+    expect(deriveDraftFinding(row(), { ...actionRequired, evidenceMapRowId: "other-row" }, assessment("NIR_CANDIDATE", "Basis.", "Assessment."))).toMatchObject({ draftFindingType: null, blockedBy: [{ category: "conformance_row_id_mismatch" }] });
+  });
+  it("fails closed for incomplete or formal authority text", () => {
+    expect(deriveDraftFinding(row(), actionRequired, assessment("NIR_CANDIDATE", null, "Assessment."))).toMatchObject({ blockedBy: [{ category: "finding_basis_missing" }] });
+    expect(deriveDraftFinding(row(), actionRequired, assessment("NIR_CANDIDATE", "The VVB formally issued a finding.", "Assessment."))).toMatchObject({ blockedBy: [{ category: "formal_authority_language" }] });
+  });
+  it("does not mutate inputs and orders multiple blockers deterministically", () => {
+    const candidate = row(); const before = structuredClone(candidate);
+    const result = deriveDraftFinding(candidate, { ...actionRequired, evidenceMapRowId: "other-row" }, assessment("NIR_CANDIDATE", null, null));
+    expect(candidate).toEqual(before);
+    expect((result as Record<string, unknown>).draftFindingRecord).toBeNull();
+    expect(result).toMatchObject({ blockedBy: [
+      { category: "conformance_row_id_mismatch" }, { category: "finding_basis_missing" }, { category: "reviewer_assessment_missing" },
+    ] });
+    expect(JSON.stringify(result)).not.toMatch(/VALIDATED|VERIFIED|APPROVED_BY_VVB|issued/i);
+  });
+});


### PR DESCRIPTION
## Roadmap

`vvb-report-presentation-layer`, Phase 4: Draft Action/Finding Contract.

## Problem solved

Define one pure centralized contract downstream of finalized Evidence Map rows and the Phase 3 conformance result that consumes an explicit draft classification and produces only a generic draft candidate or null.

## Contract

- `NIR_CANDIDATE`, `NCR_CANDIDATE`, and `OFI_CANDIDATE` are the only non-null candidate types.
- `CONFORMS`, `NOT_APPLICABLE`, and `NOT_ASSESSED` always return null candidates.
- `ACTION_REQUIRED` may return null or one candidate, but only after explicit classification input.
- Upstream statuses never select a finding type by themselves.
- Finalized Evidence Map dependency validation and Phase 3 row identity are preserved.
- Candidate records retain row and requirement identity without duplicating evidence or provenance.
- Invalid, contradictory, incomplete, unsafe, mismatched, or formal-authority inputs fail closed with typed deterministic blockers.

## Files changed

- `src/lib/evidence/draftFindingContract.ts`
- `tests/lib/evidence/draftFindingContract.test.ts`
- `docs/roadmaps/vvb-report-presentation-layer/PHASE_4_DRAFT_ACTION_FINDING_CONTRACT.md`
- `docs/roadmaps/vvb-report-presentation-layer/PLAN.md`
- `docs/roadmaps/vvb-report-presentation-layer/phase-status.json`
- `docs/roadmaps/SUMMARY.md`

## Tests and validation

- `npx jest tests/lib/evidence/draftFindingContract.test.ts tests/lib/evidence/conformanceConclusionContract.test.ts --runInBand` — 48 passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run roadmap:check` — passed
- `npm run pr:gate` — passed: 213 suites / 2,289 tests, strict eval corpus, build, dev-server health, and audit-pack smoke checks
- `git diff --check` — passed

## Roadmap state

Phase 4 done. Phase 5 next.

## Explicit non-goals

No runtime consumers, UI, reports, PDFs, fixtures, routing changes, Quick Check changes, Phase 5 logic, methodology-specific conditions, organization-specific profiles, or formal VVB authority changes were made. No formal finding is issued by this contract; all non-null outputs are generic candidates only.