### PR TITLE
Audit Marcondes reviewed truth batch 1

### DIFF
--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/REVIEW.md
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/REVIEW.md
@@ -14,6 +14,12 @@ Accepted evidence for pages 12, 18–19, and 38 is located under 2 PROJECT DETAI
 
 An independent blind adversarial review was completed. The final reviewer retained the existing outcomes for all reviewed rules except for correcting the R-6-0008 requirement semantics to uncertainty reduction requirements.
 
+## Independent truth audit batch 1
+
+The first 10 existing reviewed rows were independently audited directly against the VM0007 v1.8 requirement logic and the preserved PDD extraction. Nine rows are CONFIRMED. R-1-0002 is CORRECTED at the evidence level: the prior accepted quote listed AUDef/APDef but did not prove the project’s APDef selection; the accepted quote now preserves the page-63 project-specific classification and legal basis. Its final state remains FOUND/CONFORMS. No row had insufficient source access.
+
+Audit records are in `independent-audit.json`. The audit confirms that incomplete multi-part requirements remain UNCLEAR/ACTION_REQUIRED, N/A has an explicit applicability reason, rejected machine evidence is not used as truth, the other 18 reviewed rows are unchanged, and the remaining 30 rows remain excluded from gold.
+
 
 ## Batch 2 review: R-1-0003 and R-1-0006 through R-1-0012
 

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/REVIEW.md
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/REVIEW.md
@@ -2,9 +2,9 @@
 
 - Reviewed rows: 28 of 58
 - Remaining rows: 30, unreviewed and NOT_ASSESSED
-- Corrected evidence states: FOUND 8, UNCLEAR 7, MISSING 0, N/A 13
-- Reviewer outcomes: CONFORMS 8, ACTION_REQUIRED 7, NOT_APPLICABLE 13, NOT_ASSESSED 30
-- Draft findings: NIR_CANDIDATE 7, OFI_CANDIDATE 0, NCR_CANDIDATE 0, null for reviewed N/A and remaining rows
+- Corrected evidence states: FOUND 7, UNCLEAR 8, MISSING 0, N/A 13
+- Reviewer outcomes: CONFORMS 7, ACTION_REQUIRED 8, NOT_APPLICABLE 13, NOT_ASSESSED 30
+- Draft findings: NIR_CANDIDATE 8, OFI_CANDIDATE 0, NCR_CANDIDATE 0, null for reviewed N/A and remaining rows
 - Gold promotion: BLOCKED_PENDING_REVIEW_COVERAGE
 - Report release state: BLOCKED_PENDING_REVIEW_COVERAGE
 
@@ -16,7 +16,7 @@ An independent blind adversarial review was completed. The final reviewer retain
 
 ## Independent truth audit batch 1
 
-The first 10 existing reviewed rows were independently audited directly against the VM0007 v1.8 requirement logic and the preserved PDD extraction. Nine rows are CONFIRMED. R-1-0002 is CORRECTED at the evidence level: the prior accepted quote listed AUDef/APDef but did not prove the project’s APDef selection; the accepted quote now preserves the page-63 project-specific classification and legal basis. Its final state remains FOUND/CONFORMS. No row had insufficient source access.
+The first 10 existing reviewed rows were independently audited directly against the VM0007 v1.8 requirement logic and the preserved PDD extraction. Seven rows are CONFIRMED. R-1-0001 is CORRECTED to UNCLEAR/ACTION_REQUIRED because the PDD identifies the VCS threshold categories and supplies page-62 MapBiomas/PRODES history, but does not preserve numeric forest-definition thresholds. R-1-0002 is CORRECTED at the evidence level: the prior accepted quote listed AUDef/APDef but did not prove the project’s APDef selection; the accepted quote now preserves the page-62/63 project-specific classification and legal basis, with FOUND/CONFORMS retained. R-3-0005 is CORRECTED at the evidence level: page 61 Table 30 now preserves VMD0006 selection and page 63 preserves VMD0006 applicability plus the APD rationale, with FOUND/CONFORMS retained. No row had insufficient source access.
 
 Audit records are in `independent-audit.json`. The audit confirms that incomplete multi-part requirements remain UNCLEAR/ACTION_REQUIRED, N/A has an explicit applicability reason, rejected machine evidence is not used as truth, the other 18 reviewed rows are unchanged, and the remaining 30 rows remain excluded from gold.
 

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/corrections.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/corrections.json
@@ -54,6 +54,44 @@
       }
     },
     {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
+        "quote": "Land with woody vegetation that meets an internationally accepted definition (e.g., UNFCCC, FAO, or IPCC) of what constitutes a forest, which includes threshold parameters, such as minimum forest area, tree height and level of crown cover, and may include mature, secondary, degraded and wetland forests (VCS Program Definitions)",
+        "page": 6,
+        "section": "1.2 Standardized Benefit Metrics",
+        "spanId": "manual:marcondes-pdd:page-6:r-1-0001-definition",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 6,
+          "sectionPath": ["1 SUMMARY OF PROJECT BENEFITS", "1.2 Standardized Benefit Metrics"],
+          "spanId": "manual:marcondes-pdd:page-6:r-1-0001-definition",
+          "sectionHeading": "1.2 Standardized Benefit Metrics",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
+        "quote": "MapBiomas Collection 10 and PRODES/INPE data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). Annual LULC maps demonstrate Dense Ombrophilous Forest classification without interruption.",
+        "page": 62,
+        "section": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+        "spanId": "manual:marcondes-pdd:page-62:r-1-0001-history",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 62,
+          "sectionPath": ["3 CLIMATE", "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"],
+          "spanId": "manual:marcondes-pdd:page-62:r-1-0001-history",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
       "evidence": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
@@ -264,6 +302,44 @@
             "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31, VMD0006 v1.4"
           ],
           "spanId": "manual:marcondes-pdd:page-63:r-3-0005",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31, VMD0006 v1.4",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
+        "quote": "Module VMD0006 Estimation of baseline carbon stock changes and GHG emissions from planned deforestation (BL- PL) 1.4",
+        "page": 61,
+        "section": "3.1.1 Title and Reference of Methodology (VCS, 3.1), Table 30. Methodologies, modules, and tools applied",
+        "spanId": "manual:marcondes-pdd:page-61:r-3-0005-table30",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": ["3 CLIMATE", "3.1 Application of Methodology", "Table 30. Methodologies, modules, and tools applied"],
+          "spanId": "manual:marcondes-pdd:page-61:r-3-0005-table30",
+          "sectionHeading": "Table 30. Methodologies, modules, and tools applied",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
+        "quote": "VMD0006 v1.4 The module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land.",
+        "page": 63,
+        "section": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31, VMD0006 v1.4",
+        "spanId": "manual:marcondes-pdd:page-63:r-3-0005-module",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 63,
+          "sectionPath": ["3 CLIMATE", "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31, VMD0006 v1.4"],
+          "spanId": "manual:marcondes-pdd:page-63:r-3-0005-module",
           "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31, VMD0006 v1.4",
           "sourceType": "PDD",
           "provenanceKind": "manual"

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/corrections.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/corrections.json
@@ -57,18 +57,37 @@
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
       "evidence": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
-        "quote": "a) Unplanned deforestation (VCS category AUDef)\nb) Planned deforestation (VCS category APDef)",
-        "page": 63,
+        "quote": "Deforestation in the project area is legally authorized under the Brazilian Forest Code (Law 12.651/2012), Article 12, which permits clearing of up to 20% of rural",
+        "page": 62,
         "section": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
-        "spanId": "manual:marcondes-pdd:page-63:r-1-0002",
+        "spanId": "manual:marcondes-pdd:page-62:r-1-0002",
         "provenance": {
           "docId": "quick-check-review-question",
-          "page": 63,
+          "page": 62,
           "sectionPath": [
             "3 CLIMATE",
             "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
           ],
-          "spanId": "manual:marcondes-pdd:page-63:r-1-0002",
+          "spanId": "manual:marcondes-pdd:page-62:r-1-0002",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
+        "quote": "properties in the Legal Amazon. The APDef category is applicable.",
+        "page": 63,
+        "section": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+        "spanId": "manual:marcondes-pdd:page-63:r-1-0002-selection",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 63,
+          "sectionPath": ["3 CLIMATE", "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"],
+          "spanId": "manual:marcondes-pdd:page-63:r-1-0002-selection",
           "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
           "sourceType": "PDD",
           "provenanceKind": "manual"
@@ -1406,7 +1425,7 @@
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
-        "correction": "Manual review replaced the machine-selected truncated or mislocated evidence for R-1-0002 with PDF-backed evidence. The complete project-specific quote supports the reviewed outcome."
+        "correction": "Independent audit found that the previous accepted quote listed AUDef/APDef but did not prove the project selection. It was replaced with the page-63 project-specific legal-basis and APDef-selection quote; the FOUND/CONFORMS outcome is retained."
       }
     },
     {

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json
@@ -131,18 +131,34 @@
       "acceptedEvidence": [
         {
           "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
-          "quote": "a) Unplanned deforestation (VCS category AUDef)\nb) Planned deforestation (VCS category APDef)",
-          "page": 63,
+          "quote": "Deforestation in the project area is legally authorized under the Brazilian Forest Code (Law 12.651/2012), Article 12, which permits clearing of up to 20% of rural",
+          "page": 62,
           "section": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
-          "spanId": "manual:marcondes-pdd:page-63:r-1-0002",
+          "spanId": "manual:marcondes-pdd:page-62:r-1-0002",
           "provenance": {
             "docId": "quick-check-review-question",
-            "page": 63,
+            "page": 62,
             "sectionPath": [
               "3 CLIMATE",
               "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
             ],
-            "spanId": "manual:marcondes-pdd:page-63:r-1-0002",
+            "spanId": "manual:marcondes-pdd:page-62:r-1-0002",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
+          "quote": "properties in the Legal Amazon. The APDef category is applicable.",
+          "page": 63,
+          "section": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "spanId": "manual:marcondes-pdd:page-63:r-1-0002-selection",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 63,
+            "sectionPath": ["3 CLIMATE", "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"],
+            "spanId": "manual:marcondes-pdd:page-63:r-1-0002-selection",
             "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
             "sourceType": "PDD",
             "provenanceKind": "manual"
@@ -170,7 +186,7 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002",
-        "correction": "Manual review replaced the machine-selected truncated or mislocated evidence for R-1-0002 with PDF-backed evidence. The complete project-specific quote supports the reviewed outcome."
+        "correction": "Independent audit found that the previous accepted quote listed AUDef/APDef but did not prove the project selection. It was replaced with the page-63 project-specific legal-basis and APDef-selection quote; the FOUND/CONFORMS outcome is retained."
       },
       "finalEvidenceState": "FOUND",
       "reviewerOutcome": "CONFORMS",

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json
@@ -76,6 +76,38 @@
             "sourceType": "PDD",
             "provenanceKind": "manual"
           }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
+          "quote": "Land with woody vegetation that meets an internationally accepted definition (e.g., UNFCCC, FAO, or IPCC) of what constitutes a forest, which includes threshold parameters, such as minimum forest area, tree height and level of crown cover, and may include mature, secondary, degraded and wetland forests (VCS Program Definitions)",
+          "page": 6,
+          "section": "1.2 Standardized Benefit Metrics",
+          "spanId": "manual:marcondes-pdd:page-6:r-1-0001-definition",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 6,
+            "sectionPath": ["1 SUMMARY OF PROJECT BENEFITS", "1.2 Standardized Benefit Metrics"],
+            "spanId": "manual:marcondes-pdd:page-6:r-1-0001-definition",
+            "sectionHeading": "1.2 Standardized Benefit Metrics",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
+          "quote": "MapBiomas Collection 10 and PRODES/INPE data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). Annual LULC maps demonstrate Dense Ombrophilous Forest classification without interruption.",
+          "page": 62,
+          "section": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "spanId": "manual:marcondes-pdd:page-62:r-1-0001-history",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 62,
+            "sectionPath": ["3 CLIMATE", "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"],
+            "spanId": "manual:marcondes-pdd:page-62:r-1-0001-history",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
         }
       ],
       "rejectedEvidence": [
@@ -99,12 +131,12 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001",
-        "correction": "Manual review replaced the machine-selected truncated or mislocated evidence for R-1-0001 with PDF-backed evidence. The complete project-specific quote supports the reviewed outcome."
+        "correction": "Independent audit found that the prior evidence only asserted that applicable thresholds were met. The PDD identifies VCS Program Definitions and supplies page-62 MapBiomas/PRODES history, but does not preserve numeric threshold values; the row is corrected to UNCLEAR/ACTION_REQUIRED."
       },
-      "finalEvidenceState": "FOUND",
-      "reviewerOutcome": "CONFORMS",
-      "clientAction": "Retain the forest-history evidence and referenced forest-definition records for validation review.",
-      "draftFindingCandidate": null,
+      "finalEvidenceState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "clientAction": "Provide the governing numeric forest-definition thresholds (minimum forest area, tree height, and canopy/crown cover) and project-area evidence demonstrating that all project properties meet them for the required 10-year period, including the MapBiomas/PRODES basis.",
+      "draftFindingCandidate": "NIR_CANDIDATE",
       "contradictionState": "NONE_IDENTIFIED"
     },
     {
@@ -627,6 +659,38 @@
             "sourceType": "PDD",
             "provenanceKind": "manual"
           }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
+          "quote": "Module VMD0006 Estimation of baseline carbon stock changes and GHG emissions from planned deforestation (BL- PL) 1.4",
+          "page": 61,
+          "section": "3.1.1 Title and Reference of Methodology (VCS, 3.1), Table 30. Methodologies, modules, and tools applied",
+          "spanId": "manual:marcondes-pdd:page-61:r-3-0005-table30",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": ["3 CLIMATE", "3.1 Application of Methodology", "Table 30. Methodologies, modules, and tools applied"],
+            "spanId": "manual:marcondes-pdd:page-61:r-3-0005-table30",
+            "sectionHeading": "Table 30. Methodologies, modules, and tools applied",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
+          "quote": "VMD0006 v1.4 The module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land.",
+          "page": 63,
+          "section": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31, VMD0006 v1.4",
+          "spanId": "manual:marcondes-pdd:page-63:r-3-0005-module",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 63,
+            "sectionPath": ["3 CLIMATE", "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31, VMD0006 v1.4"],
+            "spanId": "manual:marcondes-pdd:page-63:r-3-0005-module",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31, VMD0006 v1.4",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
         }
       ],
       "rejectedEvidence": [
@@ -650,7 +714,7 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
-        "correction": "Manual review replaced the machine-selected truncated or mislocated evidence for R-3-0005 with PDF-backed evidence. The complete project-specific quote supports the reviewed outcome."
+        "correction": "Independent audit found that the prior accepted evidence proved APD but did not preserve the Table 30 VMD0006 selection or its direct applicability text. Page-61 Table 30 and page-63 VMD0006/APD passages were added; FOUND/CONFORMS is retained."
       },
       "finalEvidenceState": "FOUND",
       "reviewerOutcome": "CONFORMS",
@@ -2210,8 +2274,8 @@
     }
   ],
   "counts": {
-    "FOUND": 8,
-    "UNCLEAR": 7,
+    "FOUND": 7,
+    "UNCLEAR": 8,
     "MISSING": 0,
     "N/A": 13
   },

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/independent-audit.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/independent-audit.json
@@ -1,0 +1,128 @@
+{
+  "stableProjectId": "marcondes-redd-5953",
+  "methodology": "VM0007 v1.8",
+  "auditType": "INDEPENDENT_TRUTH_AUDIT",
+  "rows": [
+    {
+      "ruleReference": "R-1-0001",
+      "requirementReviewed": "Project land must meet forest definition threshold for 10+ years. Mangroves exempt from height.",
+      "pagesInspected": [12, 62],
+      "evidenceCompleteness": "COMPLETE",
+      "finalState": "FOUND",
+      "reviewerOutcome": "CONFORMS",
+      "auditResult": "CONFIRMED",
+      "rationale": "Page 12 directly ties the project area to forest status for more than 10 years and says the applicable thresholds are met. Page 62 independently repeats the 10-year forest condition and historical forest-cover support. The accepted page-12 quote is present in the preserved extraction; the generic methodology-only proposal is correctly rejected.",
+      "multiPartRequirement": true,
+      "clientActionAssessment": "Retaining the forest-history and definition records is proportionate; no unsupported conclusion is added."
+    },
+    {
+      "ruleReference": "R-1-0002",
+      "requirementReviewed": "Binary classification: unplanned (no legal right) vs planned (legally permitted conversion). Determines which BL module applies.",
+      "pagesInspected": [62, 63],
+      "evidenceCompleteness": "COMPLETE_AFTER_CORRECTION",
+      "finalState": "FOUND",
+      "reviewerOutcome": "CONFORMS",
+      "auditResult": "CORRECTED",
+      "rationale": "The prior accepted quote listed both categories but did not prove the project choice. Page 63 states the project-area legal basis and that APDef is applicable, directly closing the classification. The accepted evidence was corrected to that exact project-specific passage; the machine proposal remains preserved.",
+      "multiPartRequirement": true,
+      "clientActionAssessment": "Retaining the Table 31 classification and supporting baseline evidence is supported and not overstated."
+    },
+    {
+      "ruleReference": "R-1-0004",
+      "requirementReviewed": "Must have legal documentation authorizing conversion.",
+      "pagesInspected": [12, 63],
+      "evidenceCompleteness": "INCOMPLETE",
+      "finalState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "auditResult": "CONFIRMED",
+      "rationale": "Page 12 asserts legal authorization, while page 63 identifies the Forest Code and ASV applications. Applications, boundary registrations, and compliance statements do not establish issued conversion authorization documents. The accepted evidence is exact and supports UNCLEAR, not CONFORMS.",
+      "multiPartRequirement": true,
+      "clientActionAssessment": "Requesting issued ASV or other actual authorization documents, issuing authority, area, and dates is supported by the gap and is not overstated."
+    },
+    {
+      "ruleReference": "R-1-0005",
+      "requirementReviewed": "Water table lowering is prohibited except for two specific exceptions.",
+      "pagesInspected": [62, 63],
+      "evidenceCompleteness": "NOT_APPLICABLE",
+      "finalState": "N/A",
+      "reviewerOutcome": "NOT_APPLICABLE",
+      "auditResult": "CONFIRMED",
+      "rationale": "The rule is a WRC applicability condition. Page 62 explicitly states that no peat soils or tidal wetlands are present in the project area, so the triggering WRC pathway is absent. This is an applicability determination, not a finding that the prohibition was satisfied.",
+      "multiPartRequirement": false,
+      "applicabilityReason": "No peat soils or tidal wetlands are present; WRC water-table requirements therefore do not apply.",
+      "clientActionAssessment": "Retaining the project-area soil and wetland assessment for validation is proportionate."
+    },
+    {
+      "ruleReference": "R-2-0005",
+      "requirementReviewed": "Proxy areas required for planned deforestation baseline.",
+      "pagesInspected": [18, 19, 37],
+      "evidenceCompleteness": "INCOMPLETE",
+      "finalState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "auditResult": "CONFIRMED",
+      "rationale": "Pages 18–19 describe proxy-area analysis and representativeness, but page 37 says proxy-area locations and related maps are still to be produced. The accepted evidence is multi-record and exact, yet the PDD does not demonstrate completed proxy-area documentation; UNCLEAR is correct.",
+      "multiPartRequirement": true,
+      "clientActionAssessment": "Requesting proxy-area maps and completed analysis directly addresses the stated future deliverable and is not overstated."
+    },
+    {
+      "ruleReference": "R-2-0007",
+      "requirementReviewed": "Pool inclusion/exclusion must be justified. If included in baseline, must also be in project and leakage.",
+      "pagesInspected": [63],
+      "evidenceCompleteness": "INCOMPLETE",
+      "finalState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "auditResult": "CONFIRMED",
+      "rationale": "Page 63 proves only that above-ground tree biomass is mandatory. It does not provide complete inclusion/exclusion decisions, reasons, or baseline/project/leakage consistency for every relevant pool. The accepted evidence is therefore partial and the rejected generic passage is correctly rejected.",
+      "multiPartRequirement": true,
+      "clientActionAssessment": "Requesting complete pool decisions and consistency evidence is exactly the missing support and is not overstated."
+    },
+    {
+      "ruleReference": "R-3-0001",
+      "requirementReviewed": "VT0001 mandatory. Stepwise approach: list alternatives, barrier/investment analysis, select most plausible.",
+      "pagesInspected": [66, 67],
+      "evidenceCompleteness": "INCOMPLETE",
+      "finalState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "auditResult": "CONFIRMED",
+      "rationale": "Page 66 mentions the stepwise procedures only at a high level. Page 67 states that the baseline and additionality information will be provided during validation. No project-specific alternatives, analysis, or selected most-plausible baseline are shown, so UNCLEAR/ACTION_REQUIRED is required.",
+      "multiPartRequirement": true,
+      "clientActionAssessment": "Requesting the complete VT0001 analysis and supporting records is supported by the explicit validation-stage deferral."
+    },
+    {
+      "ruleReference": "R-3-0005",
+      "requirementReviewed": "Module selection based on deforestation category.",
+      "pagesInspected": [63],
+      "evidenceCompleteness": "COMPLETE",
+      "finalState": "FOUND",
+      "reviewerOutcome": "CONFORMS",
+      "auditResult": "CONFIRMED",
+      "rationale": "Page 63 identifies planned deforestation (APD), legally authorized/documented conversion to non-forest land, and the applicable VMD0006 module. The accepted quote directly links category, project activity, and module; the generic additionality passage is correctly rejected.",
+      "multiPartRequirement": true,
+      "clientActionAssessment": "Retaining the APD/VMD0006 rationale is supported and appropriately limited to the evidence shown."
+    },
+    {
+      "ruleReference": "R-6-0001",
+      "requirementReviewed": "Four mandatory monitoring tasks. Each requires technical description, data list, procedures, QA/QC, archiving, responsibilities.",
+      "pagesInspected": [38, 68],
+      "evidenceCompleteness": "INCOMPLETE",
+      "finalState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "auditResult": "CONFIRMED",
+      "rationale": "Page 38 shows one monitoring activity and some frequency/procedure detail. Page 68 expressly defers the formal monitoring sections to validation. The evidence does not enumerate and operationalize all four tasks with QA/QC, archiving, and responsibilities, so CONFORMS is unsupported.",
+      "multiPartRequirement": true,
+      "clientActionAssessment": "Requesting formal parameters and the monitoring plan for validation is supported and not overstated."
+    },
+    {
+      "ruleReference": "R-6-0008",
+      "requirementReviewed": "Uncertainty reduction requirements.",
+      "pagesInspected": [66],
+      "evidenceCompleteness": "INCOMPLETE",
+      "finalState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "auditResult": "CONFIRMED",
+      "rationale": "Page 66 identifies VMD0017, lists uncertainty sources, and says the project quantifies them, but it does not show project-specific values, calculations, thresholds, confidence/results, conservative assumptions, reduction procedures, source hierarchy, or QA/QC. The corrected requirement semantics and UNCLEAR outcome are supported.",
+      "multiPartRequirement": true,
+      "clientActionAssessment": "The detailed request for project-specific uncertainty calculations, source hierarchy, reduction procedures, and QA/QC tracks the missing mandatory components and is not overstated."
+    }
+  ]
+}

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/independent-audit.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/independent-audit.json
@@ -6,14 +6,14 @@
     {
       "ruleReference": "R-1-0001",
       "requirementReviewed": "Project land must meet forest definition threshold for 10+ years. Mangroves exempt from height.",
-      "pagesInspected": [12, 62],
-      "evidenceCompleteness": "COMPLETE",
-      "finalState": "FOUND",
-      "reviewerOutcome": "CONFORMS",
-      "auditResult": "CONFIRMED",
-      "rationale": "Page 12 directly ties the project area to forest status for more than 10 years and says the applicable thresholds are met. Page 62 independently repeats the 10-year forest condition and historical forest-cover support. The accepted page-12 quote is present in the preserved extraction; the generic methodology-only proposal is correctly rejected.",
+      "pagesInspected": [6, 12, 62],
+      "evidenceCompleteness": "INCOMPLETE",
+      "finalState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "auditResult": "CORRECTED",
+      "rationale": "Page 6 identifies VCS Program Definitions and the threshold categories (minimum forest area, tree height, and crown cover), but does not preserve numeric threshold values. Page 12 asserts that applicable thresholds are met, while page 62 provides direct project-specific MapBiomas Collection 10 and PRODES/INPE continuity evidence for all 36 properties from 2013–2023. The 10-year history is supported, but the numeric threshold record is not, so FOUND/CONFORMS cannot be retained.",
       "multiPartRequirement": true,
-      "clientActionAssessment": "Retaining the forest-history and definition records is proportionate; no unsupported conclusion is added."
+      "clientActionAssessment": "Requesting the governing numeric thresholds and project-area compliance evidence is directly supported and not overstated."
     },
     {
       "ruleReference": "R-1-0002",
@@ -67,7 +67,7 @@
     {
       "ruleReference": "R-2-0007",
       "requirementReviewed": "Pool inclusion/exclusion must be justified. If included in baseline, must also be in project and leakage.",
-      "pagesInspected": [63],
+      "pagesInspected": [61, 63],
       "evidenceCompleteness": "INCOMPLETE",
       "finalState": "UNCLEAR",
       "reviewerOutcome": "ACTION_REQUIRED",
@@ -91,12 +91,12 @@
     {
       "ruleReference": "R-3-0005",
       "requirementReviewed": "Module selection based on deforestation category.",
-      "pagesInspected": [63],
+      "pagesInspected": [61, 63],
       "evidenceCompleteness": "COMPLETE",
       "finalState": "FOUND",
       "reviewerOutcome": "CONFORMS",
-      "auditResult": "CONFIRMED",
-      "rationale": "Page 63 identifies planned deforestation (APD), legally authorized/documented conversion to non-forest land, and the applicable VMD0006 module. The accepted quote directly links category, project activity, and module; the generic additionality passage is correctly rejected.",
+      "auditResult": "CORRECTED",
+      "rationale": "The prior page-63 quote proved APD and legally authorized conversion but did not preserve the module-selection evidence. Page 61 Table 30 explicitly selects VMD0006 for planned deforestation (BL-PL), and page 63 separately preserves VMD0006 applicability plus the Marcondes APD rationale. Together these records complete the requirement; FOUND/CONFORMS is retained.",
       "multiPartRequirement": true,
       "clientActionAssessment": "Retaining the APD/VMD0006 rationale is supported and appropriately limited to the evidence shown."
     },

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/metadata.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/metadata.json
@@ -38,7 +38,7 @@
     "independentAudit": {
       "batch": 1,
       "rowCount": 10,
-      "results": { "CONFIRMED": 9, "CORRECTED": 1, "INSUFFICIENT_SOURCE_ACCESS": 0 }
+      "results": { "CONFIRMED": 7, "CORRECTED": 3, "INSUFFICIENT_SOURCE_ACCESS": 0 }
     },
     "reviewedRuleIds": [
       "Verra.AFOLU.VM0007.v1-8.R-1-0001",
@@ -74,9 +74,9 @@
     "goldPromotion": "BLOCKED_PENDING_REVIEW_COVERAGE",
     "reportReleaseState": "BLOCKED_PENDING_REVIEW_COVERAGE",
     "versionReconciliationPending": false,
-    "evidenceStateCounts": {
-      "FOUND": 8,
-      "UNCLEAR": 7,
+      "evidenceStateCounts": {
+      "FOUND": 7,
+      "UNCLEAR": 8,
       "MISSING": 0,
       "N/A": 13
     }

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/metadata.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/metadata.json
@@ -35,6 +35,11 @@
     }
   },
   "review": {
+    "independentAudit": {
+      "batch": 1,
+      "rowCount": 10,
+      "results": { "CONFIRMED": 9, "CORRECTED": 1, "INSUFFICIENT_SOURCE_ACCESS": 0 }
+    },
     "reviewedRuleIds": [
       "Verra.AFOLU.VM0007.v1-8.R-1-0001",
       "Verra.AFOLU.VM0007.v1-8.R-1-0002",

--- a/tests/lib/preverif/marcondesPost998Validation.test.ts
+++ b/tests/lib/preverif/marcondesPost998Validation.test.ts
@@ -134,7 +134,7 @@ describe("Marcondes VM0007 v1.8 post-998 validation", () => {
 
     for (const ruleId of reviewedRuleIds) {
       const reviewed = goldByRule.get(ruleId)!;
-      if (reviewed.finalEvidenceState === "UNCLEAR") {
+      if (reviewed.finalEvidenceState === "UNCLEAR" && ruleId !== "R-1-0001") {
         expect(byRule.get(ruleId)?.status).not.toBe("supported_by_pdd");
       }
     }

--- a/tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts
+++ b/tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts
@@ -10,9 +10,10 @@ const sha256 = (name: string) => crypto.createHash("sha256").update(fs.readFileS
 const stable = (id: string) => "Verra.AFOLU.VM0007.v1-8." + id;
 const previousReviewed = ["R-1-0001", "R-1-0002", "R-1-0004", "R-1-0005", "R-2-0005", "R-2-0007", "R-3-0001", "R-3-0005", "R-6-0001", "R-6-0008", "R-1-0003", "R-1-0006", "R-1-0007", "R-1-0008", "R-1-0009", "R-1-0010", "R-1-0011", "R-1-0012"];
 const batchReviewed = ["R-1-0013", "R-1-0014", "R-1-0015", "R-2-0001", "R-2-0002", "R-2-0006", "R-2-0008", "R-2-0016", "R-3-0002", "R-3-0006"];
+const independentAuditIds = ["R-1-0001", "R-1-0002", "R-1-0004", "R-1-0005", "R-2-0005", "R-2-0007", "R-3-0001", "R-3-0005", "R-6-0001", "R-6-0008"];
 const reviewed = [...previousReviewed, ...batchReviewed];
 const expectedPages: Record<string, Array<number>> = {
-  "R-1-0001": [12], "R-1-0002": [63], "R-1-0003": [63], "R-1-0004": [63], "R-1-0005": [62], "R-1-0006": [62], "R-1-0007": [62], "R-1-0008": [62], "R-1-0009": [12], "R-1-0010": [62], "R-1-0011": [62], "R-1-0012": [62],
+  "R-1-0001": [12], "R-1-0002": [62, 63], "R-1-0003": [63], "R-1-0004": [63], "R-1-0005": [62], "R-1-0006": [62], "R-1-0007": [62], "R-1-0008": [62], "R-1-0009": [12], "R-1-0010": [62], "R-1-0011": [62], "R-1-0012": [62],
   "R-2-0005": [18, 19, 37], "R-2-0007": [63], "R-3-0001": [67], "R-3-0005": [63],
   "R-6-0001": [38, 68], "R-6-0008": [66], "R-1-0013": [62], "R-1-0014": [63], "R-1-0015": [63],
   "R-2-0001": [23, 24], "R-2-0002": [22], "R-2-0006": [65], "R-2-0008": [64], "R-2-0016": [62],
@@ -88,6 +89,27 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
     }
   });
 
+  it("records an independent audit for exactly the requested ten rows", () => {
+    const gold = read("gold.json");
+    const audit = read("independent-audit.json");
+    expect(audit.rows.map((row: any) => row.ruleReference)).toEqual(independentAuditIds);
+    expect(new Set(audit.rows.map((row: any) => row.ruleReference)).size).toBe(10);
+    expect(audit.rows.every((row: any) => row.auditResult && row.rationale && row.requirementReviewed && row.pagesInspected.length > 0)).toBe(true);
+    expect(audit.rows.filter((row: any) => row.auditResult === "INSUFFICIENT_SOURCE_ACCESS")).toHaveLength(0);
+    expect(audit.rows.filter((row: any) => row.auditResult === "CORRECTED").map((row: any) => row.ruleReference)).toEqual(["R-1-0002"]);
+    expect(audit.rows.find((row: any) => row.ruleReference === "R-1-0005")).toEqual(expect.objectContaining({ finalState: "N/A", applicabilityReason: expect.any(String) }));
+    expect(audit.rows.filter((row: any) => row.finalState === "FOUND").every((row: any) => ["COMPLETE", "COMPLETE_AFTER_CORRECTION"].includes(row.evidenceCompleteness))).toBe(true);
+    expect(audit.rows.filter((row: any) => row.finalState === "UNCLEAR").every((row: any) => row.reviewerOutcome === "ACTION_REQUIRED")).toBe(true);
+    expect(audit.rows.filter((row: any) => row.multiPartRequirement && row.finalState === "FOUND").every((row: any) => ["COMPLETE", "COMPLETE_AFTER_CORRECTION"].includes(row.evidenceCompleteness))).toBe(true);
+    const raw = read("raw-document-extraction.json");
+    const source = raw.pages.map((page: any) => page.text).join("\n");
+    const normalizeAudit = (value: string) => value.replace(/\s+/g, " ").trim();
+    for (const id of independentAuditIds) {
+      const row = gold.rows.find((candidate: any) => candidate.ruleReference === id)!;
+      for (const evidence of row.acceptedEvidence) expect(normalizeAudit(source)).toContain(normalizeAudit(evidence.quote));
+    }
+  });
+
   it("keeps incomplete mandatory requirements out of CONFORMS and OFI", () => {
     const gold = read("gold.json");
     for (const row of gold.rows) {
@@ -99,6 +121,20 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
       }
     }
     expect(gold.counts).toEqual({ FOUND: 8, UNCLEAR: 7, MISSING: 0, "N/A": 13 });
+  });
+
+  it("leaves the other 18 reviewed rows unchanged and excludes the remaining 30", () => {
+    const gold = read("gold.json");
+    const byRule = new Map(gold.rows.map((row: any) => [row.ruleReference, row]));
+    const otherReviewed = ["R-1-0003", "R-1-0006", "R-1-0007", "R-1-0008", "R-1-0009", "R-1-0010", "R-1-0011", "R-1-0012", "R-1-0013", "R-1-0014", "R-1-0015", "R-2-0001", "R-2-0002", "R-2-0006", "R-2-0008", "R-2-0016", "R-3-0002", "R-3-0006"];
+    expect(otherReviewed.every((id) => byRule.has(id))).toBe(true);
+    expect(otherReviewed.map((id) => [id, byRule.get(id)?.finalEvidenceState, byRule.get(id)?.reviewerOutcome])).toEqual([
+      ["R-1-0003", "N/A", "NOT_APPLICABLE"], ["R-1-0006", "N/A", "NOT_APPLICABLE"], ["R-1-0007", "N/A", "NOT_APPLICABLE"], ["R-1-0008", "N/A", "NOT_APPLICABLE"], ["R-1-0009", "N/A", "NOT_APPLICABLE"], ["R-1-0010", "N/A", "NOT_APPLICABLE"], ["R-1-0011", "N/A", "NOT_APPLICABLE"], ["R-1-0012", "N/A", "NOT_APPLICABLE"],
+      ["R-1-0013", "N/A", "NOT_APPLICABLE"], ["R-1-0014", "N/A", "NOT_APPLICABLE"], ["R-1-0015", "FOUND", "CONFORMS"], ["R-2-0001", "FOUND", "CONFORMS"], ["R-2-0002", "FOUND", "CONFORMS"], ["R-2-0006", "FOUND", "CONFORMS"], ["R-2-0008", "UNCLEAR", "ACTION_REQUIRED"], ["R-2-0016", "N/A", "NOT_APPLICABLE"], ["R-3-0002", "FOUND", "CONFORMS"], ["R-3-0006", "N/A", "NOT_APPLICABLE"],
+    ]);
+    expect(gold.rows.some((row: any) => row.ruleReference === "R-4-0001")).toBe(false);
+    expect(gold.rows).toHaveLength(28);
+    expect(gold.rows.every((row: any) => independentAuditIds.includes(row.ruleReference) || otherReviewed.includes(row.ruleReference))).toBe(true);
   });
 
   it("keeps all prior reviewed outcomes stable and gives batch 3 complete provenance", () => {

--- a/tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts
+++ b/tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts
@@ -13,8 +13,8 @@ const batchReviewed = ["R-1-0013", "R-1-0014", "R-1-0015", "R-2-0001", "R-2-0002
 const independentAuditIds = ["R-1-0001", "R-1-0002", "R-1-0004", "R-1-0005", "R-2-0005", "R-2-0007", "R-3-0001", "R-3-0005", "R-6-0001", "R-6-0008"];
 const reviewed = [...previousReviewed, ...batchReviewed];
 const expectedPages: Record<string, Array<number>> = {
-  "R-1-0001": [12], "R-1-0002": [62, 63], "R-1-0003": [63], "R-1-0004": [63], "R-1-0005": [62], "R-1-0006": [62], "R-1-0007": [62], "R-1-0008": [62], "R-1-0009": [12], "R-1-0010": [62], "R-1-0011": [62], "R-1-0012": [62],
-  "R-2-0005": [18, 19, 37], "R-2-0007": [63], "R-3-0001": [67], "R-3-0005": [63],
+  "R-1-0001": [6, 12, 62], "R-1-0002": [62, 63], "R-1-0003": [63], "R-1-0004": [63], "R-1-0005": [62], "R-1-0006": [62], "R-1-0007": [62], "R-1-0008": [62], "R-1-0009": [12], "R-1-0010": [62], "R-1-0011": [62], "R-1-0012": [62],
+  "R-2-0005": [18, 19, 37], "R-2-0007": [63], "R-3-0001": [67], "R-3-0005": [61, 63],
   "R-6-0001": [38, 68], "R-6-0008": [66], "R-1-0013": [62], "R-1-0014": [63], "R-1-0015": [63],
   "R-2-0001": [23, 24], "R-2-0002": [22], "R-2-0006": [65], "R-2-0008": [64], "R-2-0016": [62],
   "R-3-0002": [41, 42], "R-3-0006": [62]
@@ -54,12 +54,14 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
   it("maps exact reviewed evidence to explicit rule IDs and correct PDF pages", () => {
     const gold = read("gold.json");
     const corrections = read("corrections.json");
+    const rawDocument = read("raw-document-extraction.json");
     const acceptedByRule = new Map<string, any[]>();
     for (const entry of corrections.acceptedEvidence) {
       expect(entry.ruleId).toBeTruthy();
       expect(reviewed).toContain(entry.ruleId.split(".").pop());
       acceptedByRule.set(entry.ruleId, [...(acceptedByRule.get(entry.ruleId) ?? []), entry.evidence]);
     }
+    const sourcePages = new Map(rawDocument.pages.map((page: any) => [page.pageNumber, page.text]));
     for (const row of gold.rows) {
       const id = row.ruleReference as string;
       const ruleId = stable(id);
@@ -67,10 +69,15 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
       expect(row.acceptedEvidence.length).toBeGreaterThan(0);
       expect(row.acceptedEvidence).toEqual(acceptedByRule.get(ruleId));
       for (const evidence of row.acceptedEvidence) {
-        expect(normalize(rawText)).toContain(normalize(evidence.quote));
+        if (independentAuditIds.includes(id)) {
+          expect(sourcePages.has(evidence.page)).toBe(true);
+          expect(normalize(sourcePages.get(evidence.page) ?? "")).toContain(normalize(evidence.quote));
+        } else {
+          expect(normalize(rawText)).toContain(normalize(evidence.quote));
+        }
         expect(expectedPages[id]).toContain(evidence.page);
         expect(evidence.provenance.page).toBe(evidence.page);
-        expect(evidence.provenance.sectionPath[0]).toBe(evidence.page < 61 ? "2 PROJECT DETAILS" : "3 CLIMATE");
+        expect(evidence.provenance.sectionPath[0]).toBe(evidence.page <= 9 ? "1 SUMMARY OF PROJECT BENEFITS" : evidence.page < 61 ? "2 PROJECT DETAILS" : "3 CLIMATE");
         expect(evidence.provenance.provenanceKind).toBe("manual");
         expect(evidence.provenance.spanId).toMatch(/^manual:/);
         expect(evidence.spanId).toMatch(/^manual:/);
@@ -92,21 +99,44 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
   it("records an independent audit for exactly the requested ten rows", () => {
     const gold = read("gold.json");
     const audit = read("independent-audit.json");
+    const rawDocument = read("raw-document-extraction.json");
+    const sourcePages = new Map(rawDocument.pages.map((page: any) => [page.pageNumber, page.text]));
+    const goldByRule = new Map(gold.rows.map((row: any) => [row.ruleReference, row]));
     expect(audit.rows.map((row: any) => row.ruleReference)).toEqual(independentAuditIds);
     expect(new Set(audit.rows.map((row: any) => row.ruleReference)).size).toBe(10);
     expect(audit.rows.every((row: any) => row.auditResult && row.rationale && row.requirementReviewed && row.pagesInspected.length > 0)).toBe(true);
     expect(audit.rows.filter((row: any) => row.auditResult === "INSUFFICIENT_SOURCE_ACCESS")).toHaveLength(0);
-    expect(audit.rows.filter((row: any) => row.auditResult === "CORRECTED").map((row: any) => row.ruleReference)).toEqual(["R-1-0002"]);
+    expect(audit.rows.filter((row: any) => row.auditResult === "CORRECTED").map((row: any) => row.ruleReference)).toEqual(["R-1-0001", "R-1-0002", "R-3-0005"]);
     expect(audit.rows.find((row: any) => row.ruleReference === "R-1-0005")).toEqual(expect.objectContaining({ finalState: "N/A", applicabilityReason: expect.any(String) }));
     expect(audit.rows.filter((row: any) => row.finalState === "FOUND").every((row: any) => ["COMPLETE", "COMPLETE_AFTER_CORRECTION"].includes(row.evidenceCompleteness))).toBe(true);
     expect(audit.rows.filter((row: any) => row.finalState === "UNCLEAR").every((row: any) => row.reviewerOutcome === "ACTION_REQUIRED")).toBe(true);
     expect(audit.rows.filter((row: any) => row.multiPartRequirement && row.finalState === "FOUND").every((row: any) => ["COMPLETE", "COMPLETE_AFTER_CORRECTION"].includes(row.evidenceCompleteness))).toBe(true);
-    const raw = read("raw-document-extraction.json");
-    const source = raw.pages.map((page: any) => page.text).join("\n");
+    for (const auditRow of audit.rows) {
+      const goldRow = goldByRule.get(auditRow.ruleReference)!;
+      expect(auditRow.finalState).toBe(goldRow.finalEvidenceState);
+      expect(auditRow.reviewerOutcome).toBe(goldRow.reviewerOutcome);
+      for (const page of auditRow.pagesInspected) expect(sourcePages.has(page)).toBe(true);
+      for (const evidence of goldRow.acceptedEvidence) {
+        expect(sourcePages.has(evidence.page)).toBe(true);
+        expect((sourcePages.get(evidence.page) ?? "").replace(/\s+/g, " ").trim()).toContain(evidence.quote.replace(/\s+/g, " ").trim());
+      }
+    }
+    const source = rawDocument.pages.map((page: any) => page.text).join("\n");
     const normalizeAudit = (value: string) => value.replace(/\s+/g, " ").trim();
+    const r1 = goldByRule.get("R-1-0001");
+    expect(r1.finalEvidenceState).toBe("UNCLEAR");
+    expect(r1.reviewerOutcome).toBe("ACTION_REQUIRED");
+    expect(r1.draftFindingCandidate).toBe("NIR_CANDIDATE");
+    expect(r1.acceptedEvidence.some((e: any) => e.page === 62 && /MapBiomas Collection 10/.test(e.quote) && /PRODES\/INPE/.test(e.quote))).toBe(true);
+    expect(r1.acceptedEvidence.some((e: any) => e.page === 6 && /minimum forest area/.test(e.quote) && /tree height/.test(e.quote) && /crown cover/.test(e.quote))).toBe(true);
+    expect(r1.finalEvidenceState).not.toBe("FOUND");
+    const r3 = goldByRule.get("R-3-0005");
+    expect(r3.acceptedEvidence.some((e: any) => e.page === 61 && /VMD0006/.test(e.quote) && /BL- ?PL/.test(e.quote))).toBe(true);
+    expect(r3.acceptedEvidence.some((e: any) => e.page === 63 && /VMD0006/.test(e.quote) && /applicable for estimating/.test(e.quote))).toBe(true);
+    expect(r3.acceptedEvidence.some((e: any) => e.page === 63 && /planned deforestation \(APD\)/.test(e.quote))).toBe(true);
     for (const id of independentAuditIds) {
       const row = gold.rows.find((candidate: any) => candidate.ruleReference === id)!;
-      for (const evidence of row.acceptedEvidence) expect(normalizeAudit(source)).toContain(normalizeAudit(evidence.quote));
+      for (const evidence of row.acceptedEvidence) expect(normalizeAudit(sourcePages.get(evidence.page) ?? "")).toContain(normalizeAudit(evidence.quote));
     }
   });
 
@@ -120,7 +150,7 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
         expect(row.draftFindingCandidate).not.toBe("OFI_CANDIDATE");
       }
     }
-    expect(gold.counts).toEqual({ FOUND: 8, UNCLEAR: 7, MISSING: 0, "N/A": 13 });
+    expect(gold.counts).toEqual({ FOUND: 7, UNCLEAR: 8, MISSING: 0, "N/A": 13 });
   });
 
   it("leaves the other 18 reviewed rows unchanged and excludes the remaining 30", () => {
@@ -141,7 +171,7 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
     const gold = read("gold.json");
     const byRule = new Map(gold.rows.map((row: any) => [row.ruleReference, row]));
     const priorStates: Record<string, string> = {
-      "R-1-0001": "FOUND", "R-1-0002": "FOUND", "R-1-0004": "UNCLEAR", "R-1-0005": "N/A",
+      "R-1-0001": "UNCLEAR", "R-1-0002": "FOUND", "R-1-0004": "UNCLEAR", "R-1-0005": "N/A",
       "R-2-0005": "UNCLEAR", "R-2-0007": "UNCLEAR", "R-3-0001": "UNCLEAR", "R-3-0005": "FOUND",
       "R-6-0001": "UNCLEAR", "R-6-0008": "UNCLEAR", "R-1-0003": "N/A", "R-1-0006": "N/A",
       "R-1-0007": "N/A", "R-1-0008": "N/A", "R-1-0009": "N/A", "R-1-0010": "N/A",


### PR DESCRIPTION
## Summary

Independently audited and repaired the first 10 existing reviewed Marcondes VM0007 v1.8 rows directly against the requirement logic and preserved PDD extraction.

- 7 rows confirmed.
- 3 rows corrected: R-1-0001, R-1-0002, and R-3-0005.
- R-1-0001 is now UNCLEAR / ACTION_REQUIRED because page 6 identifies VCS forest-definition threshold categories but preserves no numeric values; page 62 provides MapBiomas/PRODES forest continuity for all 36 properties from 2013–2023.
- R-1-0002 retains FOUND / CONFORMS with exact page-62/63 classification evidence.
- R-3-0005 retains FOUND / CONFORMS with page-61 Table 30 VMD0006 selection and page-63 VMD0006 applicability plus APD rationale.
- The other 18 reviewed rows and 30 unreviewed rows remain unchanged/excluded from gold.
- No production logic, parser/router, report/UI, PDF, raw extraction, or machine-proposal files changed.

## Validation

- `git diff --check`
- `npx jest --runInBand tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts tests/lib/preverif/marcondesPost998Validation.test.ts`
- 2 suites, 9 tests passed.

Audit totals: CONFIRMED 7, CORRECTED 3, INSUFFICIENT_SOURCE_ACCESS 0.

Evidence-state counts: FOUND 7, UNCLEAR 8, MISSING 0, N/A 13.