### PR TITLE
fix: expose reviewed Evidence Map truth separately

### DIFF
--- a/src/app/internal/reports/vm0007-evidence-map/[auditId]/page.tsx
+++ b/src/app/internal/reports/vm0007-evidence-map/[auditId]/page.tsx
@@ -1,16 +1,33 @@
 import Vm0007EvidenceMapDraftPage from "@/components/preverif/Vm0007EvidenceMapDraftPage";
-import { loadReviewedEvidenceMapCandidate } from "@/lib/preverif/reviewedEvidenceMapServerRegistry";
+import {
+  loadReviewedEvidenceMapCandidate,
+  loadReviewedEvidenceMapCandidates,
+} from "@/lib/preverif/reviewedEvidenceMapServerRegistry";
 
 export default async function Page({
   params,
+  searchParams,
 }: {
   params: Promise<{ auditId: string }>;
+  searchParams?: Promise<{
+    sourcePdfSha256?: string | string[];
+    sourceDocumentId?: string | string[];
+    stableProjectId?: string | string[];
+  }>;
 }) {
   const auditId = (await params).auditId;
+  const query = (await searchParams) ?? {};
+  const value = (input: string | string[] | undefined) =>
+    Array.isArray(input) ? input[0] : input;
   return (
     <Vm0007EvidenceMapDraftPage
       auditId={auditId}
-      reviewedCandidate={loadReviewedEvidenceMapCandidate(auditId)}
+      reviewedCandidate={loadReviewedEvidenceMapCandidate({
+        sourcePdfSha256: value(query.sourcePdfSha256),
+        sourceDocumentId: value(query.sourceDocumentId),
+        stableProjectId: value(query.stableProjectId),
+      })}
+      reviewedCandidates={loadReviewedEvidenceMapCandidates()}
     />
   );
 }

--- a/src/app/internal/reports/vm0007-evidence-map/[auditId]/page.tsx
+++ b/src/app/internal/reports/vm0007-evidence-map/[auditId]/page.tsx
@@ -1,5 +1,16 @@
 import Vm0007EvidenceMapDraftPage from "@/components/preverif/Vm0007EvidenceMapDraftPage";
+import { loadReviewedEvidenceMapCandidate } from "@/lib/preverif/reviewedEvidenceMapServerRegistry";
 
-export default async function Page({ params }: { params: Promise<{ auditId: string }> }) {
-  return <Vm0007EvidenceMapDraftPage auditId={(await params).auditId} />;
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ auditId: string }>;
+}) {
+  const auditId = (await params).auditId;
+  return (
+    <Vm0007EvidenceMapDraftPage
+      auditId={auditId}
+      reviewedCandidate={loadReviewedEvidenceMapCandidate(auditId)}
+    />
+  );
 }

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1214,6 +1214,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     methodologyId: string;
     methodologyVersion: string;
     evidenceFileName?: string;
+    sourcePdfSha256?: string | null;
     rawPddText: string;
     rules: readonly RuleSummary[];
   }) {
@@ -1268,6 +1269,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       loadedRulebookId: input.methodologyId,
       loadedRulebookVersion: input.methodologyVersion,
       evidenceFileName: input.evidenceFileName,
+      sourcePdfSha256: input.sourcePdfSha256,
       rawPddText: input.rawPddText,
       rules: input.rules,
       userAcceptedVersionWarning: !versionLock.versionMatch,
@@ -1290,6 +1292,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         methodologyId: detectedVm0007Method.methodologyId,
         methodologyVersion: detectedVm0007Method.methodologyVersion,
         evidenceFileName: draft.evidenceFileName || selectedEvidenceLabel,
+        sourcePdfSha256: selectedUpload?.attachment.sha256 ?? selectedPins.find((pin) => pin.pdd_document)?.pdd_document?.sha256 ?? null,
         rawPddText,
         rules,
       });
@@ -1536,6 +1539,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             methodologyId: candidate.methodologyId,
             methodologyVersion: candidate.methodologyVersion,
             evidenceFileName: activeDraft.evidenceFileName,
+            sourcePdfSha256: (() => {
+              const activeUpload = activeSession.stagedUploads.find((upload) => activeDraft.evidenceIds.includes(upload.evidenceId));
+              const activePdfPin = coalesceEvidencePins(loadPins(candidate.methodologyId, candidate.methodologyVersion)).find((pin) => activeDraft.evidenceIds.includes(pin.id) && pin.pdd_document);
+              return activeUpload?.attachment.sha256 ?? activePdfPin?.pdd_document?.sha256 ?? null;
+            })(),
             rawPddText: sourceAnalysis.rawPddText,
             rules: auditRules,
           });

--- a/src/components/preverif/Vm0007EvidenceMapDraftPage.tsx
+++ b/src/components/preverif/Vm0007EvidenceMapDraftPage.tsx
@@ -22,20 +22,35 @@ import type { EvidenceMapMode } from "@/components/preverif/evidence-map/evidenc
 export default function Vm0007EvidenceMapDraftPage({
   auditId,
   reviewedCandidate = null,
+  reviewedCandidates = [],
 }: {
   auditId: string;
   reviewedCandidate?: ReviewedEvidenceMapSnapshot | null;
+  reviewedCandidates?: readonly ReviewedEvidenceMapSnapshot[];
 }) {
   const [pkg, setPkg] = useState<Vm0007EvidenceMapDraftPackage | null>(null);
+  const [loaded, setLoaded] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [reviewRowId, setReviewRowId] = useState<string | null>(null);
-  const [mode, setMode] = useState<EvidenceMapMode>(
-    reviewedCandidate ? "reviewed" : "machine",
-  );
-  useEffect(() => setPkg(loadVm0007EvidenceMapDraft(auditId)), [auditId]);
+  const [mode, setMode] = useState<EvidenceMapMode>("reviewed");
+  useEffect(() => {
+    setPkg(loadVm0007EvidenceMapDraft(auditId));
+    setLoaded(true);
+  }, [auditId]);
 
   const closeReview = useCallback(() => setReviewRowId(null), []);
-  if (!pkg)
+  const reviewedSnapshot = pkg
+    ? (reviewedCandidates.find((candidate) =>
+        matchesReviewedEvidenceMapCase(pkg, candidate),
+      ) ??
+      (reviewedCandidate &&
+      matchesReviewedEvidenceMapCase(pkg, reviewedCandidate)
+        ? reviewedCandidate
+        : null))
+    : reviewedCandidate;
+  if (!loaded)
+    return <main className="min-h-screen bg-slate-50" aria-busy="true" />;
+  if (!pkg && !reviewedSnapshot)
     return (
       <main className="min-h-screen bg-slate-50 p-8">
         <div className="mx-auto max-w-4xl rounded-xl border border-amber-200 bg-white p-6 text-amber-900">
@@ -46,6 +61,7 @@ export default function Vm0007EvidenceMapDraftPage({
     );
 
   const finalize = () => {
+    if (!pkg) return;
     const result = finalizeVm0007EvidenceMap(pkg, "reviewer:local");
     if (result.ok) {
       setPkg(result.package);
@@ -59,6 +75,8 @@ export default function Vm0007EvidenceMapDraftPage({
     action: "approve" | "reopen",
     note: string,
   ): string | null => {
+    if (!pkg)
+      return "Machine proposal is not available for this reviewed snapshot.";
     const result =
       action === "approve"
         ? approveVm0007EvidenceMapRow(pkg, rowId, "reviewer:local", note)
@@ -74,6 +92,8 @@ export default function Vm0007EvidenceMapDraftPage({
     change: Vm0007EvidenceMapEdit,
     note: string,
   ): string | null => {
+    if (!pkg)
+      return "Machine proposal is not available for this reviewed snapshot.";
     const result = editVm0007EvidenceMapRow(
       pkg,
       rowId,
@@ -88,13 +108,10 @@ export default function Vm0007EvidenceMapDraftPage({
     );
     return null;
   };
-  const reviewedSnapshot =
-    reviewedCandidate && matchesReviewedEvidenceMapCase(pkg, reviewedCandidate)
-      ? reviewedCandidate
-      : null;
   const activeMode: EvidenceMapMode = reviewedSnapshot ? mode : "machine";
-  const reviewRow: Vm0007EvidenceMapDraftRow | null =
-    pkg.rows.find((row) => row.rowId === reviewRowId) ?? null;
+  const reviewRow: Vm0007EvidenceMapDraftRow | null = pkg
+    ? (pkg.rows.find((row) => row.rowId === reviewRowId) ?? null)
+    : null;
   return (
     <>
       <EvidenceMapWorkspace
@@ -108,7 +125,7 @@ export default function Vm0007EvidenceMapDraftPage({
       />
       <EvidenceMapReviewPanel
         row={reviewRow}
-        finalized={pkg.finalizationState === "finalized"}
+        finalized={pkg?.finalizationState === "finalized"}
         onClose={closeReview}
         onEdit={(change, note) =>
           reviewRow ? edit(reviewRow.rowId, change, note) : "Row not found."

--- a/src/components/preverif/Vm0007EvidenceMapDraftPage.tsx
+++ b/src/components/preverif/Vm0007EvidenceMapDraftPage.tsx
@@ -4,41 +4,126 @@ import { useCallback, useEffect, useState } from "react";
 import EvidenceMapReviewPanel from "@/components/preverif/evidence-map/EvidenceMapReviewPanel";
 import EvidenceMapWorkspace from "@/components/preverif/evidence-map/EvidenceMapWorkspace";
 import { loadVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
-import type { Vm0007EvidenceMapDraftPackage, Vm0007EvidenceMapDraftRow } from "@/lib/preverif/vm0007EvidenceMapDraft";
-import { approveVm0007EvidenceMapRow, editVm0007EvidenceMapRow, finalizeVm0007EvidenceMap, reopenVm0007EvidenceMapRow, type Vm0007EvidenceMapEdit } from "@/lib/preverif/vm0007EvidenceMapReview";
+import type {
+  Vm0007EvidenceMapDraftPackage,
+  Vm0007EvidenceMapDraftRow,
+} from "@/lib/preverif/vm0007EvidenceMapDraft";
+import {
+  approveVm0007EvidenceMapRow,
+  editVm0007EvidenceMapRow,
+  finalizeVm0007EvidenceMap,
+  reopenVm0007EvidenceMapRow,
+  type Vm0007EvidenceMapEdit,
+} from "@/lib/preverif/vm0007EvidenceMapReview";
+import { matchesReviewedEvidenceMapCase } from "@/lib/preverif/reviewedEvidenceMapRegistry";
+import type { ReviewedEvidenceMapSnapshot } from "@/lib/preverif/reviewedEvidenceMapTypes";
+import type { EvidenceMapMode } from "@/components/preverif/evidence-map/evidenceMapPresentationModel";
 
-export default function Vm0007EvidenceMapDraftPage({ auditId }: { auditId: string }) {
+export default function Vm0007EvidenceMapDraftPage({
+  auditId,
+  reviewedCandidate = null,
+}: {
+  auditId: string;
+  reviewedCandidate?: ReviewedEvidenceMapSnapshot | null;
+}) {
   const [pkg, setPkg] = useState<Vm0007EvidenceMapDraftPackage | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [reviewRowId, setReviewRowId] = useState<string | null>(null);
+  const [mode, setMode] = useState<EvidenceMapMode>(
+    reviewedCandidate ? "reviewed" : "machine",
+  );
   useEffect(() => setPkg(loadVm0007EvidenceMapDraft(auditId)), [auditId]);
 
   const closeReview = useCallback(() => setReviewRowId(null), []);
-  if (!pkg) return <main className="min-h-screen bg-slate-50 p-8"><div className="mx-auto max-w-4xl rounded-xl border border-amber-200 bg-white p-6 text-amber-900">Evidence Map is not available for this audit. Only a valid VM0007 v1.8 draft can be opened.</div></main>;
+  if (!pkg)
+    return (
+      <main className="min-h-screen bg-slate-50 p-8">
+        <div className="mx-auto max-w-4xl rounded-xl border border-amber-200 bg-white p-6 text-amber-900">
+          Evidence Map is not available for this audit. Only a valid VM0007 v1.8
+          draft can be opened.
+        </div>
+      </main>
+    );
 
   const finalize = () => {
     const result = finalizeVm0007EvidenceMap(pkg, "reviewer:local");
-    if (result.ok) { setPkg(result.package); setMessage("Evidence Map finalized. The readiness report is now available."); }
-    else setMessage(`Finalization blocked: ${result.blockedBy.join("; ")}`);
+    if (result.ok) {
+      setPkg(result.package);
+      setMessage(
+        "Evidence Map finalized. The readiness report is now available.",
+      );
+    } else setMessage(`Finalization blocked: ${result.blockedBy.join("; ")}`);
   };
-  const transition = (rowId: string, action: "approve" | "reopen", note: string): string | null => {
-    const result = action === "approve" ? approveVm0007EvidenceMapRow(pkg, rowId, "reviewer:local", note) : reopenVm0007EvidenceMapRow(pkg, rowId, "reviewer:local", note);
+  const transition = (
+    rowId: string,
+    action: "approve" | "reopen",
+    note: string,
+  ): string | null => {
+    const result =
+      action === "approve"
+        ? approveVm0007EvidenceMapRow(pkg, rowId, "reviewer:local", note)
+        : reopenVm0007EvidenceMapRow(pkg, rowId, "reviewer:local", note);
     if (!result.ok) return `Review action blocked: ${result.reason}`;
     setPkg(result.package);
     setMessage(`Row ${rowId} is now ${result.row.reviewState}.`);
     setReviewRowId(null);
     return null;
   };
-  const edit = (rowId: string, change: Vm0007EvidenceMapEdit, note: string): string | null => {
-    const result = editVm0007EvidenceMapRow(pkg, rowId, change, "reviewer:local", note);
+  const edit = (
+    rowId: string,
+    change: Vm0007EvidenceMapEdit,
+    note: string,
+  ): string | null => {
+    const result = editVm0007EvidenceMapRow(
+      pkg,
+      rowId,
+      change,
+      "reviewer:local",
+      note,
+    );
     if (!result.ok) return `Review action blocked: ${result.reason}`;
     setPkg(result.package);
-    setMessage(`Reviewer decision saved for ${rowId}. Approve the row to continue.`);
+    setMessage(
+      `Reviewer decision saved for ${rowId}. Approve the row to continue.`,
+    );
     return null;
   };
-  const reviewRow: Vm0007EvidenceMapDraftRow | null = pkg.rows.find((row) => row.rowId === reviewRowId) ?? null;
-  return <>
-    <EvidenceMapWorkspace pkg={pkg} message={message} onFinalize={finalize} onReview={(row) => setReviewRowId(row.rowId)} />
-    <EvidenceMapReviewPanel row={reviewRow} finalized={pkg.finalizationState === "finalized"} onClose={closeReview} onEdit={(change, note) => reviewRow ? edit(reviewRow.rowId, change, note) : "Row not found."} onApprove={(note) => reviewRow ? transition(reviewRow.rowId, "approve", note) : "Row not found."} onReopen={(note) => reviewRow ? transition(reviewRow.rowId, "reopen", note) : "Row not found."} />
-  </>;
+  const reviewedSnapshot =
+    reviewedCandidate && matchesReviewedEvidenceMapCase(pkg, reviewedCandidate)
+      ? reviewedCandidate
+      : null;
+  const activeMode: EvidenceMapMode = reviewedSnapshot ? mode : "machine";
+  const reviewRow: Vm0007EvidenceMapDraftRow | null =
+    pkg.rows.find((row) => row.rowId === reviewRowId) ?? null;
+  return (
+    <>
+      <EvidenceMapWorkspace
+        pkg={pkg}
+        reviewedSnapshot={reviewedSnapshot}
+        mode={activeMode}
+        onModeChange={setMode}
+        message={message}
+        onFinalize={finalize}
+        onReview={(row) => setReviewRowId(row.rowId)}
+      />
+      <EvidenceMapReviewPanel
+        row={reviewRow}
+        finalized={pkg.finalizationState === "finalized"}
+        onClose={closeReview}
+        onEdit={(change, note) =>
+          reviewRow ? edit(reviewRow.rowId, change, note) : "Row not found."
+        }
+        onApprove={(note) =>
+          reviewRow
+            ? transition(reviewRow.rowId, "approve", note)
+            : "Row not found."
+        }
+        onReopen={(note) =>
+          reviewRow
+            ? transition(reviewRow.rowId, "reopen", note)
+            : "Row not found."
+        }
+      />
+    </>
+  );
 }

--- a/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
+++ b/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
@@ -285,11 +285,7 @@ function RuleDetails({
   );
 }
 
-function Summary({
-  rows,
-}: {
-  rows: readonly EvidenceMapPresentationRow[];
-}) {
+function Summary({ rows }: { rows: readonly EvidenceMapPresentationRow[] }) {
   const summary = summarizeEvidenceMapPresentation(rows);
   const items = [
     ["Total rules", summary.total],
@@ -319,7 +315,7 @@ function Summary({
 }
 
 type Props = {
-  pkg: Vm0007EvidenceMapDraftPackage;
+  pkg: Vm0007EvidenceMapDraftPackage | null;
   reviewedSnapshot?: ReviewedEvidenceMapSnapshot | null;
   mode: EvidenceMapMode;
   onModeChange: (mode: EvidenceMapMode) => void;
@@ -344,15 +340,19 @@ export default function EvidenceMapWorkspace({
     () =>
       mode === "reviewed" && reviewedSnapshot
         ? buildReviewedEvidenceMapPresentation(reviewedSnapshot)
-        : buildMachineEvidenceMapPresentation(pkg),
+        : pkg
+          ? buildMachineEvidenceMapPresentation(pkg)
+          : { mode: "reviewed" as const, rows: [], readOnly: true },
     [mode, pkg, reviewedSnapshot],
   );
   const rows = useMemo(
     () => filterEvidenceMapPresentation(presentation.rows, filters),
     [presentation.rows, filters],
   );
-  const finalized = pkg.finalizationState === "finalized";
-  const allApproved = pkg.rows.every((row) => row.reviewState === "approved");
+  const finalized = pkg?.finalizationState === "finalized";
+  const allApproved = Boolean(
+    pkg?.rows.every((row) => row.reviewState === "approved"),
+  );
   const toggle = (rowId: string) =>
     setExpanded((current) => {
       const next = new Set(current);
@@ -376,8 +376,10 @@ export default function EvidenceMapWorkspace({
             <div className="flex items-center gap-2">
               <FileText size={18} className="text-blue-600" />
               <p className="text-sm font-medium text-slate-600">
-                {pkg.sourceDocument.documentName ||
-                  pkg.sourceDocument.documentId}
+                {pkg?.sourceDocument.documentName ||
+                  pkg?.sourceDocument.documentId ||
+                  reviewedSnapshot?.sourceDocument.documentName ||
+                  reviewedSnapshot?.sourceDocument.documentId}
               </p>
             </div>
             <h1 className="mt-2 text-2xl font-semibold">
@@ -385,11 +387,13 @@ export default function EvidenceMapWorkspace({
               {presentation.readOnly ? "Reviewed truth" : "Machine proposal"}
             </h1>
             <p className="mt-2 text-xs text-slate-500">
-              {pkg.methodologyId} {pkg.rulebookVersion} · Audit {pkg.auditId}
+              {pkg?.methodologyId || reviewedSnapshot?.methodologyId}{" "}
+              {pkg?.rulebookVersion || reviewedSnapshot?.methodologyVersion} ·
+              Audit {pkg?.auditId || reviewedSnapshot?.canonicalAuditId}
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-3">
-            {reviewedSnapshot ? (
+            {reviewedSnapshot && pkg ? (
               <div
                 aria-label="Evidence Map mode"
                 className="inline-flex rounded-lg border border-slate-300 bg-slate-100 p-1"
@@ -550,7 +554,7 @@ export default function EvidenceMapWorkspace({
                   readOnly={presentation.readOnly}
                   finalized={finalized}
                   onReview={() => {
-                    const machineRow = pkg.rows.find(
+                    const machineRow = pkg?.rows.find(
                       (item) => item.rowId === row.rowId,
                     );
                     if (machineRow) onReview(machineRow);

--- a/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
+++ b/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
@@ -1,110 +1,566 @@
 "use client";
 
-import { ChevronDown, FileText, FilterX, Search, ShieldCheck } from "lucide-react";
+import {
+  ChevronDown,
+  FileText,
+  FilterX,
+  Search,
+  ShieldCheck,
+} from "lucide-react";
 import { useMemo, useState } from "react";
-import type { Vm0007EvidenceMapDraftPackage, Vm0007EvidenceMapDraftRow } from "@/lib/preverif/vm0007EvidenceMapDraft";
-import { EMPTY_EVIDENCE_MAP_FILTERS, filterEvidenceMapRows, hasEvidenceMapFilters, summarizeEvidenceMap, type EvidenceMapFilters } from "./evidenceMapViewModel";
+import type {
+  Vm0007EvidenceMapDraftPackage,
+  Vm0007EvidenceMapDraftRow,
+} from "@/lib/preverif/vm0007EvidenceMapDraft";
+import type { ReviewedEvidenceMapSnapshot } from "@/lib/preverif/reviewedEvidenceMapTypes";
+import {
+  buildMachineEvidenceMapPresentation,
+  buildReviewedEvidenceMapPresentation,
+  EMPTY_PRESENTATION_FILTERS,
+  filterEvidenceMapPresentation,
+  hasPresentationFilters,
+  summarizeEvidenceMapPresentation,
+  type EvidenceMapMode,
+  type EvidenceMapPresentationFilters,
+  type EvidenceMapPresentationRow,
+} from "./evidenceMapPresentationModel";
 
 function label(value: string): string {
-  const known: Record<string, string> = {
-    supported_by_pdd: "Supported by PDD",
-    partially_supported: "Partially supported",
-    missing_evidence: "Missing evidence",
-    not_applicable: "Not applicable",
-    manual_review_needed: "Manual review needed",
-    NIR_CANDIDATE: "NIR candidate",
-    NCR_CANDIDATE: "NCR candidate",
-    OFI_CANDIDATE: "OFI candidate",
-  };
-  return known[value] ?? value.toLocaleLowerCase().replaceAll("_", " ").replace(/(^|\s)\S/g, (letter) => letter.toLocaleUpperCase());
+  return value
+    .toLocaleLowerCase()
+    .replaceAll("_", " ")
+    .replace(/(^|\s)\S/g, (letter) => letter.toLocaleUpperCase());
 }
-function dateTime(value: string | null | undefined): string { if (!value) return "Not yet"; const date = new Date(value); return Number.isNaN(date.getTime()) ? value : new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(date); }
 
 const badgeTone: Record<string, string> = {
   FOUND: "bg-emerald-50 text-emerald-800 ring-emerald-600/20",
   UNCLEAR: "bg-amber-50 text-amber-800 ring-amber-600/20",
   MISSING: "bg-rose-50 text-rose-800 ring-rose-600/20",
-  approved: "bg-emerald-50 text-emerald-800 ring-emerald-600/20",
-  edited: "bg-blue-50 text-blue-800 ring-blue-600/20",
-  reopened: "bg-amber-50 text-amber-800 ring-amber-600/20",
-  "pending review": "bg-slate-100 text-slate-700 ring-slate-500/20",
+  "N/A": "bg-slate-100 text-slate-700 ring-slate-500/20",
+  ACTION_REQUIRED: "bg-rose-50 text-rose-800 ring-rose-600/20",
+  CONFORMS: "bg-emerald-50 text-emerald-800 ring-emerald-600/20",
 };
 
-function Badge({ value }: { value: string }) { return <span className={`inline-flex whitespace-nowrap rounded-full px-2.5 py-1 text-[11px] font-semibold ring-1 ring-inset ${badgeTone[value] ?? "bg-slate-100 text-slate-700 ring-slate-500/20"}`}>{label(value)}</span>; }
-
-function EvidenceProvenance({ row, record }: { row: Vm0007EvidenceMapDraftRow; record: NonNullable<Vm0007EvidenceMapDraftRow["acceptedEvidence"]>[number] }) {
-  const section = record.section || record.provenance.sectionHeading || record.provenance.sectionPath.at(-1);
-  return <dl className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-xs text-slate-500"><div><dt className="sr-only">Page</dt><dd>Page {record.page ?? record.provenance.page ?? "—"}</dd></div><div><dt className="sr-only">Section</dt><dd>{section || "No section"}</dd></div>{record.evidenceType ? <div><dt className="sr-only">Evidence type</dt><dd>{label(record.evidenceType)}</dd></div> : null}<div title={record.provenance.spanId}><dt className="sr-only">Source</dt><dd className="max-w-[20rem] truncate">{row.sourceDocument.documentName || record.provenance.docId} · {record.provenance.spanId}</dd></div></dl>;
+function Badge({ value }: { value: string }) {
+  return (
+    <span
+      className={`inline-flex whitespace-nowrap rounded-full px-2.5 py-1 text-[11px] font-semibold ring-1 ring-inset ${badgeTone[value] ?? "bg-slate-100 text-slate-700 ring-slate-500/20"}`}
+    >
+      {label(value)}
+    </span>
+  );
 }
 
-function AcceptedEvidenceList({ row }: { row: Vm0007EvidenceMapDraftRow }) {
-  const records = row.acceptedEvidence ?? (row.proposedAcceptedEvidence ? [{ quote: row.proposedAcceptedEvidence.quote, page: row.proposedAcceptedEvidence.provenance.page, section: row.proposedAcceptedEvidence.provenance.sectionHeading, spanId: row.proposedAcceptedEvidence.provenance.spanId, provenance: row.proposedAcceptedEvidence.provenance }] : []);
-  return <section aria-labelledby={`${row.rowId}-accepted`}><div className="flex items-center justify-between"><h4 id={`${row.rowId}-accepted`} className="text-sm font-semibold text-slate-950">Accepted evidence</h4><span className="font-mono text-xs text-slate-500">{records.length}</span></div>{records.length ? <div className="mt-3 divide-y divide-slate-200 rounded-xl bg-emerald-50/50 px-4">{records.map((record, index) => <article key={`${record.spanId}-${index}`} data-evidence-record="accepted" className="py-4"><blockquote className="whitespace-pre-wrap text-sm leading-6 text-slate-800">“{record.quote}”</blockquote><EvidenceProvenance row={row} record={record} /></article>)}</div> : <p className="mt-3 text-sm text-slate-500">No accepted evidence is recorded.</p>}</section>;
+function EvidenceList({
+  row,
+  rejected = false,
+}: {
+  row: EvidenceMapPresentationRow;
+  rejected?: boolean;
+}) {
+  const records = rejected ? row.rejectedEvidence : row.acceptedEvidence;
+  const heading = rejected
+    ? "Rejected evidence"
+    : row.reviewState === "reviewed snapshot"
+      ? "Reviewed accepted evidence"
+      : "Machine proposed evidence";
+  return (
+    <section>
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-semibold text-slate-950">{heading}</h4>
+        <span className="font-mono text-xs text-slate-500">
+          {records.length}
+        </span>
+      </div>
+      {records.length ? (
+        <div
+          className={`mt-3 divide-y divide-slate-200 rounded-xl px-4 ${rejected ? "bg-amber-50/60" : "bg-emerald-50/50"}`}
+        >
+          {records.map((record, index) => (
+            <article
+              key={`${record.spanId}-${index}`}
+              data-evidence-record={rejected ? "rejected" : "accepted"}
+              className="py-4"
+            >
+              <blockquote className="whitespace-pre-wrap text-sm leading-6 text-slate-800">
+                “{record.quote}”
+              </blockquote>
+              {rejected && record.rejectionReason ? (
+                <p className="mt-3 text-sm text-amber-900">
+                  <strong>Rejected because:</strong> {record.rejectionReason}
+                </p>
+              ) : null}
+              <dl className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-xs text-slate-500">
+                <div>
+                  <dt className="sr-only">Page</dt>
+                  <dd>Page {record.page ?? record.provenance.page ?? "—"}</dd>
+                </div>
+                <div>
+                  <dt className="sr-only">Section</dt>
+                  <dd>
+                    {record.section ||
+                      record.provenance.sectionHeading ||
+                      "No section"}
+                  </dd>
+                </div>
+                <div title={record.provenance.spanId}>
+                  <dt className="sr-only">Source span</dt>
+                  <dd>
+                    {record.provenance.docId} · {record.provenance.spanId}
+                  </dd>
+                </div>
+              </dl>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-3 text-sm text-slate-500">
+          No {rejected ? "rejected" : "accepted"} evidence is recorded.
+        </p>
+      )}
+    </section>
+  );
 }
 
-function RejectedEvidenceList({ row }: { row: Vm0007EvidenceMapDraftRow }) {
-  const records = row.rejectedEvidence ?? (row.proposedRejectedEvidence ? [{ quote: row.proposedRejectedEvidence.quote, rejectionReason: row.proposedRejectedEvidence.reason, page: row.proposedRejectedEvidence.provenance.page, section: row.proposedRejectedEvidence.provenance.sectionHeading, spanId: row.proposedRejectedEvidence.provenance.spanId, provenance: row.proposedRejectedEvidence.provenance }] : []);
-  return <section aria-labelledby={`${row.rowId}-rejected`}><div className="flex items-center justify-between"><h4 id={`${row.rowId}-rejected`} className="text-sm font-semibold text-slate-950">Rejected evidence</h4><span className="font-mono text-xs text-slate-500">{records.length}</span></div>{records.length ? <div className="mt-3 divide-y divide-slate-200 rounded-xl bg-amber-50/60 px-4">{records.map((record, index) => <article key={`${record.spanId}-${index}`} data-evidence-record="rejected" className="py-4"><blockquote className="whitespace-pre-wrap text-sm leading-6 text-slate-800">“{record.quote}”</blockquote><p className="mt-3 text-sm font-medium text-amber-900"><span className="font-semibold">Rejected because:</span> {record.rejectionReason}</p><EvidenceProvenance row={row} record={record} /></article>)}</div> : <p className="mt-3 text-sm text-slate-500">No rejected evidence is recorded.</p>}</section>;
-}
-
-function ComponentCoverage({ row }: { row: Vm0007EvidenceMapDraftRow }) {
-  if (row.supportedComponents === undefined && row.missingComponents === undefined) return null;
-  return <section aria-labelledby={`${row.rowId}-coverage`} data-component-coverage className="rounded-xl border border-slate-200 p-4"><h4 id={`${row.rowId}-coverage`} className="text-sm font-semibold text-slate-950">Component coverage</h4><div className="mt-3 grid gap-4 sm:grid-cols-2"><div><p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">Supported</p><ul className="mt-2 space-y-1.5 text-sm text-slate-700">{row.supportedComponents?.length ? row.supportedComponents.map((item) => <li key={item}>✓ {item}</li>) : <li className="text-slate-500">None recorded</li>}</ul></div><div><p className="text-xs font-semibold uppercase tracking-wide text-rose-700">Missing</p><ul className="mt-2 space-y-1.5 text-sm text-slate-700">{row.missingComponents?.length ? row.missingComponents.map((item) => <li key={item}>○ {item}</li>) : <li className="text-slate-500">None recorded</li>}</ul></div></div></section>;
-}
-
-function EvidenceMapRuleDetails({ row, finalized, onReview }: { row: Vm0007EvidenceMapDraftRow; finalized: boolean; onReview: () => void }) {
-  const assessment = row.assessment;
-  return <div id={`${row.rowId}-details`} className="evidence-map-details grid overflow-hidden border-t border-slate-200 bg-slate-50/70 px-4 py-6 sm:px-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,.6fr)] lg:gap-10">
-    <div className="space-y-8">
-      <section><h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">Requirement</h3><p className="mt-3 text-sm leading-6 text-slate-800">{row.requirementText}</p><p className="mt-2 font-mono text-xs text-slate-500">{row.stableRuleId} · {row.methodologyId} {row.methodologyVersion}</p></section>
-      <section><h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">Assessment</h3><dl className="mt-3 grid gap-x-6 gap-y-4 text-sm sm:grid-cols-2"><div><dt className="text-xs text-slate-500">Audit status</dt><dd className="mt-1 font-medium text-slate-800">{label(row.rawAuditStatus)}</dd></div><div><dt className="text-xs text-slate-500">Evidence state</dt><dd className="mt-1 font-medium text-slate-800">{row.proposedEvidenceStatus}</dd></div><div><dt className="text-xs text-slate-500">Applicability</dt><dd className="mt-1 font-medium text-slate-800">{row.proposedApplicability}</dd></div><div><dt className="text-xs text-slate-500">Confidence</dt><dd className="mt-1 font-medium text-slate-800">{label(row.confidence)}</dd></div><div className="sm:col-span-2"><dt className="text-xs text-slate-500">Assessment reason</dt><dd className="mt-1 leading-6 text-slate-800">{row.assessmentReason}</dd></div>{row.reasonSelected ? <div className="sm:col-span-2"><dt className="text-xs text-slate-500">Reason selected</dt><dd className="mt-1 leading-6 text-slate-800">{row.reasonSelected}</dd></div> : null}{assessment ? <><div><dt className="text-xs text-slate-500">Reviewer support decision</dt><dd className="mt-1 font-medium text-slate-800">{assessment.conformance.requirementSupport}</dd></div><div><dt className="text-xs text-slate-500">Reviewer outcome</dt><dd className="mt-1 font-medium text-slate-800">{assessment.draftFinding.draftFindingType ?? "No finding"}</dd></div></> : null}</dl></section>
-      <AcceptedEvidenceList row={row} /><RejectedEvidenceList row={row} /><ComponentCoverage row={row} />
+function RuleDetails({
+  row,
+  readOnly,
+  finalized,
+  onReview,
+}: {
+  row: EvidenceMapPresentationRow;
+  readOnly: boolean;
+  finalized: boolean;
+  onReview: () => void;
+}) {
+  return (
+    <div
+      id={`${row.rowId}-details`}
+      className="grid overflow-hidden border-t border-slate-200 bg-slate-50/70 px-4 py-6 sm:px-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,.6fr)] lg:gap-10"
+    >
+      <div className="space-y-8">
+        <section>
+          <h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">
+            Requirement
+          </h3>
+          <p className="mt-3 text-sm leading-6 text-slate-800">
+            {row.requirementText}
+          </p>
+          <p className="mt-2 font-mono text-xs text-slate-500">
+            {row.stableRuleId}
+          </p>
+        </section>
+        <section>
+          <h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">
+            {readOnly ? "Reviewed assessment" : "Machine assessment"}
+          </h3>
+          <dl className="mt-3 grid gap-x-6 gap-y-4 text-sm sm:grid-cols-2">
+            <div>
+              <dt className="text-xs text-slate-500">Evidence state</dt>
+              <dd className="mt-1 font-medium">{row.evidenceState}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-slate-500">Reviewer outcome</dt>
+              <dd className="mt-1 font-medium">{label(row.reviewerOutcome)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-slate-500">Applicability</dt>
+              <dd className="mt-1 font-medium">{label(row.applicability)}</dd>
+            </div>
+            {row.rawAuditStatus ? (
+              <div>
+                <dt className="text-xs text-slate-500">Raw audit status</dt>
+                <dd className="mt-1 font-medium">
+                  {label(row.rawAuditStatus)}
+                </dd>
+              </div>
+            ) : null}
+            {row.confidence ? (
+              <div>
+                <dt className="text-xs text-slate-500">Confidence</dt>
+                <dd className="mt-1 font-medium">{label(row.confidence)}</dd>
+              </div>
+            ) : null}
+            {row.assessmentReason ? (
+              <div className="sm:col-span-2">
+                <dt className="text-xs text-slate-500">
+                  Machine assessment reason
+                </dt>
+                <dd className="mt-1 leading-6">{row.assessmentReason}</dd>
+              </div>
+            ) : null}
+            {row.reasonSelected ? (
+              <div className="sm:col-span-2">
+                <dt className="text-xs text-slate-500">Reason selected</dt>
+                <dd className="mt-1 leading-6">{row.reasonSelected}</dd>
+              </div>
+            ) : null}
+            {readOnly ? (
+              <>
+                <div>
+                  <dt className="text-xs text-slate-500">
+                    Draft finding candidate
+                  </dt>
+                  <dd className="mt-1 font-medium">
+                    {row.draftFindingCandidate
+                      ? label(row.draftFindingCandidate)
+                      : "None"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">
+                    Contradiction state
+                  </dt>
+                  <dd className="mt-1 font-medium">
+                    {row.contradictionState
+                      ? label(row.contradictionState)
+                      : "Not recorded"}
+                  </dd>
+                </div>
+              </>
+            ) : null}
+          </dl>
+        </section>
+        <EvidenceList row={row} />
+        <EvidenceList row={row} rejected />
+        {row.supportedComponents || row.missingComponents ? (
+          <section
+            data-component-coverage
+            className="rounded-xl border border-slate-200 p-4"
+          >
+            <h4 className="text-sm font-semibold">Component coverage</h4>
+            <p className="mt-2 text-sm">
+              {row.supportedComponents?.join(", ") || "None recorded"}
+            </p>
+            <p className="mt-2 text-sm text-slate-600">
+              {row.missingComponents?.join(", ") || "None missing"}
+            </p>
+          </section>
+        ) : null}
+      </div>
+      <aside className="mt-8 border-t border-slate-200 pt-6 lg:mt-0 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0">
+        <h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">
+          Gap and action
+        </h3>
+        <p className="mt-3 text-sm leading-6 text-slate-700">
+          {row.clientAction || row.gap || "No action recorded."}
+        </p>
+        {!readOnly ? (
+          <section className="mt-6">
+            <h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">
+              Latest review activity
+            </h3>
+            <p className="mt-3 text-sm text-slate-600">
+              {row.reviewHistory?.length ?? 0} event(s)
+              {row.reviewHistory?.length
+                ? ` · last by ${row.reviewHistory.at(-1)?.reviewerIdentity}`
+                : ""}
+            </p>
+            {row.reviewHistory?.at(-1)?.reasonOrNote ? (
+              <p className="mt-2 text-sm">
+                {row.reviewHistory.at(-1)?.reasonOrNote}
+              </p>
+            ) : null}
+          </section>
+        ) : null}
+        {readOnly ? (
+          <div className="mt-6 rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600">
+            <strong className="block text-slate-800">
+              Reviewed truth snapshot
+            </strong>
+            This historical snapshot is read-only. Save, approve, reopen, and
+            finalize controls are unavailable.
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={onReview}
+            className="mt-6 w-full rounded-lg bg-slate-950 px-4 py-2.5 text-sm font-semibold text-white"
+          >
+            {finalized ? "View review decision" : "Review decision"}
+          </button>
+        )}
+      </aside>
     </div>
-    <aside className="mt-8 space-y-6 border-t border-slate-200 pt-6 lg:mt-0 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0"><section><h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">Gap and action</h3><dl className="mt-3 space-y-4 text-sm"><div><dt className="font-medium text-slate-700">Current gap</dt><dd className="mt-1 leading-6 text-slate-600">{row.gap || "No gap recorded."}</dd></div><div><dt className="font-medium text-slate-700">Client action</dt><dd className="mt-1 leading-6 text-slate-600">{row.clientAction || "No client action recorded."}</dd></div></dl></section><section><h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">Latest review activity</h3><p className="mt-3 text-sm text-slate-600">{row.reviewHistory?.length ?? 0} event(s){row.reviewHistory?.length ? ` · last by ${row.reviewHistory.at(-1)?.reviewerIdentity}` : ""}</p>{row.reviewHistory?.at(-1)?.reasonOrNote ? <p className="mt-2 text-sm leading-6 text-slate-700">“{row.reviewHistory.at(-1)?.reasonOrNote}”</p> : null}</section><button type="button" onClick={onReview} className="w-full rounded-lg bg-slate-950 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 motion-reduce:transition-none">{finalized ? "View review decision" : "Review decision"}</button></aside>
-  </div>;
+  );
 }
 
-function EvidenceMapRuleRow({ row, expanded, finalized, onToggle, onReview }: { row: Vm0007EvidenceMapDraftRow; expanded: boolean; finalized: boolean; onToggle: () => void; onReview: () => void }) {
-  const preview = row.acceptedEvidence?.[0]?.quote ?? row.proposedAcceptedEvidence?.quote ?? row.gap ?? row.assessmentReason;
-  const page = row.acceptedEvidence?.[0]?.page ?? row.provenance?.page ?? row.page;
-  return <article data-evidence-map-row={row.rowId} className="border-b border-slate-200 last:border-b-0">
-    <button type="button" onClick={onToggle} aria-expanded={expanded} aria-controls={`${row.rowId}-details`} className="grid w-full gap-3 px-4 py-4 text-left transition hover:bg-slate-50 focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-600 sm:px-6 lg:grid-cols-[8rem_minmax(12rem,.8fr)_minmax(16rem,1.4fr)_auto] lg:items-center motion-reduce:transition-none">
-      <div><span className="font-mono text-xs font-semibold text-blue-700">{row.ruleReference}</span><span className="mt-1 block text-xs text-slate-500 lg:hidden">{row.methodologyId} {row.methodologyVersion}</span></div>
-      <div><h2 className="text-sm font-semibold leading-5 text-slate-950">{row.ruleReference.trim().toLocaleLowerCase() === row.ruleTitle.trim().toLocaleLowerCase() ? row.ruleReference : row.ruleTitle}</h2><div className="mt-2 flex flex-wrap gap-2"><Badge value={row.proposedEvidenceStatus} /><Badge value={row.reviewState ?? "pending review"} /><span className="text-xs leading-6 text-slate-500">{label(row.proposedApplicability)} · {label(row.confidence)}</span></div></div>
-      <div><p className="line-clamp-2 text-sm leading-5 text-slate-600">{preview || "No evidence or gap preview recorded."}</p>{page !== null && page !== undefined ? <p className="mt-1 text-xs text-slate-500">Page {page}</p> : null}</div>
-      <ChevronDown aria-hidden="true" className={`justify-self-end text-slate-400 transition-transform ${expanded ? "rotate-180" : ""} motion-reduce:transition-none`} size={18} />
-    </button>
-    {expanded ? <EvidenceMapRuleDetails row={row} finalized={finalized} onReview={onReview} /> : null}
-  </article>;
-}
-
-function EvidenceMapSummary({ rows, filters, onChange }: { rows: readonly Vm0007EvidenceMapDraftRow[]; filters: EvidenceMapFilters; onChange: (filters: EvidenceMapFilters) => void }) {
-  const summary = summarizeEvidenceMap(rows);
+function Summary({
+  rows,
+}: {
+  rows: readonly EvidenceMapPresentationRow[];
+}) {
+  const summary = summarizeEvidenceMapPresentation(rows);
   const items = [
-    ["Total rules", summary.total, () => onChange(EMPTY_EVIDENCE_MAP_FILTERS)],
-    ["Found", summary.found, () => onChange({ ...filters, evidenceState: filters.evidenceState === "FOUND" ? "ALL" : "FOUND" })],
-    ["Unclear", summary.unclear, () => onChange({ ...filters, evidenceState: filters.evidenceState === "UNCLEAR" ? "ALL" : "UNCLEAR" })],
-    ["Missing", summary.missing, () => onChange({ ...filters, evidenceState: filters.evidenceState === "MISSING" ? "ALL" : "MISSING" })],
-    ["Not applicable", summary.notApplicable, () => onChange({ ...filters, applicability: filters.applicability === "NOT_APPLICABLE" ? "ALL" : "NOT_APPLICABLE" })],
-    ["Action required", summary.actionRequired, () => onChange({ ...filters, reviewState: filters.reviewState === "ACTION_REQUIRED" ? "ALL" : "ACTION_REQUIRED" })],
+    ["Total rules", summary.total],
+    ["Found", summary.found],
+    ["Unclear", summary.unclear],
+    ["Missing", summary.missing],
+    ["Not applicable", summary.notApplicable],
+    ["Action required", summary.actionRequired],
   ] as const;
-  return <nav aria-label="Evidence Map summary filters" className="grid grid-cols-2 divide-x divide-y divide-slate-200 overflow-hidden border-y border-slate-200 bg-white sm:grid-cols-3 lg:grid-cols-6 lg:divide-y-0">{items.map(([name, count, click]) => <button type="button" key={name} onClick={click} className="px-4 py-4 text-left transition hover:bg-slate-50 focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-600 motion-reduce:transition-none"><span className="font-mono text-xl font-semibold tabular-nums text-slate-950">{count}</span><span className="mt-1 block text-xs font-medium text-slate-500">{name}</span></button>)}</nav>;
+  return (
+    <nav
+      aria-label="Evidence Map summary"
+      className="grid grid-cols-2 divide-x divide-y divide-slate-200 border-y border-slate-200 bg-white sm:grid-cols-3 lg:grid-cols-6"
+    >
+      {items.map(([name, count]) => (
+        <div key={name} className="px-4 py-4">
+          <span className="font-mono text-xl font-semibold tabular-nums">
+            {count}
+          </span>
+          <span className="mt-1 block text-xs font-medium text-slate-500">
+            {name}
+          </span>
+        </div>
+      ))}
+    </nav>
+  );
 }
 
-function EvidenceMapFiltersBar({ filters, count, total, onChange }: { filters: EvidenceMapFilters; count: number; total: number; onChange: (filters: EvidenceMapFilters) => void }) {
-  const selectClass = "min-h-10 rounded-lg border border-slate-300 bg-white px-3 text-sm text-slate-700 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100 motion-reduce:transition-none";
-  return <div className="sticky top-0 z-20 border-b border-slate-200 bg-slate-50/95 px-4 py-3 backdrop-blur sm:px-6"><div className="flex flex-col gap-3 xl:flex-row xl:items-center"><label className="relative min-w-64 flex-1"><span className="sr-only">Search rules</span><Search aria-hidden="true" size={17} className="pointer-events-none absolute left-3 top-3 text-slate-400" /><input type="search" value={filters.query} onChange={(event) => onChange({ ...filters, query: event.target.value })} placeholder="Search rule, requirement, gap, or action" className="min-h-10 w-full rounded-lg border border-slate-300 bg-white pl-9 pr-3 text-sm outline-none transition placeholder:text-slate-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 motion-reduce:transition-none" /></label><div className="grid grid-cols-2 gap-2 sm:grid-cols-4">{([["Evidence state", "evidenceState", ["FOUND", "UNCLEAR", "MISSING"]], ["Applicability", "applicability", ["APPLICABLE", "NOT_APPLICABLE", "UNKNOWN"]], ["Reviewer outcome", "reviewerOutcome", ["NONE", "NIR_CANDIDATE", "NCR_CANDIDATE", "OFI_CANDIDATE"]], ["Review state", "reviewState", ["pending review", "approved", "edited", "reopened"]]] as const).map(([name, field, options]) => <label key={field}><span className="sr-only">{name}</span><select aria-label={name} value={filters[field]} onChange={(event) => onChange({ ...filters, [field]: event.target.value })} className={selectClass}><option value="ALL">{name}: All</option>{options.map((option) => <option key={option} value={option}>{label(option)}</option>)}</select></label>)}</div></div><div className="mt-3 flex items-center justify-between text-xs text-slate-500"><span aria-live="polite"><strong className="font-semibold text-slate-700">{count}</strong> of {total} rules</span><button type="button" onClick={() => onChange(EMPTY_EVIDENCE_MAP_FILTERS)} disabled={!hasEvidenceMapFilters(filters)} className="inline-flex items-center gap-1.5 font-medium text-blue-700 transition hover:text-blue-900 disabled:text-slate-400 motion-reduce:transition-none"><FilterX size={14} />Clear all</button></div></div>;
-}
-
-type Props = { pkg: Vm0007EvidenceMapDraftPackage; message: string | null; onFinalize: () => void; onReview: (row: Vm0007EvidenceMapDraftRow) => void };
-export default function EvidenceMapWorkspace({ pkg, message, onFinalize, onReview }: Props) {
-  const [filters, setFilters] = useState<EvidenceMapFilters>(EMPTY_EVIDENCE_MAP_FILTERS);
+type Props = {
+  pkg: Vm0007EvidenceMapDraftPackage;
+  reviewedSnapshot?: ReviewedEvidenceMapSnapshot | null;
+  mode: EvidenceMapMode;
+  onModeChange: (mode: EvidenceMapMode) => void;
+  message: string | null;
+  onFinalize: () => void;
+  onReview: (row: Vm0007EvidenceMapDraftRow) => void;
+};
+export default function EvidenceMapWorkspace({
+  pkg,
+  reviewedSnapshot,
+  mode,
+  onModeChange,
+  message,
+  onFinalize,
+  onReview,
+}: Props) {
+  const [filters, setFilters] = useState<EvidenceMapPresentationFilters>(
+    EMPTY_PRESENTATION_FILTERS,
+  );
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
-  const rows = useMemo(() => filterEvidenceMapRows(pkg.rows, filters), [pkg.rows, filters]);
+  const presentation = useMemo(
+    () =>
+      mode === "reviewed" && reviewedSnapshot
+        ? buildReviewedEvidenceMapPresentation(reviewedSnapshot)
+        : buildMachineEvidenceMapPresentation(pkg),
+    [mode, pkg, reviewedSnapshot],
+  );
+  const rows = useMemo(
+    () => filterEvidenceMapPresentation(presentation.rows, filters),
+    [presentation.rows, filters],
+  );
   const finalized = pkg.finalizationState === "finalized";
   const allApproved = pkg.rows.every((row) => row.reviewState === "approved");
-  const toggle = (rowId: string) => setExpanded((current) => { const next = new Set(current); if (next.has(rowId)) next.delete(rowId); else next.add(rowId); return next; });
-  return <main className="min-h-screen bg-slate-50 text-slate-950"><header className="border-b border-slate-200 bg-white px-4 py-5 sm:px-6"><div className="mx-auto flex max-w-[1600px] flex-col gap-5 lg:flex-row lg:items-center lg:justify-between"><div className="min-w-0"><div className="flex items-center gap-2"><FileText size={18} className="text-blue-600" /><p className="truncate text-sm font-medium text-slate-600">{pkg.sourceDocument.documentName || pkg.sourceDocument.documentId}</p></div><h1 className="mt-2 text-2xl font-semibold tracking-tight">Evidence Map</h1><div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500"><span>{pkg.methodologyId} {pkg.rulebookVersion}</span><span aria-hidden="true">·</span><span>Audit {pkg.auditId}</span><span aria-hidden="true">·</span><span>Generated {dateTime(pkg.generatedAt)}</span>{pkg.finalizedAt ? <><span aria-hidden="true">·</span><span>Reviewed {dateTime(pkg.finalizedAt)}</span></> : null}</div></div><div className="flex flex-wrap items-center gap-3"><div className={`inline-flex items-center gap-2 rounded-full px-3 py-2 text-xs font-semibold ${finalized ? "bg-emerald-50 text-emerald-800" : "bg-amber-50 text-amber-800"}`}><span className={`h-2 w-2 rounded-full ${finalized ? "bg-emerald-500" : "bg-amber-500"}`} />{finalized ? "Finalized" : "Draft · machine proposed"}</div><button type="button" onClick={onFinalize} disabled={!allApproved || finalized} className="inline-flex min-h-10 items-center gap-2 rounded-lg bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:bg-slate-200 disabled:text-slate-500 motion-reduce:transition-none"><ShieldCheck size={17} />Finalize Evidence Map</button>{finalized ? <a href={`/quick-check/pre-validation-readiness?auditId=${encodeURIComponent(pkg.auditId)}`} className="inline-flex min-h-10 items-center rounded-lg border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-800 hover:bg-slate-50">Open readiness report</a> : null}</div></div></header>
-    <div className="mx-auto max-w-[1600px]"><div className={`border-b px-4 py-3 text-sm sm:px-6 ${finalized ? "border-emerald-200 bg-emerald-50 text-emerald-900" : "border-amber-200 bg-amber-50 text-amber-900"}`}>{finalized ? "Finalized Evidence Map. Reopening or editing a row requires re-finalization." : "Machine-proposed Evidence Map. Review every row before finalization; missing and weak evidence remains visible."}</div><EvidenceMapSummary rows={pkg.rows} filters={filters} onChange={setFilters} /><EvidenceMapFiltersBar filters={filters} count={rows.length} total={pkg.rows.length} onChange={setFilters} />{message ? <p role="status" className="border-b border-blue-100 bg-blue-50 px-6 py-3 text-sm text-blue-900">{message}</p> : null}<section aria-label="Evidence Map rules" className="bg-white">{rows.length ? rows.map((row) => <EvidenceMapRuleRow key={row.rowId} row={row} expanded={expanded.has(row.rowId)} finalized={finalized} onToggle={() => toggle(row.rowId)} onReview={() => onReview(row)} />) : <div className="px-6 py-20 text-center"><p className="font-medium text-slate-800">No rules match these filters.</p><button type="button" onClick={() => setFilters(EMPTY_EVIDENCE_MAP_FILTERS)} className="mt-3 text-sm font-semibold text-blue-700">Clear all filters</button></div>}</section></div>
-  </main>;
+  const toggle = (rowId: string) =>
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(rowId)) next.delete(rowId);
+      else next.add(rowId);
+      return next;
+    });
+  const setMode = (next: EvidenceMapMode) => {
+    setFilters(EMPTY_PRESENTATION_FILTERS);
+    setExpanded(new Set());
+    onModeChange(next);
+  };
+  const reviewerOutcomes = [
+    ...new Set(presentation.rows.map((row) => row.reviewerOutcome)),
+  ];
+  return (
+    <main className="min-h-screen bg-slate-50 text-slate-950">
+      <header className="border-b border-slate-200 bg-white px-4 py-5 sm:px-6">
+        <div className="mx-auto flex max-w-[1600px] flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <FileText size={18} className="text-blue-600" />
+              <p className="text-sm font-medium text-slate-600">
+                {pkg.sourceDocument.documentName ||
+                  pkg.sourceDocument.documentId}
+              </p>
+            </div>
+            <h1 className="mt-2 text-2xl font-semibold">
+              Evidence Map ·{" "}
+              {presentation.readOnly ? "Reviewed truth" : "Machine proposal"}
+            </h1>
+            <p className="mt-2 text-xs text-slate-500">
+              {pkg.methodologyId} {pkg.rulebookVersion} · Audit {pkg.auditId}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            {reviewedSnapshot ? (
+              <div
+                aria-label="Evidence Map mode"
+                className="inline-flex rounded-lg border border-slate-300 bg-slate-100 p-1"
+              >
+                {(["reviewed", "machine"] as const).map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    aria-pressed={mode === option}
+                    onClick={() => setMode(option)}
+                    className={`rounded-md px-3 py-2 text-sm font-semibold ${mode === option ? "bg-white text-slate-950 shadow-sm" : "text-slate-600"}`}
+                  >
+                    {option === "reviewed"
+                      ? "Reviewed truth"
+                      : "Machine proposal"}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+            <span
+              className={`rounded-full px-3 py-2 text-xs font-semibold ${presentation.readOnly ? "bg-blue-50 text-blue-800" : "bg-amber-50 text-amber-800"}`}
+            >
+              {presentation.readOnly
+                ? "Reviewed truth snapshot"
+                : finalized
+                  ? "Finalized machine package"
+                  : "Draft · machine proposed"}
+            </span>
+            <button
+              type="button"
+              onClick={onFinalize}
+              disabled={presentation.readOnly || !allApproved || finalized}
+              className="inline-flex min-h-10 items-center gap-2 rounded-lg bg-blue-600 px-4 text-sm font-semibold text-white disabled:bg-slate-200 disabled:text-slate-500"
+            >
+              <ShieldCheck size={17} />
+              Finalize Evidence Map
+            </button>
+          </div>
+        </div>
+      </header>
+      <div className="mx-auto max-w-[1600px]">
+        <div
+          className={`border-b px-4 py-3 text-sm sm:px-6 ${presentation.readOnly ? "border-blue-200 bg-blue-50 text-blue-900" : "border-amber-200 bg-amber-50 text-amber-900"}`}
+        >
+          {presentation.readOnly
+            ? "Reviewed truth snapshot. Historical reviewed evidence and outcomes are shown separately from the live machine proposal."
+            : "Machine proposal. Live proposal fields are shown unchanged; switch modes to compare reviewed truth."}
+        </div>
+        <Summary rows={presentation.rows} />
+        <div className="sticky top-0 z-20 border-b border-slate-200 bg-slate-50/95 px-4 py-3 sm:px-6">
+          <div className="flex flex-wrap gap-2">
+            <label className="relative min-w-64 flex-1">
+              <Search
+                size={17}
+                className="absolute left-3 top-3 text-slate-400"
+              />
+              <input
+                aria-label="Search rules"
+                type="search"
+                value={filters.query}
+                onChange={(event) =>
+                  setFilters({ ...filters, query: event.target.value })
+                }
+                placeholder="Search rules"
+                className="min-h-10 w-full rounded-lg border border-slate-300 bg-white pl-9 pr-3 text-sm"
+              />
+            </label>
+            <select
+              aria-label="Evidence state"
+              value={filters.evidenceState}
+              onChange={(event) =>
+                setFilters({
+                  ...filters,
+                  evidenceState: event.target
+                    .value as EvidenceMapPresentationFilters["evidenceState"],
+                })
+              }
+              className="rounded-lg border border-slate-300 bg-white px-3 text-sm"
+            >
+              <option value="ALL">Evidence state: All</option>
+              {["FOUND", "UNCLEAR", "MISSING", "N/A"].map((value) => (
+                <option key={value}>{value}</option>
+              ))}
+            </select>
+            <select
+              aria-label="Reviewer outcome"
+              value={filters.reviewerOutcome}
+              onChange={(event) =>
+                setFilters({ ...filters, reviewerOutcome: event.target.value })
+              }
+              className="rounded-lg border border-slate-300 bg-white px-3 text-sm"
+            >
+              <option value="ALL">Reviewer outcome: All</option>
+              {reviewerOutcomes.map((value) => (
+                <option key={value}>{value}</option>
+              ))}
+            </select>
+            <button
+              type="button"
+              disabled={!hasPresentationFilters(filters)}
+              onClick={() => setFilters(EMPTY_PRESENTATION_FILTERS)}
+              className="inline-flex items-center gap-1.5 px-3 text-sm font-medium text-blue-700 disabled:text-slate-400"
+            >
+              <FilterX size={14} />
+              Clear all
+            </button>
+          </div>
+          <p className="mt-2 text-xs text-slate-500">
+            {rows.length} of {presentation.rows.length} rules
+          </p>
+        </div>
+        {message && !presentation.readOnly ? (
+          <p
+            role="status"
+            className="border-b border-blue-100 bg-blue-50 px-6 py-3 text-sm text-blue-900"
+          >
+            {message}
+          </p>
+        ) : null}
+        <section aria-label="Evidence Map rules" className="bg-white">
+          {rows.map((row) => (
+            <article
+              key={row.rowId}
+              data-evidence-map-row={row.rowId}
+              className="border-b border-slate-200"
+            >
+              <button
+                type="button"
+                onClick={() => toggle(row.rowId)}
+                aria-expanded={expanded.has(row.rowId)}
+                className="grid w-full gap-3 px-4 py-4 text-left sm:px-6 lg:grid-cols-[8rem_minmax(12rem,.8fr)_minmax(16rem,1.4fr)_auto] lg:items-center"
+              >
+                <span className="font-mono text-xs font-semibold text-blue-700">
+                  {row.ruleReference}
+                </span>
+                <div>
+                  <h2 className="text-sm font-semibold">{row.ruleTitle}</h2>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    <Badge value={row.evidenceState} />
+                    <Badge value={row.reviewerOutcome} />
+                  </div>
+                </div>
+                <p className="line-clamp-2 text-sm text-slate-600">
+                  {row.acceptedEvidence[0]?.quote ||
+                    row.gap ||
+                    row.clientAction ||
+                    row.assessmentReason ||
+                    "No evidence preview recorded."}
+                </p>
+                <ChevronDown
+                  size={18}
+                  className={expanded.has(row.rowId) ? "rotate-180" : ""}
+                />
+              </button>
+              {expanded.has(row.rowId) ? (
+                <RuleDetails
+                  row={row}
+                  readOnly={presentation.readOnly}
+                  finalized={finalized}
+                  onReview={() => {
+                    const machineRow = pkg.rows.find(
+                      (item) => item.rowId === row.rowId,
+                    );
+                    if (machineRow) onReview(machineRow);
+                  }}
+                />
+              ) : null}
+            </article>
+          ))}
+        </section>
+      </div>
+    </main>
+  );
 }

--- a/src/components/preverif/evidence-map/evidenceMapPresentationModel.ts
+++ b/src/components/preverif/evidence-map/evidenceMapPresentationModel.ts
@@ -1,0 +1,225 @@
+import type { Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
+import type {
+  ReviewedEvidenceMapSnapshot,
+  ReviewedEvidenceRecord,
+} from "@/lib/preverif/reviewedEvidenceMapTypes";
+
+export type EvidenceMapMode = "reviewed" | "machine";
+export type EvidenceMapPresentationEvidence = ReviewedEvidenceRecord;
+export type EvidenceMapPresentationRow = Readonly<{
+  rowId: string;
+  stableRuleId: string;
+  ruleReference: string;
+  ruleTitle: string;
+  requirementText: string;
+  evidenceState: "FOUND" | "UNCLEAR" | "MISSING" | "N/A";
+  applicability: "APPLICABLE" | "NOT_APPLICABLE" | "UNKNOWN";
+  reviewerOutcome: string;
+  reviewState: string;
+  acceptedEvidence: readonly EvidenceMapPresentationEvidence[];
+  rejectedEvidence: readonly EvidenceMapPresentationEvidence[];
+  draftFindingCandidate: string | null;
+  contradictionState: string | null;
+  clientAction: string;
+  gap: string;
+  rawAuditStatus: string | null;
+  confidence: string | null;
+  assessmentReason: string | null;
+  notApplicable: boolean;
+  actionRequired: boolean;
+  supportedComponents: readonly string[] | null;
+  missingComponents: readonly string[] | null;
+  reasonSelected: string | null;
+  reviewHistory: Vm0007EvidenceMapDraftPackage["rows"][number]["reviewHistory"];
+}>;
+
+export type EvidenceMapPresentation = Readonly<{
+  mode: EvidenceMapMode;
+  rows: readonly EvidenceMapPresentationRow[];
+  readOnly: boolean;
+}>;
+
+function machineEvidence(
+  row: Vm0007EvidenceMapDraftPackage["rows"][number],
+): readonly EvidenceMapPresentationEvidence[] {
+  if (row.acceptedEvidence?.length) return row.acceptedEvidence;
+  const evidence = row.proposedAcceptedEvidence;
+  if (!evidence) return [];
+  return [
+    {
+      quote: evidence.quote,
+      page: evidence.provenance.page,
+      section: evidence.provenance.sectionHeading,
+      spanId: evidence.provenance.spanId,
+      provenance: evidence.provenance,
+    },
+  ];
+}
+
+function machineRejected(
+  row: Vm0007EvidenceMapDraftPackage["rows"][number],
+): readonly EvidenceMapPresentationEvidence[] {
+  if (row.rejectedEvidence?.length) return row.rejectedEvidence;
+  const evidence = row.proposedRejectedEvidence;
+  if (!evidence) return [];
+  return [
+    {
+      quote: evidence.quote,
+      page: evidence.provenance.page,
+      section: evidence.provenance.sectionHeading,
+      spanId: evidence.provenance.spanId,
+      provenance: evidence.provenance,
+      rejectionReason: evidence.reason,
+    },
+  ];
+}
+
+export function buildMachineEvidenceMapPresentation(
+  pkg: Vm0007EvidenceMapDraftPackage,
+): EvidenceMapPresentation {
+  return {
+    mode: "machine",
+    readOnly: false,
+    rows: pkg.rows.map((row) => ({
+      rowId: row.rowId,
+      stableRuleId: row.stableRuleId,
+      ruleReference: row.ruleReference,
+      ruleTitle: row.ruleTitle,
+      requirementText: row.requirementText,
+      evidenceState: row.proposedEvidenceStatus,
+      applicability: row.proposedApplicability,
+      reviewerOutcome: row.assessment?.draftFinding.draftFindingType ?? "NONE",
+      reviewState: row.reviewState ?? "pending review",
+      acceptedEvidence: machineEvidence(row),
+      rejectedEvidence: machineRejected(row),
+      draftFindingCandidate: null,
+      contradictionState: null,
+      clientAction: row.clientAction,
+      gap: row.gap,
+      rawAuditStatus: row.rawAuditStatus,
+      confidence: row.confidence,
+      assessmentReason: row.assessmentReason,
+      notApplicable: row.proposedApplicability === "NOT_APPLICABLE",
+      actionRequired: (row.reviewState ?? "pending review") !== "approved",
+      supportedComponents: row.supportedComponents ?? null,
+      missingComponents: row.missingComponents ?? null,
+      reasonSelected: row.reasonSelected ?? null,
+      reviewHistory: row.reviewHistory,
+    })),
+  };
+}
+
+export function buildReviewedEvidenceMapPresentation(
+  snapshot: ReviewedEvidenceMapSnapshot,
+): EvidenceMapPresentation {
+  return {
+    mode: "reviewed",
+    readOnly: true,
+    rows: snapshot.rows.map((row) => ({
+      rowId: row.rowId,
+      stableRuleId: row.stableRuleId,
+      ruleReference: row.ruleReference,
+      ruleTitle: row.ruleReference,
+      requirementText: row.requirementText,
+      evidenceState: row.finalEvidenceState,
+      applicability:
+        row.finalEvidenceState === "N/A" ? "NOT_APPLICABLE" : "APPLICABLE",
+      reviewerOutcome: row.reviewerOutcome,
+      reviewState: "reviewed snapshot",
+      acceptedEvidence: row.reviewerEvidence,
+      rejectedEvidence: row.rejectedEvidence,
+      draftFindingCandidate: row.draftFindingCandidate,
+      contradictionState: row.contradictionState,
+      clientAction: row.clientAction,
+      gap: "",
+      rawAuditStatus: null,
+      confidence: null,
+      assessmentReason: null,
+      notApplicable: row.finalEvidenceState === "N/A",
+      actionRequired: row.reviewerOutcome === "ACTION_REQUIRED",
+      supportedComponents: null,
+      missingComponents: null,
+      reasonSelected: null,
+      reviewHistory: [],
+    })),
+  };
+}
+
+export type EvidenceMapPresentationFilters = Readonly<{
+  query: string;
+  evidenceState: "ALL" | EvidenceMapPresentationRow["evidenceState"];
+  applicability: "ALL" | EvidenceMapPresentationRow["applicability"];
+  reviewerOutcome: string;
+  reviewState: string;
+}>;
+
+export const EMPTY_PRESENTATION_FILTERS: EvidenceMapPresentationFilters = {
+  query: "",
+  evidenceState: "ALL",
+  applicability: "ALL",
+  reviewerOutcome: "ALL",
+  reviewState: "ALL",
+};
+
+export function summarizeEvidenceMapPresentation(
+  rows: readonly EvidenceMapPresentationRow[],
+) {
+  return rows.reduce(
+    (summary, row) => ({
+      total: summary.total + 1,
+      found: summary.found + Number(row.evidenceState === "FOUND"),
+      unclear: summary.unclear + Number(row.evidenceState === "UNCLEAR"),
+      missing: summary.missing + Number(row.evidenceState === "MISSING"),
+      notApplicable: summary.notApplicable + Number(row.notApplicable),
+      actionRequired: summary.actionRequired + Number(row.actionRequired),
+    }),
+    {
+      total: 0,
+      found: 0,
+      unclear: 0,
+      missing: 0,
+      notApplicable: 0,
+      actionRequired: 0,
+    },
+  );
+}
+
+export function filterEvidenceMapPresentation(
+  rows: readonly EvidenceMapPresentationRow[],
+  filters: EvidenceMapPresentationFilters,
+) {
+  const query = filters.query.trim().toLocaleLowerCase();
+  return rows.filter((row) => {
+    const searchable = [
+      row.ruleReference,
+      row.ruleTitle,
+      row.requirementText,
+      row.assessmentReason,
+      row.gap,
+      row.clientAction,
+    ]
+      .join(" ")
+      .toLocaleLowerCase();
+    return (
+      (!query || searchable.includes(query)) &&
+      (filters.evidenceState === "ALL" ||
+        row.evidenceState === filters.evidenceState) &&
+      (filters.applicability === "ALL" ||
+        row.applicability === filters.applicability) &&
+      (filters.reviewerOutcome === "ALL" ||
+        row.reviewerOutcome === filters.reviewerOutcome) &&
+      (filters.reviewState === "ALL" || row.reviewState === filters.reviewState)
+    );
+  });
+}
+
+export function hasPresentationFilters(
+  filters: EvidenceMapPresentationFilters,
+): boolean {
+  return (
+    filters.query.trim() !== "" ||
+    Object.entries(filters).some(
+      ([key, value]) => key !== "query" && value !== "ALL",
+    )
+  );
+}

--- a/src/lib/preverif/reviewedEvidenceMapAdapter.ts
+++ b/src/lib/preverif/reviewedEvidenceMapAdapter.ts
@@ -1,0 +1,159 @@
+import type {
+  ReviewedEvidenceMapRow,
+  ReviewedEvidenceMapSnapshot,
+  ReviewedEvidenceRecord,
+  ReviewedEvidenceState,
+  ReviewedOutcome,
+} from "./reviewedEvidenceMapTypes";
+
+type UnknownRecord = Record<string, unknown>;
+const evidenceStates = new Set<ReviewedEvidenceState>([
+  "FOUND",
+  "UNCLEAR",
+  "MISSING",
+  "N/A",
+]);
+const reviewerOutcomes = new Set<ReviewedOutcome>([
+  "CONFORMS",
+  "ACTION_REQUIRED",
+  "NOT_APPLICABLE",
+]);
+
+function record(value: unknown): UnknownRecord | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : null;
+}
+
+function text(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function evidenceRecord(value: unknown): ReviewedEvidenceRecord | null {
+  const outer = record(value);
+  const source = record(outer?.evidence) ?? outer;
+  const provenance = record(source?.provenance);
+  const quote = text(source?.quote);
+  const spanId = text(source?.spanId) ?? text(provenance?.spanId);
+  const docId = text(provenance?.docId);
+  if (!source || !provenance || !quote || !spanId || !docId) return null;
+  const pageValue =
+    typeof source.page === "number"
+      ? source.page
+      : typeof provenance.page === "number"
+        ? provenance.page
+        : null;
+  const section = text(source.section) ?? text(provenance.sectionHeading);
+  return {
+    quote,
+    page: pageValue,
+    section,
+    spanId,
+    provenance: {
+      docId,
+      page: typeof provenance.page === "number" ? provenance.page : pageValue,
+      sectionPath: Array.isArray(provenance.sectionPath)
+        ? provenance.sectionPath.filter(
+            (item): item is string => typeof item === "string",
+          )
+        : [],
+      spanId,
+      sectionHeading: text(provenance.sectionHeading) ?? section,
+      sourceType: text(provenance.sourceType),
+    },
+    ...(text(source.rejectionReason) || text(outer?.rejectionReason)
+      ? {
+          rejectionReason:
+            text(source.rejectionReason) ?? text(outer?.rejectionReason)!,
+        }
+      : {}),
+  };
+}
+
+function reviewedRow(
+  value: unknown,
+  auditId: string,
+): ReviewedEvidenceMapRow | null {
+  const source = record(value);
+  const stableRuleId = text(source?.ruleId);
+  const state = source?.finalEvidenceState;
+  const outcome = source?.reviewerOutcome;
+  if (
+    !source ||
+    source.reviewStatus !== "REVIEWED" ||
+    !stableRuleId ||
+    !evidenceStates.has(state as ReviewedEvidenceState) ||
+    !reviewerOutcomes.has(outcome as ReviewedOutcome)
+  )
+    return null;
+  const reviewerEvidence = Array.isArray(source.acceptedEvidence)
+    ? source.acceptedEvidence.map(evidenceRecord)
+    : [];
+  const rejectedEvidence = Array.isArray(source.rejectedEvidence)
+    ? source.rejectedEvidence.map(evidenceRecord)
+    : [];
+  if (
+    reviewerEvidence.some((item) => item === null) ||
+    rejectedEvidence.some((item) => item === null)
+  )
+    return null;
+  return {
+    rowId: `${auditId}:${stableRuleId}`,
+    stableRuleId,
+    ruleReference: text(source.ruleReference) ?? stableRuleId,
+    requirementText: text(source.requirement) ?? stableRuleId,
+    finalEvidenceState: state as ReviewedEvidenceState,
+    reviewerOutcome: outcome as ReviewedOutcome,
+    reviewerEvidence: reviewerEvidence as ReviewedEvidenceRecord[],
+    rejectedEvidence: rejectedEvidence as ReviewedEvidenceRecord[],
+    draftFindingCandidate: text(source.draftFindingCandidate),
+    contradictionState: text(source.contradictionState) ?? "NOT_RECORDED",
+    clientAction: text(source.clientAction) ?? "",
+  };
+}
+
+export function adaptReviewedEvidenceMap(input: {
+  reviewed: unknown;
+  draft: unknown;
+  metadata: unknown;
+}): ReviewedEvidenceMapSnapshot | null {
+  const reviewed = record(input.reviewed);
+  const draft = record(input.draft);
+  const metadata = record(input.metadata);
+  const draftRows = Array.isArray(draft?.rows) ? draft.rows : [];
+  const firstDraftRow = record(draftRows[0]);
+  const canonicalAuditId = text(firstDraftRow?.auditId);
+  const stableProjectId = text(reviewed?.stableProjectId);
+  const sourceDocument = record(metadata?.sourceDocument);
+  const sourceHash =
+    text(sourceDocument?.contentSha256) ?? text(metadata?.sourcePdfSha256);
+  const rawRows = Array.isArray(reviewed?.rows) ? reviewed.rows : [];
+  if (
+    !canonicalAuditId ||
+    !stableProjectId ||
+    stableProjectId !== text(metadata?.stableProjectId) ||
+    !sourceHash ||
+    !rawRows.length
+  )
+    return null;
+  const rows = rawRows.map((row) => reviewedRow(row, canonicalAuditId));
+  if (
+    rows.some((row) => row === null) ||
+    new Set(rows.map((row) => row?.stableRuleId)).size !== rows.length
+  )
+    return null;
+  return {
+    canonicalAuditId,
+    stableProjectId,
+    sourceDocument: {
+      documentId: text(sourceDocument?.documentId) ?? "reviewed-snapshot",
+      documentName:
+        text(sourceDocument?.documentName) ?? text(metadata?.sourcePdfName),
+      contentSha256: sourceHash,
+    },
+    methodologyId: "VM0007",
+    methodologyVersion: "v1.8",
+    rows: rows as ReviewedEvidenceMapRow[],
+    readOnly: true,
+  };
+}

--- a/src/lib/preverif/reviewedEvidenceMapRegistry.ts
+++ b/src/lib/preverif/reviewedEvidenceMapRegistry.ts
@@ -1,0 +1,33 @@
+import type { Vm0007EvidenceMapDraftPackage } from "./vm0007EvidenceMapDraft";
+import type { ReviewedEvidenceMapSnapshot } from "./reviewedEvidenceMapTypes";
+
+export type ReviewedEvidenceMapRegistryEntry = Readonly<{
+  canonicalAuditId: string;
+  stableProjectId: string;
+  sourcePdfSha256: string;
+}>;
+
+export function matchesReviewedEvidenceMapCase(
+  pkg: Vm0007EvidenceMapDraftPackage,
+  snapshot: ReviewedEvidenceMapSnapshot,
+): boolean {
+  return (
+    pkg.auditId === snapshot.canonicalAuditId &&
+    pkg.sourceDocument.contentSha256 ===
+      snapshot.sourceDocument.contentSha256 &&
+    pkg.sourceDocument.documentId === snapshot.sourceDocument.documentId
+  );
+}
+
+export function findReviewedEvidenceMapEntry(
+  entries: readonly ReviewedEvidenceMapRegistryEntry[],
+  identity: { auditId: string; sourcePdfSha256: string | null },
+): ReviewedEvidenceMapRegistryEntry | null {
+  return (
+    entries.find(
+      (entry) =>
+        entry.canonicalAuditId === identity.auditId &&
+        entry.sourcePdfSha256 === identity.sourcePdfSha256,
+    ) ?? null
+  );
+}

--- a/src/lib/preverif/reviewedEvidenceMapRegistry.ts
+++ b/src/lib/preverif/reviewedEvidenceMapRegistry.ts
@@ -7,27 +7,54 @@ export type ReviewedEvidenceMapRegistryEntry = Readonly<{
   sourcePdfSha256: string;
 }>;
 
+export type ReviewedEvidenceMapIdentity = Readonly<{
+  auditId?: string | null;
+  sourcePdfSha256?: string | null;
+  sourceDocumentId?: string | null;
+  stableProjectId?: string | null;
+}>;
+
+export function matchesReviewedEvidenceMapIdentity(
+  identity: ReviewedEvidenceMapIdentity,
+  snapshot: ReviewedEvidenceMapSnapshot,
+): boolean {
+  const sourceHash = identity.sourcePdfSha256?.trim();
+  const sourceDocumentId = identity.sourceDocumentId?.trim();
+  const stableProjectId = identity.stableProjectId?.trim();
+  return (
+    Boolean(sourceHash) &&
+    sourceHash === snapshot.sourceDocument.contentSha256 &&
+    (!sourceDocumentId ||
+      sourceDocumentId === snapshot.sourceDocument.documentId) &&
+    (!stableProjectId || stableProjectId === snapshot.stableProjectId)
+  );
+}
+
 export function matchesReviewedEvidenceMapCase(
   pkg: Vm0007EvidenceMapDraftPackage,
   snapshot: ReviewedEvidenceMapSnapshot,
 ): boolean {
-  return (
-    pkg.auditId === snapshot.canonicalAuditId &&
-    pkg.sourceDocument.contentSha256 ===
-      snapshot.sourceDocument.contentSha256 &&
-    pkg.sourceDocument.documentId === snapshot.sourceDocument.documentId
+  return matchesReviewedEvidenceMapIdentity(
+    {
+      auditId: pkg.auditId,
+      sourcePdfSha256: pkg.sourceDocument.contentSha256,
+      sourceDocumentId: pkg.sourceDocument.documentId,
+    },
+    snapshot,
   );
 }
 
 export function findReviewedEvidenceMapEntry(
   entries: readonly ReviewedEvidenceMapRegistryEntry[],
-  identity: { auditId: string; sourcePdfSha256: string | null },
+  identity: ReviewedEvidenceMapIdentity,
 ): ReviewedEvidenceMapRegistryEntry | null {
   return (
     entries.find(
       (entry) =>
-        entry.canonicalAuditId === identity.auditId &&
-        entry.sourcePdfSha256 === identity.sourcePdfSha256,
+        Boolean(identity.sourcePdfSha256) &&
+        entry.sourcePdfSha256 === identity.sourcePdfSha256 &&
+        (!identity.stableProjectId ||
+          entry.stableProjectId === identity.stableProjectId),
     ) ?? null
   );
 }

--- a/src/lib/preverif/reviewedEvidenceMapServerRegistry.ts
+++ b/src/lib/preverif/reviewedEvidenceMapServerRegistry.ts
@@ -4,6 +4,10 @@ import reviewed from "../../../tests/fixtures/preverif/marcondes-vm0007-v18-evid
 import draft from "../../../tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.draft.json";
 import metadata from "../../../tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/metadata.json";
 import { adaptReviewedEvidenceMap } from "./reviewedEvidenceMapAdapter";
+import {
+  matchesReviewedEvidenceMapIdentity,
+  type ReviewedEvidenceMapIdentity,
+} from "./reviewedEvidenceMapRegistry";
 import type { ReviewedEvidenceMapSnapshot } from "./reviewedEvidenceMapTypes";
 
 const marcondes = adaptReviewedEvidenceMap({ reviewed, draft, metadata });
@@ -14,10 +18,16 @@ if (!marcondes)
 
 const reviewedCases: readonly ReviewedEvidenceMapSnapshot[] = [marcondes];
 
+export function loadReviewedEvidenceMapCandidates(): readonly ReviewedEvidenceMapSnapshot[] {
+  return reviewedCases;
+}
+
 export function loadReviewedEvidenceMapCandidate(
-  auditId: string,
+  identity: ReviewedEvidenceMapIdentity,
 ): ReviewedEvidenceMapSnapshot | null {
   return (
-    reviewedCases.find((entry) => entry.canonicalAuditId === auditId) ?? null
+    reviewedCases.find((entry) =>
+      matchesReviewedEvidenceMapIdentity(identity, entry),
+    ) ?? null
   );
 }

--- a/src/lib/preverif/reviewedEvidenceMapServerRegistry.ts
+++ b/src/lib/preverif/reviewedEvidenceMapServerRegistry.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import reviewed from "../../../tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json";
+import draft from "../../../tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.draft.json";
+import metadata from "../../../tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/metadata.json";
+import { adaptReviewedEvidenceMap } from "./reviewedEvidenceMapAdapter";
+import type { ReviewedEvidenceMapSnapshot } from "./reviewedEvidenceMapTypes";
+
+const marcondes = adaptReviewedEvidenceMap({ reviewed, draft, metadata });
+if (!marcondes)
+  throw new Error(
+    "The Marcondes reviewed Evidence Map artifact is incomplete or invalid.",
+  );
+
+const reviewedCases: readonly ReviewedEvidenceMapSnapshot[] = [marcondes];
+
+export function loadReviewedEvidenceMapCandidate(
+  auditId: string,
+): ReviewedEvidenceMapSnapshot | null {
+  return (
+    reviewedCases.find((entry) => entry.canonicalAuditId === auditId) ?? null
+  );
+}

--- a/src/lib/preverif/reviewedEvidenceMapTypes.ts
+++ b/src/lib/preverif/reviewedEvidenceMapTypes.ts
@@ -1,0 +1,48 @@
+export type ReviewedEvidenceState = "FOUND" | "UNCLEAR" | "MISSING" | "N/A";
+export type ReviewedOutcome = "CONFORMS" | "ACTION_REQUIRED" | "NOT_APPLICABLE";
+
+export type ReviewedEvidenceProvenance = Readonly<{
+  docId: string;
+  page: number | null;
+  sectionPath: readonly string[];
+  spanId: string;
+  sectionHeading: string | null;
+  sourceType: string | null;
+}>;
+
+export type ReviewedEvidenceRecord = Readonly<{
+  quote: string;
+  page: number | null;
+  section: string | null;
+  spanId: string;
+  provenance: ReviewedEvidenceProvenance;
+  rejectionReason?: string;
+}>;
+
+export type ReviewedEvidenceMapRow = Readonly<{
+  rowId: string;
+  stableRuleId: string;
+  ruleReference: string;
+  requirementText: string;
+  finalEvidenceState: ReviewedEvidenceState;
+  reviewerOutcome: ReviewedOutcome;
+  reviewerEvidence: readonly ReviewedEvidenceRecord[];
+  rejectedEvidence: readonly ReviewedEvidenceRecord[];
+  draftFindingCandidate: string | null;
+  contradictionState: string;
+  clientAction: string;
+}>;
+
+export type ReviewedEvidenceMapSnapshot = Readonly<{
+  canonicalAuditId: string;
+  stableProjectId: string;
+  sourceDocument: Readonly<{
+    documentId: string;
+    documentName: string | null;
+    contentSha256: string;
+  }>;
+  methodologyId: string;
+  methodologyVersion: string;
+  rows: readonly ReviewedEvidenceMapRow[];
+  readOnly: true;
+}>;

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -152,6 +152,7 @@ export function buildAndSaveVm0007GapReportAudit(input: {
   loadedRulebookId: string;
   loadedRulebookVersion: string;
   evidenceFileName?: string;
+  sourcePdfSha256?: string | null;
   rawPddText: string;
   rules: readonly RuleSummary[];
   userAcceptedVersionWarning?: boolean;
@@ -195,7 +196,7 @@ export function buildAndSaveVm0007GapReportAudit(input: {
     evidenceFileName: input.evidenceFileName?.trim() || undefined,
     userAcceptedVersionWarning: input.userAcceptedVersionWarning,
     audit,
-    sourceDocument: { documentId: context.evidenceDocument.docId, documentName: input.evidenceFileName?.trim() || null, contentSha256: null },
+    sourceDocument: { documentId: context.evidenceDocument.docId, documentName: input.evidenceFileName?.trim() || null, contentSha256: input.sourcePdfSha256?.trim() || null },
   };
   saveVm0007GapReportAudit(record);
   const auditSaved = loadVm0007GapReportAudit(record.auditId) !== null;

--- a/tests/components/evidenceMapPresentationModel.test.ts
+++ b/tests/components/evidenceMapPresentationModel.test.ts
@@ -1,0 +1,16 @@
+import { buildMachineEvidenceMapPresentation, buildReviewedEvidenceMapPresentation, summarizeEvidenceMapPresentation } from "@/components/preverif/evidence-map/evidenceMapPresentationModel";
+import type { Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
+import type { ReviewedEvidenceMapSnapshot } from "@/lib/preverif/reviewedEvidenceMapTypes";
+
+test("machine and reviewed presentations use separate status, outcome, and evidence fields without mutation", () => {
+  const provenance = { docId: "doc", page: 1, sectionPath: ["Machine"], spanId: "machine-span", sectionHeading: "Machine", sourceType: "PDD" };
+  const machine = { rows: [{ rowId: "row", stableRuleId: "rule", ruleReference: "R-1", ruleTitle: "Rule", requirementText: "Requirement", proposedEvidenceStatus: "MISSING", proposedApplicability: "APPLICABLE", proposedAcceptedEvidence: { quote: "Machine quote", provenance }, proposedRejectedEvidence: null, reviewState: "pending review", assessmentReason: "Machine reason", gap: "Machine gap", clientAction: "Machine action", rawAuditStatus: "missing_evidence", confidence: "low" }] } as Vm0007EvidenceMapDraftPackage;
+  const reviewed = { readOnly: true, rows: [{ rowId: "row", stableRuleId: "rule", ruleReference: "R-1", requirementText: "Requirement", finalEvidenceState: "FOUND", reviewerOutcome: "CONFORMS", reviewerEvidence: [{ quote: "Reviewed quote", page: 9, section: "Reviewed", spanId: "reviewed-span", provenance: { ...provenance, page: 9, spanId: "reviewed-span", sectionHeading: "Reviewed" } }], rejectedEvidence: [], draftFindingCandidate: null, contradictionState: "NONE_IDENTIFIED", clientAction: "" }] } as ReviewedEvidenceMapSnapshot;
+  const before = structuredClone(machine);
+  const machineView = buildMachineEvidenceMapPresentation(machine);
+  const reviewedView = buildReviewedEvidenceMapPresentation(reviewed);
+  expect(machineView.rows[0]).toMatchObject({ evidenceState: "MISSING", acceptedEvidence: [{ quote: "Machine quote" }] });
+  expect(reviewedView.rows[0]).toMatchObject({ evidenceState: "FOUND", reviewerOutcome: "CONFORMS", acceptedEvidence: [{ quote: "Reviewed quote", page: 9 }] });
+  expect(summarizeEvidenceMapPresentation(reviewedView.rows)).toMatchObject({ found: 1, actionRequired: 0 });
+  expect(machine).toEqual(before);
+});

--- a/tests/components/vm0007EvidenceMapDraftPage.test.tsx
+++ b/tests/components/vm0007EvidenceMapDraftPage.test.tsx
@@ -3,68 +3,305 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import Vm0007EvidenceMapDraftPage from "@/components/preverif/Vm0007EvidenceMapDraftPage";
-import { loadVm0007EvidenceMapDraft, saveVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
-import type { Vm0007EvidenceMapDraftPackage, Vm0007EvidenceMapDraftRow } from "@/lib/preverif/vm0007EvidenceMapDraft";
-import type { ReviewedEvidenceMapSnapshot, ReviewedEvidenceState, ReviewedOutcome } from "@/lib/preverif/reviewedEvidenceMapTypes";
+import {
+  loadVm0007EvidenceMapDraft,
+  saveVm0007EvidenceMapDraft,
+} from "@/lib/preverif/vm0007EvidenceMapDraftStore";
+import type {
+  Vm0007EvidenceMapDraftPackage,
+  Vm0007EvidenceMapDraftRow,
+} from "@/lib/preverif/vm0007EvidenceMapDraft";
+import type {
+  ReviewedEvidenceMapSnapshot,
+  ReviewedEvidenceState,
+  ReviewedOutcome,
+} from "@/lib/preverif/reviewedEvidenceMapTypes";
 
-const provenance = (spanId: string, page: number | null = 12) => ({ docId: "doc", page, sectionPath: ["Project implementation"], spanId, sectionHeading: "Project implementation", sourceType: "PDD" });
+const provenance = (spanId: string, page: number | null = 12) => ({
+  docId: "doc",
+  page,
+  sectionPath: ["Project implementation"],
+  spanId,
+  sectionHeading: "Project implementation",
+  sourceType: "PDD",
+});
 
 function makeRows(auditId: string): Vm0007EvidenceMapDraftRow[] {
   return Array.from({ length: 58 }, (_, index) => {
-    const state = index === 0 ? "FOUND" : index === 1 || index === 3 || index === 4 ? "UNCLEAR" : "MISSING";
-    const raw = index === 0 ? "supported_by_pdd" : index === 1 ? "partially_supported" : index === 3 ? "not_applicable" : index === 4 ? "manual_review_needed" : "missing_evidence";
+    const state =
+      index === 0
+        ? "FOUND"
+        : index === 1 || index === 3 || index === 4
+          ? "UNCLEAR"
+          : "MISSING";
+    const raw =
+      index === 0
+        ? "supported_by_pdd"
+        : index === 1
+          ? "partially_supported"
+          : index === 3
+            ? "not_applicable"
+            : index === 4
+              ? "manual_review_needed"
+              : "missing_evidence";
     return {
-      rowId: `${auditId}:R-${index + 1}`, auditId, ruleReference: `R-${index + 1}`, ruleTitle: index === 0 ? " r-1 " : index === 1 ? "Rule Two" : `Rule ${index + 1}`, stableRuleId: `R-${index + 1}`,
-      requirementText: index === 0 ? "The project must document implementation and monitoring." : "Requirement", methodologyId: "VM0007", methodologyVersion: "v1.8", rawAuditStatus: raw,
-      upstreamStatus: state, proposedEvidenceStatus: state, proposedApplicability: index === 3 ? "NOT_APPLICABLE" : index === 4 ? "UNKNOWN" : "APPLICABLE",
-      proposedAcceptedEvidence: index === 0 ? { quote: "Legacy accepted project evidence.", provenance: provenance("legacy-accepted") } : null,
-      proposedRejectedEvidence: index === 0 ? { quote: "Legacy boilerplate.", reason: "Methodology instructions are not project evidence.", provenance: provenance("legacy-rejected", 4) } : null,
-      ...(index === 0 ? {
-        acceptedEvidence: [
-          { quote: "The implementation plan names the responsible team.", page: 12, section: "Project implementation", spanId: "accepted-1", evidenceType: "project_specific_implementation" as const, provenance: provenance("accepted-1") },
-          { quote: "Monitoring occurs every six months.", page: 21, section: "Monitoring", spanId: "accepted-2", evidenceType: "project_specific_implementation" as const, provenance: { ...provenance("accepted-2", 21), sectionPath: ["Monitoring"], sectionHeading: "Monitoring" } },
-        ],
-        rejectedEvidence: [{ quote: "Projects should implement monitoring.", page: 4, section: "Methodology", spanId: "rejected-1", evidenceType: "methodology_boilerplate" as const, rejectionReason: "Generic methodology instruction; it does not describe this project.", provenance: { ...provenance("rejected-1", 4), sectionPath: ["Methodology"], sectionHeading: "Methodology" } }],
-        supportedComponents: ["implementation"], missingComponents: ["monitoring records"], reasonSelected: "The strongest project-specific passages were retained.",
-      } : {}),
-      assessmentReason: state === "MISSING" ? "No project evidence was found." : "Evidence was assessed without changing audit truth.", gap: state === "MISSING" ? "Provide project evidence." : "Confirm the retained evidence.", clientAction: "Review the source document.", confidence: state === "FOUND" ? "high" : "low",
-      searchCoverage: { searched: true, searchedDocumentIds: ["doc"], notes: null }, sourceDocument: { documentId: "doc", documentName: "Project PDD.pdf", contentSha256: null },
-      quote: index === 0 ? "Legacy accepted project evidence." : null, page: index === 0 ? 12 : null, section: index === 0 ? "Project implementation" : null, spanId: index === 0 ? "legacy-accepted" : null, provenance: index === 0 ? provenance("legacy-accepted") : null,
-      finalizationState: "draft", reviewState: "pending review", reviewHistory: [], rowVersion: 1, finalizationActorRef: null, finalizedAt: null, finalizationBasis: null, reviewHistoryRef: null,
-      proposalSource: "VM0007_QUICK_CHECK_AUDIT", proposalTimestamp: "2026-07-11T00:00:00.000Z",
+      rowId: `${auditId}:R-${index + 1}`,
+      auditId,
+      ruleReference: `R-${index + 1}`,
+      ruleTitle:
+        index === 0 ? " r-1 " : index === 1 ? "Rule Two" : `Rule ${index + 1}`,
+      stableRuleId: `R-${index + 1}`,
+      requirementText:
+        index === 0
+          ? "The project must document implementation and monitoring."
+          : "Requirement",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1.8",
+      rawAuditStatus: raw,
+      upstreamStatus: state,
+      proposedEvidenceStatus: state,
+      proposedApplicability:
+        index === 3 ? "NOT_APPLICABLE" : index === 4 ? "UNKNOWN" : "APPLICABLE",
+      proposedAcceptedEvidence:
+        index === 0
+          ? {
+              quote: "Legacy accepted project evidence.",
+              provenance: provenance("legacy-accepted"),
+            }
+          : null,
+      proposedRejectedEvidence:
+        index === 0
+          ? {
+              quote: "Legacy boilerplate.",
+              reason: "Methodology instructions are not project evidence.",
+              provenance: provenance("legacy-rejected", 4),
+            }
+          : null,
+      ...(index === 0
+        ? {
+            acceptedEvidence: [
+              {
+                quote: "The implementation plan names the responsible team.",
+                page: 12,
+                section: "Project implementation",
+                spanId: "accepted-1",
+                evidenceType: "project_specific_implementation" as const,
+                provenance: provenance("accepted-1"),
+              },
+              {
+                quote: "Monitoring occurs every six months.",
+                page: 21,
+                section: "Monitoring",
+                spanId: "accepted-2",
+                evidenceType: "project_specific_implementation" as const,
+                provenance: {
+                  ...provenance("accepted-2", 21),
+                  sectionPath: ["Monitoring"],
+                  sectionHeading: "Monitoring",
+                },
+              },
+            ],
+            rejectedEvidence: [
+              {
+                quote: "Projects should implement monitoring.",
+                page: 4,
+                section: "Methodology",
+                spanId: "rejected-1",
+                evidenceType: "methodology_boilerplate" as const,
+                rejectionReason:
+                  "Generic methodology instruction; it does not describe this project.",
+                provenance: {
+                  ...provenance("rejected-1", 4),
+                  sectionPath: ["Methodology"],
+                  sectionHeading: "Methodology",
+                },
+              },
+            ],
+            supportedComponents: ["implementation"],
+            missingComponents: ["monitoring records"],
+            reasonSelected:
+              "The strongest project-specific passages were retained.",
+          }
+        : {}),
+      assessmentReason:
+        state === "MISSING"
+          ? "No project evidence was found."
+          : "Evidence was assessed without changing audit truth.",
+      gap:
+        state === "MISSING"
+          ? "Provide project evidence."
+          : "Confirm the retained evidence.",
+      clientAction: "Review the source document.",
+      confidence: state === "FOUND" ? "high" : "low",
+      searchCoverage: {
+        searched: true,
+        searchedDocumentIds: ["doc"],
+        notes: null,
+      },
+      sourceDocument: {
+        documentId: "doc",
+        documentName: "Project PDD.pdf",
+        contentSha256: null,
+      },
+      quote: index === 0 ? "Legacy accepted project evidence." : null,
+      page: index === 0 ? 12 : null,
+      section: index === 0 ? "Project implementation" : null,
+      spanId: index === 0 ? "legacy-accepted" : null,
+      provenance: index === 0 ? provenance("legacy-accepted") : null,
+      finalizationState: "draft",
+      reviewState: "pending review",
+      reviewHistory: [],
+      rowVersion: 1,
+      finalizationActorRef: null,
+      finalizedAt: null,
+      finalizationBasis: null,
+      reviewHistoryRef: null,
+      proposalSource: "VM0007_QUICK_CHECK_AUDIT",
+      proposalTimestamp: "2026-07-11T00:00:00.000Z",
     } satisfies Vm0007EvidenceMapDraftRow;
   });
 }
 
 function savePackage(auditId: string, rows = makeRows(auditId)) {
-  expect(saveVm0007EvidenceMapDraft({ auditId, generatedAt: "2026-07-11T00:00:00.000Z", methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "v1.8", sourceDocument: rows[0].sourceDocument, proposalState: "MACHINE_PROPOSED", rows, blockedBy: [], contractVersion: "vm0007-evidence-map-draft-v1" } as Vm0007EvidenceMapDraftPackage)).toBe(true);
+  expect(
+    saveVm0007EvidenceMapDraft({
+      auditId,
+      generatedAt: "2026-07-11T00:00:00.000Z",
+      methodologyId: "VM0007",
+      rulebookVersion: "v1.8",
+      pddDeclaredMethodologyVersion: "v1.8",
+      sourceDocument: rows[0].sourceDocument,
+      proposalState: "MACHINE_PROPOSED",
+      rows,
+      blockedBy: [],
+      contractVersion: "vm0007-evidence-map-draft-v1",
+    } as Vm0007EvidenceMapDraftPackage),
+  ).toBe(true);
 }
 
-async function renderPage(auditId: string, reviewedCandidate?: ReviewedEvidenceMapSnapshot): Promise<{ container: HTMLDivElement; root: Root }> {
+async function renderPage(
+  auditId: string,
+  reviewedCandidate?: ReviewedEvidenceMapSnapshot,
+  reviewedCandidates: readonly ReviewedEvidenceMapSnapshot[] = [],
+): Promise<{ container: HTMLDivElement; root: Root }> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
-  await act(async () => { root.render(<Vm0007EvidenceMapDraftPage auditId={auditId} reviewedCandidate={reviewedCandidate} />); });
+  await act(async () => {
+    root.render(
+      <Vm0007EvidenceMapDraftPage
+        auditId={auditId}
+        reviewedCandidate={reviewedCandidate}
+        reviewedCandidates={reviewedCandidates}
+      />,
+    );
+  });
   return { container, root };
 }
 
-function click(element: Element | null) { expect(element).not.toBeNull(); act(() => { (element as HTMLElement).click(); }); }
-function change(element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null, value: string) { expect(element).not.toBeNull(); act(() => { const setter = Object.getOwnPropertyDescriptor(element instanceof HTMLSelectElement ? HTMLSelectElement.prototype : element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype, "value")?.set; setter?.call(element, value); element?.dispatchEvent(new Event("change", { bubbles: true })); element?.dispatchEvent(new Event("input", { bubbles: true })); }); }
+function click(element: Element | null) {
+  expect(element).not.toBeNull();
+  act(() => {
+    (element as HTMLElement).click();
+  });
+}
+function change(
+  element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null,
+  value: string,
+) {
+  expect(element).not.toBeNull();
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(
+      element instanceof HTMLSelectElement
+        ? HTMLSelectElement.prototype
+        : element instanceof HTMLTextAreaElement
+          ? HTMLTextAreaElement.prototype
+          : HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(element, value);
+    element?.dispatchEvent(new Event("change", { bubbles: true }));
+    element?.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
 
-afterEach(() => { document.body.innerHTML = ""; window.localStorage.clear(); });
+afterEach(() => {
+  document.body.innerHTML = "";
+  window.localStorage.clear();
+});
 
 describe("VM0007 Evidence Map review workspace", () => {
   test("defaults a matching reviewed case to a read-only snapshot and switches without persistence", async () => {
     const auditId = "reviewed-ui";
-    const rows = makeRows(auditId).map((row) => ({ ...row, sourceDocument: { ...row.sourceDocument, contentSha256: "reviewed-hash" } }));
+    const rows = makeRows(auditId).map((row) => ({
+      ...row,
+      sourceDocument: { ...row.sourceDocument, contentSha256: "reviewed-hash" },
+    }));
     savePackage(auditId, rows);
     const reviewedRows = rows.map((row, index) => {
-      const finalEvidenceState: ReviewedEvidenceState = index < 6 ? "FOUND" : index < 26 ? "UNCLEAR" : index < 36 ? "MISSING" : "N/A";
-      const reviewerOutcome: ReviewedOutcome = index < 6 ? "CONFORMS" : index < 36 ? "ACTION_REQUIRED" : "NOT_APPLICABLE";
-      return { rowId: row.rowId, stableRuleId: row.stableRuleId, ruleReference: row.ruleReference, requirementText: row.requirementText, finalEvidenceState, reviewerOutcome, reviewerEvidence: index === 0 ? [{ quote: "Reviewed canonical quote.", page: 9, section: "Reviewed section", spanId: "reviewed-span", provenance: { docId: "doc", page: 9, sectionPath: ["Reviewed section"], spanId: "reviewed-span", sectionHeading: "Reviewed section", sourceType: "PDD" } }] : [], rejectedEvidence: [], draftFindingCandidate: reviewerOutcome === "ACTION_REQUIRED" ? "NIR_CANDIDATE" : null, contradictionState: "NONE_IDENTIFIED", clientAction: "Reviewed action." };
+      const finalEvidenceState: ReviewedEvidenceState =
+        index < 6
+          ? "FOUND"
+          : index < 26
+            ? "UNCLEAR"
+            : index < 36
+              ? "MISSING"
+              : "N/A";
+      const reviewerOutcome: ReviewedOutcome =
+        index < 6
+          ? "CONFORMS"
+          : index < 36
+            ? "ACTION_REQUIRED"
+            : "NOT_APPLICABLE";
+      return {
+        rowId: row.rowId,
+        stableRuleId: row.stableRuleId,
+        ruleReference: row.ruleReference,
+        requirementText: row.requirementText,
+        finalEvidenceState,
+        reviewerOutcome,
+        reviewerEvidence:
+          index === 0
+            ? [
+                {
+                  quote: "Reviewed canonical quote.",
+                  page: 9,
+                  section: "Reviewed section",
+                  spanId: "reviewed-span",
+                  provenance: {
+                    docId: "doc",
+                    page: 9,
+                    sectionPath: ["Reviewed section"],
+                    spanId: "reviewed-span",
+                    sectionHeading: "Reviewed section",
+                    sourceType: "PDD",
+                  },
+                },
+              ]
+            : [],
+        rejectedEvidence: [],
+        draftFindingCandidate:
+          reviewerOutcome === "ACTION_REQUIRED" ? "NIR_CANDIDATE" : null,
+        contradictionState: "NONE_IDENTIFIED",
+        clientAction: "Reviewed action.",
+      };
     });
-    const snapshot: ReviewedEvidenceMapSnapshot = { canonicalAuditId: auditId, stableProjectId: "project", sourceDocument: { documentId: "doc", documentName: "Project PDD.pdf", contentSha256: "reviewed-hash" }, methodologyId: "VM0007", methodologyVersion: "v1.8", rows: reviewedRows, readOnly: true };
-    const before = window.localStorage.getItem(`article6:vm0007-evidence-map-draft:v1:${auditId}`);
+    const snapshot: ReviewedEvidenceMapSnapshot = {
+      canonicalAuditId: "historical-marcondes-audit",
+      stableProjectId: "project",
+      sourceDocument: {
+        documentId: "doc",
+        documentName: "Project PDD.pdf",
+        contentSha256: "reviewed-hash",
+      },
+      methodologyId: "VM0007",
+      methodologyVersion: "v1.8",
+      rows: reviewedRows,
+      readOnly: true,
+    };
+    const before = window.localStorage.getItem(
+      `article6:vm0007-evidence-map-draft:v1:${auditId}`,
+    );
     const { container, root } = await renderPage(auditId, snapshot);
     expect(container.textContent).toContain("Evidence Map · Reviewed truth");
     expect(container.textContent).toContain("6Found");
@@ -72,23 +309,64 @@ describe("VM0007 Evidence Map review workspace", () => {
     expect(container.textContent).toContain("10Missing");
     expect(container.textContent).toContain("22Not applicable");
     expect(container.textContent).toContain("30Action required");
-    expect(Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Finalize Evidence Map"))?.hasAttribute("disabled")).toBe(true);
-    click(container.querySelector(`[data-evidence-map-row="${auditId}:R-1"] > button`));
+    expect(
+      Array.from(container.querySelectorAll("button"))
+        .find((button) => button.textContent?.includes("Finalize Evidence Map"))
+        ?.hasAttribute("disabled"),
+    ).toBe(true);
+    click(
+      container.querySelector(
+        `[data-evidence-map-row="${auditId}:R-1"] > button`,
+      ),
+    );
     expect(container.textContent).toContain("Reviewed canonical quote.");
     expect(container.textContent).toContain("Page 9");
-    expect(container.textContent).toContain("Save, approve, reopen, and finalize controls are unavailable.");
-    click(Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "Machine proposal") ?? null);
+    expect(container.textContent).toContain(
+      "Save, approve, reopen, and finalize controls are unavailable.",
+    );
+    click(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Machine proposal",
+      ) ?? null,
+    );
     expect(container.textContent).toContain("Evidence Map · Machine proposal");
     expect(container.textContent).toContain("1Found");
-    expect(container.textContent).toContain("The implementation plan names the responsible team.");
-    expect(window.localStorage.getItem(`article6:vm0007-evidence-map-draft:v1:${auditId}`)).toBe(before);
+    expect(container.textContent).toContain(
+      "The implementation plan names the responsible team.",
+    );
+    expect(
+      window.localStorage.getItem(
+        `article6:vm0007-evidence-map-draft:v1:${auditId}`,
+      ),
+    ).toBe(before);
     act(() => root.unmount());
+
+    window.localStorage.clear();
+    const reviewedOnly = await renderPage(
+      "generated-without-machine",
+      snapshot,
+    );
+    expect(reviewedOnly.container.textContent).toContain(
+      "Evidence Map · Reviewed truth",
+    );
+    expect(reviewedOnly.container.textContent).not.toContain(
+      "Machine proposal",
+    );
+    expect(
+      Array.from(reviewedOnly.container.querySelectorAll("button"))
+        .find((button) => button.textContent?.includes("Finalize Evidence Map"))
+        ?.hasAttribute("disabled"),
+    ).toBe(true);
+    act(() => reviewedOnly.root.unmount());
   });
 
   test("shows all rows and truthful summary counts by default, including missing rows", async () => {
-    const auditId = "ui-default"; savePackage(auditId);
+    const auditId = "ui-default";
+    savePackage(auditId);
     const { container, root } = await renderPage(auditId);
-    expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(58);
+    expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(
+      58,
+    );
     expect(container.textContent).toContain("1Found");
     expect(container.textContent).toContain("3Unclear");
     expect(container.textContent).toContain("54Missing");
@@ -101,58 +379,163 @@ describe("VM0007 Evidence Map review workspace", () => {
   });
 
   test("filters immediately and clearing restores every row", async () => {
-    const auditId = "ui-filters"; savePackage(auditId);
+    const auditId = "ui-filters";
+    savePackage(auditId);
     const { container, root } = await renderPage(auditId);
-    change(container.querySelector('select[aria-label="Evidence state"]'), "FOUND");
-    expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(1);
+    change(
+      container.querySelector('select[aria-label="Evidence state"]'),
+      "FOUND",
+    );
+    expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(
+      1,
+    );
     expect(container.textContent).toContain("1 of 58 rules");
-    click(Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Clear all")) ?? null);
-    expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(58);
-    const search = container.querySelector<HTMLInputElement>('input[type="search"]');
+    click(
+      Array.from(container.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Clear all"),
+      ) ?? null,
+    );
+    expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(
+      58,
+    );
+    const search = container.querySelector<HTMLInputElement>(
+      'input[type="search"]',
+    );
     change(search, "Rule Two");
-    expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(1);
+    expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(
+      1,
+    );
     expect(container.textContent).toContain("Rule Two");
     change(search, "");
-    expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(58);
+    expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(
+      58,
+    );
     act(() => root.unmount());
   });
 
   test("expands rich and legacy details without attaching component coverage to evidence records", async () => {
-    const auditId = "ui-rich"; savePackage(auditId);
+    const auditId = "ui-rich";
+    savePackage(auditId);
     const { container, root } = await renderPage(auditId);
-    click(container.querySelector(`[data-evidence-map-row="${auditId}:R-1"] > button`));
-    expect(container.textContent).toContain("The implementation plan names the responsible team.");
-    expect(container.textContent).toContain("Monitoring occurs every six months.");
-    expect(container.textContent).toContain("Projects should implement monitoring.");
-    expect(container.textContent).toContain("Generic methodology instruction; it does not describe this project.");
+    click(
+      container.querySelector(
+        `[data-evidence-map-row="${auditId}:R-1"] > button`,
+      ),
+    );
+    expect(container.textContent).toContain(
+      "The implementation plan names the responsible team.",
+    );
+    expect(container.textContent).toContain(
+      "Monitoring occurs every six months.",
+    );
+    expect(container.textContent).toContain(
+      "Projects should implement monitoring.",
+    );
+    expect(container.textContent).toContain(
+      "Generic methodology instruction; it does not describe this project.",
+    );
     expect(container.textContent).toContain("implementation");
     expect(container.textContent).toContain("monitoring records");
-    expect(container.textContent).toContain("The strongest project-specific passages were retained.");
-    expect(container.querySelectorAll('[data-evidence-record="accepted"]')).toHaveLength(2);
-    expect(container.querySelectorAll('[data-evidence-record="rejected"]')).toHaveLength(1);
-    for (const evidence of container.querySelectorAll("[data-evidence-record]")) expect(evidence.querySelector("[data-component-coverage]")).toBeNull();
+    expect(container.textContent).toContain(
+      "The strongest project-specific passages were retained.",
+    );
+    expect(
+      container.querySelectorAll('[data-evidence-record="accepted"]'),
+    ).toHaveLength(2);
+    expect(
+      container.querySelectorAll('[data-evidence-record="rejected"]'),
+    ).toHaveLength(1);
+    for (const evidence of container.querySelectorAll("[data-evidence-record]"))
+      expect(evidence.querySelector("[data-component-coverage]")).toBeNull();
     act(() => root.unmount());
   });
 
   test("uses an accessible review panel and the existing reviewer workflow without browser prompts", async () => {
     const promptSpy = jest.spyOn(window, "prompt");
-    const auditId = "ui-review"; const rows = makeRows(auditId);
-    rows[0] = { ...rows[0], reviewState: "edited", reviewHistory: [{ reviewerIdentity: "reviewer:local", timestamp: "2026-07-11T01:00:00.000Z", reasonOrNote: "Canonical assessment completed.", previousState: "pending review", newState: "edited", presentationContractVersion: "v1", reviewPolicyVersion: "policy-v1" }], assessment: { evidenceMapRowId: rows[0].rowId, rowVersion: 1, applicability: { decision: "APPLICABLE", decisionBasis: "The requirement applies to the project." }, conformance: { requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE", versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE" }, draftFinding: { draftFindingType: null, findingBasis: null, reviewerAssessment: null }, reviewState: "CURRENT" } };
+    const auditId = "ui-review";
+    const rows = makeRows(auditId);
+    rows[0] = {
+      ...rows[0],
+      reviewState: "edited",
+      reviewHistory: [
+        {
+          reviewerIdentity: "reviewer:local",
+          timestamp: "2026-07-11T01:00:00.000Z",
+          reasonOrNote: "Canonical assessment completed.",
+          previousState: "pending review",
+          newState: "edited",
+          presentationContractVersion: "v1",
+          reviewPolicyVersion: "policy-v1",
+        },
+      ],
+      assessment: {
+        evidenceMapRowId: rows[0].rowId,
+        rowVersion: 1,
+        applicability: {
+          decision: "APPLICABLE",
+          decisionBasis: "The requirement applies to the project.",
+        },
+        conformance: {
+          requirementSupport: "SUPPORTED",
+          searchCoverageAssessment: "ADEQUATE",
+          provenanceAssessment: "COMPLETE",
+          versionIdentityAssessment: "MATCHED",
+          contradictionAssessment: "NONE",
+        },
+        draftFinding: {
+          draftFindingType: null,
+          findingBasis: null,
+          reviewerAssessment: null,
+        },
+        reviewState: "CURRENT",
+      },
+    };
     savePackage(auditId, rows);
     const truthBefore = loadVm0007EvidenceMapDraft(auditId)?.rows[0];
     const { container, root } = await renderPage(auditId);
-    click(container.querySelector(`[data-evidence-map-row="${auditId}:R-1"] > button`));
-    click(Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "Review decision") ?? null);
+    click(
+      container.querySelector(
+        `[data-evidence-map-row="${auditId}:R-1"] > button`,
+      ),
+    );
+    click(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Review decision",
+      ) ?? null,
+    );
     const dialog = document.querySelector('[role="dialog"]');
-    expect(dialog).not.toBeNull(); expect(dialog?.getAttribute("aria-modal")).toBe("true");
-    change(dialog?.querySelector<HTMLTextAreaElement>('textarea[placeholder="Why are you making this decision?"]') ?? null, "Evidence and canonical assessment reviewed.");
-    click(Array.from(dialog?.querySelectorAll("button") ?? []).find((button) => button.textContent === "Approve row") ?? null);
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute("aria-modal")).toBe("true");
+    change(
+      dialog?.querySelector<HTMLTextAreaElement>(
+        'textarea[placeholder="Why are you making this decision?"]',
+      ) ?? null,
+      "Evidence and canonical assessment reviewed.",
+    );
+    click(
+      Array.from(dialog?.querySelectorAll("button") ?? []).find(
+        (button) => button.textContent === "Approve row",
+      ) ?? null,
+    );
     const truthAfter = loadVm0007EvidenceMapDraft(auditId)?.rows[0];
     expect(truthAfter?.reviewState).toBe("approved");
     expect(truthAfter?.reviewHistory).toHaveLength(2);
-    expect({ status: truthAfter?.rawAuditStatus, confidence: truthAfter?.confidence, applicability: truthAfter?.proposedApplicability, accepted: truthAfter?.acceptedEvidence, rejected: truthAfter?.rejectedEvidence }).toEqual({ status: truthBefore?.rawAuditStatus, confidence: truthBefore?.confidence, applicability: truthBefore?.proposedApplicability, accepted: truthBefore?.acceptedEvidence, rejected: truthBefore?.rejectedEvidence });
+    expect({
+      status: truthAfter?.rawAuditStatus,
+      confidence: truthAfter?.confidence,
+      applicability: truthAfter?.proposedApplicability,
+      accepted: truthAfter?.acceptedEvidence,
+      rejected: truthAfter?.rejectedEvidence,
+    }).toEqual({
+      status: truthBefore?.rawAuditStatus,
+      confidence: truthBefore?.confidence,
+      applicability: truthBefore?.proposedApplicability,
+      accepted: truthBefore?.acceptedEvidence,
+      rejected: truthBefore?.rejectedEvidence,
+    });
     expect(promptSpy).not.toHaveBeenCalled();
-    promptSpy.mockRestore(); act(() => root.unmount());
+    promptSpy.mockRestore();
+    act(() => root.unmount());
   });
 
   test("reopens a finalized row with a required note while preserving evidence truth and review history", async () => {
@@ -170,51 +553,172 @@ describe("VM0007 Evidence Map review workspace", () => {
       reviewState: "approved",
       reviewHistoryRef: `${auditId}:${rows[0].rowId}:history:2`,
       reviewHistory: [
-        { reviewerIdentity: "reviewer:local", timestamp: "2026-07-11T01:00:00.000Z", reasonOrNote: "Canonical assessment completed.", previousState: "pending review", newState: "edited", presentationContractVersion: "v1", reviewPolicyVersion: "policy-v1" },
-        { reviewerIdentity: "reviewer:local", timestamp: "2026-07-11T02:00:00.000Z", reasonOrNote: "Evidence and assessment approved.", previousState: "edited", newState: "approved", presentationContractVersion: "v1", reviewPolicyVersion: "policy-v1" },
+        {
+          reviewerIdentity: "reviewer:local",
+          timestamp: "2026-07-11T01:00:00.000Z",
+          reasonOrNote: "Canonical assessment completed.",
+          previousState: "pending review",
+          newState: "edited",
+          presentationContractVersion: "v1",
+          reviewPolicyVersion: "policy-v1",
+        },
+        {
+          reviewerIdentity: "reviewer:local",
+          timestamp: "2026-07-11T02:00:00.000Z",
+          reasonOrNote: "Evidence and assessment approved.",
+          previousState: "edited",
+          newState: "approved",
+          presentationContractVersion: "v1",
+          reviewPolicyVersion: "policy-v1",
+        },
       ],
-      assessment: { evidenceMapRowId: rows[0].rowId, rowVersion: 1, applicability: { decision: "APPLICABLE", decisionBasis: "The requirement applies to the project." }, conformance: { requirementSupport: "SUPPORTED", searchCoverageAssessment: "ADEQUATE", provenanceAssessment: "COMPLETE", versionIdentityAssessment: "MATCHED", contradictionAssessment: "NONE" }, draftFinding: { draftFindingType: null, findingBasis: null, reviewerAssessment: null }, reviewState: "CURRENT" },
+      assessment: {
+        evidenceMapRowId: rows[0].rowId,
+        rowVersion: 1,
+        applicability: {
+          decision: "APPLICABLE",
+          decisionBasis: "The requirement applies to the project.",
+        },
+        conformance: {
+          requirementSupport: "SUPPORTED",
+          searchCoverageAssessment: "ADEQUATE",
+          provenanceAssessment: "COMPLETE",
+          versionIdentityAssessment: "MATCHED",
+          contradictionAssessment: "NONE",
+        },
+        draftFinding: {
+          draftFindingType: null,
+          findingBasis: null,
+          reviewerAssessment: null,
+        },
+        reviewState: "CURRENT",
+      },
     };
-    expect(saveVm0007EvidenceMapDraft({ auditId, generatedAt: "2026-07-11T00:00:00.000Z", methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "v1.8", sourceDocument: rows[0].sourceDocument, proposalState: "MACHINE_PROPOSED", rows, blockedBy: [], contractVersion: "vm0007-evidence-map-draft-v1", finalizationState: "finalized", finalizedBy: "reviewer:local", finalizedAt, finalizationBasis: "Reviewer-approved Evidence Map finalization." } as Vm0007EvidenceMapDraftPackage)).toBe(true);
+    expect(
+      saveVm0007EvidenceMapDraft({
+        auditId,
+        generatedAt: "2026-07-11T00:00:00.000Z",
+        methodologyId: "VM0007",
+        rulebookVersion: "v1.8",
+        pddDeclaredMethodologyVersion: "v1.8",
+        sourceDocument: rows[0].sourceDocument,
+        proposalState: "MACHINE_PROPOSED",
+        rows,
+        blockedBy: [],
+        contractVersion: "vm0007-evidence-map-draft-v1",
+        finalizationState: "finalized",
+        finalizedBy: "reviewer:local",
+        finalizedAt,
+        finalizationBasis: "Reviewer-approved Evidence Map finalization.",
+      } as Vm0007EvidenceMapDraftPackage),
+    ).toBe(true);
     const truthBefore = loadVm0007EvidenceMapDraft(auditId)?.rows[0];
 
     const { container, root } = await renderPage(auditId);
-    click(container.querySelector(`[data-evidence-map-row="${auditId}:R-1"] > button`));
+    click(
+      container.querySelector(
+        `[data-evidence-map-row="${auditId}:R-1"] > button`,
+      ),
+    );
     expect(container.textContent).toContain("Latest review activity");
     expect(container.textContent).not.toContain("Review history");
-    expect(container.textContent).toContain("2 event(s) · last by reviewer:local");
-    expect(container.textContent).toContain("Evidence and assessment approved.");
-    click(Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "View review decision") ?? null);
+    expect(container.textContent).toContain(
+      "2 event(s) · last by reviewer:local",
+    );
+    expect(container.textContent).toContain(
+      "Evidence and assessment approved.",
+    );
+    click(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "View review decision",
+      ) ?? null,
+    );
 
     const dialog = document.querySelector('[role="dialog"]');
     expect(dialog).not.toBeNull();
-    expect(Array.from(dialog?.querySelectorAll("select, input") ?? []).every((field) => (field as HTMLInputElement | HTMLSelectElement).disabled)).toBe(true);
-    expect(dialog?.querySelector<HTMLTextAreaElement>('textarea:not([placeholder])')?.disabled).toBe(true);
-    expect(Array.from(dialog?.querySelectorAll("button") ?? []).find((button) => button.textContent === "Save reviewer decision")?.hasAttribute("disabled")).toBe(true);
-    expect(Array.from(dialog?.querySelectorAll("button") ?? []).find((button) => button.textContent === "Approve row")?.hasAttribute("disabled")).toBe(true);
-    const note = dialog?.querySelector<HTMLTextAreaElement>('textarea[placeholder="Why are you making this decision?"]') ?? null;
+    expect(
+      Array.from(dialog?.querySelectorAll("select, input") ?? []).every(
+        (field) => (field as HTMLInputElement | HTMLSelectElement).disabled,
+      ),
+    ).toBe(true);
+    expect(
+      dialog?.querySelector<HTMLTextAreaElement>("textarea:not([placeholder])")
+        ?.disabled,
+    ).toBe(true);
+    expect(
+      Array.from(dialog?.querySelectorAll("button") ?? [])
+        .find((button) => button.textContent === "Save reviewer decision")
+        ?.hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      Array.from(dialog?.querySelectorAll("button") ?? [])
+        .find((button) => button.textContent === "Approve row")
+        ?.hasAttribute("disabled"),
+    ).toBe(true);
+    const note =
+      dialog?.querySelector<HTMLTextAreaElement>(
+        'textarea[placeholder="Why are you making this decision?"]',
+      ) ?? null;
     expect(note?.disabled).toBe(false);
 
-    click(Array.from(dialog?.querySelectorAll("button") ?? []).find((button) => button.textContent === "Reopen") ?? null);
+    click(
+      Array.from(dialog?.querySelectorAll("button") ?? []).find(
+        (button) => button.textContent === "Reopen",
+      ) ?? null,
+    );
     expect(document.querySelector('[role="dialog"]')).not.toBeNull();
-    expect(document.querySelector('[role="alert"]')?.textContent).toContain("Add a review note");
-    expect(loadVm0007EvidenceMapDraft(auditId)?.finalizationState).toBe("finalized");
-    expect(loadVm0007EvidenceMapDraft(auditId)?.rows[0].reviewHistory).toHaveLength(2);
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+      "Add a review note",
+    );
+    expect(loadVm0007EvidenceMapDraft(auditId)?.finalizationState).toBe(
+      "finalized",
+    );
+    expect(
+      loadVm0007EvidenceMapDraft(auditId)?.rows[0].reviewHistory,
+    ).toHaveLength(2);
 
     change(note, "Reopening to review newly supplied context.");
-    click(Array.from(document.querySelectorAll('[role="dialog"] button')).find((button) => button.textContent === "Reopen") ?? null);
+    click(
+      Array.from(document.querySelectorAll('[role="dialog"] button')).find(
+        (button) => button.textContent === "Reopen",
+      ) ?? null,
+    );
     const reopened = loadVm0007EvidenceMapDraft(auditId);
     expect(document.querySelector('[role="dialog"]')).toBeNull();
     expect(reopened?.finalizationState).toBe("draft");
     expect(reopened?.rows[0].finalizationState).toBe("draft");
     expect(reopened?.rows[0].reviewState).toBe("reopened");
     expect(reopened?.rows[0].reviewHistory).toHaveLength(3);
-    expect(reopened?.rows[0].reviewHistory?.at(-1)).toEqual(expect.objectContaining({ previousState: "approved", newState: "reopened", reasonOrNote: "Reopening to review newly supplied context." }));
-    expect(container.textContent).toContain(`Row ${auditId}:R-1 is now reopened.`);
+    expect(reopened?.rows[0].reviewHistory?.at(-1)).toEqual(
+      expect.objectContaining({
+        previousState: "approved",
+        newState: "reopened",
+        reasonOrNote: "Reopening to review newly supplied context.",
+      }),
+    );
+    expect(container.textContent).toContain(
+      `Row ${auditId}:R-1 is now reopened.`,
+    );
     expect(container.textContent).toContain("Latest review activity");
-    expect(container.textContent).toContain("3 event(s) · last by reviewer:local");
-    expect(container.textContent).toContain("Reopening to review newly supplied context.");
-    expect({ status: reopened?.rows[0].rawAuditStatus, confidence: reopened?.rows[0].confidence, applicability: reopened?.rows[0].proposedApplicability, accepted: reopened?.rows[0].acceptedEvidence, rejected: reopened?.rows[0].rejectedEvidence }).toEqual({ status: truthBefore?.rawAuditStatus, confidence: truthBefore?.confidence, applicability: truthBefore?.proposedApplicability, accepted: truthBefore?.acceptedEvidence, rejected: truthBefore?.rejectedEvidence });
+    expect(container.textContent).toContain(
+      "3 event(s) · last by reviewer:local",
+    );
+    expect(container.textContent).toContain(
+      "Reopening to review newly supplied context.",
+    );
+    expect({
+      status: reopened?.rows[0].rawAuditStatus,
+      confidence: reopened?.rows[0].confidence,
+      applicability: reopened?.rows[0].proposedApplicability,
+      accepted: reopened?.rows[0].acceptedEvidence,
+      rejected: reopened?.rows[0].rejectedEvidence,
+    }).toEqual({
+      status: truthBefore?.rawAuditStatus,
+      confidence: truthBefore?.confidence,
+      applicability: truthBefore?.proposedApplicability,
+      accepted: truthBefore?.acceptedEvidence,
+      rejected: truthBefore?.rejectedEvidence,
+    });
     act(() => root.unmount());
   });
 });

--- a/tests/components/vm0007EvidenceMapDraftPage.test.tsx
+++ b/tests/components/vm0007EvidenceMapDraftPage.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import Vm0007EvidenceMapDraftPage from "@/components/preverif/Vm0007EvidenceMapDraftPage";
 import { loadVm0007EvidenceMapDraft, saveVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
 import type { Vm0007EvidenceMapDraftPackage, Vm0007EvidenceMapDraftRow } from "@/lib/preverif/vm0007EvidenceMapDraft";
+import type { ReviewedEvidenceMapSnapshot, ReviewedEvidenceState, ReviewedOutcome } from "@/lib/preverif/reviewedEvidenceMapTypes";
 
 const provenance = (spanId: string, page: number | null = 12) => ({ docId: "doc", page, sectionPath: ["Project implementation"], spanId, sectionHeading: "Project implementation", sourceType: "PDD" });
 
@@ -39,11 +40,11 @@ function savePackage(auditId: string, rows = makeRows(auditId)) {
   expect(saveVm0007EvidenceMapDraft({ auditId, generatedAt: "2026-07-11T00:00:00.000Z", methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "v1.8", sourceDocument: rows[0].sourceDocument, proposalState: "MACHINE_PROPOSED", rows, blockedBy: [], contractVersion: "vm0007-evidence-map-draft-v1" } as Vm0007EvidenceMapDraftPackage)).toBe(true);
 }
 
-async function renderPage(auditId: string): Promise<{ container: HTMLDivElement; root: Root }> {
+async function renderPage(auditId: string, reviewedCandidate?: ReviewedEvidenceMapSnapshot): Promise<{ container: HTMLDivElement; root: Root }> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
-  await act(async () => { root.render(<Vm0007EvidenceMapDraftPage auditId={auditId} />); });
+  await act(async () => { root.render(<Vm0007EvidenceMapDraftPage auditId={auditId} reviewedCandidate={reviewedCandidate} />); });
   return { container, root };
 }
 
@@ -53,6 +54,37 @@ function change(element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElem
 afterEach(() => { document.body.innerHTML = ""; window.localStorage.clear(); });
 
 describe("VM0007 Evidence Map review workspace", () => {
+  test("defaults a matching reviewed case to a read-only snapshot and switches without persistence", async () => {
+    const auditId = "reviewed-ui";
+    const rows = makeRows(auditId).map((row) => ({ ...row, sourceDocument: { ...row.sourceDocument, contentSha256: "reviewed-hash" } }));
+    savePackage(auditId, rows);
+    const reviewedRows = rows.map((row, index) => {
+      const finalEvidenceState: ReviewedEvidenceState = index < 6 ? "FOUND" : index < 26 ? "UNCLEAR" : index < 36 ? "MISSING" : "N/A";
+      const reviewerOutcome: ReviewedOutcome = index < 6 ? "CONFORMS" : index < 36 ? "ACTION_REQUIRED" : "NOT_APPLICABLE";
+      return { rowId: row.rowId, stableRuleId: row.stableRuleId, ruleReference: row.ruleReference, requirementText: row.requirementText, finalEvidenceState, reviewerOutcome, reviewerEvidence: index === 0 ? [{ quote: "Reviewed canonical quote.", page: 9, section: "Reviewed section", spanId: "reviewed-span", provenance: { docId: "doc", page: 9, sectionPath: ["Reviewed section"], spanId: "reviewed-span", sectionHeading: "Reviewed section", sourceType: "PDD" } }] : [], rejectedEvidence: [], draftFindingCandidate: reviewerOutcome === "ACTION_REQUIRED" ? "NIR_CANDIDATE" : null, contradictionState: "NONE_IDENTIFIED", clientAction: "Reviewed action." };
+    });
+    const snapshot: ReviewedEvidenceMapSnapshot = { canonicalAuditId: auditId, stableProjectId: "project", sourceDocument: { documentId: "doc", documentName: "Project PDD.pdf", contentSha256: "reviewed-hash" }, methodologyId: "VM0007", methodologyVersion: "v1.8", rows: reviewedRows, readOnly: true };
+    const before = window.localStorage.getItem(`article6:vm0007-evidence-map-draft:v1:${auditId}`);
+    const { container, root } = await renderPage(auditId, snapshot);
+    expect(container.textContent).toContain("Evidence Map · Reviewed truth");
+    expect(container.textContent).toContain("6Found");
+    expect(container.textContent).toContain("20Unclear");
+    expect(container.textContent).toContain("10Missing");
+    expect(container.textContent).toContain("22Not applicable");
+    expect(container.textContent).toContain("30Action required");
+    expect(Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Finalize Evidence Map"))?.hasAttribute("disabled")).toBe(true);
+    click(container.querySelector(`[data-evidence-map-row="${auditId}:R-1"] > button`));
+    expect(container.textContent).toContain("Reviewed canonical quote.");
+    expect(container.textContent).toContain("Page 9");
+    expect(container.textContent).toContain("Save, approve, reopen, and finalize controls are unavailable.");
+    click(Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "Machine proposal") ?? null);
+    expect(container.textContent).toContain("Evidence Map · Machine proposal");
+    expect(container.textContent).toContain("1Found");
+    expect(container.textContent).toContain("The implementation plan names the responsible team.");
+    expect(window.localStorage.getItem(`article6:vm0007-evidence-map-draft:v1:${auditId}`)).toBe(before);
+    act(() => root.unmount());
+  });
+
   test("shows all rows and truthful summary counts by default, including missing rows", async () => {
     const auditId = "ui-default"; savePackage(auditId);
     const { container, root } = await renderPage(auditId);

--- a/tests/lib/preverif/reviewedEvidenceMapAdapter.test.ts
+++ b/tests/lib/preverif/reviewedEvidenceMapAdapter.test.ts
@@ -1,0 +1,36 @@
+import { adaptReviewedEvidenceMap } from "@/lib/preverif/reviewedEvidenceMapAdapter";
+import { summarizeEvidenceMapPresentation, buildReviewedEvidenceMapPresentation } from "@/components/preverif/evidence-map/evidenceMapPresentationModel";
+import reviewed from "../../fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json";
+import draft from "../../fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.draft.json";
+import metadata from "../../fixtures/preverif/marcondes-vm0007-v18-evidence-map/metadata.json";
+
+describe("reviewed Evidence Map adapter", () => {
+  test("adapts every completed canonical row and derives reviewed counts", () => {
+    const snapshot = adaptReviewedEvidenceMap({ reviewed, draft, metadata });
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.rows).toHaveLength(58);
+    expect(summarizeEvidenceMapPresentation(buildReviewedEvidenceMapPresentation(snapshot!).rows)).toEqual({
+      total: 58,
+      found: 6,
+      unclear: 20,
+      missing: 10,
+      notApplicable: 22,
+      actionRequired: 30,
+    });
+  });
+
+  test("drift-checks canonical rows against metadata counts and preserves evidence provenance", () => {
+    const snapshot = adaptReviewedEvidenceMap({ reviewed, draft, metadata })!;
+    const summary = summarizeEvidenceMapPresentation(buildReviewedEvidenceMapPresentation(snapshot).rows);
+    expect({ FOUND: summary.found, UNCLEAR: summary.unclear, MISSING: summary.missing, "N/A": summary.notApplicable }).toEqual(metadata.review.evidenceStateCounts);
+    expect(summary.actionRequired).toBe(metadata.review.reviewerOutcomes.ACTION_REQUIRED);
+    const evidence = snapshot.rows.flatMap((row) => row.reviewerEvidence);
+    expect(evidence.length).toBeGreaterThan(0);
+    expect(evidence.every((item) => item.quote && item.spanId && item.provenance.docId && item.provenance.spanId)).toBe(true);
+    expect(snapshot.rows.flatMap((row) => row.rejectedEvidence).every((item) => item.rejectionReason)).toBe(true);
+  });
+
+  test("does not present partial draft rows as reviewed truth", () => {
+    expect(adaptReviewedEvidenceMap({ reviewed: draft, draft, metadata })).toBeNull();
+  });
+});

--- a/tests/lib/preverif/reviewedEvidenceMapRegistry.test.ts
+++ b/tests/lib/preverif/reviewedEvidenceMapRegistry.test.ts
@@ -1,0 +1,15 @@
+import { findReviewedEvidenceMapEntry, matchesReviewedEvidenceMapCase } from "@/lib/preverif/reviewedEvidenceMapRegistry";
+import type { Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
+import type { ReviewedEvidenceMapSnapshot } from "@/lib/preverif/reviewedEvidenceMapTypes";
+
+const entry = { canonicalAuditId: "audit-1", stableProjectId: "project-1", sourcePdfSha256: "hash-1" };
+
+test("registry matches reviewed cases by stable audit and source identity", () => {
+  expect(findReviewedEvidenceMapEntry([entry], { auditId: "audit-1", sourcePdfSha256: "hash-1" })).toEqual(entry);
+  expect(findReviewedEvidenceMapEntry([entry], { auditId: "audit-1", sourcePdfSha256: "different" })).toBeNull();
+  const pkg = { auditId: "audit-1", sourceDocument: { documentId: "doc-1", contentSha256: "hash-1" } } as Vm0007EvidenceMapDraftPackage;
+  const snapshot = { canonicalAuditId: "audit-1", sourceDocument: { documentId: "doc-1", contentSha256: "hash-1" } } as ReviewedEvidenceMapSnapshot;
+  expect(matchesReviewedEvidenceMapCase(pkg, snapshot)).toBe(true);
+  expect(matchesReviewedEvidenceMapCase({ ...pkg, auditId: "other" }, snapshot)).toBe(false);
+  expect(matchesReviewedEvidenceMapCase({ ...pkg, sourceDocument: { ...pkg.sourceDocument, contentSha256: "other" } }, snapshot)).toBe(false);
+});

--- a/tests/lib/preverif/reviewedEvidenceMapRegistry.test.ts
+++ b/tests/lib/preverif/reviewedEvidenceMapRegistry.test.ts
@@ -45,6 +45,15 @@ test("registry matches reviewed cases by stable audit and source identity", () =
     ),
   ).toBe(false);
   expect(
+    matchesReviewedEvidenceMapCase(
+      {
+        ...pkg,
+        sourceDocument: { ...pkg.sourceDocument, contentSha256: null },
+      },
+      snapshot,
+    ),
+  ).toBe(false);
+  expect(
     matchesReviewedEvidenceMapIdentity(
       {
         sourcePdfSha256: "hash-1",

--- a/tests/lib/preverif/reviewedEvidenceMapRegistry.test.ts
+++ b/tests/lib/preverif/reviewedEvidenceMapRegistry.test.ts
@@ -1,15 +1,63 @@
-import { findReviewedEvidenceMapEntry, matchesReviewedEvidenceMapCase } from "@/lib/preverif/reviewedEvidenceMapRegistry";
+import {
+  findReviewedEvidenceMapEntry,
+  matchesReviewedEvidenceMapCase,
+  matchesReviewedEvidenceMapIdentity,
+} from "@/lib/preverif/reviewedEvidenceMapRegistry";
 import type { Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
 import type { ReviewedEvidenceMapSnapshot } from "@/lib/preverif/reviewedEvidenceMapTypes";
 
-const entry = { canonicalAuditId: "audit-1", stableProjectId: "project-1", sourcePdfSha256: "hash-1" };
+const entry = {
+  canonicalAuditId: "audit-1",
+  stableProjectId: "project-1",
+  sourcePdfSha256: "hash-1",
+};
 
 test("registry matches reviewed cases by stable audit and source identity", () => {
-  expect(findReviewedEvidenceMapEntry([entry], { auditId: "audit-1", sourcePdfSha256: "hash-1" })).toEqual(entry);
-  expect(findReviewedEvidenceMapEntry([entry], { auditId: "audit-1", sourcePdfSha256: "different" })).toBeNull();
-  const pkg = { auditId: "audit-1", sourceDocument: { documentId: "doc-1", contentSha256: "hash-1" } } as Vm0007EvidenceMapDraftPackage;
-  const snapshot = { canonicalAuditId: "audit-1", sourceDocument: { documentId: "doc-1", contentSha256: "hash-1" } } as ReviewedEvidenceMapSnapshot;
+  expect(
+    findReviewedEvidenceMapEntry([entry], {
+      auditId: "generated-live-audit",
+      sourcePdfSha256: "hash-1",
+    }),
+  ).toEqual(entry);
+  expect(
+    findReviewedEvidenceMapEntry([entry], { sourcePdfSha256: "different" }),
+  ).toBeNull();
+  const pkg = {
+    auditId: "generated-live-audit",
+    sourceDocument: { documentId: "doc-1", contentSha256: "hash-1" },
+  } as Vm0007EvidenceMapDraftPackage;
+  const snapshot = {
+    canonicalAuditId: "historical-audit",
+    stableProjectId: "project-1",
+    sourceDocument: { documentId: "doc-1", contentSha256: "hash-1" },
+  } as ReviewedEvidenceMapSnapshot;
   expect(matchesReviewedEvidenceMapCase(pkg, snapshot)).toBe(true);
-  expect(matchesReviewedEvidenceMapCase({ ...pkg, auditId: "other" }, snapshot)).toBe(false);
-  expect(matchesReviewedEvidenceMapCase({ ...pkg, sourceDocument: { ...pkg.sourceDocument, contentSha256: "other" } }, snapshot)).toBe(false);
+  expect(
+    matchesReviewedEvidenceMapCase({ ...pkg, auditId: "other" }, snapshot),
+  ).toBe(true);
+  expect(
+    matchesReviewedEvidenceMapCase(
+      {
+        ...pkg,
+        sourceDocument: { ...pkg.sourceDocument, contentSha256: "other" },
+      },
+      snapshot,
+    ),
+  ).toBe(false);
+  expect(
+    matchesReviewedEvidenceMapIdentity(
+      {
+        sourcePdfSha256: "hash-1",
+        sourceDocumentId: "doc-1",
+        stableProjectId: "project-1",
+      },
+      snapshot,
+    ),
+  ).toBe(true);
+  expect(
+    matchesReviewedEvidenceMapIdentity(
+      { sourcePdfSha256: "hash-1", sourceDocumentId: "different" },
+      snapshot,
+    ),
+  ).toBe(false);
 });

--- a/tests/lib/preverif/vm0007GapReportStore.test.ts
+++ b/tests/lib/preverif/vm0007GapReportStore.test.ts
@@ -1,0 +1,91 @@
+/** @jest-environment jsdom */
+
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { sha256ArrayBuffer } from "@/lib/proof/hash";
+import {
+  buildAndSaveVm0007GapReportAudit,
+  completeVm0007EvidenceMapGeneration,
+  loadVm0007GapReportAudit,
+} from "@/lib/preverif/vm0007GapReportStore";
+import { buildVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraft";
+import {
+  readQuickCheckFixtureText,
+  VM0007_SYNCED_RULES,
+} from "../preverifVm0007Fixtures";
+
+const rawPddText = readQuickCheckFixtureText(
+  "envira-amazonia-vm0007-extracted.txt",
+).replace("VM0007 Version 4.2", "REDD-MF / VM0007 v1.8");
+
+afterEach(() => window.localStorage.clear());
+
+describe("VM0007 uploaded PDF source identity propagation", () => {
+  test("persists the SHA-256 of uploaded bytes through audit and Evidence Map package", async () => {
+    const uploadedPdfBytes = new TextEncoder().encode(
+      "original uploaded PDF bytes",
+    ).buffer;
+    const sourcePdfSha256 = await sha256ArrayBuffer(uploadedPdfBytes);
+    const result = buildAndSaveVm0007GapReportAudit({
+      methodology: {
+        methodologyId: "VM0007",
+        methodologyName: "VM0007",
+        methodologyAlias: null,
+        pddDeclaredMethodologyVersion: "v1.8",
+        versionStatus: "DECLARED",
+        evidencePage: 1,
+        evidenceSection: "Methodology",
+        evidenceQuote: "VM0007 v1.8",
+      },
+      loadedRulebookId: "VM0007",
+      loadedRulebookVersion: "v1.8",
+      evidenceFileName: "uploaded-marcondes.pdf",
+      sourcePdfSha256,
+      rawPddText,
+      rules: VM0007_SYNCED_RULES,
+      userAcceptedVersionWarning: true,
+    });
+
+    expect(result.auditSaved).toBe(true);
+    expect(result.draftBuilt).toBe(true);
+    const audit = loadVm0007GapReportAudit(result.auditId);
+    expect(audit?.sourceDocument).toEqual(
+      expect.objectContaining({
+        documentName: "uploaded-marcondes.pdf",
+        contentSha256: sourcePdfSha256,
+      }),
+    );
+
+    const directDraft = buildVm0007EvidenceMapDraft({
+      auditId: result.audit!.auditId,
+      generatedAt: result.audit!.generatedAt,
+      rules: VM0007_SYNCED_RULES,
+      audit: result.audit!.audit,
+      sourceDocument: result.audit!.sourceDocument,
+    });
+    expect(directDraft.ok).toBe(true);
+    if (!directDraft.ok) return;
+    let persisted: typeof directDraft.package | null = null;
+    const persistedResult = completeVm0007EvidenceMapGeneration({
+      audit: result.audit!,
+      auditSaved: true,
+      draft: directDraft,
+      saveDraft: (draft) => {
+        persisted = draft;
+        return true;
+      },
+      loadDraft: () => persisted,
+    });
+    expect(persistedResult.draftSaved).toBe(true);
+    expect(persisted?.sourceDocument).toEqual(
+      expect.objectContaining({
+        documentName: "uploaded-marcondes.pdf",
+        contentSha256: sourcePdfSha256,
+      }),
+    );
+    expect(
+      persisted?.rows.every(
+        (row) => row.sourceDocument.contentSha256 === sourcePdfSha256,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed

- reviewed cases now match live audits by source PDF SHA-256 and source document identity; stable project identity is checked when supplied
- canonical audit ID remains snapshot metadata only and is no longer required to equal the live audit ID
- the server registry exposes the reviewed candidate list and can resolve a candidate from source identity query parameters
- the client validates the live package source identity before enabling Reviewed truth mode
- a reviewed snapshot can render read-only without a machine localStorage package; Machine proposal controls are hidden in that state
- machine and reviewed presentations remain separate and mode changes do not write localStorage or audit data

## Canonical source

The completed 58-row reviewed truth is the repository's existing promoted `gold.json`. The current `gold.draft.json` contains only 18 completed rows, so it is used for canonical audit/proposal identity rather than presented as complete truth. `metadata.json` supplies source identity and independent totals. No fixture or gold file was modified.

## Reviewed totals

Derived from canonical reviewed rows: FOUND 6, UNCLEAR 20, MISSING 10, N/A 22, ACTION_REQUIRED 30. No counts are hardcoded in UI code.

## Validation

- 69 focused tests passed, including generated-live-audit identity matching, hash mismatch rejection, reviewed-only mode, storage immutability, read-only controls, draft persistence, review workflow, and Marcondes reconciliation/comparison
- `git diff --check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run pr:check:local`
- GitHub build/gate/pr-gate/test/verify/verify-derived/Vercel checks pass

The repository smoke script remains blocked by its unrelated existing prerequisite failure: `expected Verify control on method page` at `scripts/test-evidence-map-smoke.cjs:30`.
