### PR TITLE
chore: add fast local validation workflow (pr:check:local)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,14 +154,15 @@ npm run pr:gate
 
 If npm run pr:gate fails because of an unrelated existing failure, report the exact failing test and explain why it is unrelated.
 
-## Staged validation workflow
+### Staged validation workflow
 
 - During development, run only focused tests for the files being changed.
-- After implementation is stable, run lint, typecheck, roadmap check, and diff check.
-- Run the full `npm run pr:gate` only once, after all implementation changes are complete and before the PR is ready to merge.
-- Do not rerun `pr:gate` after every small edit.
-- Never start another `pr:gate` process while one is already running.
-- If the full gate fails, fix the reported failure, run the narrow affected test first, then rerun the full gate once.
+- After implementation is stable, run `npm run pr:check:local`.
+- Do not run the full local `npm run pr:gate` by default.
+- Push the PR after focused tests and the fast local check pass.
+- GitHub's full pr-gate, test, and build checks must pass before merge.
+- Run the full gate locally only when explicitly requested or when debugging a GitHub gate failure.
+- Codex must not remain active merely to watch GitHub checks complete.
 
 ## Verification
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "generate:manifest": "node scripts/generate-manifest-from-pack.mjs",
     "determinism:audit-pack": "node scripts/determinism-audit-pack.mjs",
     "pr:gate": "node scripts/pr-gate.mjs",
+    "pr:check:local": "npm run guard:methodology-boundary && npm run lint && npm run typecheck && npm run check:docs-layout && npm run roadmap:validate-evidence && git diff --check",
     "ci:coverage": "node scripts/compute-coverage.mjs",
     "ci:ratchet": "node scripts/gate-coverage-ratchet.mjs",
     "ci:links": "node scripts/gate-link-resolver.mjs",


### PR DESCRIPTION
## Summary

Adds `npm run pr:check:local` — a fast local validation command that runs only deterministic checks:

- `guard:methodology-boundary` — methodology boundary guard
- `lint` — ESLint
- `typecheck` — TypeScript compilation check
- `check:docs-layout` — documentation layout check
- `roadmap:validate-evidence` — roadmap evidence validation
- `git diff --check` — whitespace error check

## What stays unchanged

- `npm run pr:gate` — preserved as the complete local/CI-grade validation command
- `.github/workflows/pr-gate.yml` — not touched
- All GitHub required checks — unchanged

## Scope

- `AGENTS.md` — updated staged validation workflow
- `package.json` — added `pr:check:local` script

## Root cause of earlier typecheck failure

A stale untracked file `src/app/report/envira/page.tsx` was left in the worktree. It did not exist on `origin/main` or the PR branch. Removing it plus clearing `.next` cache resolved the failure.

## Local validation result

`npm run pr:check:local` — exit code 0. All 6 stages passed.

## Exclusions

- `public/manifest/index.json` — not modified
- No application code, tests, fixtures, roadmaps, dependencies, or generated files changed