### PR TITLE
feat: add project readiness production pipeline

### DIFF
--- a/src/lib/evidence/projectReadinessPayload.ts
+++ b/src/lib/evidence/projectReadinessPayload.ts
@@ -1,0 +1,60 @@
+import { type PresentationGateResult } from "@/lib/evidence/presentationGate";
+import { createReadinessReportViewModel, isPresentationGateResult, type ReadinessReportViewModel } from "@/lib/evidence/readinessReport";
+
+const STORAGE_PREFIX = "article6:project-readiness-payload:v1:";
+export const PROJECT_READINESS_PAYLOAD_EVENT = "article6:project-readiness-payload-saved";
+
+export type ProjectReadinessPayload = Readonly<{
+  projectId: string;
+  gateResult: PresentationGateResult;
+}>;
+
+export type ProjectReadinessPayloadSavedEventDetail = Readonly<{
+  projectId: string;
+  payload: ProjectReadinessPayload;
+}>;
+
+export function projectReadinessPayloadStorageKey(projectId: string): string {
+  return `${STORAGE_PREFIX}${projectId}`;
+}
+
+export function loadProjectReadinessPayload(projectId: string): ProjectReadinessPayload | null {
+  const normalizedProjectId = projectId.trim();
+  if (!normalizedProjectId || typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(projectReadinessPayloadStorageKey(normalizedProjectId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      parsed.projectId !== normalizedProjectId ||
+      !Object.prototype.hasOwnProperty.call(parsed, "gateResult") ||
+      !isPresentationGateResult(parsed.gateResult)
+    ) return null;
+    return { projectId: normalizedProjectId, gateResult: parsed.gateResult };
+  } catch {
+    return null;
+  }
+}
+
+export function saveProjectReadinessPayload(payload: ProjectReadinessPayload): boolean {
+  const projectId = payload.projectId.trim();
+  if (!projectId || projectId !== payload.projectId || !isPresentationGateResult(payload.gateResult)) return false;
+  if (typeof window === "undefined") return false;
+  try {
+    window.localStorage.setItem(projectReadinessPayloadStorageKey(projectId), JSON.stringify(payload));
+    window.dispatchEvent(new CustomEvent<ProjectReadinessPayloadSavedEventDetail>(PROJECT_READINESS_PAYLOAD_EVENT, {
+      detail: { projectId, payload },
+    }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createProjectReadinessReportViewModel(payload: ProjectReadinessPayload | null): ReadinessReportViewModel {
+  return createReadinessReportViewModel(payload?.gateResult ?? null);
+}
+
+export function hasProjectReadinessPayload(projectId: string): boolean {
+  return createProjectReadinessReportViewModel(loadProjectReadinessPayload(projectId)).rows.length > 0;
+}

--- a/src/lib/evidence/projectReadinessPayload.ts
+++ b/src/lib/evidence/projectReadinessPayload.ts
@@ -9,9 +9,10 @@ export type ProjectReadinessPayload = Readonly<{
   gateResult: PresentationGateResult;
 }>;
 
-export type ProjectReadinessPayloadSavedEventDetail = Readonly<{
+export type ProjectReadinessPayloadEventDetail = Readonly<{
   projectId: string;
-  payload: ProjectReadinessPayload;
+  payload: ProjectReadinessPayload | null;
+  state: "saved" | "cleared";
 }>;
 
 export function projectReadinessPayloadStorageKey(projectId: string): string {
@@ -42,8 +43,22 @@ export function saveProjectReadinessPayload(payload: ProjectReadinessPayload): b
   if (typeof window === "undefined") return false;
   try {
     window.localStorage.setItem(projectReadinessPayloadStorageKey(projectId), JSON.stringify(payload));
-    window.dispatchEvent(new CustomEvent<ProjectReadinessPayloadSavedEventDetail>(PROJECT_READINESS_PAYLOAD_EVENT, {
-      detail: { projectId, payload },
+    window.dispatchEvent(new CustomEvent<ProjectReadinessPayloadEventDetail>(PROJECT_READINESS_PAYLOAD_EVENT, {
+      detail: { projectId, payload, state: "saved" },
+    }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearProjectReadinessPayload(projectId: string): boolean {
+  const normalizedProjectId = projectId.trim();
+  if (!normalizedProjectId || normalizedProjectId !== projectId || typeof window === "undefined") return false;
+  try {
+    window.localStorage.removeItem(projectReadinessPayloadStorageKey(normalizedProjectId));
+    window.dispatchEvent(new CustomEvent<ProjectReadinessPayloadEventDetail>(PROJECT_READINESS_PAYLOAD_EVENT, {
+      detail: { projectId: normalizedProjectId, payload: null, state: "cleared" },
     }));
     return true;
   } catch {

--- a/src/lib/evidence/projectReadinessProductionPipeline.ts
+++ b/src/lib/evidence/projectReadinessProductionPipeline.ts
@@ -24,6 +24,7 @@ import {
   type ReportPresentationObject,
 } from "@/lib/evidence/reportPresentationObject";
 import {
+  clearProjectReadinessPayload,
   saveProjectReadinessPayload,
   type ProjectReadinessPayload,
 } from "@/lib/evidence/projectReadinessPayload";
@@ -52,6 +53,8 @@ export type ProjectReadinessPipelineBlock = Readonly<{
     | "applicability_not_assessed"
     | "conformance_not_assessed"
     | "draft_finding_blocked"
+    | "assessment_invalid"
+    | "review_state_not_finalizable"
     | "presentation_blocked"
     | "payload_not_saved";
   evidenceMapRowId: string | null;
@@ -85,6 +88,11 @@ function invalid(projectId: string | null, blockedBy: readonly ProjectReadinessP
   return { ready: false, projectId, state: "NOT_ASSESSED", blockedBy };
 }
 
+function fail(projectId: string | null, blockedBy: readonly ProjectReadinessPipelineBlock[]): ProjectReadinessPipelineResult {
+  if (projectId) clearProjectReadinessPayload(projectId);
+  return invalid(projectId, blockedBy);
+}
+
 function isInput(value: unknown): value is ProjectEvidenceMapFinalizationInput {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Partial<ProjectEvidenceMapFinalizationInput>;
@@ -100,18 +108,61 @@ function isReviewState(value: unknown): value is PresentationReviewState {
   return value === "CURRENT" || value === "PENDING_REVIEW" || value === "REOPENED" || value === "SUPERSEDED" || value === "STALE";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isTextOrNull(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isProjectEvidenceMapAssessment(value: unknown): value is ProjectEvidenceMapAssessment {
+  if (!isRecord(value) || typeof value.evidenceMapRowId !== "string" || !value.evidenceMapRowId || value.evidenceMapRowId.trim() !== value.evidenceMapRowId) return false;
+  if (!isReviewState(value.reviewState)) return false;
+  if (!isRecord(value.applicability) || !["APPLICABLE", "NOT_APPLICABLE", "NOT_EVALUATED"].includes(value.applicability.decision as string) || !isTextOrNull(value.applicability.decisionBasis)) return false;
+  if (!isRecord(value.conformance)) return false;
+  const conformanceValues: Record<string, readonly string[]> = {
+    requirementSupport: ["SUPPORTED", "NOT_SUPPORTED", "NOT_EVALUATED"],
+    searchCoverageAssessment: ["ADEQUATE", "INADEQUATE", "NOT_REQUIRED", "NOT_EVALUATED"],
+    provenanceAssessment: ["COMPLETE", "INCOMPLETE", "NOT_EVALUATED"],
+    versionIdentityAssessment: ["MATCHED", "NOT_REQUIRED", "MISMATCHED", "UNRESOLVED"],
+    contradictionAssessment: ["NONE", "BLOCKING", "NOT_EVALUATED"],
+  };
+  const conformance = value.conformance as Record<string, unknown>;
+  if (Object.entries(conformanceValues).some(([key, allowed]) => !allowed.includes(conformance[key] as string))) return false;
+  if (!isRecord(value.draftFinding) || ![null, "NIR_CANDIDATE", "NCR_CANDIDATE", "OFI_CANDIDATE"].includes(value.draftFinding.draftFindingType as string | null) || !isTextOrNull(value.draftFinding.findingBasis) || !isTextOrNull(value.draftFinding.reviewerAssessment)) return false;
+  return true;
+}
+
+function inputProjectId(value: unknown): string | null {
+  if (!isRecord(value) || typeof value.projectId !== "string") return null;
+  const projectId = value.projectId.trim();
+  return projectId && projectId === value.projectId ? projectId : null;
+}
+
 /**
  * Explicit production finalization boundary for an already-reviewed project
  * Evidence Map. It never adapts Quick Check, legacy audit, or fixture data.
  */
 export function finalizeProjectEvidenceMapForReadiness(input: unknown): ProjectReadinessPipelineResult {
-  if (!isInput(input)) return invalid(null, [block("invalid_input", null)]);
+  const projectId = inputProjectId(input);
+  if (!isInput(input)) return fail(projectId, [block("invalid_input", null)]);
 
   const rowIds = new Set<string>();
-  const assessmentByRowId = new Map(input.assessments.map((assessment) => [assessment.evidenceMapRowId, assessment]));
   const blockers: ProjectReadinessPipelineBlock[] = [];
   const presentations: ReportPresentationObject[] = [];
   const gateInputs: Array<{ presentation: ReportPresentationObject; reviewState: PresentationReviewState }> = [];
+
+  const validatedAssessments: ProjectEvidenceMapAssessment[] = [];
+  for (const assessment of input.assessments as readonly unknown[]) {
+    if (!isProjectEvidenceMapAssessment(assessment)) {
+      blockers.push(block("assessment_invalid", null));
+      continue;
+    }
+    validatedAssessments.push(assessment);
+  }
+  if (blockers.length > 0) return fail(input.projectId, blockers);
+  const assessmentByRowId = new Map(validatedAssessments.map((assessment) => [assessment.evidenceMapRowId, assessment]));
 
   if (input.rows.length === 0 || input.assessments.length !== input.rows.length) {
     blockers.push(block("assessment_missing", null, "Every finalized Evidence Map row requires one explicit assessment."));
@@ -138,6 +189,10 @@ export function finalizeProjectEvidenceMapForReadiness(input: unknown): ProjectR
     const assessment = assessmentByRowId.get(row.rowId);
     if (!assessment || assessment.evidenceMapRowId !== row.rowId || !isReviewState(assessment.reviewState)) {
       blockers.push(block("assessment_missing", row.rowId));
+      continue;
+    }
+    if (assessment.reviewState === "REOPENED" || assessment.reviewState === "SUPERSEDED" || assessment.reviewState === "STALE") {
+      blockers.push(block("review_state_not_finalizable", row.rowId, assessment.reviewState));
       continue;
     }
 
@@ -169,13 +224,13 @@ export function finalizeProjectEvidenceMapForReadiness(input: unknown): ProjectR
   }
 
   if (blockers.length > 0 || presentations.length !== input.rows.length) {
-    return invalid(input.projectId, blockers.length ? blockers : [block("presentation_blocked", null)]);
+    return fail(input.projectId, blockers.length ? blockers : [block("presentation_blocked", null)]);
   }
 
   const gateResult = evaluatePresentationReportGate(gateInputs);
   const payload: ProjectReadinessPayload = { projectId: input.projectId, gateResult };
   if (!saveProjectReadinessPayload(payload)) {
-    return invalid(input.projectId, [block("payload_not_saved", null)]);
+    return fail(input.projectId, [block("payload_not_saved", null)]);
   }
 
   return { ready: true, projectId: input.projectId, payload, gateResult, presentations };

--- a/src/lib/evidence/projectReadinessProductionPipeline.ts
+++ b/src/lib/evidence/projectReadinessProductionPipeline.ts
@@ -1,0 +1,182 @@
+import {
+  deriveApplicability,
+  type ApplicabilityAssessmentInput,
+} from "@/lib/evidence/applicabilityContract";
+import {
+  deriveConformanceConclusion,
+  type ConformanceAssessmentInput,
+} from "@/lib/evidence/conformanceConclusionContract";
+import {
+  deriveDraftFinding,
+  type DraftFindingAssessmentInput,
+} from "@/lib/evidence/draftFindingContract";
+import {
+  validateEvidenceMapDependency,
+  type EvidenceMapRow,
+} from "@/lib/evidence/evidenceMapDependencyContract";
+import {
+  evaluatePresentationReportGate,
+  type PresentationGateResult,
+  type PresentationReviewState,
+} from "@/lib/evidence/presentationGate";
+import {
+  createReportPresentationObject,
+  type ReportPresentationObject,
+} from "@/lib/evidence/reportPresentationObject";
+import {
+  saveProjectReadinessPayload,
+  type ProjectReadinessPayload,
+} from "@/lib/evidence/projectReadinessPayload";
+
+export type ProjectEvidenceMapAssessment = Readonly<{
+  evidenceMapRowId: string;
+  applicability: ApplicabilityAssessmentInput;
+  conformance: ConformanceAssessmentInput;
+  draftFinding: DraftFindingAssessmentInput;
+  reviewState: PresentationReviewState;
+}>;
+
+export type ProjectEvidenceMapFinalizationInput = Readonly<{
+  source: "PROJECT_EVIDENCE_MAP";
+  projectId: string;
+  rows: readonly EvidenceMapRow[];
+  assessments: readonly ProjectEvidenceMapAssessment[];
+}>;
+
+export type ProjectReadinessPipelineBlock = Readonly<{
+  category:
+    | "invalid_input"
+    | "duplicate_row_identity"
+    | "assessment_missing"
+    | "evidence_map_dependency_blocked"
+    | "applicability_not_assessed"
+    | "conformance_not_assessed"
+    | "draft_finding_blocked"
+    | "presentation_blocked"
+    | "payload_not_saved";
+  evidenceMapRowId: string | null;
+  detail?: string;
+}>;
+
+export type ProjectReadinessPipelineResult =
+  | Readonly<{
+      ready: true;
+      projectId: string;
+      payload: ProjectReadinessPayload;
+      gateResult: PresentationGateResult;
+      presentations: readonly ReportPresentationObject[];
+    }>
+  | Readonly<{
+      ready: false;
+      projectId: string | null;
+      state: "NOT_ASSESSED";
+      blockedBy: readonly ProjectReadinessPipelineBlock[];
+    }>;
+
+function block(
+  category: ProjectReadinessPipelineBlock["category"],
+  evidenceMapRowId: string | null,
+  detail?: string,
+): ProjectReadinessPipelineBlock {
+  return detail === undefined ? { category, evidenceMapRowId } : { category, evidenceMapRowId, detail };
+}
+
+function invalid(projectId: string | null, blockedBy: readonly ProjectReadinessPipelineBlock[]): ProjectReadinessPipelineResult {
+  return { ready: false, projectId, state: "NOT_ASSESSED", blockedBy };
+}
+
+function isInput(value: unknown): value is ProjectEvidenceMapFinalizationInput {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<ProjectEvidenceMapFinalizationInput>;
+  return candidate.source === "PROJECT_EVIDENCE_MAP" &&
+    typeof candidate.projectId === "string" &&
+    candidate.projectId.trim().length > 0 &&
+    candidate.projectId === candidate.projectId.trim() &&
+    Array.isArray(candidate.rows) &&
+    Array.isArray(candidate.assessments);
+}
+
+function isReviewState(value: unknown): value is PresentationReviewState {
+  return value === "CURRENT" || value === "PENDING_REVIEW" || value === "REOPENED" || value === "SUPERSEDED" || value === "STALE";
+}
+
+/**
+ * Explicit production finalization boundary for an already-reviewed project
+ * Evidence Map. It never adapts Quick Check, legacy audit, or fixture data.
+ */
+export function finalizeProjectEvidenceMapForReadiness(input: unknown): ProjectReadinessPipelineResult {
+  if (!isInput(input)) return invalid(null, [block("invalid_input", null)]);
+
+  const rowIds = new Set<string>();
+  const assessmentByRowId = new Map(input.assessments.map((assessment) => [assessment.evidenceMapRowId, assessment]));
+  const blockers: ProjectReadinessPipelineBlock[] = [];
+  const presentations: ReportPresentationObject[] = [];
+  const gateInputs: Array<{ presentation: ReportPresentationObject; reviewState: PresentationReviewState }> = [];
+
+  if (input.rows.length === 0 || input.assessments.length !== input.rows.length) {
+    blockers.push(block("assessment_missing", null, "Every finalized Evidence Map row requires one explicit assessment."));
+  }
+
+  for (const candidate of input.rows as readonly unknown[]) {
+    if (!candidate || typeof candidate !== "object") {
+      blockers.push(block("evidence_map_dependency_blocked", null));
+      continue;
+    }
+    const row = candidate as EvidenceMapRow;
+    if (rowIds.has(row.rowId)) {
+      blockers.push(block("duplicate_row_identity", row.rowId));
+      continue;
+    }
+    rowIds.add(row.rowId);
+
+    const dependency = validateEvidenceMapDependency(row);
+    if (!dependency.ready) {
+      blockers.push(block("evidence_map_dependency_blocked", row.rowId, dependency.blockedBy.join(", ")));
+      continue;
+    }
+
+    const assessment = assessmentByRowId.get(row.rowId);
+    if (!assessment || assessment.evidenceMapRowId !== row.rowId || !isReviewState(assessment.reviewState)) {
+      blockers.push(block("assessment_missing", row.rowId));
+      continue;
+    }
+
+    const applicability = deriveApplicability(row, assessment.applicability);
+    if (applicability.applicability === "NOT_ASSESSED") {
+      blockers.push(block("applicability_not_assessed", row.rowId));
+      continue;
+    }
+
+    const conformance = deriveConformanceConclusion(row, applicability, assessment.conformance);
+    if (conformance.conclusion === "NOT_ASSESSED") {
+      blockers.push(block("conformance_not_assessed", row.rowId));
+      continue;
+    }
+
+    const draftFinding = deriveDraftFinding(row, conformance, assessment.draftFinding);
+    if (draftFinding.draftFindingType === null && draftFinding.blockedBy?.length) {
+      blockers.push(block("draft_finding_blocked", row.rowId));
+      continue;
+    }
+
+    const presentation = createReportPresentationObject(row, applicability, conformance, draftFinding);
+    if (!presentation.ready) {
+      blockers.push(block("presentation_blocked", row.rowId));
+      continue;
+    }
+    presentations.push(presentation.presentation);
+    gateInputs.push({ presentation: presentation.presentation, reviewState: assessment.reviewState });
+  }
+
+  if (blockers.length > 0 || presentations.length !== input.rows.length) {
+    return invalid(input.projectId, blockers.length ? blockers : [block("presentation_blocked", null)]);
+  }
+
+  const gateResult = evaluatePresentationReportGate(gateInputs);
+  const payload: ProjectReadinessPayload = { projectId: input.projectId, gateResult };
+  if (!saveProjectReadinessPayload(payload)) {
+    return invalid(input.projectId, [block("payload_not_saved", null)]);
+  }
+
+  return { ready: true, projectId: input.projectId, payload, gateResult, presentations };
+}

--- a/src/lib/evidence/readinessReport.ts
+++ b/src/lib/evidence/readinessReport.ts
@@ -26,7 +26,7 @@ export type ReadinessReportViewModel = Readonly<{
   gate: PresentationGateResult;
 }>;
 
-function isGateResult(value: unknown): value is PresentationGateResult {
+export function isPresentationGateResult(value: unknown): value is PresentationGateResult {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
   if (!Array.isArray(candidate.presentations) || !candidate.presentations.every(isReportPresentationObject)) return false;
@@ -53,7 +53,7 @@ function invalidGate(): PresentationGateResult {
 }
 
 export function createReadinessReportViewModel(input: unknown): ReadinessReportViewModel {
-  const gate = isGateResult(input) ? input : invalidGate();
+  const gate = isPresentationGateResult(input) ? input : invalidGate();
   const reasons = gate.releaseState === "BLOCKED" ? gate.blockedBy : gate.releaseState === "INTERNAL_REVIEW_ONLY" ? gate.warnings : [];
   const label: ReadinessReportReleaseLabel =
     gate.releaseState === "PRE_VALIDATION_RELEASE_READY"

--- a/tests/lib/evidence/projectReadinessProductionPipeline.test.ts
+++ b/tests/lib/evidence/projectReadinessProductionPipeline.test.ts
@@ -98,7 +98,25 @@ describe("project readiness production pipeline", () => {
     expect(result.gateResult.presentations[0].evidenceProvenance[0].spanId).toBe("accepted-span");
     expect(result.gateResult.presentations[0].finalizationActorRef).toBe("reviewer:project");
     expect(event).toHaveBeenCalledTimes(1);
+    expect(event.mock.calls[0][0].detail.state).toBe("saved");
     expect(loadProjectReadinessPayload("project-1")?.gateResult).toEqual(result.gateResult);
+  });
+
+  test("malformed assessment entries fail closed without throwing", () => {
+    expect(() => finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row()],
+      assessments: [null],
+    })).not.toThrow();
+    const result = finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row()],
+      assessments: [null],
+    });
+    expect(result).toMatchObject({ ready: false, state: "NOT_ASSESSED" });
+    expect(loadProjectReadinessPayload("project-1")).toBeNull();
   });
 
   test("non-finalized rows fail closed and do not write a payload", () => {
@@ -132,6 +150,69 @@ describe("project readiness production pipeline", () => {
     });
     expect(result).toMatchObject({ ready: false, state: "NOT_ASSESSED" });
     expect(loadProjectReadinessPayload("project-1")).toBeNull();
+  });
+
+  test("a failed later finalization clears a previously saved payload and emits immediately", () => {
+    const first = finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row()],
+      assessments: [assessment()],
+    });
+    expect(first.ready).toBe(true);
+    const event = jest.fn();
+    window.addEventListener(PROJECT_READINESS_PAYLOAD_EVENT, event);
+    const failed = finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row({ finalizationState: "draft" })],
+      assessments: [assessment()],
+    });
+    window.removeEventListener(PROJECT_READINESS_PAYLOAD_EVENT, event);
+    expect(failed).toMatchObject({ ready: false, state: "NOT_ASSESSED" });
+    expect(loadProjectReadinessPayload("project-1")).toBeNull();
+    expect(event).toHaveBeenCalledTimes(1);
+    expect(event.mock.calls[0][0].detail).toEqual({ projectId: "project-1", payload: null, state: "cleared" });
+  });
+
+  test("reopened rows clear stale release-ready payloads", () => {
+    expect(finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row()],
+      assessments: [assessment()],
+    }).ready).toBe(true);
+    const result = finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row()],
+      assessments: [{ ...assessment(), reviewState: "REOPENED" }],
+    });
+    expect(result).toMatchObject({ ready: false, state: "NOT_ASSESSED" });
+    expect(loadProjectReadinessPayload("project-1")).toBeNull();
+  });
+
+  test("clearing one project does not clear another project", () => {
+    expect(finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row()],
+      assessments: [assessment()],
+    }).ready).toBe(true);
+    expect(finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-2",
+      rows: [row({ rowId: "project-row-2" })],
+      assessments: [assessment("project-row-2")],
+    }).ready).toBe(true);
+    finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row({ finalizationState: "draft" })],
+      assessments: [assessment()],
+    });
+    expect(loadProjectReadinessPayload("project-1")).toBeNull();
+    expect(loadProjectReadinessPayload("project-2")?.projectId).toBe("project-2");
   });
 
   test("legacy audit and fixture/preview inputs cannot enter the production producer", () => {

--- a/tests/lib/evidence/projectReadinessProductionPipeline.test.ts
+++ b/tests/lib/evidence/projectReadinessProductionPipeline.test.ts
@@ -1,0 +1,153 @@
+/** @jest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+import {
+  PROJECT_READINESS_PAYLOAD_EVENT,
+  loadProjectReadinessPayload,
+  projectReadinessPayloadStorageKey,
+} from "@/lib/evidence/projectReadinessPayload";
+import {
+  finalizeProjectEvidenceMapForReadiness,
+  type ProjectEvidenceMapAssessment,
+} from "@/lib/evidence/projectReadinessProductionPipeline";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+
+function row(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
+  const acceptedProvenance = {
+    docId: "project-pdd.pdf",
+    page: 8,
+    sectionPath: ["3.1"],
+    spanId: "accepted-span",
+    sectionHeading: "Requirement evidence",
+    sourceType: "PDD",
+  };
+  const rejectedProvenance = {
+    docId: "project-pdd.pdf",
+    page: 9,
+    sectionPath: ["3.2"],
+    spanId: "rejected-span",
+    sectionHeading: "Rejected evidence",
+    sourceType: "PDD",
+  };
+  return {
+    rowId: "project-row-1",
+    requirement: {
+      requirementId: "requirement-1",
+      requirementReference: "REQ-1",
+      requirementText: "The project maintains requirement evidence.",
+    },
+    methodology: { methodologyId: "VM0007", rulebookVersion: "1.8" },
+    upstreamStatus: "FOUND",
+    applicabilityState: "APPLICABLE",
+    acceptedEvidence: [{ evidenceId: "accepted-1", quote: "Accepted project evidence.", provenance: acceptedProvenance }],
+    rejectedEvidence: [{ evidenceId: "rejected-1", quote: "Rejected project evidence.", rejectionReason: "Boilerplate only.", provenance: rejectedProvenance }],
+    assessmentReason: "The reviewed project evidence supports the requirement.",
+    clientAction: null,
+    searchCoverage: { searched: true, searchedDocumentIds: ["project-pdd.pdf"], notes: null },
+    sourceDocument: { documentId: "project-pdd.pdf", documentName: "Project PDD", contentSha256: "sha256:project" },
+    evidenceProvenance: [acceptedProvenance, rejectedProvenance],
+    finalizationState: "finalized",
+    finalizationActorRef: "reviewer:project",
+    finalizedAt: "2026-07-11T00:00:00Z",
+    finalizationBasis: "Explicit project Evidence Map finalization.",
+    reviewHistoryRef: "history:project-row-1",
+    evidenceMapContractVersion: "v1",
+    reviewPolicyVersion: "policy-v1",
+    ...overrides,
+  };
+}
+
+function assessment(evidenceMapRowId = "project-row-1"): ProjectEvidenceMapAssessment {
+  return {
+    evidenceMapRowId,
+    applicability: { decision: "APPLICABLE", decisionBasis: "The finalized row is applicable." },
+    conformance: {
+      requirementSupport: "SUPPORTED",
+      searchCoverageAssessment: "ADEQUATE",
+      provenanceAssessment: "COMPLETE",
+      versionIdentityAssessment: "MATCHED",
+      contradictionAssessment: "NONE",
+    },
+    draftFinding: { draftFindingType: null, findingBasis: null, reviewerAssessment: null },
+    reviewState: "CURRENT",
+  };
+}
+
+describe("project readiness production pipeline", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  test("finalized real Evidence Map rows create and save Phase 6/7 output unchanged", () => {
+    const event = jest.fn();
+    window.addEventListener(PROJECT_READINESS_PAYLOAD_EVENT, event);
+    const result = finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row()],
+      assessments: [assessment()],
+    });
+    window.removeEventListener(PROJECT_READINESS_PAYLOAD_EVENT, event);
+
+    expect(result.ready).toBe(true);
+    if (!result.ready) return;
+    expect(result.payload.projectId).toBe("project-1");
+    expect(result.payload.gateResult).toBe(result.gateResult);
+    expect(result.gateResult.releaseState).toBe("PRE_VALIDATION_RELEASE_READY");
+    expect(result.gateResult.presentations[0].acceptedEvidence[0].quote).toBe("Accepted project evidence.");
+    expect(result.gateResult.presentations[0].rejectedEvidence[0].rejectionReason).toBe("Boilerplate only.");
+    expect(result.gateResult.presentations[0].evidenceProvenance[0].spanId).toBe("accepted-span");
+    expect(result.gateResult.presentations[0].finalizationActorRef).toBe("reviewer:project");
+    expect(event).toHaveBeenCalledTimes(1);
+    expect(loadProjectReadinessPayload("project-1")?.gateResult).toEqual(result.gateResult);
+  });
+
+  test("non-finalized rows fail closed and do not write a payload", () => {
+    const result = finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row({ finalizationState: "draft" })],
+      assessments: [assessment()],
+    });
+    expect(result).toMatchObject({ ready: false, state: "NOT_ASSESSED" });
+    expect(loadProjectReadinessPayload("project-1")).toBeNull();
+  });
+
+  test("missing review/finalization information fails closed", () => {
+    const result = finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row({ reviewHistoryRef: "" })],
+      assessments: [assessment()],
+    });
+    expect(result).toMatchObject({ ready: false, state: "NOT_ASSESSED" });
+    expect(loadProjectReadinessPayload("project-1")).toBeNull();
+  });
+
+  test("missing explicit review state fails closed", () => {
+    const result = finalizeProjectEvidenceMapForReadiness({
+      source: "PROJECT_EVIDENCE_MAP",
+      projectId: "project-1",
+      rows: [row()],
+      assessments: [{ ...assessment(), reviewState: undefined } as unknown as ProjectEvidenceMapAssessment],
+    });
+    expect(result).toMatchObject({ ready: false, state: "NOT_ASSESSED" });
+    expect(loadProjectReadinessPayload("project-1")).toBeNull();
+  });
+
+  test("legacy audit and fixture/preview inputs cannot enter the production producer", () => {
+    const legacy = finalizeProjectEvidenceMapForReadiness({
+      auditId: "vm0007-gap-1",
+      audit: { results: [] },
+      projectId: "project-1",
+    });
+    const fixture = finalizeProjectEvidenceMapForReadiness({
+      source: "READINESS_PREVIEW_FIXTURE",
+      projectId: "project-1",
+      rows: [row()],
+      assessments: [assessment()],
+    });
+    expect(legacy).toMatchObject({ ready: false, state: "NOT_ASSESSED" });
+    expect(fixture).toMatchObject({ ready: false, state: "NOT_ASSESSED" });
+    expect(window.localStorage.getItem(projectReadinessPayloadStorageKey("project-1"))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
This prerequisite PR adds the generic production boundary required before PR #984 can consume real project readiness payloads.

- Canonical source: explicit finalized project Evidence Map rows supplied to the production finalization action. Existing `ReviewWorkspace`/`RuleReview` state and legacy VM0007 audits are not adapted into Evidence Map rows.
- Finalization boundary: `finalizeProjectEvidenceMapForReadiness` in `src/lib/evidence/projectReadinessProductionPipeline.ts`.
- Phase 3 applicability, Phase 3 conformance, Phase 4 draft-finding, Phase 6 presentation, and Phase 7 gate contracts are reused directly.
- Payload saving: `saveProjectReadinessPayload` in `src/lib/evidence/projectReadinessPayload.ts`, preserving the exact gate result and its presentations.
- Immediate notification: `PROJECT_READINESS_PAYLOAD_EVENT` is dispatched after save and after clear.
- Malformed assessments, incomplete finalization, non-finalized rows, and reopened/superseded/stale review states fail closed and clear only the affected project payload.

This PR provides the generic production finalization boundary.
It does not yet invoke that boundary from a project reviewer/finalization UI.
PR #984 or a narrowly scoped integration follow-up must call it with real finalized Evidence Map rows.

## Validation
- Focused pipeline tests: 9 passed.
- `npm run lint`: passed.
- `npm run typecheck`: passed.
- `npm run roadmap:check`: passed.
- `git diff --check`: passed.
- Final `PYTHON3="$(pwd)/.venv/bin/python3" npm run pr:gate`: passed with exit code 0.
- Full Jest: 221 suites passed, 2,356 tests passed; strict corpus, hardcoding guard, health, and both audit-pack smoke stages passed. Jest reported the repository's existing worker-shutdown warning after the long parser bakeoff.

## Non-goals
- No Quick Check or upstream status semantic changes.
- No legacy VM0007 audit, raw extraction, fixture, or preview data enters the producer.
- No synthetic rows, inferred applicability, reviewer decisions, methodology-specific logic, UI redesign, reviewer persistence, fixture migration, Python/dependency changes, or Phase 10 work.
- `public/manifest/index.json` is explicitly excluded.
- PR #984 remains unchanged and should stay open as a draft pending this prerequisite.