### PR TITLE
docs: expand Marcondes VM0007 Evidence Map learning roadmap

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -341,30 +341,34 @@ Status SSOT: `docs/roadmaps/vm0007-judgement-fixtures/phase-status.json`
 Details: `docs/roadmaps/vm0007-judgement-fixtures/PLAN.md`
 
 Lane status: Active
-Tighten VM0007 gap report accuracy by improving rule-level judgment fixtures and contracts without changing production audit logic; Envira evidence-map/report fixture output is quarantined legacy REDD-MF / VM0007 v1.5 mismatch data, not validated VM0007 v1.8 truth.
+Build a progressively improving VM0007 v1.8 Evidence Map using PDF-backed machine proposals, reviewed truth, explicit corrections, and generic retrieval/router improvements.
 
 Current focus:
-- Phase 0 done: boundary-only fixture contract is documented and enforced.
-- Phase 1 done: Envira VM0007 judgment fixtures were delivered by PR #897
-- Phase 2 done: PD_REDD VM0007 judgment fixtures established with PDF-backed accepted and rejected evidence coverage.
-- Phase 3 blocked: Envira VM0007's reviewed full 58-rule audit fixture remains quarantined historical regression data with the old 30 FOUND / 8 UNCLEAR / 3 MISSING / 17 N/A split, which is not validated VM0007 v1.8 truth.
-- Phase 4 blocked: Report fixture layer remains quarantined historical regression data; internal preview output is not client-ready truth and is pending versioned re-audit before any truth-complete claim.
-- Phase 5 done: roadmap correction now states the contaminated Envira evidence-map/report fixture work is quarantined and pending versioned re-audit.
-- Phase 6 remains planned: keep the forward path separate until a clean VM0007 v1.8 version lock passes.
+- Phases 0–2 complete: the boundary, Envira rule-level fixtures, and PD_REDD rule-level fixtures remain preserved with their historical references.
+- Phases 3–4 blocked/quarantined: Envira full-audit and report material is legacy REDD-MF / VM0007 v1.5 mismatch regression data, not VM0007 v1.8 truth.
+- Phase 5 complete: the internal-preview/client-readiness boundary and legacy-fixture quarantine are documented.
+- Phase 6 active: define and enforce the two-PR truth-intake and generic-system-improvement learning contract.
+- Phase 7 planned: begin Maya Forest Corridor REDD Belize VM0007 v1.8 Evidence Map truth intake.
 
 Not active now:
-- Production audit logic changes
+- Production logic changes in truth-intake PRs
+- Quick Check extraction or routing changes
 - Report UI redesign
 - Client-facing report changes
 - LLM final judgment
-- Quick Check v2 Phase 7 work
+- Formal validation, verification, or VVB authority claims
 
 1) RC0 — Roadmap Boundary: Done — Define a boundary-only contract for VM0007 judgment fixtures: PDF truth over current output, accepted and rejected evidence requirements, UNCLEAR/MISSING discipline, no production or UI changes, and clear acceptance criteria for future fixture PRs. Delivered by PR #895.
 2) RC1 — Envira VM0007 Judgment Fixtures: Done — Added 5-10 Envira VM0007 judgment fixtures with explicit accepted evidence, rejected generic evidence examples, false-supported coverage, and expected statuses plus client actions where weak or missing. Delivered by PR #897.
 3) RC2 — PD_REDD VM0007 Judgment Fixtures: Done — Added PD_REDD VM0007 fixture coverage using the same judgment contract discipline, including accepted evidence, rejected weak or generic evidence, and explicit FOUND / UNCLEAR / MISSING / N/A expectations.
-4) RC3 — Full 58-Rule Audit Fixture Shape: Blocked — Envira VM0007's reviewed full 58-rule audit fixture is quarantined legacy REDD-MF / VM0007 v1.5 mismatch data. The historical split FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17 remains preserved as a regression fixture, but it is not validated VM0007 v1.8 truth and is pending versioned re-audit.
-5) RC4 — Report Fixture Layer: Blocked — Report fixture output remains quarantined historical regression data. Report summary expectations and internal preview output are fixture-driven and testable, but the legacy Envira report fixture is not client-ready truth and is pending versioned re-audit. Local pr:gate passed, GitHub pr-gate passed, no production audit logic changed.
-6) RC5 — Client-Readiness Gate: Planned — Keep internal preview output separate from any later client-ready reporting work.
+4) RC3 — Full 58-Rule Audit Fixture Shape: Blocked — Envira VM0007's reviewed full 58-rule audit fixture is quarantined legacy REDD-MF / VM0007 v1.5 mismatch data. The historical FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17 split remains preserved as a regression fixture, but it is not validated VM0007 v1.8 truth.
+5) RC4 — Report Fixture Layer: Blocked — Report fixture output remains quarantined historical regression data. Report summary expectations and internal preview output are fixture-driven and testable, but the legacy Envira report fixture is not client-ready truth and is pending versioned re-audit. Historical delivery is preserved as PR #914.
+6) RC5 — Client-Readiness Gate: Done — The internal-preview/client-readiness boundary is documented and legacy mismatch fixtures remain quarantined; no legacy Envira output is promoted as VM0007 v1.8 truth.
+7) RC6 — Evidence Map Learning Contract: Active — Define the repeatable two-PR cycle: PR1 truth intake with untouched machine output and partial reviewed truth; PR2 generic shared-system improvement with previous-fixture reruns and one unseen eligible PDD.
+8) RC7 — Maya VM0007 v1.8 Evidence Map Truth Intake: Planned — Intake Maya Forest Corridor REDD Belize as the first clean VM0007 v1.8 full Evidence Map learning case while preserving raw 58-row output and counting only explicitly reviewed rows as gold.
+9) RC8 — Maya Generic System Improvement: Planned — Use Maya reviewed truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures without Maya-specific hardcoding.
+10) RC9 — Review and Gold Promotion Tooling: Planned — Make partial review and correction generation easy while preserving machine proposal, reviewer correction, final truth, and explicit gold coverage separately.
+11) RC10 — Second Unseen VM0007 v1.8 PDD: Planned — Run the same truth-intake and generic-improvement cycle on an unseen eligible VM0007 v1.8 PDD to prove generalization and prevent regressions.
 
 ## vm0007-version-cleanup
 

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -348,7 +348,7 @@ Current focus:
 - Phases 3–4 blocked/quarantined: Envira full-audit and report material is legacy REDD-MF / VM0007 v1.5 mismatch regression data, not VM0007 v1.8 truth.
 - Phase 5 complete: the internal-preview/client-readiness boundary and legacy-fixture quarantine are documented.
 - Phase 6 active: define and enforce the two-PR truth-intake and generic-system-improvement learning contract.
-- Phase 7 planned: begin Marcondes REDD+ VM0007 v1.8 Evidence Map truth intake with an explicit internal v1.7/v1.8 discrepancy.
+- Phase 7 planned: begin Marcondes REDD+ as the first candidate forward VM0007 v1.8 Evidence Map learning case, pending explicit reconciliation of the internal v1.7/v1.8 discrepancy.
 
 Not active now:
 - Production logic changes in truth-intake PRs
@@ -375,7 +375,7 @@ Not active now:
 Status SSOT: `docs/roadmaps/vm0007-version-cleanup/phase-status.json`
 
 Lane status: Active
-Phase 6 Forward Path is complete: contaminated VM0007 evidence-map/report roadmap states are quarantined, mismatched VM0007 versions are blocked from normal evidence, report, PDF, and client-readiness trust paths, the legacy Envira fixture remains pending versioned re-audit, and a normalized VM0007 v1.8 path can pass the version lock without building a full Marcondes evidence map.
+Phase 6 Forward Path is complete: contaminated VM0007 evidence-map/report roadmap states are quarantined, mismatched VM0007 versions are blocked from normal evidence, report, PDF, and client-readiness trust paths, the legacy Envira fixture remains pending versioned re-audit, and a normalized VM0007 v1.8 path can pass the version lock without building a full project Evidence Map.
 
 Current focus:
 - Keep Envira quarantined as a blocked legacy REDD-MF / VM0007 v1.5 mismatch regression case
@@ -394,7 +394,7 @@ Not active now:
 3) RC3 — Phase 3: Report and PDF Blocking: Done — Prevent mismatched versions from producing normal evidence maps, reports, PDFs, or readiness claims.
 4) RC4 — Phase 4: Gate Strengthening: Done — Add tests and gates so mismatches cannot produce judgments, reports, PDFs, or client-readiness output.
 5) RC5 — Phase 5: Roadmap Correction: Done — Correct contaminated done states, mark VM0007 evidence-map work pending versioned re-audit, and preserve the legacy Envira fixture as quarantined historical regression data rather than validated VM0007 v1.8 truth.
-6) RC6 — Phase 6: Forward Path: Done — A normalized VM0007 v1.8 PDD path can pass the version lock while the legacy Envira v1.5 mismatch fixture remains blocked, without building a full Marcondes evidence map.
+6) RC6 — Phase 6: Forward Path: Done — A normalized VM0007 v1.8 PDD path can pass the version lock while the legacy Envira v1.5 mismatch fixture remains blocked, without building a full project Evidence Map.
 
 ## vvb-report-presentation-layer
 

--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -348,7 +348,7 @@ Current focus:
 - Phases 3–4 blocked/quarantined: Envira full-audit and report material is legacy REDD-MF / VM0007 v1.5 mismatch regression data, not VM0007 v1.8 truth.
 - Phase 5 complete: the internal-preview/client-readiness boundary and legacy-fixture quarantine are documented.
 - Phase 6 active: define and enforce the two-PR truth-intake and generic-system-improvement learning contract.
-- Phase 7 planned: begin Maya Forest Corridor REDD Belize VM0007 v1.8 Evidence Map truth intake.
+- Phase 7 planned: begin Marcondes REDD+ VM0007 v1.8 Evidence Map truth intake with an explicit internal v1.7/v1.8 discrepancy.
 
 Not active now:
 - Production logic changes in truth-intake PRs
@@ -365,8 +365,8 @@ Not active now:
 5) RC4 — Report Fixture Layer: Blocked — Report fixture output remains quarantined historical regression data. Report summary expectations and internal preview output are fixture-driven and testable, but the legacy Envira report fixture is not client-ready truth and is pending versioned re-audit. Historical delivery is preserved as PR #914.
 6) RC5 — Client-Readiness Gate: Done — The internal-preview/client-readiness boundary is documented and legacy mismatch fixtures remain quarantined; no legacy Envira output is promoted as VM0007 v1.8 truth.
 7) RC6 — Evidence Map Learning Contract: Active — Define the repeatable two-PR cycle: PR1 truth intake with untouched machine output and partial reviewed truth; PR2 generic shared-system improvement with previous-fixture reruns and one unseen eligible PDD.
-8) RC7 — Maya VM0007 v1.8 Evidence Map Truth Intake: Planned — Intake Maya Forest Corridor REDD Belize as the first clean VM0007 v1.8 full Evidence Map learning case while preserving raw 58-row output and counting only explicitly reviewed rows as gold.
-9) RC8 — Maya Generic System Improvement: Planned — Use Maya reviewed truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures without Maya-specific hardcoding.
+8) RC7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake: Planned — Intake Marcondes REDD+ as the first forward VM0007 v1.8 Evidence Map learning case with an explicit internal v1.7/v1.8 discrepancy while preserving raw 58-row output and counting only explicitly reviewed rows as gold.
+9) RC8 — Marcondes Generic System Improvement: Planned — Use Marcondes reviewed truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures without Marcondes-specific hardcoding.
 10) RC9 — Review and Gold Promotion Tooling: Planned — Make partial review and correction generation easy while preserving machine proposal, reviewer correction, final truth, and explicit gold coverage separately.
 11) RC10 — Second Unseen VM0007 v1.8 PDD: Planned — Run the same truth-intake and generic-improvement cycle on an unseen eligible VM0007 v1.8 PDD to prove generalization and prevent regressions.
 
@@ -375,7 +375,7 @@ Not active now:
 Status SSOT: `docs/roadmaps/vm0007-version-cleanup/phase-status.json`
 
 Lane status: Active
-Phase 6 Forward Path is complete: contaminated VM0007 evidence-map/report roadmap states are quarantined, mismatched VM0007 versions are blocked from normal evidence, report, PDF, and client-readiness trust paths, the legacy Envira fixture remains pending versioned re-audit, and a normalized VM0007 v1.8 path can pass the version lock without building a full Maya evidence map.
+Phase 6 Forward Path is complete: contaminated VM0007 evidence-map/report roadmap states are quarantined, mismatched VM0007 versions are blocked from normal evidence, report, PDF, and client-readiness trust paths, the legacy Envira fixture remains pending versioned re-audit, and a normalized VM0007 v1.8 path can pass the version lock without building a full Marcondes evidence map.
 
 Current focus:
 - Keep Envira quarantined as a blocked legacy REDD-MF / VM0007 v1.5 mismatch regression case
@@ -394,7 +394,7 @@ Not active now:
 3) RC3 — Phase 3: Report and PDF Blocking: Done — Prevent mismatched versions from producing normal evidence maps, reports, PDFs, or readiness claims.
 4) RC4 — Phase 4: Gate Strengthening: Done — Add tests and gates so mismatches cannot produce judgments, reports, PDFs, or client-readiness output.
 5) RC5 — Phase 5: Roadmap Correction: Done — Correct contaminated done states, mark VM0007 evidence-map work pending versioned re-audit, and preserve the legacy Envira fixture as quarantined historical regression data rather than validated VM0007 v1.8 truth.
-6) RC6 — Phase 6: Forward Path: Done — A normalized VM0007 v1.8 PDD path can pass the version lock while the legacy Envira v1.5 mismatch fixture remains blocked, without building a full Maya evidence map.
+6) RC6 — Phase 6: Forward Path: Done — A normalized VM0007 v1.8 PDD path can pass the version lock while the legacy Envira v1.5 mismatch fixture remains blocked, without building a full Marcondes evidence map.
 
 ## vvb-report-presentation-layer
 

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -27,7 +27,7 @@ Envira's historical VM0007 v1.5 mismatch material remains quarantined regression
 
 ### Phase 0 — Roadmap Boundary — done
 
-Define the scope of VM0007 judgment fixtures and lock the separation from production logic and Quick Check v2 Phase 7. Delivered by PR #895.
+Phase 0 is documentation-only. Fixtures must use PDF truth, not current app output. Define the scope of VM0007 judgment fixtures and lock the separation from production logic and Quick Check v2 Phase 7. Delivered by PR #895.
 
 ### Phase 1 — Envira VM0007 Judgment Fixtures — done
 
@@ -74,12 +74,22 @@ Define the repeatable two-PR cycle for safely improving the Evidence Map.
 
 ### Phase 7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake — planned
 
-- Marcondes REDD+ is the first forward VM0007 v1.8 Evidence Map learning case with an explicit internal v1.7/v1.8 discrepancy
+- Marcondes REDD+ is the first candidate forward VM0007 v1.8 Evidence Map learning case, pending explicit reconciliation of the internal v1.7/v1.8 discrepancy
 - preserve the raw 58-row machine output
 - support `reviewedRuleIds` or equivalent partial coverage
 - store reviewed truth, corrections, provenance, reviewer notes, and `REVIEW.md`
 - review high-value and uncertain rows first
 - unreviewed rows must not count as gold or accuracy evidence
+
+#### Phase 7 completion criteria
+
+- page 61 v1.7 wording is preserved exactly
+- Tables 30 and 31 v1.8 declarations are preserved exactly
+- a reviewer records the reconciled methodology version and rationale
+- the decision is stored in metadata and `REVIEW.md`
+- unresolved conflict blocks gold promotion and Evidence Map truth claims
+- no silent normalization is permitted
+- after reconciliation, Marcondes may be marked version-qualified VM0007 v1.8 truth
 
 ### Phase 8 — Marcondes Generic System Improvement — planned
 

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -1,105 +1,141 @@
-# VM0007 Judgement Fixtures Roadmap
+# VM0007 Judgement Fixtures and Evidence Map Learning Roadmap
 
 Status is sourced from `docs/roadmaps/vm0007-judgement-fixtures/phase-status.json`; docs must not drift.
 
 ## Goal
 
-Improve VM0007 gap report accuracy by tightening rule-level judgment fixtures and contracts.
+Build a progressively improving VM0007 v1.8 Evidence Map using PDF-backed machine proposals, reviewed truth, explicit corrections, and generic retrieval/router improvements.
 
-This roadmap focuses on the evidence and status layer, not production logic, not report UI redesign, and not client-facing outputs.
+This roadmap grows from the existing VM0007 judgment-fixture and gap-report accuracy work. It does not change production logic, Quick Check semantics, report UI styling, or client-facing outputs unless a later phase explicitly permits a shared-system improvement.
 
 ## Core Focus
 
-- accepted evidence
-- rejected evidence
-- expected status
-- weak / missing / not-applicable logic
-- audit summary expectations
-- report summary expectations
+- PDF-backed accepted and rejected evidence
+- explicit reviewer truth and corrections
+- applicability, provenance, search coverage, contradiction, and draft-finding assessments
+- partial review coverage without treating unreviewed rows as truth
+- generic retrieval, routing, and evidence-selection improvements
+- regression protection across clean VM0007 v1.8 PDDs and quarantined version-mismatch fixtures
 
 ## Boundary
 
-This lane is separate from Quick Check v2 Phase 7.
+This lane remains separate from Quick Check v2 Phase 7. The learning cycle may consume persisted Evidence Map output, but it must not change Quick Check extraction or routing semantics through fixture work.
 
-Do not mix judgment-fixture work into the Quick Check v2 parser / ingestion rebuild unless a later roadmap explicitly calls for that overlap.
+Envira's historical VM0007 v1.5 mismatch material remains quarantined regression data. It must never be rewritten as valid VM0007 v1.8 truth.
 
 ## Phases
 
-### Phase 0 — Roadmap Boundary
+### Phase 0 — Roadmap Boundary — done
 
-Define the scope of VM0007 judgment fixtures and lock the separation from production logic and Quick Check v2 Phase 7.
+Define the scope of VM0007 judgment fixtures and lock the separation from production logic and Quick Check v2 Phase 7. Delivered by PR #895.
 
-Phase 0 is documentation-only. It defines the contract for future fixture PRs before any Envira or PD_REDD fixture files are added.
+### Phase 1 — Envira VM0007 Judgment Fixtures — done
 
-#### Phase 0 Scope
+Add and harden Envira-specific VM0007 judgment fixtures, including accepted evidence, rejected generic evidence, false-supported cases, expected statuses, and client actions. Delivered by PR #897.
 
-- this lane is for VM0007 judgment fixtures only
-- fixtures must use PDF truth, not current app output
-- each fixture must encode accepted evidence
-- each fixture must encode rejected weak or generic evidence
-- weak evidence must stay `UNCLEAR`, not `FOUND`
-- missing evidence must stay `MISSING`
-- no production audit logic changes
-- no report UI changes
-- no client-facing report behavior changes
-- no Quick Check v2 Phase 7 work
+### Phase 2 — PD_REDD VM0007 Judgment Fixtures — done
 
-#### Future Fixture PR Contract
+Add and harden PD_REDD-style VM0007 rule-level judgments using the same PDF-backed accepted/rejected evidence contract.
 
-Every future fixture PR in this lane must:
+### Phase 3 — Full 58-Rule Audit Fixture Shape — blocked/quarantined
 
-- stay docs or fixture scoped unless a separate production-logic roadmap explicitly allows broader work
-- identify the rule IDs covered by the fixture set
-- state the PDF source of truth for each fixture set
-- encode accepted evidence that is sufficient for the expected status
-- encode rejected weak or generic evidence that must not upgrade a row to `FOUND`
-- preserve `UNCLEAR` for weak evidence and `MISSING` for absent evidence
-- define expected status per fixture
-- define expected client action whenever status is weak or missing
-- avoid using current app output as fixture truth
+Preserve the Envira full 58-rule audit fixture as a quarantined legacy REDD-MF / VM0007 v1.5 mismatch regression case. The historical FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17 split remains regression evidence only and is not VM0007 v1.8 truth.
 
-#### Acceptance For Future Fixture PRs
+### Phase 4 — Report Fixture Layer — blocked/quarantined
 
-- fixture scope is limited to VM0007 judgment fixtures
-- PDF truth is explicit
-- accepted and rejected evidence are explicit
-- status expectations are explicit
-- weak evidence remains `UNCLEAR`
-- missing evidence remains `MISSING`
-- tests and CI are not weakened
+Preserve report-facing fixture expectations and internal preview coverage for the quarantined legacy Envira material. Do not present it as client-ready or truth-complete VM0007 v1.8 output. Historical delivery is preserved as PR #914.
 
-### Phase 1 — Envira VM0007 Judgment Fixtures
+### Phase 5 — Client-Readiness Gate — done
 
-Add and harden fixtures that capture Envira-specific VM0007 judgments, including:
+Keep internal preview output separate from later client-ready reporting work. This phase records the existing quarantine and gate boundary; it does not promote the legacy Envira material to client-ready truth.
 
-- 5-10 rule-level judgment fixtures
-- accepted evidence requirements
-- rejected generic evidence examples
-- at least one false-supported case
-- at least one case where generic methodology/module-table evidence must not count as supported
-- expected status for each fixture
-- expected client action where status is weak or missing
+### Phase 6 — Evidence Map Learning Contract — active
 
-### Phase 2 — PD_REDD VM0007 Judgment Fixtures
+Define the repeatable two-PR cycle for safely improving the Evidence Map.
 
-Add and harden fixtures for PD_REDD-style VM0007 judgments with the same evidence/status contract discipline.
+#### PR1: Truth intake
 
-### Phase 3 — Full 58-Rule Audit Fixture Shape
+- validate methodology and version
+- preserve untouched machine output
+- review PDF-backed rows
+- save accepted and rejected evidence
+- record corrections
+- allow partial review
+- only reviewed rows count as gold
+- make no production logic changes
 
-Envira VM0007 now has a reviewed full 58-rule audit fixture shape, but it is quarantined legacy REDD-MF / VM0007 v1.5 mismatch regression data, not validated VM0007 v1.8 truth. The historical split FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17 remains preserved as regression evidence. Review included FOUND red-team pass, UNCLEAR/MISSING rescue check, R-1-0003 carbon-rights fix, fixture/test-only scope confirmation, `pr:gate`, and blind rebuild validation.
+#### PR2: Generic system improvement
 
-### Phase 4 — Report Fixture Layer
+- classify reusable failures
+- improve shared retrieval, routing, evidence selection, or assessment logic
+- never hardcode the project
+- rerun all previous fixtures
+- test one unseen eligible PDD
 
-Add report-facing fixture expectations for summary sections, row grouping, and internal preview output. This layer remains quarantined historical fixture data until versioned re-audit confirms the VM0007 evidence map is truth-complete.
+### Phase 7 — Maya VM0007 v1.8 Evidence Map Truth Intake — planned
 
-### Phase 5 — Client-Readiness Gate
+- Maya Forest Corridor REDD Belize is the first clean VM0007 v1.8 full Evidence Map learning case
+- preserve the raw 58-row machine output
+- support `reviewedRuleIds` or equivalent partial coverage
+- store reviewed truth, corrections, provenance, reviewer notes, and `REVIEW.md`
+- review high-value and uncertain rows first
+- unreviewed rows must not count as gold or accuracy evidence
 
-Define the gate that keeps internal preview output distinct from any later client-ready reporting work.
+### Phase 8 — Maya Generic System Improvement — planned
+
+- compare Maya machine proposals against reviewed truth
+- classify retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding errors
+- fix only reusable shared logic
+- rerun Quick Check and Evidence Map regressions
+- prohibit Maya-specific hardcoding
+
+### Phase 9 — Review and Gold Promotion Tooling — planned
+
+- make partial row review easy
+- generate corrections automatically from machine-versus-reviewer differences
+- promote only explicitly reviewed rows to gold
+- preserve machine proposal, reviewer correction, and final truth separately
+- provide coverage counts without treating unreviewed rows as failures or passes
+
+### Phase 10 — Second Unseen VM0007 v1.8 PDD — planned
+
+- intake an unseen eligible PDD
+- run the same PR1/PR2 cycle
+- prove Maya improvements generalize
+- prevent regression across Maya, earlier judgment fixtures, and version-mismatch fixtures
+
+## Fixture roles
+
+- **Maya:** first clean VM0007 v1.8 Evidence Map learning fixture.
+- **Envira:** quarantined methodology-version mismatch regression fixture.
+- **PD_REDD:** existing rule-level judgment fixture set; do not claim full VM0007 v1.8 Evidence Map truth unless separately version-validated.
+- **Future PDDs:** unseen VM0007 v1.8 generalization cases.
+
+## Required Evidence Map truth artifacts
+
+Every reviewed Evidence Map learning case should preserve, separately and traceably:
+
+- raw machine output
+- reviewed truth
+- corrections
+- `REVIEW.md`
+- metadata
+- `reviewedRuleIds` or equivalent
+- accepted evidence
+- rejected evidence and reason
+- quote, page, section, and provenance
+- applicability and basis
+- assessment reason
+- client action
+- draft finding candidate
+- reviewer notes
+- review status
 
 ## Non-Goals
 
-- No production logic changes
-- No report UI redesign
-- No client-facing report changes
-- No LLM final judgment
-- No mixing into Quick Check v2 Phase 7
+- No Quick Check status or extraction semantics changes
+- No production changes in truth-intake PRs
+- No project-specific or methodology-specific hardcoding in generic improvements
+- No report styling redesign
+- No formal validation, verification, or VVB authority language
+- No rewriting of Envira legacy mismatch data as VM0007 v1.8 truth

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -72,22 +72,22 @@ Define the repeatable two-PR cycle for safely improving the Evidence Map.
 - rerun all previous fixtures
 - test one unseen eligible PDD
 
-### Phase 7 — Maya VM0007 v1.8 Evidence Map Truth Intake — planned
+### Phase 7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake — planned
 
-- Maya Forest Corridor REDD Belize is the first clean VM0007 v1.8 full Evidence Map learning case
+- Marcondes REDD+ is the first forward VM0007 v1.8 Evidence Map learning case with an explicit internal v1.7/v1.8 discrepancy
 - preserve the raw 58-row machine output
 - support `reviewedRuleIds` or equivalent partial coverage
 - store reviewed truth, corrections, provenance, reviewer notes, and `REVIEW.md`
 - review high-value and uncertain rows first
 - unreviewed rows must not count as gold or accuracy evidence
 
-### Phase 8 — Maya Generic System Improvement — planned
+### Phase 8 — Marcondes Generic System Improvement — planned
 
-- compare Maya machine proposals against reviewed truth
+- compare Marcondes machine proposals against reviewed truth
 - classify retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding errors
 - fix only reusable shared logic
 - rerun Quick Check and Evidence Map regressions
-- prohibit Maya-specific hardcoding
+- prohibit Marcondes-specific hardcoding
 
 ### Phase 9 — Review and Gold Promotion Tooling — planned
 
@@ -101,12 +101,12 @@ Define the repeatable two-PR cycle for safely improving the Evidence Map.
 
 - intake an unseen eligible PDD
 - run the same PR1/PR2 cycle
-- prove Maya improvements generalize
-- prevent regression across Maya, earlier judgment fixtures, and version-mismatch fixtures
+- prove Marcondes improvements generalize
+- prevent regression across Marcondes, earlier judgment fixtures, and version-mismatch fixtures
 
 ## Fixture roles
 
-- **Maya:** first clean VM0007 v1.8 Evidence Map learning fixture.
+- **Marcondes:** first forward VM0007 v1.8 Evidence Map learning case with an explicit internal v1.7/v1.8 discrepancy.
 - **Envira:** quarantined methodology-version mismatch regression fixture.
 - **PD_REDD:** existing rule-level judgment fixture set; do not claim full VM0007 v1.8 Evidence Map truth unless separately version-validated.
 - **Future PDDs:** unseen VM0007 v1.8 generalization cases.

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -27,7 +27,7 @@ Envira's historical VM0007 v1.5 mismatch material remains quarantined regression
 
 ### Phase 0 — Roadmap Boundary — done
 
-Phase 0 is documentation-only. Fixtures must use PDF truth, not current app output. Define the scope of VM0007 judgment fixtures and lock the separation from production logic and Quick Check v2 Phase 7. Delivered by PR #895.
+Phase 0 is documentation-only. fixtures must use PDF truth, not current app output. Define the scope of VM0007 judgment fixtures and lock the separation from production logic and Quick Check v2 Phase 7. Delivered by PR #895.
 
 ### Phase 1 — Envira VM0007 Judgment Fixtures — done
 

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -1,26 +1,25 @@
 {
-  "name": "VM0007 Judgement Fixtures",
+  "name": "VM0007 Judgement Fixtures and Evidence Map Learning",
   "roadmapId": "vm0007-judgement-fixtures",
   "phase_meta": {
     "status": "active",
-    "summary": "Tighten VM0007 gap report accuracy by improving rule-level judgment fixtures and contracts without changing production audit logic; Envira evidence-map/report fixture output is quarantined legacy REDD-MF / VM0007 v1.5 mismatch data, not validated VM0007 v1.8 truth.",
+    "summary": "Build a progressively improving VM0007 v1.8 Evidence Map using PDF-backed machine proposals, reviewed truth, explicit corrections, and generic retrieval/router improvements.",
     "current_focus": [
-      "Phase 0 done: boundary-only fixture contract is documented and enforced.",
-      "Phase 1 done: Envira VM0007 judgment fixtures were delivered by PR #897",
-      "Phase 2 done: PD_REDD VM0007 judgment fixtures established with PDF-backed accepted and rejected evidence coverage.",
-      "Phase 3 blocked: Envira VM0007's reviewed full 58-rule audit fixture remains quarantined historical regression data with the old 30 FOUND / 8 UNCLEAR / 3 MISSING / 17 N/A split, which is not validated VM0007 v1.8 truth.",
-      "Phase 4 blocked: Report fixture layer remains quarantined historical regression data; internal preview output is not client-ready truth and is pending versioned re-audit before any truth-complete claim.",
-      "Phase 5 done: roadmap correction now states the contaminated Envira evidence-map/report fixture work is quarantined and pending versioned re-audit.",
-      "Phase 6 remains planned: keep the forward path separate until a clean VM0007 v1.8 version lock passes."
+      "Phases 0–2 complete: the boundary, Envira rule-level fixtures, and PD_REDD rule-level fixtures remain preserved with their historical references.",
+      "Phases 3–4 blocked/quarantined: Envira full-audit and report material is legacy REDD-MF / VM0007 v1.5 mismatch regression data, not VM0007 v1.8 truth.",
+      "Phase 5 complete: the internal-preview/client-readiness boundary and legacy-fixture quarantine are documented.",
+      "Phase 6 active: define and enforce the two-PR truth-intake and generic-system-improvement learning contract.",
+      "Phase 7 planned: begin Maya Forest Corridor REDD Belize VM0007 v1.8 Evidence Map truth intake."
     ],
     "not_active_now": [
-      "Production audit logic changes",
+      "Production logic changes in truth-intake PRs",
+      "Quick Check extraction or routing changes",
       "Report UI redesign",
       "Client-facing report changes",
       "LLM final judgment",
-      "Quick Check v2 Phase 7 work"
+      "Formal validation, verification, or VVB authority claims"
     ],
-    "last_updated_at": "2026-07-02T17:30:00Z"
+    "last_updated_at": "2026-07-12T00:00:00Z"
   },
   "goals": [
     {
@@ -46,9 +45,7 @@
       "id": "phase_1_envira_vm0007_judgment_fixtures",
       "title": "Envira VM0007 Judgment Fixtures",
       "status": "done",
-      "dependsOn": [
-        "phase_0_roadmap_boundary"
-      ],
+      "dependsOn": ["phase_0_roadmap_boundary"],
       "branch": "test/envira-vm0007-judgment-fixtures",
       "pr": 897,
       "doneCriteria": [
@@ -66,9 +63,7 @@
       "id": "phase_2_pd_redd_vm0007_judgment_fixtures",
       "title": "PD_REDD VM0007 Judgment Fixtures",
       "status": "done",
-      "dependsOn": [
-        "phase_1_envira_vm0007_judgment_fixtures"
-      ],
+      "dependsOn": ["phase_1_envira_vm0007_judgment_fixtures"],
       "doneCriteria": [
         "PD_REDD judgments follow the same accepted/rejected evidence contract",
         "Weak / missing / not-applicable logic is exercised with fixture coverage"
@@ -78,40 +73,100 @@
       "id": "phase_3_full_58_rule_audit_fixture_shape",
       "title": "Full 58-Rule Audit Fixture Shape",
       "status": "blocked",
-      "dependsOn": [
-        "phase_2_pd_redd_vm0007_judgment_fixtures"
-      ],
+      "dependsOn": ["phase_2_pd_redd_vm0007_judgment_fixtures"],
       "doneCriteria": [
         "All 58 VM0007 rules are represented in the fixture shape",
         "Audit-level expected status is stable and reviewable",
-        "Fixture shape supports summary verification"
+        "Fixture shape supports summary verification",
+        "Any legacy Envira material remains explicitly quarantined until versioned re-audit"
       ]
     },
     {
       "id": "phase_4_report_fixture_layer",
       "title": "Report Fixture Layer",
       "status": "blocked",
-      "dependsOn": [
-        "phase_3_full_58_rule_audit_fixture_shape"
-      ],
+      "dependsOn": ["phase_3_full_58_rule_audit_fixture_shape"],
       "branch": "test/vm0007-report-fixture-layer",
       "pr": 914,
       "doneCriteria": [
         "Report summary expectations are fixture-driven",
         "Row grouping and summary sections are testable from fixtures",
-        "Internal preview output is preserved as fixture data only and is not client-ready truth"
+        "Internal preview output is preserved as fixture data only and is not client-ready truth",
+        "Legacy Envira report output remains quarantined pending versioned re-audit"
       ]
     },
     {
       "id": "phase_5_client_readiness_gate",
       "title": "Client-Readiness Gate",
-      "status": "planned",
-      "dependsOn": [
-        "phase_4_report_fixture_layer"
-      ],
+      "status": "done",
+      "dependsOn": ["phase_4_report_fixture_layer"],
       "doneCriteria": [
         "A gate exists to prevent fixture drift from being mistaken for client-ready output",
-        "Client-readiness remains explicitly separate from internal preview work"
+        "Client-readiness remains explicitly separate from internal preview work",
+        "Quarantined legacy mismatch fixtures are not promoted as VM0007 v1.8 truth"
+      ]
+    },
+    {
+      "id": "phase_6_evidence_map_learning_contract",
+      "title": "Evidence Map Learning Contract",
+      "status": "active",
+      "dependsOn": ["phase_5_client_readiness_gate"],
+      "doneCriteria": [
+        "The repeatable two-PR truth-intake and generic-system-improvement cycle is documented",
+        "Truth intake preserves untouched machine output, supports partial review, records accepted/rejected evidence and corrections, and counts only reviewed rows as gold",
+        "Generic improvement classifies reusable failures, changes only shared logic, reruns previous fixtures, and tests an unseen eligible PDD",
+        "Truth-intake PRs do not change production logic"
+      ]
+    },
+    {
+      "id": "phase_7_maya_vm0007_v1_8_evidence_map_truth_intake",
+      "title": "Maya VM0007 v1.8 Evidence Map Truth Intake",
+      "status": "planned",
+      "dependsOn": ["phase_6_evidence_map_learning_contract"],
+      "doneCriteria": [
+        "Maya Forest Corridor REDD Belize is validated as a clean VM0007 v1.8 full Evidence Map learning case",
+        "Raw 58-row machine output is preserved",
+        "Partial coverage uses reviewedRuleIds or an equivalent explicit mechanism",
+        "Reviewed truth, corrections, provenance, reviewer notes, and REVIEW.md are stored",
+        "High-value and uncertain rows are reviewed first",
+        "Unreviewed rows do not count as gold or accuracy evidence"
+      ]
+    },
+    {
+      "id": "phase_8_maya_generic_system_improvement",
+      "title": "Maya Generic System Improvement",
+      "status": "planned",
+      "dependsOn": ["phase_7_maya_vm0007_v1_8_evidence_map_truth_intake"],
+      "doneCriteria": [
+        "Maya proposals are compared against reviewed truth",
+        "Retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding errors are classified",
+        "Only reusable shared logic is changed",
+        "Quick Check and Evidence Map regressions are rerun",
+        "Maya-specific hardcoding is prohibited"
+      ]
+    },
+    {
+      "id": "phase_9_review_and_gold_promotion_tooling",
+      "title": "Review and Gold Promotion Tooling",
+      "status": "planned",
+      "dependsOn": ["phase_8_maya_generic_system_improvement"],
+      "doneCriteria": [
+        "Partial row review is easy to perform",
+        "Corrections are generated from machine-versus-reviewer differences",
+        "Only explicitly reviewed rows are promoted to gold",
+        "Machine proposal, reviewer correction, and final truth remain separate",
+        "Coverage counts do not treat unreviewed rows as failures or passes"
+      ]
+    },
+    {
+      "id": "phase_10_second_unseen_vm0007_v1_8_pdd",
+      "title": "Second Unseen VM0007 v1.8 PDD",
+      "status": "planned",
+      "dependsOn": ["phase_9_review_and_gold_promotion_tooling"],
+      "doneCriteria": [
+        "An unseen eligible PDD completes the same PR1/PR2 cycle",
+        "Maya improvements generalize to the unseen PDD",
+        "Maya, earlier judgment fixtures, and version-mismatch fixtures remain regression-safe"
       ]
     }
   ],
@@ -134,17 +189,42 @@
     "phase_3_full_58_rule_audit_fixture_shape": {
       "title": "Full 58-Rule Audit Fixture Shape",
       "status": "blocked",
-      "summary": "Envira VM0007's reviewed full 58-rule audit fixture is quarantined legacy REDD-MF / VM0007 v1.5 mismatch data. The historical split FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17 remains preserved as a regression fixture, but it is not validated VM0007 v1.8 truth and is pending versioned re-audit."
+      "summary": "Envira VM0007's reviewed full 58-rule audit fixture is quarantined legacy REDD-MF / VM0007 v1.5 mismatch data. The historical FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17 split remains preserved as a regression fixture, but it is not validated VM0007 v1.8 truth."
     },
     "phase_4_report_fixture_layer": {
       "title": "Report Fixture Layer",
       "status": "blocked",
-      "summary": "Report fixture output remains quarantined historical regression data. Report summary expectations and internal preview output are fixture-driven and testable, but the legacy Envira report fixture is not client-ready truth and is pending versioned re-audit. Local pr:gate passed, GitHub pr-gate passed, no production audit logic changed."
+      "summary": "Report fixture output remains quarantined historical regression data. Report summary expectations and internal preview output are fixture-driven and testable, but the legacy Envira report fixture is not client-ready truth and is pending versioned re-audit. Historical delivery is preserved as PR #914."
     },
     "phase_5_client_readiness_gate": {
       "title": "Client-Readiness Gate",
+      "status": "done",
+      "summary": "The internal-preview/client-readiness boundary is documented and legacy mismatch fixtures remain quarantined; no legacy Envira output is promoted as VM0007 v1.8 truth."
+    },
+    "phase_6_evidence_map_learning_contract": {
+      "title": "Evidence Map Learning Contract",
+      "status": "active",
+      "summary": "Define the repeatable two-PR cycle: PR1 truth intake with untouched machine output and partial reviewed truth; PR2 generic shared-system improvement with previous-fixture reruns and one unseen eligible PDD."
+    },
+    "phase_7_maya_vm0007_v1_8_evidence_map_truth_intake": {
+      "title": "Maya VM0007 v1.8 Evidence Map Truth Intake",
       "status": "planned",
-      "summary": "Keep internal preview output separate from any later client-ready reporting work."
+      "summary": "Intake Maya Forest Corridor REDD Belize as the first clean VM0007 v1.8 full Evidence Map learning case while preserving raw 58-row output and counting only explicitly reviewed rows as gold."
+    },
+    "phase_8_maya_generic_system_improvement": {
+      "title": "Maya Generic System Improvement",
+      "status": "planned",
+      "summary": "Use Maya reviewed truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures without Maya-specific hardcoding."
+    },
+    "phase_9_review_and_gold_promotion_tooling": {
+      "title": "Review and Gold Promotion Tooling",
+      "status": "planned",
+      "summary": "Make partial review and correction generation easy while preserving machine proposal, reviewer correction, final truth, and explicit gold coverage separately."
+    },
+    "phase_10_second_unseen_vm0007_v1_8_pdd": {
+      "title": "Second Unseen VM0007 v1.8 PDD",
+      "status": "planned",
+      "summary": "Run the same truth-intake and generic-improvement cycle on an unseen eligible VM0007 v1.8 PDD to prove generalization and prevent regressions."
     }
   }
 }

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -9,7 +9,7 @@
       "Phases 3–4 blocked/quarantined: Envira full-audit and report material is legacy REDD-MF / VM0007 v1.5 mismatch regression data, not VM0007 v1.8 truth.",
       "Phase 5 complete: the internal-preview/client-readiness boundary and legacy-fixture quarantine are documented.",
       "Phase 6 active: define and enforce the two-PR truth-intake and generic-system-improvement learning contract.",
-      "Phase 7 planned: begin Maya Forest Corridor REDD Belize VM0007 v1.8 Evidence Map truth intake."
+      "Phase 7 planned: begin Marcondes REDD+ VM0007 v1.8 Evidence Map truth intake with an explicit internal v1.7/v1.8 discrepancy."
     ],
     "not_active_now": [
       "Production logic changes in truth-intake PRs",
@@ -119,12 +119,12 @@
       ]
     },
     {
-      "id": "phase_7_maya_vm0007_v1_8_evidence_map_truth_intake",
-      "title": "Maya VM0007 v1.8 Evidence Map Truth Intake",
+      "id": "phase_7_marcondes_vm0007_v1_8_evidence_map_truth_intake",
+      "title": "Marcondes VM0007 v1.8 Evidence Map Truth Intake",
       "status": "planned",
       "dependsOn": ["phase_6_evidence_map_learning_contract"],
       "doneCriteria": [
-        "Maya Forest Corridor REDD Belize is validated as a clean VM0007 v1.8 full Evidence Map learning case",
+        "Marcondes REDD+ is validated as a forward VM0007 v1.8 Evidence Map learning case with an explicit internal v1.7/v1.8 discrepancy",
         "Raw 58-row machine output is preserved",
         "Partial coverage uses reviewedRuleIds or an equivalent explicit mechanism",
         "Reviewed truth, corrections, provenance, reviewer notes, and REVIEW.md are stored",
@@ -133,23 +133,23 @@
       ]
     },
     {
-      "id": "phase_8_maya_generic_system_improvement",
-      "title": "Maya Generic System Improvement",
+      "id": "phase_8_marcondes_generic_system_improvement",
+      "title": "Marcondes Generic System Improvement",
       "status": "planned",
-      "dependsOn": ["phase_7_maya_vm0007_v1_8_evidence_map_truth_intake"],
+      "dependsOn": ["phase_7_marcondes_vm0007_v1_8_evidence_map_truth_intake"],
       "doneCriteria": [
-        "Maya proposals are compared against reviewed truth",
+        "Marcondes proposals are compared against reviewed truth",
         "Retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding errors are classified",
         "Only reusable shared logic is changed",
         "Quick Check and Evidence Map regressions are rerun",
-        "Maya-specific hardcoding is prohibited"
+        "Marcondes-specific hardcoding is prohibited"
       ]
     },
     {
       "id": "phase_9_review_and_gold_promotion_tooling",
       "title": "Review and Gold Promotion Tooling",
       "status": "planned",
-      "dependsOn": ["phase_8_maya_generic_system_improvement"],
+      "dependsOn": ["phase_8_marcondes_generic_system_improvement"],
       "doneCriteria": [
         "Partial row review is easy to perform",
         "Corrections are generated from machine-versus-reviewer differences",
@@ -165,8 +165,8 @@
       "dependsOn": ["phase_9_review_and_gold_promotion_tooling"],
       "doneCriteria": [
         "An unseen eligible PDD completes the same PR1/PR2 cycle",
-        "Maya improvements generalize to the unseen PDD",
-        "Maya, earlier judgment fixtures, and version-mismatch fixtures remain regression-safe"
+        "Marcondes improvements generalize to the unseen PDD",
+        "Marcondes, earlier judgment fixtures, and version-mismatch fixtures remain regression-safe"
       ]
     }
   ],
@@ -206,15 +206,15 @@
       "status": "active",
       "summary": "Define the repeatable two-PR cycle: PR1 truth intake with untouched machine output and partial reviewed truth; PR2 generic shared-system improvement with previous-fixture reruns and one unseen eligible PDD."
     },
-    "phase_7_maya_vm0007_v1_8_evidence_map_truth_intake": {
-      "title": "Maya VM0007 v1.8 Evidence Map Truth Intake",
+    "phase_7_marcondes_vm0007_v1_8_evidence_map_truth_intake": {
+      "title": "Marcondes VM0007 v1.8 Evidence Map Truth Intake",
       "status": "planned",
-      "summary": "Intake Maya Forest Corridor REDD Belize as the first clean VM0007 v1.8 full Evidence Map learning case while preserving raw 58-row output and counting only explicitly reviewed rows as gold."
+      "summary": "Intake Marcondes REDD+ as the first forward VM0007 v1.8 Evidence Map learning case with an explicit internal v1.7/v1.8 discrepancy while preserving raw 58-row output and counting only explicitly reviewed rows as gold."
     },
-    "phase_8_maya_generic_system_improvement": {
-      "title": "Maya Generic System Improvement",
+    "phase_8_marcondes_generic_system_improvement": {
+      "title": "Marcondes Generic System Improvement",
       "status": "planned",
-      "summary": "Use Maya reviewed truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures without Maya-specific hardcoding."
+      "summary": "Use Marcondes reviewed truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures without Marcondes-specific hardcoding."
     },
     "phase_9_review_and_gold_promotion_tooling": {
       "title": "Review and Gold Promotion Tooling",

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -9,7 +9,7 @@
       "Phases 3–4 blocked/quarantined: Envira full-audit and report material is legacy REDD-MF / VM0007 v1.5 mismatch regression data, not VM0007 v1.8 truth.",
       "Phase 5 complete: the internal-preview/client-readiness boundary and legacy-fixture quarantine are documented.",
       "Phase 6 active: define and enforce the two-PR truth-intake and generic-system-improvement learning contract.",
-      "Phase 7 planned: begin Marcondes REDD+ VM0007 v1.8 Evidence Map truth intake with an explicit internal v1.7/v1.8 discrepancy."
+      "Phase 7 planned: begin Marcondes REDD+ as the first candidate forward VM0007 v1.8 Evidence Map learning case, pending explicit reconciliation of the internal v1.7/v1.8 discrepancy."
     ],
     "not_active_now": [
       "Production logic changes in truth-intake PRs",
@@ -124,12 +124,19 @@
       "status": "planned",
       "dependsOn": ["phase_6_evidence_map_learning_contract"],
       "doneCriteria": [
-        "Marcondes REDD+ is validated as a forward VM0007 v1.8 Evidence Map learning case with an explicit internal v1.7/v1.8 discrepancy",
+        "Marcondes REDD+ is the first candidate forward VM0007 v1.8 Evidence Map learning case, pending explicit reconciliation of the internal v1.7/v1.8 discrepancy",
         "Raw 58-row machine output is preserved",
         "Partial coverage uses reviewedRuleIds or an equivalent explicit mechanism",
         "Reviewed truth, corrections, provenance, reviewer notes, and REVIEW.md are stored",
         "High-value and uncertain rows are reviewed first",
-        "Unreviewed rows do not count as gold or accuracy evidence"
+        "Unreviewed rows do not count as gold or accuracy evidence",
+        "page 61 v1.7 wording is preserved exactly",
+        "Tables 30 and 31 v1.8 declarations are preserved exactly",
+        "a reviewer records the reconciled methodology version and rationale",
+        "the decision is stored in metadata and REVIEW.md",
+        "unresolved conflict blocks gold promotion and Evidence Map truth claims",
+        "no silent normalization is permitted",
+        "after reconciliation, Marcondes may be marked version-qualified VM0007 v1.8 truth"
       ]
     },
     {

--- a/docs/roadmaps/vm0007-version-cleanup/phase-status.json
+++ b/docs/roadmaps/vm0007-version-cleanup/phase-status.json
@@ -2,7 +2,7 @@
   "roadmap": "vm0007-version-cleanup",
   "phase_meta": {
     "status": "active",
-    "summary": "Phase 6 Forward Path is complete: contaminated VM0007 evidence-map/report roadmap states are quarantined, mismatched VM0007 versions are blocked from normal evidence, report, PDF, and client-readiness trust paths, the legacy Envira fixture remains pending versioned re-audit, and a normalized VM0007 v1.8 path can pass the version lock without building a full Marcondes evidence map.",
+    "summary": "Phase 6 Forward Path is complete: contaminated VM0007 evidence-map/report roadmap states are quarantined, mismatched VM0007 versions are blocked from normal evidence, report, PDF, and client-readiness trust paths, the legacy Envira fixture remains pending versioned re-audit, and a normalized VM0007 v1.8 path can pass the version lock without building a full project Evidence Map.",
     "current_focus": [
       "Keep Envira quarantined as a blocked legacy REDD-MF / VM0007 v1.5 mismatch regression case",
       "Keep the existing quote/page/section integrity gates intact",
@@ -46,7 +46,7 @@
     "phase_6_forward_path": {
       "title": "Phase 6: Forward Path",
       "status": "done",
-      "summary": "A normalized VM0007 v1.8 PDD path can pass the version lock while the legacy Envira v1.5 mismatch fixture remains blocked, without building a full Marcondes evidence map."
+      "summary": "A normalized VM0007 v1.8 PDD path can pass the version lock while the legacy Envira v1.5 mismatch fixture remains blocked, without building a full project Evidence Map."
     }
   }
 }

--- a/docs/roadmaps/vm0007-version-cleanup/phase-status.json
+++ b/docs/roadmaps/vm0007-version-cleanup/phase-status.json
@@ -2,7 +2,7 @@
   "roadmap": "vm0007-version-cleanup",
   "phase_meta": {
     "status": "active",
-    "summary": "Phase 6 Forward Path is complete: contaminated VM0007 evidence-map/report roadmap states are quarantined, mismatched VM0007 versions are blocked from normal evidence, report, PDF, and client-readiness trust paths, the legacy Envira fixture remains pending versioned re-audit, and a normalized VM0007 v1.8 path can pass the version lock without building a full Maya evidence map.",
+    "summary": "Phase 6 Forward Path is complete: contaminated VM0007 evidence-map/report roadmap states are quarantined, mismatched VM0007 versions are blocked from normal evidence, report, PDF, and client-readiness trust paths, the legacy Envira fixture remains pending versioned re-audit, and a normalized VM0007 v1.8 path can pass the version lock without building a full Marcondes evidence map.",
     "current_focus": [
       "Keep Envira quarantined as a blocked legacy REDD-MF / VM0007 v1.5 mismatch regression case",
       "Keep the existing quote/page/section integrity gates intact",
@@ -46,7 +46,7 @@
     "phase_6_forward_path": {
       "title": "Phase 6: Forward Path",
       "status": "done",
-      "summary": "A normalized VM0007 v1.8 PDD path can pass the version lock while the legacy Envira v1.5 mismatch fixture remains blocked, without building a full Maya evidence map."
+      "summary": "A normalized VM0007 v1.8 PDD path can pass the version lock while the legacy Envira v1.5 mismatch fixture remains blocked, without building a full Marcondes evidence map."
     }
   }
 }

--- a/docs/roadmaps/vm0007-version-cleanup/planned.md
+++ b/docs/roadmaps/vm0007-version-cleanup/planned.md
@@ -101,7 +101,7 @@ Done when:
 
 * minimal fixture/test hook proves a clean VM0007 v1.8 PDD can pass the version lock
 * Envira remains blocked
-* no full Maya evidence map is built in this cleanup roadmap unless explicitly requested
+* no full Marcondes evidence map is built in this cleanup roadmap unless explicitly requested
 
 ## Expected PR Split
 

--- a/docs/roadmaps/vm0007-version-cleanup/planned.md
+++ b/docs/roadmaps/vm0007-version-cleanup/planned.md
@@ -101,7 +101,7 @@ Done when:
 
 * minimal fixture/test hook proves a clean VM0007 v1.8 PDD can pass the version lock
 * Envira remains blocked
-* no full Marcondes evidence map is built in this cleanup roadmap unless explicitly requested
+* no full project Evidence Map is built in this cleanup roadmap unless explicitly requested
 
 ## Expected PR Split
 


### PR DESCRIPTION
## Docs-only roadmap update

Updates the existing `vm0007-judgement-fixtures` roadmap after PR #992 merged.

### Corrected contradictions

- Reconciled Phase 5 status and current focus as complete.
- Preserved Phases 3–4 as blocked/quarantined Envira legacy VM0007 v1.5 mismatch work.
- Removed the unexplained Phase 6 drift by defining the Evidence Map Learning Contract as the active Phase 6.
- Kept PLAN.md and phase-status.json aligned.
- Preserved completed Phase 0–2 historical references and PR records.
- Updated the generated roadmap summary from the SSOT.

### Added roadmap scope

The goal now covers progressively improving a VM0007 v1.8 Evidence Map using PDF-backed machine proposals, reviewed truth, explicit corrections, and generic retrieval/router improvements.

Added:

- Phase 6 — Evidence Map Learning Contract and repeatable PR1/PR2 cycle
- Phase 7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake
- Phase 8 — Marcondes Generic System Improvement
- Phase 9 — Review and Gold Promotion Tooling
- Phase 10 — Second Unseen VM0007 v1.8 PDD
- Fixture roles
- Required Evidence Map truth artifacts

Marcondes is the first candidate forward VM0007 v1.8 Evidence Map learning case until the page 61 v1.7 versus Tables 30–31 v1.8 discrepancy is explicitly reviewed and resolved. The roadmap records that resolution in metadata and `REVIEW.md` before any reviewed rows may be promoted as VM0007 v1.8 gold. Envira remains quarantined mismatch regression data and is not rewritten as VM0007 v1.8 truth. The completed version-cleanup roadmap remains project-neutral. No production code, Quick Check logic, Evidence Map logic, fixtures, or unrelated tests changed.

### Validation

- `npm run roadmap:check`
- `npm run pr:check:local`
- `npm run pr:gate`
- `git diff --check`

Generated build artifacts were restored before commit.