### PR TITLE
test: migrate Phase 8 presentation fixtures

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -398,14 +398,15 @@ Current focus:
 - Phase 5 Applicability Contract is complete
 - Phase 6 Report Presentation Object is complete
 - Phase 7 Presentation Gates are complete
-- Phase 8 Fixture Expectation Migration is next
+- Phase 8 Fixture Expectation Migration is complete
+- Phase 9 Readiness Report and UI Consumers is next
 - Review traceability and release controls are explicit downstream requirements
 - Keep the Evidence Map upstream and canonical
 - Keep the Pre-Validation Readiness Report and UI downstream
 
 Not active now:
 - Router status renames
-- Fixture migration
+- Fixture migration is complete
 - Gap report implementation
 - Organization-specific report profiles
 - Formal verifier authority claims
@@ -418,6 +419,6 @@ Not active now:
 6) RC5 — Phase 5: Applicability Contract: Done — Require a basis-backed explicit applicability decision matching the canonical Evidence Map row; block missing, unknown, contradictory, or unevaluated applicability without changing upstream status semantics.
 7) RC6 — Phase 6: Report Presentation Object: Done — Package finalized Evidence Map rows and validated applicability, conformance, and draft-finding results into one immutable generic presentation object with preserved evidence, provenance, review metadata, versions, and identity checks.
 8) RC7 — Phase 7: Presentation Gates: Done — Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates.
-9) RC8 — Phase 8: Fixture Expectation Migration: Next — Migrate fixtures to preserve accepted and rejected evidence and use the Evidence Map-backed draft presentation expectations.
-10) RC9 — Phase 9: Readiness Report and UI Consumers: Planned — Implement downstream Pre-Validation Readiness Report and UI consumers using the finalized Evidence Map presentation contract, with a minimal reviewer workflow, centralized release-gate checks, traceable approve/edit/reopen history, and internal preview when client release is blocked.
+9) RC8 — Phase 8: Fixture Expectation Migration: Done — Migrate reviewed fixture truth through finalized Evidence Map rows and the Phase 2–7 presentation contracts while preserving accepted and rejected evidence, provenance, statuses, and legacy consumers.
+10) RC9 — Phase 9: Readiness Report and UI Consumers: Next — Implement downstream Pre-Validation Readiness Report and UI consumers using the finalized Evidence Map presentation contract, with a minimal reviewer workflow, centralized release-gate checks, traceable approve/edit/reopen history, and internal preview when client release is blocked.
 11) RC10 — Phase 10: Deprecation Review: Planned — Review old labels and organization-specific profiles only after the generic reviewer workflow and release gate are proven through a controlled pilot with qualified validation or verification professionals.

--- a/docs/roadmaps/vvb-report-presentation-layer/PHASE_8_FIXTURE_EXPECTATION_MIGRATION.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PHASE_8_FIXTURE_EXPECTATION_MIGRATION.md
@@ -1,0 +1,78 @@
+# Phase 8: Fixture Expectation Migration
+
+## Migration boundary
+
+Phase 8 migrates reviewed fixture truth at the boundary between the existing
+judgment/report fixture layer and the generic presentation contracts. Existing
+`FOUND`, `UNCLEAR`, `MISSING`, `N/A`, `answered`, `unclear`, and `no_evidence`
+values remain unchanged. The adapter accepts explicit reviewed truth and explicit
+assessment inputs; it does not infer a judgment from prose or status.
+
+The existing Envira and PD_REDD reviewed fixtures remain the upstream truth source.
+Their current report consumers and legacy wording assertions are intentionally not
+rewritten in this phase.
+
+## Old and new flow
+
+The old reviewed flow is:
+
+```text
+judgment fixture -> report-only fields -> legacy report assertions
+```
+
+The migrated presentation flow is:
+
+```text
+reviewed fixture truth
+  -> finalized Evidence Map row
+  -> Phase 3 conclusion input/result
+  -> Phase 4 draft-finding input/result
+  -> Phase 5 applicability result
+  -> Phase 6 ReportPresentationObject
+  -> Phase 7 PresentationGateInput/result
+```
+
+`tests/fixtures/fixturePresentationAdapter.ts` is the reusable packaging adapter.
+It calls the production contracts and preserves the row object, accepted and
+rejected evidence, provenance, source identity, review metadata, methodology
+identity, assessment reason, client action, and upstream status.
+
+## Compatibility and evidence rules
+
+The adapter is additive. Existing Quick Check gold fixtures, report fixtures,
+extraction expectations, router behavior, and methodology rules are untouched.
+Rejected evidence remains a separate typed collection with its rejection reason;
+it is never folded into accepted evidence or inferred from prose. Canonical
+provenance is required for strict Phase 6/7 fixtures, including document ID, page,
+section path, span ID, section heading, and source type.
+
+## Migrated fixture inventory
+
+- Generic reviewed-fixture presentation cases cover FOUND/CONFORMS, UNCLEAR with
+  ACTION_REQUIRED/NIR_CANDIDATE, pending review, contradictory input/BLOCKED,
+  single-row `NOT_EVALUATED`, and compatible multi-row `PASS`.
+- The adapter tests preserve accepted and rejected evidence exactly and verify
+  strict Phase 6 objects and real Phase 7 gate results.
+- Existing Envira VM0007 and PD_REDD VM0007 legacy consumers continue to use their
+  reviewed JSON and report fixtures unchanged.
+
+## Intentionally deferred fixtures
+
+The existing Envira and PD_REDD JSON evidence entries use `spanId: null` in their
+reviewed source truth. They are not converted into strict Phase 6 rows in Phase 8:
+inventing span IDs would manufacture provenance and violate the fixture truth rules.
+They remain covered by their existing PDF anchoring and legacy compatibility tests.
+
+## Test coverage
+
+`tests/lib/evidence/fixturePresentationAdapter.test.ts` covers evidence retention,
+provenance, status preservation, typed expectations, strict packaging, release
+states, cross-row outcomes, contradictory fixtures, and the rejected-evidence
+regression. Existing evidence, preverif, and Quick Check suites provide the legacy
+consumer coverage.
+
+## Phase 9 handoff
+
+Phase 9 can consume the adapter's strict presentation objects and gate results for
+the readiness report and reviewer UI. It must continue to treat the Evidence Map
+as canonical and use the centralized Phase 7 release gate.

--- a/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
+++ b/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
@@ -12,14 +12,15 @@
       "Phase 5 Applicability Contract is complete",
       "Phase 6 Report Presentation Object is complete",
       "Phase 7 Presentation Gates are complete",
-      "Phase 8 Fixture Expectation Migration is next",
+      "Phase 8 Fixture Expectation Migration is complete",
+      "Phase 9 Readiness Report and UI Consumers is next",
       "Review traceability and release controls are explicit downstream requirements",
       "Keep the Evidence Map upstream and canonical",
       "Keep the Pre-Validation Readiness Report and UI downstream"
     ],
     "not_active_now": [
       "Router status renames",
-      "Fixture migration",
+      "Fixture migration is complete",
       "Gap report implementation",
       "Organization-specific report profiles",
       "Formal verifier authority claims"
@@ -69,12 +70,12 @@
     },
     "phase_8_fixture_expectation_migration": {
       "title": "Phase 8: Fixture Expectation Migration",
-      "status": "next",
-      "summary": "Migrate fixtures to preserve accepted and rejected evidence and use the Evidence Map-backed draft presentation expectations."
+      "status": "done",
+      "summary": "Migrate reviewed fixture truth through finalized Evidence Map rows and the Phase 2–7 presentation contracts while preserving accepted and rejected evidence, provenance, statuses, and legacy consumers."
     },
     "phase_9_readiness_report_and_ui_consumers": {
       "title": "Phase 9: Readiness Report and UI Consumers",
-      "status": "planned",
+      "status": "next",
       "summary": "Implement downstream Pre-Validation Readiness Report and UI consumers using the finalized Evidence Map presentation contract, with a minimal reviewer workflow, centralized release-gate checks, traceable approve/edit/reopen history, and internal preview when client release is blocked."
     },
     "phase_10_deprecation_review": {

--- a/tests/fixtures/fixturePresentationAdapter.ts
+++ b/tests/fixtures/fixturePresentationAdapter.ts
@@ -1,0 +1,116 @@
+import {
+  deriveApplicability,
+  type ApplicabilityAssessmentInput,
+  type ApplicabilityResult,
+} from "@/lib/evidence/applicabilityContract";
+import {
+  deriveConformanceConclusion,
+  type ConformanceAssessmentInput,
+  type ConformanceConclusionResult,
+} from "@/lib/evidence/conformanceConclusionContract";
+import {
+  deriveDraftFinding,
+  type DraftFindingAssessmentInput,
+  type DraftFindingResult,
+} from "@/lib/evidence/draftFindingContract";
+import {
+  type EvidenceMapEvidenceProvenance,
+  type EvidenceMapRow,
+} from "@/lib/evidence/evidenceMapDependencyContract";
+import {
+  createReportPresentationObject,
+  type ReportPresentationResult,
+} from "@/lib/evidence/reportPresentationObject";
+import {
+  evaluatePresentationGate,
+  type PresentationGateInput,
+  type PresentationGateResult,
+  type PresentationReviewState,
+} from "@/lib/evidence/presentationGate";
+
+export type ReviewedFixtureEvidence = Readonly<{
+  evidenceId: string;
+  quote: string;
+  provenance: EvidenceMapEvidenceProvenance;
+}>;
+
+export type ReviewedFixtureRejectedEvidence = Readonly<{
+  evidenceId: string;
+  quote: string;
+  rejectionReason: string;
+  provenance: EvidenceMapEvidenceProvenance;
+}>;
+
+/**
+ * The fixture boundary is deliberately explicit. The adapter does not infer
+ * statuses, applicability, conformance, or finding classes from prose.
+ */
+export type ReviewedFixtureTruth = Readonly<{
+  row: EvidenceMapRow;
+  applicabilityAssessment: ApplicabilityAssessmentInput;
+  conformanceAssessment: ConformanceAssessmentInput;
+  draftFindingAssessment: DraftFindingAssessmentInput;
+  reviewState?: PresentationReviewState;
+}>;
+
+export type FixturePresentationMigration = Readonly<{
+  finalizedEvidenceMapRow: EvidenceMapRow;
+  applicabilityInput: ApplicabilityAssessmentInput;
+  applicabilityResult: ApplicabilityResult;
+  conformanceInput: ConformanceAssessmentInput;
+  conformanceResult: ConformanceConclusionResult;
+  draftFindingInput: DraftFindingAssessmentInput;
+  draftFindingResult: DraftFindingResult;
+  presentationResult: ReportPresentationResult;
+  gateInput: PresentationGateInput | null;
+  gateResult: PresentationGateResult;
+}>;
+
+/**
+ * Adapt reviewed fixture truth through the real Phase 2–7 contracts.
+ *
+ * This is packaging only: all assessments are supplied by the fixture and
+ * every decision is made by production contract functions.
+ */
+export function migrateReviewedFixtureTruth(
+  truth: ReviewedFixtureTruth,
+): FixturePresentationMigration {
+  const applicabilityResult = deriveApplicability(truth.row, truth.applicabilityAssessment);
+  const conformanceResult = deriveConformanceConclusion(
+    truth.row,
+    applicabilityResult,
+    truth.conformanceAssessment,
+  );
+  const draftFindingResult = deriveDraftFinding(
+    truth.row,
+    conformanceResult,
+    truth.draftFindingAssessment,
+  );
+  const presentationResult = createReportPresentationObject(
+    truth.row,
+    applicabilityResult,
+    conformanceResult,
+    draftFindingResult,
+  );
+  const gateInput = presentationResult.ready
+    ? truth.reviewState === undefined
+      ? { presentation: presentationResult.presentation }
+      : { presentation: presentationResult.presentation, reviewState: truth.reviewState }
+    : null;
+  const gateResult = gateInput === null
+    ? evaluatePresentationGate(null)
+    : evaluatePresentationGate(gateInput);
+
+  return {
+    finalizedEvidenceMapRow: truth.row,
+    applicabilityInput: truth.applicabilityAssessment,
+    applicabilityResult,
+    conformanceInput: truth.conformanceAssessment,
+    conformanceResult,
+    draftFindingInput: truth.draftFindingAssessment,
+    draftFindingResult,
+    presentationResult,
+    gateInput,
+    gateResult,
+  };
+}

--- a/tests/lib/evidence/fixturePresentationAdapter.test.ts
+++ b/tests/lib/evidence/fixturePresentationAdapter.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "@jest/globals";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+import { isReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
+import { evaluatePresentationReportGate } from "@/lib/evidence/presentationGate";
+import {
+  migrateReviewedFixtureTruth,
+  type ReviewedFixtureTruth,
+} from "../../fixtures/fixturePresentationAdapter";
+
+const acceptedProvenance = {
+  docId: "reviewed-pdd.pdf",
+  page: 25,
+  sectionPath: ["2", "2.2"],
+  spanId: "span:accepted-1",
+  sectionHeading: "Applicability of Methodology",
+  sourceType: "PDD",
+} as const;
+const rejectedProvenance = {
+  docId: "reviewed-pdd.pdf",
+  page: 24,
+  sectionPath: ["2", "2.1"],
+  spanId: "span:rejected-1",
+  sectionHeading: "Methodology Reference",
+  sourceType: "PDD",
+} as const;
+
+function row(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
+  return {
+    rowId: "fixture-row-1",
+    requirement: {
+      requirementId: "req-1",
+      requirementReference: "VM0007-2.2",
+      requirementText: "The project satisfies the applicability condition.",
+    },
+    methodology: { methodologyId: "VM0007", rulebookVersion: "1.8" },
+    upstreamStatus: "FOUND",
+    applicabilityState: "APPLICABLE",
+    acceptedEvidence: [{ evidenceId: "accepted-1", quote: "The project satisfies this condition.", provenance: acceptedProvenance }],
+    rejectedEvidence: [{ evidenceId: "rejected-1", quote: "Table of Contents", rejectionReason: "Navigation text is not project evidence.", provenance: rejectedProvenance }],
+    assessmentReason: "Reviewed against the project description.",
+    clientAction: null,
+    searchCoverage: { searched: true, searchedDocumentIds: ["reviewed-pdd.pdf"], notes: null },
+    sourceDocument: { documentId: "reviewed-pdd.pdf", documentName: "Reviewed PDD", contentSha256: "sha256:fixture" },
+    evidenceProvenance: [acceptedProvenance, rejectedProvenance],
+    finalizationState: "finalized",
+    finalizationActorRef: "reviewer:fixture",
+    finalizedAt: "2026-07-11T00:00:00Z",
+    finalizationBasis: "Reviewed fixture truth.",
+    reviewHistoryRef: "history:fixture-row-1",
+    evidenceMapContractVersion: "v1",
+    reviewPolicyVersion: "policy-v1",
+    ...overrides,
+  };
+}
+
+const supportedAssessment = {
+  requirementSupport: "SUPPORTED",
+  searchCoverageAssessment: "ADEQUATE",
+  provenanceAssessment: "COMPLETE",
+  versionIdentityAssessment: "MATCHED",
+  contradictionAssessment: "NONE",
+} as const;
+
+function truth(overrides: Partial<ReviewedFixtureTruth> = {}): ReviewedFixtureTruth {
+  return {
+    row: row(),
+    applicabilityAssessment: { decision: "APPLICABLE", decisionBasis: "The reviewed row marks this requirement applicable." },
+    conformanceAssessment: supportedAssessment,
+    draftFindingAssessment: { draftFindingType: null, findingBasis: null, reviewerAssessment: null },
+    ...overrides,
+  };
+}
+
+describe("migrateReviewedFixtureTruth", () => {
+  it("preserves accepted, rejected, and canonical provenance fields unchanged", () => {
+    const reviewed = truth();
+    const migrated = migrateReviewedFixtureTruth(reviewed);
+
+    expect(migrated.finalizedEvidenceMapRow).toBe(reviewed.row);
+    expect(migrated.finalizedEvidenceMapRow.acceptedEvidence).toEqual(reviewed.row.acceptedEvidence);
+    expect(migrated.finalizedEvidenceMapRow.rejectedEvidence).toEqual(reviewed.row.rejectedEvidence);
+    expect(migrated.finalizedEvidenceMapRow.evidenceProvenance).toEqual(reviewed.row.evidenceProvenance);
+    expect(migrated.presentationResult).toMatchObject({ ready: true });
+    if (!migrated.presentationResult.ready) throw new Error("Expected strict presentation object");
+    expect(migrated.presentationResult.presentation.acceptedEvidence).toEqual(reviewed.row.acceptedEvidence);
+    expect(migrated.presentationResult.presentation.rejectedEvidence).toEqual(reviewed.row.rejectedEvidence);
+    expect(migrated.presentationResult.presentation.evidenceProvenance).toEqual(reviewed.row.evidenceProvenance);
+    expect(isReportPresentationObject(migrated.presentationResult.presentation)).toBe(true);
+  });
+
+  it("does not silently drop a rejected evidence item during adaptation", () => {
+    const reviewed = truth();
+    const migrated = migrateReviewedFixtureTruth(reviewed);
+    if (!migrated.presentationResult.ready) throw new Error("Expected presentation");
+    expect(migrated.presentationResult.presentation.rejectedEvidence).toHaveLength(1);
+    expect(migrated.presentationResult.presentation.rejectedEvidence[0]).toEqual(reviewed.row.rejectedEvidence[0]);
+    expect(migrated.presentationResult.presentation.acceptedEvidence).not.toContainEqual(reviewed.row.rejectedEvidence[0]);
+  });
+
+  it("keeps upstream status unchanged and produces typed release-ready expectations", () => {
+    const reviewed = truth();
+    const migrated = migrateReviewedFixtureTruth(reviewed);
+    expect(reviewed.row.upstreamStatus).toBe("FOUND");
+    expect(migrated.finalizedEvidenceMapRow.upstreamStatus).toBe("FOUND");
+    expect(migrated.applicabilityResult).toMatchObject({ applicability: "APPLICABLE" });
+    expect(migrated.conformanceResult).toMatchObject({ conclusion: "CONFORMS" });
+    expect(migrated.draftFindingResult).toEqual({ draftFindingType: null, draftFindingRecord: null });
+    expect(migrated.gateResult).toMatchObject({ releaseState: "PRE_VALIDATION_RELEASE_READY", releaseReady: true, crossRowOutcome: "NOT_EVALUATED" });
+  });
+
+  it("uses explicit assessments for action-required and pending-review fixtures", () => {
+    const action = migrateReviewedFixtureTruth(truth({
+      row: row({ upstreamStatus: "UNCLEAR", acceptedEvidence: [], evidenceProvenance: [rejectedProvenance] }),
+      conformanceAssessment: { ...supportedAssessment, requirementSupport: "NOT_SUPPORTED" },
+      draftFindingAssessment: { draftFindingType: "NIR_CANDIDATE", findingBasis: "The evidence needs clarification.", reviewerAssessment: "Review the missing project-specific detail." },
+      reviewState: "PENDING_REVIEW",
+    }));
+    expect(action.conformanceResult).toMatchObject({ conclusion: "ACTION_REQUIRED" });
+    expect(action.draftFindingResult).toMatchObject({ draftFindingType: "NIR_CANDIDATE" });
+    expect(action.gateResult).toMatchObject({ releaseState: "INTERNAL_REVIEW_ONLY", releaseReady: false });
+  });
+
+  it("fails closed for contradictory fixture expectations", () => {
+    const contradictory = migrateReviewedFixtureTruth(truth({
+      row: row({ upstreamStatus: "UNCLEAR" }),
+      conformanceAssessment: supportedAssessment,
+    }));
+    expect(contradictory.conformanceResult).toMatchObject({ conclusion: "NOT_ASSESSED" });
+    expect(contradictory.presentationResult).toMatchObject({ ready: false, conclusion: "NOT_ASSESSED" });
+    expect(contradictory.gateResult).toMatchObject({ releaseState: "BLOCKED", releaseReady: false });
+  });
+
+  it("keeps single-row cross-row outcome unevaluated and passes compatible multi-row fixtures", () => {
+    const first = migrateReviewedFixtureTruth(truth());
+    const second = migrateReviewedFixtureTruth(truth({ row: row({ rowId: "fixture-row-2", requirement: { requirementId: "req-2", requirementReference: "VM0007-2.3", requirementText: "Another requirement." } }) }));
+    if (!first.presentationResult.ready || !second.presentationResult.ready) throw new Error("Expected presentations");
+    expect(first.gateResult.crossRowOutcome).toBe("NOT_EVALUATED");
+    expect(evaluatePresentationReportGate([
+      { presentation: first.presentationResult.presentation },
+      { presentation: second.presentationResult.presentation },
+    ])).toMatchObject({ releaseReady: true, crossRowOutcome: "PASS" });
+  });
+});


### PR DESCRIPTION
## Summary

Migrates reviewed fixture truth through the finalized Evidence Map and Phase 2–7 presentation contracts with a reusable fixture adapter.

- Preserves accepted and rejected evidence, canonical provenance, review metadata, methodology identity, and legacy statuses.
- Adds typed Phase 6/7 expectations for release-ready, pending-review, blocked, single-row, and compatible multi-row cases.
- Documents the migration boundary, compatibility strategy, deferred spanId-null fixtures, and Phase 9 handoff.

### Roadmap-Update
- slug: vvb-report-presentation-layer
- ack: human
- items:
  - RC8: done

## Validation

- Focused evidence tests: passed (including 6 new adapter tests; evidence suite 291 tests passed)
- Preverif tests: passed (109 tests)
- Quick Check gold fixtures: passed (48 tests)
- Lint: passed
- Typecheck: passed
- Fixture-hardcoding guard and test: passed
- Roadmap check: passed after staging regenerated summary
- pr:gate: build/prebuild completed through compilation, lint/type validation, and derived-artifact checks; final wrapper output was truncated before a terminal status

Existing Quick Check/router semantics and gold truth were unchanged. Rejected evidence is preserved. public/manifest/index.json was pre-existing, restored byte-for-byte, and excluded from this PR.