### PR TITLE
ci: add docs-only fast pr gate

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -18,43 +18,70 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
+      - name: Determine PR scope
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          changed_files="$(git diff --name-only --no-renames "$base" "$head")"
+          printf '%s\n' "$changed_files" | node scripts/pr-gate-scope.cjs --print
+          mode="$(printf '%s\n' "$changed_files" | node scripts/pr-gate-scope.cjs --mode)"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
       - name: Install
         run: npm ci
 
+      - name: Docs-only fast gate
+        if: steps.scope.outputs.mode == 'docs-only'
+        run: npm run check:docs-layout && npm run roadmap:validate && npm run roadmap:validate-evidence && npm run roadmap:check && git diff --check
+
       - name: Fetch methodology pack data
+        if: steps.scope.outputs.mode == 'full'
         run: npm run fetch:methodologies-pack
 
       - name: Validate roadmap SSOT
+        if: steps.scope.outputs.mode == 'full'
         run: npm run roadmap:validate
 
       - name: Enforce app vs methodologies boundary
+        if: steps.scope.outputs.mode == 'full'
         run: npm run guard:methodology-boundary
 
       - name: CI
+        if: steps.scope.outputs.mode == 'full'
         run: npm run ci
 
       - name: Strict eval corpus gate
+        if: steps.scope.outputs.mode == 'full'
         run: npm run quickcheck:eval:corpus -- --strict
 
       - name: Build verify run summary
+        if: steps.scope.outputs.mode == 'full'
         run: node scripts/ci-verify-run-summary.mjs
 
       - name: Compute coverage report
+        if: steps.scope.outputs.mode == 'full'
         run: npm run ci:coverage
 
       - name: Enforce coverage ratchet
+        if: steps.scope.outputs.mode == 'full'
         run: npm run ci:ratchet
 
       - name: Resolve evidence links
+        if: steps.scope.outputs.mode == 'full'
         run: npm run ci:links
 
       - name: Upload verify run summary
+        if: steps.scope.outputs.mode == 'full'
         uses: actions/upload-artifact@v4
         with:
           name: verify-ci-run-summary
           path: artifacts/verify/ci-run-summary.json
 
       - name: Upload CI gate artifacts
+        if: steps.scope.outputs.mode == 'full'
         uses: actions/upload-artifact@v4
         with:
           name: ci-gate-artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,12 @@ Do not change:
 - unrelated fixtures
 - unrelated dirty files
 
+## CI gate scope
+
+GitHub automatically uses the fast pr-gate when every changed file is under `docs/`.
+Mixed or non-docs PRs use the full gate.
+Codex must not manually bypass or mislabel the PR scope.
+
 8. Testing
 
 Run the focused fixture test for the new PDD.

--- a/scripts/pr-gate-scope.cjs
+++ b/scripts/pr-gate-scope.cjs
@@ -1,0 +1,81 @@
+const fs = require("node:fs");
+
+function normalizeChangedFiles(changedFiles) {
+  return changedFiles
+    .map((file) => String(file ?? "").trim().replace(/\\/g, "/"))
+    .filter((file) => file.length > 0);
+}
+
+function classifyChangedFiles(changedFiles) {
+  const files = normalizeChangedFiles(changedFiles);
+  const docsOnly = files.length > 0 && files.every((file) => file.startsWith("docs/"));
+  return {
+    files,
+    mode: docsOnly ? "docs-only" : "full",
+  };
+}
+
+function parseChangedFilesFromText(input) {
+  return String(input ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function formatSelectionLabel(mode) {
+  return mode === "docs-only" ? "docs-only fast gate" : "full gate";
+}
+
+function formatScopeDecision(result) {
+  const fileLines = result.files.length ? result.files.map((file) => `- ${file}`) : ["- (no changed files)"];
+  return ["Changed files:", ...fileLines, `Selected: ${formatSelectionLabel(result.mode)}`].join("\n");
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  let modeOnly = false;
+  let printOnly = false;
+  for (const arg of args) {
+    if (arg === "--mode") {
+      modeOnly = true;
+      continue;
+    }
+    if (arg === "--print") {
+      printOnly = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  const input = fs.readFileSync(0, "utf8");
+  const result = classifyChangedFiles(parseChangedFilesFromText(input));
+
+  if (printOnly) {
+    process.stdout.write(`${formatScopeDecision(result)}\n`);
+    return;
+  }
+
+  if (modeOnly) {
+    process.stdout.write(result.mode);
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  classifyChangedFiles,
+  formatScopeDecision,
+  formatSelectionLabel,
+  normalizeChangedFiles,
+  parseChangedFilesFromText,
+};

--- a/tests/scripts/prGateScope.test.ts
+++ b/tests/scripts/prGateScope.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "@jest/globals";
+
+const {
+  classifyChangedFiles,
+  formatScopeDecision,
+  formatSelectionLabel,
+} = require("../../scripts/pr-gate-scope.cjs") as {
+  classifyChangedFiles: (files: readonly string[]) => { files: string[]; mode: "docs-only" | "full" };
+  formatScopeDecision: (result: { files: string[]; mode: "docs-only" | "full" }) => string;
+  formatSelectionLabel: (mode: "docs-only" | "full") => string;
+};
+
+describe("pr-gate scope classifier", () => {
+  it("selects docs-only for a single docs file", () => {
+    expect(classifyChangedFiles(["docs/roadmaps/example.md"])).toEqual({
+      files: ["docs/roadmaps/example.md"],
+      mode: "docs-only",
+    });
+  });
+
+  it("selects docs-only when all changed files are under docs/", () => {
+    expect(classifyChangedFiles(["docs/roadmaps/SUMMARY.md", "docs/example.md"])).toEqual({
+      files: ["docs/roadmaps/SUMMARY.md", "docs/example.md"],
+      mode: "docs-only",
+    });
+  });
+
+  it("selects full when any non-docs file changes", () => {
+    expect(classifyChangedFiles(["docs/example.md", "package.json"])).toEqual({
+      files: ["docs/example.md", "package.json"],
+      mode: "full",
+    });
+  });
+
+  it("selects full for workflow file changes", () => {
+    expect(classifyChangedFiles([".github/workflows/pr-gate.yml"])).toEqual({
+      files: [".github/workflows/pr-gate.yml"],
+      mode: "full",
+    });
+  });
+
+  it("selects full when no changed files are reported", () => {
+    expect(classifyChangedFiles([])).toEqual({
+      files: [],
+      mode: "full",
+    });
+  });
+
+  it("formats the printed selection labels", () => {
+    expect(formatSelectionLabel("docs-only")).toBe("docs-only fast gate");
+    expect(formatSelectionLabel("full")).toBe("full gate");
+    expect(formatScopeDecision(classifyChangedFiles(["docs/example.md"]))).toContain("Selected: docs-only fast gate");
+    expect(formatScopeDecision(classifyChangedFiles(["package.json"]))).toContain("Selected: full gate");
+  });
+
+  it("prints the changed files and selection label from the CLI", () => {
+    const scriptPath = path.join(process.cwd(), "scripts", "pr-gate-scope.cjs");
+    expect(fs.existsSync(scriptPath)).toBe(true);
+
+    const stdout = execFileSync(
+      process.execPath,
+      [scriptPath, "--print"],
+      {
+        cwd: process.cwd(),
+        input: "docs/example.md\ndocs/roadmaps/SUMMARY.md\n",
+        encoding: "utf8",
+      },
+    );
+
+    expect(stdout).toContain("Changed files:");
+    expect(stdout).toContain("- docs/example.md");
+    expect(stdout).toContain("Selected: docs-only fast gate");
+  });
+});


### PR DESCRIPTION
## Purpose

Add an automatic docs-only fast path to the required GitHub `pr-gate` workflow, while preserving the existing full gate for every mixed or non-docs pull request.

The workflow still starts for every PR and keeps the same required `pr-gate` result. Scope is determined from the actual changed files, not from labels or manual input.

## Behavior

### Docs-only fast gate

Selected only when every changed file is under `docs/`.

Runs:

- `npm ci`
- `npm run check:docs-layout`
- `npm run roadmap:validate`
- `npm run roadmap:validate-evidence`
- `npm run roadmap:check`
- `git diff --check`

### Full gate

Selected when any changed file is outside `docs/`, including workflow, script, test, package, fixture, configuration, or application changes.

The existing full-gate commands remain unchanged.

This PR itself correctly uses the full gate because it changes CI, scripts, and tests.

## Changes

- Add PR changed-file scope detection to `.github/workflows/pr-gate.yml`
- Add fail-closed scope classifier in `scripts/pr-gate-scope.cjs`
- Add focused tests for docs-only, mixed, workflow-file, and empty-file-list cases
- Document the automatic CI behavior in `AGENTS.md`
- Print changed files and the selected gate mode in GitHub Actions

## Safety rules

- Empty changed-file lists select the full gate
- Mixed docs-and-code PRs select the full gate
- Workflow changes select the full gate
- No `paths-ignore` is used
- The required workflow and job name remain `pr-gate`
- Scope cannot be manually bypassed or mislabeled

## Files changed

- `.github/workflows/pr-gate.yml`
- `AGENTS.md`
- `scripts/pr-gate-scope.cjs`
- `tests/scripts/prGateScope.test.ts`

## Checks

- `npx jest tests/scripts/prGateScope.test.ts --runInBand`
- `npm run pr:check:local`
- `git diff --check`

GitHub full CI must pass before merge.