### PR TITLE
docs: add vm0007 evidence map playbook

### DIFF
--- a/docs/roadmaps/vm0007-judgement-fixtures/NEW_PDD_PLAYBOOK.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/NEW_PDD_PLAYBOOK.md
@@ -1,27 +1,162 @@
 # New PDD Playbook
 
-Use this exact workflow when adding a new PDD to the VM0007 evidence-map learning process.
+Governing contract: [SYSTEM_PROMPT.md](./SYSTEM_PROMPT.md)
 
-1. Supply the PDF path, stable project ID, project title, and optional registry ID.
-2. Confirm the PDF exists.
-3. Derive the project intake folder from the project ID.
-4. Record the source identity and file hash.
-5. Run Quick Check and document extraction.
-6. Verify project identity, methodology, and version from the PDF.
-7. Generate and preserve the untouched 58-row machine Evidence Map.
-8. Open PR1 truth intake.
-9. Review high-value, UNCLEAR, MISSING, contradictory, and weak-provenance rows.
-10. Record reviewed truth, rejected evidence, corrections, and `REVIEW.md`.
-11. Open PR2 generic system improvement.
-12. Classify reusable edge cases and improve only shared logic.
-13. Rerun all previous fixtures and regressions.
-14. Complete all intended row reviews.
-15. Finalize the Evidence Map.
-16. Generate HTML and PDF from the same finalized model.
-17. Run the client-release gate.
-18. Repeat on an unseen PDD before declaring the process standard.
+Use this exact operator sequence for every new PDD.
 
-## Intake Example
+## 1. Collect PDF, ID, title, optional registry ID
+
+- Input: PDF path, stable project ID, project title, optional registry ID
+- Action: capture the intake payload unchanged
+- Artifact produced: intake record
+- Failure condition: missing required input or conflicting identity data
+- Done condition: all required inputs are present and recorded
+
+## 2. Confirm source exists and record hash
+
+- Input: PDF path
+- Action: verify the file exists and compute a file hash
+- Artifact produced: source identity and hash
+- Failure condition: file missing, unreadable, or hash cannot be captured
+- Done condition: source existence and hash are recorded
+
+## 3. Derive project folder from ID
+
+- Input: stable project ID
+- Action: derive the project intake folder from the ID
+- Artifact produced: project intake folder path
+- Failure condition: folder cannot be derived or conflicts with the ID
+- Done condition: the intake folder is deterministically derived
+
+## 4. Run Quick Check and extraction
+
+- Input: source PDF and intake folder
+- Action: run Quick Check and document extraction
+- Artifact produced: raw Quick Check output
+- Failure condition: extraction or Quick Check fails
+- Done condition: raw extraction artifacts are available
+
+## 5. Verify identity, methodology, and version
+
+- Input: extracted text and PDF evidence
+- Action: verify project identity, methodology, and version from the PDD
+- Artifact produced: verified identity and version record
+- Failure condition: identity mismatch, methodology ambiguity, or version conflict
+- Done condition: identity, methodology, and version are explicitly resolved or flagged
+
+## 6. Create untouched 58-row machine proposal
+
+- Input: verified extraction results
+- Action: generate the 58-row machine-proposed Evidence Map without reviewer edits
+- Artifact produced: raw 58-row machine Evidence Map
+- Failure condition: fewer than 58 rows, missing evidence, or non-grounded synthesis
+- Done condition: the untouched machine proposal is preserved
+
+## 7. Preserve raw artifacts
+
+- Input: raw Quick Check output and machine proposal
+- Action: store raw artifacts with source identity, hash, and metadata
+- Artifact produced: `metadata.json`, raw artifacts, and preserved machine output
+- Failure condition: any raw artifact is overwritten or normalized away
+- Done condition: the raw evidence trail is intact
+
+## 8. Open PR1 truth intake
+
+- Input: preserved machine proposal
+- Action: open PR1 for truth intake review
+- Artifact produced: PR1 review workspace
+- Failure condition: PR1 mixes in generic system changes
+- Done condition: PR1 is limited to reviewed truth
+
+## 9. Review priority and uncertain rows
+
+- Input: machine proposal rows
+- Action: review high-value, UNCLEAR, MISSING, contradictory, and weak-provenance rows first
+- Artifact produced: reviewed rows, `reviewedRuleIds` or equivalent, accepted and rejected evidence
+- Failure condition: review skips the uncertain or high-value rows without justification
+- Done condition: priority rows are reviewed and recorded
+
+## 10. Record truth, rejected evidence, corrections, and REVIEW.md
+
+- Input: reviewed rows
+- Action: record final truth, rejected evidence and reason, corrections, and `REVIEW.md`
+- Artifact produced: `gold.draft.json`, `corrections.json`, `REVIEW.md`, reviewed truth records
+- Failure condition: exact quote, page, section, or provenance is missing
+- Done condition: reviewer-owned truth is persisted with full provenance
+
+## 11. Open PR2 generic improvement
+
+- Input: reviewed truth from PR1
+- Action: open PR2 for reusable system improvements only
+- Artifact produced: PR2 improvement workspace
+- Failure condition: PR2 includes project-specific hardcoding
+- Done condition: PR2 is scoped to shared logic only
+
+## 12. Classify reusable failures
+
+- Input: machine proposal versus reviewed truth
+- Action: classify reusable failures in parsing, retrieval, routing, selection, applicability, version, provenance, contradiction, assessment, or presentation logic
+- Artifact produced: failure taxonomy notes
+- Failure condition: failure is not reusable or is specific to one project
+- Done condition: reusable edge cases are identified
+
+## 13. Rerun regressions
+
+- Input: updated shared logic
+- Action: rerun all previous fixtures and regressions
+- Artifact produced: regression results
+- Failure condition: any regression is unresolved
+- Done condition: all prior regressions pass or are explicitly explained
+
+## 14. Complete remaining row reviews
+
+- Input: any unreviewed rows
+- Action: finish all intended row reviews
+- Artifact produced: complete review coverage record
+- Failure condition: intended rows remain unreviewed
+- Done condition: every intended row is reviewed
+
+## 15. Finalize Evidence Map
+
+- Input: complete reviewed truth
+- Action: finalize the Evidence Map
+- Artifact produced: `gold.json` and final truth
+- Failure condition: unresolved conflict remains open
+- Done condition: finalized Evidence Map is version-qualified or blocked explicitly
+
+## 16. Generate UI, HTML, and PDF from the same model
+
+- Input: finalized Evidence Map
+- Action: generate UI, HTML, and PDF from the same finalized model
+- Artifact produced: synchronized presentation outputs
+- Failure condition: outputs diverge in rows, evidence, outcomes, findings, actions, counts, provenance, or release state
+- Done condition: all presentation surfaces match the same model
+
+## 17. Run the client-release gate
+
+- Input: finalized and synchronized outputs
+- Action: run the client-release gate
+- Artifact produced: release-state check
+- Failure condition: version, applicability, provenance, contradiction, or conclusion requirements are unmet
+- Done condition: output is labeled `Pre-Validation Readiness Report` and release gates pass
+
+## 18. Run the same workflow on an unseen PDD
+
+- Input: a second unseen eligible VM0007 v1.8 PDD
+- Action: repeat the same intake and review workflow
+- Artifact produced: second-case evidence trail and regression proof
+- Failure condition: the process only works for Marcondes or requires project-specific fixes
+- Done condition: the workflow generalizes to the unseen case
+
+## 19. Promote the workflow to standard only after both cases succeed
+
+- Input: the Marcondes case and the unseen case
+- Action: confirm both succeeded under the same contract
+- Artifact produced: standard-workflow confirmation
+- Failure condition: either case fails, diverges, or depends on project-specific production changes
+- Done condition: the workflow is documented as standard only after both successes
+
+## Marcondes Intake Example
 
 PDF:
 
@@ -38,3 +173,9 @@ Title:
 Registry ID:
 
 `5953`
+
+Explicit version note:
+
+- page 61 references VM0007 v1.7
+- Tables 30-31 declare VM0007 v1.8
+- the conflict must be reviewed and reconciled before gold promotion

--- a/docs/roadmaps/vm0007-judgement-fixtures/NEW_PDD_PLAYBOOK.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/NEW_PDD_PLAYBOOK.md
@@ -1,0 +1,40 @@
+# New PDD Playbook
+
+Use this exact workflow when adding a new PDD to the VM0007 evidence-map learning process.
+
+1. Supply the PDF path, stable project ID, project title, and optional registry ID.
+2. Confirm the PDF exists.
+3. Derive the project intake folder from the project ID.
+4. Record the source identity and file hash.
+5. Run Quick Check and document extraction.
+6. Verify project identity, methodology, and version from the PDF.
+7. Generate and preserve the untouched 58-row machine Evidence Map.
+8. Open PR1 truth intake.
+9. Review high-value, UNCLEAR, MISSING, contradictory, and weak-provenance rows.
+10. Record reviewed truth, rejected evidence, corrections, and `REVIEW.md`.
+11. Open PR2 generic system improvement.
+12. Classify reusable edge cases and improve only shared logic.
+13. Rerun all previous fixtures and regressions.
+14. Complete all intended row reviews.
+15. Finalize the Evidence Map.
+16. Generate HTML and PDF from the same finalized model.
+17. Run the client-release gate.
+18. Repeat on an unseen PDD before declaring the process standard.
+
+## Intake Example
+
+PDF:
+
+`~/Desktop/vm0007_v18_pdds copy/5953-Marcondes-Brazil-pdd.pdf`
+
+ID:
+
+`marcondes-redd-brazil-5953`
+
+Title:
+
+`Marcondes REDD+`
+
+Registry ID:
+
+`5953`

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -8,6 +8,11 @@ Build a progressively improving VM0007 v1.8 Evidence Map using PDF-backed machin
 
 This roadmap grows from the existing VM0007 judgment-fixture and gap-report accuracy work. It does not change production logic, Quick Check semantics, report UI styling, or client-facing outputs unless a later phase explicitly permits a shared-system improvement.
 
+## Governing Documents
+
+- [SYSTEM_PROMPT.md](./SYSTEM_PROMPT.md) - canonical agent rules
+- [NEW_PDD_PLAYBOOK.md](./NEW_PDD_PLAYBOOK.md) - exact operator steps for adding a PDD
+
 ## Core Focus
 
 - PDF-backed accepted and rejected evidence

--- a/docs/roadmaps/vm0007-judgement-fixtures/SYSTEM_PROMPT.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/SYSTEM_PROMPT.md
@@ -1,10 +1,23 @@
 # VM0007 Evidence Map System Prompt
 
-This document is the canonical agent rule set for the VM0007 evidence-map workflow in this roadmap.
+This document is the single canonical agent contract for the VM0007 evidence-map workflow in this roadmap.
 
-## Required Inputs
+## 1. Mission and Architecture
 
-Every intake must begin with these three required inputs:
+The workflow is:
+
+PDD
+-> Quick Check/document extraction
+-> 58-row machine-proposed Evidence Map
+-> reviewer truth and corrections
+-> finalized Evidence Map
+-> Pre-Validation Readiness Report
+
+The finalized Evidence Map is the report source of truth. The report must never outgrow, override, or independently revise that finalized model.
+
+## 2. Standard Intake Contract
+
+Required inputs:
 
 - PDF path
 - stable project ID
@@ -14,68 +27,200 @@ Optional input:
 
 - registry project ID
 
-Methodology and version must be extracted from the PDD itself and must not be trusted from user input.
+Output folders must be derived from the project ID.
 
-## Truth Model
+Methodology and version must be extracted and verified from the PDD rather than accepted as user truth.
 
-The workflow must keep raw machine output separate from reviewed truth.
+## 3. Version Qualification
 
-The reviewed model must support partial coverage through `reviewedRuleIds` or an equivalent mechanism.
+Every material methodology/version declaration must be identified.
 
-The model must preserve:
+For each declaration, preserve:
 
-- accepted evidence
-- rejected evidence
 - exact quote
-- page number
-- section heading
+- page
+- section
+- table, when applicable
 - provenance
-- reviewer-owned assessment
-- finding candidates
 
-Evidence states are limited to:
+Conflicts must remain explicit.
+No silent normalization is allowed.
+Reviewer reconciliation must be recorded in metadata and `REVIEW.md`.
+Any unresolved conflict blocks gold promotion and client-report release.
+
+## 4. Machine Proposal Contract
+
+Every one of the 58 rows must have either:
+
+- a grounded `MACHINE_PROPOSED` assessment with evidence, provenance, reason, confidence, applicability, contradiction state, client action, and draft finding candidate; or
+- an explicit unresolved proposal that states what was searched and why no stronger conclusion is supported.
+
+Never invent evidence or provenance.
+
+## 5. Evidence States Versus Reviewer Outcomes
+
+Upstream evidence states are limited to:
 
 - FOUND
 - UNCLEAR
 - MISSING
 - N/A
 
-Accepted and rejected evidence must remain explicit and traceable. Weak, missing, rejected, blocked, and unresolved evidence must never be hidden or normalized away.
+State explicitly:
 
-## Review Discipline
+- FOUND does not mean CONFORMS.
+- UNCLEAR does not automatically mean NIR.
+- MISSING does not automatically mean NCR.
+- N/A requires supported applicability reasoning.
 
-Reviewer judgment owns the assessment. Machine output is only a proposal until reviewed.
+Reviewer-owned outcomes are separate:
 
-The reviewed truth layer must record:
+- CONFORMS
+- ACTION_REQUIRED
+- NOT_APPLICABLE
+- NOT_ASSESSED
 
-- reviewer-owned assessment
-- finding candidates
-- corrections
-- contradictions
-- unresolved conflicts
-- provenance for each evidence row
+Draft findings are separate again:
 
-When evidence conflicts with the intake proposal, the system must fail closed. The reviewed record must preserve the contradiction and the resulting decision rather than silently resolving it.
+- NIR_CANDIDATE
+- NCR_CANDIDATE
+- OFI_CANDIDATE
+- null
 
-No project-specific hardcoding is allowed.
+## 6. Controlled Learning Loop
 
-## Output Contract
+PR1 - Truth Intake:
 
-The UI, HTML, and PDF outputs must use the same finalized Evidence Map model.
+- preserve untouched machine output
+- support `reviewedRuleIds` or an equivalent mechanism
+- store accepted and rejected evidence
+- preserve exact quote, page, section, and provenance
+- record reviewer corrections
+- only reviewed rows count as gold
+- make no production logic changes
 
-Client output must be labeled `Pre-Validation Readiness Report`.
+PR2 - Generic System Improvement:
 
-The system must not claim formal VVB validation, verification, or any equivalent authority status.
+- compare machine proposals with reviewed truth
+- classify reusable failures
+- improve only shared parsing, retrieval, routing, selection, applicability, version, provenance, contradiction, assessment, or presentation logic
+- prohibit project-specific hardcoding
+- preserve truth fixtures
+- rerun all previous regressions
+- test an unseen eligible VM0007 v1.8 PDD
 
-## Required Provenance
+Do not claim autonomous learning, model retraining, or hidden self-improvement.
 
-Each evidence entry must preserve:
+## 7. Edge-Case Taxonomy
 
-- exact quote
-- page
-- section
+When classifying failures, use these reusable categories where they fit:
+
+- identity failure
+- methodology detection failure
+- version conflict
+- section-tree failure
+- routing failure
+- retrieval omission
+- irrelevant retrieval
+- generic-text false support
+- weak-evidence false support
+- qualifying evidence missed
+- stitched or paraphrased quote
+- wrong page or section
+- incomplete provenance
+- search coverage failure
+- applicability error
+- contradiction missed
+- assessment too strong
+- unsupported client action
+- unsupported draft finding
+- report strengthened upstream truth
+- UI/HTML/PDF drift
+
+## 8. Required Project Artifacts
+
+Each reviewed case must preserve equivalents of:
+
+- `metadata.json`
+- source identity and hash
+- raw Quick Check output
+- raw 58-row Evidence Map
+- `gold.draft.json`
+- `gold.json`
+- `corrections.json`
+- `REVIEW.md`
+- `reviewedRuleIds` or equivalent
+- accepted evidence
+- rejected evidence and reason
+- machine proposal
+- reviewer correction
+- final truth
+- report release state
+
+Do not commit source PDFs unless repository policy explicitly permits it.
+
+## 9. Partial Review
+
+Only explicitly reviewed rows count as gold or evaluation truth.
+
+Unreviewed rows cannot count as correct, incorrect, passed, failed, conforming, or client-ready.
+
+A complete client report requires all intended report rows to be reviewed and finalized.
+
+## 10. Presentation Invariants
+
+UI, HTML, and PDF must consume the same finalized model and preserve identical:
+
+- rows
+- evidence
+- rejected evidence
+- outcomes
+- findings
+- actions
+- counts
 - provenance
-- reviewed state
-- rationale for acceptance or rejection
+- release state
 
-If an item is weak, missing, rejected, blocked, or unresolved, that state must remain visible in the final model and downstream outputs.
+Layout, filtering, sorting, search, expand/collapse, typography, and PDF styling may vary.
+
+Truth may not change.
+Weak or missing rows may not be hidden.
+Rejected evidence may not be discarded.
+Conclusions may not be strengthened.
+New report evidence may not be searched independently.
+
+## 11. Client Release Gate
+
+Release requires:
+
+- version resolved
+- all intended rows reviewed
+- applicability resolved
+- accepted and rejected evidence preserved
+- provenance complete
+- contradictions resolved or visibly reported
+- supported client actions
+- conclusions no stronger than finalized rows
+- draft findings labeled as candidates
+- output labeled `Pre-Validation Readiness Report`
+
+Reject unsupported claims including:
+
+- passed
+- all clear
+- fully verified
+- ready for verification
+- approved
+- validated
+- verified
+- all requirements supported
+
+## 12. Standardization Rule
+
+This becomes the standard new-PDD workflow only after:
+
+- Marcondes completes PR1 and PR2
+- a second unseen VM0007 v1.8 PDD completes the same workflow
+- both use the same input and artifact contracts
+- no project-specific production fixes are required
+- earlier fixtures remain regression-safe

--- a/docs/roadmaps/vm0007-judgement-fixtures/SYSTEM_PROMPT.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/SYSTEM_PROMPT.md
@@ -1,0 +1,81 @@
+# VM0007 Evidence Map System Prompt
+
+This document is the canonical agent rule set for the VM0007 evidence-map workflow in this roadmap.
+
+## Required Inputs
+
+Every intake must begin with these three required inputs:
+
+- PDF path
+- stable project ID
+- project title
+
+Optional input:
+
+- registry project ID
+
+Methodology and version must be extracted from the PDD itself and must not be trusted from user input.
+
+## Truth Model
+
+The workflow must keep raw machine output separate from reviewed truth.
+
+The reviewed model must support partial coverage through `reviewedRuleIds` or an equivalent mechanism.
+
+The model must preserve:
+
+- accepted evidence
+- rejected evidence
+- exact quote
+- page number
+- section heading
+- provenance
+- reviewer-owned assessment
+- finding candidates
+
+Evidence states are limited to:
+
+- FOUND
+- UNCLEAR
+- MISSING
+- N/A
+
+Accepted and rejected evidence must remain explicit and traceable. Weak, missing, rejected, blocked, and unresolved evidence must never be hidden or normalized away.
+
+## Review Discipline
+
+Reviewer judgment owns the assessment. Machine output is only a proposal until reviewed.
+
+The reviewed truth layer must record:
+
+- reviewer-owned assessment
+- finding candidates
+- corrections
+- contradictions
+- unresolved conflicts
+- provenance for each evidence row
+
+When evidence conflicts with the intake proposal, the system must fail closed. The reviewed record must preserve the contradiction and the resulting decision rather than silently resolving it.
+
+No project-specific hardcoding is allowed.
+
+## Output Contract
+
+The UI, HTML, and PDF outputs must use the same finalized Evidence Map model.
+
+Client output must be labeled `Pre-Validation Readiness Report`.
+
+The system must not claim formal VVB validation, verification, or any equivalent authority status.
+
+## Required Provenance
+
+Each evidence entry must preserve:
+
+- exact quote
+- page
+- section
+- provenance
+- reviewed state
+- rationale for acceptance or rejection
+
+If an item is weak, missing, rejected, blocked, or unresolved, that state must remain visible in the final model and downstream outputs.


### PR DESCRIPTION
Docs-only update for the existing vm0007-judgement-fixtures roadmap.

Adds:
- SYSTEM_PROMPT.md
- NEW_PDD_PLAYBOOK.md
- PLAN.md governing-docs links

No production code, fixtures, routes, or roadmap structure changes.