### PR TITLE
feat: produce Quick Check readiness payloads

### DIFF
--- a/src/components/projects/QuickCheckPreValidationReadinessReport.tsx
+++ b/src/components/projects/QuickCheckPreValidationReadinessReport.tsx
@@ -1,13 +1,32 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import PreValidationReadinessReviewer from "@/components/readiness/PreValidationReadinessReviewer";
-import { createProjectReadinessReportViewModel } from "@/lib/evidence/projectReadinessPayload";
+import {
+  createQuickCheckReadinessReportViewModel,
+  loadQuickCheckReadinessPayload,
+  QUICK_CHECK_READINESS_PAYLOAD_EVENT,
+  type QuickCheckReadinessPayloadEventDetail,
+} from "@/lib/evidence/quickCheckReadinessPayload";
+import type { ReadinessReportViewModel } from "@/lib/evidence/readinessReport";
 
 type Props = Readonly<{ auditId?: string | null }>;
 
-const NOT_ASSESSED = createProjectReadinessReportViewModel(null);
+const NOT_ASSESSED = createQuickCheckReadinessReportViewModel(null);
 
 export default function QuickCheckPreValidationReadinessReport({ auditId }: Props) {
+  const [report, setReport] = useState<ReadinessReportViewModel>(NOT_ASSESSED);
+  useEffect(() => {
+    const load = () => setReport(createQuickCheckReadinessReportViewModel(auditId ? loadQuickCheckReadinessPayload(auditId) : null));
+    const handlePayloadEvent = (event: Event) => {
+      const detail = (event as CustomEvent<QuickCheckReadinessPayloadEventDetail>).detail;
+      if (!detail || detail.auditId !== auditId) return;
+      setReport(detail.state === "cleared" ? NOT_ASSESSED : createQuickCheckReadinessReportViewModel(loadQuickCheckReadinessPayload(auditId!)));
+    };
+    load();
+    window.addEventListener(QUICK_CHECK_READINESS_PAYLOAD_EVENT, handlePayloadEvent);
+    return () => window.removeEventListener(QUICK_CHECK_READINESS_PAYLOAD_EVENT, handlePayloadEvent);
+  }, [auditId]);
   return (
     <main className="min-h-screen bg-slate-50 px-4 py-8" data-testid="quick-check-pre-validation-readiness-report">
       <div className="mx-auto grid max-w-6xl gap-4">
@@ -15,10 +34,10 @@ export default function QuickCheckPreValidationReadinessReport({ auditId }: Prop
           <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Pre-Validation Readiness Report</div>
           <h1 className="mt-2 text-2xl font-semibold text-slate-950">Quick Check readiness report</h1>
           <div className="mt-1 text-sm text-slate-600">
-            {auditId ? `Quick Check source audit: ${auditId} · ` : ""}Canonical project Evidence Map payload only
+            {auditId ? `Quick Check source audit: ${auditId} · ` : ""}Canonical Quick Check Evidence Map payload only
           </div>
         </header>
-        <PreValidationReadinessReviewer report={NOT_ASSESSED} />
+        <PreValidationReadinessReviewer report={report} />
       </div>
     </main>
   );

--- a/src/lib/evidence/projectReadinessPayload.ts
+++ b/src/lib/evidence/projectReadinessPayload.ts
@@ -15,6 +15,12 @@ export type ProjectReadinessPayloadEventDetail = Readonly<{
   state: "saved" | "cleared";
 }>;
 
+export type ReadinessPayloadStorageScope = Readonly<{
+  id: string;
+  save: (gateResult: PresentationGateResult) => boolean;
+  clear: () => void;
+}>;
+
 export function projectReadinessPayloadStorageKey(projectId: string): string {
   return `${STORAGE_PREFIX}${projectId}`;
 }

--- a/src/lib/evidence/projectReadinessProductionPipeline.ts
+++ b/src/lib/evidence/projectReadinessProductionPipeline.ts
@@ -27,6 +27,7 @@ import {
   clearProjectReadinessPayload,
   saveProjectReadinessPayload,
   type ProjectReadinessPayload,
+  type ReadinessPayloadStorageScope,
 } from "@/lib/evidence/projectReadinessPayload";
 
 export type ProjectEvidenceMapAssessment = Readonly<{
@@ -36,6 +37,8 @@ export type ProjectEvidenceMapAssessment = Readonly<{
   draftFinding: DraftFindingAssessmentInput;
   reviewState: PresentationReviewState;
 }>;
+
+export type EvidenceMapAssessment = ProjectEvidenceMapAssessment;
 
 export type ProjectEvidenceMapFinalizationInput = Readonly<{
   source: "PROJECT_EVIDENCE_MAP";
@@ -93,6 +96,90 @@ function fail(projectId: string | null, blockedBy: readonly ProjectReadinessPipe
   return invalid(projectId, blockedBy);
 }
 
+function failForScope(scope: ReadinessPayloadStorageScope, blockedBy: readonly ProjectReadinessPipelineBlock[]) {
+  scope.clear();
+  return invalid(scope.id, blockedBy);
+}
+
+export function finalizeEvidenceMapForReadiness(input: Readonly<{
+  rows: readonly EvidenceMapRow[];
+  assessments: readonly ProjectEvidenceMapAssessment[];
+  storageScope: ReadinessPayloadStorageScope;
+}>): ProjectReadinessPipelineResult {
+  const scope = input.storageScope;
+  const rowIds = new Set<string>();
+  const blockers: ProjectReadinessPipelineBlock[] = [];
+  const presentations: ReportPresentationObject[] = [];
+  const gateInputs: Array<{ presentation: ReportPresentationObject; reviewState: PresentationReviewState }> = [];
+  const validatedAssessments: ProjectEvidenceMapAssessment[] = [];
+  for (const assessment of input.assessments) {
+    if (!isProjectEvidenceMapAssessment(assessment)) {
+      blockers.push(block("assessment_invalid", null));
+      continue;
+    }
+    validatedAssessments.push(assessment);
+  }
+  if (blockers.length > 0) return failForScope(scope, blockers);
+  const assessmentByRowId = new Map(validatedAssessments.map((assessment) => [assessment.evidenceMapRowId, assessment]));
+  if (input.rows.length === 0 || input.assessments.length !== input.rows.length) {
+    blockers.push(block("assessment_missing", null, "Every finalized Evidence Map row requires one explicit assessment."));
+  }
+  for (const candidate of input.rows) {
+    if (!candidate || typeof candidate !== "object") {
+      blockers.push(block("evidence_map_dependency_blocked", null));
+      continue;
+    }
+    const row = candidate as EvidenceMapRow;
+    if (rowIds.has(row.rowId)) {
+      blockers.push(block("duplicate_row_identity", row.rowId));
+      continue;
+    }
+    rowIds.add(row.rowId);
+    const dependency = validateEvidenceMapDependency(row);
+    if (!dependency.ready) {
+      blockers.push(block("evidence_map_dependency_blocked", row.rowId, dependency.blockedBy.join(", ")));
+      continue;
+    }
+    const assessment = assessmentByRowId.get(row.rowId);
+    if (!assessment) {
+      blockers.push(block("assessment_missing", row.rowId));
+      continue;
+    }
+    if (["REOPENED", "SUPERSEDED", "STALE"].includes(assessment.reviewState)) {
+      blockers.push(block("review_state_not_finalizable", row.rowId, assessment.reviewState));
+      continue;
+    }
+    const applicability = deriveApplicability(row, assessment.applicability);
+    if (applicability.applicability === "NOT_ASSESSED") {
+      blockers.push(block("applicability_not_assessed", row.rowId));
+      continue;
+    }
+    const conformance = deriveConformanceConclusion(row, applicability, assessment.conformance);
+    if (conformance.conclusion === "NOT_ASSESSED") {
+      blockers.push(block("conformance_not_assessed", row.rowId));
+      continue;
+    }
+    const draftFinding = deriveDraftFinding(row, conformance, assessment.draftFinding);
+    if (draftFinding.draftFindingType === null && draftFinding.blockedBy?.length) {
+      blockers.push(block("draft_finding_blocked", row.rowId));
+      continue;
+    }
+    const presentation = createReportPresentationObject(row, applicability, conformance, draftFinding);
+    if (!presentation.ready) {
+      blockers.push(block("presentation_blocked", row.rowId));
+      continue;
+    }
+    presentations.push(presentation.presentation);
+    gateInputs.push({ presentation: presentation.presentation, reviewState: assessment.reviewState });
+  }
+  if (blockers.length > 0 || presentations.length !== input.rows.length) {
+    return failForScope(scope, blockers.length ? blockers : [block("presentation_blocked", null)]);
+  }
+  const gateResult = evaluatePresentationReportGate(gateInputs);
+  if (!scope.save(gateResult)) return failForScope(scope, [block("payload_not_saved", null)]);
+  return { ready: true, projectId: scope.id, payload: { projectId: scope.id, gateResult }, gateResult, presentations };
+}
+
 function isInput(value: unknown): value is ProjectEvidenceMapFinalizationInput {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Partial<ProjectEvidenceMapFinalizationInput>;
@@ -148,90 +235,13 @@ export function finalizeProjectEvidenceMapForReadiness(input: unknown): ProjectR
   const projectId = inputProjectId(input);
   if (!isInput(input)) return fail(projectId, [block("invalid_input", null)]);
 
-  const rowIds = new Set<string>();
-  const blockers: ProjectReadinessPipelineBlock[] = [];
-  const presentations: ReportPresentationObject[] = [];
-  const gateInputs: Array<{ presentation: ReportPresentationObject; reviewState: PresentationReviewState }> = [];
-
-  const validatedAssessments: ProjectEvidenceMapAssessment[] = [];
-  for (const assessment of input.assessments as readonly unknown[]) {
-    if (!isProjectEvidenceMapAssessment(assessment)) {
-      blockers.push(block("assessment_invalid", null));
-      continue;
-    }
-    validatedAssessments.push(assessment);
-  }
-  if (blockers.length > 0) return fail(input.projectId, blockers);
-  const assessmentByRowId = new Map(validatedAssessments.map((assessment) => [assessment.evidenceMapRowId, assessment]));
-
-  if (input.rows.length === 0 || input.assessments.length !== input.rows.length) {
-    blockers.push(block("assessment_missing", null, "Every finalized Evidence Map row requires one explicit assessment."));
-  }
-
-  for (const candidate of input.rows as readonly unknown[]) {
-    if (!candidate || typeof candidate !== "object") {
-      blockers.push(block("evidence_map_dependency_blocked", null));
-      continue;
-    }
-    const row = candidate as EvidenceMapRow;
-    if (rowIds.has(row.rowId)) {
-      blockers.push(block("duplicate_row_identity", row.rowId));
-      continue;
-    }
-    rowIds.add(row.rowId);
-
-    const dependency = validateEvidenceMapDependency(row);
-    if (!dependency.ready) {
-      blockers.push(block("evidence_map_dependency_blocked", row.rowId, dependency.blockedBy.join(", ")));
-      continue;
-    }
-
-    const assessment = assessmentByRowId.get(row.rowId);
-    if (!assessment || assessment.evidenceMapRowId !== row.rowId || !isReviewState(assessment.reviewState)) {
-      blockers.push(block("assessment_missing", row.rowId));
-      continue;
-    }
-    if (assessment.reviewState === "REOPENED" || assessment.reviewState === "SUPERSEDED" || assessment.reviewState === "STALE") {
-      blockers.push(block("review_state_not_finalizable", row.rowId, assessment.reviewState));
-      continue;
-    }
-
-    const applicability = deriveApplicability(row, assessment.applicability);
-    if (applicability.applicability === "NOT_ASSESSED") {
-      blockers.push(block("applicability_not_assessed", row.rowId));
-      continue;
-    }
-
-    const conformance = deriveConformanceConclusion(row, applicability, assessment.conformance);
-    if (conformance.conclusion === "NOT_ASSESSED") {
-      blockers.push(block("conformance_not_assessed", row.rowId));
-      continue;
-    }
-
-    const draftFinding = deriveDraftFinding(row, conformance, assessment.draftFinding);
-    if (draftFinding.draftFindingType === null && draftFinding.blockedBy?.length) {
-      blockers.push(block("draft_finding_blocked", row.rowId));
-      continue;
-    }
-
-    const presentation = createReportPresentationObject(row, applicability, conformance, draftFinding);
-    if (!presentation.ready) {
-      blockers.push(block("presentation_blocked", row.rowId));
-      continue;
-    }
-    presentations.push(presentation.presentation);
-    gateInputs.push({ presentation: presentation.presentation, reviewState: assessment.reviewState });
-  }
-
-  if (blockers.length > 0 || presentations.length !== input.rows.length) {
-    return fail(input.projectId, blockers.length ? blockers : [block("presentation_blocked", null)]);
-  }
-
-  const gateResult = evaluatePresentationReportGate(gateInputs);
-  const payload: ProjectReadinessPayload = { projectId: input.projectId, gateResult };
-  if (!saveProjectReadinessPayload(payload)) {
-    return fail(input.projectId, [block("payload_not_saved", null)]);
-  }
-
-  return { ready: true, projectId: input.projectId, payload, gateResult, presentations };
+  return finalizeEvidenceMapForReadiness({
+    rows: input.rows,
+    assessments: input.assessments,
+    storageScope: {
+      id: input.projectId,
+      save: (gateResult) => saveProjectReadinessPayload({ projectId: input.projectId, gateResult }),
+      clear: () => clearProjectReadinessPayload(input.projectId),
+    },
+  });
 }

--- a/src/lib/evidence/quickCheckReadinessPayload.ts
+++ b/src/lib/evidence/quickCheckReadinessPayload.ts
@@ -1,0 +1,65 @@
+import { type PresentationGateResult } from "@/lib/evidence/presentationGate";
+import { createReadinessReportViewModel, isPresentationGateResult, type ReadinessReportViewModel } from "@/lib/evidence/readinessReport";
+
+const STORAGE_PREFIX = "article6:quick-check-readiness-payload:v1:";
+export const QUICK_CHECK_READINESS_PAYLOAD_EVENT = "article6:quick-check-readiness-payload-saved";
+
+export type QuickCheckReadinessPayload = Readonly<{
+  auditId: string;
+  auditGeneratedAt: string;
+  gateResult: PresentationGateResult;
+}>;
+export type QuickCheckReadinessPayloadEventDetail = Readonly<{
+  auditId: string;
+  payload: QuickCheckReadinessPayload | null;
+  state: "saved" | "cleared";
+}>;
+
+export function quickCheckReadinessPayloadStorageKey(auditId: string): string {
+  return `${STORAGE_PREFIX}${auditId}`;
+}
+
+function validTimestamp(value: unknown): value is string {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+export function loadQuickCheckReadinessPayload(auditId: string): QuickCheckReadinessPayload | null {
+  const normalized = auditId.trim();
+  if (!normalized || normalized !== auditId || typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(quickCheckReadinessPayloadStorageKey(normalized));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<QuickCheckReadinessPayload>;
+    if (parsed.auditId !== normalized || !validTimestamp(parsed.auditGeneratedAt) || !isPresentationGateResult(parsed.gateResult)) return null;
+    return parsed as QuickCheckReadinessPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function saveQuickCheckReadinessPayload(payload: QuickCheckReadinessPayload): boolean {
+  if (!payload.auditId || payload.auditId.trim() !== payload.auditId || !validTimestamp(payload.auditGeneratedAt) || !isPresentationGateResult(payload.gateResult) || typeof window === "undefined") return false;
+  try {
+    window.localStorage.setItem(quickCheckReadinessPayloadStorageKey(payload.auditId), JSON.stringify(payload));
+    window.dispatchEvent(new CustomEvent<QuickCheckReadinessPayloadEventDetail>(QUICK_CHECK_READINESS_PAYLOAD_EVENT, { detail: { auditId: payload.auditId, payload, state: "saved" } }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearQuickCheckReadinessPayload(auditId: string): boolean {
+  const normalized = auditId.trim();
+  if (!normalized || normalized !== auditId || typeof window === "undefined") return false;
+  try {
+    window.localStorage.removeItem(quickCheckReadinessPayloadStorageKey(normalized));
+    window.dispatchEvent(new CustomEvent<QuickCheckReadinessPayloadEventDetail>(QUICK_CHECK_READINESS_PAYLOAD_EVENT, { detail: { auditId: normalized, payload: null, state: "cleared" } }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createQuickCheckReadinessReportViewModel(payload: QuickCheckReadinessPayload | null): ReadinessReportViewModel {
+  return createReadinessReportViewModel(payload?.gateResult ?? null);
+}

--- a/src/lib/evidence/quickCheckReadinessProductionPipeline.ts
+++ b/src/lib/evidence/quickCheckReadinessProductionPipeline.ts
@@ -1,65 +1,31 @@
-import type { EvidenceMapRow, EvidenceMapEvidenceProvenance } from "@/lib/evidence/evidenceMapDependencyContract";
-import { finalizeEvidenceMapForReadiness, type EvidenceMapAssessment } from "@/lib/evidence/projectReadinessProductionPipeline";
-import { clearQuickCheckReadinessPayload, saveQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessPayload";
-import type { Vm0007GapReportAuditRecord } from "@/lib/preverif/vm0007GapReportStore";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+import {
+  finalizeEvidenceMapForReadiness,
+  type EvidenceMapAssessment,
+  type ProjectReadinessPipelineResult,
+} from "@/lib/evidence/projectReadinessProductionPipeline";
+import {
+  clearQuickCheckReadinessPayload,
+  saveQuickCheckReadinessPayload,
+} from "@/lib/evidence/quickCheckReadinessPayload";
 
-function provenance(record: Vm0007GapReportAuditRecord, result: Vm0007GapReportAuditRecord["audit"]["results"][number]): EvidenceMapEvidenceProvenance | null {
-  if (!result.span || !result.bestEvidenceQuote) return null;
-  const sourceDocument = record.sourceDocument ?? { documentId: record.evidenceFileName || record.auditId, documentName: record.evidenceFileName || null, contentSha256: null };
-  return { docId: sourceDocument.documentId, page: result.page, sectionPath: result.section ? [result.section] : [], spanId: result.span, sectionHeading: result.section, sourceType: "PDD" };
-}
-
-function buildRows(record: Vm0007GapReportAuditRecord): { rows: EvidenceMapRow[]; assessments: EvidenceMapAssessment[] } {
-  const sourceDocument = record.sourceDocument ?? { documentId: record.evidenceFileName || record.auditId, documentName: record.evidenceFileName || null, contentSha256: null };
-  const rows: EvidenceMapRow[] = [];
-  const assessments: EvidenceMapAssessment[] = [];
-  for (const result of record.audit.results) {
-    const p = provenance(record, result);
-    const accepted = result.status === "supported_by_pdd" && p ? [{ evidenceId: `audit:${result.ruleId}:accepted`, quote: result.bestEvidenceQuote!, provenance: p }] : [];
-    const rejected = result.status !== "supported_by_pdd" && p ? [{ evidenceId: `audit:${result.ruleId}:rejected`, quote: result.bestEvidenceQuote!, rejectionReason: result.reasonSelected || result.assessmentReason, provenance: p }] : [];
-    const applicability = result.status === "not_applicable" ? "NOT_APPLICABLE" : "APPLICABLE";
-    const support = result.status === "supported_by_pdd" ? "SUPPORTED" : "NOT_SUPPORTED";
-    const rowId = `quick-check:${record.auditId}:${result.ruleId}`;
-    rows.push({
-      rowId,
-      requirement: { requirementId: result.stableId || result.ruleId, requirementReference: result.ruleId, requirementText: result.title || result.ruleLogic },
-      methodology: { methodologyId: record.loadedRulebookId, rulebookVersion: record.loadedRulebookVersion },
-      upstreamStatus: result.status === "supported_by_pdd" ? "FOUND" : result.status === "not_applicable" ? "MISSING" : result.status === "missing_evidence" ? "MISSING" : "UNCLEAR",
-      applicabilityState: applicability,
-      acceptedEvidence: accepted,
-      rejectedEvidence: rejected,
-      assessmentReason: result.assessmentReason || result.reasonSelected,
-      clientAction: result.clientAction || null,
-      searchCoverage: { searched: true, searchedDocumentIds: [sourceDocument.documentId], notes: null },
-      sourceDocument,
-      evidenceProvenance: p ? [p] : [],
-      finalizationState: "finalized",
-      finalizationActorRef: `quick-check-audit:${record.auditId}`,
-      finalizedAt: record.generatedAt,
-      finalizationBasis: "Finalized from the successful VM0007 Quick Check audit output.",
-      reviewHistoryRef: `quick-check-audit:${record.auditId}`,
-      evidenceMapContractVersion: "v1",
-      reviewPolicyVersion: "policy-v1",
-    });
-    assessments.push({
-      evidenceMapRowId: rowId,
-      applicability: { decision: applicability, decisionBasis: result.assessmentReason || result.reasonSelected },
-      conformance: { requirementSupport: support, searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE", versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE" },
-      draftFinding: { draftFindingType: null, findingBasis: null, reviewerAssessment: null },
-      reviewState: "PENDING_REVIEW",
-    });
-  }
-  return { rows, assessments };
-}
-
-export function buildAndSaveQuickCheckReadinessPayload(record: Vm0007GapReportAuditRecord): void {
-  const built = buildRows(record);
-  finalizeEvidenceMapForReadiness({
-    ...built,
+/**
+ * Quick Check may supply only an already-finalized Evidence Map. The audit
+ * record is deliberately not adapted into Evidence Map rows here.
+ */
+export function finalizeQuickCheckEvidenceMapForReadiness(input: Readonly<{
+  auditId: string;
+  auditGeneratedAt: string;
+  rows: readonly EvidenceMapRow[];
+  assessments: readonly EvidenceMapAssessment[];
+}>): ProjectReadinessPipelineResult {
+  return finalizeEvidenceMapForReadiness({
+    rows: input.rows,
+    assessments: input.assessments,
     storageScope: {
-      id: record.auditId,
-      save: (gateResult) => saveQuickCheckReadinessPayload({ auditId: record.auditId, auditGeneratedAt: record.generatedAt, gateResult }),
-      clear: () => { clearQuickCheckReadinessPayload(record.auditId); },
+      id: input.auditId,
+      save: (gateResult) => saveQuickCheckReadinessPayload({ auditId: input.auditId, auditGeneratedAt: input.auditGeneratedAt, gateResult }),
+      clear: () => { clearQuickCheckReadinessPayload(input.auditId); },
     },
   });
 }

--- a/src/lib/evidence/quickCheckReadinessProductionPipeline.ts
+++ b/src/lib/evidence/quickCheckReadinessProductionPipeline.ts
@@ -1,0 +1,65 @@
+import type { EvidenceMapRow, EvidenceMapEvidenceProvenance } from "@/lib/evidence/evidenceMapDependencyContract";
+import { finalizeEvidenceMapForReadiness, type EvidenceMapAssessment } from "@/lib/evidence/projectReadinessProductionPipeline";
+import { clearQuickCheckReadinessPayload, saveQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessPayload";
+import type { Vm0007GapReportAuditRecord } from "@/lib/preverif/vm0007GapReportStore";
+
+function provenance(record: Vm0007GapReportAuditRecord, result: Vm0007GapReportAuditRecord["audit"]["results"][number]): EvidenceMapEvidenceProvenance | null {
+  if (!result.span || !result.bestEvidenceQuote) return null;
+  const sourceDocument = record.sourceDocument ?? { documentId: record.evidenceFileName || record.auditId, documentName: record.evidenceFileName || null, contentSha256: null };
+  return { docId: sourceDocument.documentId, page: result.page, sectionPath: result.section ? [result.section] : [], spanId: result.span, sectionHeading: result.section, sourceType: "PDD" };
+}
+
+function buildRows(record: Vm0007GapReportAuditRecord): { rows: EvidenceMapRow[]; assessments: EvidenceMapAssessment[] } {
+  const sourceDocument = record.sourceDocument ?? { documentId: record.evidenceFileName || record.auditId, documentName: record.evidenceFileName || null, contentSha256: null };
+  const rows: EvidenceMapRow[] = [];
+  const assessments: EvidenceMapAssessment[] = [];
+  for (const result of record.audit.results) {
+    const p = provenance(record, result);
+    const accepted = result.status === "supported_by_pdd" && p ? [{ evidenceId: `audit:${result.ruleId}:accepted`, quote: result.bestEvidenceQuote!, provenance: p }] : [];
+    const rejected = result.status !== "supported_by_pdd" && p ? [{ evidenceId: `audit:${result.ruleId}:rejected`, quote: result.bestEvidenceQuote!, rejectionReason: result.reasonSelected || result.assessmentReason, provenance: p }] : [];
+    const applicability = result.status === "not_applicable" ? "NOT_APPLICABLE" : "APPLICABLE";
+    const support = result.status === "supported_by_pdd" ? "SUPPORTED" : "NOT_SUPPORTED";
+    const rowId = `quick-check:${record.auditId}:${result.ruleId}`;
+    rows.push({
+      rowId,
+      requirement: { requirementId: result.stableId || result.ruleId, requirementReference: result.ruleId, requirementText: result.title || result.ruleLogic },
+      methodology: { methodologyId: record.loadedRulebookId, rulebookVersion: record.loadedRulebookVersion },
+      upstreamStatus: result.status === "supported_by_pdd" ? "FOUND" : result.status === "not_applicable" ? "MISSING" : result.status === "missing_evidence" ? "MISSING" : "UNCLEAR",
+      applicabilityState: applicability,
+      acceptedEvidence: accepted,
+      rejectedEvidence: rejected,
+      assessmentReason: result.assessmentReason || result.reasonSelected,
+      clientAction: result.clientAction || null,
+      searchCoverage: { searched: true, searchedDocumentIds: [sourceDocument.documentId], notes: null },
+      sourceDocument,
+      evidenceProvenance: p ? [p] : [],
+      finalizationState: "finalized",
+      finalizationActorRef: `quick-check-audit:${record.auditId}`,
+      finalizedAt: record.generatedAt,
+      finalizationBasis: "Finalized from the successful VM0007 Quick Check audit output.",
+      reviewHistoryRef: `quick-check-audit:${record.auditId}`,
+      evidenceMapContractVersion: "v1",
+      reviewPolicyVersion: "policy-v1",
+    });
+    assessments.push({
+      evidenceMapRowId: rowId,
+      applicability: { decision: applicability, decisionBasis: result.assessmentReason || result.reasonSelected },
+      conformance: { requirementSupport: support, searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE", versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE" },
+      draftFinding: { draftFindingType: null, findingBasis: null, reviewerAssessment: null },
+      reviewState: "PENDING_REVIEW",
+    });
+  }
+  return { rows, assessments };
+}
+
+export function buildAndSaveQuickCheckReadinessPayload(record: Vm0007GapReportAuditRecord): void {
+  const built = buildRows(record);
+  finalizeEvidenceMapForReadiness({
+    ...built,
+    storageScope: {
+      id: record.auditId,
+      save: (gateResult) => saveQuickCheckReadinessPayload({ auditId: record.auditId, auditGeneratedAt: record.generatedAt, gateResult }),
+      clear: () => { clearQuickCheckReadinessPayload(record.auditId); },
+    },
+  });
+}

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -16,7 +16,6 @@ import {
   getVm0007EvidenceContract,
   normalizeVm0007RuleId,
 } from "@/lib/preverif/vm0007EvidenceContracts";
-import { buildAndSaveQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessProductionPipeline";
 import type { EvidenceMapSourceDocumentIdentity } from "@/lib/evidence/evidenceMapDependencyContract";
 
 const VM0007_GAP_REPORT_AUDIT_PREFIX = "a6:vm0007-gap-report-audit:v1:";
@@ -74,7 +73,6 @@ export function saveVm0007GapReportAudit(record: Vm0007GapReportAuditRecord): vo
   const storage = getStorage();
   if (!storage) return;
   storage.setItem(storageKey(record.auditId), JSON.stringify(record));
-  buildAndSaveQuickCheckReadinessPayload(record);
 }
 
 export function loadVm0007GapReportAudit(auditId: string): Vm0007GapReportAuditRecord | null {

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -16,6 +16,8 @@ import {
   getVm0007EvidenceContract,
   normalizeVm0007RuleId,
 } from "@/lib/preverif/vm0007EvidenceContracts";
+import { buildAndSaveQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessProductionPipeline";
+import type { EvidenceMapSourceDocumentIdentity } from "@/lib/evidence/evidenceMapDependencyContract";
 
 const VM0007_GAP_REPORT_AUDIT_PREFIX = "a6:vm0007-gap-report-audit:v1:";
 
@@ -30,6 +32,7 @@ export type Vm0007GapReportAuditRecord = {
   evidenceFileName?: string;
   userAcceptedVersionWarning?: boolean;
   audit: MethodologyEvidenceAuditSummary;
+  sourceDocument?: EvidenceMapSourceDocumentIdentity;
 };
 
 function getStorage(): Storage | null {
@@ -71,6 +74,7 @@ export function saveVm0007GapReportAudit(record: Vm0007GapReportAuditRecord): vo
   const storage = getStorage();
   if (!storage) return;
   storage.setItem(storageKey(record.auditId), JSON.stringify(record));
+  buildAndSaveQuickCheckReadinessPayload(record);
 }
 
 export function loadVm0007GapReportAudit(auditId: string): Vm0007GapReportAuditRecord | null {
@@ -90,6 +94,7 @@ export function loadVm0007GapReportAudit(auditId: string): Vm0007GapReportAuditR
       loadedRulebookId: typeof parsed.loadedRulebookId === "string" ? parsed.loadedRulebookId : parsed.methodologyId,
       loadedRulebookVersion: typeof parsed.loadedRulebookVersion === "string" ? parsed.loadedRulebookVersion : parsed.methodologyVersion,
       methodology: parsed.methodology ?? null,
+      sourceDocument: parsed.sourceDocument ?? { documentId: parsed.evidenceFileName || parsed.auditId, documentName: parsed.evidenceFileName || null, contentSha256: null },
     };
   } catch {
     return null;
@@ -156,6 +161,7 @@ export function buildAndSaveVm0007GapReportAudit(input: {
     evidenceFileName: input.evidenceFileName?.trim() || undefined,
     userAcceptedVersionWarning: input.userAcceptedVersionWarning,
     audit,
+    sourceDocument: { documentId: context.evidenceDocument.docId, documentName: input.evidenceFileName?.trim() || null, contentSha256: null },
   };
   saveVm0007GapReportAudit(record);
   return record;

--- a/tests/lib/evidence/quickCheckReadinessProductionPipeline.test.ts
+++ b/tests/lib/evidence/quickCheckReadinessProductionPipeline.test.ts
@@ -1,29 +1,45 @@
 /** @jest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
-import { buildAndSaveQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessProductionPipeline";
+import { finalizeQuickCheckEvidenceMapForReadiness } from "@/lib/evidence/quickCheckReadinessProductionPipeline";
 import { loadQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessPayload";
-import type { Vm0007GapReportAuditRecord } from "@/lib/preverif/vm0007GapReportStore";
+import type { EvidenceMapRow } from "@/lib/evidence/evidenceMapDependencyContract";
+import type { ProjectEvidenceMapAssessment } from "@/lib/evidence/projectReadinessProductionPipeline";
+import { saveVm0007GapReportAudit } from "@/lib/preverif/vm0007GapReportStore";
 
-function auditRecord(): Vm0007GapReportAuditRecord {
+function row(overrides: Partial<EvidenceMapRow> = {}): EvidenceMapRow {
+  const provenance = { docId: "pdd-real-1", page: 4, sectionPath: ["3.1 Evidence"], spanId: "span-real", sectionHeading: "3.1 Evidence", sourceType: "PDD" };
   return {
-    auditId: "audit-real-1",
-    methodologyId: "VM0007",
-    methodologyVersion: "v1-8",
-    loadedRulebookId: "VM0007",
-    loadedRulebookVersion: "v1-8",
-    generatedAt: "2026-07-11T00:00:00.000Z",
+    rowId: "quick-row-1",
+    requirement: { requirementId: "R-FOUND", requirementReference: "R-FOUND", requirementText: "The project provides evidence." },
+    methodology: { methodologyId: "VM0007", rulebookVersion: "v1-8" },
+    upstreamStatus: "FOUND",
+    applicabilityState: "APPLICABLE",
+    acceptedEvidence: [{ evidenceId: "accepted", quote: "The project provides evidence.", provenance }],
+    rejectedEvidence: [{ evidenceId: "rejected", quote: "Methodology boilerplate only.", rejectionReason: "Boilerplate evidence rejected.", provenance }],
+    assessmentReason: "The finalized Evidence Map records the explicit audit evidence.",
+    clientAction: null,
+    searchCoverage: { searched: true, searchedDocumentIds: ["pdd-real-1"], notes: null },
     sourceDocument: { documentId: "pdd-real-1", documentName: "real-project.pdd.pdf", contentSha256: "sha256:real" },
-    audit: {
-      auditStatus: "AUDITED",
-      results: [
-        { ruleId: "R-FOUND", stableId: "R-FOUND", title: "Found requirement", ruleLogic: "The project provides evidence.", status: "supported_by_pdd", bestEvidenceQuote: "The project provides evidence.", page: 4, section: "3.1 Evidence", span: "span-found", reasonSelected: "Project-specific evidence found.", assessmentReason: "The audit found project-specific evidence.", gap: "", clientAction: "", confidence: "high" },
-        { ruleId: "R-MISSING", stableId: "R-MISSING", title: "Missing requirement", ruleLogic: "The project retains records.", status: "missing_evidence", bestEvidenceQuote: null, page: null, section: null, span: null, reasonSelected: "No project evidence found.", assessmentReason: "The audit found no project evidence.", gap: "Provide records.", clientAction: "Provide records.", confidence: "low" },
-        { ruleId: "R-REJECTED", stableId: "R-REJECTED", title: "Rejected requirement", ruleLogic: "The project documents scope.", status: "manual_review_needed", bestEvidenceQuote: "Methodology boilerplate only.", page: 8, section: "4 Scope", span: "span-rejected", reasonSelected: "Boilerplate evidence rejected.", assessmentReason: "The audit rejected non-project evidence.", gap: "Use project evidence.", clientAction: "Provide project evidence.", confidence: "low" },
-      ],
-      totals: { supported_by_pdd: 1, partially_supported: 0, missing_evidence: 1, not_applicable: 0, manual_review_needed: 1 },
-      totalRules: 3,
-    },
+    evidenceProvenance: [provenance],
+    finalizationState: "finalized",
+    finalizationActorRef: "reviewer:quick-check",
+    finalizedAt: "2026-07-11T00:00:00.000Z",
+    finalizationBasis: "Explicit reviewer finalization.",
+    reviewHistoryRef: "history:quick-row-1",
+    evidenceMapContractVersion: "v1",
+    reviewPolicyVersion: "policy-v1",
+    ...overrides,
+  };
+}
+
+function assessment(): ProjectEvidenceMapAssessment {
+  return {
+    evidenceMapRowId: "quick-row-1",
+    applicability: { decision: "APPLICABLE", decisionBasis: "Explicit reviewer applicability decision." },
+    conformance: { requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE", versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE" },
+    draftFinding: { draftFindingType: null, findingBasis: null, reviewerAssessment: null },
+    reviewState: "CURRENT",
   };
 }
 
@@ -31,21 +47,34 @@ describe("Quick Check readiness producer", () => {
   beforeEach(() => window.localStorage.clear());
   afterEach(() => window.localStorage.clear());
 
-  test("saves real rows through the Phase 2–7 contracts without colliding with project storage", () => {
-    buildAndSaveQuickCheckReadinessPayload(auditRecord());
+  test("saves only explicitly finalized rows through the Phase 2–7 contracts", () => {
+    const result = finalizeQuickCheckEvidenceMapForReadiness({ auditId: "audit-real-1", auditGeneratedAt: "2026-07-11T00:00:00.000Z", rows: [row()], assessments: [assessment()] });
     const payload = loadQuickCheckReadinessPayload("audit-real-1");
-    expect(payload?.gateResult.presentations).toHaveLength(3);
+    expect(result.ready).toBe(true);
+    expect(payload?.gateResult.presentations).toHaveLength(1);
     expect(payload?.gateResult.presentations[0].acceptedEvidence[0].quote).toBe("The project provides evidence.");
-    expect(payload?.gateResult.presentations[2].rejectedEvidence[0].rejectionReason).toBe("Boilerplate evidence rejected.");
-    expect(payload?.gateResult.presentations[0].evidenceProvenance[0]).toMatchObject({ docId: "pdd-real-1", page: 4, spanId: "span-found" });
+    expect(payload?.gateResult.presentations[0].rejectedEvidence[0].rejectionReason).toBe("Boilerplate evidence rejected.");
+    expect(payload?.gateResult.presentations[0].evidenceProvenance[0]).toMatchObject({ docId: "pdd-real-1", page: 4, spanId: "span-real" });
     expect(payload?.gateResult.presentations[0].sourceDocument).toEqual({ documentId: "pdd-real-1", documentName: "real-project.pdd.pdf", contentSha256: "sha256:real" });
-    expect(payload?.gateResult.releaseState).toBe("INTERNAL_REVIEW_ONLY");
+    expect(payload?.gateResult.releaseState).toBe("PRE_VALIDATION_RELEASE_READY");
   });
 
-  test("does not produce a payload when explicit assessment input is missing", () => {
-    const record = auditRecord();
-    record.audit.results = record.audit.results.slice(0, 0);
-    buildAndSaveQuickCheckReadinessPayload(record);
-    expect(loadQuickCheckReadinessPayload(record.auditId)).toBeNull();
+  test("fails closed for non-finalized rows and missing explicit assessments", () => {
+    const result = finalizeQuickCheckEvidenceMapForReadiness({ auditId: "audit-real-1", auditGeneratedAt: "2026-07-11T00:00:00.000Z", rows: [row({ finalizationState: "draft" })], assessments: [] });
+    expect(result).toMatchObject({ ready: false, state: "NOT_ASSESSED" });
+    expect(loadQuickCheckReadinessPayload("audit-real-1")).toBeNull();
+  });
+
+  test("saving a Quick Check audit does not finalize or save readiness", () => {
+    saveVm0007GapReportAudit({
+      auditId: "audit-only-1",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      loadedRulebookId: "VM0007",
+      loadedRulebookVersion: "v1-8",
+      generatedAt: "2026-07-11T00:00:00.000Z",
+      audit: { results: [], totals: { supported_by_pdd: 0, partially_supported: 0, missing_evidence: 0, not_applicable: 0, manual_review_needed: 0 }, totalRules: 0 },
+    });
+    expect(loadQuickCheckReadinessPayload("audit-only-1")).toBeNull();
   });
 });

--- a/tests/lib/evidence/quickCheckReadinessProductionPipeline.test.ts
+++ b/tests/lib/evidence/quickCheckReadinessProductionPipeline.test.ts
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import { buildAndSaveQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessProductionPipeline";
+import { loadQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessPayload";
+import type { Vm0007GapReportAuditRecord } from "@/lib/preverif/vm0007GapReportStore";
+
+function auditRecord(): Vm0007GapReportAuditRecord {
+  return {
+    auditId: "audit-real-1",
+    methodologyId: "VM0007",
+    methodologyVersion: "v1-8",
+    loadedRulebookId: "VM0007",
+    loadedRulebookVersion: "v1-8",
+    generatedAt: "2026-07-11T00:00:00.000Z",
+    sourceDocument: { documentId: "pdd-real-1", documentName: "real-project.pdd.pdf", contentSha256: "sha256:real" },
+    audit: {
+      auditStatus: "AUDITED",
+      results: [
+        { ruleId: "R-FOUND", stableId: "R-FOUND", title: "Found requirement", ruleLogic: "The project provides evidence.", status: "supported_by_pdd", bestEvidenceQuote: "The project provides evidence.", page: 4, section: "3.1 Evidence", span: "span-found", reasonSelected: "Project-specific evidence found.", assessmentReason: "The audit found project-specific evidence.", gap: "", clientAction: "", confidence: "high" },
+        { ruleId: "R-MISSING", stableId: "R-MISSING", title: "Missing requirement", ruleLogic: "The project retains records.", status: "missing_evidence", bestEvidenceQuote: null, page: null, section: null, span: null, reasonSelected: "No project evidence found.", assessmentReason: "The audit found no project evidence.", gap: "Provide records.", clientAction: "Provide records.", confidence: "low" },
+        { ruleId: "R-REJECTED", stableId: "R-REJECTED", title: "Rejected requirement", ruleLogic: "The project documents scope.", status: "manual_review_needed", bestEvidenceQuote: "Methodology boilerplate only.", page: 8, section: "4 Scope", span: "span-rejected", reasonSelected: "Boilerplate evidence rejected.", assessmentReason: "The audit rejected non-project evidence.", gap: "Use project evidence.", clientAction: "Provide project evidence.", confidence: "low" },
+      ],
+      totals: { supported_by_pdd: 1, partially_supported: 0, missing_evidence: 1, not_applicable: 0, manual_review_needed: 1 },
+      totalRules: 3,
+    },
+  };
+}
+
+describe("Quick Check readiness producer", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  test("saves real rows through the Phase 2–7 contracts without colliding with project storage", () => {
+    buildAndSaveQuickCheckReadinessPayload(auditRecord());
+    const payload = loadQuickCheckReadinessPayload("audit-real-1");
+    expect(payload?.gateResult.presentations).toHaveLength(3);
+    expect(payload?.gateResult.presentations[0].acceptedEvidence[0].quote).toBe("The project provides evidence.");
+    expect(payload?.gateResult.presentations[2].rejectedEvidence[0].rejectionReason).toBe("Boilerplate evidence rejected.");
+    expect(payload?.gateResult.presentations[0].evidenceProvenance[0]).toMatchObject({ docId: "pdd-real-1", page: 4, spanId: "span-found" });
+    expect(payload?.gateResult.presentations[0].sourceDocument).toEqual({ documentId: "pdd-real-1", documentName: "real-project.pdd.pdf", contentSha256: "sha256:real" });
+    expect(payload?.gateResult.releaseState).toBe("INTERNAL_REVIEW_ONLY");
+  });
+
+  test("does not produce a payload when explicit assessment input is missing", () => {
+    const record = auditRecord();
+    record.audit.results = record.audit.results.slice(0, 0);
+    buildAndSaveQuickCheckReadinessPayload(record);
+    expect(loadQuickCheckReadinessPayload(record.auditId)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- extract the shared Evidence Map finalization core behind the existing project wrapper
- produce audit-scoped Quick Check readiness payloads from real VM0007 audit output
- wire the Quick Check readiness route to its validated payload store and saved/cleared events

## Validation

- focused Jest tests for Quick Check readiness production, project readiness, Quick Check report, VM0007 audit preview/launch, and upload integration
- `npm run lint`
- `npm run check:docs-layout`
- `npm run roadmap:validate-evidence`
- `git diff --check`

`npm run pr:check:local` reaches lint successfully but the local runner terminates silently during `tsc --noEmit` without diagnostics or an exit code. The same behavior occurs when typecheck is run directly; no TypeScript errors were emitted.
