### PR TITLE
docs: update vm0007 phase 7 status

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -345,8 +345,8 @@ Build a progressively improving VM0007 v1.8 Evidence Map using PDF-backed machin
 
 Current focus:
 - Phase 6 complete: canonical system prompt and new-PDD playbook delivered by PR #994.
-- Phase 7 active: Marcondes truth intake and v1.7/v1.8 reconciliation.
-- Phase 8 planned: generic system improvement after reviewed truth exists.
+- Phase 7 complete: Marcondes truth intake and v1.7/v1.8 reconciliation delivered by PR #1012.
+- Phase 8 active: generic system improvement after reviewed truth exists.
 
 Not active now:
 - Production logic changes in truth-intake PRs
@@ -363,8 +363,8 @@ Not active now:
 5) RC4 — Report Fixture Layer: Blocked — Report fixture output remains quarantined historical regression data. Report summary expectations and internal preview output are fixture-driven and testable, but the legacy Envira report fixture is not client-ready truth and is pending versioned re-audit. Historical delivery is preserved as PR #914.
 6) RC5 — Client-Readiness Gate: Done — The internal-preview/client-readiness boundary is documented and legacy mismatch fixtures remain quarantined; no legacy Envira output is promoted as VM0007 v1.8 truth.
 7) RC6 — Evidence Map Learning Contract: Done — Defined the repeatable two-PR cycle for VM0007 evidence-map learning and delivered the canonical system prompt plus new-PDD playbook in PR #994.
-8) RC7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake: Active — Intake Marcondes REDD+ as the active VM0007 v1.8 truth case while reconciling the internal v1.7/v1.8 discrepancy, preserving raw 58-row output, and counting only explicitly reviewed rows as gold.
-9) RC8 — Marcondes Generic System Improvement: Planned — Use reviewed Marcondes truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures after the reviewed truth exists.
+8) RC7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake: Done — Intake Marcondes REDD+ as the completed VM0007 v1.8 truth case while reconciling the internal v1.7/v1.8 discrepancy, preserving raw 58-row output, counting only explicitly reviewed rows as gold, and delivering the result in PR #1012.
+9) RC8 — Marcondes Generic System Improvement: Active — Use reviewed Marcondes truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures after the reviewed truth exists.
 10) RC9 — Review and Gold Promotion Tooling: Planned — Make partial review and correction generation easy while preserving machine proposal, reviewer correction, final truth, and explicit gold coverage separately.
 11) RC10 — Second Unseen VM0007 v1.8 PDD: Planned — Run the same truth-intake and generic-improvement cycle on an unseen eligible VM0007 v1.8 PDD to prove generalization and prevent regressions.
 

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -79,7 +79,7 @@ Define the repeatable two-PR cycle for safely improving the Evidence Map.
 
 Delivered by PR #994 on branch `docs/vm0007-evidence-map-playbook`.
 
-### Phase 7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake — active
+### Phase 7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake — done
 
 - Marcondes REDD+ is the first candidate forward VM0007 v1.8 Evidence Map learning case, pending explicit reconciliation of the internal v1.7/v1.8 discrepancy
 - preserve the raw 58-row machine output
@@ -87,6 +87,7 @@ Delivered by PR #994 on branch `docs/vm0007-evidence-map-playbook`.
 - store reviewed truth, corrections, provenance, reviewer notes, and `REVIEW.md`
 - review high-value and uncertain rows first
 - unreviewed rows must not count as gold or accuracy evidence
+- delivered by PR #1012
 
 #### Phase 7 completion criteria
 
@@ -98,7 +99,7 @@ Delivered by PR #994 on branch `docs/vm0007-evidence-map-playbook`.
 - no silent normalization is permitted
 - after reconciliation, Marcondes may be marked version-qualified VM0007 v1.8 truth
 
-### Phase 8 — Marcondes Generic System Improvement — planned
+### Phase 8 — Marcondes Generic System Improvement — active
 
 - compare Marcondes machine proposals against reviewed truth after the reviewed truth exists
 - classify retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding errors

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -6,8 +6,8 @@
     "summary": "Build a progressively improving VM0007 v1.8 Evidence Map using PDF-backed machine proposals, reviewed truth, explicit corrections, and generic retrieval/router improvements.",
     "current_focus": [
       "Phase 6 complete: canonical system prompt and new-PDD playbook delivered by PR #994.",
-      "Phase 7 active: Marcondes truth intake and v1.7/v1.8 reconciliation.",
-      "Phase 8 planned: generic system improvement after reviewed truth exists."
+      "Phase 7 complete: Marcondes truth intake and v1.7/v1.8 reconciliation delivered by PR #1012.",
+      "Phase 8 active: generic system improvement after reviewed truth exists."
     ],
     "not_active_now": [
       "Production logic changes in truth-intake PRs",
@@ -17,7 +17,7 @@
       "LLM final judgment",
       "Formal validation, verification, or VVB authority claims"
     ],
-    "last_updated_at": "2026-07-12T00:00:00Z"
+    "last_updated_at": "2026-07-13T00:00:00Z"
   },
   "goals": [
     {
@@ -121,7 +121,7 @@
     {
       "id": "phase_7_marcondes_vm0007_v1_8_evidence_map_truth_intake",
       "title": "Marcondes VM0007 v1.8 Evidence Map Truth Intake",
-      "status": "active",
+      "status": "done",
       "dependsOn": ["phase_6_evidence_map_learning_contract"],
       "doneCriteria": [
         "Marcondes REDD+ is the first candidate forward VM0007 v1.8 Evidence Map learning case, pending explicit reconciliation of the internal v1.7/v1.8 discrepancy",
@@ -142,7 +142,7 @@
     {
       "id": "phase_8_marcondes_generic_system_improvement",
       "title": "Marcondes Generic System Improvement",
-      "status": "planned",
+      "status": "active",
       "dependsOn": ["phase_7_marcondes_vm0007_v1_8_evidence_map_truth_intake"],
       "doneCriteria": [
         "Marcondes proposals are compared against reviewed truth",
@@ -217,12 +217,12 @@
     },
     "phase_7_marcondes_vm0007_v1_8_evidence_map_truth_intake": {
       "title": "Marcondes VM0007 v1.8 Evidence Map Truth Intake",
-      "status": "active",
-      "summary": "Intake Marcondes REDD+ as the active VM0007 v1.8 truth case while reconciling the internal v1.7/v1.8 discrepancy, preserving raw 58-row output, and counting only explicitly reviewed rows as gold."
+      "status": "done",
+      "summary": "Intake Marcondes REDD+ as the completed VM0007 v1.8 truth case while reconciling the internal v1.7/v1.8 discrepancy, preserving raw 58-row output, counting only explicitly reviewed rows as gold, and delivering the result in PR #1012."
     },
     "phase_8_marcondes_generic_system_improvement": {
       "title": "Marcondes Generic System Improvement",
-      "status": "planned",
+      "status": "active",
       "summary": "Use reviewed Marcondes truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures after the reviewed truth exists."
     },
     "phase_9_review_and_gold_promotion_tooling": {


### PR DESCRIPTION
Roadmap-only update for VM0007 judgment-fixtures status tracking.

What changed:
- marked Phase 7 complete in the roadmap status JSON and plan
- marked Phase 8 active
- recorded delivery by PR #1012
- refreshed the generated roadmap summary

Checks:
- npm run roadmap:check
- npm run pr:check:local
- git diff --check