### PR TITLE
feat: wire production pre-validation readiness report

### DIFF
--- a/src/app/projects/[id]/pre-validation-readiness/page.tsx
+++ b/src/app/projects/[id]/pre-validation-readiness/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import ProjectPreValidationReadinessReport from "@/components/projects/ProjectPreValidationReadinessReport";
+
+export const metadata: Metadata = {
+  title: "Project Pre-Validation Readiness Report | app.article6",
+  description: "Project-specific Pre-Validation Readiness Report from finalized presentation data.",
+};
+
+export default async function ProjectPreValidationReadinessPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <ProjectPreValidationReadinessReport projectId={id} />;
+}

--- a/src/app/quick-check/pre-validation-readiness/page.tsx
+++ b/src/app/quick-check/pre-validation-readiness/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import QuickCheckPreValidationReadinessReport from "@/components/projects/QuickCheckPreValidationReadinessReport";
+
+export const metadata: Metadata = {
+  title: "Quick Check Pre-Validation Readiness Report | app.article6",
+  description: "Quick Check readiness report from canonical project Evidence Map data.",
+};
+
+export default async function QuickCheckPreValidationReadinessPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ auditId?: string | string[] }>;
+}) {
+  const params = await searchParams;
+  const auditId = Array.isArray(params?.auditId) ? params.auditId[0] : params?.auditId;
+  return <QuickCheckPreValidationReadinessReport auditId={auditId?.trim() || null} />;
+}

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -92,6 +92,7 @@ import { buildMethodologyVersionLock } from "@/lib/preverif/evidenceAudit";
 import {
   buildAndSaveVm0007GapReportAudit,
 } from "@/lib/preverif/vm0007GapReportStore";
+import { hasProjectReadinessPayload } from "@/lib/evidence/projectReadinessPayload";
 
 type MethodInventoryRecord = {
   code: string;
@@ -692,6 +693,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [runningEvidenceChecks, setRunningEvidenceChecks] = useState(false);
   const [uploadVm0007GapReportAuditId, setUploadVm0007GapReportAuditId] = useState<string | null>(null);
   const [generatingUploadVm0007GapReport, setGeneratingUploadVm0007GapReport] = useState(false);
+  const [linkedProjectReadinessPayload, setLinkedProjectReadinessPayload] = useState(false);
   const [selectedHeading, setSelectedHeading] = useState<DocumentHeading | null>(null);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
@@ -705,6 +707,14 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       methodologyVersion: initialVersion?.trim() || undefined,
     }),
   );
+
+  const linkedProjectId = typeof window === "undefined"
+    ? null
+    : new URLSearchParams(window.location.search).get("projectId")?.trim() || null;
+
+  useEffect(() => {
+    setLinkedProjectReadinessPayload(linkedProjectId ? hasProjectReadinessPayload(linkedProjectId) : false);
+  }, [linkedProjectId]);
 
   const draft = session.draft;
   const result = session.result;
@@ -2902,6 +2912,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             <Vm0007GapReportLaunchButton
               isVm0007Result
               auditId={uploadVm0007ReportAuditId}
+              projectId={linkedProjectId}
+              readinessPayloadAvailable={linkedProjectReadinessPayload}
               title="Internal VM0007 report"
               onGenerate={handleGenerateUploadVm0007GapReport}
               generating={generatingUploadVm0007GapReport}
@@ -3634,6 +3646,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               <Vm0007GapReportLaunchButton
                 isVm0007Result={isVm0007RenderedResult}
                 auditId={renderedResult?.vm0007GapReportAuditId}
+                projectId={linkedProjectId}
+                readinessPayloadAvailable={linkedProjectReadinessPayload}
               />
             </div>
           ) : null}

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -92,7 +92,6 @@ import { buildMethodologyVersionLock } from "@/lib/preverif/evidenceAudit";
 import {
   buildAndSaveVm0007GapReportAudit,
 } from "@/lib/preverif/vm0007GapReportStore";
-import { hasProjectReadinessPayload } from "@/lib/evidence/projectReadinessPayload";
 
 type MethodInventoryRecord = {
   code: string;
@@ -693,7 +692,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [runningEvidenceChecks, setRunningEvidenceChecks] = useState(false);
   const [uploadVm0007GapReportAuditId, setUploadVm0007GapReportAuditId] = useState<string | null>(null);
   const [generatingUploadVm0007GapReport, setGeneratingUploadVm0007GapReport] = useState(false);
-  const [linkedProjectReadinessPayload, setLinkedProjectReadinessPayload] = useState(false);
   const [selectedHeading, setSelectedHeading] = useState<DocumentHeading | null>(null);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
   const [extractionState, setExtractionState] = useState<ExtractionState>({
@@ -711,10 +709,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const linkedProjectId = typeof window === "undefined"
     ? null
     : new URLSearchParams(window.location.search).get("projectId")?.trim() || null;
-
-  useEffect(() => {
-    setLinkedProjectReadinessPayload(linkedProjectId ? hasProjectReadinessPayload(linkedProjectId) : false);
-  }, [linkedProjectId]);
 
   const draft = session.draft;
   const result = session.result;
@@ -2913,7 +2907,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               isVm0007Result
               auditId={uploadVm0007ReportAuditId}
               projectId={linkedProjectId}
-              readinessPayloadAvailable={linkedProjectReadinessPayload}
               title="Internal VM0007 report"
               onGenerate={handleGenerateUploadVm0007GapReport}
               generating={generatingUploadVm0007GapReport}
@@ -3647,7 +3640,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                 isVm0007Result={isVm0007RenderedResult}
                 auditId={renderedResult?.vm0007GapReportAuditId}
                 projectId={linkedProjectId}
-                readinessPayloadAvailable={linkedProjectReadinessPayload}
               />
             </div>
           ) : null}

--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { ArrowUpRight, Loader2 } from "lucide-react";
 import { buildVm0007GapReportHref } from "@/lib/preverif/vm0007GapReportStore";
+import { hasProjectReadinessPayload, PROJECT_READINESS_PAYLOAD_EVENT, type ProjectReadinessPayloadEventDetail } from "@/lib/evidence/projectReadinessPayload";
 
 type Vm0007GapReportLaunchButtonProps = {
   isVm0007Result: boolean;
@@ -27,12 +29,25 @@ export default function Vm0007GapReportLaunchButton({
   generateDisabled = false,
   testId = "vm0007-internal-report-section",
 }: Vm0007GapReportLaunchButtonProps) {
+  const [hasReadinessPayload, setHasReadinessPayload] = useState(readinessPayloadAvailable);
+
+  useEffect(() => {
+    setHasReadinessPayload(projectId?.trim() ? hasProjectReadinessPayload(projectId) || readinessPayloadAvailable : false);
+    const handlePayloadEvent = (event: Event) => {
+      const detail = (event as CustomEvent<ProjectReadinessPayloadEventDetail>).detail;
+      if (!projectId?.trim() || !detail || detail.projectId !== projectId) return;
+      setHasReadinessPayload(detail.state === "saved" && hasProjectReadinessPayload(projectId));
+    };
+    window.addEventListener(PROJECT_READINESS_PAYLOAD_EVENT, handlePayloadEvent);
+    return () => window.removeEventListener(PROJECT_READINESS_PAYLOAD_EVENT, handlePayloadEvent);
+  }, [projectId, readinessPayloadAvailable]);
+
   if (!isVm0007Result) return null;
 
   return (
     <div className="mt-4 rounded-xl border border-slate-200 bg-white/80 px-4 py-4" data-testid={testId}>
       <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{title}</div>
-      {projectId?.trim() && readinessPayloadAvailable ? (
+      {projectId?.trim() && hasReadinessPayload ? (
         <>
           <div className="mt-2 text-sm text-slate-600">
             Open the project Pre-Validation Readiness Report from finalized presentation data.

--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -1,16 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Link from "next/link";
 import { ArrowUpRight, Loader2 } from "lucide-react";
 import { buildVm0007GapReportHref } from "@/lib/preverif/vm0007GapReportStore";
-import { hasProjectReadinessPayload, PROJECT_READINESS_PAYLOAD_EVENT, type ProjectReadinessPayloadEventDetail } from "@/lib/evidence/projectReadinessPayload";
 
 type Vm0007GapReportLaunchButtonProps = {
   isVm0007Result: boolean;
   auditId?: string | null;
   projectId?: string | null;
-  readinessPayloadAvailable?: boolean;
   title?: string;
   onGenerate?: (() => void) | null;
   generating?: boolean;
@@ -22,32 +19,18 @@ export default function Vm0007GapReportLaunchButton({
   isVm0007Result,
   auditId,
   projectId = null,
-  readinessPayloadAvailable = false,
   title = "Internal report",
   onGenerate = null,
   generating = false,
   generateDisabled = false,
   testId = "vm0007-internal-report-section",
 }: Vm0007GapReportLaunchButtonProps) {
-  const [hasReadinessPayload, setHasReadinessPayload] = useState(readinessPayloadAvailable);
-
-  useEffect(() => {
-    setHasReadinessPayload(projectId?.trim() ? hasProjectReadinessPayload(projectId) || readinessPayloadAvailable : false);
-    const handlePayloadEvent = (event: Event) => {
-      const detail = (event as CustomEvent<ProjectReadinessPayloadEventDetail>).detail;
-      if (!projectId?.trim() || !detail || detail.projectId !== projectId) return;
-      setHasReadinessPayload(detail.state === "saved" && hasProjectReadinessPayload(projectId));
-    };
-    window.addEventListener(PROJECT_READINESS_PAYLOAD_EVENT, handlePayloadEvent);
-    return () => window.removeEventListener(PROJECT_READINESS_PAYLOAD_EVENT, handlePayloadEvent);
-  }, [projectId, readinessPayloadAvailable]);
-
   if (!isVm0007Result) return null;
 
   return (
     <div className="mt-4 rounded-xl border border-slate-200 bg-white/80 px-4 py-4" data-testid={testId}>
       <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{title}</div>
-      {projectId?.trim() && hasReadinessPayload ? (
+      {projectId?.trim() ? (
         <>
           <div className="mt-2 text-sm text-slate-600">
             Open the project Pre-Validation Readiness Report from finalized presentation data.

--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -7,6 +7,8 @@ import { buildVm0007GapReportHref } from "@/lib/preverif/vm0007GapReportStore";
 type Vm0007GapReportLaunchButtonProps = {
   isVm0007Result: boolean;
   auditId?: string | null;
+  projectId?: string | null;
+  readinessPayloadAvailable?: boolean;
   title?: string;
   onGenerate?: (() => void) | null;
   generating?: boolean;
@@ -17,6 +19,8 @@ type Vm0007GapReportLaunchButtonProps = {
 export default function Vm0007GapReportLaunchButton({
   isVm0007Result,
   auditId,
+  projectId = null,
+  readinessPayloadAvailable = false,
   title = "Internal report",
   onGenerate = null,
   generating = false,
@@ -28,7 +32,22 @@ export default function Vm0007GapReportLaunchButton({
   return (
     <div className="mt-4 rounded-xl border border-slate-200 bg-white/80 px-4 py-4" data-testid={testId}>
       <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{title}</div>
-      {auditId?.trim() ? (
+      {projectId?.trim() && readinessPayloadAvailable ? (
+        <>
+          <div className="mt-2 text-sm text-slate-600">
+            Open the project Pre-Validation Readiness Report from finalized presentation data.
+          </div>
+          <div className="mt-3">
+            <Link
+              href={`/projects/${encodeURIComponent(projectId)}/pre-validation-readiness`}
+              className="inline-flex items-center gap-2 rounded-full border border-green-600 bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:border-green-700 hover:bg-green-700"
+            >
+              <ArrowUpRight className="h-4 w-4" />
+              View Gap Report
+            </Link>
+          </div>
+        </>
+      ) : auditId?.trim() ? (
         <>
           <div className="mt-2 text-sm text-slate-600">
             Open the internal VM0007 gap report preview for manual browser print or PDF save.

--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { ArrowUpRight, Loader2 } from "lucide-react";
-import { buildVm0007GapReportHref } from "@/lib/preverif/vm0007GapReportStore";
 
 type Vm0007GapReportLaunchButtonProps = {
   isVm0007Result: boolean;
@@ -48,11 +47,11 @@ export default function Vm0007GapReportLaunchButton({
       ) : auditId?.trim() ? (
         <>
           <div className="mt-2 text-sm text-slate-600">
-            Open the internal VM0007 gap report preview for manual browser print or PDF save.
+            Open the standalone Pre-Validation Readiness Report. It remains not assessed until canonical project Evidence Map data exists.
           </div>
           <div className="mt-3">
             <Link
-              href={buildVm0007GapReportHref(auditId)}
+              href={`/quick-check/pre-validation-readiness?auditId=${encodeURIComponent(auditId)}`}
               className="inline-flex items-center gap-2 rounded-full border border-green-600 bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:border-green-700 hover:bg-green-700"
             >
               <ArrowUpRight className="h-4 w-4" />

--- a/src/components/projects/ProjectPreValidationReadinessReport.tsx
+++ b/src/components/projects/ProjectPreValidationReadinessReport.tsx
@@ -2,9 +2,12 @@
 
 import { useEffect, useState } from "react";
 import PreValidationReadinessReviewer from "@/components/readiness/PreValidationReadinessReviewer";
-import { createProjectReadinessReportViewModel, loadProjectReadinessPayload } from "@/lib/evidence/projectReadinessPayload";
-import { getProject } from "@/lib/projects/storage";
-import type { Project } from "@/lib/projects/types";
+import {
+  createProjectReadinessReportViewModel,
+  loadProjectReadinessPayload,
+  PROJECT_READINESS_PAYLOAD_EVENT,
+  type ProjectReadinessPayloadEventDetail,
+} from "@/lib/evidence/projectReadinessPayload";
 import type { ReadinessReportViewModel } from "@/lib/evidence/readinessReport";
 
 type Props = Readonly<{ projectId: string }>;
@@ -12,36 +15,29 @@ type Props = Readonly<{ projectId: string }>;
 const NOT_ASSESSED = createProjectReadinessReportViewModel(null);
 
 export default function ProjectPreValidationReadinessReport({ projectId }: Props) {
-  const [project, setProject] = useState<Project | null>(null);
   const [report, setReport] = useState<ReadinessReportViewModel>(NOT_ASSESSED);
-  const [actionMessage, setActionMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    const loadedProject = getProject(projectId);
-    const payload = loadProjectReadinessPayload(projectId);
-    setProject(loadedProject ?? null);
-    setReport(createProjectReadinessReportViewModel(payload));
+    const load = () => setReport(createProjectReadinessReportViewModel(loadProjectReadinessPayload(projectId)));
+    const handlePayloadEvent = (event: Event) => {
+      const detail = (event as CustomEvent<ProjectReadinessPayloadEventDetail>).detail;
+      if (!detail || detail.projectId !== projectId) return;
+      setReport(detail.state === "cleared" ? NOT_ASSESSED : createProjectReadinessReportViewModel(loadProjectReadinessPayload(projectId)));
+    };
+    load();
+    window.addEventListener(PROJECT_READINESS_PAYLOAD_EVENT, handlePayloadEvent);
+    return () => window.removeEventListener(PROJECT_READINESS_PAYLOAD_EVENT, handlePayloadEvent);
   }, [projectId]);
-
-  const recordPreviewAction = (action: string, rowId: string) => {
-    setActionMessage(`${action} requested for ${rowId}. This production wiring preview does not persist reviewer changes.`);
-  };
 
   return (
     <main className="min-h-screen bg-slate-50 px-4 py-8" data-testid="project-pre-validation-readiness-report">
       <div className="mx-auto grid max-w-6xl gap-4">
         <header className="rounded-2xl border border-slate-200 bg-white p-5">
           <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Pre-Validation Readiness Report</div>
-          <h1 className="mt-2 text-2xl font-semibold text-slate-950">{project?.name ?? "Project readiness report"}</h1>
+          <h1 className="mt-2 text-2xl font-semibold text-slate-950">Project readiness report</h1>
           <div className="mt-1 text-sm text-slate-600">Project ID: {projectId} · Real finalized presentation payload only</div>
         </header>
-        <PreValidationReadinessReviewer
-          report={report}
-          onApprove={(rowId) => recordPreviewAction("Approve", rowId)}
-          onEdit={(rowId) => recordPreviewAction("Edit", rowId)}
-          onReopen={(rowId) => recordPreviewAction("Reopen", rowId)}
-        />
-        {actionMessage ? <p className="rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-900" data-testid="project-readiness-action-status">{actionMessage}</p> : null}
+        <PreValidationReadinessReviewer report={report} />
       </div>
     </main>
   );

--- a/src/components/projects/ProjectPreValidationReadinessReport.tsx
+++ b/src/components/projects/ProjectPreValidationReadinessReport.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PreValidationReadinessReviewer from "@/components/readiness/PreValidationReadinessReviewer";
+import { createProjectReadinessReportViewModel, loadProjectReadinessPayload } from "@/lib/evidence/projectReadinessPayload";
+import { getProject } from "@/lib/projects/storage";
+import type { Project } from "@/lib/projects/types";
+import type { ReadinessReportViewModel } from "@/lib/evidence/readinessReport";
+
+type Props = Readonly<{ projectId: string }>;
+
+const NOT_ASSESSED = createProjectReadinessReportViewModel(null);
+
+export default function ProjectPreValidationReadinessReport({ projectId }: Props) {
+  const [project, setProject] = useState<Project | null>(null);
+  const [report, setReport] = useState<ReadinessReportViewModel>(NOT_ASSESSED);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadedProject = getProject(projectId);
+    const payload = loadProjectReadinessPayload(projectId);
+    setProject(loadedProject ?? null);
+    setReport(createProjectReadinessReportViewModel(payload));
+  }, [projectId]);
+
+  const recordPreviewAction = (action: string, rowId: string) => {
+    setActionMessage(`${action} requested for ${rowId}. This production wiring preview does not persist reviewer changes.`);
+  };
+
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-8" data-testid="project-pre-validation-readiness-report">
+      <div className="mx-auto grid max-w-6xl gap-4">
+        <header className="rounded-2xl border border-slate-200 bg-white p-5">
+          <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Pre-Validation Readiness Report</div>
+          <h1 className="mt-2 text-2xl font-semibold text-slate-950">{project?.name ?? "Project readiness report"}</h1>
+          <div className="mt-1 text-sm text-slate-600">Project ID: {projectId} · Real finalized presentation payload only</div>
+        </header>
+        <PreValidationReadinessReviewer
+          report={report}
+          onApprove={(rowId) => recordPreviewAction("Approve", rowId)}
+          onEdit={(rowId) => recordPreviewAction("Edit", rowId)}
+          onReopen={(rowId) => recordPreviewAction("Reopen", rowId)}
+        />
+        {actionMessage ? <p className="rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-900" data-testid="project-readiness-action-status">{actionMessage}</p> : null}
+      </div>
+    </main>
+  );
+}

--- a/src/components/projects/QuickCheckPreValidationReadinessReport.tsx
+++ b/src/components/projects/QuickCheckPreValidationReadinessReport.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import PreValidationReadinessReviewer from "@/components/readiness/PreValidationReadinessReviewer";
+import { createProjectReadinessReportViewModel } from "@/lib/evidence/projectReadinessPayload";
+
+type Props = Readonly<{ auditId?: string | null }>;
+
+const NOT_ASSESSED = createProjectReadinessReportViewModel(null);
+
+export default function QuickCheckPreValidationReadinessReport({ auditId }: Props) {
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-8" data-testid="quick-check-pre-validation-readiness-report">
+      <div className="mx-auto grid max-w-6xl gap-4">
+        <header className="rounded-2xl border border-slate-200 bg-white p-5">
+          <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Pre-Validation Readiness Report</div>
+          <h1 className="mt-2 text-2xl font-semibold text-slate-950">Quick Check readiness report</h1>
+          <div className="mt-1 text-sm text-slate-600">
+            {auditId ? `Quick Check source audit: ${auditId} · ` : ""}Canonical project Evidence Map payload only
+          </div>
+        </header>
+        <PreValidationReadinessReviewer report={NOT_ASSESSED} />
+      </div>
+    </main>
+  );
+}

--- a/tests/components/projectPreValidationReadinessReport.test.tsx
+++ b/tests/components/projectPreValidationReadinessReport.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, test } from "@jest/globals";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import ProjectPreValidationReadinessReport from "@/components/projects/ProjectPreValidationReadinessReport";
-import { projectReadinessPayloadStorageKey } from "@/lib/evidence/projectReadinessPayload";
+import { clearProjectReadinessPayload, saveProjectReadinessPayload } from "@/lib/evidence/projectReadinessPayload";
 import { createReadinessReportViewModel } from "@/lib/evidence/readinessReport";
 import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
 import { deriveConformanceConclusion } from "@/lib/evidence/conformanceConclusionContract";
@@ -24,6 +24,8 @@ function realPresentation() {
 }
 
 describe("ProjectPreValidationReadinessReport", () => {
+  beforeEach(() => window.localStorage.clear());
+
   test("renders not-assessed when the real project payload is missing", async () => {
     const container = document.createElement("div");
     const root = createRoot(container);
@@ -34,15 +36,43 @@ describe("ProjectPreValidationReadinessReport", () => {
 
   test("renders a blocked real gate result and preserves the reviewer surface", async () => {
     const presentation = realPresentation();
-    window.localStorage.setItem(projectReadinessPayloadStorageKey("project-1"), JSON.stringify({
-      projectId: "project-1",
-      gateResult: { releaseReady: false, releaseState: "BLOCKED", crossRowOutcome: "NOT_EVALUATED", presentations: [presentation], blockedBy: [{ category: "review_state_not_current", evidenceMapRowId: presentation.evidenceMapRowId, detail: "REOPENED" }] },
-    }));
+    expect(saveProjectReadinessPayload({ projectId: "project-1", gateResult: {
+      releaseReady: false,
+      releaseState: "BLOCKED",
+      crossRowOutcome: "NOT_EVALUATED",
+      presentations: [presentation],
+      blockedBy: [{ category: "review_state_not_current", evidenceMapRowId: presentation.evidenceMapRowId, detail: "REOPENED" }],
+    } })).toBe(true);
     const container = document.createElement("div");
     const root = createRoot(container);
     await act(async () => { root.render(<ProjectPreValidationReadinessReport projectId="project-1" />); });
     expect(container.textContent).toContain("blocked");
     expect(container.textContent).toContain("Project evidence.");
+    act(() => { root.unmount(); });
+  });
+
+  test("updates immediately for the linked project's save and clear events, but ignores another project", async () => {
+    const presentation = realPresentation();
+    const gateResult = {
+      releaseReady: false as const,
+      releaseState: "BLOCKED" as const,
+      crossRowOutcome: "NOT_EVALUATED" as const,
+      presentations: [presentation],
+      blockedBy: [{ category: "review_state_not_current" as const, evidenceMapRowId: presentation.evidenceMapRowId, detail: "REOPENED" }],
+    };
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => { root.render(<ProjectPreValidationReadinessReport projectId="project-1" />); });
+    expect(container.textContent).toContain("not assessed");
+
+    await act(async () => { expect(saveProjectReadinessPayload({ projectId: "project-1", gateResult })).toBe(true); });
+    expect(container.textContent).toContain("Project evidence.");
+
+    await act(async () => { expect(saveProjectReadinessPayload({ projectId: "project-2", gateResult })).toBe(true); });
+    expect(container.textContent).toContain("Project evidence.");
+
+    await act(async () => { expect(clearProjectReadinessPayload("project-1")).toBe(true); });
+    expect(container.textContent).toContain("not assessed");
     act(() => { root.unmount(); });
   });
 });

--- a/tests/components/projectPreValidationReadinessReport.test.tsx
+++ b/tests/components/projectPreValidationReadinessReport.test.tsx
@@ -1,0 +1,48 @@
+/** @jest-environment jsdom */
+
+import { describe, expect, test } from "@jest/globals";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import ProjectPreValidationReadinessReport from "@/components/projects/ProjectPreValidationReadinessReport";
+import { projectReadinessPayloadStorageKey } from "@/lib/evidence/projectReadinessPayload";
+import { createReadinessReportViewModel } from "@/lib/evidence/readinessReport";
+import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
+import { deriveConformanceConclusion } from "@/lib/evidence/conformanceConclusionContract";
+import { deriveDraftFinding } from "@/lib/evidence/draftFindingContract";
+import { createReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+
+function realPresentation() {
+  const provenance = { docId: "project-pdd.pdf", page: 5, sectionPath: ["2"], spanId: "project-span-1", sectionHeading: "Requirement", sourceType: "PDD" };
+  const row: EvidenceMapRow = { rowId: "project-row-1", requirement: { requirementId: "project-req-1", requirementReference: "REQ-1", requirementText: "Project requirement." }, methodology: { methodologyId: "VM0007", rulebookVersion: "1.8" }, upstreamStatus: "FOUND", applicabilityState: "APPLICABLE", acceptedEvidence: [{ evidenceId: "project-evidence-1", quote: "Project evidence.", provenance }], rejectedEvidence: [], assessmentReason: "Project review assessment.", clientAction: null, searchCoverage: { searched: true, searchedDocumentIds: ["project-pdd.pdf"], notes: null }, sourceDocument: { documentId: "project-pdd.pdf", documentName: "Project PDD", contentSha256: "sha256:project" }, evidenceProvenance: [provenance], finalizationState: "finalized", finalizationActorRef: "reviewer:project", finalizedAt: "2026-07-11T00:00:00Z", finalizationBasis: "Finalized project review.", reviewHistoryRef: "history:project-row-1", evidenceMapContractVersion: "v1", reviewPolicyVersion: "policy-v1" };
+  const applicability = deriveApplicability(row, { decision: "APPLICABLE", decisionBasis: "Project requirement applies." });
+  const conformance = deriveConformanceConclusion(row, applicability, { requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE", versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE" });
+  const draft = deriveDraftFinding(row, conformance, { draftFindingType: null, findingBasis: null, reviewerAssessment: null });
+  const packaged = createReportPresentationObject(row, applicability, conformance, draft);
+  if (!packaged.ready) throw new Error("Expected valid project presentation");
+  return packaged.presentation;
+}
+
+describe("ProjectPreValidationReadinessReport", () => {
+  test("renders not-assessed when the real project payload is missing", async () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => { root.render(<ProjectPreValidationReadinessReport projectId="missing-project" />); });
+    expect(container.textContent).toContain("not assessed");
+    act(() => { root.unmount(); });
+  });
+
+  test("renders a blocked real gate result and preserves the reviewer surface", async () => {
+    const presentation = realPresentation();
+    window.localStorage.setItem(projectReadinessPayloadStorageKey("project-1"), JSON.stringify({
+      projectId: "project-1",
+      gateResult: { releaseReady: false, releaseState: "BLOCKED", crossRowOutcome: "NOT_EVALUATED", presentations: [presentation], blockedBy: [{ category: "review_state_not_current", evidenceMapRowId: presentation.evidenceMapRowId, detail: "REOPENED" }] },
+    }));
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => { root.render(<ProjectPreValidationReadinessReport projectId="project-1" />); });
+    expect(container.textContent).toContain("blocked");
+    expect(container.textContent).toContain("Project evidence.");
+    act(() => { root.unmount(); });
+  });
+});

--- a/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
+++ b/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
@@ -367,9 +367,9 @@ describe("QuickCheckPanel upload/session boundary smoke test — proves the pane
     );
     expect(link).toBeTruthy();
     const href = link?.getAttribute("href") ?? "";
-    const auditIdMatch = href.match(/\/internal\/reports\/vm0007-gap\/(.+)$/);
+    const auditIdMatch = href.match(/\/quick-check\/pre-validation-readiness\?auditId=([^&]+)$/);
     expect(auditIdMatch?.[1]).toBeTruthy();
-    const audit = loadVm0007GapReportAudit(auditIdMatch?.[1] ?? "");
+    const audit = loadVm0007GapReportAudit(decodeURIComponent(auditIdMatch?.[1] ?? ""));
     expect(audit).not.toBeNull();
     expect(audit?.methodology?.methodologyId).toBe("VM0007");
     expect(audit?.methodology?.methodologyName).toBeTruthy();

--- a/tests/components/quickCheckPanel.vm0007GapReportEntry.test.tsx
+++ b/tests/components/quickCheckPanel.vm0007GapReportEntry.test.tsx
@@ -121,7 +121,7 @@ describe("QuickCheckPanel VM0007 gap report entry point", () => {
     expect(text).toContain("View Gap Report");
 
     const link = Array.from(container.querySelectorAll("a")).find((item) => item.textContent?.includes("View Gap Report"));
-    expect(link?.getAttribute("href")).toBe("/internal/reports/vm0007-gap/audit-quickcheck-1");
+    expect(link?.getAttribute("href")).toBe("/quick-check/pre-validation-readiness?auditId=audit-quickcheck-1");
   });
 
   test("renders a disabled helper state when VM0007 result has no report id yet", async () => {

--- a/tests/components/quickCheckPreValidationReadinessReport.test.tsx
+++ b/tests/components/quickCheckPreValidationReadinessReport.test.tsx
@@ -1,0 +1,19 @@
+/** @jest-environment jsdom */
+
+import { describe, expect, test } from "@jest/globals";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import QuickCheckPreValidationReadinessReport from "@/components/projects/QuickCheckPreValidationReadinessReport";
+
+describe("Quick Check Pre-Validation Readiness Report", () => {
+  test("renders NOT_ASSESSED without adapting legacy audit data", async () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => { root.render(<QuickCheckPreValidationReadinessReport auditId="legacy-audit-1" />); });
+    expect(container.textContent).toContain("Quick Check source audit: legacy-audit-1");
+    expect(container.textContent).toContain("not assessed");
+    expect(container.textContent).not.toContain("conformance");
+    expect(container.textContent).not.toContain("Draft finding");
+    act(() => { root.unmount(); });
+  });
+});

--- a/tests/components/vm0007GapReportLaunchButton.readiness.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.readiness.test.tsx
@@ -6,12 +6,16 @@ import { act } from "react";
 import Vm0007GapReportLaunchButton from "@/components/preverif/Vm0007GapReportLaunchButton";
 
 describe("VM0007 gap report routing compatibility", () => {
-  test("uses project readiness route only when the real payload is available", () => {
+  test("uses the project readiness route for a linked project even without a payload", () => {
     const container = document.createElement("div");
     const root = createRoot(container);
-    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" projectId="project-1" readinessPayloadAvailable />); });
+    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" projectId="project-1" />); });
     expect(container.querySelector("a")?.getAttribute("href")).toBe("/projects/project-1/pre-validation-readiness");
-    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" projectId="project-1" readinessPayloadAvailable={false} />); });
+    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" projectId="project-1" />); });
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("/projects/project-1/pre-validation-readiness");
+    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" projectId="project/a" />); });
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("/projects/project%2Fa/pre-validation-readiness");
+    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" />); });
     expect(container.querySelector("a")?.getAttribute("href")).toBe("/internal/reports/vm0007-gap/audit-1");
     act(() => { root.unmount(); });
   });

--- a/tests/components/vm0007GapReportLaunchButton.readiness.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.readiness.test.tsx
@@ -1,0 +1,18 @@
+/** @jest-environment jsdom */
+
+import { describe, expect, test } from "@jest/globals";
+import { createRoot } from "react-dom/client";
+import { act } from "react";
+import Vm0007GapReportLaunchButton from "@/components/preverif/Vm0007GapReportLaunchButton";
+
+describe("VM0007 gap report routing compatibility", () => {
+  test("uses project readiness route only when the real payload is available", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" projectId="project-1" readinessPayloadAvailable />); });
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("/projects/project-1/pre-validation-readiness");
+    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" projectId="project-1" readinessPayloadAvailable={false} />); });
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("/internal/reports/vm0007-gap/audit-1");
+    act(() => { root.unmount(); });
+  });
+});

--- a/tests/components/vm0007GapReportLaunchButton.readiness.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.readiness.test.tsx
@@ -13,10 +13,10 @@ describe("VM0007 gap report routing compatibility", () => {
     expect(container.querySelector("a")?.getAttribute("href")).toBe("/projects/project-1/pre-validation-readiness");
     act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" projectId="project-1" />); });
     expect(container.querySelector("a")?.getAttribute("href")).toBe("/projects/project-1/pre-validation-readiness");
-    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" projectId="project/a" />); });
+    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit/a" projectId="project/a" />); });
     expect(container.querySelector("a")?.getAttribute("href")).toBe("/projects/project%2Fa/pre-validation-readiness");
-    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit-1" />); });
-    expect(container.querySelector("a")?.getAttribute("href")).toBe("/internal/reports/vm0007-gap/audit-1");
+    act(() => { root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId="audit/a" />); });
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("/quick-check/pre-validation-readiness?auditId=audit%2Fa");
     act(() => { root.unmount(); });
   });
 });

--- a/tests/components/vm0007GapReportLaunchButton.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.test.tsx
@@ -88,7 +88,7 @@ describe("Vm0007GapReportLaunchButton", () => {
     const link = container.querySelector("a");
     expect(container.textContent).toContain("Internal report");
     expect(link?.textContent).toContain("View Gap Report");
-    expect(link?.getAttribute("href")).toBe("/internal/reports/vm0007-gap/audit-1");
+    expect(link?.getAttribute("href")).toBe("/quick-check/pre-validation-readiness?auditId=audit-1");
     expect(link?.className).toContain("bg-green-600");
     expect(link?.className).toContain("text-white");
   });

--- a/tests/lib/evidence/projectReadinessPayload.test.ts
+++ b/tests/lib/evidence/projectReadinessPayload.test.ts
@@ -1,0 +1,61 @@
+/** @jest-environment jsdom */
+
+import { describe, expect, test } from "@jest/globals";
+import { deriveApplicability } from "@/lib/evidence/applicabilityContract";
+import { deriveConformanceConclusion } from "@/lib/evidence/conformanceConclusionContract";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+import { deriveDraftFinding } from "@/lib/evidence/draftFindingContract";
+import { createReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
+import { createReadinessReportViewModel } from "@/lib/evidence/readinessReport";
+import { createProjectReadinessReportViewModel, hasProjectReadinessPayload, loadProjectReadinessPayload, projectReadinessPayloadStorageKey } from "@/lib/evidence/projectReadinessPayload";
+
+describe("project readiness payload boundary", () => {
+  function realGateResult() {
+    const provenance = { docId: "project-pdd.pdf", page: 5, sectionPath: ["2"], spanId: "project-span-1", sectionHeading: "Requirement", sourceType: "PDD" };
+    const row: EvidenceMapRow = {
+      rowId: "project-row-1",
+      requirement: { requirementId: "project-req-1", requirementReference: "REQ-1", requirementText: "Project requirement." },
+      methodology: { methodologyId: "VM0007", rulebookVersion: "1.8" },
+      upstreamStatus: "FOUND",
+      applicabilityState: "APPLICABLE",
+      acceptedEvidence: [{ evidenceId: "project-evidence-1", quote: "Project evidence.", provenance }],
+      rejectedEvidence: [],
+      assessmentReason: "Project review assessment.",
+      clientAction: null,
+      searchCoverage: { searched: true, searchedDocumentIds: ["project-pdd.pdf"], notes: null },
+      sourceDocument: { documentId: "project-pdd.pdf", documentName: "Project PDD", contentSha256: "sha256:project" },
+      evidenceProvenance: [provenance],
+      finalizationState: "finalized",
+      finalizationActorRef: "reviewer:project",
+      finalizedAt: "2026-07-11T00:00:00Z",
+      finalizationBasis: "Finalized project review.",
+      reviewHistoryRef: "history:project-row-1",
+      evidenceMapContractVersion: "v1",
+      reviewPolicyVersion: "policy-v1",
+    };
+    const applicability = deriveApplicability(row, { decision: "APPLICABLE", decisionBasis: "Project requirement applies." });
+    const conformance = deriveConformanceConclusion(row, applicability, { requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE", versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE" });
+    const draft = deriveDraftFinding(row, conformance, { draftFindingType: null, findingBasis: null, reviewerAssessment: null });
+    const packaged = createReportPresentationObject(row, applicability, conformance, draft);
+    if (!packaged.ready) throw new Error("Expected valid project presentation");
+    return { releaseReady: true, releaseState: "PRE_VALIDATION_RELEASE_READY", crossRowOutcome: "NOT_EVALUATED", presentations: [packaged.presentation] } as const;
+  }
+
+  test("fails closed when the project payload is missing or invalid", () => {
+    expect(createProjectReadinessReportViewModel(null).release.label).toBe("not assessed");
+    window.localStorage.setItem(projectReadinessPayloadStorageKey("project-1"), JSON.stringify({ projectId: "other-project", gateResult: {} }));
+    expect(loadProjectReadinessPayload("project-1")).toBeNull();
+    expect(hasProjectReadinessPayload("project-1")).toBe(false);
+  });
+
+  test("accepts a real Phase 7 result without re-deriving its release state", () => {
+    const gateResult = realGateResult();
+    const report = createProjectReadinessReportViewModel({ projectId: "project-1", gateResult });
+    expect(report.gate).toEqual(gateResult);
+    expect(report.release.releaseReady).toBe(true);
+    expect(report.rows[0].evidenceMapRowId).toBe("project-row-1");
+    window.localStorage.setItem(projectReadinessPayloadStorageKey("project-1"), JSON.stringify({ projectId: "project-1", gateResult }));
+    expect(hasProjectReadinessPayload("project-1")).toBe(true);
+    expect(createReadinessReportViewModel(gateResult).release.state).toBe("PRE_VALIDATION_RELEASE_READY");
+  });
+});

--- a/tests/lib/evidence/projectReadinessPayload.test.ts
+++ b/tests/lib/evidence/projectReadinessPayload.test.ts
@@ -7,7 +7,7 @@ import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContrac
 import { deriveDraftFinding } from "@/lib/evidence/draftFindingContract";
 import { createReportPresentationObject } from "@/lib/evidence/reportPresentationObject";
 import { createReadinessReportViewModel } from "@/lib/evidence/readinessReport";
-import { createProjectReadinessReportViewModel, hasProjectReadinessPayload, loadProjectReadinessPayload, projectReadinessPayloadStorageKey } from "@/lib/evidence/projectReadinessPayload";
+import { createProjectReadinessReportViewModel, hasProjectReadinessPayload, loadProjectReadinessPayload, projectReadinessPayloadStorageKey, saveProjectReadinessPayload } from "@/lib/evidence/projectReadinessPayload";
 
 describe("project readiness payload boundary", () => {
   function realGateResult() {
@@ -54,7 +54,7 @@ describe("project readiness payload boundary", () => {
     expect(report.gate).toEqual(gateResult);
     expect(report.release.releaseReady).toBe(true);
     expect(report.rows[0].evidenceMapRowId).toBe("project-row-1");
-    window.localStorage.setItem(projectReadinessPayloadStorageKey("project-1"), JSON.stringify({ projectId: "project-1", gateResult }));
+    expect(saveProjectReadinessPayload({ projectId: "project-1", gateResult })).toBe(true);
     expect(hasProjectReadinessPayload("project-1")).toBe(true);
     expect(createReadinessReportViewModel(gateResult).release.state).toBe("PRE_VALIDATION_RELEASE_READY");
   });


### PR DESCRIPTION
## Summary

- Reuses PR #985's canonical `projectReadinessPayload.ts` implementation.
- Adds production readiness routes for both linked projects and standalone Quick Check:
  - `/projects/[id]/pre-validation-readiness`
  - `/quick-check/pre-validation-readiness?auditId=<encoded auditId>`
- All Quick Check report links now open the new Pre-Validation Readiness Report UI.
- Linked projects use the project-specific route; standalone Quick Check uses the standalone route.
- The legacy `/internal/reports/vm0007-gap/...` route remains available only through direct URLs for backward compatibility.
- Project and audit identifiers are URL encoded.
- Quick Check remains consumer-only and does not adapt legacy VM0007 audits, fixtures, preview data, or raw extraction into canonical Evidence Map conclusions.
- When no canonical readiness payload exists, the production report fails closed to `NOT_ASSESSED`.
- Project reports continue to update from canonical payload saved/cleared events.
- Reviewer controls remain read-only without a production persistence workflow.

## Validation

- Focused report, routing, payload, and Quick Check integration tests passed.
- Latest smoke-test correction: 7 tests passed.
- `npm run pr:check:local` passed.
- `git diff --check` passed.
- Working tree clean.
- Current head commit: `65354e3c3424e40db35090664b7df26524adc0d4`.
- `public/manifest/index.json` was not included.

## Current production behavior

- Quick Check always opens the new readiness UI.
- A canonical project readiness payload produces the corresponding report state and rows.
- Without a canonical payload, the report displays `NOT_ASSESSED` rather than using fixture or legacy audit data.

## Remaining upstream dependency

The canonical project Evidence Map producer is not yet connected to the PR #985 finalization pipeline. Complete Evidence Map rows and explicit applicability, conformance, draft-finding, and review-state assessments are still required before production reports can display real conclusions.

This missing producer does not block the new UI or routing in this PR. It only limits production report content to `NOT_ASSESSED` until canonical data exists.