### PR TITLE
feat: add Phase 5 applicability contract

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -395,7 +395,8 @@ Current focus:
 - Phase 2 Evidence Map dependency contract is complete
 - Phase 3 Conformance Conclusion Contract is complete
 - Phase 4 Draft Action/Finding Contract is complete
-- Phase 5 Applicability Contract is next
+- Phase 5 Applicability Contract is complete
+- Phase 6 Report Presentation Object is next
 - Review traceability and release controls are explicit downstream requirements
 - Keep the Evidence Map upstream and canonical
 - Keep the Pre-Validation Readiness Report and UI downstream
@@ -412,8 +413,8 @@ Not active now:
 3) RC2 — Phase 2: Evidence Map Dependency Contract: Done — Add a generic pure dependency gate requiring finalized Evidence Map row identity, requirement and methodology identity, upstream status, applicability state, accepted and rejected evidence, assessment reason, client action, search coverage, source-document identity, and evidence provenance without mapping or judging them.
 4) RC3 — Phase 3: Conformance Conclusion Contract: Done — Consume explicit assessment inputs after the Phase 2 dependency gate to derive CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or fail-closed NOT_ASSESSED without creating draft findings.
 5) RC4 — Phase 4: Draft Action/Finding Contract: Done — Consume a Phase 3 conclusion and explicit classification to produce only generic NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, or null without selecting evidence or claiming formal authority.
-6) RC5 — Phase 5: Applicability Contract: Next — Ensure NOT_APPLICABLE is derived only from an explicit applicability decision, not from missing or unclear evidence.
-7) RC6 — Phase 6: Report Presentation Object: Planned — Define the generic presentation object with Evidence Map row identity, provenance, conformance conclusion, draft finding fields, machine-proposal traceability, reviewer finalization metadata, review history, and contract versions without replacing the canonical Evidence Map decision.
+6) RC5 — Phase 5: Applicability Contract: Done — Require a basis-backed explicit applicability decision matching the canonical Evidence Map row; block missing, unknown, contradictory, or unevaluated applicability without changing upstream status semantics.
+7) RC6 — Phase 6: Report Presentation Object: Next — Define the generic presentation object with Evidence Map row identity, provenance, conformance conclusion, draft finding fields, machine-proposal traceability, reviewer finalization metadata, review history, and contract versions without replacing the canonical Evidence Map decision.
 8) RC7 — Phase 7: Presentation Gates: Planned — Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates.
 9) RC8 — Phase 8: Fixture Expectation Migration: Planned — Migrate fixtures to preserve accepted and rejected evidence and use the Evidence Map-backed draft presentation expectations.
 10) RC9 — Phase 9: Readiness Report and UI Consumers: Planned — Implement downstream Pre-Validation Readiness Report and UI consumers using the finalized Evidence Map presentation contract, with a minimal reviewer workflow, centralized release-gate checks, traceable approve/edit/reopen history, and internal preview when client release is blocked.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_3_CONFORMANCE_CONCLUSION_CONTRACT.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_3_CONFORMANCE_CONCLUSION_CONTRACT.md
@@ -3,8 +3,8 @@
 ## Scope
 
 `deriveConformanceConclusion` is a pure, centralized contract downstream of the
-Phase 2 Evidence Map dependency gate. It consumes a candidate row and explicit
-assessment inputs and derives only `CONFORMS`, `ACTION_REQUIRED`,
+Phase 2 Evidence Map dependency gate. It consumes a candidate row, a validated
+Phase 5 applicability result, and explicit assessment inputs and derives only `CONFORMS`, `ACTION_REQUIRED`,
 `NOT_APPLICABLE`, or `NOT_ASSESSED`.
 
 It does not calculate assessments from evidence counts, quotes, search flags,
@@ -15,7 +15,9 @@ findings or choose a finding type; those are Phase 4 concerns.
 
 The row input is `unknown` and is first passed to
 `validateEvidenceMapDependency`. A row must therefore be a complete finalized
-Evidence Map row. The assessment input is:
+Evidence Map row. The second input is the successful or blocked result from
+`deriveApplicability`; a successful result must preserve the same row ID and
+match the row's canonical applicability state. The remaining assessment input is:
 
 ```ts
 type ConformanceAssessmentInput = Readonly<{
@@ -61,7 +63,7 @@ type ConformanceConclusionResult =
 | Conditions after the Phase 2 gate | Conclusion |
 | --- | --- |
 | Dependency blocked, malformed assessments, unsupported status, unknown applicability, unevaluated support, unsafe version/provenance/contradiction, conflicting support/status, or inadequate/unevaluated required search | `NOT_ASSESSED` |
-| Explicit `applicabilityState: NOT_APPLICABLE`, safe version identity, complete provenance, and no blocking contradiction | `NOT_APPLICABLE` |
+| Successful matching explicit `NOT_APPLICABLE` applicability result, safe version identity, complete provenance, and no blocking contradiction | `NOT_APPLICABLE` |
 | `APPLICABLE`, `SUPPORTED`, adequate or not-required search, complete provenance, safe version, no contradiction, and upstream `FOUND` or `answered` | `CONFORMS` |
 | `APPLICABLE`, `NOT_SUPPORTED`, the same safe gates, and upstream `FOUND`, `UNCLEAR`, `MISSING`, `answered`, `unclear`, or `no_evidence` | `ACTION_REQUIRED` |
 
@@ -74,11 +76,14 @@ Missing or unclear evidence never means `NOT_APPLICABLE`.
 
 ## Fail-closed behavior and boundaries
 
-Malformed assessment values, unknown upstream statuses, incomplete or
+Malformed applicability or assessment values, unknown upstream statuses, incomplete or
 unevaluated provenance, mismatched or unresolved version identity, blocking or
 unevaluated contradiction review, unknown applicability, and insufficient
 search coverage produce `NOT_ASSESSED`. Dependency validation always runs first;
-its reasons are preserved in validator order. Inputs are not mutated.
+its reasons are preserved in validator order. Blocked applicability is propagated
+as `NOT_ASSESSED`, and only a successful matching explicit `NOT_APPLICABLE`
+applicability result can produce the `NOT_APPLICABLE` conclusion. Inputs are not
+mutated.
 
 Phase 4 may define `NIR_CANDIDATE`, `NCR_CANDIDATE`, `OFI_CANDIDATE`, and null
 draft-finding outputs. Phase 3 does not implement those records, an

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_5_APPLICABILITY_CONTRACT.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_5_APPLICABILITY_CONTRACT.md
@@ -1,0 +1,85 @@
+# Phase 5: Applicability Contract
+
+## Scope
+
+`deriveApplicability` is the generic, pure gate between a finalized Evidence Map
+row and conformance conclusion. It makes applicability an explicit assessment;
+it never derives applicability from evidence, search, status, or text.
+
+Implementation: `src/lib/evidence/applicabilityContract.ts`
+
+Focused contract test: `tests/lib/evidence/applicabilityContract.test.ts`
+
+## Input contract
+
+The candidate is `unknown` and is validated first with
+`validateEvidenceMapDependency`. The explicit assessment is:
+
+```ts
+type ApplicabilityAssessmentInput = Readonly<{
+  decision: "APPLICABLE" | "NOT_APPLICABLE" | "NOT_EVALUATED";
+  decisionBasis: string | null;
+}>;
+```
+
+`APPLICABLE` and `NOT_APPLICABLE` require non-empty basis text.
+`NOT_EVALUATED` is an explicit blocked decision and does not require a basis.
+The row's finalized `applicabilityState` is canonical; a successful assessment
+must match it exactly.
+
+## Output contract
+
+Successful outputs preserve the Evidence Map row ID:
+
+```ts
+{ applicability: "APPLICABLE"; evidenceMapRowId: string;
+  basis: "explicit_applicable_decision" }
+{ applicability: "NOT_APPLICABLE"; evidenceMapRowId: string;
+  basis: "explicit_not_applicable_decision" }
+```
+
+Blocked output is:
+
+```ts
+{ applicability: "NOT_ASSESSED"; evidenceMapRowId: string | null;
+  blockedBy: readonly ApplicabilityContractBlock[] }
+```
+
+The result is typed, deterministic, and does not mutate either input.
+
+## Decision table
+
+| Finalized row state | Explicit assessment | Result |
+| --- | --- | --- |
+| `APPLICABLE` | `APPLICABLE` plus basis | `APPLICABLE` |
+| `NOT_APPLICABLE` | `NOT_APPLICABLE` plus basis | `NOT_APPLICABLE` |
+| `UNKNOWN` | any decision | `NOT_ASSESSED` |
+| any state | missing/malformed decision | `NOT_ASSESSED` |
+| any state | `NOT_EVALUATED` | `NOT_ASSESSED` |
+| any state | supported decision without basis | `NOT_ASSESSED` |
+| state and supported decision disagree | supported decision | `NOT_ASSESSED` |
+
+`MISSING`, `UNCLEAR`, `answered`, `unclear`, and `no_evidence` remain upstream
+values. They cannot create `NOT_APPLICABLE`. Search failure, insufficient
+support, absent quotes, and empty evidence arrays likewise cannot create it.
+
+## Typed blockers and conformance integration
+
+The contract preserves Phase 2 dependency blockers and otherwise returns typed
+blockers for invalid assessment, not-evaluated decisions, missing basis, unknown
+row state, and row/decision mismatch.
+
+`deriveConformanceConclusion` now consumes the validated applicability result.
+It preserves row identity checks, rejects malformed or mismatched applicability
+results, propagates blocked applicability as `NOT_ASSESSED`, and only allows the
+successful matching `NOT_APPLICABLE` result to produce the Phase 3
+`NOT_APPLICABLE` conclusion. A successful `APPLICABLE` result continues through
+the existing support, coverage, provenance, version, and contradiction gates.
+
+## Explicit non-goals
+
+This phase does not change Quick Check statuses, routing, extraction, evidence
+selection, fixtures, reviewed gold truth, UI, reports, PDFs, methodology logic,
+organization profiles, or formal VVB authority language. It does not decide
+whether a requirement is applicable; it only validates an explicit decision.
+Phase 6 and Phase 7 are not implemented.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_5_APPLICABILITY_CONTRACT.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_5_APPLICABILITY_CONTRACT.md
@@ -33,9 +33,9 @@ Successful outputs preserve the Evidence Map row ID:
 
 ```ts
 { applicability: "APPLICABLE"; evidenceMapRowId: string;
-  basis: "explicit_applicable_decision" }
+  basis: "explicit_applicable_decision"; decisionBasis: string }
 { applicability: "NOT_APPLICABLE"; evidenceMapRowId: string;
-  basis: "explicit_not_applicable_decision" }
+  basis: "explicit_not_applicable_decision"; decisionBasis: string }
 ```
 
 Blocked output is:
@@ -45,7 +45,12 @@ Blocked output is:
   blockedBy: readonly ApplicabilityContractBlock[] }
 ```
 
-The result is typed, deterministic, and does not mutate either input.
+The supplied basis is normalized by trimming surrounding whitespace and retained
+in successful results. `isApplicabilityResult` is the centralized runtime
+validator used by conformance integration; it rejects empty successful IDs,
+empty blocker arrays, unknown blocker categories, unknown dependency reasons,
+extra forged fields, and malformed nested blockers. The result is typed,
+deterministic, and does not mutate either input.
 
 ## Decision table
 

--- a/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
@@ -16,6 +16,8 @@ The Phase 3 conclusion contract is [Phase 3: Conformance Conclusion Contract](./
 
 The Phase 4 draft action/finding contract is [Phase 4: Draft Action/Finding Contract](./PHASE_4_DRAFT_ACTION_FINDING_CONTRACT.md). It consumes a Phase 3 conclusion and explicit candidate classification to produce only generic NIR, NCR, or OFI candidates, or null, without selecting evidence or claiming formal authority.
 
+The Phase 5 applicability contract is [Phase 5: Applicability Contract](./PHASE_5_APPLICABILITY_CONTRACT.md). It requires an explicit, basis-backed applicability decision matching the canonical Evidence Map row before applicability can enter conformance derivation.
+
 ## Product architecture
 
 Article6 has one core paid asset:
@@ -328,7 +330,7 @@ Do not mark placeholder text as FOUND. MISSING means no relevant document eviden
 - Phase 2: Evidence Map Dependency Contract — done
 - Phase 3: Conformance Conclusion Contract — done
 - Phase 4: Draft Action/Finding Contract — done
-- Phase 5: Applicability Contract — next
+- Phase 5: Applicability Contract — done
 - Phase 6: Report Presentation Object — planned
 - Phase 7: Presentation Gates — planned
 - Phase 8: Fixture Expectation Migration — planned

--- a/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
+++ b/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
@@ -9,7 +9,8 @@
       "Phase 2 Evidence Map dependency contract is complete",
       "Phase 3 Conformance Conclusion Contract is complete",
       "Phase 4 Draft Action/Finding Contract is complete",
-      "Phase 5 Applicability Contract is next",
+      "Phase 5 Applicability Contract is complete",
+      "Phase 6 Report Presentation Object is next",
       "Review traceability and release controls are explicit downstream requirements",
       "Keep the Evidence Map upstream and canonical",
       "Keep the Pre-Validation Readiness Report and UI downstream"
@@ -51,12 +52,12 @@
     },
     "phase_5_applicability_contract": {
       "title": "Phase 5: Applicability Contract",
-      "status": "next",
-      "summary": "Ensure NOT_APPLICABLE is derived only from an explicit applicability decision, not from missing or unclear evidence."
+      "status": "done",
+      "summary": "Require a basis-backed explicit applicability decision matching the canonical Evidence Map row; block missing, unknown, contradictory, or unevaluated applicability without changing upstream status semantics."
     },
     "phase_6_report_presentation_object": {
       "title": "Phase 6: Report Presentation Object",
-      "status": "planned",
+      "status": "next",
       "summary": "Define the generic presentation object with Evidence Map row identity, provenance, conformance conclusion, draft finding fields, machine-proposal traceability, reviewer finalization metadata, review history, and contract versions without replacing the canonical Evidence Map decision."
     },
     "phase_7_presentation_gates": {

--- a/src/lib/evidence/applicabilityContract.ts
+++ b/src/lib/evidence/applicabilityContract.ts
@@ -1,0 +1,118 @@
+import {
+  validateEvidenceMapDependency,
+  type EvidenceMapDependencyBlockReason,
+} from "@/lib/evidence/evidenceMapDependencyContract";
+
+export type ApplicabilityDecision = "APPLICABLE" | "NOT_APPLICABLE" | "NOT_EVALUATED";
+
+export type ApplicabilityAssessmentInput = Readonly<{
+  decision: ApplicabilityDecision;
+  decisionBasis: string | null;
+}>;
+
+export type ApplicabilityContractBlockCategory =
+  | "evidence_map_dependency_blocked"
+  | "invalid_applicability_assessment"
+  | "applicability_decision_not_evaluated"
+  | "applicability_basis_missing"
+  | "applicability_row_state_unknown"
+  | "applicability_row_state_mismatch";
+
+export type ApplicabilityContractBlock =
+  | Readonly<{
+      category: "evidence_map_dependency_blocked";
+      reason: EvidenceMapDependencyBlockReason;
+    }>
+  | Readonly<{
+      category: Exclude<ApplicabilityContractBlockCategory, "evidence_map_dependency_blocked">;
+    }>;
+
+export type ApplicabilityResult =
+  | Readonly<{
+      applicability: "APPLICABLE";
+      evidenceMapRowId: string;
+      basis: "explicit_applicable_decision";
+    }>
+  | Readonly<{
+      applicability: "NOT_APPLICABLE";
+      evidenceMapRowId: string;
+      basis: "explicit_not_applicable_decision";
+    }>
+  | Readonly<{
+      applicability: "NOT_ASSESSED";
+      evidenceMapRowId: string | null;
+      blockedBy: readonly ApplicabilityContractBlock[];
+    }>;
+
+const decisions: readonly ApplicabilityDecision[] = ["APPLICABLE", "NOT_APPLICABLE", "NOT_EVALUATED"];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function rowIdFrom(candidate: unknown): string | null {
+  return isRecord(candidate) && hasText(candidate.rowId) ? candidate.rowId : null;
+}
+
+function notAssessed(
+  evidenceMapRowId: string | null,
+  blockedBy: readonly ApplicabilityContractBlock[],
+): ApplicabilityResult {
+  return { applicability: "NOT_ASSESSED", evidenceMapRowId, blockedBy };
+}
+
+/** Validate an explicit applicability decision against a finalized Evidence Map row. */
+export function deriveApplicability(
+  candidate: unknown,
+  assessmentInput: unknown,
+): ApplicabilityResult {
+  const dependency = validateEvidenceMapDependency(candidate);
+  if (!dependency.ready) {
+    return notAssessed(
+      rowIdFrom(candidate),
+      dependency.blockedBy.map((reason) => ({
+        category: "evidence_map_dependency_blocked" as const,
+        reason,
+      })),
+    );
+  }
+
+  const row = dependency.row;
+  if (!isRecord(assessmentInput) || !decisions.includes(assessmentInput.decision as ApplicabilityDecision)) {
+    return notAssessed(row.rowId, [{ category: "invalid_applicability_assessment" }]);
+  }
+
+  const assessment = assessmentInput as ApplicabilityAssessmentInput;
+  const blockedBy: ApplicabilityContractBlock[] = [];
+  if (assessment.decision === "NOT_EVALUATED") {
+    blockedBy.push({ category: "applicability_decision_not_evaluated" });
+  }
+  if ((assessment.decision === "APPLICABLE" || assessment.decision === "NOT_APPLICABLE") && !hasText(assessment.decisionBasis)) {
+    blockedBy.push({ category: "applicability_basis_missing" });
+  }
+  if (row.applicabilityState === "UNKNOWN") {
+    blockedBy.push({ category: "applicability_row_state_unknown" });
+  }
+  if (
+    (assessment.decision === "APPLICABLE" || assessment.decision === "NOT_APPLICABLE") &&
+    assessment.decision !== row.applicabilityState
+  ) {
+    blockedBy.push({ category: "applicability_row_state_mismatch" });
+  }
+  if (blockedBy.length > 0) return notAssessed(row.rowId, blockedBy);
+
+  if (assessment.decision === "APPLICABLE") {
+    return { applicability: "APPLICABLE", evidenceMapRowId: row.rowId, basis: "explicit_applicable_decision" };
+  }
+  if (assessment.decision === "NOT_APPLICABLE") {
+    return { applicability: "NOT_APPLICABLE", evidenceMapRowId: row.rowId, basis: "explicit_not_applicable_decision" };
+  }
+  return notAssessed(row.rowId, [{ category: "applicability_decision_not_evaluated" }]);
+}
+
+export const validateApplicability = deriveApplicability;
+export const evaluateApplicability = deriveApplicability;

--- a/src/lib/evidence/applicabilityContract.ts
+++ b/src/lib/evidence/applicabilityContract.ts
@@ -32,11 +32,13 @@ export type ApplicabilityResult =
       applicability: "APPLICABLE";
       evidenceMapRowId: string;
       basis: "explicit_applicable_decision";
+      decisionBasis: string;
     }>
   | Readonly<{
       applicability: "NOT_APPLICABLE";
       evidenceMapRowId: string;
       basis: "explicit_not_applicable_decision";
+      decisionBasis: string;
     }>
   | Readonly<{
       applicability: "NOT_ASSESSED";
@@ -45,6 +47,22 @@ export type ApplicabilityResult =
     }>;
 
 const decisions: readonly ApplicabilityDecision[] = ["APPLICABLE", "NOT_APPLICABLE", "NOT_EVALUATED"];
+const applicabilityBlockCategories: readonly ApplicabilityContractBlockCategory[] = [
+  "evidence_map_dependency_blocked",
+  "invalid_applicability_assessment",
+  "applicability_decision_not_evaluated",
+  "applicability_basis_missing",
+  "applicability_row_state_unknown",
+  "applicability_row_state_mismatch",
+];
+const dependencyBlockReasons: readonly EvidenceMapDependencyBlockReason[] = [
+  "row_not_finalized", "missing_row_identity", "missing_requirement_identity", "missing_methodology_identity",
+  "missing_methodology_version", "missing_upstream_status", "missing_applicability_state",
+  "missing_accepted_evidence_field", "missing_rejected_evidence_field", "missing_assessment_reason",
+  "missing_client_action_field", "missing_search_coverage_field", "missing_source_document_identity",
+  "missing_provenance", "missing_finalization_actor_ref", "missing_finalized_at", "missing_finalization_basis",
+  "missing_review_history_ref", "missing_evidence_map_contract_version", "missing_review_policy_version",
+];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -52,6 +70,41 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function hasText(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).every((key) => keys.includes(key));
+}
+
+/** Validate an applicability result at runtime, including all nested blocker values. */
+export function isApplicabilityResult(value: unknown): value is ApplicabilityResult {
+  if (!isRecord(value) || typeof value.applicability !== "string") return false;
+  if (value.applicability === "APPLICABLE") {
+    return (
+      hasOnlyKeys(value, ["applicability", "evidenceMapRowId", "basis", "decisionBasis"]) &&
+      hasText(value.evidenceMapRowId) &&
+      value.basis === "explicit_applicable_decision" &&
+      hasText(value.decisionBasis)
+    );
+  }
+  if (value.applicability === "NOT_APPLICABLE") {
+    return (
+      hasOnlyKeys(value, ["applicability", "evidenceMapRowId", "basis", "decisionBasis"]) &&
+      hasText(value.evidenceMapRowId) &&
+      value.basis === "explicit_not_applicable_decision" &&
+      hasText(value.decisionBasis)
+    );
+  }
+  if (value.applicability !== "NOT_ASSESSED" || !hasOnlyKeys(value, ["applicability", "evidenceMapRowId", "blockedBy"])) return false;
+  if (value.evidenceMapRowId !== null && !hasText(value.evidenceMapRowId)) return false;
+  if (!Array.isArray(value.blockedBy) || value.blockedBy.length === 0) return false;
+  return value.blockedBy.every((blocker) => {
+    if (!isRecord(blocker) || typeof blocker.category !== "string" || !applicabilityBlockCategories.includes(blocker.category as ApplicabilityContractBlockCategory)) return false;
+    if (blocker.category === "evidence_map_dependency_blocked") {
+      return hasOnlyKeys(blocker, ["category", "reason"]) && typeof blocker.reason === "string" && dependencyBlockReasons.includes(blocker.reason as EvidenceMapDependencyBlockReason);
+    }
+    return hasOnlyKeys(blocker, ["category"]);
+  });
 }
 
 function rowIdFrom(candidate: unknown): string | null {
@@ -105,11 +158,12 @@ export function deriveApplicability(
   }
   if (blockedBy.length > 0) return notAssessed(row.rowId, blockedBy);
 
-  if (assessment.decision === "APPLICABLE") {
-    return { applicability: "APPLICABLE", evidenceMapRowId: row.rowId, basis: "explicit_applicable_decision" };
+  const decisionBasis = hasText(assessment.decisionBasis) ? assessment.decisionBasis.trim() : null;
+  if (assessment.decision === "APPLICABLE" && decisionBasis !== null) {
+    return { applicability: "APPLICABLE", evidenceMapRowId: row.rowId, basis: "explicit_applicable_decision", decisionBasis };
   }
-  if (assessment.decision === "NOT_APPLICABLE") {
-    return { applicability: "NOT_APPLICABLE", evidenceMapRowId: row.rowId, basis: "explicit_not_applicable_decision" };
+  if (assessment.decision === "NOT_APPLICABLE" && decisionBasis !== null) {
+    return { applicability: "NOT_APPLICABLE", evidenceMapRowId: row.rowId, basis: "explicit_not_applicable_decision", decisionBasis };
   }
   return notAssessed(row.rowId, [{ category: "applicability_decision_not_evaluated" }]);
 }

--- a/src/lib/evidence/conformanceConclusionContract.ts
+++ b/src/lib/evidence/conformanceConclusionContract.ts
@@ -5,8 +5,8 @@ import {
 } from "@/lib/evidence/evidenceMapDependencyContract";
 import type {
   ApplicabilityContractBlock,
-  ApplicabilityResult,
 } from "@/lib/evidence/applicabilityContract";
+import { isApplicabilityResult } from "@/lib/evidence/applicabilityContract";
 
 export type ConformanceConclusion =
   | "CONFORMS"
@@ -32,10 +32,6 @@ export type ConformanceAssessmentInput = Readonly<{
 
 export type ConformanceConclusionBlockCategory =
   | "evidence_map_dependency_blocked"
-  | "applicability_blocked"
-  | "applicability_result_invalid"
-  | "applicability_row_id_mismatch"
-  | "applicability_row_state_mismatch"
   | "applicability_blocked"
   | "applicability_result_invalid"
   | "applicability_row_id_mismatch"
@@ -121,31 +117,6 @@ function notAssessed(
   return { conclusion: "NOT_ASSESSED", evidenceMapRowId: row?.rowId ?? null, blockedBy };
 }
 
-function isApplicabilityResult(value: unknown): value is ApplicabilityResult {
-  if (!isRecord(value)) return false;
-  if (value.applicability === "APPLICABLE") {
-    return value.basis === "explicit_applicable_decision" && typeof value.evidenceMapRowId === "string";
-  }
-  if (value.applicability === "NOT_APPLICABLE") {
-    return value.basis === "explicit_not_applicable_decision" && typeof value.evidenceMapRowId === "string";
-  }
-  return (
-    value.applicability === "NOT_ASSESSED" &&
-    (value.evidenceMapRowId === null || typeof value.evidenceMapRowId === "string") &&
-    Array.isArray(value.blockedBy) &&
-    value.blockedBy.every((blocker) => {
-      if (!isRecord(blocker) || typeof blocker.category !== "string") return false;
-      if (blocker.category === "evidence_map_dependency_blocked") return typeof blocker.reason === "string";
-      return [
-        "invalid_applicability_assessment",
-        "applicability_decision_not_evaluated",
-        "applicability_basis_missing",
-        "applicability_row_state_unknown",
-        "applicability_row_state_mismatch",
-      ].includes(blocker.category);
-    })
-  );
-}
 
 const supportedUpstreamStatuses = new Set(["FOUND", "answered"]);
 const unsupportedUpstreamStatuses = new Set(["UNCLEAR", "MISSING", "unclear", "no_evidence"]);

--- a/src/lib/evidence/conformanceConclusionContract.ts
+++ b/src/lib/evidence/conformanceConclusionContract.ts
@@ -3,6 +3,10 @@ import {
   type EvidenceMapDependencyBlockReason,
   type EvidenceMapRow,
 } from "@/lib/evidence/evidenceMapDependencyContract";
+import type {
+  ApplicabilityContractBlock,
+  ApplicabilityResult,
+} from "@/lib/evidence/applicabilityContract";
 
 export type ConformanceConclusion =
   | "CONFORMS"
@@ -28,6 +32,14 @@ export type ConformanceAssessmentInput = Readonly<{
 
 export type ConformanceConclusionBlockCategory =
   | "evidence_map_dependency_blocked"
+  | "applicability_blocked"
+  | "applicability_result_invalid"
+  | "applicability_row_id_mismatch"
+  | "applicability_row_state_mismatch"
+  | "applicability_blocked"
+  | "applicability_result_invalid"
+  | "applicability_row_id_mismatch"
+  | "applicability_row_state_mismatch"
   | "invalid_assessment_input"
   | "unsupported_upstream_status"
   | "applicability_unknown"
@@ -50,7 +62,11 @@ export type ConformanceConclusionBlock =
       reason: EvidenceMapDependencyBlockReason;
     }>
   | Readonly<{
-      category: Exclude<ConformanceConclusionBlockCategory, "evidence_map_dependency_blocked">;
+      category: Exclude<ConformanceConclusionBlockCategory, "evidence_map_dependency_blocked" | "applicability_blocked">;
+    }>
+  | Readonly<{
+      category: "applicability_blocked";
+      reason: ApplicabilityContractBlock;
     }>;
 
 export type ConformanceConclusionResult =
@@ -94,7 +110,7 @@ function isAssessment(value: unknown): value is ConformanceAssessmentInput {
   );
 }
 
-function block(category: Exclude<ConformanceConclusionBlockCategory, "evidence_map_dependency_blocked">): ConformanceConclusionBlock {
+function block(category: Exclude<ConformanceConclusionBlockCategory, "evidence_map_dependency_blocked" | "applicability_blocked">): ConformanceConclusionBlock {
   return { category };
 }
 
@@ -105,12 +121,39 @@ function notAssessed(
   return { conclusion: "NOT_ASSESSED", evidenceMapRowId: row?.rowId ?? null, blockedBy };
 }
 
+function isApplicabilityResult(value: unknown): value is ApplicabilityResult {
+  if (!isRecord(value)) return false;
+  if (value.applicability === "APPLICABLE") {
+    return value.basis === "explicit_applicable_decision" && typeof value.evidenceMapRowId === "string";
+  }
+  if (value.applicability === "NOT_APPLICABLE") {
+    return value.basis === "explicit_not_applicable_decision" && typeof value.evidenceMapRowId === "string";
+  }
+  return (
+    value.applicability === "NOT_ASSESSED" &&
+    (value.evidenceMapRowId === null || typeof value.evidenceMapRowId === "string") &&
+    Array.isArray(value.blockedBy) &&
+    value.blockedBy.every((blocker) => {
+      if (!isRecord(blocker) || typeof blocker.category !== "string") return false;
+      if (blocker.category === "evidence_map_dependency_blocked") return typeof blocker.reason === "string";
+      return [
+        "invalid_applicability_assessment",
+        "applicability_decision_not_evaluated",
+        "applicability_basis_missing",
+        "applicability_row_state_unknown",
+        "applicability_row_state_mismatch",
+      ].includes(blocker.category);
+    })
+  );
+}
+
 const supportedUpstreamStatuses = new Set(["FOUND", "answered"]);
 const unsupportedUpstreamStatuses = new Set(["UNCLEAR", "MISSING", "unclear", "no_evidence"]);
 
 /** Derive a conclusion from a finalized Evidence Map row and explicit assessments. */
 export function deriveConformanceConclusion(
   candidate: unknown,
+  applicabilityResultInput: unknown,
   assessmentInput: unknown,
 ): ConformanceConclusionResult {
   const dependency = validateEvidenceMapDependency(candidate);
@@ -127,6 +170,22 @@ export function deriveConformanceConclusion(
   }
 
   const row = dependency.row;
+  if (!isApplicabilityResult(applicabilityResultInput)) {
+    return notAssessed(row, [block("applicability_result_invalid")]);
+  }
+  const applicabilityResult = applicabilityResultInput;
+  if (applicabilityResult.applicability === "NOT_ASSESSED") {
+    return notAssessed(
+      row,
+      applicabilityResult.blockedBy.map((reason) => ({ category: "applicability_blocked" as const, reason })),
+    );
+  }
+  if (applicabilityResult.evidenceMapRowId !== row.rowId) {
+    return notAssessed(row, [block("applicability_row_id_mismatch")]);
+  }
+  if (applicabilityResult.applicability !== row.applicabilityState) {
+    return notAssessed(row, [block("applicability_row_state_mismatch")]);
+  }
   if (!isAssessment(assessmentInput)) return notAssessed(row, [block("invalid_assessment_input")]);
 
   const assessment = assessmentInput;
@@ -135,7 +194,6 @@ export function deriveConformanceConclusion(
   if (!supportedUpstreamStatuses.has(row.upstreamStatus) && !unsupportedUpstreamStatuses.has(row.upstreamStatus)) {
     blockedBy.push(block("unsupported_upstream_status"));
   }
-  if (row.applicabilityState === "UNKNOWN") blockedBy.push(block("applicability_unknown"));
   if (assessment.requirementSupport === "NOT_EVALUATED") {
     blockedBy.push(block("requirement_support_not_evaluated"));
   }
@@ -154,7 +212,7 @@ export function deriveConformanceConclusion(
   if (assessment.provenanceAssessment === "NOT_EVALUATED") blockAndPush(blockedBy, "provenance_not_evaluated");
   if (assessment.contradictionAssessment === "BLOCKING") blockAndPush(blockedBy, "blocking_contradiction");
   if (assessment.contradictionAssessment === "NOT_EVALUATED") blockAndPush(blockedBy, "contradiction_not_evaluated");
-  if (row.applicabilityState === "APPLICABLE") {
+  if (applicabilityResult.applicability === "APPLICABLE") {
     if (assessment.searchCoverageAssessment === "INADEQUATE") blockAndPush(blockedBy, "search_coverage_inadequate");
     if (assessment.searchCoverageAssessment === "NOT_EVALUATED") blockAndPush(blockedBy, "search_coverage_not_evaluated");
   }
@@ -164,12 +222,12 @@ export function deriveConformanceConclusion(
   const safeVersion = assessment.versionIdentityAssessment === "MATCHED" || assessment.versionIdentityAssessment === "NOT_REQUIRED";
   const safeProvenance = assessment.provenanceAssessment === "COMPLETE";
   const safeContradiction = assessment.contradictionAssessment === "NONE";
-  if (row.applicabilityState === "NOT_APPLICABLE" && safeVersion && safeProvenance && safeContradiction) {
+  if (applicabilityResult.applicability === "NOT_APPLICABLE" && safeVersion && safeProvenance && safeContradiction) {
     return { conclusion: "NOT_APPLICABLE", evidenceMapRowId: row.rowId, basis: "explicit_upstream_not_applicable" };
   }
 
   const adequateSearch = assessment.searchCoverageAssessment === "ADEQUATE" || assessment.searchCoverageAssessment === "NOT_REQUIRED";
-  if (row.applicabilityState !== "APPLICABLE" || !adequateSearch || !safeVersion || !safeProvenance || !safeContradiction) {
+  if (applicabilityResult.applicability !== "APPLICABLE" || !adequateSearch || !safeVersion || !safeProvenance || !safeContradiction) {
     return notAssessed(row, [block("invalid_assessment_input")]);
   }
   if (assessment.requirementSupport === "SUPPORTED") {
@@ -180,7 +238,7 @@ export function deriveConformanceConclusion(
 
 function blockAndPush(
   blockedBy: ConformanceConclusionBlock[],
-  category: Exclude<ConformanceConclusionBlockCategory, "evidence_map_dependency_blocked">,
+  category: Exclude<ConformanceConclusionBlockCategory, "evidence_map_dependency_blocked" | "applicability_blocked">,
 ): void {
   blockedBy.push(block(category));
 }

--- a/tests/lib/evidence/applicabilityContract.test.ts
+++ b/tests/lib/evidence/applicabilityContract.test.ts
@@ -1,0 +1,62 @@
+import {
+  deriveApplicability,
+  type ApplicabilityAssessmentInput,
+  type ApplicabilityResult,
+} from "@/lib/evidence/applicabilityContract";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+
+const provenance = { docId: "doc-1", page: 1, sectionPath: ["1"], spanId: "span-1", sectionHeading: "Heading", sourceType: "PDD" };
+function row(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
+  return {
+    rowId: "row-1", requirement: { requirementId: "req-1", requirementReference: "REQ-1", requirementText: "A requirement." },
+    methodology: null, upstreamStatus: "FOUND", applicabilityState: "APPLICABLE", acceptedEvidence: [], rejectedEvidence: [],
+    assessmentReason: "Reviewed.", clientAction: null, searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null },
+    sourceDocument: { documentId: "doc-1", documentName: "source.pdf", contentSha256: null }, evidenceProvenance: [provenance],
+    finalizationState: "finalized", finalizationActorRef: "actor-1", finalizedAt: "now", finalizationBasis: "review",
+    reviewHistoryRef: "history-1", evidenceMapContractVersion: "v1", reviewPolicyVersion: "v1", ...overrides,
+  };
+}
+function assess(decision: ApplicabilityAssessmentInput["decision"], decisionBasis: string | null = "Explicit basis."): ApplicabilityAssessmentInput {
+  return { decision, decisionBasis };
+}
+function result(candidate: EvidenceMapRow, assessment: unknown): ApplicabilityResult {
+  return deriveApplicability(candidate, assessment);
+}
+
+describe("deriveApplicability", () => {
+  it("accepts explicit applicable and not-applicable decisions with a basis", () => {
+    expect(result(row(), assess("APPLICABLE"))).toEqual({ applicability: "APPLICABLE", evidenceMapRowId: "row-1", basis: "explicit_applicable_decision" });
+    const candidate = row({ applicabilityState: "NOT_APPLICABLE" });
+    expect(result(candidate, assess("NOT_APPLICABLE"))).toEqual({ applicability: "NOT_APPLICABLE", evidenceMapRowId: "row-1", basis: "explicit_not_applicable_decision" });
+  });
+  it.each([
+    [undefined, "applicabilityState", "APPLICABLE", "invalid_applicability_assessment"],
+    [assess("NOT_EVALUATED"), "applicabilityState", "APPLICABLE", "applicability_decision_not_evaluated"],
+    [assess("APPLICABLE", null), "applicabilityState", "APPLICABLE", "applicability_basis_missing"],
+    [assess("NOT_APPLICABLE", "   "), "applicabilityState", "NOT_APPLICABLE", "applicability_basis_missing"],
+  ])("fails closed for incomplete decision input", (assessment, key, state, category) => {
+    expect(result(row({ [key]: state } as Partial<EvidenceMapRow>), assessment)).toMatchObject({ applicability: "NOT_ASSESSED", blockedBy: [{ category }] });
+  });
+  it("fails closed for an unknown row and for row/decision disagreement", () => {
+    expect(result(row({ applicabilityState: "UNKNOWN" }), assess("APPLICABLE"))).toMatchObject({ blockedBy: [{ category: "applicability_row_state_unknown" }, { category: "applicability_row_state_mismatch" }] });
+    expect(result(row({ applicabilityState: "APPLICABLE" }), assess("NOT_APPLICABLE"))).toMatchObject({ blockedBy: [{ category: "applicability_row_state_mismatch" }] });
+  });
+  it.each(["MISSING", "UNCLEAR", "answered", "unclear", "no_evidence"]) ("does not infer non-applicability from upstream status %s", (upstreamStatus) => {
+    const candidate = row({ upstreamStatus });
+    expect(result(candidate, assess("APPLICABLE"))).toMatchObject({ applicability: "APPLICABLE" });
+    expect(result(candidate, assess("NOT_EVALUATED"))).toMatchObject({ applicability: "NOT_ASSESSED" });
+  });
+  it("does not let search failure or insufficient support create non-applicability", () => {
+    const candidate = row({ searchCoverage: { searched: false, searchedDocumentIds: [], notes: "search failed" }, acceptedEvidence: [] });
+    expect(result(candidate, assess("APPLICABLE"))).toMatchObject({ applicability: "APPLICABLE" });
+  });
+  it("preserves row identity, fails dependency input closed, and does not mutate inputs", () => {
+    const candidate = row();
+    const before = structuredClone(candidate);
+    expect(result(candidate, assess("APPLICABLE")).evidenceMapRowId).toBe("row-1");
+    expect(result({ ...candidate, finalizationState: "draft" }, assess("NOT_APPLICABLE"))).toMatchObject({ applicability: "NOT_ASSESSED", evidenceMapRowId: "row-1", blockedBy: [{ category: "evidence_map_dependency_blocked", reason: "row_not_finalized" }] });
+    expect(candidate).toEqual(before);
+    const many = result(row({ applicabilityState: "UNKNOWN" }), assess("NOT_APPLICABLE"));
+    expect(many).toMatchObject({ blockedBy: [{ category: "applicability_row_state_unknown" }, { category: "applicability_row_state_mismatch" }] });
+  });
+});

--- a/tests/lib/evidence/applicabilityContract.test.ts
+++ b/tests/lib/evidence/applicabilityContract.test.ts
@@ -1,5 +1,6 @@
 import {
   deriveApplicability,
+  isApplicabilityResult,
   type ApplicabilityAssessmentInput,
   type ApplicabilityResult,
 } from "@/lib/evidence/applicabilityContract";
@@ -25,9 +26,9 @@ function result(candidate: EvidenceMapRow, assessment: unknown): ApplicabilityRe
 
 describe("deriveApplicability", () => {
   it("accepts explicit applicable and not-applicable decisions with a basis", () => {
-    expect(result(row(), assess("APPLICABLE"))).toEqual({ applicability: "APPLICABLE", evidenceMapRowId: "row-1", basis: "explicit_applicable_decision" });
+    expect(result(row(), assess("APPLICABLE", "  Explicit applicability rationale.  "))).toEqual({ applicability: "APPLICABLE", evidenceMapRowId: "row-1", basis: "explicit_applicable_decision", decisionBasis: "Explicit applicability rationale." });
     const candidate = row({ applicabilityState: "NOT_APPLICABLE" });
-    expect(result(candidate, assess("NOT_APPLICABLE"))).toEqual({ applicability: "NOT_APPLICABLE", evidenceMapRowId: "row-1", basis: "explicit_not_applicable_decision" });
+    expect(result(candidate, assess("NOT_APPLICABLE"))).toEqual({ applicability: "NOT_APPLICABLE", evidenceMapRowId: "row-1", basis: "explicit_not_applicable_decision", decisionBasis: "Explicit basis." });
   });
   it.each([
     [undefined, "applicabilityState", "APPLICABLE", "invalid_applicability_assessment"],
@@ -58,5 +59,11 @@ describe("deriveApplicability", () => {
     expect(candidate).toEqual(before);
     const many = result(row({ applicabilityState: "UNKNOWN" }), assess("NOT_APPLICABLE"));
     expect(many).toMatchObject({ blockedBy: [{ category: "applicability_row_state_unknown" }, { category: "applicability_row_state_mismatch" }] });
+  });
+  it("rejects malformed or forged runtime results", () => {
+    expect(isApplicabilityResult({ applicability: "NOT_ASSESSED", evidenceMapRowId: "row-1", blockedBy: [] })).toBe(false);
+    expect(isApplicabilityResult({ applicability: "NOT_ASSESSED", evidenceMapRowId: "row-1", blockedBy: [{ category: "forged" }] })).toBe(false);
+    expect(isApplicabilityResult({ applicability: "NOT_ASSESSED", evidenceMapRowId: "row-1", blockedBy: [{ category: "evidence_map_dependency_blocked", reason: "forged" }] })).toBe(false);
+    expect(isApplicabilityResult({ applicability: "APPLICABLE", evidenceMapRowId: "", basis: "explicit_applicable_decision", decisionBasis: "Basis." })).toBe(false);
   });
 });

--- a/tests/lib/evidence/conformanceConclusionContract.test.ts
+++ b/tests/lib/evidence/conformanceConclusionContract.test.ts
@@ -3,6 +3,7 @@ import {
   type ConformanceAssessmentInput,
   type ConformanceConclusionResult,
 } from "@/lib/evidence/conformanceConclusionContract";
+import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
 import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
 
 const provenance = { docId: "doc-1", page: 1, sectionPath: ["1"], spanId: "span-1", sectionHeading: "Heading", sourceType: "PDD" };
@@ -22,23 +23,37 @@ const complete: ConformanceAssessmentInput = {
 };
 const methodology = { methodologyId: "method-1", rulebookVersion: "v1.0" };
 function assess(overrides: Partial<ConformanceAssessmentInput> = {}): ConformanceAssessmentInput { return { ...complete, ...overrides }; }
+function derive(candidate: EvidenceMapRow, assessment: ConformanceAssessmentInput): ConformanceConclusionResult {
+  return deriveConformanceConclusion(candidate, deriveApplicability(candidate, {
+    decision: candidate.applicabilityState === "UNKNOWN" ? "NOT_EVALUATED" : candidate.applicabilityState,
+    decisionBasis: "Explicit applicability basis.",
+  }), assessment);
+}
 function conclusion(result: ConformanceConclusionResult): string { return result.conclusion; }
 
 describe("deriveConformanceConclusion", () => {
   it.each(["FOUND", "answered"]) ("allows complete supported %s to conform", (upstreamStatus) => {
-    expect(conclusion(deriveConformanceConclusion(row({ upstreamStatus }), complete))).toBe("CONFORMS");
+    expect(conclusion(derive(row({ upstreamStatus }), complete))).toBe("CONFORMS");
   });
-  it("does not conform from FOUND alone", () => expect(conclusion(deriveConformanceConclusion(row(), assess({ requirementSupport: "NOT_EVALUATED" })))).toBe("NOT_ASSESSED"));
+  it("does not conform from FOUND alone", () => expect(conclusion(derive(row(), assess({ requirementSupport: "NOT_EVALUATED" })))).toBe("NOT_ASSESSED"));
   it.each(["FOUND", "UNCLEAR", "MISSING", "unclear", "no_evidence"]) ("requires explicit support for %s", (upstreamStatus) => {
-    const result = deriveConformanceConclusion(row({ upstreamStatus }), assess({ requirementSupport: "NOT_SUPPORTED" }));
+    const result = derive(row({ upstreamStatus }), assess({ requirementSupport: "NOT_SUPPORTED" }));
     expect(conclusion(result)).toBe("ACTION_REQUIRED");
   });
   it.each(["UNCLEAR", "MISSING", "unclear", "no_evidence"]) ("fails closed for supported %s", (upstreamStatus) => {
-    expect(conclusion(deriveConformanceConclusion(row({ upstreamStatus }), complete))).toBe("NOT_ASSESSED");
+    expect(conclusion(derive(row({ upstreamStatus }), complete))).toBe("NOT_ASSESSED");
   });
   it("requires explicit not-applicable applicability", () => {
-    expect(conclusion(deriveConformanceConclusion(row({ applicabilityState: "NOT_APPLICABLE" }), complete))).toBe("NOT_APPLICABLE");
-    expect(conclusion(deriveConformanceConclusion(row({ applicabilityState: "UNKNOWN" }), complete))).toBe("NOT_ASSESSED");
+    expect(conclusion(derive(row({ applicabilityState: "NOT_APPLICABLE" }), complete))).toBe("NOT_APPLICABLE");
+    expect(conclusion(derive(row({ applicabilityState: "UNKNOWN" }), complete))).toBe("NOT_ASSESSED");
+  });
+  it("requires a successful matching applicability result before deriving a conclusion", () => {
+    const candidate = row({ applicabilityState: "APPLICABLE", upstreamStatus: "MISSING" });
+    const blocked = deriveApplicability(candidate, { decision: "NOT_EVALUATED", decisionBasis: null });
+    expect(deriveConformanceConclusion(candidate, blocked, { ...complete, requirementSupport: "NOT_SUPPORTED" })).toMatchObject({ conclusion: "NOT_ASSESSED", blockedBy: [{ category: "applicability_blocked" }] });
+    const mismatch = deriveApplicability(candidate, { decision: "NOT_APPLICABLE", decisionBasis: "Explicit basis." });
+    expect(deriveConformanceConclusion(candidate, mismatch, complete)).toMatchObject({ conclusion: "NOT_ASSESSED", blockedBy: [{ category: "applicability_blocked" }] });
+    expect(deriveConformanceConclusion(candidate, deriveApplicability(candidate, { decision: "APPLICABLE", decisionBasis: "Explicit basis." }), { ...complete, requirementSupport: "NOT_SUPPORTED" })).toMatchObject({ conclusion: "ACTION_REQUIRED" });
   });
   it.each(["CONFORMS", "ACTION_REQUIRED", "NOT_APPLICABLE"]) ("allows %s with methodology only when version identity is matched", (expected) => {
     const assessment = assess({
@@ -46,18 +61,19 @@ describe("deriveConformanceConclusion", () => {
       requirementSupport: expected === "ACTION_REQUIRED" ? "NOT_SUPPORTED" : "SUPPORTED",
     });
     const candidate = row({ methodology, applicabilityState: expected === "NOT_APPLICABLE" ? "NOT_APPLICABLE" : "APPLICABLE" });
-    const result = deriveConformanceConclusion(candidate, assessment);
+    const result = derive(candidate, assessment);
     expect(conclusion(result)).toBe(expected);
   });
   it.each([
     [null, "MATCHED", "version_identity_matched_without_methodology"],
     [methodology, "NOT_REQUIRED", "version_identity_not_required_for_methodology"],
   ])("blocks inconsistent methodology/version identity combinations", (rowMethodology, versionIdentityAssessment, reason) => {
-    const result = deriveConformanceConclusion(row({ methodology: rowMethodology }), assess({ versionIdentityAssessment }));
+    const candidate = row({ methodology: rowMethodology });
+    const result = derive(candidate, assess({ versionIdentityAssessment }));
     expect(result).toMatchObject({ conclusion: "NOT_ASSESSED", blockedBy: [{ category: reason }] });
   });
   it.each(["UNCLEAR", "MISSING", "unclear", "no_evidence"]) ("does not treat %s as not applicable", (upstreamStatus) => {
-    expect(conclusion(deriveConformanceConclusion(row({ upstreamStatus }), complete))).toBe("NOT_ASSESSED");
+    expect(conclusion(derive(row({ upstreamStatus }), complete))).toBe("NOT_ASSESSED");
   });
   it.each([
     ["INADEQUATE", "search_coverage_inadequate"], ["NOT_EVALUATED", "search_coverage_not_evaluated"],
@@ -65,24 +81,24 @@ describe("deriveConformanceConclusion", () => {
     ["UNRESOLVED", "version_identity_unresolved"], ["BLOCKING", "blocking_contradiction"], ["NOT_EVALUATED", "contradiction_not_evaluated"],
   ])("blocks unsafe assessment %s", (value, reason) => {
     const key = reason.startsWith("search") ? "searchCoverageAssessment" : reason.startsWith("provenance") ? "provenanceAssessment" : reason.startsWith("version") ? "versionIdentityAssessment" : "contradictionAssessment";
-    const result = deriveConformanceConclusion(row(), assess({ [key]: value } as Partial<ConformanceAssessmentInput>));
+    const result = derive(row(), assess({ [key]: value } as Partial<ConformanceAssessmentInput>));
     expect(conclusion(result)).toBe("NOT_ASSESSED");
     expect(result).toMatchObject({ blockedBy: [{ category: reason }] });
   });
   it("preserves dependency reasons for incomplete rows", () => {
-    const result = deriveConformanceConclusion({ finalizationState: "draft" }, complete);
+    const result = deriveConformanceConclusion({ finalizationState: "draft" }, null, complete);
     expect(result.conclusion).toBe("NOT_ASSESSED");
     expect(result.evidenceMapRowId).toBeNull();
     expect(result.blockedBy).toContainEqual({ category: "evidence_map_dependency_blocked", reason: "row_not_finalized" });
   });
   it("rejects malformed assessments and unsupported statuses", () => {
-    expect(conclusion(deriveConformanceConclusion(row(), {}))).toBe("NOT_ASSESSED");
-    const result = deriveConformanceConclusion(row({ upstreamStatus: "UNKNOWN" }), complete);
+    expect(conclusion(derive(row(), {} as ConformanceAssessmentInput))).toBe("NOT_ASSESSED");
+    const result = derive(row({ upstreamStatus: "UNKNOWN" }), complete);
     expect(result).toMatchObject({ conclusion: "NOT_ASSESSED", blockedBy: [{ category: "unsupported_upstream_status" }] });
   });
   it("does not mutate inputs, includes deterministic blocks, and has no finding fields", () => {
     const candidate = row({ upstreamStatus: "UNCLEAR" }); const before = structuredClone(candidate);
-    const result = deriveConformanceConclusion(candidate, assess({ requirementSupport: "SUPPORTED", provenanceAssessment: "NOT_EVALUATED", versionIdentityAssessment: "MISMATCHED" }));
+    const result = derive(candidate, assess({ requirementSupport: "SUPPORTED", provenanceAssessment: "NOT_EVALUATED", versionIdentityAssessment: "MISMATCHED" }));
     expect(candidate).toEqual(before);
     expect((result as Record<string, unknown>).draftFindingType).toBeUndefined();
     expect((result as Record<string, unknown>).draftFindingRecord).toBeUndefined();

--- a/tests/lib/evidence/conformanceConclusionContract.test.ts
+++ b/tests/lib/evidence/conformanceConclusionContract.test.ts
@@ -54,6 +54,8 @@ describe("deriveConformanceConclusion", () => {
     const mismatch = deriveApplicability(candidate, { decision: "NOT_APPLICABLE", decisionBasis: "Explicit basis." });
     expect(deriveConformanceConclusion(candidate, mismatch, complete)).toMatchObject({ conclusion: "NOT_ASSESSED", blockedBy: [{ category: "applicability_blocked" }] });
     expect(deriveConformanceConclusion(candidate, deriveApplicability(candidate, { decision: "APPLICABLE", decisionBasis: "Explicit basis." }), { ...complete, requirementSupport: "NOT_SUPPORTED" })).toMatchObject({ conclusion: "ACTION_REQUIRED" });
+    expect(deriveConformanceConclusion(candidate, { applicability: "APPLICABLE", evidenceMapRowId: "other-row", basis: "explicit_applicable_decision", decisionBasis: "Basis." }, complete)).toMatchObject({ conclusion: "NOT_ASSESSED", blockedBy: [{ category: "applicability_row_id_mismatch" }] });
+    expect(deriveConformanceConclusion(candidate, { applicability: "NOT_ASSESSED", evidenceMapRowId: "row-1", blockedBy: [] }, complete)).toMatchObject({ conclusion: "NOT_ASSESSED", blockedBy: [{ category: "applicability_result_invalid" }] });
   });
   it.each(["CONFORMS", "ACTION_REQUIRED", "NOT_APPLICABLE"]) ("allows %s with methodology only when version identity is matched", (expected) => {
     const assessment = assess({

--- a/tests/lib/evidence/draftFindingContract.test.ts
+++ b/tests/lib/evidence/draftFindingContract.test.ts
@@ -7,6 +7,7 @@ import {
   deriveConformanceConclusion,
   type ConformanceAssessmentInput,
 } from "@/lib/evidence/conformanceConclusionContract";
+import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
 import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
 
 const provenance = { docId: "doc-1", page: 1, sectionPath: ["1"], spanId: "span-1", sectionHeading: "Heading", sourceType: "PDD" };
@@ -24,7 +25,13 @@ const conformanceAssessment: ConformanceAssessmentInput = {
   requirementSupport: "NOT_SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE",
   versionIdentityAssessment: "NOT_REQUIRED", contradictionAssessment: "NONE",
 };
-const actionRequired = deriveConformanceConclusion(row(), conformanceAssessment);
+function derive(candidate: EvidenceMapRow, assessment: ConformanceAssessmentInput): ReturnType<typeof deriveConformanceConclusion> {
+  return deriveConformanceConclusion(candidate, deriveApplicability(candidate, {
+    decision: candidate.applicabilityState === "UNKNOWN" ? "NOT_EVALUATED" : candidate.applicabilityState,
+    decisionBasis: "Explicit applicability basis.",
+  }), assessment);
+}
+const actionRequired = derive(row(), conformanceAssessment);
 const assessment = (draftFindingType: DraftFindingAssessmentInput["draftFindingType"], findingBasis: string | null = null, reviewerAssessment: string | null = null): DraftFindingAssessmentInput => ({ draftFindingType, findingBasis, reviewerAssessment });
 function findingType(result: DraftFindingResult): string | null { return result.draftFindingType; }
 
@@ -46,9 +53,9 @@ describe("deriveDraftFinding", () => {
     expect(findingIds[1]).toBe(findingIds[2]);
   });
   it.each([
-    ["CONFORMS", deriveConformanceConclusion(row({ upstreamStatus: "FOUND" }), { ...conformanceAssessment, requirementSupport: "SUPPORTED" })],
-    ["NOT_APPLICABLE", deriveConformanceConclusion(row({ applicabilityState: "NOT_APPLICABLE" }), { ...conformanceAssessment, requirementSupport: "SUPPORTED" })],
-    ["NOT_ASSESSED", deriveConformanceConclusion(row(), { ...conformanceAssessment, requirementSupport: "NOT_EVALUATED" })],
+    ["CONFORMS", derive(row({ upstreamStatus: "FOUND" }), { ...conformanceAssessment, requirementSupport: "SUPPORTED" })],
+    ["NOT_APPLICABLE", derive(row({ applicabilityState: "NOT_APPLICABLE" }), { ...conformanceAssessment, requirementSupport: "SUPPORTED" })],
+    ["NOT_ASSESSED", derive(row(), { ...conformanceAssessment, requirementSupport: "NOT_EVALUATED" })],
   ])("returns null for %s", (_label, conformance) => {
     expect(deriveDraftFinding(row(), conformance, assessment("NIR_CANDIDATE", "Basis.", "Assessment."))).toMatchObject({ draftFindingType: null, draftFindingRecord: null });
   });
@@ -57,7 +64,7 @@ describe("deriveDraftFinding", () => {
   });
   it.each(["FOUND", "UNCLEAR", "MISSING", "answered", "unclear", "no_evidence"]) ("does not infer a candidate from upstream status %s", (upstreamStatus) => {
     const candidate = row({ upstreamStatus });
-    const conformance = deriveConformanceConclusion(candidate, conformanceAssessment);
+    const conformance = derive(candidate, conformanceAssessment);
     expect(deriveDraftFinding(candidate, conformance, assessment(null))).toEqual({ draftFindingType: null, draftFindingRecord: null });
   });
   it("fails closed for invalid classification and mismatched row identity", () => {


### PR DESCRIPTION
## Roadmap

- Slug: vvb-report-presentation-layer
- Phase 5: Applicability Contract

## Scope

This PR adds a pure, generic applicability contract so NOT_APPLICABLE can only result from an explicit, basis-backed applicability decision matching the canonical finalized Evidence Map row.

## Problem solved

Previously, conformance derivation trusted row.applicabilityState directly. That allowed applicability to enter the conformance path without a separate explicit applicability assessment dependency. Missing, unclear, unsupported, or failed evidence must never independently mean NOT_APPLICABLE.

## Contract introduced

- Adds deriveApplicability / validateApplicability in src/lib/evidence/applicabilityContract.ts.
- Validates candidates through validateEvidenceMapDependency.
- Consumes typed APPLICABLE, NOT_APPLICABLE, or NOT_EVALUATED decisions.
- Requires non-empty basis for supported decisions.
- Preserves Evidence Map row identity.
- Fails closed with deterministic typed blockers for malformed, missing, unknown, unevaluated, basis-less, or contradictory input.
- Does not mutate inputs.

## Conformance integration

deriveConformanceConclusion now consumes the validated applicability result. Only a successful matching explicit NOT_APPLICABLE result can produce the Phase 3 NOT_APPLICABLE conclusion. A successful APPLICABLE result continues through existing support, coverage, provenance, version, and contradiction gates. Blocked, malformed, mismatched, or row-identity-inconsistent applicability produces NOT_ASSESSED with typed blockers.

## Tests added and updated

- Added tests/lib/evidence/applicabilityContract.test.ts.
- Updated conformance and draft-finding focused callers for the explicit applicability dependency.
- Added coverage for explicit decisions, missing/blank basis, NOT_EVALUATED, UNKNOWN rows, mismatches, upstream MISSING/UNCLEAR/answered/unclear/no_evidence, search failure, row identity, deterministic blockers, immutability, ACTION_REQUIRED continuation, and blocked conformance.
- Phase 4 draft-finding tests remain passing.

## Validation

- Focused suites: 4 suites, 83 tests passed.
- npm run lint: passed.
- npm run typecheck: passed.
- npm run roadmap:check: passed.
- npm run pr:gate: passed: build, 214 suites / 2,304 tests passed (one suite skipped and 54 tests skipped), strict corpus, server smoke, and audit-pack smoke checks.
- git diff --check: passed.
- Pre-push lint and typecheck: passed.

## Files changed

- src/lib/evidence/applicabilityContract.ts
- src/lib/evidence/conformanceConclusionContract.ts
- tests/lib/evidence/applicabilityContract.test.ts
- tests/lib/evidence/conformanceConclusionContract.test.ts
- tests/lib/evidence/draftFindingContract.test.ts
- docs/roadmaps/vvb-report-presentation-layer/PHASE_5_APPLICABILITY_CONTRACT.md
- docs/roadmaps/vvb-report-presentation-layer/PHASE_3_CONFORMANCE_CONCLUSION_CONTRACT.md
- docs/roadmaps/vvb-report-presentation-layer/PLAN.md
- docs/roadmaps/vvb-report-presentation-layer/phase-status.json
- docs/roadmaps/SUMMARY.md

## Explicit non-goals

No Quick Check behavior or status meanings, router behavior, evidence extraction, evidence acceptance/rejection, fixtures, reviewed gold truth, UI, reports, PDFs, runtime consumers, draft-finding classification, methodology-specific logic, organization profiles, or formal VVB authority language changed.

Phase 6 and Phase 7 were not implemented.

## Risk assessment

Low. The change is confined to pure typed contract modules, focused tests, and roadmap documentation. Existing conformance safety gates remain intact; callers must now provide explicit applicability results, and blocked or contradictory applicability fails closed.