### PR TITLE
fix: improve VM0007 reviewed evidence retrieval

### DIFF
--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -692,6 +692,39 @@ function projectFactBonus(text: string): number {
   return factualSignals.reduce((bonus, pattern) => bonus + (pattern.test(text) ? 10 : 0), 0);
 }
 
+function evidenceSpecificityBonus(text: string): number {
+  const normalized = normalizeText(text);
+  const lengthBonus = normalized.length <= 420 ? 8 : normalized.length <= 900 ? 4 : 0;
+  const explicitScopeBonus = /\b(?:no|not|without|excludes?|excluded|does not include|is not)\b/.test(normalized)
+    && /\b(?:peat|tidal|wetland|arr|ifm|wrc|soil|deforest|scope|activity|project)\b/.test(normalized)
+    ? 18
+    : 0;
+  const projectAssertionBonus = /\b(?:the project|project area|project activities|the pdd)\b/.test(normalized)
+    && /\b(?:is|are|has|have|includes?|excludes?|occurs?|occurring|qualifies|confirms?|states?)\b/.test(normalized)
+    ? 12
+    : 0;
+  const quantifiedFactBonus = /\b(?:all|no|at least|approximately)\s+\d+\b/.test(normalized)
+    || /\b(?:there are no|does not include|is not present|are not present)\b/.test(normalized)
+    ? 20
+    : 0;
+  const eligibilityFactBonus = /\b(?:the project|project area)\b[\s\S]{0,120}\b(?:eligible|qualifies as forest|has remained forested)\b/.test(normalized)
+    ? 40
+    : 0;
+  const applicabilityFactBonus = /\b(?:category|condition|module|rule)\b[\s\S]{0,100}\b(?:is|are)\s+(?:not\s+)?applicable\b/.test(normalized)
+    && /\b(?:project|properties|area|activity)\b/.test(normalized)
+    ? 60
+    : 0;
+  const copiedTextPenalty = /\b(?:methodology|module|tool|template|standard)\b/.test(normalized)
+    && !hasProjectSpecificMarkers(normalized)
+    ? 18
+    : 0;
+  const pendingPenalty = /\b(?:will be|to be|provided during|proxy|pending|not yet|under development|future)\b/.test(normalized)
+    || /\bnot required at the .* stage\b/.test(normalized)
+    ? 40
+    : 0;
+  return lengthBonus + explicitScopeBonus + projectAssertionBonus + quantifiedFactBonus + eligibilityFactBonus + applicabilityFactBonus - copiedTextPenalty - pendingPenalty;
+}
+
 function candidateLooksLikeBoilerplate(input: {
   rule: MethodologyEvidenceAuditRule;
   contract: MethodologyEvidenceContract;
@@ -822,17 +855,21 @@ function candidateScore(input: {
   const reliabilityBonus = input.span.reliability === "primary" ? 6 : -2;
   const headingPenalty = input.span.blockType === "section_heading" ? 14 : 0;
   const noisePenalty = input.span.noise?.length ? 10 : 0;
+  const specificityBonus = evidenceSpecificityBonus(text);
 
   const score =
     preferredSectionBonus
     + (sectionHits * 8)
-    + (ruleHits * 6)
+    // Rule-token overlap is useful for recall, but should not outweigh a
+    // complete project-specific signal or a scope/exclusion statement.
+    + (ruleHits * 3)
     + (strongHits * 9)
     + (signalTokenHits * 2)
     + (weakHits * 3)
     // Explicit project qualification language is a stronger retrieval signal
     // than generic methodology vocabulary.
     + (ruleTokens.includes("forest") && /\bthe project area qualifies as forest\b/i.test(text) ? 30 : 0)
+    + specificityBonus
     // Project markers are retained for classification diagnostics, but broad
     // factual language must not outweigh rule-specific evidence during retrieval.
     + reliabilityBonus
@@ -919,7 +956,9 @@ function selectEvidenceCandidates(input: {
     }))
     .filter((candidate): candidate is CandidateScore => candidate !== null)
     .filter((candidate) =>
-      candidate.score >= Math.max(24, input.bestCandidate.score - 12)
+      // Keep complementary project evidence when the document distributes a
+      // rule's support across sections; the top span still controls status.
+      candidate.score >= Math.max(24, input.bestCandidate.score - 40)
       || (candidate.projectFactBonus >= 10 && candidate.strongHits >= 1),
     )
     .sort((left, right) => right.score - left.score);
@@ -955,7 +994,9 @@ function selectNotApplicableCandidate(input: {
       ? (sectionLookup.get(span.sectionId)?.titleClean || sectionLookup.get(span.sectionId)?.titleRaw || null)
       : null;
 
-    const score = phraseHits * 14 + (span.reliability === "primary" ? 6 : 0);
+    const score = phraseHits * 14
+      + (span.reliability === "primary" ? 6 : 0)
+      + evidenceSpecificityBonus(text);
     const candidate: CandidateScore = {
       span,
       sectionTitle,

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -165,6 +165,32 @@ describe("auditEvidence with VM0007 contracts", () => {
     expect(result.evidence?.map((item) => item.span)).toEqual(["p12"]);
   });
 
+  it("prefers a concise project assertion over a long methodology-heavy span", () => {
+    const methodology = "The methodology requires the project proponent to demonstrate applicability, select the relevant modules, follow the applicable tools and standards, and document all required conditions. ".repeat(10);
+    const projectFact = "The project area is upland forest and the APDef category is applicable to the project activity.";
+    const result = byRuleId(auditSynthetic("R-3-0005", [
+      span(60, "methodology", methodology),
+      span(63, "project-fact", projectFact),
+    ]).results, "R-3-0005");
+
+    expect(result.page).toBe(63);
+    expect(result.evidence?.[0]?.quote).toBe(projectFact);
+    expect(result.evidence?.[0]?.span).toBe("project-fact");
+  });
+
+  it("retains explicit exclusion evidence for scope-sensitive N/A retrieval", () => {
+    const methodology = "The methodology includes peatland, tidal wetland, ARR, IFM, and WRC modules and describes their applicability conditions.";
+    const exclusion = "The project is REDD/APD only; there are no peat soils or tidal wetlands in the project area, and soil carbon is excluded.";
+    const result = byRuleId(auditSynthetic("R-1-0010", [
+      span(62, "scope-exclusion", exclusion),
+      span(63, "copied-modules", methodology),
+    ]).results, "R-1-0010");
+
+    expect(result.status).toBe("not_applicable");
+    expect(result.page).toBe(62);
+    expect(result.evidence?.[0]?.span).toBe("scope-exclusion");
+  });
+
   it.each([
     ["R-1-0004", "All property owners have filed applications for conversion authorization with the authority; the permits will be issued later."],
     ["R-3-0001", "The alternative scenarios and the VT0001 decision path will be provided during the validation stage."],

--- a/tests/lib/preverif/marcondesPost998Validation.test.ts
+++ b/tests/lib/preverif/marcondesPost998Validation.test.ts
@@ -10,6 +10,8 @@ const fixtureDir = path.join(process.cwd(), "tests/fixtures/preverif/marcondes-v
 const reviewedRuleIds = [
   "R-1-0001", "R-1-0002", "R-1-0004", "R-1-0005", "R-2-0005",
   "R-2-0007", "R-3-0001", "R-3-0005", "R-6-0001", "R-6-0008",
+  "R-1-0003", "R-1-0006", "R-1-0007", "R-1-0008", "R-1-0009",
+  "R-1-0010", "R-1-0011", "R-1-0012",
 ] as const;
 
 type JsonRecord = Record<string, any>;
@@ -145,6 +147,13 @@ describe("Marcondes VM0007 v1.8 post-998 validation", () => {
       expect(normalize(matchingRecord?.quote ?? "")).toContain(normalize(accepted.quote));
       expect(matchingRecord?.section).toEqual(expect.any(String));
       expect(matchingRecord?.span).toEqual(expect.any(String));
+    }
+
+    const notApplicableIds = reviewedRuleIds.filter((ruleId) => goldByRule.get(ruleId)!.finalEvidenceState === "N/A");
+    expect(notApplicableIds).toHaveLength(9);
+    for (const ruleId of notApplicableIds) {
+      expect(goldByRule.get(ruleId)!.acceptedEvidence.length).toBeGreaterThan(0);
+      expect(byRule.get(ruleId)?.evidence?.every((record) => record.page !== null && record.section && record.span)).toBe(true);
     }
 
     for (const ruleId of reviewedRuleIds.filter((id) => id !== "R-1-0001")) {


### PR DESCRIPTION
## Summary

- Improve shared VM0007 evidence ranking for precise project facts, applicability/exclusion statements, and distributed evidence.
- Penalize methodology-heavy and pending-stage spans while preserving conservative classification.
- Add generic synthetic coverage and expand the Marcondes regression benchmark to all 18 reviewed rules.

## Root causes

Broad spans were rewarded by rule-token overlap and could outrank concise project assertions. Scope exclusions and applicability statements received insufficient ranking weight, and complementary evidence could be dropped by the narrow score band.

## Validation

- `git diff --check`
- `npx jest --runInBand tests/lib/preverif.vm0007EvidenceAudit.test.ts tests/lib/preverif/marcondesPost998Validation.test.ts tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts`

No truth, raw extraction, historical machine proposal, or production report files were changed.
