### PR TITLE
chore: clarify parser default and silence optional Docling probe

### DIFF
--- a/docs/roadmaps/quickcheck-parser-replacement/PLAN.md
+++ b/docs/roadmaps/quickcheck-parser-replacement/PLAN.md
@@ -43,7 +43,7 @@ Status: `done` — PR [#797](https://github.com/Fredilly/app.article6/pull/797)
 
 - **PyMuPDF adapter** (`QUICK_CHECK_PARSER=pymupdf`): primary successful Phase 0B adapter.
 - **Docling adapter** (`QUICK_CHECK_PARSER=docling`): optional/unavailable-safe.
-- `current-extractor` remains the default.
+- PyMuPDF is the active default parser.
 - Both adapters fall back to `current-extractor` on failure.
 - 55+ tests covering both adapters, fallback paths, runtime init.
 
@@ -61,8 +61,8 @@ Status: `done` — PR [#801](https://github.com/Fredilly/app.article6/pull/801)
 
 Status: `done`
 
-- Default parser remains `current-extractor` (PyMuPDF available as opt-in).
-- PyMuPDF adapter is available but not promoted to default — decision can be revisited.
+- Default parser is PyMuPDF; it falls back to `current-extractor` when the native helper is unavailable.
+- Docling remains an optional experimental fallback and is not a required dependency or gate.
 
 ### Phase 1: Evidence Compiler v2 — Noise Context Detection
 

--- a/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
+++ b/docs/roadmaps/quickcheck-parser-replacement/phase-status.json
@@ -17,7 +17,7 @@
       "branch": "feat/qc-experimental-parser-adapters",
       "status": "done",
       "pr": 797,
-      "goal": "Add one or more experimental parser adapters behind feature flags while keeping currentExtractor as the default fallback. Primary successful adapter: PyMuPDF (QUICK_CHECK_PARSER=pymupdf). Docling adapter is also registered (QUICK_CHECK_PARSER=docling) but remains optional/unavailable-safe; Docling installation is not required for Phase 0B completion."
+      "goal": "Add one or more experimental parser adapters behind feature flags while keeping currentExtractor as the runtime fallback. Primary active adapter: PyMuPDF (QUICK_CHECK_PARSER=pymupdf). Docling adapter is also registered (QUICK_CHECK_PARSER=docling) but remains optional/unavailable-safe; Docling installation is not required for Phase 0B completion."
     },
     {
       "id": "phase-0c-parser-bakeoff-scorecard",

--- a/src/lib/quickCheck/evalCorpus/bakeoff.ts
+++ b/src/lib/quickCheck/evalCorpus/bakeoff.ts
@@ -180,7 +180,7 @@ function computePerPdfMetrics(parsed: ParsedDocument): ParserBakeoffPerPdfMetric
   };
 }
 
-function checkParserAvailable(parserId: string): { available: boolean; reason?: string } {
+export function checkParserAvailable(parserId: string): { available: boolean; reason?: string } {
   if (parserId === "current-extractor") {
     return { available: true };
   }
@@ -203,10 +203,14 @@ function checkParserAvailable(parserId: string): { available: boolean; reason?: 
     try {
       execFileSync(resolvePython3Path(), ["--version"], { timeout: 5000, encoding: "utf-8" });
       try {
-        execFileSync(resolvePython3Path(), ["-c", "import docling"], { timeout: 10000, encoding: "utf-8" });
+        execFileSync(
+          resolvePython3Path(),
+          ["-c", "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('docling') else 1)"],
+          { timeout: 10000, encoding: "utf-8", stdio: ["ignore", "ignore", "ignore"] },
+        );
         return { available: true };
       } catch {
-        return { available: false, reason: "python3 available but docling not installed" };
+        return { available: false, reason: "Docling unavailable; optional adapter skipped." };
       }
     } catch {
       return { available: false, reason: "python3 not available" };

--- a/tests/lib/quickCheck/parserBakeoff.test.ts
+++ b/tests/lib/quickCheck/parserBakeoff.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import path from "path";
 import { mkdirSync, writeFileSync, rmSync } from "fs";
 import {
+  checkParserAvailable,
   runParserBakeoff,
   formatParserBakeoffScorecard,
   formatParserBakeoffScorecardJson,
@@ -48,6 +49,16 @@ describe("Parser bakeoff scorecard", () => {
     const ce = scorecard.parsers.find((p) => p.parserId === "current-extractor");
     expect(ce).toBeDefined();
     expect(ce!.available).toBe(true);
+  });
+
+  it("checks missing optional Docling quietly", () => {
+    expect(() => checkParserAvailable("docling")).not.toThrow();
+
+    const docling = checkParserAvailable("docling");
+    if (!docling.available) {
+      expect(docling.reason).toBe("Docling unavailable; optional adapter skipped.");
+      expect(docling.reason).not.toMatch(/traceback|ModuleNotFoundError|No module named/i);
+    }
   });
 
   it("records parser availability truthfully", () => {


### PR DESCRIPTION
## Summary

- Keep Docling as an optional experimental fallback.
- Replace the noisy Docling availability import with a quiet `importlib.util.find_spec("docling")` probe.
- Keep PyMuPDF as the default parser and preserve current-extractor fallback and explicit Docling selection behavior.
- Retain the existing roadmap corrections from the first PR commit.

## Root cause

The bakeoff availability probe in `src/lib/quickCheck/evalCorpus/bakeoff.ts` ran `python3 -c "import docling"`. When Docling was absent, Python emitted `ModuleNotFoundError: No module named 'docling'` to stderr.

The probe now suppresses subprocess stderr and returns:

`Docling unavailable; optional adapter skipped.`

## Validation

- Focused Docling probe test passed.
- Existing Docling fallback, parser-default, and PyMuPDF boundary suites passed: 3 suites, 111 tests.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `git diff --check` passed.
- `npm run pr:gate` build passed and the test stage was terminated after the repository-wide Jest run remained active for several minutes; captured exit code: `143` (SIGTERM). The run also exposed an unrelated existing PyMuPDF/`fitz` traceback, which is outside this Docling-only change.

No Docling dependency was installed. No parser selection, extraction semantics, fixtures, gold truth, router behavior, or presentation contracts changed.
