### PR TITLE
fix: align applicability evidence with rule subject

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -346,7 +346,7 @@ Build a progressively improving VM0007 v1.8 Evidence Map using PDF-backed machin
 Current focus:
 - Phase 6 complete: canonical system prompt and new-PDD playbook delivered by PR #994.
 - Phase 7 complete: Marcondes truth intake and v1.7/v1.8 reconciliation delivered by PR #1012.
-- Phase 8 active: generic system improvement after reviewed truth exists.
+- Phase 8 active: the first generic applicability increment reduced Marcondes machine-versus-gold mismatches from 15 to 11 by preventing unrelated scope exclusions from producing N/A.
 
 Not active now:
 - Production logic changes in truth-intake PRs
@@ -364,7 +364,7 @@ Not active now:
 6) RC5 — Client-Readiness Gate: Done — The internal-preview/client-readiness boundary is documented and legacy mismatch fixtures remain quarantined; no legacy Envira output is promoted as VM0007 v1.8 truth.
 7) RC6 — Evidence Map Learning Contract: Done — Defined the repeatable two-PR cycle for VM0007 evidence-map learning and delivered the canonical system prompt plus new-PDD playbook in PR #994.
 8) RC7 — Marcondes VM0007 v1.8 Evidence Map Truth Intake: Done — Intake Marcondes REDD+ as the completed VM0007 v1.8 truth case while reconciling the internal v1.7/v1.8 discrepancy, preserving raw 58-row output, counting only explicitly reviewed rows as gold, and delivering the result in PR #1012.
-9) RC8 — Marcondes Generic System Improvement: Active — Use reviewed Marcondes truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures after the reviewed truth exists.
+9) RC8 — Marcondes Generic System Improvement: Active — Use reviewed Marcondes truth to classify and fix reusable shared-system failures. The first Phase 8 increment added rule-subject alignment for broad carbon-pool and GHG-source scope exclusions, reducing active machine-versus-gold mismatches from 15 to 11; Phase 8 remains active.
 10) RC9 — Review and Gold Promotion Tooling: Planned — Make partial review and correction generation easy while preserving machine proposal, reviewer correction, final truth, and explicit gold coverage separately.
 11) RC10 — Second Unseen VM0007 v1.8 PDD: Planned — Run the same truth-intake and generic-improvement cycle on an unseen eligible VM0007 v1.8 PDD to prove generalization and prevent regressions.
 

--- a/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
+++ b/docs/roadmaps/vm0007-judgement-fixtures/PLAN.md
@@ -106,6 +106,7 @@ Delivered by PR #994 on branch `docs/vm0007-evidence-map-playbook`.
 - fix only reusable shared logic
 - rerun Quick Check and Evidence Map regressions
 - prohibit Marcondes-specific hardcoding
+- first generic increment: require rule-subject alignment before a broad carbon-pool or GHG-source scope exclusion can produce N/A; this reduced the active Marcondes mismatch set from 15 to 11 while Phase 8 remains active
 
 ### Phase 9 — Review and Gold Promotion Tooling — planned
 

--- a/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
+++ b/docs/roadmaps/vm0007-judgement-fixtures/phase-status.json
@@ -7,7 +7,7 @@
     "current_focus": [
       "Phase 6 complete: canonical system prompt and new-PDD playbook delivered by PR #994.",
       "Phase 7 complete: Marcondes truth intake and v1.7/v1.8 reconciliation delivered by PR #1012.",
-      "Phase 8 active: generic system improvement after reviewed truth exists."
+      "Phase 8 active: the first generic applicability increment reduced Marcondes machine-versus-gold mismatches from 15 to 11 by preventing unrelated scope exclusions from producing N/A."
     ],
     "not_active_now": [
       "Production logic changes in truth-intake PRs",
@@ -17,7 +17,7 @@
       "LLM final judgment",
       "Formal validation, verification, or VVB authority claims"
     ],
-    "last_updated_at": "2026-07-13T00:00:00Z"
+    "last_updated_at": "2026-07-13T13:57:07Z"
   },
   "goals": [
     {
@@ -223,7 +223,7 @@
     "phase_8_marcondes_generic_system_improvement": {
       "title": "Marcondes Generic System Improvement",
       "status": "active",
-      "summary": "Use reviewed Marcondes truth to classify and fix reusable retrieval, routing, evidence-selection, applicability, provenance, contradiction, and finding failures after the reviewed truth exists."
+      "summary": "Use reviewed Marcondes truth to classify and fix reusable shared-system failures. The first Phase 8 increment added rule-subject alignment for broad carbon-pool and GHG-source scope exclusions, reducing active machine-versus-gold mismatches from 15 to 11; Phase 8 remains active."
     },
     "phase_9_review_and_gold_promotion_tooling": {
       "title": "Review and Gold Promotion Tooling",

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -29,6 +29,7 @@ export type ApplicabilityConfiguration = Readonly<{
   exclusionSignals: readonly string[];
   contextSignals: readonly string[];
   requireProjectSpecificContext: boolean;
+  requireRuleSubjectAlignment?: boolean;
 }>;
 
 export type MethodologyVersionLock = Readonly<{
@@ -744,6 +745,46 @@ function hasExplicitScopeExclusion(text: string): boolean {
     && /\b(?:project|project area|project activity|project scope|properties|activity)\b/.test(text);
 }
 
+function explicitScopeExclusionFragments(text: string): string[] {
+  return text
+    .split(/(?<=[.!?;])\s+|\n+/)
+    .map((fragment) => normalizeText(fragment))
+    .filter((fragment) => hasExplicitScopeExclusion(fragment));
+}
+
+function applicabilitySubjectTokens(
+  rule: MethodologyEvidenceAuditRule,
+  contract: MethodologyEvidenceContract,
+): string[] {
+  return tokenize([
+    rule.summary ?? "",
+    resolveRuleLogic(rule),
+    contract.label,
+    contract.appliesToFamily ?? "",
+  ].join(" "), TEXT_STOPWORDS).filter((token) =>
+    !/^(?:verra|afolu|vm\d+|v\d|r-\d)/.test(token)
+    && token !== "table",
+  );
+}
+
+function hasApplicabilitySubjectAlignment(input: {
+  rule: MethodologyEvidenceAuditRule;
+  contract: MethodologyEvidenceContract;
+  text: string;
+}): boolean {
+  const subjectTokens = applicabilitySubjectTokens(input.rule, input.contract);
+  if (subjectTokens.length === 0) return false;
+  const fragments = explicitScopeExclusionFragments(input.text);
+  return fragments.some((fragment) => {
+    const fragmentTokens = tokenize(fragment, TEXT_STOPWORDS);
+    return subjectTokens.some((subjectToken) => fragmentTokens.some((fragmentToken) =>
+      subjectToken === fragmentToken
+      || (Math.min(subjectToken.length, fragmentToken.length) >= 4
+        && (subjectToken.startsWith(fragmentToken) || fragmentToken.startsWith(subjectToken))),
+    ));
+  });
+}
+
 function isAcceptedProjectEvidence(candidate: CandidateScore): boolean {
   return candidate.evidenceType === "project_specific_implementation"
     || candidate.evidenceType === "project_specific_scope";
@@ -1122,7 +1163,12 @@ function selectNotApplicableCandidate(input: {
     const hasProjectContext = hasProjectSpecificMarkers(text) || hasExplicitScopeExclusion(text);
     if (applicability && (contextHits === 0 || (applicability.requireProjectSpecificContext && !hasProjectContext))) continue;
     const signalOverlap = intersectionCount(tokenize(text, TEXT_STOPWORDS), tokenize(naPhrases.join(" "), TEXT_STOPWORDS));
-    if (phraseHits === 0 && (!hasExplicitScopeExclusion(text) || signalOverlap < 2)) continue;
+    if (phraseHits === 0 && (
+      !hasExplicitScopeExclusion(text)
+      || signalOverlap < 2
+      || (applicability?.requireRuleSubjectAlignment
+        && !hasApplicabilitySubjectAlignment({ rule: input.rule, contract: input.contract, text: span.text }))
+    )) continue;
 
     const sectionTitle = span.sectionId
       ? (sectionLookup.get(span.sectionId)?.titleClean || sectionLookup.get(span.sectionId)?.titleRaw || null)

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -752,6 +752,24 @@ function explicitScopeExclusionFragments(text: string): string[] {
     .filter((fragment) => hasExplicitScopeExclusion(fragment));
 }
 
+const APPLICABILITY_SUBJECT_STOPWORDS = new Set([
+  "apply",
+  "applies",
+  "applicable",
+  "exclude",
+  "excluded",
+  "excludes",
+  "excluding",
+  "exclusion",
+  "include",
+  "included",
+  "includes",
+  "including",
+  "inclusion",
+  "inclusion/exclusion",
+  "scope",
+]);
+
 function applicabilitySubjectTokens(
   rule: MethodologyEvidenceAuditRule,
   contract: MethodologyEvidenceContract,
@@ -763,7 +781,8 @@ function applicabilitySubjectTokens(
     contract.appliesToFamily ?? "",
   ].join(" "), TEXT_STOPWORDS).filter((token) =>
     !/^(?:verra|afolu|vm\d+|v\d|r-\d)/.test(token)
-    && token !== "table",
+    && token !== "table"
+    && !APPLICABILITY_SUBJECT_STOPWORDS.has(token),
   );
 }
 
@@ -1163,12 +1182,9 @@ function selectNotApplicableCandidate(input: {
     const hasProjectContext = hasProjectSpecificMarkers(text) || hasExplicitScopeExclusion(text);
     if (applicability && (contextHits === 0 || (applicability.requireProjectSpecificContext && !hasProjectContext))) continue;
     const signalOverlap = intersectionCount(tokenize(text, TEXT_STOPWORDS), tokenize(naPhrases.join(" "), TEXT_STOPWORDS));
-    if (phraseHits === 0 && (
-      !hasExplicitScopeExclusion(text)
-      || signalOverlap < 2
-      || (applicability?.requireRuleSubjectAlignment
-        && !hasApplicabilitySubjectAlignment({ rule: input.rule, contract: input.contract, text: span.text }))
-    )) continue;
+    if (applicability?.requireRuleSubjectAlignment
+      && !hasApplicabilitySubjectAlignment({ rule: input.rule, contract: input.contract, text: span.text })) continue;
+    if (phraseHits === 0 && (!hasExplicitScopeExclusion(text) || signalOverlap < 2)) continue;
 
     const sectionTitle = span.sectionId
       ? (sectionLookup.get(span.sectionId)?.titleClean || sectionLookup.get(span.sectionId)?.titleRaw || null)

--- a/src/lib/preverif/vm0007EvidenceContracts.ts
+++ b/src/lib/preverif/vm0007EvidenceContracts.ts
@@ -324,6 +324,15 @@ const CARBON_POOLS_CONTRACT = defineContract({
     "A pool or source is excluded because the project activity does not create that pathway",
     "The project scope excludes the wetland or tidal activity that would trigger the pool or source",
   ],
+  applicability: {
+    exclusionSignals: [
+      "A pool or source is excluded because the project activity does not create that pathway",
+      "The project scope excludes the wetland or tidal activity that would trigger the pool or source",
+    ],
+    contextSignals: [],
+    requireProjectSpecificContext: true,
+    requireRuleSubjectAlignment: true,
+  },
   defaultGapMessage: "PDD does not yet show the pool or GHG source selection evidence needed for this rule.",
   clientAction: "Add the include or exclude decision for each relevant pool or source, the reason for that decision, and the citations supporting it.",
   supportsNotApplicable: true,
@@ -670,6 +679,14 @@ const CARBON_POOL_SELECTION_CONTRACT = defineContract({
   notApplicableSignals: [
     "A pool is out of scope because the project activity does not create that carbon stock pathway",
   ],
+  applicability: {
+    exclusionSignals: [
+      "A pool is out of scope because the project activity does not create that carbon stock pathway",
+    ],
+    contextSignals: [],
+    requireProjectSpecificContext: true,
+    requireRuleSubjectAlignment: true,
+  },
   defaultGapMessage: "PDD does not yet show the include or exclude decision and justification for the carbon pools used in this project.",
   clientAction: "List each relevant carbon pool, state whether it is included or excluded, and add the project-specific reason and citation for that decision.",
   supportsNotApplicable: true,

--- a/tests/lib/preverif/evidenceAuditCompleteness.test.ts
+++ b/tests/lib/preverif/evidenceAuditCompleteness.test.ts
@@ -140,6 +140,82 @@ describe("generic evidence applicability and completeness contract", () => {
     expect(engineSource).not.toContain("family:jnr-data-use");
   });
 
+  it("does not apply a project-specific scope exclusion to an unrelated rule subject", () => {
+    const contract = {
+      ...baseContract,
+      label: "Pool and source selection",
+      supportsNotApplicable: true,
+      notApplicableSignals: [
+        "A pool or source is excluded because the project activity does not create that pathway",
+        "The project scope excludes the wetland or tidal activity that would trigger the pool or source",
+      ],
+      applicability: {
+        exclusionSignals: [
+          "A pool or source is excluded because the project activity does not create that pathway",
+          "The project scope excludes the wetland or tidal activity that would trigger the pool or source",
+        ],
+        contextSignals: [],
+        requireProjectSpecificContext: true,
+        requireRuleSubjectAlignment: true,
+      },
+    };
+    const scopeEvidence = "There is no peat soil or tidal wetland in the project area.";
+    const evidenceDocument: EvidenceDocument = {
+      docId: "test",
+      rawText: scopeEvidence,
+      spans: [span(scopeEvidence)],
+    };
+    const result = auditEvidence({
+      rules: [{
+        id: "R-POOL",
+        title: "Mandatory aboveground biomass pool",
+        logic: "Aboveground biomass is always mandatory and must be included consistently in baseline and project accounting.",
+      }],
+      evidenceDocument,
+      getContract: () => contract,
+      versionContext: { methodologyId: "TEST", rulebookVersion: "v1", pddDeclaredMethodologyVersion: "v1" },
+    }).results[0];
+
+    expect(result.status).not.toBe("not_applicable");
+  });
+
+  it("retains N/A when the exclusion addresses the rule subject", () => {
+    const contract = {
+      ...baseContract,
+      label: "Wetland soil carbon pool",
+      supportsNotApplicable: true,
+      notApplicableSignals: [
+        "The project scope excludes the wetland or tidal activity that would trigger the soil carbon pool",
+      ],
+      applicability: {
+        exclusionSignals: [
+          "The project scope excludes the wetland or tidal activity that would trigger the soil carbon pool",
+        ],
+        contextSignals: [],
+        requireProjectSpecificContext: true,
+        requireRuleSubjectAlignment: true,
+      },
+    };
+    const scopeEvidence = "There is no peat soil or tidal wetland in the project area.";
+    const evidenceDocument: EvidenceDocument = {
+      docId: "test",
+      rawText: scopeEvidence,
+      spans: [span(scopeEvidence)],
+    };
+    const result = auditEvidence({
+      rules: [{
+        id: "R-WETLAND-SOIL",
+        title: "Wetland soil carbon pool",
+        logic: "The wetland soil carbon pool applies to peat or tidal wetland activities.",
+      }],
+      evidenceDocument,
+      getContract: () => contract,
+      versionContext: { methodologyId: "TEST", rulebookVersion: "v1", pddDeclaredMethodologyVersion: "v1" },
+    }).results[0];
+
+    expect(result.status).toBe("not_applicable");
+  });
+
   it("keeps scalar provenance aligned with accepted evidence", () => {
     const evidenceDocument: EvidenceDocument = {
       docId: "test",

--- a/tests/lib/preverif/evidenceAuditCompleteness.test.ts
+++ b/tests/lib/preverif/evidenceAuditCompleteness.test.ts
@@ -179,6 +179,39 @@ describe("generic evidence applicability and completeness contract", () => {
     expect(result.status).not.toBe("not_applicable");
   });
 
+  it("does not let an exact exclusion phrase bypass required rule-subject alignment", () => {
+    const exactExclusion = "The project activity does not include tidal wetland.";
+    const contract = {
+      ...baseContract,
+      label: "Pool and source selection",
+      supportsNotApplicable: true,
+      notApplicableSignals: [exactExclusion],
+      applicability: {
+        exclusionSignals: [exactExclusion],
+        contextSignals: [],
+        requireProjectSpecificContext: true,
+        requireRuleSubjectAlignment: true,
+      },
+    };
+    const evidenceDocument: EvidenceDocument = {
+      docId: "test",
+      rawText: exactExclusion,
+      spans: [span(exactExclusion)],
+    };
+    const result = auditEvidence({
+      rules: [{
+        id: "generic-biomass-rule",
+        title: "Mandatory aboveground biomass pool",
+        logic: "Aboveground biomass must be included consistently in baseline and project accounting.",
+      }],
+      evidenceDocument,
+      getContract: () => contract,
+      versionContext: { methodologyId: "TEST", rulebookVersion: "v1", pddDeclaredMethodologyVersion: "v1" },
+    }).results[0];
+
+    expect(result.status).not.toBe("not_applicable");
+  });
+
   it("retains N/A when the exclusion addresses the rule subject", () => {
     const contract = {
       ...baseContract,

--- a/tests/lib/preverif/marcondesReviewedGoldComparison.test.ts
+++ b/tests/lib/preverif/marcondesReviewedGoldComparison.test.ts
@@ -16,6 +16,8 @@ const reviewedRuleIds = [
   "R-5-0001", "R-5-0002", "R-5-0003", "R-5-0004", "R-5-0005",
 ] as const;
 
+const resolvedIrrelevantScopeRows = ["R-2-0007", "R-2-0008", "R-2-0010", "R-2-0012"] as const;
+
 type JsonRecord = Record<string, any>;
 
 function readJson(name: string): JsonRecord {
@@ -103,13 +105,22 @@ describe("Marcondes reviewed gold comparison", () => {
 
     expect(audit.results).toHaveLength(58);
     expect(comparison).toHaveLength(48);
-    expect(comparison.length - mismatches.length).toBeGreaterThanOrEqual(33);
-    expect(comparison.length - mismatches.length).toBe(33);
+    expect(comparison.length - mismatches.length).toBeGreaterThanOrEqual(37);
+    expect(comparison.length - mismatches.length).toBe(37);
     const reconciliation = readJson("mismatch-reconciliation.json");
     expect(reconciliation.rows).toHaveLength(15);
     expect(new Set(reconciliation.rows.map((row: JsonRecord) => row.ruleId)).size).toBe(15);
     const stableRuleId = (ruleId: string) => ruleId.startsWith("Verra.") ? ruleId : `Verra.AFOLU.VM0007.v1-8.${ruleId}`;
-    expect(mismatches.map((row) => stableRuleId(row.ruleId)).sort()).toEqual(reconciliation.rows.map((row: JsonRecord) => row.ruleId).sort());
+    const activeReconciliationRows = reconciliation.rows.filter((row: JsonRecord) =>
+      !resolvedIrrelevantScopeRows.some((ruleId) => row.ruleId.endsWith(ruleId)),
+    );
+    expect(mismatches.map((row) => stableRuleId(row.ruleId)).sort()).toEqual(activeReconciliationRows.map((row: JsonRecord) => row.ruleId).sort());
+    for (const ruleId of resolvedIrrelevantScopeRows) {
+      expect(comparison.find((row) => row.ruleId === ruleId)).toEqual(expect.objectContaining({
+        exact: true,
+        gold: "UNCLEAR",
+      }));
+    }
     for (const mismatch of mismatches) {
       const record = reconciliation.rows.find((row: JsonRecord) => row.ruleId === stableRuleId(mismatch.ruleId))!;
       const goldRow = goldByRule.get(mismatch.ruleId)!;


### PR DESCRIPTION
## Summary

This Phase 8 increment fixes one reusable applicability failure class: a broad project scope exclusion could be retrieved for an unrelated carbon-pool or GHG-source rule and incorrectly produce N/A.

Current main SHA at branch creation: `a1c51192edf3a0c64f6474bbf957c80dd0ee65f3`.

The shared Evidence Map applicability selector now supports an opt-in rule-subject alignment requirement. The carbon-pool selection contracts use it so fuzzy scope exclusions must address the rule subject before they can produce N/A. Existing project-specific context, accepted/rejected evidence, rejection reasons, provenance, contradiction state, applicability reasoning, and consumer-facing status contracts are preserved.

Phase 8 remains active. The roadmap records this concrete increment and the generated summary is synchronized.

## Before-change failure inventory

All 15 reconciliation-record mismatches still existed on current `main` before this change:

- `R-1-0001`: FOUND → reviewed UNCLEAR — assessment too strong / incomplete mandatory evidence.
- `R-1-0002`: UNCLEAR → reviewed FOUND — qualifying evidence missed.
- `R-1-0003`: UNCLEAR → reviewed N/A — applicability decision missed.
- `R-1-0013`: UNCLEAR → reviewed N/A — applicability decision missed.
- `R-1-0014`: UNCLEAR → reviewed FOUND — qualifying evidence missed.
- `R-1-0015`: UNCLEAR → reviewed FOUND — qualifying evidence missed.
- `R-2-0002`: UNCLEAR → reviewed N/A — applicability decision missed.
- `R-2-0004`: UNCLEAR → reviewed N/A — applicability decision missed.
- `R-2-0007`: N/A → reviewed UNCLEAR — irrelevant scope retrieval / applicability overreach.
- `R-2-0008`: N/A → reviewed UNCLEAR — irrelevant scope retrieval / applicability overreach.
- `R-2-0010`: N/A → reviewed UNCLEAR — irrelevant scope retrieval / applicability overreach.
- `R-2-0012`: N/A → reviewed UNCLEAR — irrelevant scope retrieval / applicability overreach.
- `R-2-0014`: UNCLEAR → reviewed FOUND — qualifying evidence missed.
- `R-3-0005`: UNCLEAR → reviewed FOUND — qualifying evidence missed.
- `R-4-0001`: UNCLEAR → reviewed FOUND — qualifying evidence missed.

Selected class: **irrelevant retrieval causing applicability overreach**.

Shared layer changed: Evidence Map N/A candidate selection and reusable VM0007 evidence-contract applicability configuration.

## Regression-first coverage

Generic failing coverage was added before changing shared behavior. It proves both sides of the contract:

- a peat/tidal scope exclusion cannot make an unrelated mandatory biomass-pool rule N/A;
- the same exclusion remains eligible for N/A when it addresses the wetland/soil rule subject.

Marcondes rows `R-2-0007`, `R-2-0008`, `R-2-0010`, and `R-2-0012` are regression evidence only. They are not implementation conditions. The reviewed match count improved from 33/48 to 37/48, reducing mismatches from 15 to 11.

Raw machine artifacts, `gold.json`, `corrections.json`, and all other truth artifacts are unchanged. No project names, project IDs, exact PDD quotes, page numbers, or gold strings entered production logic. There are no Marcondes- or Maya-specific branches.

## Validation

- Generic applicability/completeness and Marcondes machine-versus-gold tests: passed (13 tests).
- All Marcondes truth/reconciliation, VM0007 audit/contracts/gap report focused tests: passed (42 tests).
- Envira and PD_REDD judgments, version lock, truth-review guards, fixture gates, Evidence Map draft/review/storage, and Quick Check integration boundaries: passed.
- Additional Evidence Map storage and quarantined Envira report/PDF boundaries: passed (9 tests).
- `git diff --check`: passed.
- `npm run lint`: passed.
- `npm run typecheck`: passed.
- `npm run pr:check:local`: passed on the committed seven-file diff.
- `npm run roadmap:check`: passed.
- `npm run pr:gate`: intentionally not run locally; GitHub will run it.

Blind holdout: the approved Maya VM0007 v1.8 Quick Check PDD input was run after implementation without reading expected answers or creating Maya truth. All 58 rows audited. Compared with the previous selector behavior, only `R-2-0007` changed, conservatively from N/A to partial/UNCLEAR; the other 57 statuses were unchanged. This records generalization only and is not Maya truth intake.

## Remaining Phase 8 mismatch classes

Eleven mismatches remain for later cohesive PRs:

- four missed applicability decisions: `R-1-0003`, `R-1-0013`, `R-2-0002`, `R-2-0004`;
- six qualifying-evidence/retrieval or component-coverage misses: `R-1-0002`, `R-1-0014`, `R-1-0015`, `R-2-0014`, `R-3-0005`, `R-4-0001`;
- one assessment-too-strong / mandatory-completeness mismatch: `R-1-0001`.
