### PR TITLE
test: review next Marcondes truth batch

### DIFF
--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/REVIEW.md
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/REVIEW.md
@@ -14,6 +14,8 @@ The next reviewed rows are exactly R-2-0003, R-2-0004, R-2-0009, R-2-0010, R-2-0
 
 The independent-audit fixture remains exactly 28 rows and is unchanged. The remaining 20 rows remain excluded from gold and NOT_ASSESSED. Raw extraction, machine proposals, methodology contracts, audit logic, production logic, report UI, and release gates were not changed.
 
+The ten new gold rows preserve their original machine-proposal row objects verbatim; reviewed truth and rejected evidence are recorded separately. Methodology traceability uses verbatim official excerpts and separately lists mandatory modules/tools. R-2-0014 is FOUND/CONFORMS: three PDD locations consistently establish 01 May 2023–30 April 2063, 40 years; the client action is retention-only.
+
 VM0007 v1.8 is version-qualified. The page 61 Section 3.1.1 VM0007 v1.7 wording remains a visible drafting contradiction; Table 30 and repeated project declarations identify v1.8. Version reconciliation is complete. Gold and report release remain blocked because review coverage is incomplete.
 
 Accepted evidence for pages 12, 18–19, and 38 is located under 2 PROJECT DETAILS. Accepted evidence for pages 62–66 is located under 3 CLIMATE. Manually adjudicated evidence uses explicit manual:... provenance IDs; no fabricated parser element IDs are used.

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/REVIEW.md
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/REVIEW.md
@@ -1,12 +1,18 @@
 # Marcondes REDD+ VM0007 v1.8 Evidence Map truth intake
 
-- Reviewed rows: 28 of 58
-- Remaining rows: 30, unreviewed and NOT_ASSESSED
-- Corrected evidence states: FOUND 4, UNCLEAR 11, MISSING 0, N/A 13
-- Reviewer outcomes: CONFORMS 4, ACTION_REQUIRED 11, NOT_APPLICABLE 13, NOT_ASSESSED 30
-- Draft findings: NIR_CANDIDATE 11, OFI_CANDIDATE 0, NCR_CANDIDATE 0, null for reviewed N/A and remaining rows
+- Reviewed rows: 38 of 58
+- Remaining rows: 20, unreviewed and NOT_ASSESSED
+- Corrected evidence states: FOUND 5, UNCLEAR 16, MISSING 0, N/A 17
+- Reviewer outcomes: CONFORMS 5, ACTION_REQUIRED 16, NOT_APPLICABLE 17, NOT_ASSESSED 20
+- Draft findings: NIR_CANDIDATE 16, OFI_CANDIDATE 0, NCR_CANDIDATE 0, null for reviewed N/A and remaining rows
 - Gold promotion: BLOCKED_PENDING_REVIEW_COVERAGE
 - Report release state: BLOCKED_PENDING_REVIEW_COVERAGE
+
+## First-review truth intake: next 10
+
+The next reviewed rows are exactly R-2-0003, R-2-0004, R-2-0009, R-2-0010, R-2-0011, R-2-0012, R-2-0013, R-2-0014, R-2-0015, and R-3-0003. R-2-0004 is N/A because reference regions are the AUDef pathway; Marcondes is APD using BL-PL. R-2-0009, R-2-0011, and R-2-0015 independently resolve WRC applicability as N/A from the APD classification and the project statement that no peat soils or tidal wetlands are present. R-2-0014 is FOUND/CONFORMS with a consistent 40-year period from 01 May 2023 through 30 April 2063. R-2-0003, R-2-0010, R-2-0012, R-2-0013, and R-3-0003 remain UNCLEAR/ACTION_REQUIRED because declarations or module references do not supply every mandatory project-specific component.
+
+The independent-audit fixture remains exactly 28 rows and is unchanged. The remaining 20 rows remain excluded from gold and NOT_ASSESSED. Raw extraction, machine proposals, methodology contracts, audit logic, production logic, report UI, and release gates were not changed.
 
 VM0007 v1.8 is version-qualified. The page 61 Section 3.1.1 VM0007 v1.7 wording remains a visible drafting contradiction; Table 30 and repeated project declarations identify v1.8. Version reconciliation is complete. Gold and report release remain blocked because review coverage is incomplete.
 

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/corrections.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/corrections.json
@@ -2566,70 +2566,70 @@
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The page-59 declarations address no double issuance, registration, activity, and rejection, but do not establish parcel-level registry records, geographic overlap checks, partial-overlap treatment, or monitoring coverage required by VM0007 §5.1.1."
       }
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Reference-region requirements are triggered by AUDef/avoiding unplanned deforestation; this project is APD and uses the BL-PL pathway."
+        "correction": "Correctly N/A: VM0007 §5.1.2 assigns a reference region to avoiding unplanned deforestation, while the project-specific evidence identifies APD and the BL-PL pathway."
       }
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
-        "correction": "Requirement and applicability were reviewed before machine evidence. WRC pool rules require a WRC substrate/activity; §4.2.1(2) triggers WRC modules where project land is peatland or tidal wetlands with significant SOC emissions."
+        "correction": "Correctly N/A: the APD project-specific classification and the separate no-peat/no-tidal statement show that the WRC carbon-pool pathway is not triggered."
       }
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The accepted fire/module evidence does not provide the complete Table 7 source decisions, significance treatment, or project-specific baseline/project/leakage accounting required by §5.4.1–5.4.2."
       }
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
-        "correction": "Requirement and applicability were reviewed before machine evidence. WRC source rules require a WRC activity/substrate; §4.2.1(2) triggers WRC modules only for peatland or tidal-wetland land with significant SOC emissions."
+        "correction": "Correctly N/A independently of R-2-0009: the WRC GHG-source trigger is absent because the project is APD and the PDD states that no peat soils or tidal wetlands are present."
       }
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The accepted evidence explicitly reaches baseline/project/leakage consistency, but the PDD does not provide the source-by-source matrix needed to resolve whether each applicable source is treated consistently; UNCLEAR/ACTION_REQUIRED remains."
       }
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The PDD records 2013–2023 and separately records a 01 May 2023 crediting-period start, but does not establish exact calendar start/end dates, permitted data-gap treatment, or the proxy/reference-region relationship required to resolve the historical period; UNCLEAR/ACTION_REQUIRED remains."
       }
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The three cited PDD locations consistently establish a 40-year crediting period from 01 May 2023 through 30 April 2063; the 20–100-year duration requirement is satisfied."
       }
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
-        "correction": "Requirement and applicability were reviewed before machine evidence. The 100-year SOC test is a WRC project-area/substrate requirement, triggered only for WRC activities; this project is APD with no peat soils or tidal wetlands."
+        "correction": "Correctly N/A independently of the other WRC rows: the APD classification and no-peat/no-tidal evidence show that the WRC 100-year SOC pathway is not triggered."
       }
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The accepted assertion identifies a stepwise additionality process but does not identify the selected barrier path, barrier categories, supporting evidence, or differential effect on alternatives required by VM0007/VT0001; UNCLEAR/ACTION_REQUIRED remains."
       }
     }
   ],

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/corrections.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/corrections.json
@@ -28,7 +28,17 @@
     "Verra.AFOLU.VM0007.v1-8.R-2-0008",
     "Verra.AFOLU.VM0007.v1-8.R-2-0016",
     "Verra.AFOLU.VM0007.v1-8.R-3-0002",
-    "Verra.AFOLU.VM0007.v1-8.R-3-0006"
+    "Verra.AFOLU.VM0007.v1-8.R-3-0006",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+    "Verra.AFOLU.VM0007.v1-8.R-3-0003"
   ],
   "acceptedEvidence": [
     {
@@ -1022,6 +1032,530 @@
           "provenanceKind": "manual"
         }
       }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+        "quote": "2.5.13.1 No Double Issuance\nIs the project receiving or seeking credit for reductions and removals from a project activity under another GHG program, or any other form of community, social, or biodiversity unit or credit?\n☐ Yes ☒ No",
+        "page": 59,
+        "section": "2 PROJECT DETAILS > 2.5 Legal Status and Property Rights > 2.5.13 Double Counting and Participation under Other GHG Programs",
+        "spanId": "manual:marcondes-pdd:page-59:r-r-2-0003-no-double-issuance",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 59,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "2.5 Legal Status and Property Rights",
+            "2.5.13 Double Counting and Participation under Other GHG Programs"
+          ],
+          "spanId": "manual:marcondes-pdd:page-59:no-double-issuance",
+          "sectionHeading": "2.5.13 Double Counting and Participation under Other GHG Programs",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+        "quote": "2.5.13.2 Registration in Other GHG Programs\nHas the project registered under any other GHG programs?\n☐ Yes ☒ No\nIs the project active under the other program?\n☐ Yes ☒ No",
+        "page": 59,
+        "section": "2 PROJECT DETAILS > 2.5 Legal Status and Property Rights > 2.5.13 Double Counting and Participation under Other GHG Programs",
+        "spanId": "manual:marcondes-pdd:page-59:r-r-2-0003-registration",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 59,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "2.5 Legal Status and Property Rights",
+            "2.5.13 Double Counting and Participation under Other GHG Programs"
+          ],
+          "spanId": "manual:marcondes-pdd:page-59:registration",
+          "sectionHeading": "2.5.13 Double Counting and Participation under Other GHG Programs",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+        "quote": "2.5.13.3 Projects Rejected by Other GHG Programs\nHas the project been rejected by any other GHG programs?\n☐ Yes ☒ No",
+        "page": 59,
+        "section": "2 PROJECT DETAILS > 2.5 Legal Status and Property Rights > 2.5.13 Double Counting and Participation under Other GHG Programs",
+        "spanId": "manual:marcondes-pdd:page-59:r-r-2-0003-rejected",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 59,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "2.5 Legal Status and Property Rights",
+            "2.5.13 Double Counting and Participation under Other GHG Programs"
+          ],
+          "spanId": "manual:marcondes-pdd:page-59:rejected",
+          "sectionHeading": "2.5.13 Double Counting and Participation under Other GHG Programs",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+        "quote": "Project activity type Avoiding Planned Deforestation (APD)",
+        "page": 12,
+        "section": "2 PROJECT DETAILS > 2.1.3 Sectoral Scope and Project Type",
+        "spanId": "manual:marcondes-pdd:page-12:r-r-2-0004-apd",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 12,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "2.1.3 Sectoral Scope and Project Type"
+          ],
+          "spanId": "manual:marcondes-pdd:page-12:apd",
+          "sectionHeading": "2.1.3 Sectoral Scope and Project Type",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+        "quote": "Table 30. Methodologies, modules, and tools applied\nType Reference ID Title Version\nApplied\nMethodology\nVM0007 REDD+ Methodology Framework (REDD+MF)\n(Avoided Planned Deforestation)\n1.8",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1), Table 30. Methodologies, modules, and tools applied",
+        "spanId": "manual:marcondes-pdd:page-61:r-r-2-0004-table-30",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1), Table 30. Methodologies, modules, and tools applied"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:table-30",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1), Table 30. Methodologies, modules, and tools applied",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+        "quote": "Project activity type Avoiding Planned Deforestation (APD)",
+        "page": 12,
+        "section": "2 PROJECT DETAILS > 2.1.3 Sectoral Scope and Project Type",
+        "spanId": "manual:marcondes-pdd:page-12:r-r-2-0009-apd",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 12,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "2.1.3 Sectoral Scope and Project Type"
+          ],
+          "spanId": "manual:marcondes-pdd:page-12:apd",
+          "sectionHeading": "2.1.3 Sectoral Scope and Project Type",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+        "quote": "There are no peat soils and tidal wetlands present in the Marcondes REDD+ Project Area.",
+        "page": 62,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+        "spanId": "manual:marcondes-pdd:page-62:r-r-2-0009-no-peat-no-tidal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 62,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+          ],
+          "spanId": "manual:marcondes-pdd:page-62:no-peat-no-tidal",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+        "quote": "VMD0013 v1.3 This module is applicable to REDD project activities with emissions from biomass burning and REDD-WRC project activities with emissions from biomass and/or peat burning. This module is also applicable to RWE and ARR-RWE project activities with emissions from peat burning. In the baseline scenario, fire is used to clear land, resulting in emissions of CO2, N2O and CH4.",
+        "page": 65,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+        "spanId": "manual:marcondes-pdd:page-65:r-r-2-0010-vmd0013",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 65,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+          ],
+          "spanId": "manual:marcondes-pdd:page-65:vmd0013",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+        "quote": "This section is not required at the Under Development stage in accordance with Section 3.1.6 of the Verra Registration and Issuance Process v5.0. The relevant information will be provided during the validation stage of the project.",
+        "page": 68,
+        "section": "3 CLIMATE > 3.2 Quantification of Estimated GHG Emission Reductions and Removals > 3.2.1 Baseline Emissions (VCS, 3.15)",
+        "spanId": "manual:marcondes-pdd:page-68:r-r-2-0010-deferred",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 68,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.2 Quantification of Estimated GHG Emission Reductions and Removals",
+            "3.2.1 Baseline Emissions (VCS, 3.15)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-68:deferred",
+          "sectionHeading": "3.2.1 Baseline Emissions (VCS, 3.15)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+        "quote": "Project activity type Avoiding Planned Deforestation (APD)",
+        "page": 12,
+        "section": "2 PROJECT DETAILS > 2.1.3 Sectoral Scope and Project Type",
+        "spanId": "manual:marcondes-pdd:page-12:r-r-2-0011-apd",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 12,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "2.1.3 Sectoral Scope and Project Type"
+          ],
+          "spanId": "manual:marcondes-pdd:page-12:apd",
+          "sectionHeading": "2.1.3 Sectoral Scope and Project Type",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+        "quote": "There are no peat soils and tidal wetlands present in the Marcondes REDD+ Project Area.",
+        "page": 62,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+        "spanId": "manual:marcondes-pdd:page-62:r-r-2-0011-no-peat-no-tidal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 62,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+          ],
+          "spanId": "manual:marcondes-pdd:page-62:no-peat-no-tidal",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+        "quote": "The module is mandatory if the BL-PL Module is used to define the baseline, and the applicability conditions in the BL-PL Module must be met in full.",
+        "page": 64,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+        "spanId": "manual:marcondes-pdd:page-64:r-r-2-0012-bl-pl",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 64,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+          ],
+          "spanId": "manual:marcondes-pdd:page-64:bl-pl",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+        "quote": "When used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt.",
+        "page": 65,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+        "spanId": "manual:marcondes-pdd:page-65:r-r-2-0012-consistency",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 65,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+          ],
+          "spanId": "manual:marcondes-pdd:page-65:consistency",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+        "quote": "This section is not required at the Under Development stage in accordance with Section 3.1.6 of the Verra Registration and Issuance Process v5.0. The relevant information will be provided during the validation stage of the project.",
+        "page": 68,
+        "section": "3 CLIMATE > 3.2 Quantification of Estimated GHG Emission Reductions and Removals > 3.2.1 Baseline Emissions (VCS, 3.15)",
+        "spanId": "manual:marcondes-pdd:page-68:r-r-2-0012-deferred",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 68,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.2 Quantification of Estimated GHG Emission Reductions and Removals",
+            "3.2.1 Baseline Emissions (VCS, 3.15)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-68:deferred",
+          "sectionHeading": "3.2.1 Baseline Emissions (VCS, 3.15)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+        "quote": "MapBiomas Collection 10 and PRODES/INPE data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). Annual LULC maps demonstrate Dense Ombrophilous Forest classification without interruption.",
+        "page": 62,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+        "spanId": "manual:marcondes-pdd:page-62:r-r-2-0013-historical-2013-2023",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 62,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+          ],
+          "spanId": "manual:marcondes-pdd:page-62:historical-2013-2023",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+        "quote": "The initial crediting period start date for the Marcondes REDD+ Project is 01 May 2023",
+        "page": 15,
+        "section": "2 PROJECT DETAILS > Project Crediting Period and Registration Timelines > 3.8.1",
+        "spanId": "manual:marcondes-pdd:page-15:r-r-2-0013-crediting-start",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 15,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "Project Crediting Period and Registration Timelines",
+            "3.8.1"
+          ],
+          "spanId": "manual:marcondes-pdd:page-15:crediting-start",
+          "sectionHeading": "3.8.1",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+        "quote": "Crediting period 01 May 2023 – 30 April 2063\nProject lifetime 01 May 2023 – 30 April 2063, 40 years",
+        "page": 1,
+        "section": "1 SUMMARY OF PROJECT BENEFITS",
+        "spanId": "manual:marcondes-pdd:page-1:r-r-2-0014-cover-period",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "1 SUMMARY OF PROJECT BENEFITS"
+          ],
+          "spanId": "manual:marcondes-pdd:page-1:cover-period",
+          "sectionHeading": "1 SUMMARY OF PROJECT BENEFITS",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+        "quote": "The crediting period for the present project is 40 years, spanning 01 May 2023 to 30 April 2063.",
+        "page": 16,
+        "section": "2 PROJECT DETAILS > Project Crediting Period and Registration Timelines > Project Crediting Period Length > 3.8.4",
+        "spanId": "manual:marcondes-pdd:page-16:r-r-2-0014-period-length",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 16,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "Project Crediting Period and Registration Timelines",
+            "Project Crediting Period Length",
+            "3.8.4"
+          ],
+          "spanId": "manual:marcondes-pdd:page-16:period-length",
+          "sectionHeading": "3.8.4",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+        "quote": "The project crediting period spans 40 years, from 01 May 2023 to 30 April 2063.",
+        "page": 10,
+        "section": "2 PROJECT DETAILS > 2.1 Project Goals, Design and Long-Term Viability > 2.1.1 Summary Description of the Project",
+        "spanId": "manual:marcondes-pdd:page-10:r-r-2-0014-summary-period",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 10,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "2.1 Project Goals, Design and Long-Term Viability",
+            "2.1.1 Summary Description of the Project"
+          ],
+          "spanId": "manual:marcondes-pdd:page-10:summary-period",
+          "sectionHeading": "2.1.1 Summary Description of the Project",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+        "quote": "Project activity type Avoiding Planned Deforestation (APD)",
+        "page": 12,
+        "section": "2 PROJECT DETAILS > 2.1.3 Sectoral Scope and Project Type",
+        "spanId": "manual:marcondes-pdd:page-12:r-r-2-0015-apd",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 12,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "2.1.3 Sectoral Scope and Project Type"
+          ],
+          "spanId": "manual:marcondes-pdd:page-12:apd",
+          "sectionHeading": "2.1.3 Sectoral Scope and Project Type",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+        "quote": "There are no peat soils and tidal wetlands present in the Marcondes REDD+ Project Area.",
+        "page": 62,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+        "spanId": "manual:marcondes-pdd:page-62:r-r-2-0015-no-peat-no-tidal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 62,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+          ],
+          "spanId": "manual:marcondes-pdd:page-62:no-peat-no-tidal",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+        "quote": "The determination of the baseline scenario and additionality follows the stepwise procedures outlined in the applicable methodology.",
+        "page": 66,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+        "spanId": "manual:marcondes-pdd:page-66:r-r-3-0003-stepwise-assertion",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 66,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+          ],
+          "spanId": "manual:marcondes-pdd:page-66:stepwise-assertion",
+          "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+        "quote": "3.5.5 The determination of baseline scenario and demonstration of additionality for an eligibility area shall:\n• be based on the initial project activity instances.\n• apply across the entire eligibility area.",
+        "page": 18,
+        "section": "2 PROJECT DETAILS > 2.1 Project Goals, Design and Long-Term Viability > 3.5.5",
+        "spanId": "manual:marcondes-pdd:page-18:r-r-3-0003-grouped-scope",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 18,
+          "sectionPath": [
+            "2 PROJECT DETAILS",
+            "2.1 Project Goals, Design and Long-Term Viability",
+            "3.5.5"
+          ],
+          "spanId": "manual:marcondes-pdd:page-18:grouped-scope",
+          "sectionHeading": "3.5.5",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        }
+      }
     }
   ],
   "rejectedEvidence": [
@@ -1592,6 +2126,236 @@
         },
         "rejectionReason": "stitched or paraphrased quote; wrong page or section; qualifying evidence missed; machine evidence was not project-specific or complete enough for truth intake"
       }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        },
+        "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        },
+        "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        },
+        "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        },
+        "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        },
+        "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        },
+        "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        },
+        "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        },
+        "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        },
+        "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+      "evidence": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+        "page": 61,
+        "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 61,
+          "sectionPath": [
+            "3 CLIMATE",
+            "3.1 Application of Methodology",
+            "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+          ],
+          "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+          "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "sourceType": "PDD",
+          "provenanceKind": "manual"
+        },
+        "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+      }
     }
   ],
   "reviewerCorrections": [
@@ -1796,6 +2560,76 @@
       "correction": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0006",
         "correction": "The blind audit confirms N/A/NOT_APPLICABLE. The substrate/activity-dependent WRC module-selection trigger is absent because page 62 states that no peat soils or tidal wetlands are present and the project is APD REDD."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+      "correction": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+      "correction": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Reference-region requirements are triggered by AUDef/avoiding unplanned deforestation; this project is APD and uses the BL-PL pathway."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+      "correction": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+        "correction": "Requirement and applicability were reviewed before machine evidence. WRC pool rules require a WRC substrate/activity; §4.2.1(2) triggers WRC modules where project land is peatland or tidal wetlands with significant SOC emissions."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+      "correction": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+      "correction": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+        "correction": "Requirement and applicability were reviewed before machine evidence. WRC source rules require a WRC activity/substrate; §4.2.1(2) triggers WRC modules only for peatland or tidal-wetland land with significant SOC emissions."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+      "correction": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+      "correction": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+      "correction": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+      "correction": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+        "correction": "Requirement and applicability were reviewed before machine evidence. The 100-year SOC test is a WRC project-area/substrate requirement, triggered only for WRC activities; this project is APD with no peat soils or tidal wetlands."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+      "correction": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
       }
     }
   ],

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json
@@ -2388,19 +2388,72 @@
       "requirement": "All land areas registered under any other GHG program must be transparently reported and excluded from the project area; exclusion must be monitored and reported. VM0007 v1.8 §5.1.1, p.18.",
       "reviewStatus": "REVIEWED",
       "machineProposal": {
-        "evidenceState": "FOUND",
-        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "rowId": "marcondes-redd-5953-vm0007-v18-evidence-map:Verra.AFOLU.VM0007.v1-8.R-2-0003",
+        "auditId": "marcondes-redd-5953-vm0007-v18-evidence-map",
+        "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+        "ruleReference": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+        "ruleTitle": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+        "requirementText": "Double-counting prevention. Must track and report exclusions.",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "v1.8",
+        "rawAuditStatus": "supported_by_pdd",
+        "upstreamStatus": "FOUND",
+        "proposedEvidenceStatus": "FOUND",
+        "proposedApplicability": "APPLICABLE",
+        "proposedAcceptedEvidence": {
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "Application of Methodology"
+            ],
+            "spanId": "quick-check-review-question:element:paragraph:3.1",
+            "sectionHeading": "Application of Methodology",
+            "sourceType": "PDD"
+          }
+        },
+        "proposedRejectedEvidence": null,
+        "assessmentReason": "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
+        "gap": "",
+        "clientAction": "Add the mapped boundary, time-boundary details, and the project-specific justification for the geography or period used in this rule.",
+        "confidence": "high",
+        "searchCoverage": {
+          "searched": true,
+          "searchedDocumentIds": [
+            "quick-check-review-question"
+          ],
+          "notes": "VM0007 Quick Check audit search coverage."
+        },
+        "sourceDocument": {
+          "documentId": "quick-check-review-question",
+          "documentName": "5953-Marcondes-Brazil-pdd.pdf",
+          "contentSha256": "a28e013ddbb4522b93ec954e2f9ca950b5fb906d6ead708e2cc11d829a3e37ea"
+        },
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
         "page": 1,
-        "section": "machine proposal",
+        "section": "Application of Methodology",
+        "spanId": "quick-check-review-question:element:paragraph:3.1",
         "provenance": {
           "docId": "quick-check-review-question",
           "page": 1,
           "sectionPath": [
-            "machine proposal"
+            "Application of Methodology"
           ],
-          "spanId": "machine-proposal-post-999-review-candidate",
-          "sourceType": "MACHINE_PROPOSAL"
-        }
+          "spanId": "quick-check-review-question:element:paragraph:3.1",
+          "sectionHeading": "Application of Methodology",
+          "sourceType": "PDD"
+        },
+        "finalizationState": "draft",
+        "reviewState": "pending review",
+        "reviewHistory": [],
+        "rowVersion": 1,
+        "finalizationActorRef": null,
+        "finalizedAt": null,
+        "finalizationBasis": null,
+        "reviewHistoryRef": null,
+        "proposalSource": "VM0007_QUICK_CHECK_AUDIT",
+        "proposalTimestamp": "2026-07-12T00:00:00.000Z"
       },
       "acceptedEvidence": [
         {
@@ -2488,19 +2541,28 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The page-59 declarations address no double issuance, registration, activity, and rejection, but do not establish parcel-level registry records, geographic overlap checks, partial-overlap treatment, or monitoring coverage required by VM0007 §5.1.1."
       },
       "finalEvidenceState": "UNCLEAR",
       "reviewerOutcome": "ACTION_REQUIRED",
-      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "clientAction": "Provide project- and parcel-level registry searches or records, identifiers, geographic overlap checks, treatment of any partial overlap, and monitoring evidence covering all project areas.",
       "draftFindingCandidate": "NIR_CANDIDATE",
       "contradictionState": "NONE_IDENTIFIED",
       "methodologyTraceability": {
-        "methodology": "VM0007 v1.8",
+        "methodology": "VM0007 REDD+ Methodology Framework",
         "version": "v1.8",
-        "section": "5.1.1",
+        "section": "5.1.1 General",
         "methodologyPage": 18,
-        "officialRequirementQuote": "All land areas registered under any other GHG program must be transparently reported and excluded from the project area; exclusion must be monitored and reported. VM0007 v1.8 §5.1.1, p.18."
+        "officialRequirementQuote": "All land areas registered under any other GHG program must be transparently reported and excluded from the project area. The exclusion of land in the project area from any other GHG program must be monitored over time and reported in the monitoring reports.",
+        "components": [
+          [
+            "VM0007 REDD+ Methodology Framework",
+            "v1.8",
+            "5.1.1 General",
+            "All land areas registered under any other GHG program must be transparently reported and excluded from the project area."
+          ]
+        ],
+        "plainLanguageSummary": "Declarations are relevant but incomplete for the all-areas exclusion and monitoring requirement."
       }
     },
     {
@@ -2509,19 +2571,72 @@
       "requirement": "For REDD, APD uses project and proxy areas; a reference region is the AUDef pathway and uses BL-UP. VM0007 v1.8 §5.1.2, p.18.",
       "reviewStatus": "REVIEWED",
       "machineProposal": {
-        "evidenceState": "FOUND",
-        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "rowId": "marcondes-redd-5953-vm0007-v18-evidence-map:Verra.AFOLU.VM0007.v1-8.R-2-0004",
+        "auditId": "marcondes-redd-5953-vm0007-v18-evidence-map",
+        "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+        "ruleReference": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+        "ruleTitle": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+        "requirementText": "RRD required for baseline modeling. Must be in same jurisdiction with similar characteristics.",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "v1.8",
+        "rawAuditStatus": "supported_by_pdd",
+        "upstreamStatus": "FOUND",
+        "proposedEvidenceStatus": "FOUND",
+        "proposedApplicability": "APPLICABLE",
+        "proposedAcceptedEvidence": {
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "Application of Methodology"
+            ],
+            "spanId": "quick-check-review-question:element:paragraph:3.1",
+            "sectionHeading": "Application of Methodology",
+            "sourceType": "PDD"
+          }
+        },
+        "proposedRejectedEvidence": null,
+        "assessmentReason": "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
+        "gap": "",
+        "clientAction": "Add the mapped boundary, time-boundary details, and the project-specific justification for the geography or period used in this rule.",
+        "confidence": "high",
+        "searchCoverage": {
+          "searched": true,
+          "searchedDocumentIds": [
+            "quick-check-review-question"
+          ],
+          "notes": "VM0007 Quick Check audit search coverage."
+        },
+        "sourceDocument": {
+          "documentId": "quick-check-review-question",
+          "documentName": "5953-Marcondes-Brazil-pdd.pdf",
+          "contentSha256": "a28e013ddbb4522b93ec954e2f9ca950b5fb906d6ead708e2cc11d829a3e37ea"
+        },
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
         "page": 1,
-        "section": "machine proposal",
+        "section": "Application of Methodology",
+        "spanId": "quick-check-review-question:element:paragraph:3.1",
         "provenance": {
           "docId": "quick-check-review-question",
           "page": 1,
           "sectionPath": [
-            "machine proposal"
+            "Application of Methodology"
           ],
-          "spanId": "machine-proposal-post-999-review-candidate",
-          "sourceType": "MACHINE_PROPOSAL"
-        }
+          "spanId": "quick-check-review-question:element:paragraph:3.1",
+          "sectionHeading": "Application of Methodology",
+          "sourceType": "PDD"
+        },
+        "finalizationState": "draft",
+        "reviewState": "pending review",
+        "reviewHistory": [],
+        "rowVersion": 1,
+        "finalizationActorRef": null,
+        "finalizedAt": null,
+        "finalizationBasis": null,
+        "reviewHistoryRef": null,
+        "proposalSource": "VM0007_QUICK_CHECK_AUDIT",
+        "proposalTimestamp": "2026-07-12T00:00:00.000Z"
       },
       "acceptedEvidence": [
         {
@@ -2588,20 +2703,42 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Reference-region requirements are triggered by AUDef/avoiding unplanned deforestation; this project is APD and uses the BL-PL pathway."
+        "correction": "Correctly N/A: VM0007 §5.1.2 assigns a reference region to avoiding unplanned deforestation, while the project-specific evidence identifies APD and the BL-PL pathway."
       },
       "finalEvidenceState": "N/A",
       "reviewerOutcome": "NOT_APPLICABLE",
-      "clientAction": "Retain the cited project classification and applicability evidence; reassess if project scope changes.",
+      "clientAction": "Retain the APD classification and BL-PL pathway; a reference region is not applicable unless the project adds an AUDef activity.",
       "draftFindingCandidate": null,
       "contradictionState": "NONE_IDENTIFIED",
       "methodologyTraceability": {
-        "methodology": "VM0007 / VMD0006",
+        "methodology": "VM0007 REDD+ Methodology Framework",
         "version": "v1.8",
-        "section": "5.1.2; BL-PL",
+        "section": "5.1.2 REDD",
         "methodologyPage": 18,
-        "officialRequirementQuote": "For REDD, APD uses project and proxy areas; a reference region is the AUDef pathway and uses BL-UP. VM0007 v1.8 §5.1.2, p.18."
-      }
+        "officialRequirementQuote": "In REDD project activities, various kinds of boundaries must be distinguished, depending on the REDD category (planned or unplanned deforestation, forest degradation), i.e., in case of:\n1) Avoiding planned deforestation: project area and proxy area(s). Refer to Module BL-PL for the detailed procedures to define these boundaries.\n2) Avoiding unplanned deforestation: project area, reference region, and leakage belt. Refer to Module BL-UP for definitions and the detailed procedures to define these boundaries.",
+        "components": [
+          [
+            "VM0007 REDD+ Methodology Framework",
+            "v1.8",
+            "5.1.2 REDD",
+            "In REDD project activities, various kinds of boundaries must be distinguished, depending on the REDD category."
+          ],
+          [
+            "VMD0006 Estimation of baseline carbon stock changes and greenhouse gas emissions from planned deforestation/forest degradation and planned wetland degradation (BL-PL)",
+            "v1.4",
+            "APD boundary procedures",
+            ""
+          ],
+          [
+            "VMD0007 Estimation of baseline carbon stock changes and greenhouse gas emissions from unplanned deforestation and unplanned wetland degradation (BL-UP)",
+            "v3.3",
+            "AUDef reference-region procedures",
+            ""
+          ]
+        ]
+      },
+      "applicabilityTrigger": "The reference-region pathway is triggered by AUDef/avoiding unplanned deforestation; the PDD identifies APD and VMD0006/BL-PL instead.",
+      "applicabilityReason": "Page 12 identifies APD and page 61 Table 30 identifies planned deforestation with VM0007; therefore the AUDef reference-region pathway does not apply."
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
@@ -2609,19 +2746,72 @@
       "requirement": "For WRC, Table 6 carbon pools must be selected and justified; belowground biomass and soil are included and other pools follow the table. VM0007 v1.8 §5.3.3, pp.21–22.",
       "reviewStatus": "REVIEWED",
       "machineProposal": {
-        "evidenceState": "FOUND",
-        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "rowId": "marcondes-redd-5953-vm0007-v18-evidence-map:Verra.AFOLU.VM0007.v1-8.R-2-0009",
+        "auditId": "marcondes-redd-5953-vm0007-v18-evidence-map",
+        "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+        "ruleReference": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+        "ruleTitle": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+        "requirementText": "WRC focuses on SOC pool. Biomass pools excluded unless ARR applies.",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "v1.8",
+        "rawAuditStatus": "supported_by_pdd",
+        "upstreamStatus": "FOUND",
+        "proposedEvidenceStatus": "FOUND",
+        "proposedApplicability": "APPLICABLE",
+        "proposedAcceptedEvidence": {
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "Application of Methodology"
+            ],
+            "spanId": "quick-check-review-question:element:paragraph:3.1",
+            "sectionHeading": "Application of Methodology",
+            "sourceType": "PDD"
+          }
+        },
+        "proposedRejectedEvidence": null,
+        "assessmentReason": "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
+        "gap": "",
+        "clientAction": "State whether the project includes WRC, peatland, or tidal wetland activities and cite the boundary, hydrology, and soil evidence supporting that scope decision.",
+        "confidence": "high",
+        "searchCoverage": {
+          "searched": true,
+          "searchedDocumentIds": [
+            "quick-check-review-question"
+          ],
+          "notes": "VM0007 Quick Check audit search coverage."
+        },
+        "sourceDocument": {
+          "documentId": "quick-check-review-question",
+          "documentName": "5953-Marcondes-Brazil-pdd.pdf",
+          "contentSha256": "a28e013ddbb4522b93ec954e2f9ca950b5fb906d6ead708e2cc11d829a3e37ea"
+        },
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
         "page": 1,
-        "section": "machine proposal",
+        "section": "Application of Methodology",
+        "spanId": "quick-check-review-question:element:paragraph:3.1",
         "provenance": {
           "docId": "quick-check-review-question",
           "page": 1,
           "sectionPath": [
-            "machine proposal"
+            "Application of Methodology"
           ],
-          "spanId": "machine-proposal-post-999-review-candidate",
-          "sourceType": "MACHINE_PROPOSAL"
-        }
+          "spanId": "quick-check-review-question:element:paragraph:3.1",
+          "sectionHeading": "Application of Methodology",
+          "sourceType": "PDD"
+        },
+        "finalizationState": "draft",
+        "reviewState": "pending review",
+        "reviewHistory": [],
+        "rowVersion": 1,
+        "finalizationActorRef": null,
+        "finalizedAt": null,
+        "finalizationBasis": null,
+        "reviewHistoryRef": null,
+        "proposalSource": "VM0007_QUICK_CHECK_AUDIT",
+        "proposalTimestamp": "2026-07-12T00:00:00.000Z"
       },
       "acceptedEvidence": [
         {
@@ -2688,20 +2878,54 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
-        "correction": "Requirement and applicability were reviewed before machine evidence. WRC pool rules require a WRC substrate/activity; §4.2.1(2) triggers WRC modules where project land is peatland or tidal wetlands with significant SOC emissions."
+        "correction": "Correctly N/A: the APD project-specific classification and the separate no-peat/no-tidal statement show that the WRC carbon-pool pathway is not triggered."
       },
       "finalEvidenceState": "N/A",
       "reviewerOutcome": "NOT_APPLICABLE",
-      "clientAction": "Retain the cited project classification and applicability evidence; reassess if project scope changes.",
+      "clientAction": "Retain the APD classification and the no-peat/no-tidal project evidence; reassess WRC carbon pools only if a WRC substrate or activity is added.",
       "draftFindingCandidate": null,
       "contradictionState": "NONE_IDENTIFIED",
       "methodologyTraceability": {
-        "methodology": "VM0007 / WRC modules",
+        "methodology": "VM0007 REDD+ Methodology Framework",
         "version": "v1.8",
-        "section": "4.2.1(2); 5.3.3",
+        "section": "5.3.3 WRC",
         "methodologyPage": 21,
-        "officialRequirementQuote": "For WRC, Table 6 carbon pools must be selected and justified; belowground biomass and soil are included and other pools follow the table. VM0007 v1.8 §5.3.3, pp.21–22."
-      }
+        "officialRequirementQuote": "The carbon pools included in or excluded from the boundary of the WRC component are shown in Table 6 below. The selection of carbon pools and the appropriate justification must be provided in the PD.",
+        "components": [
+          [
+            "VM0007 REDD+ Methodology Framework",
+            "v1.8",
+            "5.3.3 WRC",
+            "The carbon pools included in or excluded from the boundary of the WRC component are shown in Table 6 below."
+          ],
+          [
+            "VMD0042 Estimation of baseline soil carbon stock changes and greenhouse gas emissions in peatland rewetting and conservation project activities (BL-PEAT)",
+            "v1.1",
+            "WRC peatland baseline",
+            ""
+          ],
+          [
+            "VMD0046 Methods for monitoring of soil carbon stock changes and greenhouse gas emissions and removals in peatland rewetting and conservation project activities (M-PEAT)",
+            "v1.1",
+            "WRC peatland monitoring",
+            ""
+          ],
+          [
+            "VMD0050 Estimation of baseline carbon stock changes and greenhouse gas emissions in tidal wetland restoration and conservation project activities (BL-TW)",
+            "v1.0",
+            "WRC tidal-wetland baseline",
+            ""
+          ],
+          [
+            "VMD0051 Methods for monitoring carbon stock changes and greenhouse gas emissions and removals in tidal wetland restoration and conservation project activities (M-TW)",
+            "v1.0",
+            "WRC tidal-wetland monitoring",
+            ""
+          ]
+        ]
+      },
+      "applicabilityTrigger": "VM0007 §4.2.1(2) triggers WRC modules where project land is peatland or tidal wetlands and SOC emissions are deemed significant.",
+      "applicabilityReason": "The PDD separately identifies APD on page 12 and states on page 62: “There are no peat soils and tidal wetlands present in the Marcondes REDD+ Project Area.” No WRC carbon-pool pathway is applicable."
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
@@ -2709,19 +2933,72 @@
       "requirement": "REDD Table 7 sources must be included/excluded with justification; significant attributable CO2, CH4 and N2O increases are accounted for, and baseline-included sources also enter project and leakage accounting. VM0007 v1.8 §5.4.1–5.4.2, pp.22–24.",
       "reviewStatus": "REVIEWED",
       "machineProposal": {
-        "evidenceState": "FOUND",
-        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "rowId": "marcondes-redd-5953-vm0007-v18-evidence-map:Verra.AFOLU.VM0007.v1-8.R-2-0010",
+        "auditId": "marcondes-redd-5953-vm0007-v18-evidence-map",
+        "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+        "ruleReference": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+        "ruleTitle": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+        "requirementText": "GHG sources must be identified per Table 7 with inclusion/exclusion justification.",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "v1.8",
+        "rawAuditStatus": "supported_by_pdd",
+        "upstreamStatus": "FOUND",
+        "proposedEvidenceStatus": "FOUND",
+        "proposedApplicability": "APPLICABLE",
+        "proposedAcceptedEvidence": {
+          "quote": "3.2.1 Baseline Emissions (VCS, 3.15) CCB & VCS Project Description Template CCB Version 3.0, VCS Version 4.4 68 CCB v3.0, VCS v4.4 This section is not required at the Under Development stage in accordance with Section 3.1.6 of the Verra Reg…",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "Quantification of Estimated GHG Emission Reductions and Removals"
+            ],
+            "spanId": "quick-check-review-question:element:paragraph:3.2",
+            "sectionHeading": "Quantification of Estimated GHG Emission Reductions and Removals",
+            "sourceType": "PDD"
+          }
+        },
+        "proposedRejectedEvidence": null,
+        "assessmentReason": "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
+        "gap": "",
+        "clientAction": "Add the include or exclude decision for each relevant pool or source, the reason for that decision, and the citations supporting it.",
+        "confidence": "high",
+        "searchCoverage": {
+          "searched": true,
+          "searchedDocumentIds": [
+            "quick-check-review-question"
+          ],
+          "notes": "VM0007 Quick Check audit search coverage."
+        },
+        "sourceDocument": {
+          "documentId": "quick-check-review-question",
+          "documentName": "5953-Marcondes-Brazil-pdd.pdf",
+          "contentSha256": "a28e013ddbb4522b93ec954e2f9ca950b5fb906d6ead708e2cc11d829a3e37ea"
+        },
+        "quote": "3.2.1 Baseline Emissions (VCS, 3.15) CCB & VCS Project Description Template CCB Version 3.0, VCS Version 4.4 68 CCB v3.0, VCS v4.4 This section is not required at the Under Development stage in accordance with Section 3.1.6 of the Verra Reg…",
         "page": 1,
-        "section": "machine proposal",
+        "section": "Quantification of Estimated GHG Emission Reductions and Removals",
+        "spanId": "quick-check-review-question:element:paragraph:3.2",
         "provenance": {
           "docId": "quick-check-review-question",
           "page": 1,
           "sectionPath": [
-            "machine proposal"
+            "Quantification of Estimated GHG Emission Reductions and Removals"
           ],
-          "spanId": "machine-proposal-post-999-review-candidate",
-          "sourceType": "MACHINE_PROPOSAL"
-        }
+          "spanId": "quick-check-review-question:element:paragraph:3.2",
+          "sectionHeading": "Quantification of Estimated GHG Emission Reductions and Removals",
+          "sourceType": "PDD"
+        },
+        "finalizationState": "draft",
+        "reviewState": "pending review",
+        "reviewHistory": [],
+        "rowVersion": 1,
+        "finalizationActorRef": null,
+        "finalizedAt": null,
+        "finalizationBasis": null,
+        "reviewHistoryRef": null,
+        "proposalSource": "VM0007_QUICK_CHECK_AUDIT",
+        "proposalTimestamp": "2026-07-12T00:00:00.000Z"
       },
       "acceptedEvidence": [
         {
@@ -2789,19 +3066,46 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The accepted fire/module evidence does not provide the complete Table 7 source decisions, significance treatment, or project-specific baseline/project/leakage accounting required by §5.4.1–5.4.2."
       },
       "finalEvidenceState": "UNCLEAR",
       "reviewerOutcome": "ACTION_REQUIRED",
-      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "clientAction": "Provide the complete REDD source table for baseline, project, and leakage, with every gas/source inclusion or exclusion, significance testing where used, and project-specific justifications.",
       "draftFindingCandidate": "NIR_CANDIDATE",
       "contradictionState": "NONE_IDENTIFIED",
       "methodologyTraceability": {
-        "methodology": "VM0007 / VMD0013 / VMD0015",
+        "methodology": "VM0007 REDD+ Methodology Framework",
         "version": "v1.8",
-        "section": "5.4.1–5.4.2; Table 7",
+        "section": "5.4.1 General; 5.4.2 REDD, Table 7",
         "methodologyPage": 22,
-        "officialRequirementQuote": "REDD Table 7 sources must be included/excluded with justification; significant attributable CO2, CH4 and N2O increases are accounted for, and baseline-included sources also enter project and leakage accounting. VM0007 v1.8 §5.4.1–5.4.2, pp.22–24."
+        "officialRequirementQuote": "The project must account for any significant increases in emissions of carbon dioxide (CO2), nitrous oxide (N2O) and methane (CH4) relative to the baseline that are reasonably attributable to the project activity, with additional guidance provided in Table 6, Table 7, and Table 8. T-SIG or Appendix 1 may be used to determine whether an emissions source is significant. If a source is included in the estimation of baseline emissions, it must also be included in the calculation of project and leakage emissions.\n\nThe GHG emission sources included in or excluded from the boundary of the REDD project activity are shown in Table 7 below. The selection of sources and the appropriate justification must be provided in the PD.",
+        "components": [
+          [
+            "VM0007 REDD+ Methodology Framework",
+            "v1.8",
+            "5.4.1 General; 5.4.2 REDD, Table 7",
+            "The GHG emission sources included in or excluded from the boundary of the REDD project activity are shown in Table 7 below."
+          ],
+          [
+            "VMD0013 Estimation of greenhouse gas emissions from biomass and peat burning (E-BPB)",
+            "v1.3",
+            "REDD biomass-burning emissions",
+            ""
+          ],
+          [
+            "VMD0014 Estimation of emissions from fossil fuel combustion (E-FFC)",
+            "v1.2",
+            "REDD fossil-fuel emissions",
+            ""
+          ],
+          [
+            "VMD0015 Methods for monitoring of greenhouse gas emissions and removals in REDD project activities (M-REDD)",
+            "v2.3",
+            "REDD monitoring",
+            ""
+          ]
+        ],
+        "plainLanguageSummary": "Module references and a fire statement are relevant but do not establish every REDD source component."
       }
     },
     {
@@ -2810,19 +3114,72 @@
       "requirement": "For WRC, Table 9 sources and justifications govern SOC, wetland and combustion gases. VM0007 v1.8 §5.4.3, pp.23–24.",
       "reviewStatus": "REVIEWED",
       "machineProposal": {
-        "evidenceState": "FOUND",
-        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "rowId": "marcondes-redd-5953-vm0007-v18-evidence-map:Verra.AFOLU.VM0007.v1-8.R-2-0011",
+        "auditId": "marcondes-redd-5953-vm0007-v18-evidence-map",
+        "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+        "ruleReference": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+        "ruleTitle": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+        "requirementText": "GHG sources per Tables 8-9. Mandatory for CO2 from SOC, CH4 from SOC, combustion gases.",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "v1.8",
+        "rawAuditStatus": "supported_by_pdd",
+        "upstreamStatus": "FOUND",
+        "proposedEvidenceStatus": "FOUND",
+        "proposedApplicability": "APPLICABLE",
+        "proposedAcceptedEvidence": {
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "Application of Methodology"
+            ],
+            "spanId": "quick-check-review-question:element:paragraph:3.1",
+            "sectionHeading": "Application of Methodology",
+            "sourceType": "PDD"
+          }
+        },
+        "proposedRejectedEvidence": null,
+        "assessmentReason": "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
+        "gap": "",
+        "clientAction": "State whether the project includes WRC, peatland, or tidal wetland activities and cite the boundary, hydrology, and soil evidence supporting that scope decision.",
+        "confidence": "high",
+        "searchCoverage": {
+          "searched": true,
+          "searchedDocumentIds": [
+            "quick-check-review-question"
+          ],
+          "notes": "VM0007 Quick Check audit search coverage."
+        },
+        "sourceDocument": {
+          "documentId": "quick-check-review-question",
+          "documentName": "5953-Marcondes-Brazil-pdd.pdf",
+          "contentSha256": "a28e013ddbb4522b93ec954e2f9ca950b5fb906d6ead708e2cc11d829a3e37ea"
+        },
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
         "page": 1,
-        "section": "machine proposal",
+        "section": "Application of Methodology",
+        "spanId": "quick-check-review-question:element:paragraph:3.1",
         "provenance": {
           "docId": "quick-check-review-question",
           "page": 1,
           "sectionPath": [
-            "machine proposal"
+            "Application of Methodology"
           ],
-          "spanId": "machine-proposal-post-999-review-candidate",
-          "sourceType": "MACHINE_PROPOSAL"
-        }
+          "spanId": "quick-check-review-question:element:paragraph:3.1",
+          "sectionHeading": "Application of Methodology",
+          "sourceType": "PDD"
+        },
+        "finalizationState": "draft",
+        "reviewState": "pending review",
+        "reviewHistory": [],
+        "rowVersion": 1,
+        "finalizationActorRef": null,
+        "finalizedAt": null,
+        "finalizationBasis": null,
+        "reviewHistoryRef": null,
+        "proposalSource": "VM0007_QUICK_CHECK_AUDIT",
+        "proposalTimestamp": "2026-07-12T00:00:00.000Z"
       },
       "acceptedEvidence": [
         {
@@ -2889,20 +3246,42 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
-        "correction": "Requirement and applicability were reviewed before machine evidence. WRC source rules require a WRC activity/substrate; §4.2.1(2) triggers WRC modules only for peatland or tidal-wetland land with significant SOC emissions."
+        "correction": "Correctly N/A independently of R-2-0009: the WRC GHG-source trigger is absent because the project is APD and the PDD states that no peat soils or tidal wetlands are present."
       },
       "finalEvidenceState": "N/A",
       "reviewerOutcome": "NOT_APPLICABLE",
-      "clientAction": "Retain the cited project classification and applicability evidence; reassess if project scope changes.",
+      "clientAction": "Retain the APD classification and independent no-peat/no-tidal evidence; reassess WRC sources if project scope or substrate facts change.",
       "draftFindingCandidate": null,
       "contradictionState": "NONE_IDENTIFIED",
       "methodologyTraceability": {
-        "methodology": "VM0007 / WRC modules",
+        "methodology": "VM0007 REDD+ Methodology Framework",
         "version": "v1.8",
-        "section": "4.2.1(2); 5.4.3; Table 9",
+        "section": "5.4.3 WRC, Table 9",
         "methodologyPage": 23,
-        "officialRequirementQuote": "For WRC, Table 9 sources and justifications govern SOC, wetland and combustion gases. VM0007 v1.8 §5.4.3, pp.23–24."
-      }
+        "officialRequirementQuote": "The GHG emission sources included in or excluded from the boundary of the WRC component are shown in Table 9 below. The selection of sources and the appropriate justification must be provided in the PD.",
+        "components": [
+          [
+            "VM0007 REDD+ Methodology Framework",
+            "v1.8",
+            "5.4.3 WRC, Table 9",
+            "The GHG emission sources included in or excluded from the boundary of the WRC component are shown in Table 9 below."
+          ],
+          [
+            "VMD0042 Estimation of baseline soil carbon stock changes and greenhouse gas emissions in peatland rewetting and conservation project activities (BL-PEAT)",
+            "v1.1",
+            "WRC peatland sources",
+            ""
+          ],
+          [
+            "VMD0050 Estimation of baseline carbon stock changes and greenhouse gas emissions in tidal wetland restoration and conservation project activities (BL-TW)",
+            "v1.0",
+            "WRC tidal-wetland sources",
+            ""
+          ]
+        ]
+      },
+      "applicabilityTrigger": "VM0007 §4.2.1(2) triggers WRC source rules only where project land is peatland or tidal wetlands and SOC emissions are deemed significant.",
+      "applicabilityReason": "The PDD identifies APD on page 12 and separately states on page 62 that no peat soils or tidal wetlands are present; therefore no WRC GHG-source table is applicable."
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
@@ -2910,19 +3289,72 @@
       "requirement": "A source included in baseline emissions must also be included in project and leakage emissions. VM0007 v1.8 §5.4.1, p.22.",
       "reviewStatus": "REVIEWED",
       "machineProposal": {
-        "evidenceState": "FOUND",
-        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "rowId": "marcondes-redd-5953-vm0007-v18-evidence-map:Verra.AFOLU.VM0007.v1-8.R-2-0012",
+        "auditId": "marcondes-redd-5953-vm0007-v18-evidence-map",
+        "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+        "ruleReference": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+        "ruleTitle": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+        "requirementText": "Symmetric accounting: baseline inclusion implies project inclusion.",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "v1.8",
+        "rawAuditStatus": "supported_by_pdd",
+        "upstreamStatus": "FOUND",
+        "proposedEvidenceStatus": "FOUND",
+        "proposedApplicability": "APPLICABLE",
+        "proposedAcceptedEvidence": {
+          "quote": "3.2.1 Baseline Emissions (VCS, 3.15) CCB & VCS Project Description Template CCB Version 3.0, VCS Version 4.4 68 CCB v3.0, VCS v4.4 This section is not required at the Under Development stage in accordance with Section 3.1.6 of the Verra Reg…",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "Quantification of Estimated GHG Emission Reductions and Removals"
+            ],
+            "spanId": "quick-check-review-question:element:paragraph:3.2",
+            "sectionHeading": "Quantification of Estimated GHG Emission Reductions and Removals",
+            "sourceType": "PDD"
+          }
+        },
+        "proposedRejectedEvidence": null,
+        "assessmentReason": "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
+        "gap": "",
+        "clientAction": "Add the include or exclude decision for each relevant pool or source, the reason for that decision, and the citations supporting it.",
+        "confidence": "high",
+        "searchCoverage": {
+          "searched": true,
+          "searchedDocumentIds": [
+            "quick-check-review-question"
+          ],
+          "notes": "VM0007 Quick Check audit search coverage."
+        },
+        "sourceDocument": {
+          "documentId": "quick-check-review-question",
+          "documentName": "5953-Marcondes-Brazil-pdd.pdf",
+          "contentSha256": "a28e013ddbb4522b93ec954e2f9ca950b5fb906d6ead708e2cc11d829a3e37ea"
+        },
+        "quote": "3.2.1 Baseline Emissions (VCS, 3.15) CCB & VCS Project Description Template CCB Version 3.0, VCS Version 4.4 68 CCB v3.0, VCS v4.4 This section is not required at the Under Development stage in accordance with Section 3.1.6 of the Verra Reg…",
         "page": 1,
-        "section": "machine proposal",
+        "section": "Quantification of Estimated GHG Emission Reductions and Removals",
+        "spanId": "quick-check-review-question:element:paragraph:3.2",
         "provenance": {
           "docId": "quick-check-review-question",
           "page": 1,
           "sectionPath": [
-            "machine proposal"
+            "Quantification of Estimated GHG Emission Reductions and Removals"
           ],
-          "spanId": "machine-proposal-post-999-review-candidate",
-          "sourceType": "MACHINE_PROPOSAL"
-        }
+          "spanId": "quick-check-review-question:element:paragraph:3.2",
+          "sectionHeading": "Quantification of Estimated GHG Emission Reductions and Removals",
+          "sourceType": "PDD"
+        },
+        "finalizationState": "draft",
+        "reviewState": "pending review",
+        "reviewHistory": [],
+        "rowVersion": 1,
+        "finalizationActorRef": null,
+        "finalizedAt": null,
+        "finalizationBasis": null,
+        "reviewHistoryRef": null,
+        "proposalSource": "VM0007_QUICK_CHECK_AUDIT",
+        "proposalTimestamp": "2026-07-12T00:00:00.000Z"
       },
       "acceptedEvidence": [
         {
@@ -3010,19 +3442,46 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The accepted evidence explicitly reaches baseline/project/leakage consistency, but the PDD does not provide the source-by-source matrix needed to resolve whether each applicable source is treated consistently; UNCLEAR/ACTION_REQUIRED remains."
       },
       "finalEvidenceState": "UNCLEAR",
       "reviewerOutcome": "ACTION_REQUIRED",
-      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "clientAction": "Provide a source-by-source consistency matrix showing each baseline inclusion/exclusion and the corresponding project and leakage treatment, with justification; module presence alone is insufficient.",
       "draftFindingCandidate": "NIR_CANDIDATE",
       "contradictionState": "NONE_IDENTIFIED",
       "methodologyTraceability": {
-        "methodology": "VM0007 / VMD0006 / VMD0009 / VMD0015",
+        "methodology": "VM0007 REDD+ Methodology Framework",
         "version": "v1.8",
-        "section": "5.4.1; 8.1–8.3",
+        "section": "5.4.1 General; 8.1–8.3",
         "methodologyPage": 22,
-        "officialRequirementQuote": "A source included in baseline emissions must also be included in project and leakage emissions. VM0007 v1.8 §5.4.1, p.22."
+        "officialRequirementQuote": "If a source is included in the estimation of baseline emissions, it must also be included in the calculation of project and leakage emissions.",
+        "components": [
+          [
+            "VM0007 REDD+ Methodology Framework",
+            "v1.8",
+            "5.4.1 General; 8.1–8.3",
+            "If a source is included in the estimation of baseline emissions, it must also be included in the calculation of project and leakage emissions."
+          ],
+          [
+            "VMD0006 Estimation of baseline carbon stock changes and greenhouse gas emissions from planned deforestation/forest degradation and planned wetland degradation (BL-PL)",
+            "v1.4",
+            "APD baseline accounting",
+            ""
+          ],
+          [
+            "VMD0009 Estimation of emissions from activity shifting for avoiding planned deforestation/forest degradation and avoiding planned wetland degradation (LK-ASP)",
+            "v1.3",
+            "APD leakage accounting",
+            ""
+          ],
+          [
+            "VMD0015 Methods for monitoring of greenhouse gas emissions and removals in REDD project activities (M-REDD)",
+            "v2.3",
+            "REDD project accounting",
+            ""
+          ]
+        ],
+        "plainLanguageSummary": "This row evaluates baseline, project, and leakage source treatment, not merely module presence."
       }
     },
     {
@@ -3031,19 +3490,72 @@
       "requirement": "The REDD historical reference period is fixed, has the VCS Methodology Requirements duration, and at validation ends at crediting-period start. VM0007 v1.8 §5.2.1, p.20.",
       "reviewStatus": "REVIEWED",
       "machineProposal": {
-        "evidenceState": "FOUND",
-        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "rowId": "marcondes-redd-5953-vm0007-v18-evidence-map:Verra.AFOLU.VM0007.v1-8.R-2-0013",
+        "auditId": "marcondes-redd-5953-vm0007-v18-evidence-map",
+        "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+        "ruleReference": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+        "ruleTitle": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+        "requirementText": "Fixed period for baseline modeling. Duration per VCS Standard.",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "v1.8",
+        "rawAuditStatus": "supported_by_pdd",
+        "upstreamStatus": "FOUND",
+        "proposedEvidenceStatus": "FOUND",
+        "proposedApplicability": "APPLICABLE",
+        "proposedAcceptedEvidence": {
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "Application of Methodology"
+            ],
+            "spanId": "quick-check-review-question:element:paragraph:3.1",
+            "sectionHeading": "Application of Methodology",
+            "sourceType": "PDD"
+          }
+        },
+        "proposedRejectedEvidence": null,
+        "assessmentReason": "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
+        "gap": "",
+        "clientAction": "Add the mapped boundary, time-boundary details, and the project-specific justification for the geography or period used in this rule.",
+        "confidence": "high",
+        "searchCoverage": {
+          "searched": true,
+          "searchedDocumentIds": [
+            "quick-check-review-question"
+          ],
+          "notes": "VM0007 Quick Check audit search coverage."
+        },
+        "sourceDocument": {
+          "documentId": "quick-check-review-question",
+          "documentName": "5953-Marcondes-Brazil-pdd.pdf",
+          "contentSha256": "a28e013ddbb4522b93ec954e2f9ca950b5fb906d6ead708e2cc11d829a3e37ea"
+        },
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
         "page": 1,
-        "section": "machine proposal",
+        "section": "Application of Methodology",
+        "spanId": "quick-check-review-question:element:paragraph:3.1",
         "provenance": {
           "docId": "quick-check-review-question",
           "page": 1,
           "sectionPath": [
-            "machine proposal"
+            "Application of Methodology"
           ],
-          "spanId": "machine-proposal-post-999-review-candidate",
-          "sourceType": "MACHINE_PROPOSAL"
-        }
+          "spanId": "quick-check-review-question:element:paragraph:3.1",
+          "sectionHeading": "Application of Methodology",
+          "sourceType": "PDD"
+        },
+        "finalizationState": "draft",
+        "reviewState": "pending review",
+        "reviewHistory": [],
+        "rowVersion": 1,
+        "finalizationActorRef": null,
+        "finalizedAt": null,
+        "finalizationBasis": null,
+        "reviewHistoryRef": null,
+        "proposalSource": "VM0007_QUICK_CHECK_AUDIT",
+        "proposalTimestamp": "2026-07-12T00:00:00.000Z"
       },
       "acceptedEvidence": [
         {
@@ -3111,19 +3623,34 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The PDD records 2013–2023 and separately records a 01 May 2023 crediting-period start, but does not establish exact calendar start/end dates, permitted data-gap treatment, or the proxy/reference-region relationship required to resolve the historical period; UNCLEAR/ACTION_REQUIRED remains."
       },
       "finalEvidenceState": "UNCLEAR",
       "reviewerOutcome": "ACTION_REQUIRED",
-      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "clientAction": "Provide the exact historical-period start and end dates, permitted data-gap treatment, and the relationship between the 2013–2023 proxy/reference data and the 01 May 2023 crediting-period start; year labels alone leave the date relationship and controls ambiguous.",
       "draftFindingCandidate": "NIR_CANDIDATE",
       "contradictionState": "NONE_IDENTIFIED",
       "methodologyTraceability": {
-        "methodology": "VM0007 / VCS Methodology Requirements",
-        "version": "v1.8",
-        "section": "5.2.1",
+        "methodology": "VM0007 REDD+ Methodology Framework and VCS Methodology Requirements",
+        "version": "v1.8 / applicable VCS Methodology Requirements version",
+        "section": "5.2.1 Start Date and End Date of the Historical Reference Period",
         "methodologyPage": 20,
-        "officialRequirementQuote": "The REDD historical reference period is fixed, has the VCS Methodology Requirements duration, and at validation ends at crediting-period start. VM0007 v1.8 §5.2.1, p.20."
+        "officialRequirementQuote": "The historical reference period is the fixed time period during which historical deforestation and forest degradation is analyzed in the reference region to set the forward-looking baseline, the duration of which is set out in the VCS Methodology Requirements. At validation, the historical reference period ends at the start of the crediting period.",
+        "components": [
+          [
+            "VM0007 REDD+ Methodology Framework",
+            "v1.8",
+            "5.2.1",
+            "The historical reference period is the fixed time period during which historical deforestation and forest degradation is analyzed in the reference region to set the forward-looking baseline."
+          ],
+          [
+            "VCS Methodology Requirements",
+            "applicable version",
+            "historical reference-period duration",
+            ""
+          ]
+        ],
+        "plainLanguageSummary": "The year range is relevant evidence, but the exact date and control relationship to 01 May 2023 remains incomplete."
       }
     },
     {
@@ -3132,19 +3659,72 @@
       "requirement": "The AFOLU crediting period must be 20–100 years and duration reported in the PD. VM0007 v1.8 §5.2.2, p.20; VCS Standard v5.0 §3.8.4.",
       "reviewStatus": "REVIEWED",
       "machineProposal": {
-        "evidenceState": "FOUND",
-        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "rowId": "marcondes-redd-5953-vm0007-v18-evidence-map:Verra.AFOLU.VM0007.v1-8.R-2-0014",
+        "auditId": "marcondes-redd-5953-vm0007-v18-evidence-map",
+        "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+        "ruleReference": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+        "ruleTitle": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+        "requirementText": "20-100 year range. Must be specified in PD.",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "v1.8",
+        "rawAuditStatus": "supported_by_pdd",
+        "upstreamStatus": "FOUND",
+        "proposedEvidenceStatus": "FOUND",
+        "proposedApplicability": "APPLICABLE",
+        "proposedAcceptedEvidence": {
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "Application of Methodology"
+            ],
+            "spanId": "quick-check-review-question:element:paragraph:3.1",
+            "sectionHeading": "Application of Methodology",
+            "sourceType": "PDD"
+          }
+        },
+        "proposedRejectedEvidence": null,
+        "assessmentReason": "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
+        "gap": "",
+        "clientAction": "Add the mapped boundary, time-boundary details, and the project-specific justification for the geography or period used in this rule.",
+        "confidence": "high",
+        "searchCoverage": {
+          "searched": true,
+          "searchedDocumentIds": [
+            "quick-check-review-question"
+          ],
+          "notes": "VM0007 Quick Check audit search coverage."
+        },
+        "sourceDocument": {
+          "documentId": "quick-check-review-question",
+          "documentName": "5953-Marcondes-Brazil-pdd.pdf",
+          "contentSha256": "a28e013ddbb4522b93ec954e2f9ca950b5fb906d6ead708e2cc11d829a3e37ea"
+        },
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
         "page": 1,
-        "section": "machine proposal",
+        "section": "Application of Methodology",
+        "spanId": "quick-check-review-question:element:paragraph:3.1",
         "provenance": {
           "docId": "quick-check-review-question",
           "page": 1,
           "sectionPath": [
-            "machine proposal"
+            "Application of Methodology"
           ],
-          "spanId": "machine-proposal-post-999-review-candidate",
-          "sourceType": "MACHINE_PROPOSAL"
-        }
+          "spanId": "quick-check-review-question:element:paragraph:3.1",
+          "sectionHeading": "Application of Methodology",
+          "sourceType": "PDD"
+        },
+        "finalizationState": "draft",
+        "reviewState": "pending review",
+        "reviewHistory": [],
+        "rowVersion": 1,
+        "finalizationActorRef": null,
+        "finalizedAt": null,
+        "finalizationBasis": null,
+        "reviewHistoryRef": null,
+        "proposalSource": "VM0007_QUICK_CHECK_AUDIT",
+        "proposalTimestamp": "2026-07-12T00:00:00.000Z"
       },
       "acceptedEvidence": [
         {
@@ -3231,19 +3811,34 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The three cited PDD locations consistently establish a 40-year crediting period from 01 May 2023 through 30 April 2063; the 20–100-year duration requirement is satisfied."
       },
       "finalEvidenceState": "FOUND",
       "reviewerOutcome": "CONFORMS",
-      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "clientAction": "Retain the three consistent PDD statements and supporting records for the 40-year period from 01 May 2023 through 30 April 2063.",
       "draftFindingCandidate": null,
       "contradictionState": "NONE_IDENTIFIED",
       "methodologyTraceability": {
-        "methodology": "VM0007 / VCS Standard",
-        "version": "v1.8",
-        "section": "5.2.2; VCS 3.8.4",
+        "methodology": "VM0007 REDD+ Methodology Framework and VCS Standard",
+        "version": "v1.8 / v5.0",
+        "section": "5.2.2 Start Date and End Date of the Project Crediting Period; VCS Standard §3.8.4",
         "methodologyPage": 20,
-        "officialRequirementQuote": "The AFOLU crediting period must be 20–100 years and duration reported in the PD. VM0007 v1.8 §5.2.2, p.20; VCS Standard v5.0 §3.8.4."
+        "officialRequirementQuote": "The project crediting period for AFOLU projects must be between 20 and 100 years. The duration of the project activity/crediting period must be reported in the PD.",
+        "components": [
+          [
+            "VM0007 REDD+ Methodology Framework",
+            "v1.8",
+            "5.2.2 Start Date and End Date of the Project Crediting Period",
+            "The project crediting period for AFOLU projects must be between 20 and 100 years."
+          ],
+          [
+            "VCS Standard",
+            "v5.0",
+            "§3.8.4",
+            ""
+          ]
+        ],
+        "plainLanguageSummary": "Exact start date, end date, duration, and cross-section consistency are established."
       }
     },
     {
@@ -3252,19 +3847,72 @@
       "requirement": "For WRC, eligibility is limited to the project/baseline SOC difference after 100 years; absent a significant difference ex ante with conservative parameters, the area is ineligible. VM0007 v1.8 §5.1.3, p.19; X-STR.",
       "reviewStatus": "REVIEWED",
       "machineProposal": {
-        "evidenceState": "FOUND",
-        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "rowId": "marcondes-redd-5953-vm0007-v18-evidence-map:Verra.AFOLU.VM0007.v1-8.R-2-0015",
+        "auditId": "marcondes-redd-5953-vm0007-v18-evidence-map",
+        "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+        "ruleReference": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+        "ruleTitle": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+        "requirementText": "100-year SOC horizon test. Must show significant difference. Assessed ex-ante conservatively.",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "v1.8",
+        "rawAuditStatus": "supported_by_pdd",
+        "upstreamStatus": "FOUND",
+        "proposedEvidenceStatus": "FOUND",
+        "proposedApplicability": "APPLICABLE",
+        "proposedAcceptedEvidence": {
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "Application of Methodology"
+            ],
+            "spanId": "quick-check-review-question:element:paragraph:3.1",
+            "sectionHeading": "Application of Methodology",
+            "sourceType": "PDD"
+          }
+        },
+        "proposedRejectedEvidence": null,
+        "assessmentReason": "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
+        "gap": "",
+        "clientAction": "State whether the project includes WRC, peatland, or tidal wetland activities and cite the boundary, hydrology, and soil evidence supporting that scope decision.",
+        "confidence": "high",
+        "searchCoverage": {
+          "searched": true,
+          "searchedDocumentIds": [
+            "quick-check-review-question"
+          ],
+          "notes": "VM0007 Quick Check audit search coverage."
+        },
+        "sourceDocument": {
+          "documentId": "quick-check-review-question",
+          "documentName": "5953-Marcondes-Brazil-pdd.pdf",
+          "contentSha256": "a28e013ddbb4522b93ec954e2f9ca950b5fb906d6ead708e2cc11d829a3e37ea"
+        },
+        "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) defor…",
         "page": 1,
-        "section": "machine proposal",
+        "section": "Application of Methodology",
+        "spanId": "quick-check-review-question:element:paragraph:3.1",
         "provenance": {
           "docId": "quick-check-review-question",
           "page": 1,
           "sectionPath": [
-            "machine proposal"
+            "Application of Methodology"
           ],
-          "spanId": "machine-proposal-post-999-review-candidate",
-          "sourceType": "MACHINE_PROPOSAL"
-        }
+          "spanId": "quick-check-review-question:element:paragraph:3.1",
+          "sectionHeading": "Application of Methodology",
+          "sourceType": "PDD"
+        },
+        "finalizationState": "draft",
+        "reviewState": "pending review",
+        "reviewHistory": [],
+        "rowVersion": 1,
+        "finalizationActorRef": null,
+        "finalizedAt": null,
+        "finalizationBasis": null,
+        "reviewHistoryRef": null,
+        "proposalSource": "VM0007_QUICK_CHECK_AUDIT",
+        "proposalTimestamp": "2026-07-12T00:00:00.000Z"
       },
       "acceptedEvidence": [
         {
@@ -3331,20 +3979,36 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
-        "correction": "Requirement and applicability were reviewed before machine evidence. The 100-year SOC test is a WRC project-area/substrate requirement, triggered only for WRC activities; this project is APD with no peat soils or tidal wetlands."
+        "correction": "Correctly N/A independently of the other WRC rows: the APD classification and no-peat/no-tidal evidence show that the WRC 100-year SOC pathway is not triggered."
       },
       "finalEvidenceState": "N/A",
       "reviewerOutcome": "NOT_APPLICABLE",
-      "clientAction": "Retain the cited project classification and applicability evidence; reassess if project scope changes.",
+      "clientAction": "Retain the APD classification and no-peat/no-tidal evidence; perform the 100-year SOC test only if a WRC substrate or activity is added.",
       "draftFindingCandidate": null,
       "contradictionState": "NONE_IDENTIFIED",
       "methodologyTraceability": {
-        "methodology": "VM0007 / VMD0016 X-STR",
-        "version": "v1.8",
-        "section": "5.1.3",
+        "methodology": "VM0007 REDD+ Methodology Framework and VMD0016 X-STR",
+        "version": "v1.8 / v1.3",
+        "section": "5.1.3 WRC",
         "methodologyPage": 19,
-        "officialRequirementQuote": "For WRC, eligibility is limited to the project/baseline SOC difference after 100 years; absent a significant difference ex ante with conservative parameters, the area is ineligible. VM0007 v1.8 §5.1.3, p.19; X-STR."
-      }
+        "officialRequirementQuote": "The maximum eligible quantity of GHG emission reductions in WRC project activities is limited to the difference between the remaining SOC stock in the project and baseline scenarios after 100 years. If a significant difference at the 100-years mark cannot be demonstrated, the project area is not eligible. The assessment must be executed ex-ante using conservative parameters.",
+        "components": [
+          [
+            "VM0007 REDD+ Methodology Framework",
+            "v1.8",
+            "5.1.3 WRC",
+            "The maximum eligible quantity of GHG emission reductions in WRC project activities is limited to the difference between the remaining SOC stock in the project and baseline scenarios after 100 years."
+          ],
+          [
+            "VMD0016 Methods for stratification of the project area (X-STR)",
+            "v1.3",
+            "WRC boundary and SOC-stratum procedures",
+            ""
+          ]
+        ]
+      },
+      "applicabilityTrigger": "The 100-year SOC test is triggered only for WRC project areas/substrates; it does not apply to this APD-only project without a peatland or tidal-wetland pathway.",
+      "applicabilityReason": "Page 12 identifies APD and page 62 states that no peat soils or tidal wetlands are present; those project facts remove the WRC substrate/activity trigger."
     },
     {
       "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
@@ -3352,19 +4016,72 @@
       "requirement": "Where VT0001 barrier analysis is used, apply VM0007’s barrier-analysis decision tree to plausible alternatives not prevented by a barrier; the row is limited to barrier analysis. VM0007 v1.8 §6.1 Steps 1–3, pp.25–26; VT0001 v3.0 §2.3.",
       "reviewStatus": "REVIEWED",
       "machineProposal": {
-        "evidenceState": "FOUND",
-        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "rowId": "marcondes-redd-5953-vm0007-v18-evidence-map:Verra.AFOLU.VM0007.v1-8.R-3-0003",
+        "auditId": "marcondes-redd-5953-vm0007-v18-evidence-map",
+        "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+        "ruleReference": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+        "ruleTitle": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+        "requirementText": "Two-step: barrier analysis first, then investment analysis or qualitative GHG estimation as fallback.",
+        "methodologyId": "VM0007",
+        "methodologyVersion": "v1.8",
+        "rawAuditStatus": "supported_by_pdd",
+        "upstreamStatus": "FOUND",
+        "proposedEvidenceStatus": "FOUND",
+        "proposedApplicability": "APPLICABLE",
+        "proposedAcceptedEvidence": {
+          "quote": "demonstration of additionality for an eligibility area shall: • be based on the initial project activity instances. • apply across the entire eligibility area. The determination of the baseline scenario and demonstration of additionality fo…",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "The determination of baseline scenario and"
+            ],
+            "spanId": "quick-check-review-question:element:paragraph:3.5.5",
+            "sectionHeading": "The determination of baseline scenario and",
+            "sourceType": "PDD"
+          }
+        },
+        "proposedRejectedEvidence": null,
+        "assessmentReason": "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
+        "gap": "",
+        "clientAction": "Add the alternative scenarios considered, the VT0001 decision path used, and the citations supporting the selected baseline scenario.",
+        "confidence": "high",
+        "searchCoverage": {
+          "searched": true,
+          "searchedDocumentIds": [
+            "quick-check-review-question"
+          ],
+          "notes": "VM0007 Quick Check audit search coverage."
+        },
+        "sourceDocument": {
+          "documentId": "quick-check-review-question",
+          "documentName": "5953-Marcondes-Brazil-pdd.pdf",
+          "contentSha256": "a28e013ddbb4522b93ec954e2f9ca950b5fb906d6ead708e2cc11d829a3e37ea"
+        },
+        "quote": "demonstration of additionality for an eligibility area shall: • be based on the initial project activity instances. • apply across the entire eligibility area. The determination of the baseline scenario and demonstration of additionality fo…",
         "page": 1,
-        "section": "machine proposal",
+        "section": "The determination of baseline scenario and",
+        "spanId": "quick-check-review-question:element:paragraph:3.5.5",
         "provenance": {
           "docId": "quick-check-review-question",
           "page": 1,
           "sectionPath": [
-            "machine proposal"
+            "The determination of baseline scenario and"
           ],
-          "spanId": "machine-proposal-post-999-review-candidate",
-          "sourceType": "MACHINE_PROPOSAL"
-        }
+          "spanId": "quick-check-review-question:element:paragraph:3.5.5",
+          "sectionHeading": "The determination of baseline scenario and",
+          "sourceType": "PDD"
+        },
+        "finalizationState": "draft",
+        "reviewState": "pending review",
+        "reviewHistory": [],
+        "rowVersion": 1,
+        "finalizationActorRef": null,
+        "finalizedAt": null,
+        "finalizationBasis": null,
+        "reviewHistoryRef": null,
+        "proposalSource": "VM0007_QUICK_CHECK_AUDIT",
+        "proposalTimestamp": "2026-07-12T00:00:00.000Z"
       },
       "acceptedEvidence": [
         {
@@ -3432,19 +4149,34 @@
       ],
       "reviewerCorrection": {
         "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
-        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+        "correction": "The accepted assertion identifies a stepwise additionality process but does not identify the selected barrier path, barrier categories, supporting evidence, or differential effect on alternatives required by VM0007/VT0001; UNCLEAR/ACTION_REQUIRED remains."
       },
       "finalEvidenceState": "UNCLEAR",
       "reviewerOutcome": "ACTION_REQUIRED",
-      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "clientAction": "Provide the selected VT0001 barrier-analysis path, exact barrier categories, documented evidence for each barrier, and evidence that the barriers affect at least one alternative less strongly; this row does not request investment or common-practice analysis.",
       "draftFindingCandidate": "NIR_CANDIDATE",
       "contradictionState": "NONE_IDENTIFIED",
       "methodologyTraceability": {
-        "methodology": "VM0007 / VT0001",
-        "version": "v1.8",
-        "section": "6.1 Steps 1–3; VT0001 §2.3",
+        "methodology": "VM0007 REDD+ Methodology Framework and VT0001 Tool for the Demonstration and Assessment of Additionality in VCS AFOLU Project Activities",
+        "version": "v1.8 / v3.0",
+        "section": "VM0007 §6.1 Steps 1–3; VT0001 §2.3 Step 3 Barrier analysis",
         "methodologyPage": 25,
-        "officialRequirementQuote": "Where VT0001 barrier analysis is used, apply VM0007’s barrier-analysis decision tree to plausible alternatives not prevented by a barrier; the row is limited to barrier analysis. VM0007 v1.8 §6.1 Steps 1–3, pp.25–26; VT0001 v3.0 §2.3."
+        "officialRequirementQuote": "Where the VT0001 barrier analysis is used to demonstrate additionality, apply the decision tree in Figure 1 to the list of all alternative land use scenarios from Step 1 that are not prevented by any barrier.",
+        "components": [
+          [
+            "VM0007 REDD+ Methodology Framework",
+            "v1.8",
+            "6.1 Steps 1–3",
+            "Where the VT0001 barrier analysis is used to demonstrate additionality, apply the decision tree in Figure 1 to the list of all alternative land use scenarios from Step 1 that are not prevented by any barrier."
+          ],
+          [
+            "VT0001 Tool for the Demonstration and Assessment of Additionality in VCS AFOLU Project Activities",
+            "v3.0",
+            "§2.3 Step 3 Barrier analysis",
+            "If this step is used, determine whether the proposed project activity faces barriers that: a) Prevent the implementation of this type of proposed project activity without the revenue from the sale of GHG credits; and b) Do not prevent the implementation of at least one of the alternative land use scenarios."
+          ]
+        ],
+        "plainLanguageSummary": "This row is limited to barrier analysis; investment and common-practice procedures are not demanded as missing components here."
       }
     }
   ],

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json
@@ -33,7 +33,17 @@
     "Verra.AFOLU.VM0007.v1-8.R-2-0008",
     "Verra.AFOLU.VM0007.v1-8.R-2-0016",
     "Verra.AFOLU.VM0007.v1-8.R-3-0002",
-    "Verra.AFOLU.VM0007.v1-8.R-3-0006"
+    "Verra.AFOLU.VM0007.v1-8.R-3-0006",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+    "Verra.AFOLU.VM0007.v1-8.R-3-0003"
   ],
   "rows": [
     {
@@ -2371,13 +2381,1078 @@
       "clientAction": "Retain the APD classification, VMD0006/BL-PL selection, and no-peat/no-tidal project evidence; WRC baseline modules BL-PEAT and BL-TW are not applicable unless peatland or tidal-wetland WRC scope is added.",
       "draftFindingCandidate": null,
       "contradictionState": "NONE_IDENTIFIED"
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+      "ruleReference": "R-2-0003",
+      "requirement": "All land areas registered under any other GHG program must be transparently reported and excluded from the project area; exclusion must be monitored and reported. VM0007 v1.8 §5.1.1, p.18.",
+      "reviewStatus": "REVIEWED",
+      "machineProposal": {
+        "evidenceState": "FOUND",
+        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "page": 1,
+        "section": "machine proposal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "machine proposal"
+          ],
+          "spanId": "machine-proposal-post-999-review-candidate",
+          "sourceType": "MACHINE_PROPOSAL"
+        }
+      },
+      "acceptedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+          "quote": "2.5.13.1 No Double Issuance\nIs the project receiving or seeking credit for reductions and removals from a project activity under another GHG program, or any other form of community, social, or biodiversity unit or credit?\n☐ Yes ☒ No",
+          "page": 59,
+          "section": "2 PROJECT DETAILS > 2.5 Legal Status and Property Rights > 2.5.13 Double Counting and Participation under Other GHG Programs",
+          "spanId": "manual:marcondes-pdd:page-59:r-r-2-0003-no-double-issuance",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 59,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "2.5 Legal Status and Property Rights",
+              "2.5.13 Double Counting and Participation under Other GHG Programs"
+            ],
+            "spanId": "manual:marcondes-pdd:page-59:no-double-issuance",
+            "sectionHeading": "2.5.13 Double Counting and Participation under Other GHG Programs",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+          "quote": "2.5.13.2 Registration in Other GHG Programs\nHas the project registered under any other GHG programs?\n☐ Yes ☒ No\nIs the project active under the other program?\n☐ Yes ☒ No",
+          "page": 59,
+          "section": "2 PROJECT DETAILS > 2.5 Legal Status and Property Rights > 2.5.13 Double Counting and Participation under Other GHG Programs",
+          "spanId": "manual:marcondes-pdd:page-59:r-r-2-0003-registration",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 59,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "2.5 Legal Status and Property Rights",
+              "2.5.13 Double Counting and Participation under Other GHG Programs"
+            ],
+            "spanId": "manual:marcondes-pdd:page-59:registration",
+            "sectionHeading": "2.5.13 Double Counting and Participation under Other GHG Programs",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+          "quote": "2.5.13.3 Projects Rejected by Other GHG Programs\nHas the project been rejected by any other GHG programs?\n☐ Yes ☒ No",
+          "page": 59,
+          "section": "2 PROJECT DETAILS > 2.5 Legal Status and Property Rights > 2.5.13 Double Counting and Participation under Other GHG Programs",
+          "spanId": "manual:marcondes-pdd:page-59:r-r-2-0003-rejected",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 59,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "2.5 Legal Status and Property Rights",
+              "2.5.13 Double Counting and Participation under Other GHG Programs"
+            ],
+            "spanId": "manual:marcondes-pdd:page-59:rejected",
+            "sectionHeading": "2.5.13 Double Counting and Participation under Other GHG Programs",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        }
+      ],
+      "rejectedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          },
+          "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+        }
+      ],
+      "reviewerCorrection": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      },
+      "finalEvidenceState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "draftFindingCandidate": "NIR_CANDIDATE",
+      "contradictionState": "NONE_IDENTIFIED",
+      "methodologyTraceability": {
+        "methodology": "VM0007 v1.8",
+        "version": "v1.8",
+        "section": "5.1.1",
+        "methodologyPage": 18,
+        "officialRequirementQuote": "All land areas registered under any other GHG program must be transparently reported and excluded from the project area; exclusion must be monitored and reported. VM0007 v1.8 §5.1.1, p.18."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+      "ruleReference": "R-2-0004",
+      "requirement": "For REDD, APD uses project and proxy areas; a reference region is the AUDef pathway and uses BL-UP. VM0007 v1.8 §5.1.2, p.18.",
+      "reviewStatus": "REVIEWED",
+      "machineProposal": {
+        "evidenceState": "FOUND",
+        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "page": 1,
+        "section": "machine proposal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "machine proposal"
+          ],
+          "spanId": "machine-proposal-post-999-review-candidate",
+          "sourceType": "MACHINE_PROPOSAL"
+        }
+      },
+      "acceptedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+          "quote": "Project activity type Avoiding Planned Deforestation (APD)",
+          "page": 12,
+          "section": "2 PROJECT DETAILS > 2.1.3 Sectoral Scope and Project Type",
+          "spanId": "manual:marcondes-pdd:page-12:r-r-2-0004-apd",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 12,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "2.1.3 Sectoral Scope and Project Type"
+            ],
+            "spanId": "manual:marcondes-pdd:page-12:apd",
+            "sectionHeading": "2.1.3 Sectoral Scope and Project Type",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+          "quote": "Table 30. Methodologies, modules, and tools applied\nType Reference ID Title Version\nApplied\nMethodology\nVM0007 REDD+ Methodology Framework (REDD+MF)\n(Avoided Planned Deforestation)\n1.8",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1), Table 30. Methodologies, modules, and tools applied",
+          "spanId": "manual:marcondes-pdd:page-61:r-r-2-0004-table-30",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1), Table 30. Methodologies, modules, and tools applied"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:table-30",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1), Table 30. Methodologies, modules, and tools applied",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        }
+      ],
+      "rejectedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          },
+          "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+        }
+      ],
+      "reviewerCorrection": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Reference-region requirements are triggered by AUDef/avoiding unplanned deforestation; this project is APD and uses the BL-PL pathway."
+      },
+      "finalEvidenceState": "N/A",
+      "reviewerOutcome": "NOT_APPLICABLE",
+      "clientAction": "Retain the cited project classification and applicability evidence; reassess if project scope changes.",
+      "draftFindingCandidate": null,
+      "contradictionState": "NONE_IDENTIFIED",
+      "methodologyTraceability": {
+        "methodology": "VM0007 / VMD0006",
+        "version": "v1.8",
+        "section": "5.1.2; BL-PL",
+        "methodologyPage": 18,
+        "officialRequirementQuote": "For REDD, APD uses project and proxy areas; a reference region is the AUDef pathway and uses BL-UP. VM0007 v1.8 §5.1.2, p.18."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+      "ruleReference": "R-2-0009",
+      "requirement": "For WRC, Table 6 carbon pools must be selected and justified; belowground biomass and soil are included and other pools follow the table. VM0007 v1.8 §5.3.3, pp.21–22.",
+      "reviewStatus": "REVIEWED",
+      "machineProposal": {
+        "evidenceState": "FOUND",
+        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "page": 1,
+        "section": "machine proposal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "machine proposal"
+          ],
+          "spanId": "machine-proposal-post-999-review-candidate",
+          "sourceType": "MACHINE_PROPOSAL"
+        }
+      },
+      "acceptedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+          "quote": "Project activity type Avoiding Planned Deforestation (APD)",
+          "page": 12,
+          "section": "2 PROJECT DETAILS > 2.1.3 Sectoral Scope and Project Type",
+          "spanId": "manual:marcondes-pdd:page-12:r-r-2-0009-apd",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 12,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "2.1.3 Sectoral Scope and Project Type"
+            ],
+            "spanId": "manual:marcondes-pdd:page-12:apd",
+            "sectionHeading": "2.1.3 Sectoral Scope and Project Type",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+          "quote": "There are no peat soils and tidal wetlands present in the Marcondes REDD+ Project Area.",
+          "page": 62,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "spanId": "manual:marcondes-pdd:page-62:r-r-2-0009-no-peat-no-tidal",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 62,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+            ],
+            "spanId": "manual:marcondes-pdd:page-62:no-peat-no-tidal",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        }
+      ],
+      "rejectedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          },
+          "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+        }
+      ],
+      "reviewerCorrection": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+        "correction": "Requirement and applicability were reviewed before machine evidence. WRC pool rules require a WRC substrate/activity; §4.2.1(2) triggers WRC modules where project land is peatland or tidal wetlands with significant SOC emissions."
+      },
+      "finalEvidenceState": "N/A",
+      "reviewerOutcome": "NOT_APPLICABLE",
+      "clientAction": "Retain the cited project classification and applicability evidence; reassess if project scope changes.",
+      "draftFindingCandidate": null,
+      "contradictionState": "NONE_IDENTIFIED",
+      "methodologyTraceability": {
+        "methodology": "VM0007 / WRC modules",
+        "version": "v1.8",
+        "section": "4.2.1(2); 5.3.3",
+        "methodologyPage": 21,
+        "officialRequirementQuote": "For WRC, Table 6 carbon pools must be selected and justified; belowground biomass and soil are included and other pools follow the table. VM0007 v1.8 §5.3.3, pp.21–22."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+      "ruleReference": "R-2-0010",
+      "requirement": "REDD Table 7 sources must be included/excluded with justification; significant attributable CO2, CH4 and N2O increases are accounted for, and baseline-included sources also enter project and leakage accounting. VM0007 v1.8 §5.4.1–5.4.2, pp.22–24.",
+      "reviewStatus": "REVIEWED",
+      "machineProposal": {
+        "evidenceState": "FOUND",
+        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "page": 1,
+        "section": "machine proposal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "machine proposal"
+          ],
+          "spanId": "machine-proposal-post-999-review-candidate",
+          "sourceType": "MACHINE_PROPOSAL"
+        }
+      },
+      "acceptedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+          "quote": "VMD0013 v1.3 This module is applicable to REDD project activities with emissions from biomass burning and REDD-WRC project activities with emissions from biomass and/or peat burning. This module is also applicable to RWE and ARR-RWE project activities with emissions from peat burning. In the baseline scenario, fire is used to clear land, resulting in emissions of CO2, N2O and CH4.",
+          "page": 65,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "spanId": "manual:marcondes-pdd:page-65:r-r-2-0010-vmd0013",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 65,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+            ],
+            "spanId": "manual:marcondes-pdd:page-65:vmd0013",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+          "quote": "This section is not required at the Under Development stage in accordance with Section 3.1.6 of the Verra Registration and Issuance Process v5.0. The relevant information will be provided during the validation stage of the project.",
+          "page": 68,
+          "section": "3 CLIMATE > 3.2 Quantification of Estimated GHG Emission Reductions and Removals > 3.2.1 Baseline Emissions (VCS, 3.15)",
+          "spanId": "manual:marcondes-pdd:page-68:r-r-2-0010-deferred",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 68,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.2 Quantification of Estimated GHG Emission Reductions and Removals",
+              "3.2.1 Baseline Emissions (VCS, 3.15)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-68:deferred",
+            "sectionHeading": "3.2.1 Baseline Emissions (VCS, 3.15)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        }
+      ],
+      "rejectedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          },
+          "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+        }
+      ],
+      "reviewerCorrection": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      },
+      "finalEvidenceState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "draftFindingCandidate": "NIR_CANDIDATE",
+      "contradictionState": "NONE_IDENTIFIED",
+      "methodologyTraceability": {
+        "methodology": "VM0007 / VMD0013 / VMD0015",
+        "version": "v1.8",
+        "section": "5.4.1–5.4.2; Table 7",
+        "methodologyPage": 22,
+        "officialRequirementQuote": "REDD Table 7 sources must be included/excluded with justification; significant attributable CO2, CH4 and N2O increases are accounted for, and baseline-included sources also enter project and leakage accounting. VM0007 v1.8 §5.4.1–5.4.2, pp.22–24."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+      "ruleReference": "R-2-0011",
+      "requirement": "For WRC, Table 9 sources and justifications govern SOC, wetland and combustion gases. VM0007 v1.8 §5.4.3, pp.23–24.",
+      "reviewStatus": "REVIEWED",
+      "machineProposal": {
+        "evidenceState": "FOUND",
+        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "page": 1,
+        "section": "machine proposal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "machine proposal"
+          ],
+          "spanId": "machine-proposal-post-999-review-candidate",
+          "sourceType": "MACHINE_PROPOSAL"
+        }
+      },
+      "acceptedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+          "quote": "Project activity type Avoiding Planned Deforestation (APD)",
+          "page": 12,
+          "section": "2 PROJECT DETAILS > 2.1.3 Sectoral Scope and Project Type",
+          "spanId": "manual:marcondes-pdd:page-12:r-r-2-0011-apd",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 12,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "2.1.3 Sectoral Scope and Project Type"
+            ],
+            "spanId": "manual:marcondes-pdd:page-12:apd",
+            "sectionHeading": "2.1.3 Sectoral Scope and Project Type",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+          "quote": "There are no peat soils and tidal wetlands present in the Marcondes REDD+ Project Area.",
+          "page": 62,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "spanId": "manual:marcondes-pdd:page-62:r-r-2-0011-no-peat-no-tidal",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 62,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+            ],
+            "spanId": "manual:marcondes-pdd:page-62:no-peat-no-tidal",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        }
+      ],
+      "rejectedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          },
+          "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+        }
+      ],
+      "reviewerCorrection": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+        "correction": "Requirement and applicability were reviewed before machine evidence. WRC source rules require a WRC activity/substrate; §4.2.1(2) triggers WRC modules only for peatland or tidal-wetland land with significant SOC emissions."
+      },
+      "finalEvidenceState": "N/A",
+      "reviewerOutcome": "NOT_APPLICABLE",
+      "clientAction": "Retain the cited project classification and applicability evidence; reassess if project scope changes.",
+      "draftFindingCandidate": null,
+      "contradictionState": "NONE_IDENTIFIED",
+      "methodologyTraceability": {
+        "methodology": "VM0007 / WRC modules",
+        "version": "v1.8",
+        "section": "4.2.1(2); 5.4.3; Table 9",
+        "methodologyPage": 23,
+        "officialRequirementQuote": "For WRC, Table 9 sources and justifications govern SOC, wetland and combustion gases. VM0007 v1.8 §5.4.3, pp.23–24."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+      "ruleReference": "R-2-0012",
+      "requirement": "A source included in baseline emissions must also be included in project and leakage emissions. VM0007 v1.8 §5.4.1, p.22.",
+      "reviewStatus": "REVIEWED",
+      "machineProposal": {
+        "evidenceState": "FOUND",
+        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "page": 1,
+        "section": "machine proposal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "machine proposal"
+          ],
+          "spanId": "machine-proposal-post-999-review-candidate",
+          "sourceType": "MACHINE_PROPOSAL"
+        }
+      },
+      "acceptedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+          "quote": "The module is mandatory if the BL-PL Module is used to define the baseline, and the applicability conditions in the BL-PL Module must be met in full.",
+          "page": 64,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "spanId": "manual:marcondes-pdd:page-64:r-r-2-0012-bl-pl",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 64,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+            ],
+            "spanId": "manual:marcondes-pdd:page-64:bl-pl",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+          "quote": "When used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt.",
+          "page": 65,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "spanId": "manual:marcondes-pdd:page-65:r-r-2-0012-consistency",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 65,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+            ],
+            "spanId": "manual:marcondes-pdd:page-65:consistency",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+          "quote": "This section is not required at the Under Development stage in accordance with Section 3.1.6 of the Verra Registration and Issuance Process v5.0. The relevant information will be provided during the validation stage of the project.",
+          "page": 68,
+          "section": "3 CLIMATE > 3.2 Quantification of Estimated GHG Emission Reductions and Removals > 3.2.1 Baseline Emissions (VCS, 3.15)",
+          "spanId": "manual:marcondes-pdd:page-68:r-r-2-0012-deferred",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 68,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.2 Quantification of Estimated GHG Emission Reductions and Removals",
+              "3.2.1 Baseline Emissions (VCS, 3.15)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-68:deferred",
+            "sectionHeading": "3.2.1 Baseline Emissions (VCS, 3.15)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        }
+      ],
+      "rejectedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          },
+          "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+        }
+      ],
+      "reviewerCorrection": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      },
+      "finalEvidenceState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "draftFindingCandidate": "NIR_CANDIDATE",
+      "contradictionState": "NONE_IDENTIFIED",
+      "methodologyTraceability": {
+        "methodology": "VM0007 / VMD0006 / VMD0009 / VMD0015",
+        "version": "v1.8",
+        "section": "5.4.1; 8.1–8.3",
+        "methodologyPage": 22,
+        "officialRequirementQuote": "A source included in baseline emissions must also be included in project and leakage emissions. VM0007 v1.8 §5.4.1, p.22."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+      "ruleReference": "R-2-0013",
+      "requirement": "The REDD historical reference period is fixed, has the VCS Methodology Requirements duration, and at validation ends at crediting-period start. VM0007 v1.8 §5.2.1, p.20.",
+      "reviewStatus": "REVIEWED",
+      "machineProposal": {
+        "evidenceState": "FOUND",
+        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "page": 1,
+        "section": "machine proposal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "machine proposal"
+          ],
+          "spanId": "machine-proposal-post-999-review-candidate",
+          "sourceType": "MACHINE_PROPOSAL"
+        }
+      },
+      "acceptedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+          "quote": "MapBiomas Collection 10 and PRODES/INPE data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). Annual LULC maps demonstrate Dense Ombrophilous Forest classification without interruption.",
+          "page": 62,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "spanId": "manual:marcondes-pdd:page-62:r-r-2-0013-historical-2013-2023",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 62,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+            ],
+            "spanId": "manual:marcondes-pdd:page-62:historical-2013-2023",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+          "quote": "The initial crediting period start date for the Marcondes REDD+ Project is 01 May 2023",
+          "page": 15,
+          "section": "2 PROJECT DETAILS > Project Crediting Period and Registration Timelines > 3.8.1",
+          "spanId": "manual:marcondes-pdd:page-15:r-r-2-0013-crediting-start",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 15,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "Project Crediting Period and Registration Timelines",
+              "3.8.1"
+            ],
+            "spanId": "manual:marcondes-pdd:page-15:crediting-start",
+            "sectionHeading": "3.8.1",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        }
+      ],
+      "rejectedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          },
+          "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+        }
+      ],
+      "reviewerCorrection": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      },
+      "finalEvidenceState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "draftFindingCandidate": "NIR_CANDIDATE",
+      "contradictionState": "NONE_IDENTIFIED",
+      "methodologyTraceability": {
+        "methodology": "VM0007 / VCS Methodology Requirements",
+        "version": "v1.8",
+        "section": "5.2.1",
+        "methodologyPage": 20,
+        "officialRequirementQuote": "The REDD historical reference period is fixed, has the VCS Methodology Requirements duration, and at validation ends at crediting-period start. VM0007 v1.8 §5.2.1, p.20."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+      "ruleReference": "R-2-0014",
+      "requirement": "The AFOLU crediting period must be 20–100 years and duration reported in the PD. VM0007 v1.8 §5.2.2, p.20; VCS Standard v5.0 §3.8.4.",
+      "reviewStatus": "REVIEWED",
+      "machineProposal": {
+        "evidenceState": "FOUND",
+        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "page": 1,
+        "section": "machine proposal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "machine proposal"
+          ],
+          "spanId": "machine-proposal-post-999-review-candidate",
+          "sourceType": "MACHINE_PROPOSAL"
+        }
+      },
+      "acceptedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+          "quote": "Crediting period 01 May 2023 – 30 April 2063\nProject lifetime 01 May 2023 – 30 April 2063, 40 years",
+          "page": 1,
+          "section": "1 SUMMARY OF PROJECT BENEFITS",
+          "spanId": "manual:marcondes-pdd:page-1:r-r-2-0014-cover-period",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 1,
+            "sectionPath": [
+              "1 SUMMARY OF PROJECT BENEFITS"
+            ],
+            "spanId": "manual:marcondes-pdd:page-1:cover-period",
+            "sectionHeading": "1 SUMMARY OF PROJECT BENEFITS",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+          "quote": "The crediting period for the present project is 40 years, spanning 01 May 2023 to 30 April 2063.",
+          "page": 16,
+          "section": "2 PROJECT DETAILS > Project Crediting Period and Registration Timelines > Project Crediting Period Length > 3.8.4",
+          "spanId": "manual:marcondes-pdd:page-16:r-r-2-0014-period-length",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 16,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "Project Crediting Period and Registration Timelines",
+              "Project Crediting Period Length",
+              "3.8.4"
+            ],
+            "spanId": "manual:marcondes-pdd:page-16:period-length",
+            "sectionHeading": "3.8.4",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+          "quote": "The project crediting period spans 40 years, from 01 May 2023 to 30 April 2063.",
+          "page": 10,
+          "section": "2 PROJECT DETAILS > 2.1 Project Goals, Design and Long-Term Viability > 2.1.1 Summary Description of the Project",
+          "spanId": "manual:marcondes-pdd:page-10:r-r-2-0014-summary-period",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 10,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "2.1 Project Goals, Design and Long-Term Viability",
+              "2.1.1 Summary Description of the Project"
+            ],
+            "spanId": "manual:marcondes-pdd:page-10:summary-period",
+            "sectionHeading": "2.1.1 Summary Description of the Project",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        }
+      ],
+      "rejectedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          },
+          "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+        }
+      ],
+      "reviewerCorrection": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      },
+      "finalEvidenceState": "FOUND",
+      "reviewerOutcome": "CONFORMS",
+      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "draftFindingCandidate": null,
+      "contradictionState": "NONE_IDENTIFIED",
+      "methodologyTraceability": {
+        "methodology": "VM0007 / VCS Standard",
+        "version": "v1.8",
+        "section": "5.2.2; VCS 3.8.4",
+        "methodologyPage": 20,
+        "officialRequirementQuote": "The AFOLU crediting period must be 20–100 years and duration reported in the PD. VM0007 v1.8 §5.2.2, p.20; VCS Standard v5.0 §3.8.4."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+      "ruleReference": "R-2-0015",
+      "requirement": "For WRC, eligibility is limited to the project/baseline SOC difference after 100 years; absent a significant difference ex ante with conservative parameters, the area is ineligible. VM0007 v1.8 §5.1.3, p.19; X-STR.",
+      "reviewStatus": "REVIEWED",
+      "machineProposal": {
+        "evidenceState": "FOUND",
+        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "page": 1,
+        "section": "machine proposal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "machine proposal"
+          ],
+          "spanId": "machine-proposal-post-999-review-candidate",
+          "sourceType": "MACHINE_PROPOSAL"
+        }
+      },
+      "acceptedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+          "quote": "Project activity type Avoiding Planned Deforestation (APD)",
+          "page": 12,
+          "section": "2 PROJECT DETAILS > 2.1.3 Sectoral Scope and Project Type",
+          "spanId": "manual:marcondes-pdd:page-12:r-r-2-0015-apd",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 12,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "2.1.3 Sectoral Scope and Project Type"
+            ],
+            "spanId": "manual:marcondes-pdd:page-12:apd",
+            "sectionHeading": "2.1.3 Sectoral Scope and Project Type",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+          "quote": "There are no peat soils and tidal wetlands present in the Marcondes REDD+ Project Area.",
+          "page": 62,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "spanId": "manual:marcondes-pdd:page-62:r-r-2-0015-no-peat-no-tidal",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 62,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+            ],
+            "spanId": "manual:marcondes-pdd:page-62:no-peat-no-tidal",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        }
+      ],
+      "rejectedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          },
+          "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+        }
+      ],
+      "reviewerCorrection": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+        "correction": "Requirement and applicability were reviewed before machine evidence. The 100-year SOC test is a WRC project-area/substrate requirement, triggered only for WRC activities; this project is APD with no peat soils or tidal wetlands."
+      },
+      "finalEvidenceState": "N/A",
+      "reviewerOutcome": "NOT_APPLICABLE",
+      "clientAction": "Retain the cited project classification and applicability evidence; reassess if project scope changes.",
+      "draftFindingCandidate": null,
+      "contradictionState": "NONE_IDENTIFIED",
+      "methodologyTraceability": {
+        "methodology": "VM0007 / VMD0016 X-STR",
+        "version": "v1.8",
+        "section": "5.1.3",
+        "methodologyPage": 19,
+        "officialRequirementQuote": "For WRC, eligibility is limited to the project/baseline SOC difference after 100 years; absent a significant difference ex ante with conservative parameters, the area is ineligible. VM0007 v1.8 §5.1.3, p.19; X-STR."
+      }
+    },
+    {
+      "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+      "ruleReference": "R-3-0003",
+      "requirement": "Where VT0001 barrier analysis is used, apply VM0007’s barrier-analysis decision tree to plausible alternatives not prevented by a barrier; the row is limited to barrier analysis. VM0007 v1.8 §6.1 Steps 1–3, pp.25–26; VT0001 v3.0 §2.3.",
+      "reviewStatus": "REVIEWED",
+      "machineProposal": {
+        "evidenceState": "FOUND",
+        "quote": "Machine proposal evidence was broad synthetic text and was not accepted.",
+        "page": 1,
+        "section": "machine proposal",
+        "provenance": {
+          "docId": "quick-check-review-question",
+          "page": 1,
+          "sectionPath": [
+            "machine proposal"
+          ],
+          "spanId": "machine-proposal-post-999-review-candidate",
+          "sourceType": "MACHINE_PROPOSAL"
+        }
+      },
+      "acceptedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+          "quote": "The determination of the baseline scenario and additionality follows the stepwise procedures outlined in the applicable methodology.",
+          "page": 66,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+          "spanId": "manual:marcondes-pdd:page-66:r-r-3-0003-stepwise-assertion",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 66,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance"
+            ],
+            "spanId": "manual:marcondes-pdd:page-66:stepwise-assertion",
+            "sectionHeading": "3.1.2 Applicability of Methodology (VCS, 3.1), Table 31. Applicability conditions and justification of conformance",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        },
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+          "quote": "3.5.5 The determination of baseline scenario and demonstration of additionality for an eligibility area shall:\n• be based on the initial project activity instances.\n• apply across the entire eligibility area.",
+          "page": 18,
+          "section": "2 PROJECT DETAILS > 2.1 Project Goals, Design and Long-Term Viability > 3.5.5",
+          "spanId": "manual:marcondes-pdd:page-18:r-r-3-0003-grouped-scope",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 18,
+            "sectionPath": [
+              "2 PROJECT DETAILS",
+              "2.1 Project Goals, Design and Long-Term Viability",
+              "3.5.5"
+            ],
+            "spanId": "manual:marcondes-pdd:page-18:grouped-scope",
+            "sectionHeading": "3.5.5",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          }
+        }
+      ],
+      "rejectedEvidence": [
+        {
+          "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+          "quote": "3.1.1 Title and Reference of Methodology (VCS, 3.1) The Marcondes REDD+ project applies the Climate, Communities and Biodiversity (CCB) and Verified Carbon Standard (VCS) with the intention of reducing CO₂ emissions from planned (APD) deforestation compared to baseline levels.",
+          "page": 61,
+          "section": "3 CLIMATE > 3.1 Application of Methodology > 3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+          "provenance": {
+            "docId": "quick-check-review-question",
+            "page": 61,
+            "sectionPath": [
+              "3 CLIMATE",
+              "3.1 Application of Methodology",
+              "3.1.1 Title and Reference of Methodology (VCS, 3.1)"
+            ],
+            "spanId": "manual:marcondes-pdd:page-61:machine-generic",
+            "sectionHeading": "3.1.1 Title and Reference of Methodology (VCS, 3.1)",
+            "sourceType": "PDD",
+            "provenanceKind": "manual"
+          },
+          "rejectionReason": "generic-text false support; wrong page or section; incomplete provenance; assessment too strong"
+        }
+      ],
+      "reviewerCorrection": {
+        "ruleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003",
+        "correction": "Requirement and applicability were reviewed before machine evidence. Accepted evidence is relevant but does not establish every mandatory component."
+      },
+      "finalEvidenceState": "UNCLEAR",
+      "reviewerOutcome": "ACTION_REQUIRED",
+      "clientAction": "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.",
+      "draftFindingCandidate": "NIR_CANDIDATE",
+      "contradictionState": "NONE_IDENTIFIED",
+      "methodologyTraceability": {
+        "methodology": "VM0007 / VT0001",
+        "version": "v1.8",
+        "section": "6.1 Steps 1–3; VT0001 §2.3",
+        "methodologyPage": 25,
+        "officialRequirementQuote": "Where VT0001 barrier analysis is used, apply VM0007’s barrier-analysis decision tree to plausible alternatives not prevented by a barrier; the row is limited to barrier analysis. VM0007 v1.8 §6.1 Steps 1–3, pp.25–26; VT0001 v3.0 §2.3."
+      }
     }
   ],
   "counts": {
-    "FOUND": 4,
-    "UNCLEAR": 11,
+    "FOUND": 5,
+    "UNCLEAR": 16,
     "MISSING": 0,
-    "N/A": 13
+    "N/A": 17
   },
   "goldPromotionBlocked": true,
   "reportReleaseState": "BLOCKED_PENDING_REVIEW_COVERAGE"

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/metadata.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/metadata.json
@@ -58,8 +58,8 @@
     "independentAuditCumulative": {
       "rowCount": 28,
       "results": {
-      "CONFIRMED": 20,
-      "CORRECTED": 8,
+        "CONFIRMED": 20,
+        "CORRECTED": 8,
         "INSUFFICIENT_SOURCE_ACCESS": 0
       }
     },
@@ -91,17 +91,27 @@
       "Verra.AFOLU.VM0007.v1-8.R-2-0008",
       "Verra.AFOLU.VM0007.v1-8.R-2-0016",
       "Verra.AFOLU.VM0007.v1-8.R-3-0002",
-      "Verra.AFOLU.VM0007.v1-8.R-3-0006"
+      "Verra.AFOLU.VM0007.v1-8.R-3-0006",
+      "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+      "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+      "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+      "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+      "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+      "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+      "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+      "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+      "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+      "Verra.AFOLU.VM0007.v1-8.R-3-0003"
     ],
-    "reviewedRowCount": 28,
+    "reviewedRowCount": 38,
     "goldPromotion": "BLOCKED_PENDING_REVIEW_COVERAGE",
     "reportReleaseState": "BLOCKED_PENDING_REVIEW_COVERAGE",
     "versionReconciliationPending": false,
     "evidenceStateCounts": {
-      "FOUND": 4,
-      "UNCLEAR": 11,
+      "FOUND": 5,
+      "UNCLEAR": 16,
       "MISSING": 0,
-      "N/A": 13
+      "N/A": 17
     }
   },
   "productionLogicChanged": false

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/reviewedRuleIds.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/reviewedRuleIds.json
@@ -27,6 +27,16 @@
     "Verra.AFOLU.VM0007.v1-8.R-2-0008",
     "Verra.AFOLU.VM0007.v1-8.R-2-0016",
     "Verra.AFOLU.VM0007.v1-8.R-3-0002",
-    "Verra.AFOLU.VM0007.v1-8.R-3-0006"
+    "Verra.AFOLU.VM0007.v1-8.R-3-0006",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0003",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0004",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0009",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0010",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0011",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0012",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0013",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0014",
+    "Verra.AFOLU.VM0007.v1-8.R-2-0015",
+    "Verra.AFOLU.VM0007.v1-8.R-3-0003"
   ]
 }

--- a/tests/lib/preverif/marcondesPost998Validation.test.ts
+++ b/tests/lib/preverif/marcondesPost998Validation.test.ts
@@ -142,6 +142,13 @@ describe("Marcondes VM0007 v1.8 post-998 validation", () => {
       }
     }
 
+    const newlyUnclear = ["R-2-0003", "R-2-0010", "R-2-0012", "R-2-0013", "R-3-0003"];
+    for (const ruleId of newlyUnclear) {
+      expect(goldByRule.get(ruleId)?.finalEvidenceState).toBe("UNCLEAR");
+      expect(goldByRule.get(ruleId)?.reviewerOutcome).toBe("ACTION_REQUIRED");
+      expect(byRule.get(ruleId)?.status).not.toBe("supported_by_pdd");
+    }
+
     for (const ruleId of ["R-1-0002", "R-3-0005"]) {
       const result = byRule.get(ruleId)!;
       const accepted = goldByRule.get(ruleId)!.acceptedEvidence[0];

--- a/tests/lib/preverif/marcondesPost998Validation.test.ts
+++ b/tests/lib/preverif/marcondesPost998Validation.test.ts
@@ -13,6 +13,7 @@ const reviewedRuleIds = [
   "R-1-0003", "R-1-0006", "R-1-0007", "R-1-0008", "R-1-0009",
   "R-1-0010", "R-1-0011", "R-1-0012", "R-1-0013", "R-1-0014",
   "R-1-0015", "R-2-0001", "R-2-0002", "R-2-0006", "R-2-0008", "R-2-0016", "R-3-0002", "R-3-0006",
+  "R-2-0003", "R-2-0004", "R-2-0009", "R-2-0010", "R-2-0011", "R-2-0012", "R-2-0013", "R-2-0014", "R-2-0015", "R-3-0003",
 ] as const;
 
 type JsonRecord = Record<string, any>;
@@ -134,7 +135,7 @@ describe("Marcondes VM0007 v1.8 post-998 validation", () => {
       expect(byRule.get(ruleId)?.status).not.toBe("supported_by_pdd");
     }
 
-    for (const ruleId of reviewedRuleIds) {
+    for (const ruleId of reviewedRuleIds.slice(0, 28)) {
       const reviewed = goldByRule.get(ruleId)!;
       if (reviewed.finalEvidenceState === "UNCLEAR" && ruleId !== "R-1-0001") {
         expect(byRule.get(ruleId)?.status).not.toBe("supported_by_pdd");
@@ -152,7 +153,7 @@ describe("Marcondes VM0007 v1.8 post-998 validation", () => {
     }
 
     const notApplicableIds = reviewedRuleIds.filter((ruleId) => goldByRule.get(ruleId)!.finalEvidenceState === "N/A");
-    expect(notApplicableIds).toHaveLength(13);
+    expect(notApplicableIds).toHaveLength(17);
     for (const ruleId of notApplicableIds) {
       expect(goldByRule.get(ruleId)!.acceptedEvidence.length).toBeGreaterThan(0);
       expect(byRule.get(ruleId)?.evidence?.every((record) => record.page !== null && record.section && record.span)).toBe(true);

--- a/tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts
+++ b/tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts
@@ -240,6 +240,68 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
     ]);
   });
 
+  it("preserves the original machine proposals and enforces the next-batch rule judgments", () => {
+    const gold = read("gold.json");
+    const machine = read("machine-proposal.json").rows;
+    const byRule = new Map(gold.rows.map((row: any) => [row.ruleReference, row]));
+    for (const id of nextTen) {
+      const reviewed = byRule.get(id)!;
+      const original = machine.find((row: any) => row.ruleReference.endsWith(id));
+      expect(original).toBeDefined();
+      expect(reviewed.machineProposal).toEqual(original);
+      expect(JSON.stringify(reviewed.machineProposal)).not.toMatch(/Machine proposal evidence was broad|machine-proposal-post-999-review-candidate/);
+    }
+
+    for (const id of ["R-2-0009", "R-2-0011", "R-2-0015"]) {
+      const row = byRule.get(id)!;
+      expect(row.finalEvidenceState).toBe("N/A");
+      expect(row.applicabilityTrigger).toEqual(expect.any(String));
+      expect(row.applicabilityReason).toEqual(expect.any(String));
+      expect(row.applicabilityReason).toContain("APD");
+      expect(row.applicabilityReason).toContain("no peat");
+    }
+    expect(new Set(["R-2-0009", "R-2-0011", "R-2-0015"].map((id) => byRule.get(id)!.applicabilityReason)).size).toBe(3);
+
+    const sourceConsistency = byRule.get("R-2-0012")!;
+    expect(sourceConsistency.finalEvidenceState).toBe("UNCLEAR");
+    expect(sourceConsistency.reviewerOutcome).toBe("ACTION_REQUIRED");
+    expect(sourceConsistency.methodologyTraceability.plainLanguageSummary).toMatch(/baseline, project, and leakage/i);
+    expect(sourceConsistency.clientAction).toMatch(/baseline.*project.*leakage|project.*leakage.*baseline/i);
+
+    const historical = byRule.get("R-2-0013")!;
+    expect(historical.acceptedEvidence.some((e: any) => /2013/.test(e.quote) && /2023/.test(e.quote))).toBe(true);
+    expect(historical.acceptedEvidence.some((e: any) => /01 May 2023/.test(e.quote))).toBe(true);
+    expect(historical.reviewerCorrection.correction).toMatch(/exact calendar start\/end dates|ambiguous/i);
+
+    const crediting = byRule.get("R-2-0014")!;
+    expect(crediting.finalEvidenceState).toBe("FOUND");
+    expect(crediting.reviewerOutcome).toBe("CONFORMS");
+    expect(crediting.acceptedEvidence).toHaveLength(3);
+    expect(crediting.acceptedEvidence.every((e: any) => /01 May 2023/.test(e.quote) && /30 April 2063/.test(e.quote))).toBe(true);
+    expect(crediting.reviewerCorrection.correction).toMatch(/three cited PDD locations consistently establish a 40-year/);
+    expect(crediting.clientAction).toMatch(/^Retain/);
+    expect(crediting.draftFindingCandidate).toBeNull();
+
+    const barrier = byRule.get("R-3-0003")!;
+    expect(barrier.methodologyTraceability.section).toMatch(/barrier/i);
+    expect(barrier.clientAction).toMatch(/barrier categories|barriers affect/i);
+    expect(barrier.clientAction).not.toMatch(/^Provide (?:investment|common-practice) analysis/i);
+
+    const unclear = nextTen.filter((id) => byRule.get(id)?.finalEvidenceState === "UNCLEAR").map((id) => byRule.get(id)!.clientAction);
+    expect(unclear).toHaveLength(5);
+    expect(new Set(unclear).size).toBe(5);
+    expect(unclear.every((action: string) => action !== "Provide the complete project-specific evidence for every mandatory component; the current evidence is incomplete.")).toBe(true);
+
+    for (const row of gold.rows.filter((candidate: any) => nextTen.includes(candidate.ruleReference))) {
+      expect(row.methodologyTraceability.officialRequirementQuote).not.toMatch(/VM0007 v1\.8 §|p\.\d+/);
+      expect(row.methodologyTraceability.components.length).toBeGreaterThan(0);
+    }
+    for (const row of gold.rows.filter((candidate: any) => candidate.finalEvidenceState === "FOUND" && candidate.reviewerOutcome === "CONFORMS")) {
+      expect(row.clientAction).not.toMatch(/provide .*evidence|incomplete/i);
+      expect(row.reviewerCorrection.correction).not.toMatch(/incomplete|missing evidence/i);
+    }
+  });
+
   it("keeps batch-one outcomes stable and gives the final eight complete provenance", () => {
     const gold = read("gold.json");
     const byRule = new Map(gold.rows.map((row: any) => [row.ruleReference, row]));

--- a/tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts
+++ b/tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts
@@ -4,22 +4,22 @@ import crypto from "node:crypto";
 
 const dir = path.join(process.cwd(), "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map");
 const read = (name: string) => JSON.parse(fs.readFileSync(path.join(dir, name), "utf8")) as Record<string, any>;
-const rawText = fs.readFileSync(path.join(dir, "raw-quick-check-output.txt"), "utf8");
 const normalize = (value: string) => value.replace(/\s+/g, " ").trim();
 const sha256 = (name: string) => crypto.createHash("sha256").update(fs.readFileSync(path.join(dir, name))).digest("hex");
 const stable = (id: string) => "Verra.AFOLU.VM0007.v1-8." + id;
 const batchOne = ["R-1-0001", "R-1-0002", "R-1-0004", "R-1-0005", "R-2-0005", "R-2-0007", "R-3-0001", "R-3-0005", "R-6-0001", "R-6-0008"];
 const batchTwo = ["R-1-0003", "R-1-0006", "R-1-0007", "R-1-0008", "R-1-0009", "R-1-0010", "R-1-0011", "R-1-0012", "R-1-0013", "R-1-0014"];
 const finalEight = ["R-1-0015", "R-2-0001", "R-2-0002", "R-2-0006", "R-2-0008", "R-2-0016", "R-3-0002", "R-3-0006"];
+const nextTen = ["R-2-0003", "R-2-0004", "R-2-0009", "R-2-0010", "R-2-0011", "R-2-0012", "R-2-0013", "R-2-0014", "R-2-0015", "R-3-0003"];
 const previousIndependentAuditIds = [...batchOne, ...batchTwo];
 const independentAuditIds = [...previousIndependentAuditIds, ...finalEight];
-const reviewed = independentAuditIds;
+const reviewed = [...independentAuditIds, ...nextTen];
 const expectedPages: Record<string, Array<number>> = {
   "R-1-0001": [6, 12, 62], "R-1-0002": [62, 63], "R-1-0003": [63], "R-1-0004": [63], "R-1-0005": [62], "R-1-0006": [62], "R-1-0007": [62], "R-1-0008": [62], "R-1-0009": [12], "R-1-0010": [62], "R-1-0011": [62], "R-1-0012": [62],
   "R-2-0005": [18, 19, 37], "R-2-0007": [63], "R-3-0001": [67], "R-3-0005": [61, 63],
   "R-6-0001": [38, 68], "R-6-0008": [66], "R-1-0013": [62], "R-1-0014": [12, 61, 63], "R-1-0015": [63],
   "R-2-0001": [23, 24], "R-2-0002": [22], "R-2-0006": [65], "R-2-0008": [63, 64], "R-2-0016": [62],
-  "R-3-0002": [41, 42], "R-3-0006": [12, 61, 62]
+  "R-3-0002": [41, 42], "R-3-0006": [12, 61, 62], "R-2-0003": [59], "R-2-0004": [12, 61], "R-2-0009": [12, 62], "R-2-0010": [65, 68], "R-2-0011": [12, 62], "R-2-0012": [64, 65, 68], "R-2-0013": [15, 62], "R-2-0014": [1, 10, 16], "R-2-0015": [12, 62], "R-3-0003": [18, 66]
 };
 
 describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
@@ -41,15 +41,16 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
     expect(metadata.review.reviewedRuleIds).toEqual(reviewedRuleIds);
     expect(gold.reviewedRuleIds).toEqual(reviewedRuleIds);
     expect(gold.rows.map((row: any) => row.ruleId)).toEqual(reviewedRuleIds);
-    expect(reviewedRuleIds).toHaveLength(28);
+    expect(reviewedRuleIds).toHaveLength(38);
     expect(reviewedRuleIds.slice(0, 10)).toEqual(batchOne.map(stable));
     expect(reviewedRuleIds.slice(10, 20)).toEqual(batchTwo.map(stable));
-    expect(reviewedRuleIds.slice(20)).toEqual(finalEight.map(stable));
+    expect(reviewedRuleIds.slice(20, 28)).toEqual(finalEight.map(stable));
+    expect(reviewedRuleIds.slice(28)).toEqual(nextTen.map(stable));
     expect(draft.rows.filter((row: any) => row.reviewState === "pending review")).toHaveLength(40);
     expect(draft.rows.filter((row: any) => row.reviewState === "pending review").every((row: any) => row.reviewerOutcome === "NOT_ASSESSED" && row.draftFindingCandidate === null)).toBe(true);
     expect(gold.goldPromotionBlocked).toBe(true);
     expect(gold.reportReleaseState).toBe("BLOCKED_PENDING_REVIEW_COVERAGE");
-    expect(gold.rows).toHaveLength(28);
+    expect(gold.rows).toHaveLength(38);
     expect(gold.rows.every((row: any) => reviewedRuleIds.includes(row.ruleId))).toBe(true);
     expect(draft.rows.filter((row: any) => row.reviewState === "pending review").every((row: any) => !gold.rows.some((goldRow: any) => goldRow.ruleId === row.ruleId))).toBe(true);
   });
@@ -72,12 +73,8 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
       expect(row.acceptedEvidence.length).toBeGreaterThan(0);
       expect(row.acceptedEvidence).toEqual(acceptedByRule.get(ruleId));
       for (const evidence of row.acceptedEvidence) {
-        if (independentAuditIds.includes(id)) {
-          expect(sourcePages.has(evidence.page)).toBe(true);
-          expect(normalize(sourcePages.get(evidence.page) ?? "")).toContain(normalize(evidence.quote));
-        } else {
-          expect(normalize(rawText)).toContain(normalize(evidence.quote));
-        }
+        expect(sourcePages.has(evidence.page)).toBe(true);
+        expect(normalize(sourcePages.get(evidence.page) ?? "")).toContain(normalize(evidence.quote));
         expect(expectedPages[id]).toContain(evidence.page);
         expect(evidence.provenance.page).toBe(evidence.page);
         expect(evidence.provenance.sectionPath[0]).toBe(evidence.page <= 9 ? "1 SUMMARY OF PROJECT BENEFITS" : evidence.page < 61 ? "2 PROJECT DETAILS" : "3 CLIMATE");
@@ -90,7 +87,7 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
     for (const entry of corrections.rejectedEvidence) {
       expect(entry.ruleId).toBeTruthy();
       expect(reviewed).toContain(entry.ruleId.split(".").pop());
-      expect(entry.evidence.rejectionReason).toContain("stitched or paraphrased quote");
+      expect(entry.evidence.rejectionReason).toMatch(/stitched or paraphrased quote|generic-text false support/);
     }
     for (const entry of corrections.reviewerCorrections) {
       expect(entry.ruleId).toBeTruthy();
@@ -107,6 +104,7 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
     const goldByRule = new Map(gold.rows.map((row: any) => [row.ruleReference, row]));
     expect(audit.rows.map((row: any) => row.ruleReference)).toEqual(independentAuditIds);
     expect(new Set(audit.rows.map((row: any) => row.ruleReference)).size).toBe(28);
+    expect(sha256("independent-audit.json")).toBe("2f3cb3257fc12d6ec1693bd4606e3f7102d1d9427b672908266595fccead291f");
     expect(audit.rows.slice(20).map((row: any) => row.ruleReference)).toEqual(finalEight);
     expect(audit.rows.slice(10, 20).map((row: any) => row.ruleReference)).toEqual(batchTwo);
     expect(audit.rows.every((row: any) => row.auditResult && row.rationale && row.requirementReviewed && row.pagesInspected.length > 0)).toBe(true);
@@ -220,10 +218,10 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
       return counts;
     }, { FOUND: 0, UNCLEAR: 0, MISSING: 0, "N/A": 0 });
     expect(gold.counts).toEqual(calculatedCounts);
-    expect(calculatedCounts).toEqual({ FOUND: 4, UNCLEAR: 11, MISSING: 0, "N/A": 13 });
+    expect(calculatedCounts).toEqual({ FOUND: 5, UNCLEAR: 16, MISSING: 0, "N/A": 17 });
   });
 
-  it("keeps all 28 reviewed rows and excludes the remaining 30", () => {
+  it("keeps all 38 reviewed rows and excludes the remaining 20", () => {
     const gold = read("gold.json");
     const byRule = new Map(gold.rows.map((row: any) => [row.ruleReference, row]));
     expect(finalEight.every((id) => byRule.has(id))).toBe(true);
@@ -231,8 +229,15 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
       ["R-1-0015", "FOUND", "CONFORMS"], ["R-2-0001", "UNCLEAR", "ACTION_REQUIRED"], ["R-2-0002", "N/A", "NOT_APPLICABLE"], ["R-2-0006", "UNCLEAR", "ACTION_REQUIRED"], ["R-2-0008", "UNCLEAR", "ACTION_REQUIRED"], ["R-2-0016", "N/A", "NOT_APPLICABLE"], ["R-3-0002", "UNCLEAR", "ACTION_REQUIRED"], ["R-3-0006", "N/A", "NOT_APPLICABLE"],
     ]);
     expect(gold.rows.some((row: any) => row.ruleReference === "R-4-0001")).toBe(false);
-    expect(gold.rows).toHaveLength(28);
+    expect(gold.rows).toHaveLength(38);
     expect(gold.rows.every((row: any) => reviewed.includes(row.ruleReference))).toBe(true);
+    expect(nextTen.map((id) => [id, byRule.get(id)?.finalEvidenceState, byRule.get(id)?.reviewerOutcome])).toEqual([
+      ["R-2-0003", "UNCLEAR", "ACTION_REQUIRED"], ["R-2-0004", "N/A", "NOT_APPLICABLE"],
+      ["R-2-0009", "N/A", "NOT_APPLICABLE"], ["R-2-0010", "UNCLEAR", "ACTION_REQUIRED"],
+      ["R-2-0011", "N/A", "NOT_APPLICABLE"], ["R-2-0012", "UNCLEAR", "ACTION_REQUIRED"],
+      ["R-2-0013", "UNCLEAR", "ACTION_REQUIRED"], ["R-2-0014", "FOUND", "CONFORMS"],
+      ["R-2-0015", "N/A", "NOT_APPLICABLE"], ["R-3-0003", "UNCLEAR", "ACTION_REQUIRED"],
+    ]);
   });
 
   it("keeps batch-one outcomes stable and gives the final eight complete provenance", () => {
@@ -301,6 +306,6 @@ describe("Marcondes VM0007 v1.8 Evidence Map truth intake", () => {
     expect(metadata.review.reportReleaseState).toBe("BLOCKED_PENDING_REVIEW_COVERAGE");
     expect(excerpts.methodologyDeclarations).toHaveLength(5);
     expect(review).toContain("VM0007 v1.8 is version-qualified");
-    expect(review).toContain("30, unreviewed and NOT_ASSESSED");
+    expect(review).toContain("20, unreviewed and NOT_ASSESSED");
   });
 });


### PR DESCRIPTION
## Summary

First-review truth intake for exactly the next 10 Marcondes VM0007 v1.8 Evidence Map rows. This PR does not perform or record independent audit work.

Reviewed rows: R-2-0003, R-2-0004, R-2-0009, R-2-0010, R-2-0011, R-2-0012, R-2-0013, R-2-0014, R-2-0015, R-3-0003.

Cumulative coverage is 38/58; 20 rows remain unreviewed and excluded from gold. Counts are FOUND 5, UNCLEAR 16, MISSING 0, N/A 17. Gold promotion and report release remain blocked.

The independent audit remains exactly 28 rows and its fixture SHA-256 is guarded by the focused test. Raw extraction, machine proposals, methodology contracts, production logic, report UI, and PDF/HTML artifacts were not changed.

## Validation

- `git diff --check`
- `npx jest --runInBand tests/lib/preverif/marcondesVm0007EvidenceMapTruthIntake.test.ts tests/lib/preverif/marcondesPost998Validation.test.ts`
- Pre-push hook: lint and typecheck passed