### PR TITLE
feat: add Phase 6 report presentation object

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -396,7 +396,8 @@ Current focus:
 - Phase 3 Conformance Conclusion Contract is complete
 - Phase 4 Draft Action/Finding Contract is complete
 - Phase 5 Applicability Contract is complete
-- Phase 6 Report Presentation Object is next
+- Phase 6 Report Presentation Object is complete
+- Phase 7 Presentation Gates are next
 - Review traceability and release controls are explicit downstream requirements
 - Keep the Evidence Map upstream and canonical
 - Keep the Pre-Validation Readiness Report and UI downstream
@@ -414,8 +415,8 @@ Not active now:
 4) RC3 — Phase 3: Conformance Conclusion Contract: Done — Consume explicit assessment inputs after the Phase 2 dependency gate to derive CONFORMS, ACTION_REQUIRED, NOT_APPLICABLE, or fail-closed NOT_ASSESSED without creating draft findings.
 5) RC4 — Phase 4: Draft Action/Finding Contract: Done — Consume a Phase 3 conclusion and explicit classification to produce only generic NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, or null without selecting evidence or claiming formal authority.
 6) RC5 — Phase 5: Applicability Contract: Done — Require a basis-backed explicit applicability decision matching the canonical Evidence Map row; block missing, unknown, contradictory, or unevaluated applicability without changing upstream status semantics.
-7) RC6 — Phase 6: Report Presentation Object: Next — Define the generic presentation object with Evidence Map row identity, provenance, conformance conclusion, draft finding fields, machine-proposal traceability, reviewer finalization metadata, review history, and contract versions without replacing the canonical Evidence Map decision.
-8) RC7 — Phase 7: Presentation Gates: Planned — Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates.
+7) RC6 — Phase 6: Report Presentation Object: Done — Package finalized Evidence Map rows and validated applicability, conformance, and draft-finding results into one immutable generic presentation object with preserved evidence, provenance, review metadata, versions, and identity checks.
+8) RC7 — Phase 7: Presentation Gates: Next — Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates.
 9) RC8 — Phase 8: Fixture Expectation Migration: Planned — Migrate fixtures to preserve accepted and rejected evidence and use the Evidence Map-backed draft presentation expectations.
 10) RC9 — Phase 9: Readiness Report and UI Consumers: Planned — Implement downstream Pre-Validation Readiness Report and UI consumers using the finalized Evidence Map presentation contract, with a minimal reviewer workflow, centralized release-gate checks, traceable approve/edit/reopen history, and internal preview when client release is blocked.
 11) RC10 — Phase 10: Deprecation Review: Planned — Review old labels and organization-specific profiles only after the generic reviewer workflow and release gate are proven through a controlled pilot with qualified validation or verification professionals.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_6_REPORT_PRESENTATION_OBJECT.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_6_REPORT_PRESENTATION_OBJECT.md
@@ -1,0 +1,107 @@
+# Phase 6: Report Presentation Object
+
+## Scope
+
+`createReportPresentationObject` is a pure packaging contract downstream of the
+finalized Evidence Map and the Phase 3–5 validated results. It creates one
+generic immutable pre-validation presentation object. It does not calculate any
+judgment.
+
+Implementation: `src/lib/evidence/reportPresentationObject.ts`
+
+Focused contract test: `tests/lib/evidence/reportPresentationObject.test.ts`
+
+## Input contract
+
+The function accepts four values:
+
+```ts
+createReportPresentationObject(
+  candidate: unknown,
+  applicabilityResult: unknown,
+  conformanceConclusion: unknown,
+  draftFindingResult: unknown,
+): ReportPresentationResult
+```
+
+The candidate must pass `validateEvidenceMapDependency`. The other values must
+be valid outputs of the applicability, conformance, and draft-finding
+contracts. Every successful value must preserve the same Evidence Map row ID.
+Blocked applicability or conformance results are not packageable.
+
+## Presentation object schema
+
+```ts
+type ReportPresentationObject = Readonly<{
+  profile: "GENERIC_PRE_VALIDATION";
+  evidenceMapRowId: string;
+  requirement: EvidenceMapRequirementIdentity;
+  methodology: EvidenceMapMethodologyIdentity | null;
+  upstreamStatus: string;
+  applicabilityResult: ApplicabilityResult;
+  conformanceConclusion: ConformanceConclusionResult;
+  draftFindingResult: DraftFindingResult;
+  acceptedEvidence: readonly EvidenceMapAcceptedEvidence[];
+  rejectedEvidence: readonly EvidenceMapRejectedEvidence[];
+  assessmentReason: string;
+  clientAction: string | null;
+  searchCoverage: EvidenceMapSearchCoverage;
+  sourceDocument: EvidenceMapSourceDocumentIdentity;
+  evidenceProvenance: readonly EvidenceMapEvidenceProvenance[];
+  finalizationActorRef: string;
+  finalizedAt: string;
+  finalizationBasis: string;
+  reviewHistoryRef: string;
+  evidenceMapContractVersion: string;
+  reviewPolicyVersion: string;
+  presentationContractVersion: "v1";
+  machineProposalTraceability: MachineProposalTraceability | null;
+}>;
+```
+
+No separate machine-proposal record is available at this contract boundary, so
+`machineProposalTraceability` is explicitly `null`. The field is reserved for
+traceability supplied by a later upstream contract and is not inferred here.
+
+The output is deep-cloned and deeply frozen. Inputs are never mutated. The
+applicability result, including its decision basis, is retained; conformance
+and draft-finding results are packaged without recalculation.
+
+## Blocked result schema
+
+```ts
+type ReportPresentationResult =
+  | { ready: true; presentation: ReportPresentationObject }
+  | {
+      ready: false;
+      conclusion: "NOT_ASSESSED";
+      evidenceMapRowId: string | null;
+      blockedBy: readonly ReportPresentationBlock[];
+    };
+```
+
+Dependency blockers retain their Phase 2 reason. Applicability, conformance,
+and draft-finding blockers retain the typed upstream blocker as their reason.
+Malformed results, row mismatches, contradictory applicability/conformance,
+blocked upstream results, and draft-finding/conclusion contradictions fail
+closed deterministically.
+
+## Identity and evidence preservation rules
+
+The candidate row ID is the canonical identity. Applicability, conformance, and
+candidate draft-finding record IDs must match it. Accepted evidence, rejected
+evidence and rejection reasons, provenance, source-document identity, review
+metadata, versions, assessment reason, client action, and upstream status are
+copied exactly. The packaging contract never searches for, selects, discards,
+rewrites, or reclassifies evidence.
+
+Draft findings remain only `NIR_CANDIDATE`, `NCR_CANDIDATE`, `OFI_CANDIDATE`, or
+`null`. A presentation object contains no issued, approved, closed, validated,
+or verified finding state.
+
+## Authority boundaries and explicit non-goals
+
+This phase does not infer applicability, derive conformance, assess evidence,
+classify findings, replace the Evidence Map, or create a second source of truth.
+It does not implement report UI, PDFs, runtime consumers, fixture migration,
+release gates, methodology-specific logic, formal VVB authority, or Phase 7.

--- a/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
@@ -18,6 +18,8 @@ The Phase 4 draft action/finding contract is [Phase 4: Draft Action/Finding Cont
 
 The Phase 5 applicability contract is [Phase 5: Applicability Contract](./PHASE_5_APPLICABILITY_CONTRACT.md). It requires an explicit, basis-backed applicability decision matching the canonical Evidence Map row before applicability can enter conformance derivation.
 
+The Phase 6 report presentation object is [Phase 6: Report Presentation Object](./PHASE_6_REPORT_PRESENTATION_OBJECT.md). It packages validated Evidence Map, applicability, conformance, and draft-finding outputs into one immutable generic presentation object without deriving any judgment or replacing the Evidence Map.
+
 ## Product architecture
 
 Article6 has one core paid asset:
@@ -331,8 +333,8 @@ Do not mark placeholder text as FOUND. MISSING means no relevant document eviden
 - Phase 3: Conformance Conclusion Contract — done
 - Phase 4: Draft Action/Finding Contract — done
 - Phase 5: Applicability Contract — done
-- Phase 6: Report Presentation Object — planned
-- Phase 7: Presentation Gates — planned
+- Phase 6: Report Presentation Object — done
+- Phase 7: Presentation Gates — next
 - Phase 8: Fixture Expectation Migration — planned
 - Phase 9: Readiness Report and UI Consumers — planned
 - Phase 10: Deprecation Review — planned

--- a/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
+++ b/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
@@ -10,7 +10,8 @@
       "Phase 3 Conformance Conclusion Contract is complete",
       "Phase 4 Draft Action/Finding Contract is complete",
       "Phase 5 Applicability Contract is complete",
-      "Phase 6 Report Presentation Object is next",
+      "Phase 6 Report Presentation Object is complete",
+      "Phase 7 Presentation Gates are next",
       "Review traceability and release controls are explicit downstream requirements",
       "Keep the Evidence Map upstream and canonical",
       "Keep the Pre-Validation Readiness Report and UI downstream"
@@ -57,12 +58,12 @@
     },
     "phase_6_report_presentation_object": {
       "title": "Phase 6: Report Presentation Object",
-      "status": "next",
-      "summary": "Define the generic presentation object with Evidence Map row identity, provenance, conformance conclusion, draft finding fields, machine-proposal traceability, reviewer finalization metadata, review history, and contract versions without replacing the canonical Evidence Map decision."
+      "status": "done",
+      "summary": "Package finalized Evidence Map rows and validated applicability, conformance, and draft-finding results into one immutable generic presentation object with preserved evidence, provenance, review metadata, versions, and identity checks."
     },
     "phase_7_presentation_gates": {
       "title": "Phase 7: Presentation Gates",
-      "status": "planned",
+      "status": "next",
       "summary": "Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates."
     },
     "phase_8_fixture_expectation_migration": {

--- a/src/lib/evidence/applicabilityContract.ts
+++ b/src/lib/evidence/applicabilityContract.ts
@@ -76,6 +76,14 @@ function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): b
   return Object.keys(value).every((key) => keys.includes(key));
 }
 
+export function isApplicabilityContractBlock(value: unknown): value is ApplicabilityContractBlock {
+  if (!isRecord(value) || typeof value.category !== "string" || !applicabilityBlockCategories.includes(value.category as ApplicabilityContractBlockCategory)) return false;
+  if (value.category === "evidence_map_dependency_blocked") {
+    return hasOnlyKeys(value, ["category", "reason"]) && typeof value.reason === "string" && dependencyBlockReasons.includes(value.reason as EvidenceMapDependencyBlockReason);
+  }
+  return hasOnlyKeys(value, ["category"]);
+}
+
 /** Validate an applicability result at runtime, including all nested blocker values. */
 export function isApplicabilityResult(value: unknown): value is ApplicabilityResult {
   if (!isRecord(value) || typeof value.applicability !== "string") return false;
@@ -98,13 +106,7 @@ export function isApplicabilityResult(value: unknown): value is ApplicabilityRes
   if (value.applicability !== "NOT_ASSESSED" || !hasOnlyKeys(value, ["applicability", "evidenceMapRowId", "blockedBy"])) return false;
   if (value.evidenceMapRowId !== null && !hasText(value.evidenceMapRowId)) return false;
   if (!Array.isArray(value.blockedBy) || value.blockedBy.length === 0) return false;
-  return value.blockedBy.every((blocker) => {
-    if (!isRecord(blocker) || typeof blocker.category !== "string" || !applicabilityBlockCategories.includes(blocker.category as ApplicabilityContractBlockCategory)) return false;
-    if (blocker.category === "evidence_map_dependency_blocked") {
-      return hasOnlyKeys(blocker, ["category", "reason"]) && typeof blocker.reason === "string" && dependencyBlockReasons.includes(blocker.reason as EvidenceMapDependencyBlockReason);
-    }
-    return hasOnlyKeys(blocker, ["category"]);
-  });
+  return value.blockedBy.every(isApplicabilityContractBlock);
 }
 
 function rowIdFrom(candidate: unknown): string | null {

--- a/src/lib/evidence/conformanceConclusionContract.ts
+++ b/src/lib/evidence/conformanceConclusionContract.ts
@@ -117,6 +117,32 @@ function notAssessed(
   return { conclusion: "NOT_ASSESSED", evidenceMapRowId: row?.rowId ?? null, blockedBy };
 }
 
+/** Validate a conformance result supplied by a downstream packaging contract. */
+export function isConformanceConclusionResult(value: unknown): value is ConformanceConclusionResult {
+  if (!isRecord(value) || typeof value.conclusion !== "string") return false;
+  if (value.conclusion === "NOT_ASSESSED") {
+    return (
+      (value.evidenceMapRowId === null || (typeof value.evidenceMapRowId === "string" && value.evidenceMapRowId.trim().length > 0)) &&
+      Array.isArray(value.blockedBy) &&
+      value.blockedBy.length > 0 &&
+      value.blockedBy.every((blocker) => isRecord(blocker) && typeof blocker.category === "string")
+    );
+  }
+  const basis = value.conclusion === "CONFORMS"
+    ? "supported_applicable_requirement"
+    : value.conclusion === "ACTION_REQUIRED"
+      ? "applicable_requirement_not_supported"
+      : value.conclusion === "NOT_APPLICABLE"
+        ? "explicit_upstream_not_applicable"
+        : null;
+  return (
+    basis !== null &&
+    typeof value.evidenceMapRowId === "string" &&
+    value.evidenceMapRowId.trim().length > 0 &&
+    value.basis === basis
+  );
+}
+
 
 const supportedUpstreamStatuses = new Set(["FOUND", "answered"]);
 const unsupportedUpstreamStatuses = new Set(["UNCLEAR", "MISSING", "unclear", "no_evidence"]);

--- a/src/lib/evidence/conformanceConclusionContract.ts
+++ b/src/lib/evidence/conformanceConclusionContract.ts
@@ -6,7 +6,7 @@ import {
 import type {
   ApplicabilityContractBlock,
 } from "@/lib/evidence/applicabilityContract";
-import { isApplicabilityResult } from "@/lib/evidence/applicabilityContract";
+import { isApplicabilityContractBlock, isApplicabilityResult } from "@/lib/evidence/applicabilityContract";
 
 export type ConformanceConclusion =
   | "CONFORMS"
@@ -94,6 +94,22 @@ const assessmentValues = {
   versionIdentityAssessment: ["MATCHED", "NOT_REQUIRED", "MISMATCHED", "UNRESOLVED"],
   contradictionAssessment: ["NONE", "BLOCKING", "NOT_EVALUATED"],
 } as const;
+const conformanceBlockCategories: readonly ConformanceConclusionBlockCategory[] = [
+  "evidence_map_dependency_blocked", "applicability_blocked", "applicability_result_invalid", "applicability_row_id_mismatch",
+  "applicability_row_state_mismatch", "invalid_assessment_input", "unsupported_upstream_status", "applicability_unknown",
+  "requirement_support_not_evaluated", "upstream_status_conflicts_with_support", "search_coverage_inadequate",
+  "search_coverage_not_evaluated", "provenance_incomplete", "provenance_not_evaluated",
+  "version_identity_not_required_for_methodology", "version_identity_matched_without_methodology", "version_identity_mismatch",
+  "version_identity_unresolved", "blocking_contradiction", "contradiction_not_evaluated",
+];
+const dependencyBlockReasons: readonly EvidenceMapDependencyBlockReason[] = [
+  "row_not_finalized", "missing_row_identity", "missing_requirement_identity", "missing_methodology_identity",
+  "missing_methodology_version", "missing_upstream_status", "missing_applicability_state",
+  "missing_accepted_evidence_field", "missing_rejected_evidence_field", "missing_assessment_reason",
+  "missing_client_action_field", "missing_search_coverage_field", "missing_source_document_identity",
+  "missing_provenance", "missing_finalization_actor_ref", "missing_finalized_at", "missing_finalization_basis",
+  "missing_review_history_ref", "missing_evidence_map_contract_version", "missing_review_policy_version",
+];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -104,6 +120,21 @@ function isAssessment(value: unknown): value is ConformanceAssessmentInput {
   return (Object.keys(assessmentValues) as (keyof ConformanceAssessmentInput)[]).every((key) =>
     (assessmentValues[key] as readonly unknown[]).includes(value[key]),
   );
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).every((key) => keys.includes(key));
+}
+
+function isConformanceBlock(value: unknown): value is ConformanceConclusionBlock {
+  if (!isRecord(value) || typeof value.category !== "string" || !conformanceBlockCategories.includes(value.category as ConformanceConclusionBlockCategory)) return false;
+  if (value.category === "evidence_map_dependency_blocked") {
+    return hasOnlyKeys(value, ["category", "reason"]) && typeof value.reason === "string" && dependencyBlockReasons.includes(value.reason as EvidenceMapDependencyBlockReason);
+  }
+  if (value.category === "applicability_blocked") {
+    return hasOnlyKeys(value, ["category", "reason"]) && isApplicabilityContractBlock(value.reason);
+  }
+  return hasOnlyKeys(value, ["category"]);
 }
 
 function block(category: Exclude<ConformanceConclusionBlockCategory, "evidence_map_dependency_blocked" | "applicability_blocked">): ConformanceConclusionBlock {
@@ -122,10 +153,11 @@ export function isConformanceConclusionResult(value: unknown): value is Conforma
   if (!isRecord(value) || typeof value.conclusion !== "string") return false;
   if (value.conclusion === "NOT_ASSESSED") {
     return (
+      hasOnlyKeys(value, ["conclusion", "evidenceMapRowId", "blockedBy"]) &&
       (value.evidenceMapRowId === null || (typeof value.evidenceMapRowId === "string" && value.evidenceMapRowId.trim().length > 0)) &&
       Array.isArray(value.blockedBy) &&
       value.blockedBy.length > 0 &&
-      value.blockedBy.every((blocker) => isRecord(blocker) && typeof blocker.category === "string")
+      value.blockedBy.every(isConformanceBlock)
     );
   }
   const basis = value.conclusion === "CONFORMS"
@@ -136,6 +168,7 @@ export function isConformanceConclusionResult(value: unknown): value is Conforma
         ? "explicit_upstream_not_applicable"
         : null;
   return (
+    hasOnlyKeys(value, ["conclusion", "evidenceMapRowId", "basis"]) &&
     basis !== null &&
     typeof value.evidenceMapRowId === "string" &&
     value.evidenceMapRowId.trim().length > 0 &&

--- a/src/lib/evidence/draftFindingContract.ts
+++ b/src/lib/evidence/draftFindingContract.ts
@@ -2,10 +2,7 @@ import {
   validateEvidenceMapDependency,
   type EvidenceMapDependencyBlockReason,
 } from "@/lib/evidence/evidenceMapDependencyContract";
-import type {
-  ConformanceConclusion,
-  ConformanceConclusionResult,
-} from "@/lib/evidence/conformanceConclusionContract";
+import { isConformanceConclusionResult } from "@/lib/evidence/conformanceConclusionContract";
 
 export type DraftFindingType = "NIR_CANDIDATE" | "NCR_CANDIDATE" | "OFI_CANDIDATE" | null;
 
@@ -60,13 +57,20 @@ export type DraftFindingResult =
     }>;
 
 const draftFindingTypes = ["NIR_CANDIDATE", "NCR_CANDIDATE", "OFI_CANDIDATE"] as const;
-const conclusions: readonly ConformanceConclusion[] = [
-  "CONFORMS",
-  "ACTION_REQUIRED",
-  "NOT_APPLICABLE",
-  "NOT_ASSESSED",
-];
 const authorityLanguage = /\b(?:issued|formally\s+issued|validated|verified|approved\s+by\s+(?:a\s+)?vvb|closed\s+(?:a\s+)?finding|formal\s+finding)\b/i;
+const draftFindingBlockCategories: readonly DraftFindingBlockCategory[] = [
+  "evidence_map_dependency_blocked", "invalid_conformance_result", "conformance_row_id_mismatch",
+  "invalid_draft_finding_assessment", "classification_not_explicit", "classification_not_allowed_for_conclusion",
+  "finding_basis_missing", "reviewer_assessment_missing", "formal_authority_language",
+];
+const dependencyBlockReasons: readonly EvidenceMapDependencyBlockReason[] = [
+  "row_not_finalized", "missing_row_identity", "missing_requirement_identity", "missing_methodology_identity",
+  "missing_methodology_version", "missing_upstream_status", "missing_applicability_state",
+  "missing_accepted_evidence_field", "missing_rejected_evidence_field", "missing_assessment_reason",
+  "missing_client_action_field", "missing_search_coverage_field", "missing_source_document_identity",
+  "missing_provenance", "missing_finalization_actor_ref", "missing_finalized_at", "missing_finalization_basis",
+  "missing_review_history_ref", "missing_evidence_map_contract_version", "missing_review_policy_version",
+];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -76,17 +80,16 @@ function isDraftFindingType(value: unknown): value is DraftFindingType {
   return value === null || (typeof value === "string" && draftFindingTypes.includes(value as (typeof draftFindingTypes)[number]));
 }
 
-function isConformanceResult(value: unknown): value is ConformanceConclusionResult {
-  if (!isRecord(value) || !conclusions.includes(value.conclusion as ConformanceConclusion)) return false;
-  if (value.conclusion === "NOT_ASSESSED") {
-    return (value.evidenceMapRowId === null || typeof value.evidenceMapRowId === "string") && Array.isArray(value.blockedBy);
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).every((key) => keys.includes(key));
+}
+
+function isDraftFindingBlock(value: unknown): value is DraftFindingBlock {
+  if (!isRecord(value) || typeof value.category !== "string" || !draftFindingBlockCategories.includes(value.category as DraftFindingBlockCategory)) return false;
+  if (value.category === "evidence_map_dependency_blocked") {
+    return hasOnlyKeys(value, ["category", "reason"]) && typeof value.reason === "string" && dependencyBlockReasons.includes(value.reason as EvidenceMapDependencyBlockReason);
   }
-  const basis = value.conclusion === "CONFORMS"
-    ? "supported_applicable_requirement"
-    : value.conclusion === "ACTION_REQUIRED"
-      ? "applicable_requirement_not_supported"
-      : "explicit_upstream_not_applicable";
-  return typeof value.evidenceMapRowId === "string" && value.basis === basis;
+  return hasOnlyKeys(value, ["category"]);
 }
 
 function isAssessment(value: unknown): value is DraftFindingAssessmentInput {
@@ -112,6 +115,33 @@ function nonEmptyText(value: string | null): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+/** Validate the complete Phase 4 result shape before presentation packaging. */
+export function isDraftFindingResult(value: unknown): value is DraftFindingResult {
+  if (!isRecord(value) || !hasOnlyKeys(value, ["draftFindingType", "draftFindingRecord", "blockedBy"])) return false;
+  if (value.draftFindingType === null) {
+    if (value.draftFindingRecord !== null) return false;
+    if (!Object.prototype.hasOwnProperty.call(value, "blockedBy")) return Object.keys(value).length === 2;
+    return Array.isArray(value.blockedBy) && value.blockedBy.length > 0 && value.blockedBy.every(isDraftFindingBlock);
+  }
+  if (!isDraftFindingType(value.draftFindingType) || value.draftFindingRecord === null || !isRecord(value.draftFindingRecord) || Object.keys(value).length !== 2) return false;
+  const record = value.draftFindingRecord;
+  return (
+    hasOnlyKeys(record, ["findingId", "profile", "evidenceMapRowId", "requirementId", "conformanceConclusion", "draftFindingType", "findingBasis", "clientResponse", "reviewerAssessment", "closingRemarks"]) &&
+    typeof record.findingId === "string" && nonEmptyText(record.findingId) &&
+    record.profile === "GENERIC_PRE_VALIDATION" &&
+    typeof record.evidenceMapRowId === "string" && nonEmptyText(record.evidenceMapRowId) &&
+    typeof record.requirementId === "string" && nonEmptyText(record.requirementId) &&
+    record.conformanceConclusion === "ACTION_REQUIRED" &&
+    record.draftFindingType === value.draftFindingType &&
+    typeof record.findingBasis === "string" && nonEmptyText(record.findingBasis) &&
+    !authorityLanguage.test(record.findingBasis) &&
+    record.clientResponse === null &&
+    typeof record.reviewerAssessment === "string" && nonEmptyText(record.reviewerAssessment) &&
+    !authorityLanguage.test(record.reviewerAssessment) &&
+    record.closingRemarks === null
+  );
+}
+
 /** Map an explicit Phase 4 classification to a generic draft candidate. */
 export function deriveDraftFinding(
   candidate: unknown,
@@ -130,7 +160,7 @@ export function deriveDraftFinding(
 
   const row = dependency.row;
   const blockedBy: DraftFindingBlock[] = [];
-  if (!isConformanceResult(conformanceResult)) {
+  if (!isConformanceConclusionResult(conformanceResult)) {
     blockedBy.push(block("invalid_conformance_result"));
   } else if (conformanceResult.evidenceMapRowId !== null && conformanceResult.evidenceMapRowId !== row.rowId) {
     blockedBy.push(block("conformance_row_id_mismatch"));
@@ -155,13 +185,13 @@ export function deriveDraftFinding(
     }
   }
 
-  const conclusion = isConformanceResult(conformanceResult) ? conformanceResult.conclusion : null;
+  const conclusion = isConformanceConclusionResult(conformanceResult) ? conformanceResult.conclusion : null;
   if (conclusion !== "ACTION_REQUIRED" && isAssessment(assessmentInput) && assessmentInput.draftFindingType !== null) {
     blockedBy.push(block("classification_not_allowed_for_conclusion"));
   }
 
   if (blockedBy.length > 0) return nullFinding(blockedBy);
-  if (!isConformanceResult(conformanceResult) || !isAssessment(assessmentInput)) return nullFinding();
+  if (!isConformanceConclusionResult(conformanceResult) || !isAssessment(assessmentInput)) return nullFinding();
   if (conformanceResult.conclusion !== "ACTION_REQUIRED" || assessmentInput.draftFindingType === null) return nullFinding();
 
   const findingBasis = assessmentInput.findingBasis as string;

--- a/src/lib/evidence/reportPresentationObject.ts
+++ b/src/lib/evidence/reportPresentationObject.ts
@@ -13,7 +13,7 @@ import {
   type ConformanceConclusionBlock,
   type ConformanceConclusionResult,
 } from "@/lib/evidence/conformanceConclusionContract";
-import type { DraftFindingBlock, DraftFindingResult } from "@/lib/evidence/draftFindingContract";
+import { isDraftFindingResult, type DraftFindingBlock, type DraftFindingResult } from "@/lib/evidence/draftFindingContract";
 
 export const PRESENTATION_CONTRACT_VERSION = "v1" as const;
 
@@ -63,6 +63,8 @@ export type ReportPresentationBlock =
         | "conformance_applicability_mismatch"
         | "invalid_draft_finding_result"
         | "draft_finding_row_id_mismatch"
+        | "draft_finding_requirement_id_mismatch"
+        | "draft_finding_id_mismatch"
         | "draft_finding_conclusion_mismatch";
     }>;
 
@@ -101,30 +103,6 @@ function cloneAndFreeze<T>(value: T): T {
     ? value.map((entry) => cloneAndFreeze(entry))
     : Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, cloneAndFreeze(entry)]));
   return Object.freeze(clone) as T;
-}
-
-function isDraftFindingResult(value: unknown): value is DraftFindingResult {
-  if (!isRecord(value) || !("draftFindingType" in value) || !("draftFindingRecord" in value)) return false;
-  const type = value.draftFindingType;
-  if (type === null) {
-    return value.draftFindingRecord === null &&
-      (!Object.prototype.hasOwnProperty.call(value, "blockedBy") || (Array.isArray(value.blockedBy) && value.blockedBy.length > 0));
-  }
-  if (type !== "NIR_CANDIDATE" && type !== "NCR_CANDIDATE" && type !== "OFI_CANDIDATE") return false;
-  const record = value.draftFindingRecord;
-  if (!isRecord(record)) return false;
-  return (
-    record.profile === "GENERIC_PRE_VALIDATION" &&
-    hasText(record.findingId) &&
-    hasText(record.evidenceMapRowId) &&
-    hasText(record.requirementId) &&
-    record.conformanceConclusion === "ACTION_REQUIRED" &&
-    record.draftFindingType === type &&
-    hasText(record.findingBasis) &&
-    record.clientResponse === null &&
-    hasText(record.reviewerAssessment) &&
-    record.closingRemarks === null
-  );
 }
 
 /** Package validated upstream outputs without deriving or rewriting any judgment. */
@@ -184,6 +162,12 @@ export function createReportPresentationObject(
   }
   if (draftFindingResult.draftFindingRecord !== null && draftFindingResult.draftFindingRecord.evidenceMapRowId !== row.rowId) {
     return blocked(row.rowId, [{ category: "draft_finding_row_id_mismatch" }]);
+  }
+  if (draftFindingResult.draftFindingRecord !== null && draftFindingResult.draftFindingRecord.requirementId !== row.requirement.requirementId) {
+    return blocked(row.rowId, [{ category: "draft_finding_requirement_id_mismatch" }]);
+  }
+  if (draftFindingResult.draftFindingRecord !== null && draftFindingResult.draftFindingRecord.findingId !== `draft:${row.rowId}`) {
+    return blocked(row.rowId, [{ category: "draft_finding_id_mismatch" }]);
   }
   if (
     (draftFindingResult.draftFindingRecord !== null && conformanceConclusion.conclusion !== "ACTION_REQUIRED") ||

--- a/src/lib/evidence/reportPresentationObject.ts
+++ b/src/lib/evidence/reportPresentationObject.ts
@@ -1,0 +1,223 @@
+import {
+  validateEvidenceMapDependency,
+  type EvidenceMapDependencyBlockReason,
+  type EvidenceMapRow,
+} from "@/lib/evidence/evidenceMapDependencyContract";
+import {
+  isApplicabilityResult,
+  type ApplicabilityContractBlock,
+  type ApplicabilityResult,
+} from "@/lib/evidence/applicabilityContract";
+import {
+  isConformanceConclusionResult,
+  type ConformanceConclusionBlock,
+  type ConformanceConclusionResult,
+} from "@/lib/evidence/conformanceConclusionContract";
+import type { DraftFindingBlock, DraftFindingResult } from "@/lib/evidence/draftFindingContract";
+
+export const PRESENTATION_CONTRACT_VERSION = "v1" as const;
+
+export type MachineProposalTraceability = Readonly<{
+  source: "EVIDENCE_MAP";
+  evidenceMapRowId: string;
+}>;
+
+export type ReportPresentationObject = Readonly<{
+  profile: "GENERIC_PRE_VALIDATION";
+  evidenceMapRowId: string;
+  requirement: EvidenceMapRow["requirement"];
+  methodology: EvidenceMapRow["methodology"];
+  upstreamStatus: string;
+  applicabilityResult: ApplicabilityResult;
+  conformanceConclusion: ConformanceConclusionResult;
+  draftFindingResult: DraftFindingResult;
+  acceptedEvidence: EvidenceMapRow["acceptedEvidence"];
+  rejectedEvidence: EvidenceMapRow["rejectedEvidence"];
+  assessmentReason: string;
+  clientAction: string | null;
+  searchCoverage: EvidenceMapRow["searchCoverage"];
+  sourceDocument: EvidenceMapRow["sourceDocument"];
+  evidenceProvenance: EvidenceMapRow["evidenceProvenance"];
+  finalizationActorRef: string;
+  finalizedAt: string;
+  finalizationBasis: string;
+  reviewHistoryRef: string;
+  evidenceMapContractVersion: string;
+  reviewPolicyVersion: string;
+  presentationContractVersion: typeof PRESENTATION_CONTRACT_VERSION;
+  machineProposalTraceability: MachineProposalTraceability | null;
+}>;
+
+export type ReportPresentationBlock =
+  | Readonly<{ category: "evidence_map_dependency_blocked"; reason: EvidenceMapDependencyBlockReason }>
+  | Readonly<{ category: "applicability_blocked"; reason: ApplicabilityContractBlock }>
+  | Readonly<{ category: "conformance_blocked"; reason: ConformanceConclusionBlock }>
+  | Readonly<{ category: "draft_finding_blocked"; reason: DraftFindingBlock }>
+  | Readonly<{
+      category:
+        | "invalid_applicability_result"
+        | "applicability_row_id_mismatch"
+        | "applicability_row_state_mismatch"
+        | "invalid_conformance_result"
+        | "conformance_row_id_mismatch"
+        | "conformance_applicability_mismatch"
+        | "invalid_draft_finding_result"
+        | "draft_finding_row_id_mismatch"
+        | "draft_finding_conclusion_mismatch";
+    }>;
+
+export type ReportPresentationResult =
+  | Readonly<{ ready: true; presentation: ReportPresentationObject }>
+  | Readonly<{
+      ready: false;
+      conclusion: "NOT_ASSESSED";
+      evidenceMapRowId: string | null;
+      blockedBy: readonly ReportPresentationBlock[];
+    }>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function rowIdFrom(candidate: unknown): string | null {
+  return isRecord(candidate) && hasText(candidate.rowId) ? candidate.rowId : null;
+}
+
+function blocked(
+  evidenceMapRowId: string | null,
+  blockedBy: readonly ReportPresentationBlock[],
+): ReportPresentationResult {
+  return { ready: false, conclusion: "NOT_ASSESSED", evidenceMapRowId, blockedBy };
+}
+
+function cloneAndFreeze<T>(value: T): T {
+  if (value === null || typeof value !== "object") return value;
+  if (Object.isFrozen(value)) return value;
+  const clone = Array.isArray(value)
+    ? value.map((entry) => cloneAndFreeze(entry))
+    : Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, cloneAndFreeze(entry)]));
+  return Object.freeze(clone) as T;
+}
+
+function isDraftFindingResult(value: unknown): value is DraftFindingResult {
+  if (!isRecord(value) || !("draftFindingType" in value) || !("draftFindingRecord" in value)) return false;
+  const type = value.draftFindingType;
+  if (type === null) {
+    return value.draftFindingRecord === null &&
+      (!Object.prototype.hasOwnProperty.call(value, "blockedBy") || (Array.isArray(value.blockedBy) && value.blockedBy.length > 0));
+  }
+  if (type !== "NIR_CANDIDATE" && type !== "NCR_CANDIDATE" && type !== "OFI_CANDIDATE") return false;
+  const record = value.draftFindingRecord;
+  if (!isRecord(record)) return false;
+  return (
+    record.profile === "GENERIC_PRE_VALIDATION" &&
+    hasText(record.findingId) &&
+    hasText(record.evidenceMapRowId) &&
+    hasText(record.requirementId) &&
+    record.conformanceConclusion === "ACTION_REQUIRED" &&
+    record.draftFindingType === type &&
+    hasText(record.findingBasis) &&
+    record.clientResponse === null &&
+    hasText(record.reviewerAssessment) &&
+    record.closingRemarks === null
+  );
+}
+
+/** Package validated upstream outputs without deriving or rewriting any judgment. */
+export function createReportPresentationObject(
+  candidate: unknown,
+  applicabilityResultInput: unknown,
+  conformanceConclusionInput: unknown,
+  draftFindingResultInput: unknown,
+): ReportPresentationResult {
+  const dependency = validateEvidenceMapDependency(candidate);
+  if (!dependency.ready) {
+    return blocked(
+      rowIdFrom(candidate),
+      dependency.blockedBy.map((reason) => ({ category: "evidence_map_dependency_blocked" as const, reason })),
+    );
+  }
+
+  const row = dependency.row;
+  if (!isApplicabilityResult(applicabilityResultInput)) {
+    return blocked(row.rowId, [{ category: "invalid_applicability_result" }]);
+  }
+  const applicabilityResult = applicabilityResultInput;
+  if (applicabilityResult.applicability === "NOT_ASSESSED") {
+    return blocked(row.rowId, applicabilityResult.blockedBy.map((reason) => ({ category: "applicability_blocked" as const, reason })));
+  }
+  if (applicabilityResult.evidenceMapRowId !== row.rowId) {
+    return blocked(row.rowId, [{ category: "applicability_row_id_mismatch" }]);
+  }
+  if (applicabilityResult.applicability !== row.applicabilityState) {
+    return blocked(row.rowId, [{ category: "applicability_row_state_mismatch" }]);
+  }
+
+  if (!isConformanceConclusionResult(conformanceConclusionInput)) {
+    return blocked(row.rowId, [{ category: "invalid_conformance_result" }]);
+  }
+  const conformanceConclusion = conformanceConclusionInput;
+  if (conformanceConclusion.conclusion === "NOT_ASSESSED") {
+    return blocked(row.rowId, conformanceConclusion.blockedBy.map((reason) => ({ category: "conformance_blocked" as const, reason })));
+  }
+  if (conformanceConclusion.evidenceMapRowId !== row.rowId) {
+    return blocked(row.rowId, [{ category: "conformance_row_id_mismatch" }]);
+  }
+  if (
+    (applicabilityResult.applicability === "APPLICABLE" && conformanceConclusion.conclusion === "NOT_APPLICABLE") ||
+    (applicabilityResult.applicability === "NOT_APPLICABLE" && conformanceConclusion.conclusion !== "NOT_APPLICABLE")
+  ) {
+    return blocked(row.rowId, [{ category: "conformance_applicability_mismatch" }]);
+  }
+
+  if (!isDraftFindingResult(draftFindingResultInput)) {
+    return blocked(row.rowId, [{ category: "invalid_draft_finding_result" }]);
+  }
+  const draftFindingResult = draftFindingResultInput;
+  const draftFindingBlockers = "blockedBy" in draftFindingResult ? draftFindingResult.blockedBy : undefined;
+  if (draftFindingResult.draftFindingType === null && draftFindingBlockers !== undefined && draftFindingBlockers.length > 0) {
+    return blocked(row.rowId, draftFindingBlockers.map((reason) => ({ category: "draft_finding_blocked" as const, reason })));
+  }
+  if (draftFindingResult.draftFindingRecord !== null && draftFindingResult.draftFindingRecord.evidenceMapRowId !== row.rowId) {
+    return blocked(row.rowId, [{ category: "draft_finding_row_id_mismatch" }]);
+  }
+  if (
+    (draftFindingResult.draftFindingRecord !== null && conformanceConclusion.conclusion !== "ACTION_REQUIRED") ||
+    (draftFindingResult.draftFindingRecord === null && draftFindingResult.draftFindingType !== null)
+  ) {
+    return blocked(row.rowId, [{ category: "draft_finding_conclusion_mismatch" }]);
+  }
+
+  const presentation: ReportPresentationObject = {
+    profile: "GENERIC_PRE_VALIDATION",
+    evidenceMapRowId: row.rowId,
+    requirement: row.requirement,
+    methodology: row.methodology,
+    upstreamStatus: row.upstreamStatus,
+    applicabilityResult,
+    conformanceConclusion,
+    draftFindingResult,
+    acceptedEvidence: row.acceptedEvidence,
+    rejectedEvidence: row.rejectedEvidence,
+    assessmentReason: row.assessmentReason,
+    clientAction: row.clientAction,
+    searchCoverage: row.searchCoverage,
+    sourceDocument: row.sourceDocument,
+    evidenceProvenance: row.evidenceProvenance,
+    finalizationActorRef: row.finalizationActorRef,
+    finalizedAt: row.finalizedAt,
+    finalizationBasis: row.finalizationBasis,
+    reviewHistoryRef: row.reviewHistoryRef,
+    evidenceMapContractVersion: row.evidenceMapContractVersion,
+    reviewPolicyVersion: row.reviewPolicyVersion,
+    presentationContractVersion: PRESENTATION_CONTRACT_VERSION,
+    machineProposalTraceability: null,
+  };
+  return { ready: true, presentation: cloneAndFreeze(presentation) };
+}
+
+export const deriveReportPresentationObject = createReportPresentationObject;

--- a/src/lib/evidence/reportPresentationObject.ts
+++ b/src/lib/evidence/reportPresentationObject.ts
@@ -98,7 +98,6 @@ function blocked(
 
 function cloneAndFreeze<T>(value: T): T {
   if (value === null || typeof value !== "object") return value;
-  if (Object.isFrozen(value)) return value;
   const clone = Array.isArray(value)
     ? value.map((entry) => cloneAndFreeze(entry))
     : Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, cloneAndFreeze(entry)]));

--- a/tests/lib/evidence/reportPresentationObject.test.ts
+++ b/tests/lib/evidence/reportPresentationObject.test.ts
@@ -94,6 +94,34 @@ describe("createReportPresentationObject", () => {
     const draft = deriveDraftFinding(candidate, conformance, { draftFindingType: "NIR_CANDIDATE", findingBasis: "Basis.", reviewerAssessment: "Review." });
     expect(createReportPresentationObject(candidate, applicability, conformance, draft)).toMatchObject({ ready: false, blockedBy: [{ category: "draft_finding_blocked" }] });
   });
+  it("rejects adversarial result shapes and draft identity corruption", () => {
+    const candidate = row();
+    const { applicability, conformance, draftFinding } = inputs(candidate);
+    if (draftFinding.draftFindingRecord === null) throw new Error("Expected a draft finding record");
+    expect(createReportPresentationObject(candidate, applicability, conformance, {
+      ...draftFinding,
+      draftFindingRecord: { ...draftFinding.draftFindingRecord, requirementId: "wrong-requirement" },
+    })).toMatchObject({ ready: false, blockedBy: [{ category: "draft_finding_requirement_id_mismatch" }] });
+    expect(createReportPresentationObject(candidate, applicability, conformance, {
+      ...draftFinding,
+      draftFindingRecord: { ...draftFinding.draftFindingRecord, findingId: "draft:wrong-row" },
+    })).toMatchObject({ ready: false, blockedBy: [{ category: "draft_finding_id_mismatch" }] });
+    expect(createReportPresentationObject(candidate, applicability, conformance, {
+      ...draftFinding,
+      issued: true,
+    })).toMatchObject({ ready: false, blockedBy: [{ category: "invalid_draft_finding_result" }] });
+    expect(createReportPresentationObject(candidate, applicability, {
+      ...conformance,
+      authority: "formal",
+    }, draftFinding)).toMatchObject({ ready: false, blockedBy: [{ category: "invalid_conformance_result" }] });
+
+    const blocked = deriveConformanceConclusion(candidate, applicability, { ...conformanceAssessment, requirementSupport: "NOT_EVALUATED" });
+    if (blocked.conclusion !== "NOT_ASSESSED") throw new Error("Expected a blocked conformance result");
+    expect(createReportPresentationObject(candidate, applicability, {
+      ...blocked,
+      blockedBy: [{ category: "forged_blocker" }],
+    }, draftFinding)).toMatchObject({ ready: false, blockedBy: [{ category: "invalid_conformance_result" }] });
+  });
   it("does not add formal authority fields or language", () => {
     const candidate = row();
     const { applicability, conformance, draftFinding } = inputs(candidate);

--- a/tests/lib/evidence/reportPresentationObject.test.ts
+++ b/tests/lib/evidence/reportPresentationObject.test.ts
@@ -28,6 +28,11 @@ function inputs(candidate: EvidenceMapRow = row()) {
   const draftFinding = deriveDraftFinding(candidate, conformance, { draftFindingType: "NIR_CANDIDATE", findingBasis: "Provide missing evidence.", reviewerAssessment: "Candidate for review." });
   return { applicability, conformance, draftFinding };
 }
+function expectDeepFrozen(value: unknown): void {
+  if (value === null || typeof value !== "object") return;
+  expect(Object.isFrozen(value)).toBe(true);
+  Object.values(value).forEach(expectDeepFrozen);
+}
 
 describe("createReportPresentationObject", () => {
   it("packages a valid finalized row into one immutable presentation object", () => {
@@ -129,5 +134,37 @@ describe("createReportPresentationObject", () => {
     expect(JSON.stringify(result)).not.toMatch(/issued|approved|closed|validated|verified|authority/i);
     if (!result.ready) throw new Error("Expected a ready presentation");
     expect(Object.keys(result.presentation)).not.toEqual(expect.arrayContaining(["finding", "authority", "approval", "validation"]));
+  });
+  it("deep-clones shallow-frozen Evidence Map and validated result inputs", () => {
+    const candidate = row();
+    Object.freeze(candidate.acceptedEvidence);
+    Object.freeze(candidate.rejectedEvidence);
+    const { applicability, conformance, draftFinding } = inputs(candidate);
+    Object.freeze(applicability);
+    Object.freeze(conformance);
+    Object.freeze(draftFinding);
+
+    if (draftFinding.draftFindingRecord === null) throw new Error("Expected a draft finding record");
+    const originalAcceptedItem = candidate.acceptedEvidence[0];
+    const originalApplicability = applicability;
+    const originalConformance = conformance;
+    const originalDraftRecord = draftFinding.draftFindingRecord;
+    const result = createReportPresentationObject(candidate, applicability, conformance, draftFinding);
+    if (!result.ready) throw new Error("Expected a ready presentation");
+
+    expect(result.presentation.acceptedEvidence).not.toBe(candidate.acceptedEvidence);
+    expect(result.presentation.acceptedEvidence[0]).not.toBe(originalAcceptedItem);
+    expect(result.presentation.acceptedEvidence[0].provenance).not.toBe(originalAcceptedItem.provenance);
+    expect(result.presentation.applicabilityResult).not.toBe(originalApplicability);
+    expect(result.presentation.conformanceConclusion).not.toBe(originalConformance);
+    expect(result.presentation.draftFindingResult).not.toBe(draftFinding);
+    expect(result.presentation.draftFindingResult.draftFindingRecord).not.toBe(originalDraftRecord);
+    expectDeepFrozen(result.presentation);
+
+    const mutableAcceptedItem = originalAcceptedItem as unknown as { quote: string; provenance: { sectionHeading: string } };
+    mutableAcceptedItem.quote = "Mutated after packaging.";
+    mutableAcceptedItem.provenance.sectionHeading = "Mutated heading.";
+    expect(result.presentation.acceptedEvidence[0].quote).toBe("Accepted quote.");
+    expect(result.presentation.acceptedEvidence[0].provenance.sectionHeading).toBe("Evidence");
   });
 });

--- a/tests/lib/evidence/reportPresentationObject.test.ts
+++ b/tests/lib/evidence/reportPresentationObject.test.ts
@@ -1,0 +1,105 @@
+import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
+import { deriveConformanceConclusion, type ConformanceAssessmentInput } from "@/lib/evidence/conformanceConclusionContract";
+import { deriveDraftFinding } from "@/lib/evidence/draftFindingContract";
+import { createReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+
+const provenance = { docId: "doc-1", page: 2, sectionPath: ["3", "3.1"], spanId: "span-1", sectionHeading: "Evidence", sourceType: "PDD" };
+function row(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
+  return {
+    rowId: "row-1", requirement: { requirementId: "req-1", requirementReference: "REQ-1", requirementText: "A requirement." },
+    methodology: { methodologyId: "method-1", rulebookVersion: "v1.0" }, upstreamStatus: "MISSING", applicabilityState: "APPLICABLE",
+    acceptedEvidence: [{ evidenceId: "accepted-1", quote: "Accepted quote.", provenance }],
+    rejectedEvidence: [{ evidenceId: "rejected-1", quote: "Rejected quote.", rejectionReason: "Boilerplate.", provenance }],
+    assessmentReason: "The requirement is not demonstrated.", clientAction: "Provide supporting evidence.",
+    searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: "Searched source." },
+    sourceDocument: { documentId: "doc-1", documentName: "source.pdf", contentSha256: "hash-1" }, evidenceProvenance: [provenance],
+    finalizationState: "finalized", finalizationActorRef: "actor-1", finalizedAt: "2026-07-10T00:00:00Z", finalizationBasis: "reviewed row",
+    reviewHistoryRef: "history-1", evidenceMapContractVersion: "v1", reviewPolicyVersion: "policy-v1", ...overrides,
+  };
+}
+const conformanceAssessment: ConformanceAssessmentInput = {
+  requirementSupport: "NOT_SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE",
+  versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE",
+};
+function inputs(candidate: EvidenceMapRow = row()) {
+  const applicability = deriveApplicability(candidate, { decision: "APPLICABLE", decisionBasis: "  Requirement applies to this project.  " });
+  const conformance = deriveConformanceConclusion(candidate, applicability, conformanceAssessment);
+  const draftFinding = deriveDraftFinding(candidate, conformance, { draftFindingType: "NIR_CANDIDATE", findingBasis: "Provide missing evidence.", reviewerAssessment: "Candidate for review." });
+  return { applicability, conformance, draftFinding };
+}
+
+describe("createReportPresentationObject", () => {
+  it("packages a valid finalized row into one immutable presentation object", () => {
+    const candidate = row();
+    const before = structuredClone(candidate);
+    const { applicability, conformance, draftFinding } = inputs(candidate);
+    const result = createReportPresentationObject(candidate, applicability, conformance, draftFinding);
+    expect(result).toMatchObject({ ready: true, presentation: {
+      profile: "GENERIC_PRE_VALIDATION", evidenceMapRowId: "row-1", presentationContractVersion: "v1",
+      applicabilityResult: applicability, conformanceConclusion: conformance, draftFindingResult: draftFinding,
+      requirement: candidate.requirement, methodology: candidate.methodology, upstreamStatus: "MISSING",
+      assessmentReason: candidate.assessmentReason, clientAction: candidate.clientAction,
+      finalizationActorRef: candidate.finalizationActorRef, finalizedAt: candidate.finalizedAt,
+      finalizationBasis: candidate.finalizationBasis, reviewHistoryRef: candidate.reviewHistoryRef,
+      evidenceMapContractVersion: candidate.evidenceMapContractVersion, reviewPolicyVersion: candidate.reviewPolicyVersion,
+      machineProposalTraceability: null,
+    } });
+    if (!result.ready) throw new Error("Expected a ready presentation");
+    expect(result.presentation.acceptedEvidence).toEqual(candidate.acceptedEvidence);
+    expect(result.presentation.rejectedEvidence).toEqual(candidate.rejectedEvidence);
+    expect(result.presentation.evidenceProvenance).toEqual(candidate.evidenceProvenance);
+    expect(result.presentation.sourceDocument).toEqual(candidate.sourceDocument);
+    expect(result.presentation.applicabilityResult).toEqual({ applicability: "APPLICABLE", evidenceMapRowId: "row-1", basis: "explicit_applicable_decision", decisionBasis: "Requirement applies to this project." });
+    expect(candidate).toEqual(before);
+    expect(Object.isFrozen(result.presentation)).toBe(true);
+    expect(Object.isFrozen(result.presentation.acceptedEvidence)).toBe(true);
+    expect(Object.isFrozen(result.presentation.rejectedEvidence[0])).toBe(true);
+  });
+  it("preserves supplied conclusions and draft classifications without recalculation", () => {
+    const candidate = row();
+    const { applicability, conformance, draftFinding } = inputs(candidate);
+    const result = createReportPresentationObject(candidate, applicability, conformance, draftFinding);
+    if (!result.ready) throw new Error("Expected a ready presentation");
+    expect(result.presentation.conformanceConclusion).toEqual(conformance);
+    expect(result.presentation.draftFindingResult).toEqual(draftFinding);
+    expect(result.presentation.draftFindingResult).toMatchObject({ draftFindingType: "NIR_CANDIDATE" });
+  });
+  it.each(["applicability", "conformance", "draftFinding"])("fails closed for a %s row identity mismatch", (kind) => {
+    const candidate = row();
+    const other = row({ rowId: "row-2" });
+    const current = inputs(candidate);
+    const foreign = inputs(other);
+    const result = createReportPresentationObject(candidate, kind === "applicability" ? foreign.applicability : current.applicability, kind === "conformance" ? foreign.conformance : current.conformance, kind === "draftFinding" ? foreign.draftFinding : current.draftFinding);
+    expect(result).toMatchObject({ ready: false, conclusion: "NOT_ASSESSED" });
+    const category = kind === "draftFinding" ? "draft_finding_row_id_mismatch" : `${kind}_row_id_mismatch`;
+    expect(result).toMatchObject({ blockedBy: [expect.objectContaining({ category })] });
+  });
+  it("rejects blocked applicability and blocked conformance", () => {
+    const candidate = row();
+    const blockedApplicability = deriveApplicability(candidate, { decision: "NOT_EVALUATED", decisionBasis: null });
+    expect(createReportPresentationObject(candidate, blockedApplicability, null, null)).toMatchObject({ ready: false, blockedBy: [{ category: "applicability_blocked" }] });
+    const { applicability } = inputs(candidate);
+    const blockedConformance = deriveConformanceConclusion(candidate, applicability, { ...conformanceAssessment, requirementSupport: "NOT_EVALUATED" });
+    expect(createReportPresentationObject(candidate, applicability, blockedConformance, null)).toMatchObject({ ready: false, blockedBy: [{ category: "conformance_blocked" }] });
+  });
+  it("rejects malformed input and draft/conclusion contradictions", () => {
+    const malformed = createReportPresentationObject({}, null, null, null);
+    expect(malformed).toMatchObject({ ready: false });
+    if (malformed.ready) throw new Error("Expected malformed input to be blocked");
+    expect(malformed.blockedBy).toEqual(expect.arrayContaining([expect.objectContaining({ category: "evidence_map_dependency_blocked" })]));
+    const candidate = row({ applicabilityState: "NOT_APPLICABLE", upstreamStatus: "FOUND" });
+    const applicability = deriveApplicability(candidate, { decision: "NOT_APPLICABLE", decisionBasis: "Not applicable." });
+    const conformance = deriveConformanceConclusion(candidate, applicability, { ...conformanceAssessment, requirementSupport: "SUPPORTED" });
+    const draft = deriveDraftFinding(candidate, conformance, { draftFindingType: "NIR_CANDIDATE", findingBasis: "Basis.", reviewerAssessment: "Review." });
+    expect(createReportPresentationObject(candidate, applicability, conformance, draft)).toMatchObject({ ready: false, blockedBy: [{ category: "draft_finding_blocked" }] });
+  });
+  it("does not add formal authority fields or language", () => {
+    const candidate = row();
+    const { applicability, conformance, draftFinding } = inputs(candidate);
+    const result = createReportPresentationObject(candidate, applicability, conformance, draftFinding);
+    expect(JSON.stringify(result)).not.toMatch(/issued|approved|closed|validated|verified|authority/i);
+    if (!result.ready) throw new Error("Expected a ready presentation");
+    expect(Object.keys(result.presentation)).not.toEqual(expect.arrayContaining(["finding", "authority", "approval", "validation"]));
+  });
+});


### PR DESCRIPTION
## Roadmap

- Slug: vvb-report-presentation-layer
- Phase 6: Report Presentation Object

## Scope

Harden the Phase 6 validation and immutability boundary so only strict, canonical Phase 3–4 result shapes can be packaged into the immutable presentation object.

## Changes

- Export the strict runtime DraftFindingResult validator from draftFindingContract.ts.
- Make conformance and draft-finding validators reject unknown keys, invalid blocker categories/reasons, empty IDs, malformed nested records, authority language, and unsupported lifecycle fields.
- Remove the duplicate draft-finding validator from reportPresentationObject.ts.
- Require draft finding row ID, requirement ID, and canonical finding ID consistency during packaging.
- Always recursively clone and freeze every object and array, including shallow-frozen inputs; no source object or array is reused.
- Add regression coverage for shallow-frozen Evidence Map evidence and shallow-frozen applicability, conformance, and draft-finding results.
- Preserve existing valid Phase 3–6 behavior and fail closed for adversarial inputs.

## Files changed in this update

- src/lib/evidence/reportPresentationObject.ts
- tests/lib/evidence/reportPresentationObject.test.ts

## Focused tests

- 4 suites, 74 tests passed.
- Covers shallow-frozen nested evidence/result inputs, reference separation, recursive freezing, post-packaging source mutation isolation, wrong draft requirement ID, wrong finding ID, extra issued/authority/lifecycle fields, invalid conformance blockers, extra conformance/draft result properties, and all existing Phase 3–6 behavior.

## Validation

- npm run lint: passed.
- npm run typecheck: passed.
- npm run roadmap:check: passed.
- npm run pr:gate: passed — 215 suites / 2,315 tests passed, 1 suite skipped, 54 tests skipped; build, strict corpus, server smoke, and audit-pack smoke checks passed.
- git diff --check: passed.
- Pre-push lint and typecheck: passed.

## Explicit non-goals

No Quick Check behavior, routing, Evidence Map semantics, fixtures, gold truth, UI, reports, PDFs, roadmap phase status, or Phase 7 behavior changed.

## Risk assessment

Low. The changes harden pure runtime validation and recursive packaging immutability without changing judgment derivation or evidence semantics.