### PR TITLE
docs: close out vm0007 phase 6

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -344,11 +344,9 @@ Lane status: Active
 Build a progressively improving VM0007 v1.8 Evidence Map using PDF-backed machine proposals, reviewed truth, explicit corrections, and generic retrieval/router improvements.
 
 Current focus:
-- Phases 0–2 complete: the boundary, Envira rule-level fixtures, and PD_REDD rule-level fixtures remain preserved with their historical references.
-- Phases 3–4 blocked/quarantined: Envira full-audit and report material is legacy REDD-MF / VM0007 v1.5 mismatch regression data, not VM0007 v1.8 truth.
-- Phase 5 complete: the internal-preview/client-readiness boundary and legacy-fixture quarantine are documented.
-- Phase 6 active: define and enforce the two-PR truth-intake and generic-system-improvement learning contract.
-- Phase 7 planned: begin Marcondes REDD+ as the first candidate forward VM0007 v1.8 Evidence Map learning case, pending explicit reconciliation of the internal v1.7/v1.8 discrepancy.
+- Phase 6 complete: canonical system prompt and new-PDD playbook delivered by PR #994.
+- Phase 7 active: Marcondes truth intake and v1.7/v1.8 reconciliation.
+- Phase 8 planned: generic system improvement after reviewed truth exists.
 
 Not active now:
 - Production logic changes in truth-intake PRs
@@ -364,9 +362,9 @@ Not active now:
 4) RC3 — Full 58-Rule Audit Fixture Shape: Blocked — Envira VM0007's reviewed full 58-rule audit fixture is quarantined legacy REDD-MF / VM0007 v1.5 mismatch data. The historical FOUND 30 / UNCLEAR 8 / MISSING 3 / N/A 17 split remains preserved as a regression fixture, but it is not validated VM0007 v1.8 truth.
 5) RC4 — Report Fixture Layer: Blocked — Report fixture output remains quarantined historical regression data. Report summary expectations and internal preview output are fixture-driven and testable, but the legacy Envira report fixture is not client-ready truth and is pending versioned re-audit. Historical delivery is preserved as PR #914.
 6) RC5 — Client-Readiness Gate: Done — The internal-preview/client-readiness boundary is documented and legacy mismatch fixtures remain quarantined; no legacy Envira output is promoted as VM0007 v1.8 truth.
-7) RC6 — Evidence Map Learning Contract: Active — Define the repeatable two-PR cycle: PR1 truth intake with untouched machine output and partial reviewed truth; PR2 generic shared-system improvement with previous-fixture reruns and one unseen eligible PDD.
-8) RC7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake: Planned — Intake Marcondes REDD+ as the first forward VM0007 v1.8 Evidence Map learning case with an explicit internal v1.7/v1.8 discrepancy while preserving raw 58-row output and counting only explicitly reviewed rows as gold.
-9) RC8 — Marcondes Generic System Improvement: Planned — Use Marcondes reviewed truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures without Marcondes-specific hardcoding.
+7) RC6 — Evidence Map Learning Contract: Done — Defined the repeatable two-PR cycle for VM0007 evidence-map learning and delivered the canonical system prompt plus new-PDD playbook in PR #994.
+8) RC7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake: Active — Intake Marcondes REDD+ as the active VM0007 v1.8 truth case while reconciling the internal v1.7/v1.8 discrepancy, preserving raw 58-row output, and counting only explicitly reviewed rows as gold.
+9) RC8 — Marcondes Generic System Improvement: Planned — Use reviewed Marcondes truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures after the reviewed truth exists.
 10) RC9 — Review and Gold Promotion Tooling: Planned — Make partial review and correction generation easy while preserving machine proposal, reviewer correction, final truth, and explicit gold coverage separately.
 11) RC10 — Second Unseen VM0007 v1.8 PDD: Planned — Run the same truth-intake and generic-improvement cycle on an unseen eligible VM0007 v1.8 PDD to prove generalization and prevent regressions.
 

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -54,7 +54,7 @@ Preserve report-facing fixture expectations and internal preview coverage for th
 
 Keep internal preview output separate from later client-ready reporting work. This phase records the existing quarantine and gate boundary; it does not promote the legacy Envira material to client-ready truth.
 
-### Phase 6 — Evidence Map Learning Contract — active
+### Phase 6 — Evidence Map Learning Contract — done
 
 Define the repeatable two-PR cycle for safely improving the Evidence Map.
 
@@ -77,7 +77,9 @@ Define the repeatable two-PR cycle for safely improving the Evidence Map.
 - rerun all previous fixtures
 - test one unseen eligible PDD
 
-### Phase 7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake — planned
+Delivered by PR #994 on branch `docs/vm0007-evidence-map-playbook`.
+
+### Phase 7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake — active
 
 - Marcondes REDD+ is the first candidate forward VM0007 v1.8 Evidence Map learning case, pending explicit reconciliation of the internal v1.7/v1.8 discrepancy
 - preserve the raw 58-row machine output
@@ -98,7 +100,7 @@ Define the repeatable two-PR cycle for safely improving the Evidence Map.
 
 ### Phase 8 — Marcondes Generic System Improvement — planned
 
-- compare Marcondes machine proposals against reviewed truth
+- compare Marcondes machine proposals against reviewed truth after the reviewed truth exists
 - classify retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding errors
 - fix only reusable shared logic
 - rerun Quick Check and Evidence Map regressions

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -5,11 +5,9 @@
     "status": "active",
     "summary": "Build a progressively improving VM0007 v1.8 Evidence Map using PDF-backed machine proposals, reviewed truth, explicit corrections, and generic retrieval/router improvements.",
     "current_focus": [
-      "Phases 0–2 complete: the boundary, Envira rule-level fixtures, and PD_REDD rule-level fixtures remain preserved with their historical references.",
-      "Phases 3–4 blocked/quarantined: Envira full-audit and report material is legacy REDD-MF / VM0007 v1.5 mismatch regression data, not VM0007 v1.8 truth.",
-      "Phase 5 complete: the internal-preview/client-readiness boundary and legacy-fixture quarantine are documented.",
-      "Phase 6 active: define and enforce the two-PR truth-intake and generic-system-improvement learning contract.",
-      "Phase 7 planned: begin Marcondes REDD+ as the first candidate forward VM0007 v1.8 Evidence Map learning case, pending explicit reconciliation of the internal v1.7/v1.8 discrepancy."
+      "Phase 6 complete: canonical system prompt and new-PDD playbook delivered by PR #994.",
+      "Phase 7 active: Marcondes truth intake and v1.7/v1.8 reconciliation.",
+      "Phase 8 planned: generic system improvement after reviewed truth exists."
     ],
     "not_active_now": [
       "Production logic changes in truth-intake PRs",
@@ -109,8 +107,10 @@
     {
       "id": "phase_6_evidence_map_learning_contract",
       "title": "Evidence Map Learning Contract",
-      "status": "active",
+      "status": "done",
       "dependsOn": ["phase_5_client_readiness_gate"],
+      "branch": "docs/vm0007-evidence-map-playbook",
+      "pr": 994,
       "doneCriteria": [
         "The repeatable two-PR truth-intake and generic-system-improvement cycle is documented",
         "Truth intake preserves untouched machine output, supports partial review, records accepted/rejected evidence and corrections, and counts only reviewed rows as gold",
@@ -121,7 +121,7 @@
     {
       "id": "phase_7_marcondes_vm0007_v1_8_evidence_map_truth_intake",
       "title": "Marcondes VM0007 v1.8 Evidence Map Truth Intake",
-      "status": "planned",
+      "status": "active",
       "dependsOn": ["phase_6_evidence_map_learning_contract"],
       "doneCriteria": [
         "Marcondes REDD+ is the first candidate forward VM0007 v1.8 Evidence Map learning case, pending explicit reconciliation of the internal v1.7/v1.8 discrepancy",
@@ -210,18 +210,20 @@
     },
     "phase_6_evidence_map_learning_contract": {
       "title": "Evidence Map Learning Contract",
-      "status": "active",
-      "summary": "Define the repeatable two-PR cycle: PR1 truth intake with untouched machine output and partial reviewed truth; PR2 generic shared-system improvement with previous-fixture reruns and one unseen eligible PDD."
+      "status": "done",
+      "branch": "docs/vm0007-evidence-map-playbook",
+      "pr": 994,
+      "summary": "Defined the repeatable two-PR cycle for VM0007 evidence-map learning and delivered the canonical system prompt plus new-PDD playbook in PR #994."
     },
     "phase_7_marcondes_vm0007_v1_8_evidence_map_truth_intake": {
       "title": "Marcondes VM0007 v1.8 Evidence Map Truth Intake",
-      "status": "planned",
-      "summary": "Intake Marcondes REDD+ as the first forward VM0007 v1.8 Evidence Map learning case with an explicit internal v1.7/v1.8 discrepancy while preserving raw 58-row output and counting only explicitly reviewed rows as gold."
+      "status": "active",
+      "summary": "Intake Marcondes REDD+ as the active VM0007 v1.8 truth case while reconciling the internal v1.7/v1.8 discrepancy, preserving raw 58-row output, and counting only explicitly reviewed rows as gold."
     },
     "phase_8_marcondes_generic_system_improvement": {
       "title": "Marcondes Generic System Improvement",
       "status": "planned",
-      "summary": "Use Marcondes reviewed truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures without Marcondes-specific hardcoding."
+      "summary": "Use reviewed Marcondes truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures after the reviewed truth exists."
     },
     "phase_9_review_and_gold_promotion_tooling": {
       "title": "Review and Gold Promotion Tooling",


### PR DESCRIPTION
## Purpose

Close out Phase 6 after PR #994 delivered the canonical system prompt and new-PDD playbook, then make Phase 7 the active roadmap focus.

This is docs-only, but the roadmap files are the project status source of truth. Using a PR preserves review history, runs the roadmap consistency checks, and keeps `PLAN.md`, `phase-status.json`, and generated `SUMMARY.md` synchronized.

## Changes

- Mark Phase 6 — Evidence Map Learning Contract as done
- Record PR #994 and branch `docs/vm0007-evidence-map-playbook`
- Mark Phase 7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake as active
- Update current focus to Phase 7
- Keep Envira only in historical/quarantined roadmap entries
- Regenerate `docs/roadmaps/SUMMARY.md`

## Files changed

- `docs/roadmaps/vm0007-judgement-fixtures/phase-status.json`
- `docs/roadmaps/vm0007-judgement-fixtures/PLAN.md`
- `docs/roadmaps/SUMMARY.md`

## Scope

No production code, fixtures, Quick Check logic, Evidence Map logic, report logic, system prompt, or playbook changes.

## Checks

- `npm run roadmap:check`
- `npm run pr:check:local`
- `git diff --check`

GitHub CI must pass before merge.