### PR TITLE
feat: expose rich audit evidence to Evidence Map UI

### DIFF
--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -1234,6 +1234,7 @@ function classifyStatus(input: {
   confidence: EvidenceAuditConfidence;
   assessmentReason: string;
   gap: string;
+  componentCoverage?: { supported: readonly string[]; missing: readonly string[] };
 } {
   if (input.notApplicableCandidate) {
     return {
@@ -1318,6 +1319,7 @@ function classifyStatus(input: {
         confidence: "low",
         assessmentReason: `Project-specific evidence is incomplete: missing mandatory components ${componentCoverage.missing.join(", ")}.`,
         gap: input.contract.defaultGapMessage,
+        componentCoverage,
       };
     }
 
@@ -1329,6 +1331,7 @@ function classifyStatus(input: {
         confidence: "high",
         assessmentReason: "All mandatory evidence components are supported by project-specific implementation evidence.",
         gap: "",
+        componentCoverage,
       };
     }
 
@@ -1354,6 +1357,7 @@ function classifyStatus(input: {
         confidence: assessmentCandidate.score >= 56 ? "high" : "medium",
         assessmentReason: "The selected PDD span contains project-specific language that aligns well with the rule logic and contract evidence signals.",
         gap: "",
+        componentCoverage,
       };
     }
 
@@ -1368,6 +1372,7 @@ function classifyStatus(input: {
         confidence: "medium",
         assessmentReason: "The selected PDD span contains dense project-specific implementation facts matching the contract vocabulary.",
         gap: "",
+        componentCoverage,
       };
     }
 
@@ -1377,6 +1382,7 @@ function classifyStatus(input: {
         confidence: "medium",
         assessmentReason: "The PDD contains a relevant span for this rule, but it does not fully cover the evidence expected by the contract.",
         gap: input.contract.defaultGapMessage,
+        componentCoverage,
       };
     }
 
@@ -1385,6 +1391,7 @@ function classifyStatus(input: {
       confidence: "low",
       assessmentReason: "The PDD contains a possible match, but the evidence is too weak or ambiguous to classify confidently.",
       gap: input.contract.defaultGapMessage,
+      componentCoverage,
     };
   }
 
@@ -1428,6 +1435,7 @@ function resultFromCandidate(input: {
   confidence: EvidenceAuditConfidence;
   assessmentReason: string;
   gap: string;
+  componentCoverage?: { supported: readonly string[]; missing: readonly string[] };
   normalizeRuleId?: (ruleId: string) => string;
 }): MethodologyEvidenceAuditResult {
   const acceptedEvidenceCandidates = (input.evidenceCandidates ?? []).filter(isAcceptedProjectEvidence);
@@ -1464,6 +1472,10 @@ function resultFromCandidate(input: {
       span: candidate.span.spanId,
       evidenceType: candidate.evidenceType,
       rejectionReason: candidate.rejectionReason ?? undefined,
+      ...(input.componentCoverage && (input.contract.mandatoryComponents?.length ?? 0) > 0
+        && candidate.evidenceType === "project_specific_implementation"
+        ? { supportedComponents: input.componentCoverage.supported, missingComponents: input.componentCoverage.missing }
+        : {}),
     })),
     rejectedEvidence: [...rejectedEvidenceCandidates, ...(input.candidate && !isAcceptedProjectEvidence(input.candidate) ? [input.candidate] : [])]
       .filter((candidate, index, all) => all.findIndex((other) => other.span.spanId === candidate.span.spanId) === index)
@@ -1554,6 +1566,7 @@ export function auditEvidence(input: MethodologyEvidenceAuditInput): Methodology
       confidence: classified.confidence,
       assessmentReason: classified.assessmentReason,
       gap: classified.gap,
+      componentCoverage: classified.componentCoverage,
       normalizeRuleId: input.normalizeRuleId,
     });
   });

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -96,6 +96,8 @@ export type MethodologyEvidenceAuditResult = {
   evidence?: readonly MethodologyEvidenceRecord[];
   /** Rejected source-backed candidates retained for diagnostics without presenting them as accepted evidence. */
   rejectedEvidence?: readonly MethodologyEvidenceRecord[];
+  supportedComponents?: readonly string[];
+  missingComponents?: readonly string[];
   page: number | null;
   section: string | null;
   span: string | null;
@@ -113,8 +115,6 @@ export type MethodologyEvidenceRecord = Readonly<{
   span: string;
   evidenceType?: EvidenceType;
   rejectionReason?: string;
-  supportedComponents?: readonly string[];
-  missingComponents?: readonly string[];
 }>;
 
 export type MethodologyEvidenceAuditSummary = {
@@ -1472,10 +1472,6 @@ function resultFromCandidate(input: {
       span: candidate.span.spanId,
       evidenceType: candidate.evidenceType,
       rejectionReason: candidate.rejectionReason ?? undefined,
-      ...(input.componentCoverage && (input.contract.mandatoryComponents?.length ?? 0) > 0
-        && candidate.evidenceType === "project_specific_implementation"
-        ? { supportedComponents: input.componentCoverage.supported, missingComponents: input.componentCoverage.missing }
-        : {}),
     })),
     rejectedEvidence: [...rejectedEvidenceCandidates, ...(input.candidate && !isAcceptedProjectEvidence(input.candidate) ? [input.candidate] : [])]
       .filter((candidate, index, all) => all.findIndex((other) => other.span.spanId === candidate.span.spanId) === index)
@@ -1487,6 +1483,9 @@ function resultFromCandidate(input: {
         evidenceType: candidate.evidenceType,
         rejectionReason: candidate.rejectionReason ?? "Candidate was not accepted as sufficient evidence.",
       })),
+    ...(input.componentCoverage && (input.contract.mandatoryComponents?.length ?? 0) > 0
+      ? { supportedComponents: input.componentCoverage.supported, missingComponents: input.componentCoverage.missing }
+      : {}),
     page: provenanceCandidate?.span.page ?? null,
     section: sectionLabel,
     span: provenanceCandidate?.span.spanId ?? null,

--- a/src/lib/preverif/vm0007EvidenceMapDraft.ts
+++ b/src/lib/preverif/vm0007EvidenceMapDraft.ts
@@ -159,11 +159,11 @@ function isEvidence(value: unknown, rejected: boolean): boolean {
   return !rejected || hasText(value.reason);
 }
 
-function isEvidenceRecord(value: unknown): value is Vm0007EvidenceMapDraftEvidenceRecord {
+function isEvidenceRecord(value: unknown, rejectionReasonRequired: boolean): value is Vm0007EvidenceMapDraftEvidenceRecord {
   return isRecord(value) && hasText(value.quote) && (value.page === null || (typeof value.page === "number" && Number.isFinite(value.page))) &&
     hasNullableText(value.section) && hasText(value.spanId) && isProvenance(value.provenance) &&
     (value.evidenceType === undefined || (EVIDENCE_TYPES as readonly unknown[]).includes(value.evidenceType)) &&
-    (value.rejectionReason === undefined || hasText(value.rejectionReason)) &&
+    (rejectionReasonRequired ? hasText(value.rejectionReason) : value.rejectionReason === undefined || hasText(value.rejectionReason)) &&
     (value.supportedComponents === undefined || (Array.isArray(value.supportedComponents) && value.supportedComponents.every((component) => hasText(component)))) &&
     (value.missingComponents === undefined || (Array.isArray(value.missingComponents) && value.missingComponents.every((component) => hasText(component))));
 }
@@ -261,8 +261,8 @@ export function validateVm0007EvidenceMapDraftPackage(value: unknown, expectedAu
       (row.quote !== null && !hasText(row.quote)) || (row.page !== null && (typeof row.page !== "number" || !Number.isFinite(row.page))) ||
       !hasNullableText(row.section) || !hasNullableText(row.spanId) || (row.provenance !== null && !isProvenance(row.provenance)) ||
       (row.proposedAcceptedEvidence !== null && !isEvidence(row.proposedAcceptedEvidence, false)) || (row.proposedRejectedEvidence !== null && !isEvidence(row.proposedRejectedEvidence, true)) ||
-      (row.acceptedEvidence !== undefined && (!Array.isArray(row.acceptedEvidence) || row.acceptedEvidence.some((record) => !isEvidenceRecord(record)))) ||
-      (row.rejectedEvidence !== undefined && (!Array.isArray(row.rejectedEvidence) || row.rejectedEvidence.some((record) => !isEvidenceRecord(record)))) ||
+      (row.acceptedEvidence !== undefined && (!Array.isArray(row.acceptedEvidence) || row.acceptedEvidence.some((record) => !isEvidenceRecord(record, false)))) ||
+      (row.rejectedEvidence !== undefined && (!Array.isArray(row.rejectedEvidence) || row.rejectedEvidence.some((record) => !isEvidenceRecord(record, true)))) ||
       (row.reasonSelected !== undefined && !hasText(row.reasonSelected))) return false;
     rowIds.add(row.rowId);
     ruleIds.add(row.ruleReference);

--- a/src/lib/preverif/vm0007EvidenceMapDraft.ts
+++ b/src/lib/preverif/vm0007EvidenceMapDraft.ts
@@ -7,7 +7,9 @@ import type {
 } from "@/lib/evidence/evidenceMapDependencyContract";
 import type {
   EvidenceAuditStatus,
+  EvidenceType,
   MethodologyEvidenceAuditResult,
+  MethodologyEvidenceRecord,
   MethodologyEvidenceAuditSummary,
 } from "@/lib/preverif/evidenceAudit";
 import { EVIDENCE_AUDIT_STATUSES } from "@/lib/preverif/evidenceAudit";
@@ -22,6 +24,18 @@ export const VM0007_EVIDENCE_MAP_DRAFT_PROPOSAL_STATE = "MACHINE_PROPOSED" as co
 
 export type DraftApplicability = "APPLICABLE" | "NOT_APPLICABLE" | "UNKNOWN";
 export type DraftEvidenceStatus = "FOUND" | "UNCLEAR" | "MISSING";
+
+export type Vm0007EvidenceMapDraftEvidenceRecord = {
+  quote: string;
+  page: number | null;
+  section: string | null;
+  spanId: string;
+  evidenceType?: EvidenceType;
+  rejectionReason?: string;
+  supportedComponents?: readonly string[];
+  missingComponents?: readonly string[];
+  provenance: EvidenceMapEvidenceProvenance;
+};
 
 export type Vm0007EvidenceMapDraftRow = {
   rowId: string;
@@ -38,6 +52,9 @@ export type Vm0007EvidenceMapDraftRow = {
   proposedApplicability: DraftApplicability;
   proposedAcceptedEvidence: { quote: string; provenance: EvidenceMapEvidenceProvenance } | null;
   proposedRejectedEvidence: { quote: string; reason: string; provenance: EvidenceMapEvidenceProvenance } | null;
+  acceptedEvidence?: readonly Vm0007EvidenceMapDraftEvidenceRecord[];
+  rejectedEvidence?: readonly Vm0007EvidenceMapDraftEvidenceRecord[];
+  reasonSelected?: string;
   assessmentReason: string;
   gap: string;
   clientAction: string;
@@ -90,13 +107,21 @@ const DRAFT_ROW_KEYS = new Set([
   "rowId", "auditId", "stableRuleId", "ruleReference", "ruleTitle", "requirementText",
   "methodologyId", "methodologyVersion", "rawAuditStatus", "upstreamStatus",
   "proposedEvidenceStatus", "proposedApplicability", "proposedAcceptedEvidence",
-  "proposedRejectedEvidence", "assessmentReason", "gap", "clientAction", "confidence",
+  "proposedRejectedEvidence", "acceptedEvidence", "rejectedEvidence", "reasonSelected",
+  "assessmentReason", "gap", "clientAction", "confidence",
   "searchCoverage", "sourceDocument", "quote", "page", "section", "spanId", "provenance",
   "finalizationState", "proposalSource", "proposalTimestamp",
   "reviewState", "reviewHistory", "rowVersion", "finalizationActorRef", "finalizedAt", "finalizationBasis", "reviewHistoryRef",
   "assessment",
 ]);
 const DRAFT_PACKAGE_KEYS = new Set(["auditId", "generatedAt", "methodologyId", "rulebookVersion", "pddDeclaredMethodologyVersion", "sourceDocument", "proposalState", "rows", "blockedBy", "contractVersion", "mapVersion", "finalizationState", "finalizedBy", "finalizedAt", "finalizationBasis"]);
+const EVIDENCE_TYPES: readonly EvidenceType[] = [
+  "project_specific_implementation",
+  "project_specific_scope",
+  "methodology_boilerplate",
+  "module_or_tool_declaration",
+  "incomplete_or_noisy",
+];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -132,6 +157,36 @@ function isSearchCoverage(value: unknown): value is EvidenceMapSearchCoverage {
 function isEvidence(value: unknown, rejected: boolean): boolean {
   if (!isRecord(value) || !hasText(value.quote) || !isProvenance(value.provenance)) return false;
   return !rejected || hasText(value.reason);
+}
+
+function isEvidenceRecord(value: unknown): value is Vm0007EvidenceMapDraftEvidenceRecord {
+  return isRecord(value) && hasText(value.quote) && (value.page === null || (typeof value.page === "number" && Number.isFinite(value.page))) &&
+    hasNullableText(value.section) && hasText(value.spanId) && isProvenance(value.provenance) &&
+    (value.evidenceType === undefined || (EVIDENCE_TYPES as readonly unknown[]).includes(value.evidenceType)) &&
+    (value.rejectionReason === undefined || hasText(value.rejectionReason)) &&
+    (value.supportedComponents === undefined || (Array.isArray(value.supportedComponents) && value.supportedComponents.every((component) => hasText(component)))) &&
+    (value.missingComponents === undefined || (Array.isArray(value.missingComponents) && value.missingComponents.every((component) => hasText(component))));
+}
+
+function evidenceRecordFor(record: MethodologyEvidenceRecord, sourceDocument: EvidenceMapSourceDocumentIdentity): Vm0007EvidenceMapDraftEvidenceRecord {
+  return {
+    quote: record.quote,
+    page: record.page,
+    section: record.section,
+    spanId: record.span,
+    ...(record.evidenceType !== undefined ? { evidenceType: record.evidenceType } : {}),
+    ...(record.rejectionReason !== undefined ? { rejectionReason: record.rejectionReason } : {}),
+    ...(record.supportedComponents !== undefined ? { supportedComponents: record.supportedComponents } : {}),
+    ...(record.missingComponents !== undefined ? { missingComponents: record.missingComponents } : {}),
+    provenance: {
+      docId: sourceDocument.documentId,
+      page: record.page,
+      sectionPath: record.section ? [record.section] : [],
+      spanId: record.span,
+      sectionHeading: record.section,
+      sourceType: "PDD",
+    },
+  };
 }
 
 function isExplicitNotApplicableScopeBasis(reason: unknown): reason is string {
@@ -205,12 +260,18 @@ export function validateVm0007EvidenceMapDraftPackage(value: unknown, expectedAu
       (row.rowVersion !== undefined && (typeof row.rowVersion !== "number" || !Number.isInteger(row.rowVersion) || row.rowVersion < 1)) ||
       (row.quote !== null && !hasText(row.quote)) || (row.page !== null && (typeof row.page !== "number" || !Number.isFinite(row.page))) ||
       !hasNullableText(row.section) || !hasNullableText(row.spanId) || (row.provenance !== null && !isProvenance(row.provenance)) ||
-      (row.proposedAcceptedEvidence !== null && !isEvidence(row.proposedAcceptedEvidence, false)) || (row.proposedRejectedEvidence !== null && !isEvidence(row.proposedRejectedEvidence, true))) return false;
+      (row.proposedAcceptedEvidence !== null && !isEvidence(row.proposedAcceptedEvidence, false)) || (row.proposedRejectedEvidence !== null && !isEvidence(row.proposedRejectedEvidence, true)) ||
+      (row.acceptedEvidence !== undefined && (!Array.isArray(row.acceptedEvidence) || row.acceptedEvidence.some((record) => !isEvidenceRecord(record)))) ||
+      (row.rejectedEvidence !== undefined && (!Array.isArray(row.rejectedEvidence) || row.rejectedEvidence.some((record) => !isEvidenceRecord(record)))) ||
+      (row.reasonSelected !== undefined && !hasText(row.reasonSelected))) return false;
     rowIds.add(row.rowId);
     ruleIds.add(row.ruleReference);
     stableRuleIds.add(row.stableRuleId);
     if (row.sourceDocument.documentId !== value.sourceDocument.documentId || !row.searchCoverage.searchedDocumentIds.includes(value.sourceDocument.documentId)) return false;
     if (row.provenance && row.provenance.docId !== row.sourceDocument.documentId) return false;
+    const rowSourceDocumentId = row.sourceDocument.documentId;
+    if ([...(Array.isArray(row.acceptedEvidence) ? row.acceptedEvidence : []), ...(Array.isArray(row.rejectedEvidence) ? row.rejectedEvidence : [])]
+      .some((record) => !isRecord(record) || !isRecord(record.provenance) || record.provenance.docId !== rowSourceDocumentId)) return false;
   }
   if (value.finalizationState === "finalized" &&
       (!hasText(value.finalizedBy) || !hasText(value.finalizedAt) || !hasText(value.finalizationBasis) ||
@@ -274,6 +335,9 @@ export function buildVm0007EvidenceMapDraft(input: {
       proposedApplicability: mapped.proposedApplicability,
       proposedAcceptedEvidence: mapped.accepted,
       proposedRejectedEvidence: mapped.rejected,
+      ...(result.evidence !== undefined ? { acceptedEvidence: result.evidence.map((record) => evidenceRecordFor(record, sourceDocument)) } : {}),
+      ...(result.rejectedEvidence !== undefined ? { rejectedEvidence: result.rejectedEvidence.map((record) => evidenceRecordFor(record, sourceDocument)) } : {}),
+      reasonSelected: result.reasonSelected,
       assessmentReason: result.assessmentReason,
       gap: result.gap,
       clientAction: result.clientAction,

--- a/src/lib/preverif/vm0007EvidenceMapDraft.ts
+++ b/src/lib/preverif/vm0007EvidenceMapDraft.ts
@@ -32,8 +32,6 @@ export type Vm0007EvidenceMapDraftEvidenceRecord = {
   spanId: string;
   evidenceType?: EvidenceType;
   rejectionReason?: string;
-  supportedComponents?: readonly string[];
-  missingComponents?: readonly string[];
   provenance: EvidenceMapEvidenceProvenance;
 };
 
@@ -54,6 +52,8 @@ export type Vm0007EvidenceMapDraftRow = {
   proposedRejectedEvidence: { quote: string; reason: string; provenance: EvidenceMapEvidenceProvenance } | null;
   acceptedEvidence?: readonly Vm0007EvidenceMapDraftEvidenceRecord[];
   rejectedEvidence?: readonly Vm0007EvidenceMapDraftEvidenceRecord[];
+  supportedComponents?: readonly string[];
+  missingComponents?: readonly string[];
   reasonSelected?: string;
   assessmentReason: string;
   gap: string;
@@ -107,7 +107,7 @@ const DRAFT_ROW_KEYS = new Set([
   "rowId", "auditId", "stableRuleId", "ruleReference", "ruleTitle", "requirementText",
   "methodologyId", "methodologyVersion", "rawAuditStatus", "upstreamStatus",
   "proposedEvidenceStatus", "proposedApplicability", "proposedAcceptedEvidence",
-  "proposedRejectedEvidence", "acceptedEvidence", "rejectedEvidence", "reasonSelected",
+  "proposedRejectedEvidence", "acceptedEvidence", "rejectedEvidence", "supportedComponents", "missingComponents", "reasonSelected",
   "assessmentReason", "gap", "clientAction", "confidence",
   "searchCoverage", "sourceDocument", "quote", "page", "section", "spanId", "provenance",
   "finalizationState", "proposalSource", "proposalTimestamp",
@@ -163,9 +163,7 @@ function isEvidenceRecord(value: unknown, rejectionReasonRequired: boolean): val
   return isRecord(value) && hasText(value.quote) && (value.page === null || (typeof value.page === "number" && Number.isFinite(value.page))) &&
     hasNullableText(value.section) && hasText(value.spanId) && isProvenance(value.provenance) &&
     (value.evidenceType === undefined || (EVIDENCE_TYPES as readonly unknown[]).includes(value.evidenceType)) &&
-    (rejectionReasonRequired ? hasText(value.rejectionReason) : value.rejectionReason === undefined || hasText(value.rejectionReason)) &&
-    (value.supportedComponents === undefined || (Array.isArray(value.supportedComponents) && value.supportedComponents.every((component) => hasText(component)))) &&
-    (value.missingComponents === undefined || (Array.isArray(value.missingComponents) && value.missingComponents.every((component) => hasText(component))));
+    (rejectionReasonRequired ? hasText(value.rejectionReason) : value.rejectionReason === undefined || hasText(value.rejectionReason));
 }
 
 function evidenceRecordFor(record: MethodologyEvidenceRecord, sourceDocument: EvidenceMapSourceDocumentIdentity): Vm0007EvidenceMapDraftEvidenceRecord {
@@ -176,8 +174,6 @@ function evidenceRecordFor(record: MethodologyEvidenceRecord, sourceDocument: Ev
     spanId: record.span,
     ...(record.evidenceType !== undefined ? { evidenceType: record.evidenceType } : {}),
     ...(record.rejectionReason !== undefined ? { rejectionReason: record.rejectionReason } : {}),
-    ...(record.supportedComponents !== undefined ? { supportedComponents: record.supportedComponents } : {}),
-    ...(record.missingComponents !== undefined ? { missingComponents: record.missingComponents } : {}),
     provenance: {
       docId: sourceDocument.documentId,
       page: record.page,
@@ -263,6 +259,8 @@ export function validateVm0007EvidenceMapDraftPackage(value: unknown, expectedAu
       (row.proposedAcceptedEvidence !== null && !isEvidence(row.proposedAcceptedEvidence, false)) || (row.proposedRejectedEvidence !== null && !isEvidence(row.proposedRejectedEvidence, true)) ||
       (row.acceptedEvidence !== undefined && (!Array.isArray(row.acceptedEvidence) || row.acceptedEvidence.some((record) => !isEvidenceRecord(record, false)))) ||
       (row.rejectedEvidence !== undefined && (!Array.isArray(row.rejectedEvidence) || row.rejectedEvidence.some((record) => !isEvidenceRecord(record, true)))) ||
+      (row.supportedComponents !== undefined && (!Array.isArray(row.supportedComponents) || row.supportedComponents.some((component) => !hasText(component)))) ||
+      (row.missingComponents !== undefined && (!Array.isArray(row.missingComponents) || row.missingComponents.some((component) => !hasText(component)))) ||
       (row.reasonSelected !== undefined && !hasText(row.reasonSelected))) return false;
     rowIds.add(row.rowId);
     ruleIds.add(row.ruleReference);
@@ -337,6 +335,8 @@ export function buildVm0007EvidenceMapDraft(input: {
       proposedRejectedEvidence: mapped.rejected,
       ...(result.evidence !== undefined ? { acceptedEvidence: result.evidence.map((record) => evidenceRecordFor(record, sourceDocument)) } : {}),
       ...(result.rejectedEvidence !== undefined ? { rejectedEvidence: result.rejectedEvidence.map((record) => evidenceRecordFor(record, sourceDocument)) } : {}),
+      ...(result.supportedComponents !== undefined ? { supportedComponents: result.supportedComponents } : {}),
+      ...(result.missingComponents !== undefined ? { missingComponents: result.missingComponents } : {}),
       reasonSelected: result.reasonSelected,
       assessmentReason: result.assessmentReason,
       gap: result.gap,

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -199,8 +199,8 @@ describe("auditEvidence with VM0007 contracts", () => {
     expect(result.status).not.toBe("supported_by_pdd");
     expect(result.bestEvidenceQuote).toBeNull();
     expect(result.rejectedEvidence?.[0]?.quote).toBe(text);
-    expect(result.rejectedEvidence?.[0]?.supportedComponents).toBeUndefined();
-    expect(result.rejectedEvidence?.[0]?.missingComponents).toBeUndefined();
+    expect(result.rejectedEvidence?.[0]).not.toHaveProperty("supportedComponents");
+    expect(result.rejectedEvidence?.[0]).not.toHaveProperty("missingComponents");
   });
 
   it("produces useful Envira-like outputs across the main VM0007 categories", () => {

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -199,6 +199,8 @@ describe("auditEvidence with VM0007 contracts", () => {
     expect(result.status).not.toBe("supported_by_pdd");
     expect(result.bestEvidenceQuote).toBeNull();
     expect(result.rejectedEvidence?.[0]?.quote).toBe(text);
+    expect(result.rejectedEvidence?.[0]?.supportedComponents).toBeUndefined();
+    expect(result.rejectedEvidence?.[0]?.missingComponents).toBeUndefined();
   });
 
   it("produces useful Envira-like outputs across the main VM0007 categories", () => {

--- a/tests/lib/preverif/vm0007EvidenceMapDraft.test.ts
+++ b/tests/lib/preverif/vm0007EvidenceMapDraft.test.ts
@@ -56,6 +56,72 @@ describe("VM0007 v1.8 draft Evidence Map", () => {
     expect(validateVm0007EvidenceMapDraftPackage(reloaded, "mixed-audit")).toBe(true);
   });
 
+  it("retains rich accepted and rejected audit evidence without changing audit outcomes", () => {
+    const firstResult = {
+      ...result(rules[0].id, "partially_supported"),
+      reasonSelected: "Strongest project-specific candidate retained.",
+      evidence: [
+        {
+          quote: "Exact accepted quote one.", page: 4, section: "Project design", span: "accepted-1",
+          evidenceType: "project_specific_implementation" as const,
+          supportedComponents: ["implementation"], missingComponents: ["monitoring"],
+        },
+        {
+          quote: "Exact accepted quote two.", page: 5, section: "Monitoring", span: "accepted-2",
+          evidenceType: "project_specific_scope" as const,
+          supportedComponents: ["scope", "monitoring"], missingComponents: [],
+        },
+      ],
+      rejectedEvidence: [{
+        quote: "Exact rejected methodology quote.", page: 9, section: "Methodology", span: "rejected-1",
+        evidenceType: "methodology_boilerplate" as const,
+        rejectionReason: "Methodology instructions are not project evidence.",
+        supportedComponents: [], missingComponents: ["implementation", "monitoring"],
+      }],
+    };
+    const auditResults = rules.map((rule, index) => index === 0 ? firstResult : result(rule.id, "missing_evidence", index));
+    const statusesBefore = auditResults.map((item) => item.status);
+    const built = buildVm0007EvidenceMapDraft({
+      auditId: "rich-evidence-audit",
+      generatedAt: "2026-07-13T00:00:00.000Z",
+      rules,
+      audit: audit(auditResults),
+      sourceDocument,
+    });
+
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+    const row = built.package.rows[0];
+    expect(row.acceptedEvidence).toHaveLength(2);
+    expect(row.acceptedEvidence?.map((record) => record.quote)).toEqual([
+      "Exact accepted quote one.",
+      "Exact accepted quote two.",
+    ]);
+    expect(row.acceptedEvidence?.[0]).toEqual(expect.objectContaining({
+      evidenceType: "project_specific_implementation",
+      supportedComponents: ["implementation"],
+      missingComponents: ["monitoring"],
+      provenance: expect.objectContaining({ docId: "pdd-1", page: 4, spanId: "accepted-1", sectionHeading: "Project design" }),
+    }));
+    expect(row.rejectedEvidence?.[0]).toEqual(expect.objectContaining({
+      quote: "Exact rejected methodology quote.",
+      evidenceType: "methodology_boilerplate",
+      rejectionReason: "Methodology instructions are not project evidence.",
+      supportedComponents: [],
+      missingComponents: ["implementation", "monitoring"],
+      provenance: expect.objectContaining({ docId: "pdd-1", page: 9, spanId: "rejected-1", sectionHeading: "Methodology" }),
+    }));
+    expect(row.reasonSelected).toBe("Strongest project-specific candidate retained.");
+    expect(row.assessmentReason).toBe(firstResult.assessmentReason);
+    expect(row.rawAuditStatus).toBe("partially_supported");
+    expect(row.upstreamStatus).toBe("UNCLEAR");
+    expect(row.proposedEvidenceStatus).toBe("UNCLEAR");
+    expect(row.proposedApplicability).toBe("APPLICABLE");
+    expect(row.proposedAcceptedEvidence?.quote).toBe(firstResult.bestEvidenceQuote);
+    expect(auditResults.map((item) => item.status)).toEqual(statusesBefore);
+    expect(validateVm0007EvidenceMapDraftPackage(built.package, "rich-evidence-audit")).toBe(true);
+  });
+
   it("maps evidence statuses without fabricating or finalizing evidence", () => {
     const supported = mapVm0007DraftStatus("supported_by_pdd", result("R-01-0001", "supported_by_pdd"), sourceDocument);
     expect(supported.upstreamStatus).toBe("FOUND");

--- a/tests/lib/preverif/vm0007EvidenceMapDraft.test.ts
+++ b/tests/lib/preverif/vm0007EvidenceMapDraft.test.ts
@@ -66,20 +66,19 @@ describe("VM0007 v1.8 draft Evidence Map", () => {
         {
           quote: "Exact accepted quote one.", page: 4, section: "Project design", span: "accepted-1",
           evidenceType: "project_specific_implementation" as const,
-          supportedComponents: ["implementation"], missingComponents: ["monitoring"],
         },
         {
           quote: "Exact accepted quote two.", page: 5, section: "Monitoring", span: "accepted-2",
           evidenceType: "project_specific_scope" as const,
-          supportedComponents: ["scope", "monitoring"], missingComponents: [],
         },
       ],
       rejectedEvidence: [{
         quote: "Exact rejected methodology quote.", page: 9, section: "Methodology", span: "rejected-1",
         evidenceType: "methodology_boilerplate" as const,
         rejectionReason: "Methodology instructions are not project evidence.",
-        supportedComponents: [], missingComponents: ["implementation", "monitoring"],
       }],
+      supportedComponents: ["implementation"],
+      missingComponents: ["monitoring"],
     };
     const auditResults = rules.map((rule, index) => index === 0 ? firstResult : result(rule.id, "missing_evidence", index));
     const statusesBefore = auditResults.map((item) => item.status);
@@ -101,18 +100,20 @@ describe("VM0007 v1.8 draft Evidence Map", () => {
     ]);
     expect(row.acceptedEvidence?.[0]).toEqual(expect.objectContaining({
       evidenceType: "project_specific_implementation",
-      supportedComponents: ["implementation"],
-      missingComponents: ["monitoring"],
       provenance: expect.objectContaining({ docId: "pdd-1", page: 4, spanId: "accepted-1", sectionHeading: "Project design" }),
     }));
+    expect(row.acceptedEvidence?.[0]).not.toHaveProperty("supportedComponents");
+    expect(row.acceptedEvidence?.[0]).not.toHaveProperty("missingComponents");
     expect(row.rejectedEvidence?.[0]).toEqual(expect.objectContaining({
       quote: "Exact rejected methodology quote.",
       evidenceType: "methodology_boilerplate",
       rejectionReason: "Methodology instructions are not project evidence.",
-      supportedComponents: [],
-      missingComponents: ["implementation", "monitoring"],
       provenance: expect.objectContaining({ docId: "pdd-1", page: 9, spanId: "rejected-1", sectionHeading: "Methodology" }),
     }));
+    expect(row.rejectedEvidence?.[0]).not.toHaveProperty("supportedComponents");
+    expect(row.rejectedEvidence?.[0]).not.toHaveProperty("missingComponents");
+    expect(row.supportedComponents).toEqual(["implementation"]);
+    expect(row.missingComponents).toEqual(["monitoring"]);
     expect(row.reasonSelected).toBe("Strongest project-specific candidate retained.");
     expect(row.assessmentReason).toBe(firstResult.assessmentReason);
     expect(row.rawAuditStatus).toBe("partially_supported");
@@ -184,14 +185,14 @@ describe("VM0007 v1.8 draft Evidence Map", () => {
       confidence: "low",
       bestEvidenceQuote: exactQuote,
       span: "real-audit-span",
-    }));
-    expect(auditedResult.bestEvidenceQuote).toBe(auditedResult.evidence?.[0]?.quote);
-    expect(auditedResult.span).toBe(auditedResult.evidence?.[0]?.span);
-    expect(auditedResult.evidence?.[0]).toEqual(expect.objectContaining({
-      quote: exactQuote,
       supportedComponents: ["equation", "inputs"],
       missingComponents: ["result"],
     }));
+    expect(auditedResult.bestEvidenceQuote).toBe(auditedResult.evidence?.[0]?.quote);
+    expect(auditedResult.span).toBe(auditedResult.evidence?.[0]?.span);
+    expect(auditedResult.evidence?.[0]?.quote).toBe(exactQuote);
+    expect(auditedResult.evidence?.[0]).not.toHaveProperty("supportedComponents");
+    expect(auditedResult.evidence?.[0]).not.toHaveProperty("missingComponents");
     const built = buildVm0007EvidenceMapDraft({
       auditId: "real-component-coverage-audit",
       generatedAt: "2026-07-13T00:00:00.000Z",
@@ -205,10 +206,12 @@ describe("VM0007 v1.8 draft Evidence Map", () => {
     const row = built.package.rows[0];
     expect(row.acceptedEvidence?.[0]).toEqual(expect.objectContaining({
       quote: exactQuote,
-      supportedComponents: ["equation", "inputs"],
-      missingComponents: ["result"],
       spanId: "real-audit-span",
     }));
+    expect(row.acceptedEvidence?.[0]).not.toHaveProperty("supportedComponents");
+    expect(row.acceptedEvidence?.[0]).not.toHaveProperty("missingComponents");
+    expect(row.supportedComponents).toEqual(["equation", "inputs"]);
+    expect(row.missingComponents).toEqual(["result"]);
     expect({
       status: row.rawAuditStatus,
       confidence: row.confidence,
@@ -218,6 +221,7 @@ describe("VM0007 v1.8 draft Evidence Map", () => {
     }).toEqual(outcomeBeforeDraft);
     expect(row.proposedApplicability).toBe("APPLICABLE");
     expect(row.proposedEvidenceStatus).toBe("UNCLEAR");
+    expect(validateVm0007EvidenceMapDraftPackage(built.package, "real-component-coverage-audit")).toBe(true);
   });
 
   it("maps evidence statuses without fabricating or finalizing evidence", () => {

--- a/tests/lib/preverif/vm0007EvidenceMapDraft.test.ts
+++ b/tests/lib/preverif/vm0007EvidenceMapDraft.test.ts
@@ -5,7 +5,9 @@ import { validateVm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007Evid
 import { loadVm0007EvidenceMapDraft, saveVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
 import { loadMethodRules } from "@/app/m/_lib/methodRules";
 import type { RuleSummary } from "@/app/m/_lib/methodRules";
+import { auditEvidence } from "@/lib/preverif/evidenceAudit";
 import type { MethodologyEvidenceAuditResult, MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
+import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
 
 const sourceDocument = { documentId: "pdd-1", documentName: "project-pdd.pdf", contentSha256: null };
 const rules: RuleSummary[] = Array.from({ length: 58 }, (_, index) => ({ id: `R-${String(index + 1).padStart(2, "0")}-0001`, title: `Rule ${index + 1}`, snippet: `Requirement ${index + 1}`, text: `Requirement ${index + 1}`, tags: [] }));
@@ -120,6 +122,102 @@ describe("VM0007 v1.8 draft Evidence Map", () => {
     expect(row.proposedAcceptedEvidence?.quote).toBe(firstResult.bestEvidenceQuote);
     expect(auditResults.map((item) => item.status)).toEqual(statusesBefore);
     expect(validateVm0007EvidenceMapDraftPackage(built.package, "rich-evidence-audit")).toBe(true);
+  });
+
+  it("carries real audit mandatory component coverage into the draft without changing decisions", () => {
+    const exactQuote = "The project calculated the equation using project inputs.";
+    const evidenceDocument: EvidenceDocument = {
+      docId: sourceDocument.documentId,
+      rawText: exactQuote,
+      spans: [{
+        spanId: "real-audit-span",
+        docId: sourceDocument.documentId,
+        page: 7,
+        sectionId: "project-evidence",
+        heading: "Project evidence",
+        headingPath: ["Project evidence"],
+        sectionPath: ["Project evidence"],
+        blockType: "paragraph",
+        text: exactQuote,
+        normalizedText: exactQuote.toLowerCase(),
+        charStart: null,
+        charEnd: null,
+        reliability: "primary",
+        confidence: 1,
+      }],
+    };
+    const realAudit = auditEvidence({
+      rules: rules.map((rule) => ({ id: rule.id, title: rule.title, logic: "project implementation" })),
+      evidenceDocument,
+      getContract: () => ({
+        id: "test:component-coverage",
+        label: "Project implementation",
+        methodologyId: "VM0007",
+        rulebookVersion: "v1.8",
+        pddSectionsToSearch: ["Project evidence"],
+        strongEvidenceSignals: ["project implementation"],
+        weakEvidenceSignals: [],
+        rejectSignals: ["methodology requires"],
+        notApplicableSignals: [],
+        mandatoryComponents: [
+          { id: "equation", description: "Equation", signals: ["equation"] },
+          { id: "inputs", description: "Inputs", signals: ["inputs"] },
+          { id: "result", description: "Result", signals: ["result"] },
+        ],
+        defaultGapMessage: "Add the missing project evidence.",
+        clientAction: "Add the missing project evidence.",
+        supportsNotApplicable: false,
+      }),
+      versionContext: { methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "v1.8" },
+    });
+    const auditedResult = realAudit.results[0];
+    const outcomeBeforeDraft = {
+      status: auditedResult.status,
+      confidence: auditedResult.confidence,
+      assessmentReason: auditedResult.assessmentReason,
+      bestEvidenceQuote: auditedResult.bestEvidenceQuote,
+      span: auditedResult.span,
+    };
+
+    expect(auditedResult).toEqual(expect.objectContaining({
+      status: "partially_supported",
+      confidence: "low",
+      bestEvidenceQuote: exactQuote,
+      span: "real-audit-span",
+    }));
+    expect(auditedResult.bestEvidenceQuote).toBe(auditedResult.evidence?.[0]?.quote);
+    expect(auditedResult.span).toBe(auditedResult.evidence?.[0]?.span);
+    expect(auditedResult.evidence?.[0]).toEqual(expect.objectContaining({
+      quote: exactQuote,
+      supportedComponents: ["equation", "inputs"],
+      missingComponents: ["result"],
+    }));
+    const built = buildVm0007EvidenceMapDraft({
+      auditId: "real-component-coverage-audit",
+      generatedAt: "2026-07-13T00:00:00.000Z",
+      rules,
+      audit: realAudit,
+      sourceDocument,
+    });
+
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+    const row = built.package.rows[0];
+    expect(row.acceptedEvidence?.[0]).toEqual(expect.objectContaining({
+      quote: exactQuote,
+      supportedComponents: ["equation", "inputs"],
+      missingComponents: ["result"],
+      spanId: "real-audit-span",
+    }));
+    expect({
+      status: row.rawAuditStatus,
+      confidence: row.confidence,
+      assessmentReason: row.assessmentReason,
+      bestEvidenceQuote: row.proposedAcceptedEvidence?.quote,
+      span: row.acceptedEvidence?.[0]?.spanId,
+    }).toEqual(outcomeBeforeDraft);
+    expect(row.proposedApplicability).toBe("APPLICABLE");
+    expect(row.proposedEvidenceStatus).toBe("UNCLEAR");
   });
 
   it("maps evidence statuses without fabricating or finalizing evidence", () => {

--- a/tests/lib/preverif/vm0007EvidenceMapDraftStore.test.ts
+++ b/tests/lib/preverif/vm0007EvidenceMapDraftStore.test.ts
@@ -39,6 +39,14 @@ function makePackage(): Vm0007EvidenceMapDraftPackage {
   return { auditId, generatedAt: "2026-07-11T00:00:00.000Z", methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "Version 1.8", sourceDocument: rows[0].sourceDocument, proposalState: "MACHINE_PROPOSED", rows, blockedBy: [], contractVersion: "vm0007-evidence-map-draft-v1" };
 }
 
+const richEvidenceRecord = {
+  quote: "Project-specific evidence.",
+  page: 1,
+  section: "Evidence",
+  spanId: "span-rich-1",
+  provenance: { docId: "doc-1", page: 1, sectionPath: ["Evidence"], spanId: "span-rich-1", sectionHeading: "Evidence", sourceType: "PDD" },
+};
+
 describe("VM0007 draft package storage validation", () => {
   beforeEach(() => localStorage.clear());
 
@@ -69,6 +77,29 @@ describe("VM0007 draft package storage validation", () => {
     expect(validateVm0007EvidenceMapDraftPackage(legacyPackage, legacyPackage.auditId)).toBe(true);
     expect(saveVm0007EvidenceMapDraft(legacyPackage)).toBe(true);
     expect(loadVm0007EvidenceMapDraft(legacyPackage.auditId)).not.toBeNull();
+  });
+
+  test("accepts rich accepted evidence without a rejection reason", () => {
+    const pkg = makePackage();
+    pkg.rows[0] = { ...pkg.rows[0], acceptedEvidence: [richEvidenceRecord] };
+
+    expect(pkg.rows[0].acceptedEvidence?.[0].rejectionReason).toBeUndefined();
+    expect(validateVm0007EvidenceMapDraftPackage(pkg)).toBe(true);
+  });
+
+  test("accepts rich rejected evidence with a non-empty rejection reason", () => {
+    const pkg = makePackage();
+    pkg.rows[0] = { ...pkg.rows[0], rejectedEvidence: [{ ...richEvidenceRecord, rejectionReason: "Methodology boilerplate is not project evidence." }] };
+
+    expect(validateVm0007EvidenceMapDraftPackage(pkg)).toBe(true);
+  });
+
+  test("rejects a rich rejected evidence record without a rejection reason", () => {
+    const pkg = makePackage();
+    pkg.rows[0] = { ...pkg.rows[0], rejectedEvidence: [richEvidenceRecord] };
+
+    expect(validateVm0007EvidenceMapDraftPackage(pkg)).toBe(false);
+    expect(saveVm0007EvidenceMapDraft(pkg)).toBe(false);
   });
 
   test("allows supported and explicitly not-applicable rows with empty gaps", () => {

--- a/tests/lib/preverif/vm0007EvidenceMapDraftStore.test.ts
+++ b/tests/lib/preverif/vm0007EvidenceMapDraftStore.test.ts
@@ -48,6 +48,7 @@ describe("VM0007 draft package storage validation", () => {
     ["unknown status", (pkg: Vm0007EvidenceMapDraftPackage) => ({ ...pkg, rows: pkg.rows.map((row, index) => index === 0 ? { ...row, rawAuditStatus: "future_status" } : row) })],
     ["wrong version", (pkg: Vm0007EvidenceMapDraftPackage) => ({ ...pkg, rulebookVersion: "v1.7" })],
     ["malformed provenance", (pkg: Vm0007EvidenceMapDraftPackage) => ({ ...pkg, rows: pkg.rows.map((row, index) => index === 0 ? { ...row, proposedAcceptedEvidence: { quote: "evidence", provenance: { docId: "doc-1" } } } : row) })],
+    ["malformed rich evidence", (pkg: Vm0007EvidenceMapDraftPackage) => ({ ...pkg, rows: pkg.rows.map((row, index) => index === 0 ? { ...row, rejectedEvidence: [{ quote: "evidence", page: 1, section: "Evidence", spanId: "span-1", rejectionReason: "Rejected.", provenance: { docId: "doc-1" } }] } : row) })],
   ])("rejects %s without throwing or saving", (_, mutate) => {
     const invalid = mutate(makePackage());
     expect(() => saveVm0007EvidenceMapDraft(invalid)).not.toThrow();
@@ -60,6 +61,14 @@ describe("VM0007 draft package storage validation", () => {
   test("rejects malformed JSON when loading", () => {
     localStorage.setItem("article6:vm0007-evidence-map-draft:v1:storage-audit", "{broken");
     expect(loadVm0007EvidenceMapDraft("storage-audit")).toBeNull();
+  });
+
+  test("accepts persisted draft packages created before rich presentation fields were added", () => {
+    const legacyPackage = makePackage();
+    expect(legacyPackage.rows.every((row) => !("acceptedEvidence" in row) && !("rejectedEvidence" in row) && !("reasonSelected" in row))).toBe(true);
+    expect(validateVm0007EvidenceMapDraftPackage(legacyPackage, legacyPackage.auditId)).toBe(true);
+    expect(saveVm0007EvidenceMapDraft(legacyPackage)).toBe(true);
+    expect(loadVm0007EvidenceMapDraft(legacyPackage.auditId)).not.toBeNull();
   });
 
   test("allows supported and explicitly not-applicable rows with empty gaps", () => {

--- a/tests/lib/preverif/vm0007EvidenceMapDraftStore.test.ts
+++ b/tests/lib/preverif/vm0007EvidenceMapDraftStore.test.ts
@@ -57,6 +57,7 @@ describe("VM0007 draft package storage validation", () => {
     ["wrong version", (pkg: Vm0007EvidenceMapDraftPackage) => ({ ...pkg, rulebookVersion: "v1.7" })],
     ["malformed provenance", (pkg: Vm0007EvidenceMapDraftPackage) => ({ ...pkg, rows: pkg.rows.map((row, index) => index === 0 ? { ...row, proposedAcceptedEvidence: { quote: "evidence", provenance: { docId: "doc-1" } } } : row) })],
     ["malformed rich evidence", (pkg: Vm0007EvidenceMapDraftPackage) => ({ ...pkg, rows: pkg.rows.map((row, index) => index === 0 ? { ...row, rejectedEvidence: [{ quote: "evidence", page: 1, section: "Evidence", spanId: "span-1", rejectionReason: "Rejected.", provenance: { docId: "doc-1" } }] } : row) })],
+    ["malformed component coverage", (pkg: Vm0007EvidenceMapDraftPackage) => ({ ...pkg, rows: pkg.rows.map((row, index) => index === 0 ? { ...row, supportedComponents: ["valid", " "] } : row) })],
   ])("rejects %s without throwing or saving", (_, mutate) => {
     const invalid = mutate(makePackage());
     expect(() => saveVm0007EvidenceMapDraft(invalid)).not.toThrow();
@@ -73,10 +74,17 @@ describe("VM0007 draft package storage validation", () => {
 
   test("accepts persisted draft packages created before rich presentation fields were added", () => {
     const legacyPackage = makePackage();
-    expect(legacyPackage.rows.every((row) => !("acceptedEvidence" in row) && !("rejectedEvidence" in row) && !("reasonSelected" in row))).toBe(true);
+    expect(legacyPackage.rows.every((row) => !("acceptedEvidence" in row) && !("rejectedEvidence" in row) && !("supportedComponents" in row) && !("missingComponents" in row) && !("reasonSelected" in row))).toBe(true);
     expect(validateVm0007EvidenceMapDraftPackage(legacyPackage, legacyPackage.auditId)).toBe(true);
     expect(saveVm0007EvidenceMapDraft(legacyPackage)).toBe(true);
     expect(loadVm0007EvidenceMapDraft(legacyPackage.auditId)).not.toBeNull();
+  });
+
+  test("accepts optional aggregate component coverage on a row", () => {
+    const pkg = makePackage();
+    pkg.rows[0] = { ...pkg.rows[0], supportedComponents: ["equation", "inputs"], missingComponents: ["result"] };
+
+    expect(validateVm0007EvidenceMapDraftPackage(pkg)).toBe(true);
   });
 
   test("accepts rich accepted evidence without a rejection reason", () => {


### PR DESCRIPTION
## Summary

- Presentation data only: retains richer audit evidence records in the Evidence Map draft package for UI consumption.
- The production audit path forwards its existing aggregate mandatory component coverage to the Evidence Map row without recomputing it or attributing it to individual evidence records.
- No audit or decision changes: statuses, applicability, confidence, evidence ranking, retrieval, and routing are unchanged.
- Backward compatibility is preserved, including the existing singular evidence, quote, location, and provenance fields.
- Existing persisted drafts remain valid because every new presentation field is optional.

## Fields added

- Optional acceptedEvidence and rejectedEvidence record arrays.
- Evidence type and rejection reason on retained records.
- Optional aggregate supported and missing evidence components on Evidence Map rows.
- Detailed record-level provenance.
- Existing upstream reasonSelected assessment-selection reasoning.

## Validation

- Focused Evidence Map draft and storage tests: 35 passed.
- git diff --check
- npm run lint
- npm run typecheck
- npm run pr:check:local
- Dev server smoke check: HTTP 200.
- npm run pr:gate intentionally deferred to GitHub per request.

Truth fixtures, reviewed gold, raw artifacts, reports, and PDFs are unchanged.