### PR TITLE
feat: add Phase 7 presentation gates

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -397,7 +397,8 @@ Current focus:
 - Phase 4 Draft Action/Finding Contract is complete
 - Phase 5 Applicability Contract is complete
 - Phase 6 Report Presentation Object is complete
-- Phase 7 Presentation Gates are next
+- Phase 7 Presentation Gates are complete
+- Phase 8 Fixture Expectation Migration is next
 - Review traceability and release controls are explicit downstream requirements
 - Keep the Evidence Map upstream and canonical
 - Keep the Pre-Validation Readiness Report and UI downstream
@@ -416,7 +417,7 @@ Not active now:
 5) RC4 — Phase 4: Draft Action/Finding Contract: Done — Consume a Phase 3 conclusion and explicit classification to produce only generic NIR_CANDIDATE, NCR_CANDIDATE, OFI_CANDIDATE, or null without selecting evidence or claiming formal authority.
 6) RC5 — Phase 5: Applicability Contract: Done — Require a basis-backed explicit applicability decision matching the canonical Evidence Map row; block missing, unknown, contradictory, or unevaluated applicability without changing upstream status semantics.
 7) RC6 — Phase 6: Report Presentation Object: Done — Package finalized Evidence Map rows and validated applicability, conformance, and draft-finding results into one immutable generic presentation object with preserved evidence, provenance, review metadata, versions, and identity checks.
-8) RC7 — Phase 7: Presentation Gates: Next — Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates.
-9) RC8 — Phase 8: Fixture Expectation Migration: Planned — Migrate fixtures to preserve accepted and rejected evidence and use the Evidence Map-backed draft presentation expectations.
+8) RC7 — Phase 7: Presentation Gates: Done — Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates.
+9) RC8 — Phase 8: Fixture Expectation Migration: Next — Migrate fixtures to preserve accepted and rejected evidence and use the Evidence Map-backed draft presentation expectations.
 10) RC9 — Phase 9: Readiness Report and UI Consumers: Planned — Implement downstream Pre-Validation Readiness Report and UI consumers using the finalized Evidence Map presentation contract, with a minimal reviewer workflow, centralized release-gate checks, traceable approve/edit/reopen history, and internal preview when client release is blocked.
 11) RC10 — Phase 10: Deprecation Review: Planned — Review old labels and organization-specific profiles only after the generic reviewer workflow and release gate are proven through a controlled pilot with qualified validation or verification professionals.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_7_PRESENTATION_GATES.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_7_PRESENTATION_GATES.md
@@ -18,15 +18,28 @@ rejected evidence, provenance, and supported presentation version.
 The report-level gate accepts a readonly array of Phase 6 objects and adds
 generic duplicate-row, same-requirement conclusion, and methodology/version
 consistency checks. It does not add project- or methodology-specific rules.
+An empty report is invalid and fails closed.
 
 ## Output contract
 
-The result is either a readonly presentation collection with
-releaseReady=true and releaseState=PRE_VALIDATION_RELEASE_READY, or a readonly
-presentation collection with releaseReady=false, releaseState=BLOCKED, and a
-non-empty blockedBy collection. A blocked result is fail-closed and cannot be
-interpreted as release-ready. Both result branches and their blocker
-collections are immutable.
+The result uses these release states:
+
+- PRE_VALIDATION_RELEASE_READY
+- INTERNAL_REVIEW_ONLY
+- BLOCKED
+
+It also reports a cross-row outcome:
+
+- PASS when available generic cross-row values agree;
+- WARNING when review is pending and release is limited to internal review;
+- BLOCKED when a cross-row contradiction exists;
+- NOT_EVALUATED when the Phase 6 object does not contain a value, such as
+  shared project facts or assumptions.
+
+An empty report returns BLOCKED with the typed empty_report blocker. A blocked
+result is fail-closed and cannot be interpreted as release-ready. Gate results,
+presentations, warnings, blockers, and nested values are deep-cloned and deeply
+frozen.
 
 ## Gate decision table
 
@@ -41,7 +54,7 @@ collections are immutable.
 | Provenance | Packaged provenance and evidence provenance remain traceable | Provenance is absent or malformed |
 | Version identity | Methodology/version and contract versions are supported | Version identity is unresolved, mismatched, or unsupported |
 | Review state | Current or unavailable review state | Reopened, superseded, or stale state |
-| Cross-row consistency | Unique row IDs and consistent generic identities | Duplicate rows, conflicting requirement conclusions, or methodology drift |
+| Cross-row consistency | Unique row IDs and consistent generic identities | Duplicate rows, conflicting applicability/conclusions, methodology drift, accepted-versus-unreliable evidence, or contradictory supplied facts/assumptions |
 
 ACTION_REQUIRED may preserve missing or insufficient evidence. FOUND alone
 never proves CONFORMS; the Phase 3 explicit support result and this gate's
@@ -50,11 +63,11 @@ accepted-evidence check are both required.
 ## Typed blockers
 
 Blockers are PresentationGateBlock values with a deterministic category and
-the affected row ID where available. Categories cover invalid presentation,
-finalization/review traceability, applicability/conformance inconsistency,
-evidence/search/provenance failure, methodology or contract-version failure,
-non-current review state, duplicate identity, conflicting requirement
-conclusion, and inconsistent methodology identity.
+the affected row ID where available. Structural shape failures use
+invalid_presentation_object. Release-safety failures retain specific
+finalization_identity_missing, review_history_missing, applicability,
+contract-version, evidence, search, provenance, review-state, and cross-row
+categories.
 
 ## Authority boundary and non-goals
 
@@ -62,5 +75,7 @@ The result uses only pre-validation language. It does not claim VVB approval,
 validation, verification, issuance, closure, or formal authority. This phase
 does not migrate fixtures, implement report or UI consumers, create PDFs,
 change Quick Check or Evidence Map semantics, rename legacy statuses, alter
-gold truth, or implement methodology-specific release rules. Phase 8 remains
-the next roadmap phase.
+gold truth, or implement methodology-specific release rules. Shared project
+facts and assumptions are checked only when supplied by the Phase 6 object;
+otherwise those checks are explicitly NOT_EVALUATED. Phase 8 remains the next
+roadmap phase.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_7_PRESENTATION_GATES.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_7_PRESENTATION_GATES.md
@@ -1,0 +1,66 @@
+# Phase 7: Presentation Gates
+
+## Scope
+
+evaluatePresentationGate and evaluatePresentationReportGate are pure,
+generic release-safety contracts downstream of the immutable Phase 6
+ReportPresentationObject. They inspect packaged values only. They do not
+search documents, select evidence, infer applicability, derive conformance, or
+classify draft findings.
+
+## Input contract
+
+The per-object gate accepts one ReportPresentationObject value. The value must
+pass the strict Phase 6 runtime validator, including finalized-row metadata,
+typed applicability/conformance/draft-finding results, preserved accepted and
+rejected evidence, provenance, and supported presentation version.
+
+The report-level gate accepts a readonly array of Phase 6 objects and adds
+generic duplicate-row, same-requirement conclusion, and methodology/version
+consistency checks. It does not add project- or methodology-specific rules.
+
+## Output contract
+
+The result is either a readonly presentation collection with
+releaseReady=true and releaseState=PRE_VALIDATION_RELEASE_READY, or a readonly
+presentation collection with releaseReady=false, releaseState=BLOCKED, and a
+non-empty blockedBy collection. A blocked result is fail-closed and cannot be
+interpreted as release-ready. Both result branches and their blocker
+collections are immutable.
+
+## Gate decision table
+
+| Gate | Pass condition | Blocking condition |
+| --- | --- | --- |
+| Presentation validity | Strict Phase 6 object shape | Malformed, extra, blocked, or unsupported result shape |
+| Finalization traceability | Row ID, finalization actor, timestamp, and basis are present | Any traceability value is absent or invalid |
+| Review history | Non-empty review history reference | Missing or blank reference |
+| Applicability consistency | Explicit successful applicability agrees with packaged conclusion | Unknown, mismatched, or contradictory applicability |
+| Evidence sufficiency | CONFORMS has accepted evidence with provenance | CONFORMS has no accepted evidence |
+| Search coverage | Applicable rows record completed search coverage | Required search is incomplete or unresolved |
+| Provenance | Packaged provenance and evidence provenance remain traceable | Provenance is absent or malformed |
+| Version identity | Methodology/version and contract versions are supported | Version identity is unresolved, mismatched, or unsupported |
+| Review state | Current or unavailable review state | Reopened, superseded, or stale state |
+| Cross-row consistency | Unique row IDs and consistent generic identities | Duplicate rows, conflicting requirement conclusions, or methodology drift |
+
+ACTION_REQUIRED may preserve missing or insufficient evidence. FOUND alone
+never proves CONFORMS; the Phase 3 explicit support result and this gate's
+accepted-evidence check are both required.
+
+## Typed blockers
+
+Blockers are PresentationGateBlock values with a deterministic category and
+the affected row ID where available. Categories cover invalid presentation,
+finalization/review traceability, applicability/conformance inconsistency,
+evidence/search/provenance failure, methodology or contract-version failure,
+non-current review state, duplicate identity, conflicting requirement
+conclusion, and inconsistent methodology identity.
+
+## Authority boundary and non-goals
+
+The result uses only pre-validation language. It does not claim VVB approval,
+validation, verification, issuance, closure, or formal authority. This phase
+does not migrate fixtures, implement report or UI consumers, create PDFs,
+change Quick Check or Evidence Map semantics, rename legacy statuses, alter
+gold truth, or implement methodology-specific release rules. Phase 8 remains
+the next roadmap phase.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_7_PRESENTATION_GATES.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_7_PRESENTATION_GATES.md
@@ -10,8 +10,9 @@ classify draft findings.
 
 ## Input contract
 
-The per-object gate accepts one ReportPresentationObject value. The value must
-pass the strict Phase 6 runtime validator, including finalized-row metadata,
+The per-object gate accepts one typed PresentationGateInput containing a strict
+Phase 6 ReportPresentationObject and optional typed review state. The Phase 6
+object itself remains unchanged. It must pass the strict Phase 6 runtime validator, including finalized-row metadata,
 typed applicability/conformance/draft-finding results, preserved accepted and
 rejected evidence, provenance, and supported presentation version.
 
@@ -30,11 +31,10 @@ The result uses these release states:
 
 It also reports a cross-row outcome:
 
-- PASS when available generic cross-row values agree;
+- PASS when at least one typed methodology/version or composite-requirement comparison succeeds;
 - WARNING when review is pending and release is limited to internal review;
 - BLOCKED when a cross-row contradiction exists;
-- NOT_EVALUATED when the Phase 6 object does not contain a value, such as
-  shared project facts or assumptions.
+- NOT_EVALUATED when fewer than two comparable rows exist or typed comparison data is unavailable.
 
 An empty report returns BLOCKED with the typed empty_report blocker. A blocked
 result is fail-closed and cannot be interpreted as release-ready. Gate results,
@@ -50,9 +50,9 @@ frozen.
 | Review history | Non-empty review history reference | Missing or blank reference |
 | Applicability consistency | Explicit successful applicability agrees with packaged conclusion | Unknown, mismatched, or contradictory applicability |
 | Evidence sufficiency | CONFORMS has accepted evidence with provenance | CONFORMS has no accepted evidence |
-| Search coverage | Applicable rows record completed search coverage | Required search is incomplete or unresolved |
-| Provenance | Packaged provenance and evidence provenance remain traceable | Provenance is absent or malformed |
-| Version identity | Methodology/version and contract versions are supported | Version identity is unresolved, mismatched, or unsupported |
+| Search linkage | Evidence provenance document appears in searched document IDs | Evidence references an unsearched document |
+| Provenance | Every evidence item has a matching canonical provenance entry | Evidence provenance is orphaned |
+| Version identity | Same methodology ID has one rulebook version | Same methodology ID carries conflicting versions |
 | Review state | Current or unavailable review state | Reopened, superseded, or stale state |
 | Cross-row consistency | Unique row IDs and consistent generic identities | Duplicate rows, conflicting applicability/conclusions, methodology drift, accepted-versus-unreliable evidence, or contradictory supplied facts/assumptions |
 
@@ -75,7 +75,7 @@ The result uses only pre-validation language. It does not claim VVB approval,
 validation, verification, issuance, closure, or formal authority. This phase
 does not migrate fixtures, implement report or UI consumers, create PDFs,
 change Quick Check or Evidence Map semantics, rename legacy statuses, alter
-gold truth, or implement methodology-specific release rules. Shared project
-facts and assumptions are checked only when supplied by the Phase 6 object;
-otherwise those checks are explicitly NOT_EVALUATED. Phase 8 remains the next
-roadmap phase.
+gold truth, or implement methodology-specific release rules. Project facts,
+assumptions, and accepted-versus-rejected reliability conflicts are
+NOT_EVALUATED until a typed upstream contract provides them; prose fields are
+never interpreted by this gate. Phase 8 remains the next roadmap phase.

--- a/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
@@ -334,8 +334,8 @@ Do not mark placeholder text as FOUND. MISSING means no relevant document eviden
 - Phase 4: Draft Action/Finding Contract — done
 - Phase 5: Applicability Contract — done
 - Phase 6: Report Presentation Object — done
-- Phase 7: Presentation Gates — next
-- Phase 8: Fixture Expectation Migration — planned
+- Phase 7: Presentation Gates — done
+- Phase 8: Fixture Expectation Migration — next
 - Phase 9: Readiness Report and UI Consumers — planned
 - Phase 10: Deprecation Review — planned
 

--- a/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
+++ b/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
@@ -11,7 +11,8 @@
       "Phase 4 Draft Action/Finding Contract is complete",
       "Phase 5 Applicability Contract is complete",
       "Phase 6 Report Presentation Object is complete",
-      "Phase 7 Presentation Gates are next",
+      "Phase 7 Presentation Gates are complete",
+      "Phase 8 Fixture Expectation Migration is next",
       "Review traceability and release controls are explicit downstream requirements",
       "Keep the Evidence Map upstream and canonical",
       "Keep the Pre-Validation Readiness Report and UI downstream"
@@ -23,7 +24,7 @@
       "Organization-specific report profiles",
       "Formal verifier authority claims"
     ],
-    "last_updated_at": "2026-07-10T00:00:00Z"
+    "last_updated_at": "2026-07-11T00:00:00Z"
   },
   "phases": {
     "phase_0_report_terminology_contract": {
@@ -63,12 +64,12 @@
     },
     "phase_7_presentation_gates": {
       "title": "Phase 7: Presentation Gates",
-      "status": "next",
+      "status": "done",
       "summary": "Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates."
     },
     "phase_8_fixture_expectation_migration": {
       "title": "Phase 8: Fixture Expectation Migration",
-      "status": "planned",
+      "status": "next",
       "summary": "Migrate fixtures to preserve accepted and rejected evidence and use the Evidence Map-backed draft presentation expectations."
     },
     "phase_9_readiness_report_and_ui_consumers": {

--- a/src/lib/evidence/presentationGate.ts
+++ b/src/lib/evidence/presentationGate.ts
@@ -1,0 +1,156 @@
+import {
+  isReportPresentationObject,
+  PRESENTATION_CONTRACT_VERSION,
+  type ReportPresentationObject,
+} from "@/lib/evidence/reportPresentationObject";
+import type { EvidenceMapMethodologyIdentity } from "@/lib/evidence/evidenceMapDependencyContract";
+
+export type PresentationGateBlockCategory =
+  | "invalid_presentation_object"
+  | "finalization_identity_missing"
+  | "review_history_missing"
+  | "applicability_inconsistent"
+  | "conformance_applicability_inconsistent"
+  | "evidence_insufficient_for_conformance"
+  | "search_coverage_incomplete"
+  | "provenance_incomplete"
+  | "methodology_version_unresolved"
+  | "methodology_version_mismatch"
+  | "unsupported_contract_version"
+  | "review_state_not_current"
+  | "duplicate_row_identity"
+  | "conflicting_requirement_conclusion"
+  | "inconsistent_methodology_identity";
+
+export type PresentationGateBlock = Readonly<{
+  category: PresentationGateBlockCategory;
+  evidenceMapRowId: string | null;
+  detail?: string;
+}>;
+
+export type PresentationGateResult =
+  | Readonly<{
+      releaseReady: true;
+      releaseState: "PRE_VALIDATION_RELEASE_READY";
+      presentations: readonly ReportPresentationObject[];
+    }>
+  | Readonly<{
+      releaseReady: false;
+      releaseState: "BLOCKED";
+      presentations: readonly ReportPresentationObject[];
+      blockedBy: readonly PresentationGateBlock[];
+    }>;
+
+const supportedContractVersions = {
+  evidenceMap: new Set(["v1", "evidence-map-contract-1"]),
+  reviewPolicy: new Set(["v1", "policy-v1", "review-policy-1"]),
+};
+const unresolvedVersion = /^(?:unknown|unresolved|unsupported|n\/a)$/i;
+const mismatchedVersion = /^mismatch(?:ed)?$/i;
+const nonCurrentReviewState = /^(?:reopened|superseded|stale)$/i;
+
+function block(category: PresentationGateBlockCategory, evidenceMapRowId: string | null, detail?: string): PresentationGateBlock {
+  return Object.freeze(detail === undefined ? { category, evidenceMapRowId } : { category, evidenceMapRowId, detail });
+}
+
+function immutableResult(result: PresentationGateResult): PresentationGateResult {
+  if (result.releaseReady) return Object.freeze({ ...result, presentations: Object.freeze([...result.presentations]) });
+  return Object.freeze({ ...result, presentations: Object.freeze([...result.presentations]), blockedBy: Object.freeze([...result.blockedBy]) });
+}
+
+function methodologyKey(methodology: EvidenceMapMethodologyIdentity | null): string {
+  return methodology === null ? "none" : `${methodology.methodologyId}@${methodology.rulebookVersion}`;
+}
+
+function evaluatePresentation(presentation: unknown): readonly PresentationGateBlock[] {
+  if (!isReportPresentationObject(presentation)) return [block("invalid_presentation_object", null)];
+  const rowId = presentation.evidenceMapRowId;
+  const blockers: PresentationGateBlock[] = [];
+  if (!rowId || !presentation.finalizationActorRef || !presentation.finalizedAt || !presentation.finalizationBasis) {
+    blockers.push(block("finalization_identity_missing", rowId));
+  }
+  if (!presentation.reviewHistoryRef.trim()) blockers.push(block("review_history_missing", rowId));
+
+  const applicability = presentation.applicabilityResult;
+  const conclusion = presentation.conformanceConclusion;
+  if ((applicability.applicability === "APPLICABLE" && conclusion.conclusion === "NOT_APPLICABLE") ||
+      (applicability.applicability === "NOT_APPLICABLE" && conclusion.conclusion !== "NOT_APPLICABLE")) {
+    blockers.push(block("conformance_applicability_inconsistent", rowId));
+  }
+  if (applicability.evidenceMapRowId !== rowId ||
+      (applicability.applicability === "APPLICABLE" && presentation.upstreamStatus === "UNKNOWN")) {
+    blockers.push(block("applicability_inconsistent", rowId));
+  }
+  if (presentation.reviewState !== undefined && nonCurrentReviewState.test(presentation.reviewState)) {
+    blockers.push(block("review_state_not_current", rowId, presentation.reviewState));
+  }
+  if (conclusion.conclusion === "CONFORMS" && presentation.acceptedEvidence.length === 0) {
+    blockers.push(block("evidence_insufficient_for_conformance", rowId));
+  }
+  if (applicability.applicability === "APPLICABLE" &&
+      (!presentation.searchCoverage.searched || presentation.searchCoverage.searchedDocumentIds.length === 0 ||
+        (presentation.searchCoverage.notes !== null && /^(?:unknown|unresolved|incomplete)$/i.test(presentation.searchCoverage.notes.trim())))) {
+    blockers.push(block("search_coverage_incomplete", rowId));
+  }
+  if (presentation.evidenceProvenance.length === 0 ||
+      presentation.acceptedEvidence.some((evidence) => evidence.provenance.spanId.length === 0) ||
+      presentation.rejectedEvidence.some((evidence) => evidence.provenance.spanId.length === 0)) {
+    blockers.push(block("provenance_incomplete", rowId));
+  }
+  if (presentation.methodology !== null) {
+    if (mismatchedVersion.test(presentation.methodology.rulebookVersion)) {
+      blockers.push(block("methodology_version_mismatch", rowId));
+    } else if (unresolvedVersion.test(presentation.methodology.rulebookVersion)) {
+      blockers.push(block("methodology_version_unresolved", rowId));
+    }
+    if (presentation.methodology.methodologyId.trim() === "" || presentation.methodology.rulebookVersion.trim() === "") {
+      blockers.push(block("methodology_version_mismatch", rowId));
+    }
+  }
+  if (!supportedContractVersions.evidenceMap.has(presentation.evidenceMapContractVersion) ||
+      !supportedContractVersions.reviewPolicy.has(presentation.reviewPolicyVersion) ||
+      presentation.presentationContractVersion !== PRESENTATION_CONTRACT_VERSION) {
+    blockers.push(block("unsupported_contract_version", rowId));
+  }
+  return blockers;
+}
+
+/** Evaluate one immutable Phase 6 object without deriving any upstream judgment. */
+export function evaluatePresentationGate(presentation: unknown): PresentationGateResult {
+  const blockers = evaluatePresentation(presentation);
+  const presentations = isReportPresentationObject(presentation) ? [presentation] : [];
+  return immutableResult(blockers.length === 0
+    ? { releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY", presentations }
+    : { releaseReady: false, releaseState: "BLOCKED", presentations, blockedBy: blockers });
+}
+
+/** Evaluate a report-level package for duplicate identities and generic cross-row contradictions. */
+export function evaluatePresentationReportGate(presentationsInput: unknown): PresentationGateResult {
+  const input = Array.isArray(presentationsInput) ? presentationsInput : [];
+  const presentations = input.filter(isReportPresentationObject);
+  const blockers: PresentationGateBlock[] = [];
+  if (!Array.isArray(presentationsInput) || presentations.length !== input.length) {
+    blockers.push(block("invalid_presentation_object", null));
+  }
+  presentations.forEach((presentation) => blockers.push(...evaluatePresentation(presentation)));
+  const rowIds = new Set<string>();
+  const requirementConclusions = new Map<string, string>();
+  const methodologyIdentities = new Set<string>();
+  presentations.forEach((presentation) => {
+    if (rowIds.has(presentation.evidenceMapRowId)) blockers.push(block("duplicate_row_identity", presentation.evidenceMapRowId));
+    rowIds.add(presentation.evidenceMapRowId);
+    const requirementKey = presentation.requirement.requirementId;
+    const priorConclusion = requirementConclusions.get(requirementKey);
+    if (priorConclusion !== undefined && priorConclusion !== presentation.conformanceConclusion.conclusion) {
+      blockers.push(block("conflicting_requirement_conclusion", presentation.evidenceMapRowId, requirementKey));
+    }
+    requirementConclusions.set(requirementKey, presentation.conformanceConclusion.conclusion);
+    methodologyIdentities.add(methodologyKey(presentation.methodology));
+  });
+  if (methodologyIdentities.size > 1) blockers.push(block("inconsistent_methodology_identity", null));
+  return immutableResult(blockers.length === 0
+    ? { releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY", presentations }
+    : { releaseReady: false, releaseState: "BLOCKED", presentations, blockedBy: blockers });
+}
+
+export const evaluatePresentationGates = evaluatePresentationReportGate;

--- a/src/lib/evidence/presentationGate.ts
+++ b/src/lib/evidence/presentationGate.ts
@@ -1,305 +1,138 @@
 import {
-  isReportPresentationInput,
+  isReportPresentationObject,
   PRESENTATION_CONTRACT_VERSION,
   type ReportPresentationObject,
 } from "@/lib/evidence/reportPresentationObject";
-import type { EvidenceMapMethodologyIdentity } from "@/lib/evidence/evidenceMapDependencyContract";
+
+export type PresentationReviewState = "CURRENT" | "PENDING_REVIEW" | "REOPENED" | "SUPERSEDED" | "STALE";
+export type PresentationGateInput = Readonly<{ presentation: ReportPresentationObject; reviewState?: PresentationReviewState }>;
+export type CrossRowOutcome = "PASS" | "WARNING" | "BLOCKED" | "NOT_EVALUATED";
+export type PresentationReleaseState = "PRE_VALIDATION_RELEASE_READY" | "INTERNAL_REVIEW_ONLY" | "BLOCKED";
 
 export type PresentationGateBlockCategory =
-  | "empty_report"
-  | "invalid_presentation_object"
-  | "finalization_identity_missing"
-  | "review_history_missing"
-  | "applicability_inconsistent"
-  | "conflicting_applicability"
-  | "conformance_applicability_inconsistent"
-  | "evidence_insufficient_for_conformance"
-  | "search_coverage_incomplete"
-  | "provenance_incomplete"
-  | "methodology_version_unresolved"
-  | "methodology_version_mismatch"
-  | "unsupported_contract_version"
-  | "review_state_not_current"
-  | "review_pending"
-  | "duplicate_row_identity"
-  | "conflicting_requirement_conclusion"
-  | "inconsistent_methodology_identity"
-  | "cross_row_evidence_conflict"
-  | "contradictory_shared_fact"
-  | "contradictory_assumption";
-
-export type PresentationGateBlock = Readonly<{
-  category: PresentationGateBlockCategory;
-  evidenceMapRowId: string | null;
-  detail?: string;
-}>;
-
-export type CrossRowOutcome = "PASS" | "WARNING" | "BLOCKED" | "NOT_EVALUATED";
-export type PresentationReleaseState =
-  | "PRE_VALIDATION_RELEASE_READY"
-  | "INTERNAL_REVIEW_ONLY"
-  | "BLOCKED";
-
+  | "invalid_report_input" | "empty_report" | "invalid_presentation_object"
+  | "finalization_identity_missing" | "finalized_at_invalid" | "review_history_missing"
+  | "applicability_inconsistent" | "conclusion_invariant_violation"
+  | "unsupported_upstream_status" | "unsupported_contract_version"
+  | "accepted_evidence_missing_provenance" | "evidence_provenance_not_linked"
+  | "evidence_document_not_searched" | "duplicate_row_identity"
+  | "conflicting_methodology_version" | "conflicting_requirement_conclusion"
+  | "review_state_not_current";
+export type PresentationGateBlock = Readonly<{ category: PresentationGateBlockCategory; evidenceMapRowId: string | null; detail?: string }>;
 export type PresentationGateResult =
-  | Readonly<{
-      releaseReady: true;
-      releaseState: "PRE_VALIDATION_RELEASE_READY";
-      crossRowOutcome: CrossRowOutcome;
-      presentations: readonly ReportPresentationObject[];
-    }>
-  | Readonly<{
-      releaseReady: false;
-      releaseState: "INTERNAL_REVIEW_ONLY";
-      crossRowOutcome: "WARNING";
-      presentations: readonly ReportPresentationObject[];
-      warnings: readonly PresentationGateBlock[];
-    }>
-  | Readonly<{
-      releaseReady: false;
-      releaseState: "BLOCKED";
-      crossRowOutcome: "BLOCKED" | "NOT_EVALUATED";
-      presentations: readonly ReportPresentationObject[];
-      blockedBy: readonly PresentationGateBlock[];
-    }>;
+  | Readonly<{ releaseReady: true; releaseState: "PRE_VALIDATION_RELEASE_READY"; crossRowOutcome: CrossRowOutcome; presentations: readonly ReportPresentationObject[] }>
+  | Readonly<{ releaseReady: false; releaseState: "INTERNAL_REVIEW_ONLY"; crossRowOutcome: "WARNING"; presentations: readonly ReportPresentationObject[]; warnings: readonly PresentationGateBlock[] }>
+  | Readonly<{ releaseReady: false; releaseState: "BLOCKED"; crossRowOutcome: CrossRowOutcome; presentations: readonly ReportPresentationObject[]; blockedBy: readonly PresentationGateBlock[] }>;
 
-const supportedContractVersions = {
-  evidenceMap: new Set(["v1", "evidence-map-contract-1"]),
-  reviewPolicy: new Set(["v1", "policy-v1", "review-policy-1"]),
-};
-const unresolvedVersion = /^(?:unknown|unresolved|unsupported|n\/a)$/i;
-const mismatchedVersion = /^mismatch(?:ed)?$/i;
-const nonCurrentReviewState = /^(?:reopened|superseded|stale)$/i;
-const unreliableReason = /\b(?:unreliable|not reliable|cannot be relied upon)\b/i;
+const allowedGateInputKeys = ["presentation", "reviewState"] as const;
+const allowedReviewStates: readonly PresentationReviewState[] = ["CURRENT", "PENDING_REVIEW", "REOPENED", "SUPERSEDED", "STALE"];
+const supportedStatuses = new Set(["FOUND", "answered", "UNCLEAR", "MISSING", "unclear", "no_evidence"]);
+const supportedContractVersions = { evidenceMap: new Set(["v1", "evidence-map-contract-1"]), reviewPolicy: new Set(["v1", "policy-v1", "review-policy-1"]) };
 
-function hasText(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function normalizeAssumption(value: string): string {
-  return value.trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-function assumptionFamily(value: string): { family: string; value: string } | null {
-  const normalized = normalizeAssumption(value);
-  const match = /^(.*\bis\b)\s+(.+)$/.exec(normalized);
-  return match === null ? null : { family: match[1], value: match[2] };
-}
-
-function evidenceIdentity(evidence: ReportPresentationObject["acceptedEvidence"][number]): string {
-  const provenance = evidence.provenance;
-  return JSON.stringify({
-    docId: provenance.docId,
-    spanId: provenance.spanId,
-    page: provenance.page,
-    sectionPath: provenance.sectionPath,
-  });
-}
-
-function block(category: PresentationGateBlockCategory, evidenceMapRowId: string | null, detail?: string): PresentationGateBlock {
-  return Object.freeze(detail === undefined ? { category, evidenceMapRowId } : { category, evidenceMapRowId, detail });
-}
-
+function isRecord(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null; }
+function hasText(value: unknown): value is string { return typeof value === "string" && value.trim().length > 0; }
+function block(category: PresentationGateBlockCategory, evidenceMapRowId: string | null, detail?: string): PresentationGateBlock { return Object.freeze(detail === undefined ? { category, evidenceMapRowId } : { category, evidenceMapRowId, detail }); }
 function cloneAndFreeze<T>(value: T): T {
   if (value === null || typeof value !== "object") return value;
-  const clone = Array.isArray(value)
-    ? value.map((entry) => cloneAndFreeze(entry))
-    : Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, cloneAndFreeze(entry)]));
+  const clone = Array.isArray(value) ? value.map(cloneAndFreeze) : Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, cloneAndFreeze(entry)]));
   return Object.freeze(clone) as T;
 }
-
-function immutableResult(result: PresentationGateResult): PresentationGateResult {
-  const presentations = Object.freeze(result.presentations.map((presentation) => cloneAndFreeze(presentation)));
-  if (result.releaseState === "PRE_VALIDATION_RELEASE_READY") return Object.freeze({ ...result, presentations });
-  if (result.releaseState === "INTERNAL_REVIEW_ONLY") {
-    return Object.freeze({ ...result, presentations, warnings: Object.freeze([...result.warnings]) });
-  }
-  return Object.freeze({ ...result, presentations, blockedBy: Object.freeze([...result.blockedBy]) });
+function canonicalProvenance(value: { docId: string; spanId: string; page: number | null; sectionPath: readonly string[] }): string {
+  return JSON.stringify([value.docId, value.spanId, value.page, value.sectionPath]);
 }
-
-function methodologyKey(methodology: EvidenceMapMethodologyIdentity | null): string {
-  return methodology === null ? "none" : methodology.methodologyId + "@" + methodology.rulebookVersion;
+function isIsoTimestamp(value: unknown): value is string {
+  return hasText(value) && /^\d{4}-\d{2}-\d{2}T/.test(value) && !Number.isNaN(Date.parse(value));
 }
-
-function evaluatePresentation(presentation: unknown): {
-  blockers: readonly PresentationGateBlock[];
-  warnings: readonly PresentationGateBlock[];
-} {
-  if (!isReportPresentationInput(presentation)) {
-    return { blockers: [block("invalid_presentation_object", null)], warnings: [] };
-  }
-  const rowId = hasText(presentation.evidenceMapRowId) ? presentation.evidenceMapRowId : null;
+function isGateInput(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && Object.keys(value).every((key) => allowedGateInputKeys.includes(key as typeof allowedGateInputKeys[number])) &&
+    Object.prototype.hasOwnProperty.call(value, "presentation") &&
+    (value.reviewState === undefined || allowedReviewStates.includes(value.reviewState as PresentationReviewState));
+}
+function rowId(value: unknown): string | null {
+  return isRecord(value) && hasText(value.evidenceMapRowId) ? value.evidenceMapRowId : null;
+}
+function presentationShapeBlockers(candidate: unknown): readonly PresentationGateBlock[] {
+  const id = rowId(candidate);
+  if (!isRecord(candidate)) return [block("invalid_presentation_object", null)];
   const blockers: PresentationGateBlock[] = [];
-  const warnings: PresentationGateBlock[] = [];
-  if (!hasText(presentation.evidenceMapRowId)) blockers.push(block("invalid_presentation_object", null));
-  if (!hasText(presentation.finalizationActorRef) || !hasText(presentation.finalizedAt) || !hasText(presentation.finalizationBasis)) {
-    blockers.push(block("finalization_identity_missing", rowId));
-  }
-  if (!hasText(presentation.reviewHistoryRef)) blockers.push(block("review_history_missing", rowId));
-
-  const applicability = presentation.applicabilityResult;
+  if (!hasText(candidate.finalizationActorRef) || !hasText(candidate.finalizationBasis)) blockers.push(block("finalization_identity_missing", id));
+  if (!isIsoTimestamp(candidate.finalizedAt)) blockers.push(block("finalized_at_invalid", id));
+  if (!hasText(candidate.reviewHistoryRef)) blockers.push(block("review_history_missing", id));
+  return blockers;
+}
+function rowBlockers(presentation: ReportPresentationObject): readonly PresentationGateBlock[] {
+  const blockers: PresentationGateBlock[] = [];
+  const id = presentation.evidenceMapRowId;
   const conclusion = presentation.conformanceConclusion;
-  if (applicability.evidenceMapRowId !== presentation.evidenceMapRowId) {
-    blockers.push(block("applicability_inconsistent", rowId));
-  }
-  if ((applicability.applicability === "APPLICABLE" && conclusion.conclusion === "NOT_APPLICABLE") ||
-      (applicability.applicability === "NOT_APPLICABLE" && conclusion.conclusion !== "NOT_APPLICABLE")) {
-    blockers.push(block("conformance_applicability_inconsistent", rowId));
-  }
-  if (conclusion.evidenceMapRowId !== presentation.evidenceMapRowId) {
-    blockers.push(block("conformance_applicability_inconsistent", rowId));
-  }
-  const draftRecord = presentation.draftFindingResult.draftFindingRecord;
-  if (draftRecord !== null &&
-      (draftRecord.evidenceMapRowId !== presentation.evidenceMapRowId ||
-        draftRecord.requirementId !== presentation.requirement.requirementId ||
-        draftRecord.findingId !== "draft:" + presentation.evidenceMapRowId)) {
-    blockers.push(block("applicability_inconsistent", rowId, "draft-finding identity mismatch"));
-  }
-  if (presentation.reviewState !== undefined) {
-    if (nonCurrentReviewState.test(presentation.reviewState)) {
-      blockers.push(block("review_state_not_current", rowId, presentation.reviewState));
-    } else if (presentation.reviewState === "pending_review") {
-      warnings.push(block("review_pending", rowId));
-    }
-  }
-  if (conclusion.conclusion === "CONFORMS" && presentation.acceptedEvidence.length === 0) {
-    blockers.push(block("evidence_insufficient_for_conformance", rowId));
-  }
-  if (applicability.applicability === "APPLICABLE" &&
-      (!presentation.searchCoverage.searched || presentation.searchCoverage.searchedDocumentIds.length === 0 ||
-        (presentation.searchCoverage.notes !== null && /^(?:unknown|unresolved|incomplete)$/i.test(presentation.searchCoverage.notes.trim())))) {
-    blockers.push(block("search_coverage_incomplete", rowId));
-  }
-  if (presentation.evidenceProvenance.length === 0 ||
-      presentation.acceptedEvidence.some((evidence) => evidence.provenance.spanId.length === 0) ||
-      presentation.rejectedEvidence.some((evidence) => evidence.provenance.spanId.length === 0)) {
-    blockers.push(block("provenance_incomplete", rowId));
-  }
-  if (presentation.methodology !== null) {
-    if (mismatchedVersion.test(presentation.methodology.rulebookVersion)) {
-      blockers.push(block("methodology_version_mismatch", rowId));
-    } else if (unresolvedVersion.test(presentation.methodology.rulebookVersion)) {
-      blockers.push(block("methodology_version_unresolved", rowId));
-    }
-  }
-  if (!supportedContractVersions.evidenceMap.has(presentation.evidenceMapContractVersion) ||
-      !supportedContractVersions.reviewPolicy.has(presentation.reviewPolicyVersion) ||
-      presentation.presentationContractVersion !== PRESENTATION_CONTRACT_VERSION) {
-    blockers.push(block("unsupported_contract_version", rowId));
-  }
-  return { blockers, warnings };
-}
-
-function resultFor(
-  presentations: readonly ReportPresentationObject[],
-  blockers: readonly PresentationGateBlock[],
-  warnings: readonly PresentationGateBlock[],
-  crossRowOutcome: CrossRowOutcome,
-): PresentationGateResult {
-  if (blockers.length > 0) {
-    return immutableResult({
-      releaseReady: false,
-      releaseState: "BLOCKED",
-      crossRowOutcome: blockers.some((entry) => entry.category === "empty_report") ? "NOT_EVALUATED" : crossRowOutcome === "NOT_EVALUATED" ? "NOT_EVALUATED" : "BLOCKED",
-      presentations,
-      blockedBy: blockers,
-    });
-  }
-  if (warnings.length > 0) {
-    return immutableResult({
-      releaseReady: false,
-      releaseState: "INTERNAL_REVIEW_ONLY",
-      crossRowOutcome: "WARNING",
-      presentations,
-      warnings,
-    });
-  }
-  return immutableResult({
-    releaseReady: true,
-    releaseState: "PRE_VALIDATION_RELEASE_READY",
-    crossRowOutcome,
-    presentations,
+  const draft = presentation.draftFindingResult;
+  if (!supportedStatuses.has(presentation.upstreamStatus)) blockers.push(block("unsupported_upstream_status", id));
+  if (conclusion.conclusion === "CONFORMS" && !["FOUND", "answered"].includes(presentation.upstreamStatus)) blockers.push(block("conclusion_invariant_violation", id, "CONFORMS requires FOUND or answered"));
+  if ((conclusion.conclusion === "CONFORMS" || conclusion.conclusion === "NOT_APPLICABLE") && draft.draftFindingType !== null) blockers.push(block("conclusion_invariant_violation", id));
+  if (draft.draftFindingType !== null && conclusion.conclusion !== "ACTION_REQUIRED") blockers.push(block("conclusion_invariant_violation", id));
+  if (draft.draftFindingRecord !== null && draft.draftFindingRecord.conformanceConclusion !== conclusion.conclusion) blockers.push(block("conclusion_invariant_violation", id));
+  if (!supportedContractVersions.evidenceMap.has(presentation.evidenceMapContractVersion) || !supportedContractVersions.reviewPolicy.has(presentation.reviewPolicyVersion) || presentation.presentationContractVersion !== PRESENTATION_CONTRACT_VERSION) blockers.push(block("unsupported_contract_version", id));
+  const provenance = new Set(presentation.evidenceProvenance.map(canonicalProvenance));
+  const evidence = [...presentation.acceptedEvidence, ...presentation.rejectedEvidence];
+  evidence.forEach((item) => {
+    const key = canonicalProvenance(item.provenance);
+    if (!provenance.has(key)) blockers.push(block("evidence_provenance_not_linked", id));
+    if (presentation.applicabilityResult.applicability === "APPLICABLE" && !presentation.searchCoverage.searchedDocumentIds.includes(item.provenance.docId)) blockers.push(block("evidence_document_not_searched", id, item.provenance.docId));
   });
+  if (conclusion.conclusion === "CONFORMS" && presentation.acceptedEvidence.length === 0) blockers.push(block("accepted_evidence_missing_provenance", id));
+  return blockers;
 }
-
-/** Evaluate one Phase 6 object without deriving any upstream judgment. */
-export function evaluatePresentationGate(presentation: unknown): PresentationGateResult {
-  const evaluation = evaluatePresentation(presentation);
-  const presentations = isReportPresentationInput(presentation) ? [presentation] : [];
-  return resultFor(presentations, evaluation.blockers, evaluation.warnings, "NOT_EVALUATED");
+function finish(presentations: readonly ReportPresentationObject[], blockers: readonly PresentationGateBlock[], warnings: readonly PresentationGateBlock[], crossRowOutcome: CrossRowOutcome): PresentationGateResult {
+  const frozen = Object.freeze(presentations.map(cloneAndFreeze));
+  if (blockers.length > 0) return Object.freeze({ releaseReady: false, releaseState: "BLOCKED", crossRowOutcome, presentations: frozen, blockedBy: Object.freeze([...blockers]) });
+  if (warnings.length > 0) return Object.freeze({ releaseReady: false, releaseState: "INTERNAL_REVIEW_ONLY", crossRowOutcome: "WARNING", presentations: frozen, warnings: Object.freeze([...warnings]) });
+  return Object.freeze({ releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY", crossRowOutcome, presentations: frozen });
 }
-
-/** Evaluate a report-level package for generic cross-row consistency. */
-export function evaluatePresentationReportGate(presentationsInput: unknown): PresentationGateResult {
-  if (!Array.isArray(presentationsInput) || presentationsInput.length === 0) {
-    return resultFor([], [block("empty_report", null)], [], "NOT_EVALUATED");
-  }
-  const presentations = presentationsInput.filter(isReportPresentationInput);
+function evaluateInputs(input: unknown): { presentations: readonly ReportPresentationObject[]; blockers: readonly PresentationGateBlock[]; warnings: readonly PresentationGateBlock[]; validInputs: readonly PresentationGateInput[] } {
+  const raw = Array.isArray(input) ? input : [];
   const blockers: PresentationGateBlock[] = [];
   const warnings: PresentationGateBlock[] = [];
-  if (presentations.length !== presentationsInput.length) blockers.push(block("invalid_presentation_object", null));
-  presentations.forEach((presentation) => {
-    const evaluation = evaluatePresentation(presentation);
-    blockers.push(...evaluation.blockers);
-    warnings.push(...evaluation.warnings);
+  const validInputs: PresentationGateInput[] = [];
+  raw.forEach((entry) => {
+    if (!isGateInput(entry)) { blockers.push(block("invalid_report_input", null)); return; }
+    const presentation = entry.presentation;
+    const metadata = presentationShapeBlockers(presentation);
+    if (metadata.length > 0) { blockers.push(...metadata); return; }
+    if (!isReportPresentationObject(presentation)) { blockers.push(block("invalid_presentation_object", rowId(presentation))); return; }
+    if (entry.reviewState === "REOPENED" || entry.reviewState === "SUPERSEDED" || entry.reviewState === "STALE") blockers.push(block("review_state_not_current", presentation.evidenceMapRowId, entry.reviewState));
+    if (entry.reviewState === "PENDING_REVIEW") warnings.push(block("review_state_not_current", presentation.evidenceMapRowId, entry.reviewState));
+    blockers.push(...rowBlockers(presentation));
+    validInputs.push(entry as PresentationGateInput);
   });
-
-  const rowIds = new Set<string>();
-  const requirementApplicability = new Map<string, string>();
-  const requirementConclusions = new Map<string, string>();
-  const methodologyIdentities = new Set<string>();
-  const acceptedEvidence = new Map<string, string>();
-  const rejectedEvidence = new Map<string, string>();
-  const sharedFacts = new Map<string, string>();
-  const assumptions = new Map<string, string>();
-  presentations.forEach((presentation) => {
-    const rowId = presentation.evidenceMapRowId;
-    if (rowIds.has(rowId)) blockers.push(block("duplicate_row_identity", rowId));
-    rowIds.add(rowId);
-    const requirementKey = presentation.requirement.requirementId;
-    const priorApplicability = requirementApplicability.get(requirementKey);
-    if (priorApplicability !== undefined && priorApplicability !== presentation.applicabilityResult.applicability) {
-      blockers.push(block("conflicting_applicability", rowId, requirementKey));
-    }
-    requirementApplicability.set(requirementKey, presentation.applicabilityResult.applicability);
-    const priorConclusion = requirementConclusions.get(requirementKey);
-    if (priorConclusion !== undefined && priorConclusion !== presentation.conformanceConclusion.conclusion) {
-      blockers.push(block("conflicting_requirement_conclusion", rowId, requirementKey));
-    }
-    requirementConclusions.set(requirementKey, presentation.conformanceConclusion.conclusion);
-    methodologyIdentities.add(methodologyKey(presentation.methodology));
-    presentation.acceptedEvidence.forEach((evidence) => acceptedEvidence.set(evidenceIdentity(evidence), rowId));
-    presentation.rejectedEvidence.forEach((evidence) => rejectedEvidence.set(evidenceIdentity(evidence), evidence.rejectionReason));
-    if (presentation.sharedProjectFacts !== undefined) {
-      Object.entries(presentation.sharedProjectFacts).forEach(([key, value]) => {
-        const normalized = JSON.stringify(value);
-        const prior = sharedFacts.get(key);
-        if (prior !== undefined && prior !== normalized) blockers.push(block("contradictory_shared_fact", rowId, key));
-        sharedFacts.set(key, normalized);
-      });
-    }
-    presentation.assumptions?.forEach((assumption) => {
-      const parsed = assumptionFamily(assumption);
-      if (parsed === null) return;
-      const prior = assumptions.get(parsed.family);
-      if (prior !== undefined && prior !== parsed.value) blockers.push(block("contradictory_assumption", rowId, parsed.family));
-      assumptions.set(parsed.family, parsed.value);
-    });
-  });
-  if (methodologyIdentities.size > 1) blockers.push(block("inconsistent_methodology_identity", null));
-  acceptedEvidence.forEach((_rowId, evidenceId) => {
-    if (rejectedEvidence.has(evidenceId) && unreliableReason.test(rejectedEvidence.get(evidenceId) ?? "")) {
-      blockers.push(block("cross_row_evidence_conflict", null, evidenceId));
-    }
-  });
-  const crossRowOutcome: CrossRowOutcome = blockers.length > 0
-    ? "BLOCKED"
-    : warnings.length > 0
-      ? "WARNING"
-      : presentations.some((presentation) => presentation.sharedProjectFacts !== undefined || presentation.assumptions !== undefined)
-        ? "PASS"
-        : "NOT_EVALUATED";
-  return resultFor(presentations, blockers, warnings, crossRowOutcome);
+  return { presentations: validInputs.map((entry) => entry.presentation), blockers, warnings, validInputs };
 }
-
+export function evaluatePresentationGate(input: unknown): PresentationGateResult {
+  if (!isGateInput(input)) return finish([], [block("invalid_report_input", null)], [], "NOT_EVALUATED");
+  return evaluatePresentationReportGate([input]);
+}
+export function evaluatePresentationReportGate(input: unknown): PresentationGateResult {
+  if (!Array.isArray(input)) return finish([], [block("invalid_report_input", null)], [], "NOT_EVALUATED");
+  if (input.length === 0) return finish([], [block("empty_report", null)], [], "NOT_EVALUATED");
+  const evaluated = evaluateInputs(input);
+  const blockers = [...evaluated.blockers];
+  const methodologies = new Map<string, string>();
+  const requirements = new Map<string, string>();
+  const rowIds = new Set<string>();
+  let comparisons = 0;
+  evaluated.validInputs.forEach(({ presentation }) => {
+    const id = presentation.evidenceMapRowId;
+    if (rowIds.has(id)) blockers.push(block("duplicate_row_identity", id));
+    rowIds.add(id);
+    const method = presentation.methodology === null ? "null-methodology" : presentation.methodology.methodologyId;
+    const version = presentation.methodology === null ? "null" : presentation.methodology.rulebookVersion;
+    const priorVersion = methodologies.get(method);
+    if (priorVersion !== undefined) { comparisons += 1; if (priorVersion !== version) blockers.push(block("conflicting_methodology_version", id, method)); }
+    methodologies.set(method, version);
+    const key = method + "@" + version + ":" + presentation.requirement.requirementId;
+    const priorConclusion = requirements.get(key);
+    if (priorConclusion !== undefined) { comparisons += 1; if (priorConclusion !== presentation.conformanceConclusion.conclusion) blockers.push(block("conflicting_requirement_conclusion", id, key)); }
+    requirements.set(key, presentation.conformanceConclusion.conclusion);
+  });
+  const crossRowOutcome: CrossRowOutcome = blockers.some((entry) => ["duplicate_row_identity", "conflicting_methodology_version", "conflicting_requirement_conclusion"].includes(entry.category)) ? "BLOCKED" : comparisons > 0 ? "PASS" : "NOT_EVALUATED";
+  return finish(evaluated.presentations, blockers, evaluated.warnings, crossRowOutcome);
+}
 export const evaluatePresentationGates = evaluatePresentationReportGate;

--- a/src/lib/evidence/presentationGate.ts
+++ b/src/lib/evidence/presentationGate.ts
@@ -6,10 +6,12 @@ import {
 import type { EvidenceMapMethodologyIdentity } from "@/lib/evidence/evidenceMapDependencyContract";
 
 export type PresentationGateBlockCategory =
+  | "empty_report"
   | "invalid_presentation_object"
   | "finalization_identity_missing"
   | "review_history_missing"
   | "applicability_inconsistent"
+  | "conflicting_applicability"
   | "conformance_applicability_inconsistent"
   | "evidence_insufficient_for_conformance"
   | "search_coverage_incomplete"
@@ -18,9 +20,13 @@ export type PresentationGateBlockCategory =
   | "methodology_version_mismatch"
   | "unsupported_contract_version"
   | "review_state_not_current"
+  | "review_pending"
   | "duplicate_row_identity"
   | "conflicting_requirement_conclusion"
-  | "inconsistent_methodology_identity";
+  | "inconsistent_methodology_identity"
+  | "cross_row_evidence_conflict"
+  | "contradictory_shared_fact"
+  | "contradictory_assumption";
 
 export type PresentationGateBlock = Readonly<{
   category: PresentationGateBlockCategory;
@@ -28,15 +34,30 @@ export type PresentationGateBlock = Readonly<{
   detail?: string;
 }>;
 
+export type CrossRowOutcome = "PASS" | "WARNING" | "BLOCKED" | "NOT_EVALUATED";
+export type PresentationReleaseState =
+  | "PRE_VALIDATION_RELEASE_READY"
+  | "INTERNAL_REVIEW_ONLY"
+  | "BLOCKED";
+
 export type PresentationGateResult =
   | Readonly<{
       releaseReady: true;
       releaseState: "PRE_VALIDATION_RELEASE_READY";
+      crossRowOutcome: CrossRowOutcome;
       presentations: readonly ReportPresentationObject[];
     }>
   | Readonly<{
       releaseReady: false;
+      releaseState: "INTERNAL_REVIEW_ONLY";
+      crossRowOutcome: "WARNING";
+      presentations: readonly ReportPresentationObject[];
+      warnings: readonly PresentationGateBlock[];
+    }>
+  | Readonly<{
+      releaseReady: false;
       releaseState: "BLOCKED";
+      crossRowOutcome: "BLOCKED" | "NOT_EVALUATED";
       presentations: readonly ReportPresentationObject[];
       blockedBy: readonly PresentationGateBlock[];
     }>;
@@ -48,41 +69,78 @@ const supportedContractVersions = {
 const unresolvedVersion = /^(?:unknown|unresolved|unsupported|n\/a)$/i;
 const mismatchedVersion = /^mismatch(?:ed)?$/i;
 const nonCurrentReviewState = /^(?:reopened|superseded|stale)$/i;
+const unreliableReason = /\b(?:unreliable|not reliable|cannot be relied upon)\b/i;
+
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
 
 function block(category: PresentationGateBlockCategory, evidenceMapRowId: string | null, detail?: string): PresentationGateBlock {
   return Object.freeze(detail === undefined ? { category, evidenceMapRowId } : { category, evidenceMapRowId, detail });
 }
 
+function cloneAndFreeze<T>(value: T): T {
+  if (value === null || typeof value !== "object") return value;
+  const clone = Array.isArray(value)
+    ? value.map((entry) => cloneAndFreeze(entry))
+    : Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, cloneAndFreeze(entry)]));
+  return Object.freeze(clone) as T;
+}
+
 function immutableResult(result: PresentationGateResult): PresentationGateResult {
-  if (result.releaseReady) return Object.freeze({ ...result, presentations: Object.freeze([...result.presentations]) });
-  return Object.freeze({ ...result, presentations: Object.freeze([...result.presentations]), blockedBy: Object.freeze([...result.blockedBy]) });
+  const presentations = Object.freeze(result.presentations.map((presentation) => cloneAndFreeze(presentation)));
+  if (result.releaseState === "PRE_VALIDATION_RELEASE_READY") return Object.freeze({ ...result, presentations });
+  if (result.releaseState === "INTERNAL_REVIEW_ONLY") {
+    return Object.freeze({ ...result, presentations, warnings: Object.freeze([...result.warnings]) });
+  }
+  return Object.freeze({ ...result, presentations, blockedBy: Object.freeze([...result.blockedBy]) });
 }
 
 function methodologyKey(methodology: EvidenceMapMethodologyIdentity | null): string {
-  return methodology === null ? "none" : `${methodology.methodologyId}@${methodology.rulebookVersion}`;
+  return methodology === null ? "none" : methodology.methodologyId + "@" + methodology.rulebookVersion;
 }
 
-function evaluatePresentation(presentation: unknown): readonly PresentationGateBlock[] {
-  if (!isReportPresentationObject(presentation)) return [block("invalid_presentation_object", null)];
-  const rowId = presentation.evidenceMapRowId;
+function evaluatePresentation(presentation: unknown): {
+  blockers: readonly PresentationGateBlock[];
+  warnings: readonly PresentationGateBlock[];
+} {
+  if (!isReportPresentationObject(presentation)) {
+    return { blockers: [block("invalid_presentation_object", null)], warnings: [] };
+  }
+  const rowId = hasText(presentation.evidenceMapRowId) ? presentation.evidenceMapRowId : null;
   const blockers: PresentationGateBlock[] = [];
-  if (!rowId || !presentation.finalizationActorRef || !presentation.finalizedAt || !presentation.finalizationBasis) {
+  const warnings: PresentationGateBlock[] = [];
+  if (!hasText(presentation.evidenceMapRowId)) blockers.push(block("invalid_presentation_object", null));
+  if (!hasText(presentation.finalizationActorRef) || !hasText(presentation.finalizedAt) || !hasText(presentation.finalizationBasis)) {
     blockers.push(block("finalization_identity_missing", rowId));
   }
-  if (!presentation.reviewHistoryRef.trim()) blockers.push(block("review_history_missing", rowId));
+  if (!hasText(presentation.reviewHistoryRef)) blockers.push(block("review_history_missing", rowId));
 
   const applicability = presentation.applicabilityResult;
   const conclusion = presentation.conformanceConclusion;
+  if (applicability.evidenceMapRowId !== presentation.evidenceMapRowId) {
+    blockers.push(block("applicability_inconsistent", rowId));
+  }
   if ((applicability.applicability === "APPLICABLE" && conclusion.conclusion === "NOT_APPLICABLE") ||
       (applicability.applicability === "NOT_APPLICABLE" && conclusion.conclusion !== "NOT_APPLICABLE")) {
     blockers.push(block("conformance_applicability_inconsistent", rowId));
   }
-  if (applicability.evidenceMapRowId !== rowId ||
-      (applicability.applicability === "APPLICABLE" && presentation.upstreamStatus === "UNKNOWN")) {
-    blockers.push(block("applicability_inconsistent", rowId));
+  if (conclusion.evidenceMapRowId !== presentation.evidenceMapRowId) {
+    blockers.push(block("conformance_applicability_inconsistent", rowId));
   }
-  if (presentation.reviewState !== undefined && nonCurrentReviewState.test(presentation.reviewState)) {
-    blockers.push(block("review_state_not_current", rowId, presentation.reviewState));
+  const draftRecord = presentation.draftFindingResult.draftFindingRecord;
+  if (draftRecord !== null &&
+      (draftRecord.evidenceMapRowId !== presentation.evidenceMapRowId ||
+        draftRecord.requirementId !== presentation.requirement.requirementId ||
+        draftRecord.findingId !== "draft:" + presentation.evidenceMapRowId)) {
+    blockers.push(block("applicability_inconsistent", rowId, "draft-finding identity mismatch"));
+  }
+  if (presentation.reviewState !== undefined) {
+    if (nonCurrentReviewState.test(presentation.reviewState)) {
+      blockers.push(block("review_state_not_current", rowId, presentation.reviewState));
+    } else if (presentation.reviewState === "pending_review") {
+      warnings.push(block("review_pending", rowId));
+    }
   }
   if (conclusion.conclusion === "CONFORMS" && presentation.acceptedEvidence.length === 0) {
     blockers.push(block("evidence_insufficient_for_conformance", rowId));
@@ -103,54 +161,124 @@ function evaluatePresentation(presentation: unknown): readonly PresentationGateB
     } else if (unresolvedVersion.test(presentation.methodology.rulebookVersion)) {
       blockers.push(block("methodology_version_unresolved", rowId));
     }
-    if (presentation.methodology.methodologyId.trim() === "" || presentation.methodology.rulebookVersion.trim() === "") {
-      blockers.push(block("methodology_version_mismatch", rowId));
-    }
   }
   if (!supportedContractVersions.evidenceMap.has(presentation.evidenceMapContractVersion) ||
       !supportedContractVersions.reviewPolicy.has(presentation.reviewPolicyVersion) ||
       presentation.presentationContractVersion !== PRESENTATION_CONTRACT_VERSION) {
     blockers.push(block("unsupported_contract_version", rowId));
   }
-  return blockers;
+  return { blockers, warnings };
 }
 
-/** Evaluate one immutable Phase 6 object without deriving any upstream judgment. */
-export function evaluatePresentationGate(presentation: unknown): PresentationGateResult {
-  const blockers = evaluatePresentation(presentation);
-  const presentations = isReportPresentationObject(presentation) ? [presentation] : [];
-  return immutableResult(blockers.length === 0
-    ? { releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY", presentations }
-    : { releaseReady: false, releaseState: "BLOCKED", presentations, blockedBy: blockers });
-}
-
-/** Evaluate a report-level package for duplicate identities and generic cross-row contradictions. */
-export function evaluatePresentationReportGate(presentationsInput: unknown): PresentationGateResult {
-  const input = Array.isArray(presentationsInput) ? presentationsInput : [];
-  const presentations = input.filter(isReportPresentationObject);
-  const blockers: PresentationGateBlock[] = [];
-  if (!Array.isArray(presentationsInput) || presentations.length !== input.length) {
-    blockers.push(block("invalid_presentation_object", null));
+function resultFor(
+  presentations: readonly ReportPresentationObject[],
+  blockers: readonly PresentationGateBlock[],
+  warnings: readonly PresentationGateBlock[],
+  crossRowOutcome: CrossRowOutcome,
+): PresentationGateResult {
+  if (blockers.length > 0) {
+    return immutableResult({
+      releaseReady: false,
+      releaseState: "BLOCKED",
+      crossRowOutcome: blockers.some((entry) => entry.category === "empty_report") ? "NOT_EVALUATED" : crossRowOutcome === "NOT_EVALUATED" ? "NOT_EVALUATED" : "BLOCKED",
+      presentations,
+      blockedBy: blockers,
+    });
   }
-  presentations.forEach((presentation) => blockers.push(...evaluatePresentation(presentation)));
+  if (warnings.length > 0) {
+    return immutableResult({
+      releaseReady: false,
+      releaseState: "INTERNAL_REVIEW_ONLY",
+      crossRowOutcome: "WARNING",
+      presentations,
+      warnings,
+    });
+  }
+  return immutableResult({
+    releaseReady: true,
+    releaseState: "PRE_VALIDATION_RELEASE_READY",
+    crossRowOutcome,
+    presentations,
+  });
+}
+
+/** Evaluate one Phase 6 object without deriving any upstream judgment. */
+export function evaluatePresentationGate(presentation: unknown): PresentationGateResult {
+  const evaluation = evaluatePresentation(presentation);
+  const presentations = isReportPresentationObject(presentation) ? [presentation] : [];
+  return resultFor(presentations, evaluation.blockers, evaluation.warnings, "NOT_EVALUATED");
+}
+
+/** Evaluate a report-level package for generic cross-row consistency. */
+export function evaluatePresentationReportGate(presentationsInput: unknown): PresentationGateResult {
+  if (!Array.isArray(presentationsInput) || presentationsInput.length === 0) {
+    return resultFor([], [block("empty_report", null)], [], "NOT_EVALUATED");
+  }
+  const presentations = presentationsInput.filter(isReportPresentationObject);
+  const blockers: PresentationGateBlock[] = [];
+  const warnings: PresentationGateBlock[] = [];
+  if (presentations.length !== presentationsInput.length) blockers.push(block("invalid_presentation_object", null));
+  presentations.forEach((presentation) => {
+    const evaluation = evaluatePresentation(presentation);
+    blockers.push(...evaluation.blockers);
+    warnings.push(...evaluation.warnings);
+  });
+
   const rowIds = new Set<string>();
+  const requirementApplicability = new Map<string, string>();
   const requirementConclusions = new Map<string, string>();
   const methodologyIdentities = new Set<string>();
+  const acceptedEvidence = new Map<string, string>();
+  const rejectedEvidence = new Map<string, string>();
+  const sharedFacts = new Map<string, string>();
+  const assumptions = new Map<string, string>();
   presentations.forEach((presentation) => {
-    if (rowIds.has(presentation.evidenceMapRowId)) blockers.push(block("duplicate_row_identity", presentation.evidenceMapRowId));
-    rowIds.add(presentation.evidenceMapRowId);
+    const rowId = presentation.evidenceMapRowId;
+    if (rowIds.has(rowId)) blockers.push(block("duplicate_row_identity", rowId));
+    rowIds.add(rowId);
     const requirementKey = presentation.requirement.requirementId;
+    const priorApplicability = requirementApplicability.get(requirementKey);
+    if (priorApplicability !== undefined && priorApplicability !== presentation.applicabilityResult.applicability) {
+      blockers.push(block("conflicting_applicability", rowId, requirementKey));
+    }
+    requirementApplicability.set(requirementKey, presentation.applicabilityResult.applicability);
     const priorConclusion = requirementConclusions.get(requirementKey);
     if (priorConclusion !== undefined && priorConclusion !== presentation.conformanceConclusion.conclusion) {
-      blockers.push(block("conflicting_requirement_conclusion", presentation.evidenceMapRowId, requirementKey));
+      blockers.push(block("conflicting_requirement_conclusion", rowId, requirementKey));
     }
     requirementConclusions.set(requirementKey, presentation.conformanceConclusion.conclusion);
     methodologyIdentities.add(methodologyKey(presentation.methodology));
+    presentation.acceptedEvidence.forEach((evidence) => acceptedEvidence.set(evidence.evidenceId, rowId));
+    presentation.rejectedEvidence.forEach((evidence) => rejectedEvidence.set(evidence.evidenceId, evidence.rejectionReason));
+    if (presentation.sharedProjectFacts !== undefined) {
+      Object.entries(presentation.sharedProjectFacts).forEach(([key, value]) => {
+        const normalized = JSON.stringify(value);
+        const prior = sharedFacts.get(key);
+        if (prior !== undefined && prior !== normalized) blockers.push(block("contradictory_shared_fact", rowId, key));
+        sharedFacts.set(key, normalized);
+      });
+    }
+    presentation.assumptions?.forEach((assumption) => {
+      const key = assumption.trim().toLowerCase();
+      const prior = assumptions.get(key);
+      if (prior !== undefined && prior !== assumption) blockers.push(block("contradictory_assumption", rowId, key));
+      assumptions.set(key, assumption);
+    });
   });
   if (methodologyIdentities.size > 1) blockers.push(block("inconsistent_methodology_identity", null));
-  return immutableResult(blockers.length === 0
-    ? { releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY", presentations }
-    : { releaseReady: false, releaseState: "BLOCKED", presentations, blockedBy: blockers });
+  acceptedEvidence.forEach((_rowId, evidenceId) => {
+    if (rejectedEvidence.has(evidenceId) && unreliableReason.test(rejectedEvidence.get(evidenceId) ?? "")) {
+      blockers.push(block("cross_row_evidence_conflict", null, evidenceId));
+    }
+  });
+  const crossRowOutcome: CrossRowOutcome = blockers.length > 0
+    ? "BLOCKED"
+    : warnings.length > 0
+      ? "WARNING"
+      : presentations.some((presentation) => presentation.sharedProjectFacts !== undefined || presentation.assumptions !== undefined)
+        ? "PASS"
+        : "NOT_EVALUATED";
+  return resultFor(presentations, blockers, warnings, crossRowOutcome);
 }
 
 export const evaluatePresentationGates = evaluatePresentationReportGate;

--- a/src/lib/evidence/presentationGate.ts
+++ b/src/lib/evidence/presentationGate.ts
@@ -1,5 +1,5 @@
 import {
-  isReportPresentationObject,
+  isReportPresentationInput,
   PRESENTATION_CONTRACT_VERSION,
   type ReportPresentationObject,
 } from "@/lib/evidence/reportPresentationObject";
@@ -75,6 +75,26 @@ function hasText(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function normalizeAssumption(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function assumptionFamily(value: string): { family: string; value: string } | null {
+  const normalized = normalizeAssumption(value);
+  const match = /^(.*\bis\b)\s+(.+)$/.exec(normalized);
+  return match === null ? null : { family: match[1], value: match[2] };
+}
+
+function evidenceIdentity(evidence: ReportPresentationObject["acceptedEvidence"][number]): string {
+  const provenance = evidence.provenance;
+  return JSON.stringify({
+    docId: provenance.docId,
+    spanId: provenance.spanId,
+    page: provenance.page,
+    sectionPath: provenance.sectionPath,
+  });
+}
+
 function block(category: PresentationGateBlockCategory, evidenceMapRowId: string | null, detail?: string): PresentationGateBlock {
   return Object.freeze(detail === undefined ? { category, evidenceMapRowId } : { category, evidenceMapRowId, detail });
 }
@@ -104,7 +124,7 @@ function evaluatePresentation(presentation: unknown): {
   blockers: readonly PresentationGateBlock[];
   warnings: readonly PresentationGateBlock[];
 } {
-  if (!isReportPresentationObject(presentation)) {
+  if (!isReportPresentationInput(presentation)) {
     return { blockers: [block("invalid_presentation_object", null)], warnings: [] };
   }
   const rowId = hasText(presentation.evidenceMapRowId) ? presentation.evidenceMapRowId : null;
@@ -205,7 +225,7 @@ function resultFor(
 /** Evaluate one Phase 6 object without deriving any upstream judgment. */
 export function evaluatePresentationGate(presentation: unknown): PresentationGateResult {
   const evaluation = evaluatePresentation(presentation);
-  const presentations = isReportPresentationObject(presentation) ? [presentation] : [];
+  const presentations = isReportPresentationInput(presentation) ? [presentation] : [];
   return resultFor(presentations, evaluation.blockers, evaluation.warnings, "NOT_EVALUATED");
 }
 
@@ -214,7 +234,7 @@ export function evaluatePresentationReportGate(presentationsInput: unknown): Pre
   if (!Array.isArray(presentationsInput) || presentationsInput.length === 0) {
     return resultFor([], [block("empty_report", null)], [], "NOT_EVALUATED");
   }
-  const presentations = presentationsInput.filter(isReportPresentationObject);
+  const presentations = presentationsInput.filter(isReportPresentationInput);
   const blockers: PresentationGateBlock[] = [];
   const warnings: PresentationGateBlock[] = [];
   if (presentations.length !== presentationsInput.length) blockers.push(block("invalid_presentation_object", null));
@@ -248,8 +268,8 @@ export function evaluatePresentationReportGate(presentationsInput: unknown): Pre
     }
     requirementConclusions.set(requirementKey, presentation.conformanceConclusion.conclusion);
     methodologyIdentities.add(methodologyKey(presentation.methodology));
-    presentation.acceptedEvidence.forEach((evidence) => acceptedEvidence.set(evidence.evidenceId, rowId));
-    presentation.rejectedEvidence.forEach((evidence) => rejectedEvidence.set(evidence.evidenceId, evidence.rejectionReason));
+    presentation.acceptedEvidence.forEach((evidence) => acceptedEvidence.set(evidenceIdentity(evidence), rowId));
+    presentation.rejectedEvidence.forEach((evidence) => rejectedEvidence.set(evidenceIdentity(evidence), evidence.rejectionReason));
     if (presentation.sharedProjectFacts !== undefined) {
       Object.entries(presentation.sharedProjectFacts).forEach(([key, value]) => {
         const normalized = JSON.stringify(value);
@@ -259,10 +279,11 @@ export function evaluatePresentationReportGate(presentationsInput: unknown): Pre
       });
     }
     presentation.assumptions?.forEach((assumption) => {
-      const key = assumption.trim().toLowerCase();
-      const prior = assumptions.get(key);
-      if (prior !== undefined && prior !== assumption) blockers.push(block("contradictory_assumption", rowId, key));
-      assumptions.set(key, assumption);
+      const parsed = assumptionFamily(assumption);
+      if (parsed === null) return;
+      const prior = assumptions.get(parsed.family);
+      if (prior !== undefined && prior !== parsed.value) blockers.push(block("contradictory_assumption", rowId, parsed.family));
+      assumptions.set(parsed.family, parsed.value);
     });
   });
   if (methodologyIdentities.size > 1) blockers.push(block("inconsistent_methodology_identity", null));

--- a/src/lib/evidence/reportPresentationObject.ts
+++ b/src/lib/evidence/reportPresentationObject.ts
@@ -46,9 +46,6 @@ export type ReportPresentationObject = Readonly<{
   reviewPolicyVersion: string;
   presentationContractVersion: typeof PRESENTATION_CONTRACT_VERSION;
   machineProposalTraceability: MachineProposalTraceability | null;
-  reviewState?: "current" | "pending_review" | "reopened" | "superseded" | "stale";
-  sharedProjectFacts?: Readonly<Record<string, string | number | boolean | null>>;
-  assumptions?: readonly string[];
 }>;
 
 export type ReportPresentationBlock =
@@ -151,28 +148,19 @@ const requiredPresentationKeys = [
   "reviewPolicyVersion", "presentationContractVersion", "machineProposalTraceability",
 ] as const;
 const releaseMetadataKeys = ["finalizationActorRef", "finalizedAt", "finalizationBasis", "reviewHistoryRef"] as const;
-const optionalPresentationKeys = ["reviewState", "sharedProjectFacts", "assumptions"] as const;
-
-function parseReportPresentationInput(value: unknown, strict: boolean): value is ReportPresentationObject {
-  if (!isRecord(value) || !hasRequiredKeys(value, requiredPresentationKeys, [...releaseMetadataKeys, ...optionalPresentationKeys])) return false;
-  if (strict && !releaseMetadataKeys.every((key) => Object.prototype.hasOwnProperty.call(value, key))) return false;
+function parseReportPresentationObject(value: unknown): value is ReportPresentationObject {
+  if (!isRecord(value) || !hasRequiredKeys(value, [...requiredPresentationKeys, ...releaseMetadataKeys], [])) return false;
   if (value.profile !== "GENERIC_PRE_VALIDATION" || !hasText(value.evidenceMapRowId) || !hasText(value.upstreamStatus) ||
       !hasText(value.assessmentReason) || (value.clientAction !== null && !hasText(value.clientAction)) ||
-      !releaseMetadataKeys.every((key) => value[key] === undefined || typeof value[key] === "string") ||
-      (strict && !releaseMetadataKeys.every((key) => hasText(value[key]))) ||
+      !releaseMetadataKeys.every((key) => hasText(value[key])) ||
       !hasText(value.evidenceMapContractVersion) || !hasText(value.reviewPolicyVersion) ||
       value.presentationContractVersion !== PRESENTATION_CONTRACT_VERSION ||
-      (value.reviewState !== undefined && value.reviewState !== "current" && value.reviewState !== "pending_review" && value.reviewState !== "reopened" && value.reviewState !== "superseded" && value.reviewState !== "stale") ||
-      (value.assumptions !== undefined && (!Array.isArray(value.assumptions) || !value.assumptions.every((entry) => hasText(entry)))) ||
-      (value.sharedProjectFacts !== undefined && (!isRecord(value.sharedProjectFacts) || Object.values(value.sharedProjectFacts).some((entry) =>
-        entry !== null && typeof entry !== "string" && typeof entry !== "number" && typeof entry !== "boolean"))) ||
       !isStrictEvidenceMapFields(value) || !isApplicabilityResult(value.applicabilityResult) ||
       !isConformanceConclusionResult(value.conformanceConclusion) || !isDraftFindingResult(value.draftFindingResult)) return false;
   if (value.machineProposalTraceability !== null &&
       (!isRecord(value.machineProposalTraceability) || !hasOnlyKeys(value.machineProposalTraceability, ["source", "evidenceMapRowId"]) ||
        value.machineProposalTraceability.source !== "EVIDENCE_MAP" || value.machineProposalTraceability.evidenceMapRowId !== value.evidenceMapRowId)) return false;
   if (value.applicabilityResult.applicability === "NOT_ASSESSED" || value.conformanceConclusion.conclusion === "NOT_ASSESSED") return false;
-  if (!strict) return true;
   const draftRecord = value.draftFindingResult.draftFindingRecord;
   return value.applicabilityResult.evidenceMapRowId === value.evidenceMapRowId &&
     value.conformanceConclusion.evidenceMapRowId === value.evidenceMapRowId &&
@@ -184,12 +172,7 @@ function parseReportPresentationInput(value: unknown, strict: boolean): value is
 
 /** Strict runtime validator for the immutable Phase 6 boundary. */
 export function isReportPresentationObject(value: unknown): value is ReportPresentationObject {
-  return parseReportPresentationInput(value, true);
-}
-
-/** Permissive structural parser used by Phase 7 before release-safety blockers are evaluated. */
-export function isReportPresentationInput(value: unknown): value is ReportPresentationObject {
-  return parseReportPresentationInput(value, false);
+  return parseReportPresentationObject(value);
 }
 
 function rowIdFrom(candidate: unknown): string | null {

--- a/src/lib/evidence/reportPresentationObject.ts
+++ b/src/lib/evidence/reportPresentationObject.ts
@@ -46,6 +46,7 @@ export type ReportPresentationObject = Readonly<{
   reviewPolicyVersion: string;
   presentationContractVersion: typeof PRESENTATION_CONTRACT_VERSION;
   machineProposalTraceability: MachineProposalTraceability | null;
+  reviewState?: "current" | "reopened" | "superseded" | "stale";
 }>;
 
 export type ReportPresentationBlock =
@@ -83,6 +84,82 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function hasText(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).length === keys.length && Object.keys(value).every((key) => keys.includes(key));
+}
+
+function hasAllowedKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).every((key) => keys.includes(key));
+}
+
+function isEvidenceProvenance(value: unknown): boolean {
+  if (!isRecord(value) || !hasOnlyKeys(value, ["docId", "page", "sectionPath", "spanId", "sectionHeading", "sourceType"])) {
+    return false;
+  }
+  return (
+    hasText(value.docId) &&
+    (value.page === null || (typeof value.page === "number" && Number.isFinite(value.page))) &&
+    Array.isArray(value.sectionPath) &&
+    value.sectionPath.every((entry) => typeof entry === "string") &&
+    hasText(value.spanId) &&
+    (value.sectionHeading === null || hasText(value.sectionHeading)) &&
+    (value.sourceType === null || hasText(value.sourceType))
+  );
+}
+
+function isStrictEvidenceMapFields(value: Record<string, unknown>): boolean {
+  if (!isRecord(value.requirement) || !hasOnlyKeys(value.requirement, ["requirementId", "requirementReference", "requirementText"]) ||
+      !hasText(value.requirement.requirementId) || !hasText(value.requirement.requirementReference) || !hasText(value.requirement.requirementText)) return false;
+  if (value.methodology !== null &&
+      (!isRecord(value.methodology) || !hasOnlyKeys(value.methodology, ["methodologyId", "rulebookVersion"]) ||
+       !hasText(value.methodology.methodologyId) || !hasText(value.methodology.rulebookVersion))) return false;
+  if (!isRecord(value.searchCoverage) || !hasOnlyKeys(value.searchCoverage, ["searched", "searchedDocumentIds", "notes"]) ||
+      typeof value.searchCoverage.searched !== "boolean" || !Array.isArray(value.searchCoverage.searchedDocumentIds) ||
+      !value.searchCoverage.searchedDocumentIds.every((entry) => hasText(entry)) ||
+      (value.searchCoverage.notes !== null && !hasText(value.searchCoverage.notes))) return false;
+  if (!isRecord(value.sourceDocument) || !hasOnlyKeys(value.sourceDocument, ["documentId", "documentName", "contentSha256"]) ||
+      !hasText(value.sourceDocument.documentId) ||
+      (value.sourceDocument.documentName !== null && !hasText(value.sourceDocument.documentName)) ||
+      (value.sourceDocument.contentSha256 !== null && !hasText(value.sourceDocument.contentSha256))) return false;
+  if (!Array.isArray(value.evidenceProvenance) || !value.evidenceProvenance.every(isEvidenceProvenance)) return false;
+  if (!Array.isArray(value.acceptedEvidence) || !value.acceptedEvidence.every((item) =>
+    isRecord(item) && hasOnlyKeys(item, ["evidenceId", "quote", "provenance"]) && hasText(item.evidenceId) && hasText(item.quote) && isEvidenceProvenance(item.provenance))) return false;
+  if (!Array.isArray(value.rejectedEvidence) || !value.rejectedEvidence.every((item) =>
+    isRecord(item) && hasOnlyKeys(item, ["evidenceId", "quote", "rejectionReason", "provenance"]) && hasText(item.evidenceId) &&
+    hasText(item.quote) && hasText(item.rejectionReason) && isEvidenceProvenance(item.provenance))) return false;
+  return true;
+}
+
+/** Strict runtime validator for the immutable Phase 6 boundary. */
+export function isReportPresentationObject(value: unknown): value is ReportPresentationObject {
+  if (!isRecord(value) || !hasAllowedKeys(value, [
+    "profile", "evidenceMapRowId", "requirement", "methodology", "upstreamStatus", "applicabilityResult",
+    "conformanceConclusion", "draftFindingResult", "acceptedEvidence", "rejectedEvidence", "assessmentReason",
+    "clientAction", "searchCoverage", "sourceDocument", "evidenceProvenance", "finalizationActorRef", "finalizedAt",
+    "finalizationBasis", "reviewHistoryRef", "evidenceMapContractVersion", "reviewPolicyVersion", "presentationContractVersion",
+    "machineProposalTraceability", "reviewState",
+  ])) return false;
+  if (value.profile !== "GENERIC_PRE_VALIDATION" || !hasText(value.evidenceMapRowId) || !hasText(value.upstreamStatus) ||
+      !hasText(value.assessmentReason) || (value.clientAction !== null && !hasText(value.clientAction)) ||
+      !hasText(value.finalizationActorRef) || !hasText(value.finalizedAt) || !hasText(value.finalizationBasis) ||
+      !hasText(value.reviewHistoryRef) || !hasText(value.evidenceMapContractVersion) || !hasText(value.reviewPolicyVersion) ||
+      value.presentationContractVersion !== PRESENTATION_CONTRACT_VERSION ||
+      (value.reviewState !== undefined && value.reviewState !== "current" && value.reviewState !== "reopened" && value.reviewState !== "superseded" && value.reviewState !== "stale") ||
+      !isStrictEvidenceMapFields(value) || !isApplicabilityResult(value.applicabilityResult) ||
+      !isConformanceConclusionResult(value.conformanceConclusion) || !isDraftFindingResult(value.draftFindingResult)) return false;
+  if (value.machineProposalTraceability !== null &&
+      (!isRecord(value.machineProposalTraceability) || !hasOnlyKeys(value.machineProposalTraceability, ["source", "evidenceMapRowId"]) ||
+       value.machineProposalTraceability.source !== "EVIDENCE_MAP" || value.machineProposalTraceability.evidenceMapRowId !== value.evidenceMapRowId)) return false;
+  return value.applicabilityResult.applicability !== "NOT_ASSESSED" &&
+    value.conformanceConclusion.conclusion !== "NOT_ASSESSED" &&
+    (value.applicabilityResult.evidenceMapRowId === value.evidenceMapRowId) &&
+    value.conformanceConclusion.evidenceMapRowId === value.evidenceMapRowId &&
+    (value.draftFindingResult.draftFindingRecord === null ||
+      (value.draftFindingResult.draftFindingRecord.evidenceMapRowId === value.evidenceMapRowId &&
+        value.draftFindingResult.draftFindingRecord.requirementId === (value.requirement as ReportPresentationObject["requirement"]).requirementId &&
+        value.draftFindingResult.draftFindingRecord.findingId === ("draft:" + value.evidenceMapRowId)));
 }
 
 function rowIdFrom(candidate: unknown): string | null {

--- a/src/lib/evidence/reportPresentationObject.ts
+++ b/src/lib/evidence/reportPresentationObject.ts
@@ -46,7 +46,9 @@ export type ReportPresentationObject = Readonly<{
   reviewPolicyVersion: string;
   presentationContractVersion: typeof PRESENTATION_CONTRACT_VERSION;
   machineProposalTraceability: MachineProposalTraceability | null;
-  reviewState?: "current" | "reopened" | "superseded" | "stale";
+  reviewState?: "current" | "pending_review" | "reopened" | "superseded" | "stale";
+  sharedProjectFacts?: Readonly<Record<string, string | number | boolean | null>>;
+  assumptions?: readonly string[];
 }>;
 
 export type ReportPresentationBlock =
@@ -139,27 +141,27 @@ export function isReportPresentationObject(value: unknown): value is ReportPrese
     "conformanceConclusion", "draftFindingResult", "acceptedEvidence", "rejectedEvidence", "assessmentReason",
     "clientAction", "searchCoverage", "sourceDocument", "evidenceProvenance", "finalizationActorRef", "finalizedAt",
     "finalizationBasis", "reviewHistoryRef", "evidenceMapContractVersion", "reviewPolicyVersion", "presentationContractVersion",
-    "machineProposalTraceability", "reviewState",
+    "machineProposalTraceability", "reviewState", "sharedProjectFacts", "assumptions",
   ])) return false;
   if (value.profile !== "GENERIC_PRE_VALIDATION" || !hasText(value.evidenceMapRowId) || !hasText(value.upstreamStatus) ||
       !hasText(value.assessmentReason) || (value.clientAction !== null && !hasText(value.clientAction)) ||
-      !hasText(value.finalizationActorRef) || !hasText(value.finalizedAt) || !hasText(value.finalizationBasis) ||
-      !hasText(value.reviewHistoryRef) || !hasText(value.evidenceMapContractVersion) || !hasText(value.reviewPolicyVersion) ||
+      (value.finalizationActorRef !== undefined && typeof value.finalizationActorRef !== "string") ||
+      (value.finalizedAt !== undefined && typeof value.finalizedAt !== "string") ||
+      (value.finalizationBasis !== undefined && typeof value.finalizationBasis !== "string") ||
+      (value.reviewHistoryRef !== undefined && typeof value.reviewHistoryRef !== "string") ||
+      !hasText(value.evidenceMapContractVersion) || !hasText(value.reviewPolicyVersion) ||
       value.presentationContractVersion !== PRESENTATION_CONTRACT_VERSION ||
-      (value.reviewState !== undefined && value.reviewState !== "current" && value.reviewState !== "reopened" && value.reviewState !== "superseded" && value.reviewState !== "stale") ||
+      (value.reviewState !== undefined && value.reviewState !== "current" && value.reviewState !== "pending_review" && value.reviewState !== "reopened" && value.reviewState !== "superseded" && value.reviewState !== "stale") ||
+      (value.assumptions !== undefined && (!Array.isArray(value.assumptions) || !value.assumptions.every((entry) => hasText(entry)))) ||
+      (value.sharedProjectFacts !== undefined && (!isRecord(value.sharedProjectFacts) || Object.values(value.sharedProjectFacts).some((entry) =>
+        entry !== null && typeof entry !== "string" && typeof entry !== "number" && typeof entry !== "boolean"))) ||
       !isStrictEvidenceMapFields(value) || !isApplicabilityResult(value.applicabilityResult) ||
       !isConformanceConclusionResult(value.conformanceConclusion) || !isDraftFindingResult(value.draftFindingResult)) return false;
   if (value.machineProposalTraceability !== null &&
       (!isRecord(value.machineProposalTraceability) || !hasOnlyKeys(value.machineProposalTraceability, ["source", "evidenceMapRowId"]) ||
        value.machineProposalTraceability.source !== "EVIDENCE_MAP" || value.machineProposalTraceability.evidenceMapRowId !== value.evidenceMapRowId)) return false;
   return value.applicabilityResult.applicability !== "NOT_ASSESSED" &&
-    value.conformanceConclusion.conclusion !== "NOT_ASSESSED" &&
-    (value.applicabilityResult.evidenceMapRowId === value.evidenceMapRowId) &&
-    value.conformanceConclusion.evidenceMapRowId === value.evidenceMapRowId &&
-    (value.draftFindingResult.draftFindingRecord === null ||
-      (value.draftFindingResult.draftFindingRecord.evidenceMapRowId === value.evidenceMapRowId &&
-        value.draftFindingResult.draftFindingRecord.requirementId === (value.requirement as ReportPresentationObject["requirement"]).requirementId &&
-        value.draftFindingResult.draftFindingRecord.findingId === ("draft:" + value.evidenceMapRowId)));
+    value.conformanceConclusion.conclusion !== "NOT_ASSESSED";
 }
 
 function rowIdFrom(candidate: unknown): string | null {

--- a/src/lib/evidence/reportPresentationObject.ts
+++ b/src/lib/evidence/reportPresentationObject.ts
@@ -96,6 +96,16 @@ function hasAllowedKeys(value: Record<string, unknown>, keys: readonly string[])
   return Object.keys(value).every((key) => keys.includes(key));
 }
 
+function hasRequiredKeys(
+  value: Record<string, unknown>,
+  requiredKeys: readonly string[],
+  optionalKeys: readonly string[],
+): boolean {
+  const allowedKeys = [...requiredKeys, ...optionalKeys];
+  return requiredKeys.every((key) => Object.prototype.hasOwnProperty.call(value, key)) &&
+    hasAllowedKeys(value, allowedKeys);
+}
+
 function isEvidenceProvenance(value: unknown): boolean {
   if (!isRecord(value) || !hasOnlyKeys(value, ["docId", "page", "sectionPath", "spanId", "sectionHeading", "sourceType"])) {
     return false;
@@ -134,21 +144,22 @@ function isStrictEvidenceMapFields(value: Record<string, unknown>): boolean {
   return true;
 }
 
-/** Strict runtime validator for the immutable Phase 6 boundary. */
-export function isReportPresentationObject(value: unknown): value is ReportPresentationObject {
-  if (!isRecord(value) || !hasAllowedKeys(value, [
-    "profile", "evidenceMapRowId", "requirement", "methodology", "upstreamStatus", "applicabilityResult",
-    "conformanceConclusion", "draftFindingResult", "acceptedEvidence", "rejectedEvidence", "assessmentReason",
-    "clientAction", "searchCoverage", "sourceDocument", "evidenceProvenance", "finalizationActorRef", "finalizedAt",
-    "finalizationBasis", "reviewHistoryRef", "evidenceMapContractVersion", "reviewPolicyVersion", "presentationContractVersion",
-    "machineProposalTraceability", "reviewState", "sharedProjectFacts", "assumptions",
-  ])) return false;
+const requiredPresentationKeys = [
+  "profile", "evidenceMapRowId", "requirement", "methodology", "upstreamStatus", "applicabilityResult",
+  "conformanceConclusion", "draftFindingResult", "acceptedEvidence", "rejectedEvidence", "assessmentReason",
+  "clientAction", "searchCoverage", "sourceDocument", "evidenceProvenance", "evidenceMapContractVersion",
+  "reviewPolicyVersion", "presentationContractVersion", "machineProposalTraceability",
+] as const;
+const releaseMetadataKeys = ["finalizationActorRef", "finalizedAt", "finalizationBasis", "reviewHistoryRef"] as const;
+const optionalPresentationKeys = ["reviewState", "sharedProjectFacts", "assumptions"] as const;
+
+function parseReportPresentationInput(value: unknown, strict: boolean): value is ReportPresentationObject {
+  if (!isRecord(value) || !hasRequiredKeys(value, requiredPresentationKeys, [...releaseMetadataKeys, ...optionalPresentationKeys])) return false;
+  if (strict && !releaseMetadataKeys.every((key) => Object.prototype.hasOwnProperty.call(value, key))) return false;
   if (value.profile !== "GENERIC_PRE_VALIDATION" || !hasText(value.evidenceMapRowId) || !hasText(value.upstreamStatus) ||
       !hasText(value.assessmentReason) || (value.clientAction !== null && !hasText(value.clientAction)) ||
-      (value.finalizationActorRef !== undefined && typeof value.finalizationActorRef !== "string") ||
-      (value.finalizedAt !== undefined && typeof value.finalizedAt !== "string") ||
-      (value.finalizationBasis !== undefined && typeof value.finalizationBasis !== "string") ||
-      (value.reviewHistoryRef !== undefined && typeof value.reviewHistoryRef !== "string") ||
+      !releaseMetadataKeys.every((key) => value[key] === undefined || typeof value[key] === "string") ||
+      (strict && !releaseMetadataKeys.every((key) => hasText(value[key]))) ||
       !hasText(value.evidenceMapContractVersion) || !hasText(value.reviewPolicyVersion) ||
       value.presentationContractVersion !== PRESENTATION_CONTRACT_VERSION ||
       (value.reviewState !== undefined && value.reviewState !== "current" && value.reviewState !== "pending_review" && value.reviewState !== "reopened" && value.reviewState !== "superseded" && value.reviewState !== "stale") ||
@@ -160,8 +171,25 @@ export function isReportPresentationObject(value: unknown): value is ReportPrese
   if (value.machineProposalTraceability !== null &&
       (!isRecord(value.machineProposalTraceability) || !hasOnlyKeys(value.machineProposalTraceability, ["source", "evidenceMapRowId"]) ||
        value.machineProposalTraceability.source !== "EVIDENCE_MAP" || value.machineProposalTraceability.evidenceMapRowId !== value.evidenceMapRowId)) return false;
-  return value.applicabilityResult.applicability !== "NOT_ASSESSED" &&
-    value.conformanceConclusion.conclusion !== "NOT_ASSESSED";
+  if (value.applicabilityResult.applicability === "NOT_ASSESSED" || value.conformanceConclusion.conclusion === "NOT_ASSESSED") return false;
+  if (!strict) return true;
+  const draftRecord = value.draftFindingResult.draftFindingRecord;
+  return value.applicabilityResult.evidenceMapRowId === value.evidenceMapRowId &&
+    value.conformanceConclusion.evidenceMapRowId === value.evidenceMapRowId &&
+    (draftRecord === null ||
+      (draftRecord.evidenceMapRowId === value.evidenceMapRowId &&
+        draftRecord.requirementId === (value.requirement as ReportPresentationObject["requirement"]).requirementId &&
+        draftRecord.findingId === "draft:" + value.evidenceMapRowId));
+}
+
+/** Strict runtime validator for the immutable Phase 6 boundary. */
+export function isReportPresentationObject(value: unknown): value is ReportPresentationObject {
+  return parseReportPresentationInput(value, true);
+}
+
+/** Permissive structural parser used by Phase 7 before release-safety blockers are evaluated. */
+export function isReportPresentationInput(value: unknown): value is ReportPresentationObject {
+  return parseReportPresentationInput(value, false);
 }
 
 function rowIdFrom(candidate: unknown): string | null {

--- a/tests/lib/evidence/presentationGate.test.ts
+++ b/tests/lib/evidence/presentationGate.test.ts
@@ -7,185 +7,80 @@ import { evaluatePresentationGate, evaluatePresentationReportGate } from "@/lib/
 
 const provenance = { docId: "doc-1", page: 2, sectionPath: ["3"], spanId: "span-1", sectionHeading: "Evidence", sourceType: "PDD" };
 function row(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
-  return {
-    rowId: "row-1",
-    requirement: { requirementId: "req-1", requirementReference: "REQ-1", requirementText: "A requirement." },
-    methodology: { methodologyId: "method-1", rulebookVersion: "v1.0" },
-    upstreamStatus: "FOUND", applicabilityState: "APPLICABLE",
-    acceptedEvidence: [{ evidenceId: "accepted-1", quote: "Evidence.", provenance }], rejectedEvidence: [],
-    assessmentReason: "Reviewed.", clientAction: null,
-    searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null },
-    sourceDocument: { documentId: "doc-1", documentName: "source.pdf", contentSha256: "hash" }, evidenceProvenance: [provenance],
-    finalizationState: "finalized", finalizationActorRef: "actor-1", finalizedAt: "2026-07-10T00:00:00Z",
-    finalizationBasis: "reviewed", reviewHistoryRef: "history-1", evidenceMapContractVersion: "v1", reviewPolicyVersion: "policy-v1",
-    ...overrides,
-  };
+  return { rowId: "row-1", requirement: { requirementId: "req-1", requirementReference: "REQ-1", requirementText: "Requirement." },
+    methodology: { methodologyId: "method-1", rulebookVersion: "v1" }, upstreamStatus: "FOUND", applicabilityState: "APPLICABLE",
+    acceptedEvidence: [{ evidenceId: "accepted-1", quote: "Evidence.", provenance }], rejectedEvidence: [], assessmentReason: "Reviewed.", clientAction: null,
+    searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null }, sourceDocument: { documentId: "doc-1", documentName: "source.pdf", contentSha256: "hash" },
+    evidenceProvenance: [provenance], finalizationState: "finalized", finalizationActorRef: "actor-1", finalizedAt: "2026-07-10T00:00:00Z", finalizationBasis: "reviewed",
+    reviewHistoryRef: "history-1", evidenceMapContractVersion: "v1", reviewPolicyVersion: "policy-v1", ...overrides };
 }
-const assessment: ConformanceAssessmentInput = {
-  requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE",
-  versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE",
-};
-function presentation(candidate: EvidenceMapRow = row(), conformanceInput: ConformanceAssessmentInput = assessment): ReportPresentationObject {
-  const applicability = deriveApplicability(candidate, { decision: candidate.applicabilityState === "NOT_APPLICABLE" ? "NOT_APPLICABLE" : "APPLICABLE", decisionBasis: "Explicit basis." });
-  const conformance = deriveConformanceConclusion(candidate, applicability, conformanceInput);
-  const draft = deriveDraftFinding(candidate, conformance, { draftFindingType: null, findingBasis: null, reviewerAssessment: null });
-  const result = createReportPresentationObject(candidate, applicability, conformance, draft);
-  if (!result.ready) throw new Error("Expected a valid presentation object");
+const assessed: ConformanceAssessmentInput = { requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE", versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE" };
+function presentation(candidate: EvidenceMapRow = row(), assessment: ConformanceAssessmentInput = assessed): ReportPresentationObject {
+  const applicability = deriveApplicability(candidate, { decision: candidate.applicabilityState === "NOT_APPLICABLE" ? "NOT_APPLICABLE" : "APPLICABLE", decisionBasis: "Basis." });
+  const conclusion = deriveConformanceConclusion(candidate, applicability, assessment);
+  const draft = deriveDraftFinding(candidate, conclusion, { draftFindingType: null, findingBasis: null, reviewerAssessment: null });
+  const result = createReportPresentationObject(candidate, applicability, conclusion, draft);
+  if (!result.ready) throw new Error("Expected presentation");
   return result.presentation;
 }
-function withChanges(value: ReportPresentationObject, changes: Record<string, unknown>): unknown {
-  return { ...value, ...changes };
-}
-function expectDeepFrozen(value: unknown): void {
-  if (value === null || typeof value !== "object") return;
-  expect(Object.isFrozen(value)).toBe(true);
-  Object.values(value).forEach(expectDeepFrozen);
-}
+const input = (value: ReportPresentationObject, reviewState?: "CURRENT" | "PENDING_REVIEW" | "REOPENED" | "SUPERSEDED" | "STALE") => reviewState === undefined ? { presentation: value } : { presentation: value, reviewState };
+function deepFrozen(value: unknown): void { if (value && typeof value === "object") { expect(Object.isFrozen(value)).toBe(true); Object.values(value).forEach(deepFrozen); } }
 
 describe("presentation gates", () => {
-  it("passes a complete valid presentation object", () => {
-    const result = evaluatePresentationGate(presentation());
-    expect(result).toMatchObject({ releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY" });
-    expect(evaluatePresentationReportGate([presentation()])).toMatchObject({ releaseReady: true, crossRowOutcome: "NOT_EVALUATED" });
+  it("distinguishes malformed and empty reports", () => {
+    expect(evaluatePresentationReportGate({})).toMatchObject({ releaseState: "BLOCKED", blockedBy: [{ category: "invalid_report_input" }] });
+    expect(evaluatePresentationReportGate([])).toMatchObject({ releaseState: "BLOCKED", blockedBy: [{ category: "empty_report" }] });
   });
-
-  it("blocks an empty report", () => {
-    expect(evaluatePresentationReportGate([])).toMatchObject({
-      releaseReady: false, releaseState: "BLOCKED", crossRowOutcome: "NOT_EVALUATED",
-      blockedBy: [{ category: "empty_report" }],
-    });
+  it("passes a valid linked row and reports a single row as NOT_EVALUATED", () => {
+    expect(evaluatePresentationReportGate([input(presentation())])).toMatchObject({ releaseReady: true, crossRowOutcome: "NOT_EVALUATED" });
   });
-
-  it("uses INTERNAL_REVIEW_ONLY for warning-only reports", () => {
-    expect(evaluatePresentationReportGate([withChanges(presentation(), { reviewState: "pending_review" })])).toMatchObject({
-      releaseReady: false, releaseState: "INTERNAL_REVIEW_ONLY", crossRowOutcome: "WARNING",
-      warnings: [{ category: "review_pending" }],
-    });
+  it("uses typed review state without changing Phase 6", () => {
+    expect(evaluatePresentationGate(input(presentation(), "PENDING_REVIEW"))).toMatchObject({ releaseState: "INTERNAL_REVIEW_ONLY", crossRowOutcome: "WARNING" });
+    expect(evaluatePresentationGate(input(presentation(), "REOPENED"))).toMatchObject({ releaseState: "BLOCKED", blockedBy: [{ category: "review_state_not_current" }] });
   });
-
-  it.each([
-    ["malformed presentation", null, "invalid_presentation_object"],
-    ["missing review history", withChanges(presentation(), { reviewHistoryRef: "" }), "review_history_missing"],
-    ["untraceable finalization", withChanges(presentation(), { finalizationActorRef: "" }), "finalization_identity_missing"],
-    ["inconsistent applicability", withChanges(presentation(), { applicabilityResult: { applicability: "APPLICABLE", evidenceMapRowId: "other", basis: "explicit_applicable_decision", decisionBasis: "Basis." } }), "applicability_inconsistent"],
-    ["unsupported conformance evidence", withChanges(presentation(), { acceptedEvidence: [] }), "evidence_insufficient_for_conformance"],
-    ["incomplete search coverage", withChanges(presentation(), { searchCoverage: { searched: false, searchedDocumentIds: [], notes: null } }), "search_coverage_incomplete"],
-    ["missing provenance", withChanges(presentation(), { evidenceProvenance: [] }), "provenance_incomplete"],
-    ["unresolved methodology version", withChanges(presentation(), { methodology: { methodologyId: "method-1", rulebookVersion: "unresolved" } }), "methodology_version_unresolved"],
-    ["unsupported contract version", withChanges(presentation(), { evidenceMapContractVersion: "v2" }), "unsupported_contract_version"],
-    ["reopened row", withChanges(presentation(), { reviewState: "reopened" }), "review_state_not_current"],
-    ["superseded row", withChanges(presentation(), { reviewState: "superseded" }), "review_state_not_current"],
-  ])("blocks %s", (_name, input, category) => {
-    const result = evaluatePresentationGate(input);
-    expect(result.releaseReady).toBe(false);
-    if (result.releaseReady) throw new Error("Expected a blocked result");
-    expect(result.blockedBy).toContainEqual(expect.objectContaining({ category }));
+  it.each([["MISSING"], ["UNCLEAR"]])("blocks %s from CONFORMS", (upstreamStatus) => {
+    const candidate = row({ upstreamStatus, acceptedEvidence: [{ evidenceId: "a", quote: "q", provenance }] });
+    const forged = { ...presentation(), upstreamStatus };
+    expect(evaluatePresentationGate(input(forged))).toMatchObject({ releaseState: "BLOCKED", blockedBy: [{ category: "conclusion_invariant_violation" }] });
+    expect(candidate.upstreamStatus).toBe(upstreamStatus);
   });
-
-  it("allows ACTION_REQUIRED to preserve missing evidence", () => {
-    const candidate = row({ upstreamStatus: "MISSING", acceptedEvidence: [], searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null } });
-    const applicability = deriveApplicability(candidate, { decision: "APPLICABLE", decisionBasis: "Explicit basis." });
-    const conformance = deriveConformanceConclusion(candidate, applicability, { ...assessment, requirementSupport: "NOT_SUPPORTED" });
-    const draft = deriveDraftFinding(candidate, conformance, { draftFindingType: "NCR_CANDIDATE", findingBasis: "Evidence is missing.", reviewerAssessment: "Candidate." });
-    const packaged = createReportPresentationObject(candidate, applicability, conformance, draft);
-    if (!packaged.ready) throw new Error("Expected packaging to succeed");
-    expect(evaluatePresentationGate(packaged.presentation)).toMatchObject({ releaseReady: true });
+  it("blocks unknown upstream status and CONFORMS draft findings", () => {
+    const unknown = evaluatePresentationGate(input({ ...presentation(), upstreamStatus: "OTHER" }));
+    if (unknown.releaseReady || unknown.releaseState !== "BLOCKED") throw new Error("Expected blocked");
+    expect(unknown.blockedBy).toEqual(expect.arrayContaining([expect.objectContaining({ category: "unsupported_upstream_status" })]));
+    const p = presentation();
+    const drafted = evaluatePresentationGate(input({ ...p, draftFindingResult: { draftFindingType: "NIR_CANDIDATE", draftFindingRecord: { findingId: "draft:row-1", profile: "GENERIC_PRE_VALIDATION", evidenceMapRowId: "row-1", requirementId: "req-1", conformanceConclusion: "ACTION_REQUIRED", draftFindingType: "NIR_CANDIDATE", findingBasis: "Basis", clientResponse: null, reviewerAssessment: "Review", closingRemarks: null } } }));
+    if (drafted.releaseReady || drafted.releaseState !== "BLOCKED") throw new Error("Expected blocked");
+    expect(drafted.blockedBy).toEqual(expect.arrayContaining([expect.objectContaining({ category: "conclusion_invariant_violation" })]));
   });
-
-  it("blocks duplicate rows, conflicting requirement conclusions, and methodology drift", () => {
-    const first = presentation();
-    const duplicate = presentation(row({ rowId: "row-1", requirement: { ...row().requirement, requirementId: "req-2" } }));
-    const conflict = presentation(row({ rowId: "row-2", upstreamStatus: "MISSING", acceptedEvidence: [], searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null } }), { ...assessment, requirementSupport: "NOT_SUPPORTED" });
-    const drift = presentation(row({ rowId: "row-3", requirement: { requirementId: "req-3", requirementReference: "REQ-3", requirementText: "Another requirement." }, methodology: { methodologyId: "other-method", rulebookVersion: "v2.0" } }));
-    const result = evaluatePresentationReportGate([first, duplicate, conflict, drift]);
-    expect(result.releaseReady).toBe(false);
-    if (!result.releaseReady) expect(result.blockedBy.map((blocker) => blocker.category)).toEqual([
-      "duplicate_row_identity", "conflicting_requirement_conclusion", "inconsistent_methodology_identity",
-    ]);
+  it("allows missing-evidence ACTION_REQUIRED without provenance", () => {
+    const candidate = row({ upstreamStatus: "MISSING", acceptedEvidence: [], rejectedEvidence: [], evidenceProvenance: [] });
+    expect(evaluatePresentationGate(input(presentation(candidate, { ...assessed, requirementSupport: "NOT_SUPPORTED" })))).toMatchObject({ releaseReady: true });
   });
-
-  it("blocks contradictory applicability and accepted-versus-rejected evidence", () => {
-    const applicable = presentation();
-    const notApplicable = presentation(row({
-      rowId: "row-2", applicabilityState: "NOT_APPLICABLE", requirement: row().requirement,
-      acceptedEvidence: [], rejectedEvidence: [{ evidenceId: "accepted-1", quote: "Evidence.", rejectionReason: "Unreliable evidence.", provenance }],
-    }), { ...assessment, requirementSupport: "NOT_SUPPORTED" });
-    const result = evaluatePresentationReportGate([applicable, notApplicable]);
-    expect(result.releaseReady).toBe(false);
-    if (!result.releaseReady) expect(result.blockedBy.map((blocker) => blocker.category)).toEqual(expect.arrayContaining([
-      "conflicting_applicability", "cross_row_evidence_conflict",
-    ]));
+  it("blocks orphan and unsearched evidence provenance", () => {
+    const p = presentation();
+    expect(evaluatePresentationGate(input({ ...p, evidenceProvenance: [] }))).toMatchObject({ blockedBy: [{ category: "evidence_provenance_not_linked" }] });
+    expect(evaluatePresentationGate(input({ ...p, searchCoverage: { ...p.searchCoverage, searchedDocumentIds: [] } }))).toMatchObject({ blockedBy: [{ category: "evidence_document_not_searched" }] });
   });
-
-  it("detects contradictory shared facts and assumptions when supplied", () => {
-    const first = withChanges(presentation(), { sharedProjectFacts: { location: "A" }, assumptions: ["baseline is fixed"] });
-    const second = withChanges(presentation(row({ rowId: "row-2", requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Another requirement." } })), {
-      sharedProjectFacts: { location: "B" }, assumptions: ["BASELINE IS FIXED"],
-    });
-    const result = evaluatePresentationReportGate([first, second]);
-    expect(result).toMatchObject({ releaseReady: false });
-    if (!result.releaseReady) expect(result.blockedBy.map((blocker) => blocker.category)).toEqual(expect.arrayContaining([
-      "contradictory_shared_fact",
-    ]));
+  it("allows multi-method reports and scopes requirement collisions by methodology/version", () => {
+    const other = presentation(row({ rowId: "row-2", methodology: { methodologyId: "method-2", rulebookVersion: "v1" } }));
+    expect(evaluatePresentationReportGate([input(presentation()), input(other)])).toMatchObject({ releaseReady: true, crossRowOutcome: "NOT_EVALUATED" });
   });
-
-  it("treats case and whitespace assumption differences as equivalent", () => {
-    const first = withChanges(presentation(), { assumptions: ["baseline   is fixed"] });
-    const second = withChanges(presentation(row({ rowId: "row-2", requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Another requirement." } })), {
-      assumptions: [" BASELINE IS FIXED "],
-    });
-    expect(evaluatePresentationReportGate([first, second])).toMatchObject({ releaseReady: true });
+  it("blocks conflicting versions and conclusions within one composite requirement identity", () => {
+    const version = presentation(row({ rowId: "row-2", methodology: { methodologyId: "method-1", rulebookVersion: "v2" }, requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Other." } }));
+    expect(evaluatePresentationReportGate([input(presentation()), input(version)])).toMatchObject({ blockedBy: [{ category: "conflicting_methodology_version" }] });
+    const action = presentation(row({ rowId: "row-3", upstreamStatus: "MISSING", acceptedEvidence: [], rejectedEvidence: [], evidenceProvenance: [], searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null } }), { ...assessed, requirementSupport: "NOT_SUPPORTED" });
+    expect(evaluatePresentationReportGate([input(presentation()), input(action)])).toMatchObject({ blockedBy: [{ category: "conflicting_requirement_conclusion" }] });
   });
-
-  it("detects genuinely conflicting assumptions", () => {
-    const first = withChanges(presentation(), { assumptions: ["baseline is fixed"] });
-    const second = withChanges(presentation(row({ rowId: "row-2", requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Another requirement." } })), {
-      assumptions: ["baseline is variable"],
-    });
-    const result = evaluatePresentationReportGate([first, second]);
-    expect(result).toMatchObject({ releaseReady: false, blockedBy: [{ category: "contradictory_assumption" }] });
+  it("does not turn a per-row failure into a cross-row contradiction", () => {
+    expect(evaluatePresentationReportGate([input({ ...presentation(), finalizedAt: "not-a-date" })])).toMatchObject({ releaseState: "BLOCKED", crossRowOutcome: "NOT_EVALUATED", blockedBy: [{ category: "finalized_at_invalid" }] });
   });
-
-  it("uses provenance rather than evidenceId for cross-row evidence conflicts", () => {
-    const first = presentation();
-    const unrelated = presentation(row({
-      rowId: "row-2",
-      requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Another requirement." },
-      acceptedEvidence: [{ evidenceId: "accepted-1", quote: "Other evidence.", provenance: { ...provenance, docId: "doc-2", spanId: "span-2" } }],
-    }));
-    expect(evaluatePresentationReportGate([first, unrelated])).toMatchObject({ releaseReady: true });
-    const rejectedSameSpan = presentation(row({
-      rowId: "row-3",
-      requirement: { requirementId: "req-3", requirementReference: "REQ-3", requirementText: "Third requirement." },
-      acceptedEvidence: [],
-      rejectedEvidence: [{ evidenceId: "different-id", quote: "Rejected evidence.", rejectionReason: "Unreliable evidence.", provenance }],
-    }), { ...assessment, requirementSupport: "NOT_SUPPORTED" });
-    expect(evaluatePresentationReportGate([first, rejectedSameSpan])).toMatchObject({
-      releaseReady: false, blockedBy: [{ category: "cross_row_evidence_conflict" }],
-    });
-  });
-
-  it("reports PASS when supplied cross-row facts agree", () => {
-    const first = withChanges(presentation(), { sharedProjectFacts: { location: "A" }, assumptions: ["baseline is fixed"] });
-    const second = withChanges(presentation(row({ rowId: "row-2", requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Another requirement." } })), {
-      sharedProjectFacts: { location: "A" }, assumptions: ["baseline is fixed"],
-    });
-    expect(evaluatePresentationReportGate([first, second])).toMatchObject({
-      releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY", crossRowOutcome: "PASS",
-    });
-  });
-
-  it("preserves evidence, leaves inputs unchanged, and freezes output", () => {
-    const input = structuredClone(presentation());
-    const before = structuredClone(input);
-    const result = evaluatePresentationGate(input);
-    expect(input).toEqual(before);
-    expect(result).toMatchObject({ releaseReady: true });
-    if (!result.releaseReady) throw new Error("Expected a ready result");
-    expect(result.presentations[0]).not.toBe(input);
-    expectDeepFrozen(result);
-    input.acceptedEvidence[0].quote = "Mutated caller input.";
+  it("deep-clones and freezes results without formal authority language", () => {
+    const mutable = structuredClone(presentation());
+    const result = evaluatePresentationGate(input(mutable));
+    if (result.releaseReady === false && result.releaseState === "BLOCKED") throw new Error("Expected ready");
+    deepFrozen(result); mutable.acceptedEvidence[0].quote = "changed";
     expect(result.presentations[0].acceptedEvidence[0].quote).toBe("Evidence.");
-    expect(JSON.stringify(result)).not.toMatch(/issued|approved|validated|verified|authority/i);
+    expect(JSON.stringify(result)).not.toMatch(/approved by vvb|validated|verified|issued/i);
   });
 });

--- a/tests/lib/evidence/presentationGate.test.ts
+++ b/tests/lib/evidence/presentationGate.test.ts
@@ -1,0 +1,96 @@
+import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
+import { deriveConformanceConclusion, type ConformanceAssessmentInput } from "@/lib/evidence/conformanceConclusionContract";
+import { deriveDraftFinding } from "@/lib/evidence/draftFindingContract";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+import { createReportPresentationObject, type ReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
+import { evaluatePresentationGate, evaluatePresentationReportGate } from "@/lib/evidence/presentationGate";
+
+const provenance = { docId: "doc-1", page: 2, sectionPath: ["3"], spanId: "span-1", sectionHeading: "Evidence", sourceType: "PDD" };
+function row(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
+  return {
+    rowId: "row-1",
+    requirement: { requirementId: "req-1", requirementReference: "REQ-1", requirementText: "A requirement." },
+    methodology: { methodologyId: "method-1", rulebookVersion: "v1.0" },
+    upstreamStatus: "FOUND", applicabilityState: "APPLICABLE",
+    acceptedEvidence: [{ evidenceId: "accepted-1", quote: "Evidence.", provenance }], rejectedEvidence: [],
+    assessmentReason: "Reviewed.", clientAction: null,
+    searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null },
+    sourceDocument: { documentId: "doc-1", documentName: "source.pdf", contentSha256: "hash" }, evidenceProvenance: [provenance],
+    finalizationState: "finalized", finalizationActorRef: "actor-1", finalizedAt: "2026-07-10T00:00:00Z",
+    finalizationBasis: "reviewed", reviewHistoryRef: "history-1", evidenceMapContractVersion: "v1", reviewPolicyVersion: "policy-v1",
+    ...overrides,
+  };
+}
+const assessment: ConformanceAssessmentInput = {
+  requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE",
+  versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE",
+};
+function presentation(candidate: EvidenceMapRow = row(), conformanceInput: ConformanceAssessmentInput = assessment): ReportPresentationObject {
+  const applicability = deriveApplicability(candidate, { decision: "APPLICABLE", decisionBasis: "Explicit basis." });
+  const conformance = deriveConformanceConclusion(candidate, applicability, conformanceInput);
+  const draft = deriveDraftFinding(candidate, conformance, { draftFindingType: null, findingBasis: null, reviewerAssessment: null });
+  const result = createReportPresentationObject(candidate, applicability, conformance, draft);
+  if (!result.ready) throw new Error("Expected a valid presentation object");
+  return result.presentation;
+}
+function withChanges(value: ReportPresentationObject, changes: Record<string, unknown>): unknown {
+  return { ...value, ...changes };
+}
+
+describe("presentation gates", () => {
+  it("passes a complete valid presentation object", () => {
+    const result = evaluatePresentationGate(presentation());
+    expect(result).toMatchObject({ releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY" });
+  });
+
+  it.each([
+    ["malformed presentation", null, "invalid_presentation_object"],
+    ["missing review history", withChanges(presentation(), { reviewHistoryRef: "" }), "invalid_presentation_object"],
+    ["untraceable finalization", withChanges(presentation(), { finalizationActorRef: "" }), "invalid_presentation_object"],
+    ["inconsistent applicability", withChanges(presentation(), { applicabilityResult: { applicability: "APPLICABLE", evidenceMapRowId: "other", basis: "explicit_applicable_decision", decisionBasis: "Basis." } }), "invalid_presentation_object"],
+    ["unsupported conformance evidence", withChanges(presentation(), { acceptedEvidence: [] }), "evidence_insufficient_for_conformance"],
+    ["incomplete search coverage", withChanges(presentation(), { searchCoverage: { searched: false, searchedDocumentIds: [], notes: null } }), "search_coverage_incomplete"],
+    ["missing provenance", withChanges(presentation(), { evidenceProvenance: [] }), "provenance_incomplete"],
+    ["unresolved methodology version", withChanges(presentation(), { methodology: { methodologyId: "method-1", rulebookVersion: "unresolved" } }), "methodology_version_unresolved"],
+    ["unsupported contract version", withChanges(presentation(), { evidenceMapContractVersion: "v2" }), "unsupported_contract_version"],
+    ["reopened row", withChanges(presentation(), { reviewState: "reopened" }), "review_state_not_current"],
+    ["superseded row", withChanges(presentation(), { reviewState: "superseded" }), "review_state_not_current"],
+  ])("blocks %s", (_name, input, category) => {
+    const result = evaluatePresentationGate(input);
+    expect(result.releaseReady).toBe(false);
+    if (result.releaseReady) throw new Error("Expected a blocked result");
+    expect(result.blockedBy).toContainEqual(expect.objectContaining({ category }));
+  });
+
+  it("allows ACTION_REQUIRED to preserve missing evidence", () => {
+    const candidate = row({ upstreamStatus: "MISSING", acceptedEvidence: [], searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null } });
+    const applicability = deriveApplicability(candidate, { decision: "APPLICABLE", decisionBasis: "Explicit basis." });
+    const conformance = deriveConformanceConclusion(candidate, applicability, { ...assessment, requirementSupport: "NOT_SUPPORTED" });
+    const draft = deriveDraftFinding(candidate, conformance, { draftFindingType: "NCR_CANDIDATE", findingBasis: "Evidence is missing.", reviewerAssessment: "Candidate." });
+    const packaged = createReportPresentationObject(candidate, applicability, conformance, draft);
+    if (!packaged.ready) throw new Error("Expected packaging to succeed");
+    expect(evaluatePresentationGate(packaged.presentation)).toMatchObject({ releaseReady: true });
+  });
+
+  it("blocks duplicate rows, conflicting requirement conclusions, and methodology drift", () => {
+    const first = presentation();
+    const duplicate = presentation(row({ rowId: "row-1", requirement: { ...row().requirement, requirementId: "req-2" } }));
+    const conflict = presentation(row({ rowId: "row-2", upstreamStatus: "MISSING", acceptedEvidence: [], searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null } }), { ...assessment, requirementSupport: "NOT_SUPPORTED" });
+    const drift = presentation(row({ rowId: "row-3", requirement: { requirementId: "req-3", requirementReference: "REQ-3", requirementText: "Another requirement." }, methodology: { methodologyId: "other-method", rulebookVersion: "v2.0" } }));
+    const result = evaluatePresentationReportGate([first, duplicate, conflict, drift]);
+    expect(result.releaseReady).toBe(false);
+    if (!result.releaseReady) expect(result.blockedBy.map((blocker) => blocker.category)).toEqual([
+      "duplicate_row_identity", "conflicting_requirement_conclusion", "inconsistent_methodology_identity",
+    ]);
+  });
+
+  it("preserves evidence, leaves inputs unchanged, and freezes output", () => {
+    const input = presentation();
+    const before = structuredClone(input);
+    const result = evaluatePresentationGate(input);
+    expect(input).toEqual(before);
+    expect(result).toMatchObject({ releaseReady: true });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(JSON.stringify(result)).not.toMatch(/issued|approved|validated|verified|authority/i);
+  });
+});

--- a/tests/lib/evidence/presentationGate.test.ts
+++ b/tests/lib/evidence/presentationGate.test.ts
@@ -125,8 +125,44 @@ describe("presentation gates", () => {
     const result = evaluatePresentationReportGate([first, second]);
     expect(result).toMatchObject({ releaseReady: false });
     if (!result.releaseReady) expect(result.blockedBy.map((blocker) => blocker.category)).toEqual(expect.arrayContaining([
-      "contradictory_shared_fact", "contradictory_assumption",
+      "contradictory_shared_fact",
     ]));
+  });
+
+  it("treats case and whitespace assumption differences as equivalent", () => {
+    const first = withChanges(presentation(), { assumptions: ["baseline   is fixed"] });
+    const second = withChanges(presentation(row({ rowId: "row-2", requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Another requirement." } })), {
+      assumptions: [" BASELINE IS FIXED "],
+    });
+    expect(evaluatePresentationReportGate([first, second])).toMatchObject({ releaseReady: true });
+  });
+
+  it("detects genuinely conflicting assumptions", () => {
+    const first = withChanges(presentation(), { assumptions: ["baseline is fixed"] });
+    const second = withChanges(presentation(row({ rowId: "row-2", requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Another requirement." } })), {
+      assumptions: ["baseline is variable"],
+    });
+    const result = evaluatePresentationReportGate([first, second]);
+    expect(result).toMatchObject({ releaseReady: false, blockedBy: [{ category: "contradictory_assumption" }] });
+  });
+
+  it("uses provenance rather than evidenceId for cross-row evidence conflicts", () => {
+    const first = presentation();
+    const unrelated = presentation(row({
+      rowId: "row-2",
+      requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Another requirement." },
+      acceptedEvidence: [{ evidenceId: "accepted-1", quote: "Other evidence.", provenance: { ...provenance, docId: "doc-2", spanId: "span-2" } }],
+    }));
+    expect(evaluatePresentationReportGate([first, unrelated])).toMatchObject({ releaseReady: true });
+    const rejectedSameSpan = presentation(row({
+      rowId: "row-3",
+      requirement: { requirementId: "req-3", requirementReference: "REQ-3", requirementText: "Third requirement." },
+      acceptedEvidence: [],
+      rejectedEvidence: [{ evidenceId: "different-id", quote: "Rejected evidence.", rejectionReason: "Unreliable evidence.", provenance }],
+    }), { ...assessment, requirementSupport: "NOT_SUPPORTED" });
+    expect(evaluatePresentationReportGate([first, rejectedSameSpan])).toMatchObject({
+      releaseReady: false, blockedBy: [{ category: "cross_row_evidence_conflict" }],
+    });
   });
 
   it("reports PASS when supplied cross-row facts agree", () => {

--- a/tests/lib/evidence/presentationGate.test.ts
+++ b/tests/lib/evidence/presentationGate.test.ts
@@ -26,7 +26,7 @@ const assessment: ConformanceAssessmentInput = {
   versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE",
 };
 function presentation(candidate: EvidenceMapRow = row(), conformanceInput: ConformanceAssessmentInput = assessment): ReportPresentationObject {
-  const applicability = deriveApplicability(candidate, { decision: "APPLICABLE", decisionBasis: "Explicit basis." });
+  const applicability = deriveApplicability(candidate, { decision: candidate.applicabilityState === "NOT_APPLICABLE" ? "NOT_APPLICABLE" : "APPLICABLE", decisionBasis: "Explicit basis." });
   const conformance = deriveConformanceConclusion(candidate, applicability, conformanceInput);
   const draft = deriveDraftFinding(candidate, conformance, { draftFindingType: null, findingBasis: null, reviewerAssessment: null });
   const result = createReportPresentationObject(candidate, applicability, conformance, draft);
@@ -36,18 +36,38 @@ function presentation(candidate: EvidenceMapRow = row(), conformanceInput: Confo
 function withChanges(value: ReportPresentationObject, changes: Record<string, unknown>): unknown {
   return { ...value, ...changes };
 }
+function expectDeepFrozen(value: unknown): void {
+  if (value === null || typeof value !== "object") return;
+  expect(Object.isFrozen(value)).toBe(true);
+  Object.values(value).forEach(expectDeepFrozen);
+}
 
 describe("presentation gates", () => {
   it("passes a complete valid presentation object", () => {
     const result = evaluatePresentationGate(presentation());
     expect(result).toMatchObject({ releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY" });
+    expect(evaluatePresentationReportGate([presentation()])).toMatchObject({ releaseReady: true, crossRowOutcome: "NOT_EVALUATED" });
+  });
+
+  it("blocks an empty report", () => {
+    expect(evaluatePresentationReportGate([])).toMatchObject({
+      releaseReady: false, releaseState: "BLOCKED", crossRowOutcome: "NOT_EVALUATED",
+      blockedBy: [{ category: "empty_report" }],
+    });
+  });
+
+  it("uses INTERNAL_REVIEW_ONLY for warning-only reports", () => {
+    expect(evaluatePresentationReportGate([withChanges(presentation(), { reviewState: "pending_review" })])).toMatchObject({
+      releaseReady: false, releaseState: "INTERNAL_REVIEW_ONLY", crossRowOutcome: "WARNING",
+      warnings: [{ category: "review_pending" }],
+    });
   });
 
   it.each([
     ["malformed presentation", null, "invalid_presentation_object"],
-    ["missing review history", withChanges(presentation(), { reviewHistoryRef: "" }), "invalid_presentation_object"],
-    ["untraceable finalization", withChanges(presentation(), { finalizationActorRef: "" }), "invalid_presentation_object"],
-    ["inconsistent applicability", withChanges(presentation(), { applicabilityResult: { applicability: "APPLICABLE", evidenceMapRowId: "other", basis: "explicit_applicable_decision", decisionBasis: "Basis." } }), "invalid_presentation_object"],
+    ["missing review history", withChanges(presentation(), { reviewHistoryRef: "" }), "review_history_missing"],
+    ["untraceable finalization", withChanges(presentation(), { finalizationActorRef: "" }), "finalization_identity_missing"],
+    ["inconsistent applicability", withChanges(presentation(), { applicabilityResult: { applicability: "APPLICABLE", evidenceMapRowId: "other", basis: "explicit_applicable_decision", decisionBasis: "Basis." } }), "applicability_inconsistent"],
     ["unsupported conformance evidence", withChanges(presentation(), { acceptedEvidence: [] }), "evidence_insufficient_for_conformance"],
     ["incomplete search coverage", withChanges(presentation(), { searchCoverage: { searched: false, searchedDocumentIds: [], notes: null } }), "search_coverage_incomplete"],
     ["missing provenance", withChanges(presentation(), { evidenceProvenance: [] }), "provenance_incomplete"],
@@ -84,13 +104,52 @@ describe("presentation gates", () => {
     ]);
   });
 
+  it("blocks contradictory applicability and accepted-versus-rejected evidence", () => {
+    const applicable = presentation();
+    const notApplicable = presentation(row({
+      rowId: "row-2", applicabilityState: "NOT_APPLICABLE", requirement: row().requirement,
+      acceptedEvidence: [], rejectedEvidence: [{ evidenceId: "accepted-1", quote: "Evidence.", rejectionReason: "Unreliable evidence.", provenance }],
+    }), { ...assessment, requirementSupport: "NOT_SUPPORTED" });
+    const result = evaluatePresentationReportGate([applicable, notApplicable]);
+    expect(result.releaseReady).toBe(false);
+    if (!result.releaseReady) expect(result.blockedBy.map((blocker) => blocker.category)).toEqual(expect.arrayContaining([
+      "conflicting_applicability", "cross_row_evidence_conflict",
+    ]));
+  });
+
+  it("detects contradictory shared facts and assumptions when supplied", () => {
+    const first = withChanges(presentation(), { sharedProjectFacts: { location: "A" }, assumptions: ["baseline is fixed"] });
+    const second = withChanges(presentation(row({ rowId: "row-2", requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Another requirement." } })), {
+      sharedProjectFacts: { location: "B" }, assumptions: ["BASELINE IS FIXED"],
+    });
+    const result = evaluatePresentationReportGate([first, second]);
+    expect(result).toMatchObject({ releaseReady: false });
+    if (!result.releaseReady) expect(result.blockedBy.map((blocker) => blocker.category)).toEqual(expect.arrayContaining([
+      "contradictory_shared_fact", "contradictory_assumption",
+    ]));
+  });
+
+  it("reports PASS when supplied cross-row facts agree", () => {
+    const first = withChanges(presentation(), { sharedProjectFacts: { location: "A" }, assumptions: ["baseline is fixed"] });
+    const second = withChanges(presentation(row({ rowId: "row-2", requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Another requirement." } })), {
+      sharedProjectFacts: { location: "A" }, assumptions: ["baseline is fixed"],
+    });
+    expect(evaluatePresentationReportGate([first, second])).toMatchObject({
+      releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY", crossRowOutcome: "PASS",
+    });
+  });
+
   it("preserves evidence, leaves inputs unchanged, and freezes output", () => {
-    const input = presentation();
+    const input = structuredClone(presentation());
     const before = structuredClone(input);
     const result = evaluatePresentationGate(input);
     expect(input).toEqual(before);
     expect(result).toMatchObject({ releaseReady: true });
-    expect(Object.isFrozen(result)).toBe(true);
+    if (!result.releaseReady) throw new Error("Expected a ready result");
+    expect(result.presentations[0]).not.toBe(input);
+    expectDeepFrozen(result);
+    input.acceptedEvidence[0].quote = "Mutated caller input.";
+    expect(result.presentations[0].acceptedEvidence[0].quote).toBe("Evidence.");
     expect(JSON.stringify(result)).not.toMatch(/issued|approved|validated|verified|authority/i);
   });
 });

--- a/tests/lib/evidence/reportPresentationObject.test.ts
+++ b/tests/lib/evidence/reportPresentationObject.test.ts
@@ -1,7 +1,7 @@
 import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
 import { deriveConformanceConclusion, type ConformanceAssessmentInput } from "@/lib/evidence/conformanceConclusionContract";
 import { deriveDraftFinding } from "@/lib/evidence/draftFindingContract";
-import { createReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
+import { createReportPresentationObject, isReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
 import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
 
 const provenance = { docId: "doc-1", page: 2, sectionPath: ["3", "3.1"], spanId: "span-1", sectionHeading: "Evidence", sourceType: "PDD" };
@@ -35,6 +35,21 @@ function expectDeepFrozen(value: unknown): void {
 }
 
 describe("createReportPresentationObject", () => {
+  it("keeps the strict Phase 6 validator fail-closed for missing metadata and identity mismatch", () => {
+    const candidate = row();
+    const { applicability, conformance, draftFinding } = inputs(candidate);
+    const result = createReportPresentationObject(candidate, applicability, conformance, draftFinding);
+    if (!result.ready) throw new Error("Expected a ready presentation");
+    const missingMetadata = { ...result.presentation };
+    delete (missingMetadata as { finalizationActorRef?: string }).finalizationActorRef;
+    const mismatchedApplicability = {
+      ...result.presentation,
+      applicabilityResult: { ...result.presentation.applicabilityResult, evidenceMapRowId: "other-row" },
+    };
+    expect(isReportPresentationObject(missingMetadata)).toBe(false);
+    expect(isReportPresentationObject(mismatchedApplicability)).toBe(false);
+  });
+
   it("packages a valid finalized row into one immutable presentation object", () => {
     const candidate = row();
     const before = structuredClone(candidate);


### PR DESCRIPTION
## Roadmap
- Slug: vvb-report-presentation-layer
- Phase 7: Presentation Gates

## Scope
Phase 7 now uses a typed PresentationGateInput wrapper. The Phase 6 ReportPresentationObject remains strict, immutable, and unchanged by review-state or cross-row metadata.

## Release states
- PRE_VALIDATION_RELEASE_READY
- INTERNAL_REVIEW_ONLY
- BLOCKED

## Contract behavior
- Strict Phase 6 validation requires all metadata, identities, and schema fields.
- Phase 7 distinguishes invalid report input from an empty report.
- Gate-only review state is typed: CURRENT, PENDING_REVIEW, REOPENED, SUPERSEDED, STALE.
- Conclusions, provenance linkage, searched-document linkage, timestamps, and composite methodology/requirement consistency are checked without prose inference.
- Project facts, assumptions, and accepted/rejected reliability contradictions are NOT_EVALUATED pending typed upstream data.

## Files changed
- src/lib/evidence/reportPresentationObject.ts
- src/lib/evidence/presentationGate.ts
- tests/lib/evidence/reportPresentationObject.test.ts
- tests/lib/evidence/presentationGate.test.ts
- docs/roadmaps/vvb-report-presentation-layer/PHASE_7_PRESENTATION_GATES.md

## Validation
- Focused Phase 2-7 contracts: 6 suites, 107 tests passed.
- npm run lint: passed.
- npm run typecheck: passed.
- npm run roadmap:check: passed.
- git diff --check: passed.

## Explicit non-goals
No Quick Check behavior changes, Evidence Map semantic changes, Phase 3 or Phase 4 changes, gold or Phase 8 fixture changes, report UI, PDF output, legacy terminology, or methodology-specific logic.

Phase 8 was not started and remains out of scope.