### PR TITLE
docs(roadmap): complete RC0 and activate RC1

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -139,8 +139,8 @@ Not active now:
 Status SSOT: `docs/roadmaps/interactive-evidence-review-mvp/phase-status.json`
 Details: `docs/roadmaps/interactive-evidence-review-mvp/PLAN.md`
 
-1) RC0 — Roadmap contract: Active
-2) RC1 — Readable interactive workspace: Next
+1) RC0 — Roadmap contract: Done
+2) RC1 — Readable interactive workspace: Active
 3) RC2 — Accuracy benchmark: Planned
 4) RC3 — Generic accuracy improvements: Planned
 5) RC4 — Guided reviewer interaction: Planned

--- a/docs/roadmaps/interactive-evidence-review-mvp/PLAN.md
+++ b/docs/roadmaps/interactive-evidence-review-mvp/PLAN.md
@@ -24,8 +24,8 @@ truthfulness > reviewer usability > measurable accuracy > visual polish
 
 | Phase | Title | Status | Gate |
 |---|---|---|---|
-| 0 | Roadmap contract | Active | Roadmap files validate and no production code changes |
-| 1 | Readable interactive workspace | Next | A reviewer can scan all 58 rows and understand an expanded row without visual confusion |
+| 0 | Roadmap contract | Done | Roadmap files validate and no production code changes |
+| 1 | Readable interactive workspace | Active | A reviewer can scan all 58 rows and understand an expanded row without visual confusion |
 | 2 | Accuracy benchmark | Planned | Highest-impact generic failure modes are ranked and reproducible |
 | 3 | Generic accuracy improvements | Planned | Accuracy improves without fixture regressions |
 | 4 | Guided reviewer interaction | Planned | A reviewer can complete all 58 decisions without leaving the Evidence Map |

--- a/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
+++ b/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
@@ -1,15 +1,15 @@
 {
   "RC0": "done",
-  "currentPhase": "RC0",
+  "currentPhase": "RC1",
   "name": "Interactive Evidence Review MVP",
   "phases": {
     "phase_0_roadmap_contract": {
       "title": "Roadmap contract",
-      "status": "active"
+      "status": "done"
     },
     "phase_1_readable_interactive_workspace": {
       "title": "Readable interactive workspace",
-      "status": "next"
+      "status": "active"
     },
     "phase_2_accuracy_benchmark": {
       "title": "Accuracy benchmark",


### PR DESCRIPTION
## Summary

- mark RC0 complete in the roadmap SSOT
- set RC1 as the active phase
- align the human-readable phase table with the SSOT
- regenerate the derived roadmap summary
- change documentation only; no production, fixture, parser, review, persistence, report, or export code

## Validation

- compared branch against `main`
- exactly three documentation files changed
- docs-only fast gate selected

### Roadmap-Update
- slug: interactive-evidence-review-mvp
- items:
  - RC0: done
  - RC1: in_progress
