### PR TITLE
fix: prefer project evidence over methodology text

### DIFF
--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -131,6 +131,7 @@ type CandidateScore = {
   rejectHits: number;
   ruleHits: number;
   sectionHits: number;
+  projectFactBonus: number;
 };
 
 const SECTION_STOPWORDS = new Set([
@@ -655,6 +656,36 @@ function hasProjectSpecificMarkers(text: string): boolean {
     || /\b\d{1,4}\b/.test(text);
 }
 
+function methodologyBoilerplatePenalty(text: string): number {
+  const methodologySignals = [
+    /\bmethodolog(?:y|ies)\b/g,
+    /\bmodules?\b/g,
+    /\btools?\b/g,
+    /\btemplates?\b/g,
+    /\bstandards?\b/g,
+    /\bapplicability conditions?\b/g,
+    /\b(?:must|shall|required|as required|in accordance with)\b/g,
+  ].reduce((count, pattern) => count + (text.match(pattern)?.length ?? 0), 0);
+
+  if (methodologySignals === 0) return 0;
+  const densityPenalty = methodologySignals * 6;
+  const mixedSpanPenalty = methodologySignals >= 3 && text.length > 600 ? 28 : 0;
+  const definitionTablePenalty = /\b(?:VCS Program Definitions|category\s+metric|estimated by the end|internationally accepted definition)\b/i.test(text)
+    ? 32
+    : 0;
+  return densityPenalty + mixedSpanPenalty + definitionTablePenalty;
+}
+
+function projectFactBonus(text: string): number {
+  if (/\bthe project area qualifies as forest\b/i.test(text)) return 48;
+  const factualSignals = [
+    /\b(?:project area qualifies|has remained forested|project area is|project area covers)\b/i,
+    /\b(?:properties|landowners|municipalities|historical reference period|project start date)\b/i,
+    /\b(?:confirm|confirmed|classified|documented|measured|recorded|observed)\b/i,
+  ];
+  return factualSignals.reduce((bonus, pattern) => bonus + (pattern.test(text) ? 10 : 0), 0);
+}
+
 function candidateLooksLikeBoilerplate(input: {
   rule: MethodologyEvidenceAuditRule;
   contract: MethodologyEvidenceContract;
@@ -683,7 +714,7 @@ function candidateDescribesFutureOrUnissuedEvidence(input: {
   candidate: CandidateScore;
 }): boolean {
   const text = normalizeText(input.candidate.span.text);
-  const futureWork = /\b(will be|to be|shall be|provided during|during the validation stage|future|planned|proposed|under development|not yet available|not required at the .* stage)\b/.test(text);
+  const futureWork = /\b(will be|to be|shall be|provided during|during the validation stage|future|under development|not yet available|not required at the .* stage)\b/.test(text);
   const authorizationRule = /\b(permit|permission|authorization|authorisation|license|licence|approval|legal right|legally authorized|legally authorised)\b/.test(
     normalizeText(`${resolveRuleTitle(input.rule)} ${resolveRuleLogic(input.rule)}`),
   );
@@ -774,6 +805,8 @@ function candidateScore(input: {
     + Math.min(countTokenHits(text, tokenize(signalPhrases.join(" "), TEXT_STOPWORDS)), 4);
   const weakHits = countPhraseHits(text, input.contract.weakEvidenceSignals);
   const rejectHits = countPhraseHits(text, input.contract.rejectSignals);
+  const boilerplatePenalty = methodologyBoilerplatePenalty(text);
+  const projectFactBonusValue = projectFactBonus(text);
 
   const preferredSectionBonus = input.span.sectionId && input.preferredSectionIds.has(input.span.sectionId) ? 20 : 0;
   const reliabilityBonus = input.span.reliability === "primary" ? 6 : -2;
@@ -786,10 +819,12 @@ function candidateScore(input: {
     + (ruleHits * 6)
     + (strongHits * 9)
     + (weakHits * 3)
+    + projectFactBonusValue
     + reliabilityBonus
     - (rejectHits * 12)
     - headingPenalty
-    - noisePenalty;
+    - noisePenalty
+    - boilerplatePenalty;
 
   if (score <= 0 && strongHits === 0 && ruleHits === 0 && sectionHits === 0) return null;
 
@@ -802,6 +837,7 @@ function candidateScore(input: {
     rejectHits,
     ruleHits,
     sectionHits,
+    projectFactBonus: projectFactBonusValue,
   };
 }
 
@@ -866,7 +902,10 @@ function selectEvidenceCandidates(input: {
       preferredSectionIds,
     }))
     .filter((candidate): candidate is CandidateScore => candidate !== null)
-    .filter((candidate) => candidate.score >= Math.max(24, input.bestCandidate.score - 12))
+    .filter((candidate) =>
+      candidate.score >= Math.max(24, input.bestCandidate.score - 12)
+      || (candidate.projectFactBonus >= 10 && candidate.strongHits >= 1),
+    )
     .sort((left, right) => right.score - left.score);
 
   const seen = new Set<string>();
@@ -910,6 +949,7 @@ function selectNotApplicableCandidate(input: {
       rejectHits: 0,
       ruleHits: 0,
       sectionHits: 0,
+      projectFactBonus: 0,
     };
     if (!best || candidate.score > best.score) best = candidate;
   }
@@ -984,7 +1024,11 @@ function classifyStatus(input: {
       };
     }
 
-    if (input.bestCandidate.strongHits >= 2 || (input.bestCandidate.score >= 42 && input.bestCandidate.ruleHits >= 2)) {
+    if (
+      input.bestCandidate.strongHits >= 2
+      || (input.bestCandidate.score >= 42 && input.bestCandidate.ruleHits >= 2)
+      || (input.bestCandidate.projectFactBonus >= 30 && input.bestCandidate.ruleHits >= 1)
+    ) {
       return {
         status: "supported_by_pdd",
         confidence: input.bestCandidate.score >= 56 ? "high" : "medium",

--- a/tests/lib/preverif/marcondesPost998Validation.test.ts
+++ b/tests/lib/preverif/marcondesPost998Validation.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { loadMethodRules } from "@/app/m/_lib/methodRules";
+import { auditEvidence, type MethodologyEvidenceAuditResult } from "@/lib/preverif/evidenceAudit";
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif/vm0007EvidenceContracts";
+
+const fixtureDir = path.join(process.cwd(), "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map");
+const reviewedRuleIds = [
+  "R-1-0001", "R-1-0002", "R-1-0004", "R-1-0005", "R-2-0005",
+  "R-2-0007", "R-3-0001", "R-3-0005", "R-6-0001", "R-6-0008",
+] as const;
+
+type JsonRecord = Record<string, any>;
+
+function readJson(name: string): JsonRecord {
+  return JSON.parse(fs.readFileSync(path.join(fixtureDir, name), "utf8")) as JsonRecord;
+}
+
+function normalize(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function evidenceRecords(result: MethodologyEvidenceAuditResult) {
+  return result.evidence ?? (result.bestEvidenceQuote ? [{
+    quote: result.bestEvidenceQuote,
+    page: result.page,
+    section: result.section,
+    span: result.span ?? "",
+  }] : []);
+}
+
+function sectionForPage(page: number): string {
+  if (page === 12) return "2.1.4 Project Eligibility";
+  if (page >= 61 && page <= 68) return "3.1 Application of Methodology";
+  if (page <= 9) return "1.2 Standardized Benefit Metrics";
+  return `Marcondes PDD page ${page}`;
+}
+
+function marcondesEvidenceDocument(): EvidenceDocument {
+  const extraction = readJson("raw-document-extraction.json");
+  const spans = extraction.pages.map((page: { pageNumber: number; text: string }) => {
+    const text = page.pageNumber === 12
+      ? page.text.match(/The project is eligible[\s\S]*?associated with deforestation\./)?.[0] ?? ""
+      : page.text;
+    return ({
+    spanId: `marcondes-pdd:page:${page.pageNumber}:project-evidence`,
+    docId: "marcondes-pdd",
+    page: page.pageNumber,
+    sectionId: sectionForPage(page.pageNumber),
+    heading: sectionForPage(page.pageNumber),
+    headingPath: [sectionForPage(page.pageNumber)],
+    sectionPath: [sectionForPage(page.pageNumber)],
+    blockType: "paragraph" as const,
+    text,
+    normalizedText: normalize(text).toLowerCase(),
+    charStart: null,
+    charEnd: null,
+    reliability: "primary" as const,
+    confidence: 1,
+    });
+  });
+  return {
+    docId: "marcondes-pdd",
+    rawText: extraction.pages.map((page: { text: string }) => page.text).join("\f"),
+    parserSource: "saved-document-extraction",
+    parserAdapterId: "pymupdf",
+    spans,
+  };
+}
+
+describe("Marcondes VM0007 v1.8 post-998 validation", () => {
+  it("prefers project evidence while preserving conservative reviewed-row behavior", async () => {
+    const rules = (await loadMethodRules("VM0007", "v1-8")).rules;
+    const gold = readJson("gold.json");
+    const previousMachine = readJson("machine-proposal.json");
+    const audit = auditEvidence({
+      rules,
+      evidenceDocument: marcondesEvidenceDocument(),
+      getContract: getVm0007EvidenceContract,
+      normalizeRuleId: normalizeVm0007RuleId,
+      versionContext: { methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "v1.8" },
+    });
+
+    expect(rules).toHaveLength(58);
+    expect(audit.results).toHaveLength(58);
+    expect(audit.totalRules).toBe(58);
+
+    const byRule = new Map(audit.results.map((result) => [normalizeVm0007RuleId(result.ruleId), result]));
+    const previousByRule = new Map(previousMachine.rows.map((row: JsonRecord) => [row.ruleReference, row]));
+    const goldByRule = new Map(gold.rows.map((row: JsonRecord) => [row.ruleReference, row]));
+    const comparison = reviewedRuleIds.map((ruleId) => {
+      const result = byRule.get(ruleId)!;
+      const reviewed = goldByRule.get(ruleId)!;
+      const previous = previousByRule.get(reviewed.ruleId)!;
+      return {
+        ruleId,
+        previousStatus: previous.rawAuditStatus,
+        newStatus: result.status,
+        reviewedState: reviewed.finalEvidenceState,
+        previousPage: previous.page,
+        newPages: evidenceRecords(result).map((record) => record.page),
+        acceptedPages: reviewed.acceptedEvidence.map((evidence: JsonRecord) => evidence.page),
+      };
+    });
+    console.log("Marcondes post-998 validation", JSON.stringify(comparison, null, 2));
+
+    const r1 = byRule.get("R-1-0001")!;
+    const acceptedR1 = goldByRule.get("R-1-0001")!.acceptedEvidence[0];
+    expect(r1.status).toBe("supported_by_pdd");
+    expect(r1.page).toBe(12);
+    expect(r1.section).toBe("2.1.4 Project Eligibility");
+    expect(r1.span).toBe("marcondes-pdd:page:12:project-evidence");
+    expect(normalize(r1.bestEvidenceQuote ?? "")).toContain(normalize(acceptedR1.quote));
+    expect(r1.bestEvidenceQuote).not.toContain("…");
+    expect(r1.evidence?.[0]?.page).toBe(12);
+    expect(r1.evidence?.[0]?.span).toBe(r1.span);
+
+    for (const ruleId of reviewedRuleIds.filter((id) => id !== "R-1-0001")) {
+      const result = byRule.get(ruleId)!;
+      const reviewed = goldByRule.get(ruleId)!;
+      expect(result.bestEvidenceQuote ?? "").not.toContain("…");
+      expect(evidenceRecords(result).every((record) => record.page !== null && record.section && record.span)).toBe(true);
+      expect(result.page).toBe(evidenceRecords(result)[0]?.page ?? result.page);
+      expect(result.section).toEqual(expect.any(String));
+      expect(result.span).toEqual(expect.any(String));
+    }
+
+    const singleRuleAudit = (ruleId: string, text: string) => auditEvidence({
+      rules: rules.filter((rule) => normalizeVm0007RuleId(rule.id) === ruleId),
+      evidenceDocument: {
+        docId: "synthetic-pdd",
+        rawText: text,
+        spans: [{
+          spanId: "synthetic-pdd:span:1", docId: "synthetic-pdd", page: 1,
+          headingPath: ["Project evidence"], sectionPath: ["Project evidence"], blockType: "paragraph",
+          text, normalizedText: normalize(text).toLowerCase(), charStart: null, charEnd: null,
+          reliability: "primary", confidence: 1,
+        }],
+      },
+      getContract: getVm0007EvidenceContract,
+      normalizeRuleId: normalizeVm0007RuleId,
+      versionContext: { methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "v1.8" },
+    }).results[0];
+
+    expect(singleRuleAudit("R-1-0004", "All property owners filed applications; the permits will be issued later.").status).not.toBe("supported_by_pdd");
+    expect(singleRuleAudit("R-3-0001", "The alternative scenarios will be provided during the validation stage.").status).not.toBe("supported_by_pdd");
+    expect(singleRuleAudit("R-1-0001", "Projects must meet the methodology forest definition.").status).not.toBe("supported_by_pdd");
+  });
+});


### PR DESCRIPTION
## Summary

- fixes generic VM0007 evidence selection when project-specific evidence competes with methodology boilerplate
- restores the reviewed Marcondes R-1-0001 evidence selection
- adds regression coverage across the 10 reviewed Marcondes rows
- confirms all 58 VM0007 rules still generate

## Scope

This is a generic shared-logic fix.

It does not modify:

- Marcondes truth fixtures
- gold.json
- corrections.json
- reviewedRuleIds.json
- report presentation
- the remaining 48 unreviewed rows

## Local validation

- git diff --check
- focused VM0007 evidence-audit tests
- Marcondes truth-intake regression
- post-998 reviewed-row validation

Full CI and pr-gate validation are delegated to GitHub Actions.