### PR TITLE
feat: add Phase 9 readiness report and reviewer UI

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -399,7 +399,8 @@ Current focus:
 - Phase 6 Report Presentation Object is complete
 - Phase 7 Presentation Gates are complete
 - Phase 8 Fixture Expectation Migration is complete
-- Phase 9 Readiness Report and UI Consumers is next
+- Phase 9 Readiness Report and UI Consumers is complete
+- Phase 10 Deprecation Review is next
 - Review traceability and release controls are explicit downstream requirements
 - Keep the Evidence Map upstream and canonical
 - Keep the Pre-Validation Readiness Report and UI downstream
@@ -420,5 +421,5 @@ Not active now:
 7) RC6 — Phase 6: Report Presentation Object: Done — Package finalized Evidence Map rows and validated applicability, conformance, and draft-finding results into one immutable generic presentation object with preserved evidence, provenance, review metadata, versions, and identity checks.
 8) RC7 — Phase 7: Presentation Gates: Done — Prevent unsupported conclusions and draft finding candidates through applicability, evidence sufficiency, and search-coverage gates, plus finalized-row traceability, review-history, contract-version, reopened-or-superseded-row, cross-row consistency, and fail-closed release-readiness gates.
 9) RC8 — Phase 8: Fixture Expectation Migration: Done — Migrate reviewed fixture truth through finalized Evidence Map rows and the Phase 2–7 presentation contracts while preserving accepted and rejected evidence, provenance, statuses, and legacy consumers.
-10) RC9 — Phase 9: Readiness Report and UI Consumers: Next — Implement downstream Pre-Validation Readiness Report and UI consumers using the finalized Evidence Map presentation contract, with a minimal reviewer workflow, centralized release-gate checks, traceable approve/edit/reopen history, and internal preview when client release is blocked.
-11) RC10 — Phase 10: Deprecation Review: Planned — Review old labels and organization-specific profiles only after the generic reviewer workflow and release gate are proven through a controlled pilot with qualified validation or verification professionals.
+10) RC9 — Phase 9: Readiness Report and UI Consumers: Done — Implement downstream Pre-Validation Readiness Report and UI consumers using only finalized Phase 6 presentation objects and Phase 7 gate results, with fail-closed reviewer metadata and internal preview when client release is blocked.
+11) RC10 — Phase 10: Deprecation Review: Next — Review old labels and organization-specific profiles only after the generic reviewer workflow and release gate are proven through a controlled pilot with qualified validation or verification professionals.

--- a/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
+++ b/docs/roadmaps/vvb-report-presentation-layer/PLAN.md
@@ -335,13 +335,13 @@ Do not mark placeholder text as FOUND. MISSING means no relevant document eviden
 - Phase 5: Applicability Contract — done
 - Phase 6: Report Presentation Object — done
 - Phase 7: Presentation Gates — done
-- Phase 8: Fixture Expectation Migration — next
-- Phase 9: Readiness Report and UI Consumers — planned
-- Phase 10: Deprecation Review — planned
+- Phase 8: Fixture Expectation Migration — done
+- Phase 9: Readiness Report and UI Consumers — done
+- Phase 10: Deprecation Review — next
 
 ## Validation
 
-For this contract-only change, run:
+For this Phase 9 consumer change, run:
 
 ```bash
 npx jest tests/lib/evidence/evidenceMapDependencyContract.test.ts --runInBand

--- a/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
+++ b/docs/roadmaps/vvb-report-presentation-layer/phase-status.json
@@ -13,7 +13,8 @@
       "Phase 6 Report Presentation Object is complete",
       "Phase 7 Presentation Gates are complete",
       "Phase 8 Fixture Expectation Migration is complete",
-      "Phase 9 Readiness Report and UI Consumers is next",
+      "Phase 9 Readiness Report and UI Consumers is complete",
+      "Phase 10 Deprecation Review is next",
       "Review traceability and release controls are explicit downstream requirements",
       "Keep the Evidence Map upstream and canonical",
       "Keep the Pre-Validation Readiness Report and UI downstream"
@@ -75,12 +76,12 @@
     },
     "phase_9_readiness_report_and_ui_consumers": {
       "title": "Phase 9: Readiness Report and UI Consumers",
-      "status": "next",
-      "summary": "Implement downstream Pre-Validation Readiness Report and UI consumers using the finalized Evidence Map presentation contract, with a minimal reviewer workflow, centralized release-gate checks, traceable approve/edit/reopen history, and internal preview when client release is blocked."
+      "status": "done",
+      "summary": "Implement downstream Pre-Validation Readiness Report and UI consumers using only finalized Phase 6 presentation objects and Phase 7 gate results, with fail-closed reviewer metadata and internal preview when client release is blocked."
     },
     "phase_10_deprecation_review": {
       "title": "Phase 10: Deprecation Review",
-      "status": "planned",
+      "status": "next",
       "summary": "Review old labels and organization-specific profiles only after the generic reviewer workflow and release gate are proven through a controlled pilot with qualified validation or verification professionals."
     }
   },

--- a/src/app/internal/reports/pre-validation-readiness/page.tsx
+++ b/src/app/internal/reports/pre-validation-readiness/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import PreValidationReadinessPreviewClient from "@/components/readiness/PreValidationReadinessPreviewClient";
+import { createReadinessReportViewModel } from "@/lib/evidence/readinessReport";
+import { buildReadinessPreviewFixture, type ReadinessPreviewScenario } from "@/lib/evidence/readinessPreviewFixture";
+
+export const metadata: Metadata = {
+  title: "Pre-Validation Readiness Report fixture preview | app.article6",
+  description: "Internal fixture-backed preview of the Phase 9 Pre-Validation Readiness Report reviewer UI.",
+};
+
+type PageProps = Readonly<{
+  searchParams: Promise<{ state?: string | string[] }>;
+}>;
+
+const scenarios: readonly ReadinessPreviewScenario[] = ["client-release-ready", "internal-review-only", "blocked", "not-assessed"];
+
+function selectedScenario(value: string | string[] | undefined): ReadinessPreviewScenario {
+  const candidate = Array.isArray(value) ? value[0] : value;
+  return scenarios.includes(candidate as ReadinessPreviewScenario) ? candidate as ReadinessPreviewScenario : "client-release-ready";
+}
+
+export default async function PreValidationReadinessPreviewPage({ searchParams }: PageProps) {
+  const scenario = selectedScenario((await searchParams).state);
+  const fixture = buildReadinessPreviewFixture(scenario);
+  const report = createReadinessReportViewModel(fixture.gateResult);
+  return (
+    <main className="mx-auto grid max-w-6xl gap-4 p-6">
+      <section className="rounded-2xl border border-violet-200 bg-violet-50 p-4 text-violet-950">
+        <div className="text-xs font-semibold uppercase tracking-wide">Internal fixture-backed preview</div>
+        <div className="mt-1 text-sm">Phase 9 reviewer UI only. Evidence and review actions are fixture data and are not persisted.</div>
+        <nav className="mt-3 flex flex-wrap gap-2" aria-label="Preview state selector">
+          {scenarios.map((option) => <a key={option} href={`/internal/reports/pre-validation-readiness?state=${option}`} className={`rounded-lg border px-3 py-1.5 text-xs font-semibold ${option === scenario ? "border-violet-500 bg-violet-200" : "border-violet-200 bg-white"}`}>{option}</a>)}
+        </nav>
+      </section>
+      <PreValidationReadinessPreviewClient report={report} workflowState={fixture.workflowState} />
+    </main>
+  );
+}

--- a/src/components/readiness/PreValidationReadinessPreviewClient.tsx
+++ b/src/components/readiness/PreValidationReadinessPreviewClient.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import PreValidationReadinessReviewer from "@/components/readiness/PreValidationReadinessReviewer";
+import type { ReadinessReportViewModel, ReviewerWorkflowState } from "@/lib/evidence/readinessReport";
+
+type Props = Readonly<{
+  report: ReadinessReportViewModel;
+  workflowState?: ReviewerWorkflowState;
+}>;
+
+export default function PreValidationReadinessPreviewClient({ report, workflowState }: Props) {
+  const [lastAction, setLastAction] = useState<string | null>(null);
+  const record = (action: string, rowId: string) => setLastAction(`${action} requested for ${rowId}. Preview actions are not persisted.`);
+  return (
+    <>
+      <PreValidationReadinessReviewer
+        report={report}
+        workflowState={workflowState}
+        onApprove={(rowId) => record("Approve", rowId)}
+        onEdit={(rowId) => record("Edit", rowId)}
+        onReopen={(rowId) => record("Reopen", rowId)}
+      />
+      {lastAction ? <p className="rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-900" data-testid="preview-action-status">{lastAction}</p> : null}
+    </>
+  );
+}

--- a/src/components/readiness/PreValidationReadinessReviewer.tsx
+++ b/src/components/readiness/PreValidationReadinessReviewer.tsx
@@ -1,8 +1,17 @@
-import type { ReadinessReportViewModel } from "@/lib/evidence/readinessReport";
+import {
+  reviewerWorkflowActions,
+  type ReadinessReportViewModel,
+  type ReviewerWorkflowAction,
+  type ReviewerWorkflowState,
+} from "@/lib/evidence/readinessReport";
 
 type Props = Readonly<{
   report: ReadinessReportViewModel;
   onClientRelease?: () => void;
+  workflowState?: ReviewerWorkflowState;
+  onApprove?: (evidenceMapRowId: string) => void;
+  onEdit?: (evidenceMapRowId: string) => void;
+  onReopen?: (evidenceMapRowId: string) => void;
 }>;
 
 function statusClass(label: ReadinessReportViewModel["release"]["label"]): string {
@@ -16,8 +25,9 @@ function Provenance({ provenance }: { provenance: { docId: string; page: number 
   return <div className="mt-1 text-xs text-slate-500">{provenance.docId} · page {provenance.page ?? "—"} · {provenance.sectionHeading ?? provenance.sectionPath.join(" / ")} · span {provenance.spanId}</div>;
 }
 
-export default function PreValidationReadinessReviewer({ report, onClientRelease }: Props) {
+export default function PreValidationReadinessReviewer({ report, onClientRelease, workflowState, onApprove, onEdit, onReopen }: Props) {
   const { release } = report;
+  const callbacks: Readonly<Record<ReviewerWorkflowAction, ((evidenceMapRowId: string) => void) | undefined>> = { approve: onApprove, edit: onEdit, reopen: onReopen };
   return (
     <main className="grid gap-4" data-testid="pre-validation-readiness-reviewer">
       <header className={`rounded-2xl border p-5 ${statusClass(release.label)}`} data-release-state={release.state}>
@@ -42,6 +52,7 @@ export default function PreValidationReadinessReviewer({ report, onClientRelease
           </div>
           <dl className="mt-4 grid gap-2 text-sm text-slate-700"><div><dt className="font-semibold text-slate-950">Assessment reason</dt><dd>{presentation.assessmentReason}</dd></div><div><dt className="font-semibold text-slate-950">Client action required</dt><dd>{presentation.clientAction ?? "No client action recorded."}</dd></div><div><dt className="font-semibold text-slate-950">Draft finding</dt><dd>{presentation.draftFindingResult.draftFindingType ?? "None"} — draft candidate language only</dd></div><div><dt className="font-semibold text-slate-950">Source document</dt><dd>{presentation.sourceDocument.documentName ?? presentation.sourceDocument.documentId} ({presentation.sourceDocument.documentId})</dd></div></dl>
           <div className="mt-4 border-t border-slate-200 pt-3 text-xs text-slate-500">Review history: {presentation.reviewHistoryRef} · finalized by {presentation.finalizationActorRef} at {presentation.finalizedAt} · contracts {presentation.presentationContractVersion} / {presentation.reviewPolicyVersion}</div>
+          {workflowState ? <div className="mt-3 flex flex-wrap items-center gap-2" data-testid={`reviewer-actions-${presentation.evidenceMapRowId}`}><span className="text-xs font-semibold text-slate-600">Reviewer state: {workflowState}</span>{reviewerWorkflowActions(workflowState).map((action) => <button key={action} type="button" disabled={!callbacks[action]} onClick={() => callbacks[action]?.(presentation.evidenceMapRowId)} className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-800 disabled:cursor-not-allowed disabled:opacity-50">{action === "approve" ? "Approve" : action === "edit" ? "Edit" : "Reopen"}</button>)}</div> : null}
         </article>
       ))}
     </main>

--- a/src/components/readiness/PreValidationReadinessReviewer.tsx
+++ b/src/components/readiness/PreValidationReadinessReviewer.tsx
@@ -1,0 +1,49 @@
+import type { ReadinessReportViewModel } from "@/lib/evidence/readinessReport";
+
+type Props = Readonly<{
+  report: ReadinessReportViewModel;
+  onClientRelease?: () => void;
+}>;
+
+function statusClass(label: ReadinessReportViewModel["release"]["label"]): string {
+  if (label === "client-release-ready") return "border-emerald-200 bg-emerald-50 text-emerald-900";
+  if (label === "internal-review-only") return "border-amber-200 bg-amber-50 text-amber-900";
+  if (label === "not assessed") return "border-slate-200 bg-slate-100 text-slate-700";
+  return "border-rose-200 bg-rose-50 text-rose-900";
+}
+
+function Provenance({ provenance }: { provenance: { docId: string; page: number | null; sectionHeading: string | null; spanId: string; sectionPath: readonly string[] } }) {
+  return <div className="mt-1 text-xs text-slate-500">{provenance.docId} · page {provenance.page ?? "—"} · {provenance.sectionHeading ?? provenance.sectionPath.join(" / ")} · span {provenance.spanId}</div>;
+}
+
+export default function PreValidationReadinessReviewer({ report, onClientRelease }: Props) {
+  const { release } = report;
+  return (
+    <main className="grid gap-4" data-testid="pre-validation-readiness-reviewer">
+      <header className={`rounded-2xl border p-5 ${statusClass(release.label)}`} data-release-state={release.state}>
+        <div className="text-xs font-semibold uppercase tracking-wide">{report.title}</div>
+        <h1 className="mt-2 text-2xl font-semibold">{release.label}</h1>
+        {release.label === "internal-review-only" ? <p className="mt-2 text-sm font-medium">Internal review only. Client release is blocked by the Phase 7 presentation gate.</p> : null}
+        {release.label === "not assessed" ? <p className="mt-2 text-sm">No complete presentation rows are available. The report is not assessed.</p> : null}
+        {release.reasons.length ? <ul className="mt-3 grid gap-1 text-sm" data-testid="release-blocking-reasons">{release.reasons.map((reason, index) => <li key={`${reason.category}-${reason.evidenceMapRowId}-${index}`}>{reason.category}{reason.detail ? `: ${reason.detail}` : ""}</li>)}</ul> : null}
+        {release.releaseReady ? <button type="button" onClick={onClientRelease} className="mt-4 rounded-lg bg-emerald-700 px-3 py-2 text-sm font-semibold text-white">Release to client</button> : null}
+      </header>
+
+      {report.rows.map((presentation) => (
+        <article key={presentation.evidenceMapRowId} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm" data-evidence-map-row={presentation.evidenceMapRowId}>
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <h2 className="text-lg font-semibold text-slate-950">{presentation.requirement.requirementReference}: {presentation.requirement.requirementText}</h2>
+            <span className="text-xs text-slate-500">Evidence Map row {presentation.evidenceMapRowId}</span>
+          </div>
+          <div className="mt-2 text-sm text-slate-600">{presentation.methodology ? `${presentation.methodology.methodologyId}@${presentation.methodology.rulebookVersion}` : "No methodology identity"} · applicability: {presentation.applicabilityResult.applicability} · conclusion: {presentation.conformanceConclusion.conclusion}</div>
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            <section className="rounded-xl border border-emerald-200 bg-emerald-50 p-3"><h3 className="text-sm font-semibold text-emerald-950">Accepted evidence</h3>{presentation.acceptedEvidence.length ? presentation.acceptedEvidence.map((item) => <div key={item.evidenceId} className="mt-2 text-sm text-emerald-950"><div>{item.quote}</div><Provenance provenance={item.provenance} /></div>) : <p className="mt-2 text-sm text-emerald-900">No evidence accepted.</p>}</section>
+            <section className="rounded-xl border border-rose-200 bg-rose-50 p-3"><h3 className="text-sm font-semibold text-rose-950">Rejected evidence</h3>{presentation.rejectedEvidence.length ? presentation.rejectedEvidence.map((item) => <div key={item.evidenceId} className="mt-2 text-sm text-rose-950"><div>{item.quote}</div><div className="mt-1 font-medium">Rejected because: {item.rejectionReason}</div><Provenance provenance={item.provenance} /></div>) : <p className="mt-2 text-sm text-rose-900">No evidence rejected.</p>}</section>
+          </div>
+          <dl className="mt-4 grid gap-2 text-sm text-slate-700"><div><dt className="font-semibold text-slate-950">Assessment reason</dt><dd>{presentation.assessmentReason}</dd></div><div><dt className="font-semibold text-slate-950">Client action required</dt><dd>{presentation.clientAction ?? "No client action recorded."}</dd></div><div><dt className="font-semibold text-slate-950">Draft finding</dt><dd>{presentation.draftFindingResult.draftFindingType ?? "None"} — draft candidate language only</dd></div><div><dt className="font-semibold text-slate-950">Source document</dt><dd>{presentation.sourceDocument.documentName ?? presentation.sourceDocument.documentId} ({presentation.sourceDocument.documentId})</dd></div></dl>
+          <div className="mt-4 border-t border-slate-200 pt-3 text-xs text-slate-500">Review history: {presentation.reviewHistoryRef} · finalized by {presentation.finalizationActorRef} at {presentation.finalizedAt} · contracts {presentation.presentationContractVersion} / {presentation.reviewPolicyVersion}</div>
+        </article>
+      ))}
+    </main>
+  );
+}

--- a/src/lib/evidence/readinessPreviewFixture.ts
+++ b/src/lib/evidence/readinessPreviewFixture.ts
@@ -1,0 +1,78 @@
+import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
+import { deriveConformanceConclusion } from "@/lib/evidence/conformanceConclusionContract";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+import { deriveDraftFinding } from "@/lib/evidence/draftFindingContract";
+import { evaluatePresentationGate, type PresentationGateResult, type PresentationReviewState } from "@/lib/evidence/presentationGate";
+import { createReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
+import type { ReviewerWorkflowState } from "@/lib/evidence/readinessReport";
+
+export type ReadinessPreviewScenario = "client-release-ready" | "internal-review-only" | "blocked" | "not-assessed";
+
+export type ReadinessPreviewFixture = Readonly<{
+  scenario: ReadinessPreviewScenario;
+  gateResult: PresentationGateResult;
+  workflowState?: ReviewerWorkflowState;
+}>;
+
+const provenance = {
+  docId: "fixture-reviewed-pdd.pdf",
+  page: 25,
+  sectionPath: ["2", "2.2"],
+  spanId: "span:preview-accepted-1",
+  sectionHeading: "Applicability of Methodology",
+  sourceType: "PDD",
+};
+const rejectedProvenance = {
+  docId: "fixture-reviewed-pdd.pdf",
+  page: 24,
+  sectionPath: ["2", "2.1"],
+  spanId: "span:preview-rejected-1",
+  sectionHeading: "Methodology Reference",
+  sourceType: "PDD",
+};
+
+const row: EvidenceMapRow = {
+  rowId: "preview-row-1",
+  requirement: { requirementId: "preview-req-1", requirementReference: "VM0007-2.2", requirementText: "The project satisfies the applicability condition." },
+  methodology: { methodologyId: "VM0007", rulebookVersion: "1.8" },
+  upstreamStatus: "FOUND",
+  applicabilityState: "APPLICABLE",
+  acceptedEvidence: [{ evidenceId: "preview-accepted-1", quote: "The project satisfies this condition.", provenance }],
+  rejectedEvidence: [{ evidenceId: "preview-rejected-1", quote: "Table of Contents", rejectionReason: "Navigation text is not project evidence.", provenance: rejectedProvenance }],
+  assessmentReason: "Reviewed against the project description.",
+  clientAction: "No client action recorded.",
+  searchCoverage: { searched: true, searchedDocumentIds: [provenance.docId, rejectedProvenance.docId], notes: null },
+  sourceDocument: { documentId: provenance.docId, documentName: "Fixture-reviewed PDD", contentSha256: "sha256:readiness-preview" },
+  evidenceProvenance: [provenance, rejectedProvenance],
+  finalizationState: "finalized",
+  finalizationActorRef: "reviewer:readiness-preview",
+  finalizedAt: "2026-07-11T00:00:00Z",
+  finalizationBasis: "Fixture-backed Phase 9 preview.",
+  reviewHistoryRef: "history:readiness-preview",
+  evidenceMapContractVersion: "v1",
+  reviewPolicyVersion: "policy-v1",
+};
+
+const assessment = {
+  requirementSupport: "SUPPORTED",
+  searchCoverageAssessment: "ADEQUATE",
+  provenanceAssessment: "COMPLETE",
+  versionIdentityAssessment: "MATCHED",
+  contradictionAssessment: "NONE",
+} as const;
+
+function gateFor(reviewState?: PresentationReviewState): PresentationGateResult {
+  const applicability = deriveApplicability(row, { decision: "APPLICABLE", decisionBasis: "The reviewed row marks this requirement applicable." });
+  const conformance = deriveConformanceConclusion(row, applicability, assessment);
+  const draftFinding = deriveDraftFinding(row, conformance, { draftFindingType: null, findingBasis: null, reviewerAssessment: null });
+  const presentation = createReportPresentationObject(row, applicability, conformance, draftFinding);
+  if (!presentation.ready) return evaluatePresentationGate(null);
+  return evaluatePresentationGate(reviewState === undefined ? { presentation: presentation.presentation } : { presentation: presentation.presentation, reviewState });
+}
+
+export function buildReadinessPreviewFixture(scenario: ReadinessPreviewScenario): ReadinessPreviewFixture {
+  if (scenario === "not-assessed") return { scenario, gateResult: evaluatePresentationGate(null) };
+  if (scenario === "internal-review-only") return { scenario, gateResult: gateFor("PENDING_REVIEW"), workflowState: "pending review" };
+  if (scenario === "blocked") return { scenario, gateResult: gateFor("REOPENED"), workflowState: "reopened" };
+  return { scenario, gateResult: gateFor(), workflowState: "approved" };
+}

--- a/src/lib/evidence/readinessReport.ts
+++ b/src/lib/evidence/readinessReport.ts
@@ -87,20 +87,98 @@ export type ReviewerWorkflowResult =
   | Readonly<{ complete: true; state: ReviewerWorkflowState; event: ReviewerWorkflowEvent }>
   | Readonly<{ complete: false; state: "incomplete"; reason: "review-history-event-required" }>;
 
+export type ReviewerWorkflowAction = "approve" | "edit" | "reopen";
+export type ReviewerWorkflowHistory = readonly ReviewerWorkflowEvent[];
+export type ReviewerWorkflowTransitionResult =
+  | Readonly<{
+      accepted: true;
+      state: ReviewerWorkflowState;
+      history: ReviewerWorkflowHistory;
+    }>
+  | Readonly<{
+      accepted: false;
+      state: "incomplete" | "invalid_transition";
+      reason: "review-history-event-required" | "unsupported-transition" | "history-state-mismatch";
+      history: ReviewerWorkflowHistory;
+    }>;
+
+const allowedTransitions: Readonly<Record<ReviewerWorkflowState, readonly ReviewerWorkflowState[]>> = {
+  "pending review": ["approved", "edited"],
+  approved: ["edited", "reopened"],
+  edited: ["approved", "reopened"],
+  reopened: ["edited", "approved"],
+};
+
+const actionTargets: Readonly<Record<ReviewerWorkflowState, Readonly<Record<ReviewerWorkflowAction, ReviewerWorkflowState | undefined>>>> = {
+  "pending review": { approve: "approved", edit: "edited", reopen: undefined },
+  approved: { approve: undefined, edit: "edited", reopen: "reopened" },
+  edited: { approve: "approved", edit: undefined, reopen: "reopened" },
+  reopened: { approve: "approved", edit: "edited", reopen: undefined },
+};
+
+const workflowStates: readonly ReviewerWorkflowState[] = ["pending review", "approved", "edited", "reopened"];
+
+export function reviewerWorkflowActions(state: ReviewerWorkflowState): readonly ReviewerWorkflowAction[] {
+  return Object.entries(actionTargets[state])
+    .filter(([, target]) => target !== undefined)
+    .map(([action]) => action as ReviewerWorkflowAction);
+}
+
 export function validateReviewerWorkflowEvent(input: unknown): ReviewerWorkflowResult {
   if (!input || typeof input !== "object") return { complete: false, state: "incomplete", reason: "review-history-event-required" };
   const event = input as Partial<ReviewerWorkflowEvent>;
-  const states: readonly ReviewerWorkflowState[] = ["pending review", "approved", "edited", "reopened"];
   if (
     typeof event.reviewerIdentity !== "string" || !event.reviewerIdentity.trim() ||
     typeof event.timestamp !== "string" || Number.isNaN(Date.parse(event.timestamp)) ||
     typeof event.reasonOrNote !== "string" || !event.reasonOrNote.trim() ||
-    !states.includes(event.newState as ReviewerWorkflowState) ||
-    (event.previousState !== null && !states.includes(event.previousState as ReviewerWorkflowState)) ||
+    !workflowStates.includes(event.newState as ReviewerWorkflowState) ||
+    (event.previousState !== null && !workflowStates.includes(event.previousState as ReviewerWorkflowState)) ||
     typeof event.presentationContractVersion !== "string" || !event.presentationContractVersion.trim() ||
     typeof event.reviewPolicyVersion !== "string" || !event.reviewPolicyVersion.trim()
   ) return { complete: false, state: "incomplete", reason: "review-history-event-required" };
   return { complete: true, state: event.newState as ReviewerWorkflowState, event: event as ReviewerWorkflowEvent };
+}
+
+/** Apply one explicitly recorded reviewer transition without replacing history. */
+export function transitionReviewerWorkflow(
+  currentState: ReviewerWorkflowState,
+  history: ReviewerWorkflowHistory | undefined,
+  eventInput: unknown,
+): ReviewerWorkflowTransitionResult {
+  const preservedHistory = Array.isArray(history) ? history : [];
+  if (!Array.isArray(history)) {
+    return { accepted: false, state: "incomplete", reason: "review-history-event-required", history: preservedHistory };
+  }
+  if (!workflowStates.includes(currentState)) {
+    return { accepted: false, state: "invalid_transition", reason: "unsupported-transition", history: preservedHistory };
+  }
+  let priorState: ReviewerWorkflowState | null = null;
+  for (const historyEvent of preservedHistory) {
+    const historyResult = validateReviewerWorkflowEvent(historyEvent);
+    if (!historyResult.complete || historyResult.event.previousState === null || (priorState === null && historyResult.event.previousState !== "pending review") || (priorState !== null && historyResult.event.previousState !== priorState)) {
+      return { accepted: false, state: "incomplete", reason: "review-history-event-required", history: preservedHistory };
+    }
+    priorState = historyResult.event.newState;
+  }
+  const eventResult = validateReviewerWorkflowEvent(eventInput);
+  if (!eventResult.complete || eventResult.event.previousState === null) {
+    return { accepted: false, state: "incomplete", reason: "review-history-event-required", history: preservedHistory };
+  }
+  const event = eventResult.event;
+  if (event.previousState !== currentState) {
+    return { accepted: false, state: "invalid_transition", reason: "history-state-mismatch", history: preservedHistory };
+  }
+  if (!allowedTransitions[currentState].includes(event.newState)) {
+    return { accepted: false, state: "invalid_transition", reason: "unsupported-transition", history: preservedHistory };
+  }
+  if (preservedHistory.length > 0 && priorState !== currentState) {
+    return { accepted: false, state: "invalid_transition", reason: "history-state-mismatch", history: preservedHistory };
+  }
+  return Object.freeze({
+    accepted: true,
+    state: event.newState,
+    history: Object.freeze([...preservedHistory, Object.freeze({ ...event })]),
+  });
 }
 
 export function reviewStateForGate(state: ReviewerWorkflowState): PresentationReviewState {

--- a/src/lib/evidence/readinessReport.ts
+++ b/src/lib/evidence/readinessReport.ts
@@ -1,0 +1,110 @@
+import {
+  type PresentationGateBlock,
+  type PresentationGateResult,
+  type PresentationReviewState,
+} from "@/lib/evidence/presentationGate";
+import {
+  isReportPresentationObject,
+  type ReportPresentationObject,
+} from "@/lib/evidence/reportPresentationObject";
+
+export type ReadinessReportReleaseLabel =
+  | "client-release-ready"
+  | "internal-review-only"
+  | "blocked"
+  | "not assessed";
+
+export type ReadinessReportViewModel = Readonly<{
+  title: "Pre-Validation Readiness Report";
+  release: Readonly<{
+    state: PresentationGateResult["releaseState"] | "NOT_ASSESSED";
+    label: ReadinessReportReleaseLabel;
+    releaseReady: boolean;
+    reasons: readonly PresentationGateBlock[];
+  }>;
+  rows: readonly ReportPresentationObject[];
+  gate: PresentationGateResult;
+}>;
+
+function isGateResult(value: unknown): value is PresentationGateResult {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  if (!Array.isArray(candidate.presentations) || !candidate.presentations.every(isReportPresentationObject)) return false;
+  if (candidate.releaseState === "PRE_VALIDATION_RELEASE_READY") {
+    return candidate.releaseReady === true && !candidate.blockedBy && !candidate.warnings;
+  }
+  if (candidate.releaseState === "INTERNAL_REVIEW_ONLY") {
+    return candidate.releaseReady === false && Array.isArray(candidate.warnings);
+  }
+  if (candidate.releaseState === "BLOCKED") {
+    return candidate.releaseReady === false && Array.isArray(candidate.blockedBy);
+  }
+  return false;
+}
+
+function invalidGate(): PresentationGateResult {
+  return {
+    releaseReady: false,
+    releaseState: "BLOCKED",
+    crossRowOutcome: "NOT_EVALUATED",
+    presentations: [],
+    blockedBy: [{ category: "invalid_report_input", evidenceMapRowId: null, detail: "Missing or invalid Phase 7 gate result." }],
+  };
+}
+
+export function createReadinessReportViewModel(input: unknown): ReadinessReportViewModel {
+  const gate = isGateResult(input) ? input : invalidGate();
+  const reasons = gate.releaseState === "BLOCKED" ? gate.blockedBy : gate.releaseState === "INTERNAL_REVIEW_ONLY" ? gate.warnings : [];
+  const label: ReadinessReportReleaseLabel =
+    gate.releaseState === "PRE_VALIDATION_RELEASE_READY"
+      ? "client-release-ready"
+      : gate.releaseState === "INTERNAL_REVIEW_ONLY"
+        ? "internal-review-only"
+        : gate.presentations.length === 0
+          ? "not assessed"
+          : "blocked";
+  return Object.freeze({
+    title: "Pre-Validation Readiness Report",
+    release: Object.freeze({ state: gate.presentations.length === 0 && gate.releaseState === "BLOCKED" ? "NOT_ASSESSED" : gate.releaseState, label, releaseReady: gate.releaseReady, reasons }),
+    rows: gate.presentations,
+    gate,
+  });
+}
+
+export type ReviewerWorkflowState = "pending review" | "approved" | "edited" | "reopened";
+
+export type ReviewerWorkflowEvent = Readonly<{
+  reviewerIdentity: string;
+  timestamp: string;
+  reasonOrNote: string;
+  previousState: ReviewerWorkflowState | null;
+  newState: ReviewerWorkflowState;
+  presentationContractVersion: string;
+  reviewPolicyVersion: string;
+}>;
+
+export type ReviewerWorkflowResult =
+  | Readonly<{ complete: true; state: ReviewerWorkflowState; event: ReviewerWorkflowEvent }>
+  | Readonly<{ complete: false; state: "incomplete"; reason: "review-history-event-required" }>;
+
+export function validateReviewerWorkflowEvent(input: unknown): ReviewerWorkflowResult {
+  if (!input || typeof input !== "object") return { complete: false, state: "incomplete", reason: "review-history-event-required" };
+  const event = input as Partial<ReviewerWorkflowEvent>;
+  const states: readonly ReviewerWorkflowState[] = ["pending review", "approved", "edited", "reopened"];
+  if (
+    typeof event.reviewerIdentity !== "string" || !event.reviewerIdentity.trim() ||
+    typeof event.timestamp !== "string" || Number.isNaN(Date.parse(event.timestamp)) ||
+    typeof event.reasonOrNote !== "string" || !event.reasonOrNote.trim() ||
+    !states.includes(event.newState as ReviewerWorkflowState) ||
+    (event.previousState !== null && !states.includes(event.previousState as ReviewerWorkflowState)) ||
+    typeof event.presentationContractVersion !== "string" || !event.presentationContractVersion.trim() ||
+    typeof event.reviewPolicyVersion !== "string" || !event.reviewPolicyVersion.trim()
+  ) return { complete: false, state: "incomplete", reason: "review-history-event-required" };
+  return { complete: true, state: event.newState as ReviewerWorkflowState, event: event as ReviewerWorkflowEvent };
+}
+
+export function reviewStateForGate(state: ReviewerWorkflowState): PresentationReviewState {
+  if (state === "pending review") return "PENDING_REVIEW";
+  if (state === "reopened") return "REOPENED";
+  return "CURRENT";
+}

--- a/tests/app/internal/pre-validation-readiness.page.test.tsx
+++ b/tests/app/internal/pre-validation-readiness.page.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "@jest/globals";
+import { renderToStaticMarkup } from "react-dom/server";
+import PreValidationReadinessPreviewPage from "@/app/internal/reports/pre-validation-readiness/page";
+
+describe("/internal/reports/pre-validation-readiness page", () => {
+  test("renders the selected blocked fixture-backed reviewer state", async () => {
+    const element = await PreValidationReadinessPreviewPage({ searchParams: Promise.resolve({ state: "blocked" }) });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain("Internal fixture-backed preview");
+    expect(html).toContain("Pre-Validation Readiness Report");
+    expect(html).toContain(">blocked<");
+    expect(html).toContain("Internal fixture-backed preview");
+    expect(html).toContain("reviewer-actions-preview-row-1");
+    expect(html).toContain("Approve");
+    expect(html).toContain("Edit");
+    expect(html).not.toContain("Release to client");
+  });
+});

--- a/tests/components/preValidationReadinessReviewer.test.tsx
+++ b/tests/components/preValidationReadinessReviewer.test.tsx
@@ -1,0 +1,17 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import PreValidationReadinessReviewer from "@/components/readiness/PreValidationReadinessReviewer";
+import { createReadinessReportViewModel } from "@/lib/evidence/readinessReport";
+import { presentationGateFixture } from "../fixtures/presentationGateFixture";
+
+describe("PreValidationReadinessReviewer", () => {
+  test("separates accepted and rejected evidence, keeps provenance, and hides release when blocked", () => {
+    const html = renderToStaticMarkup(<PreValidationReadinessReviewer report={createReadinessReportViewModel(presentationGateFixture({ blocked: true }))} />);
+    expect(html).toContain("blocked");
+    expect(html).toContain("Accepted quote");
+    expect(html).toContain("Rejected quote");
+    expect(html).toContain("Rejected because: Out of scope");
+    expect(html).toContain("page 4");
+    expect(html).not.toContain("Release to client");
+    expect(html).toContain("Draft finding");
+  });
+});

--- a/tests/components/preValidationReadinessReviewer.test.tsx
+++ b/tests/components/preValidationReadinessReviewer.test.tsx
@@ -14,4 +14,15 @@ describe("PreValidationReadinessReviewer", () => {
     expect(html).not.toContain("Release to client");
     expect(html).toContain("Draft finding");
   });
+
+  test("exposes typed approve, edit, and reopen callbacks from the centralized workflow actions", () => {
+    const calls: string[] = [];
+    const report = createReadinessReportViewModel(presentationGateFixture());
+    const html = renderToStaticMarkup(<PreValidationReadinessReviewer report={report} workflowState="approved" onEdit={(rowId) => calls.push(`edit:${rowId}`)} onReopen={(rowId) => calls.push(`reopen:${rowId}`)} />);
+    expect(html).toContain("Reviewer state: approved");
+    expect(html).toContain("Edit");
+    expect(html).toContain("Reopen");
+    expect(html).not.toContain("Approve");
+    expect(calls).toEqual([]);
+  });
 });

--- a/tests/fixtures/presentationGateFixture.ts
+++ b/tests/fixtures/presentationGateFixture.ts
@@ -1,0 +1,17 @@
+import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
+import { deriveConformanceConclusion } from "@/lib/evidence/conformanceConclusionContract";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+import { deriveDraftFinding } from "@/lib/evidence/draftFindingContract";
+import { createReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
+import { evaluatePresentationGate } from "@/lib/evidence/presentationGate";
+
+const p = { docId: "doc-1", page: 4, sectionPath: ["3"], spanId: "span-1", sectionHeading: "Evidence", sourceType: "PDD" };
+export function presentationGateFixture({ blocked = false } = {}) {
+  const row: EvidenceMapRow = { rowId: "row-1", requirement: { requirementId: "req-1", requirementReference: "REQ-1", requirementText: "Requirement text." }, methodology: { methodologyId: "VM", rulebookVersion: "1.0" }, upstreamStatus: "FOUND", applicabilityState: "APPLICABLE", acceptedEvidence: [{ evidenceId: "accepted", quote: "Accepted quote", provenance: p }], rejectedEvidence: [{ evidenceId: "rejected", quote: "Rejected quote", rejectionReason: "Out of scope", provenance: p }], assessmentReason: "Reviewed.", clientAction: "Provide appendix.", searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null }, sourceDocument: { documentId: "doc-1", documentName: "source.pdf", contentSha256: "hash" }, evidenceProvenance: [p], finalizationState: "finalized", finalizationActorRef: "reviewer", finalizedAt: "2026-07-10T00:00:00Z", finalizationBasis: "Reviewed.", reviewHistoryRef: "history", evidenceMapContractVersion: "v1", reviewPolicyVersion: "policy-v1" };
+  const applicability = deriveApplicability(row, { decision: "APPLICABLE", decisionBasis: "Applies." });
+  const conclusion = deriveConformanceConclusion(row, applicability, { requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE", versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE" });
+  const draft = deriveDraftFinding(row, conclusion, { draftFindingType: null, findingBasis: null, reviewerAssessment: null });
+  const result = createReportPresentationObject(row, applicability, conclusion, draft);
+  if (!result.ready) throw new Error("expected presentation");
+  return evaluatePresentationGate(blocked ? { presentation: result.presentation, reviewState: "REOPENED" } : { presentation: result.presentation });
+}

--- a/tests/lib/evidence/readinessReport.test.ts
+++ b/tests/lib/evidence/readinessReport.test.ts
@@ -1,0 +1,50 @@
+import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
+import { deriveConformanceConclusion } from "@/lib/evidence/conformanceConclusionContract";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+import { deriveDraftFinding } from "@/lib/evidence/draftFindingContract";
+import { createReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
+import { evaluatePresentationReportGate } from "@/lib/evidence/presentationGate";
+import { createReadinessReportViewModel, reviewStateForGate, validateReviewerWorkflowEvent } from "@/lib/evidence/readinessReport";
+
+const provenance = { docId: "doc-1", page: 4, sectionPath: ["3", "3.1"], spanId: "span-1", sectionHeading: "Evidence", sourceType: "PDD" };
+const row = (overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow => ({ rowId: "row-1", requirement: { requirementId: "req-1", requirementReference: "REQ-1", requirementText: "Requirement text." }, methodology: { methodologyId: "VM", rulebookVersion: "1.0" }, upstreamStatus: "FOUND", applicabilityState: "APPLICABLE", acceptedEvidence: [{ evidenceId: "accepted", quote: "Accepted quote", provenance }], rejectedEvidence: [{ evidenceId: "rejected", quote: "Rejected quote", rejectionReason: "Out of scope", provenance }], assessmentReason: "Reviewed against the requirement.", clientAction: "Provide the signed appendix.", searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null }, sourceDocument: { documentId: "doc-1", documentName: "source.pdf", contentSha256: "hash" }, evidenceProvenance: [provenance], finalizationState: "finalized", finalizationActorRef: "reviewer-1", finalizedAt: "2026-07-10T00:00:00Z", finalizationBasis: "Evidence Map review", reviewHistoryRef: "history-1", evidenceMapContractVersion: "v1", reviewPolicyVersion: "policy-v1", ...overrides });
+function presentation(candidate = row()) {
+  const applicability = deriveApplicability(candidate, { decision: "APPLICABLE", decisionBasis: "Requirement applies." });
+  const conclusion = deriveConformanceConclusion(candidate, applicability, { requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE", versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE" });
+  const draft = deriveDraftFinding(candidate, conclusion, { draftFindingType: null, findingBasis: null, reviewerAssessment: null });
+  const result = createReportPresentationObject(candidate, applicability, conclusion, draft);
+  if (!result.ready) throw new Error("expected presentation");
+  return result.presentation;
+}
+
+describe("Phase 9 readiness report consumer", () => {
+  test("handles single and multi-row gate results without remapping upstream status", () => {
+    const first = presentation();
+    const second = presentation(row({ rowId: "row-2", requirement: { requirementId: "req-2", requirementReference: "REQ-2", requirementText: "Second requirement." } }));
+    expect(createReadinessReportViewModel(evaluatePresentationReportGate([{ presentation: first }])).release.label).toBe("client-release-ready");
+    const model = createReadinessReportViewModel(evaluatePresentationReportGate([{ presentation: first }, { presentation: second }]));
+    expect(model.rows).toHaveLength(2);
+    expect(model.rows[0].upstreamStatus).toBe("FOUND");
+  });
+
+  test("renders blocked reports internally and preserves every gate reason", () => {
+    const gate = evaluatePresentationReportGate([{ presentation: presentation(), reviewState: "REOPENED" }]);
+    const model = createReadinessReportViewModel(gate);
+    expect(model.release.label).toBe("blocked");
+    expect(model.release.reasons).toEqual(expect.arrayContaining([expect.objectContaining({ category: "review_state_not_current" })]));
+  });
+
+  test("fails closed for missing presentation data and does not derive release readiness", () => {
+    const model = createReadinessReportViewModel(null);
+    expect(model.release.label).toBe("not assessed");
+    expect(model.release.releaseReady).toBe(false);
+    expect(model.release.reasons[0].category).toBe("invalid_report_input");
+  });
+
+  test("requires a real review event and preserves workflow metadata", () => {
+    expect(validateReviewerWorkflowEvent(null)).toEqual({ complete: false, state: "incomplete", reason: "review-history-event-required" });
+    const result = validateReviewerWorkflowEvent({ reviewerIdentity: "r-1", timestamp: "2026-07-11T00:00:00Z", reasonOrNote: "Reviewed evidence.", previousState: "pending review", newState: "approved", presentationContractVersion: "v1", reviewPolicyVersion: "policy-v1" });
+    expect(result).toMatchObject({ complete: true, state: "approved", event: { reviewerIdentity: "r-1", previousState: "pending review" } });
+    expect(reviewStateForGate("reopened")).toBe("REOPENED");
+  });
+});

--- a/tests/lib/evidence/readinessReport.test.ts
+++ b/tests/lib/evidence/readinessReport.test.ts
@@ -4,7 +4,7 @@ import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContrac
 import { deriveDraftFinding } from "@/lib/evidence/draftFindingContract";
 import { createReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
 import { evaluatePresentationReportGate } from "@/lib/evidence/presentationGate";
-import { createReadinessReportViewModel, reviewStateForGate, validateReviewerWorkflowEvent } from "@/lib/evidence/readinessReport";
+import { createReadinessReportViewModel, reviewStateForGate, transitionReviewerWorkflow, validateReviewerWorkflowEvent, type ReviewerWorkflowEvent, type ReviewerWorkflowState } from "@/lib/evidence/readinessReport";
 
 const provenance = { docId: "doc-1", page: 4, sectionPath: ["3", "3.1"], spanId: "span-1", sectionHeading: "Evidence", sourceType: "PDD" };
 const row = (overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow => ({ rowId: "row-1", requirement: { requirementId: "req-1", requirementReference: "REQ-1", requirementText: "Requirement text." }, methodology: { methodologyId: "VM", rulebookVersion: "1.0" }, upstreamStatus: "FOUND", applicabilityState: "APPLICABLE", acceptedEvidence: [{ evidenceId: "accepted", quote: "Accepted quote", provenance }], rejectedEvidence: [{ evidenceId: "rejected", quote: "Rejected quote", rejectionReason: "Out of scope", provenance }], assessmentReason: "Reviewed against the requirement.", clientAction: "Provide the signed appendix.", searchCoverage: { searched: true, searchedDocumentIds: ["doc-1"], notes: null }, sourceDocument: { documentId: "doc-1", documentName: "source.pdf", contentSha256: "hash" }, evidenceProvenance: [provenance], finalizationState: "finalized", finalizationActorRef: "reviewer-1", finalizedAt: "2026-07-10T00:00:00Z", finalizationBasis: "Evidence Map review", reviewHistoryRef: "history-1", evidenceMapContractVersion: "v1", reviewPolicyVersion: "policy-v1", ...overrides });
@@ -46,5 +46,42 @@ describe("Phase 9 readiness report consumer", () => {
     const result = validateReviewerWorkflowEvent({ reviewerIdentity: "r-1", timestamp: "2026-07-11T00:00:00Z", reasonOrNote: "Reviewed evidence.", previousState: "pending review", newState: "approved", presentationContractVersion: "v1", reviewPolicyVersion: "policy-v1" });
     expect(result).toMatchObject({ complete: true, state: "approved", event: { reviewerIdentity: "r-1", previousState: "pending review" } });
     expect(reviewStateForGate("reopened")).toBe("REOPENED");
+  });
+
+  test("accepts every supported transition and rejects unsupported transitions", () => {
+    const transitions: Array<[ReviewerWorkflowState, ReviewerWorkflowState]> = [
+      ["pending review", "approved"], ["pending review", "edited"], ["approved", "edited"], ["approved", "reopened"],
+      ["edited", "approved"], ["edited", "reopened"], ["reopened", "edited"], ["reopened", "approved"],
+    ];
+    for (const [previousState, newState] of transitions) {
+      const event: ReviewerWorkflowEvent = { reviewerIdentity: "reviewer-1", timestamp: "2026-07-11T00:00:00Z", reasonOrNote: `Move to ${newState}.`, previousState, newState, presentationContractVersion: "v1", reviewPolicyVersion: "policy-v1" };
+      expect(transitionReviewerWorkflow(previousState, [], event)).toMatchObject({ accepted: true, state: newState, history: [event] });
+    }
+    const unsupported: ReviewerWorkflowEvent = { reviewerIdentity: "reviewer-1", timestamp: "2026-07-11T00:00:00Z", reasonOrNote: "Cannot skip review.", previousState: "pending review", newState: "reopened", presentationContractVersion: "v1", reviewPolicyVersion: "policy-v1" };
+    expect(transitionReviewerWorkflow("pending review", [], unsupported)).toMatchObject({ accepted: false, state: "invalid_transition", reason: "unsupported-transition" });
+  });
+
+  test("appends history, preserves metadata, and fails closed for incomplete history", () => {
+    const first: ReviewerWorkflowEvent = { reviewerIdentity: "r-1", timestamp: "2026-07-11T00:00:00Z", reasonOrNote: "Initial review.", previousState: "pending review", newState: "approved", presentationContractVersion: "v1", reviewPolicyVersion: "policy-v1" };
+    const second: ReviewerWorkflowEvent = { ...first, reviewerIdentity: "r-2", timestamp: "2026-07-11T01:00:00Z", reasonOrNote: "Reopened for edits.", previousState: "approved", newState: "reopened" };
+    const result = transitionReviewerWorkflow("approved", [first], second);
+    expect(result).toMatchObject({ accepted: true, history: [first, second] });
+    expect(result.history).not.toBe([second]);
+    expect(transitionReviewerWorkflow("pending review", undefined, first)).toMatchObject({ accepted: false, state: "incomplete" });
+    expect(transitionReviewerWorkflow("pending review", [], null)).toMatchObject({ accepted: false, state: "incomplete" });
+    expect(transitionReviewerWorkflow("approved", [{ ...first, previousState: "edited" }], second)).toMatchObject({ accepted: false, state: "incomplete" });
+  });
+
+  test("reopening uses the Phase 7 gate and leaves evidence and provenance unchanged", () => {
+    const before = presentation();
+    const event: ReviewerWorkflowEvent = { reviewerIdentity: "r-1", timestamp: "2026-07-11T00:00:00Z", reasonOrNote: "Reopen for clarification.", previousState: "approved", newState: "reopened", presentationContractVersion: "v1", reviewPolicyVersion: "policy-v1" };
+    expect(transitionReviewerWorkflow("approved", [], event)).toMatchObject({ accepted: true, state: "reopened" });
+    const after = evaluatePresentationReportGate([{ presentation: before, reviewState: reviewStateForGate("reopened") }]);
+    expect(after.releaseReady).toBe(false);
+    expect(after.releaseState).toBe("BLOCKED");
+    expect(after.presentations[0].acceptedEvidence).toEqual(before.acceptedEvidence);
+    expect(after.presentations[0].rejectedEvidence).toEqual(before.rejectedEvidence);
+    expect(after.presentations[0].evidenceProvenance).toEqual(before.evidenceProvenance);
+    expect(evaluatePresentationReportGate([{ presentation: before, reviewState: "PENDING_REVIEW" }])).toMatchObject({ releaseReady: false, releaseState: "INTERNAL_REVIEW_ONLY" });
   });
 });


### PR DESCRIPTION
## Summary

- Add a typed Pre-Validation Readiness Report view model that consumes only finalized Phase 6 presentation objects and Phase 7 gate results.
- Add a reviewer UI that preserves accepted and rejected evidence, rejection reasons, provenance, assessment basis, client action, review metadata, and gate blockers.
- Add centralized fail-closed reviewer workflow transitions with append-only review history.
- Add an internal fixture-backed preview route for visual inspection of all release states.
- Mark Phase 9 complete and Phase 10 next.

## Behavior

- Supports `client-release-ready`, `internal-review-only`, `blocked`, and `not-assessed` states.
- Phase 7 remains the sole release authority.
- Reopened or incomplete review history blocks release.
- Reviewer workflow supports the eight allowed approve/edit/reopen transitions and rejects unsupported or malformed transitions.
- Accepted evidence, rejected evidence, rejection reasons, provenance, upstream statuses, and presentation metadata remain unchanged.
- UI consumers render existing decisions and do not derive conformance, applicability, draft findings, or release readiness.

## Internal preview

Route:

`/internal/reports/pre-validation-readiness`

State selector:

`?state=client-release-ready|internal-review-only|blocked|not-assessed`

The preview is fixture-backed, clearly labeled internal, and uses non-persistent Approve/Edit/Reopen callbacks. It is not connected to the production “View gap report” flow.

## Reviewer workflow

- Centralized pure transition contract
- Append-only history
- Required reviewer identity, timestamp, note, previous state, new state, presentation contract version, and review policy version
- Incomplete or malformed history fails closed
- Reopening removes client-release eligibility through the existing Phase 7 gate

## Checks

- Focused Phase 9 tests: 10 passed
- `npm run lint`
- `npm run typecheck`
- `npm run roadmap:check`
- `git diff --check`
- `npm run pr:gate` passed: 220 suites, 2,347 tests

## Non-goals

- No production wiring from “View gap report” to the readiness route
- No Quick Check or upstream status changes
- No Evidence Map contract changes
- No Phase 10 deprecation work
- No production persistence for reviewer actions
- No changes to `public/manifest/index.json`

## Final status

The worktree contains only the pre-existing, intentionally excluded `public/manifest/index.json` modification.