### PR TITLE
fix: polish RC1 Evidence Map workspace

### DIFF
--- a/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
+++ b/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
@@ -6,6 +6,7 @@ import {
   FilterX,
   Search,
   ShieldCheck,
+  SlidersHorizontal,
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import type {
@@ -77,40 +78,7 @@ function EvidenceList({
           className={`mt-3 divide-y divide-slate-200 rounded-xl px-4 ${rejected ? "bg-amber-50/60" : "bg-emerald-50/50"}`}
         >
           {records.map((record, index) => (
-            <article
-              key={`${record.spanId}-${index}`}
-              data-evidence-record={rejected ? "rejected" : "accepted"}
-              className="py-4"
-            >
-              <blockquote className="whitespace-pre-wrap text-sm leading-6 text-slate-800">
-                “{record.quote}”
-              </blockquote>
-              {rejected && record.rejectionReason ? (
-                <p className="mt-3 text-sm text-amber-900">
-                  <strong>Rejected because:</strong> {record.rejectionReason}
-                </p>
-              ) : null}
-              <dl className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-xs text-slate-500">
-                <div>
-                  <dt className="sr-only">Page</dt>
-                  <dd>Page {record.page ?? record.provenance.page ?? "—"}</dd>
-                </div>
-                <div>
-                  <dt className="sr-only">Section</dt>
-                  <dd>
-                    {record.section ||
-                      record.provenance.sectionHeading ||
-                      "No section"}
-                  </dd>
-                </div>
-                <div title={record.provenance.spanId}>
-                  <dt className="sr-only">Source span</dt>
-                  <dd>
-                    {record.provenance.docId} · {record.provenance.spanId}
-                  </dd>
-                </div>
-              </dl>
-            </article>
+            <EvidenceRecord key={`${record.spanId}-${index}`} record={record} rejected={rejected} />
           ))}
         </div>
       ) : (
@@ -119,6 +87,38 @@ function EvidenceList({
         </p>
       )}
     </section>
+  );
+}
+
+function EvidenceRecord({
+  record,
+  rejected,
+}: {
+  record: EvidenceMapPresentationRow["acceptedEvidence"][number];
+  rejected: boolean;
+}) {
+  const [showFull, setShowFull] = useState(false);
+  const isLong = record.quote.length > 360 || record.quote.split("\n").length > 8;
+  const detailsId = `evidence-${record.spanId}-details`;
+  return (
+    <article data-evidence-record={rejected ? "rejected" : "accepted"} className="py-4 first:pt-0 last:pb-0">
+      <blockquote className={`whitespace-pre-wrap text-sm leading-6 text-slate-800 ${isLong && !showFull ? "line-clamp-6" : ""}`}>
+        “{record.quote}”
+      </blockquote>
+      {isLong ? (
+        <button type="button" aria-expanded={showFull} aria-controls={detailsId} onClick={() => setShowFull((current) => !current)} className="mt-2 min-h-10 text-sm font-medium text-blue-700 underline decoration-blue-300 underline-offset-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
+          {showFull ? "Show less" : "Show full evidence"}
+        </button>
+      ) : null}
+      <div id={detailsId}>
+        {rejected && record.rejectionReason ? <p className="mt-3 text-sm text-amber-900"><strong>Rejected because:</strong> {record.rejectionReason}</p> : null}
+        <dl className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-xs text-slate-500">
+          <div><dt className="sr-only">Page</dt><dd>Page {record.page ?? record.provenance.page ?? "—"}</dd></div>
+          <div><dt className="sr-only">Section</dt><dd>{record.section || record.provenance.sectionHeading || "No section"}</dd></div>
+          <div title={record.provenance.spanId}><dt className="sr-only">Source span</dt><dd>{record.provenance.docId} · {record.provenance.spanId}</dd></div>
+        </dl>
+      </div>
+    </article>
   );
 }
 
@@ -298,14 +298,14 @@ function Summary({ rows }: { rows: readonly EvidenceMapPresentationRow[] }) {
   return (
     <nav
       aria-label="Evidence Map summary"
-      className="grid grid-cols-2 divide-x divide-y divide-slate-200 border-y border-slate-200 bg-white sm:grid-cols-3 lg:grid-cols-6"
+      className="flex flex-wrap items-center gap-x-5 gap-y-2 border-y border-slate-200 py-3 text-sm"
     >
       {items.map(([name, count]) => (
-        <div key={name} className="px-4 py-4">
-          <span className="font-mono text-xl font-semibold tabular-nums">
+        <div key={name} className="flex items-baseline gap-1.5 border-l border-slate-200 pl-5 first:border-l-0 first:pl-0">
+          <span className={`font-mono font-semibold tabular-nums ${name === "Action required" ? "text-rose-700" : "text-slate-950"}`}>
             {count}
           </span>
-          <span className="mt-1 block text-xs font-medium text-slate-500">
+          <span className="text-xs font-medium text-slate-500">
             {name}
           </span>
         </div>
@@ -336,6 +336,7 @@ export default function EvidenceMapWorkspace({
     EMPTY_PRESENTATION_FILTERS,
   );
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [filtersOpen, setFiltersOpen] = useState(false);
   const presentation = useMemo(
     () =>
       mode === "reviewed" && reviewedSnapshot
@@ -368,10 +369,21 @@ export default function EvidenceMapWorkspace({
   const reviewerOutcomes = [
     ...new Set(presentation.rows.map((row) => row.reviewerOutcome)),
   ];
+  const activeFilterCount = [
+    filters.evidenceState !== "ALL",
+    filters.applicability !== "ALL",
+    filters.reviewerOutcome !== "ALL",
+    filters.reviewState !== "ALL",
+  ].filter(Boolean).length;
+  const filtersActive = hasPresentationFilters(filters);
+  const setPresentationFilter = <K extends keyof EvidenceMapPresentationFilters>(
+    key: K,
+    value: EvidenceMapPresentationFilters[K],
+  ) => setFilters((current) => ({ ...current, [key]: value }));
   return (
-    <main className="min-h-screen bg-slate-50 text-slate-950">
-      <header className="border-b border-slate-200 bg-white px-4 py-5 sm:px-6">
-        <div className="mx-auto flex max-w-[1600px] flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+    <main className="min-h-screen w-full bg-slate-50 text-slate-950">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-4 py-8 md:px-8">
+        <header className="flex flex-col gap-4 border-b border-slate-200 pb-5 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <div className="flex items-center gap-2">
               <FileText size={18} className="text-blue-600" />
@@ -382,10 +394,8 @@ export default function EvidenceMapWorkspace({
                   reviewedSnapshot?.sourceDocument.documentId}
               </p>
             </div>
-            <h1 className="mt-2 text-2xl font-semibold">
-              Evidence Map ·{" "}
-              {presentation.readOnly ? "Reviewed truth" : "Machine proposal"}
-            </h1>
+            <p className="mt-3 text-xs font-medium uppercase tracking-[.08em] text-slate-500">Evidence Map</p>
+            <h1 className="mt-1 text-2xl font-semibold tracking-tight">Evidence Map · {presentation.readOnly ? "Reviewed truth" : "Machine proposal"}</h1>
             <p className="mt-2 text-xs text-slate-500">
               {pkg?.methodologyId || reviewedSnapshot?.methodologyId}{" "}
               {pkg?.rulebookVersion || reviewedSnapshot?.methodologyVersion} ·
@@ -432,18 +442,14 @@ export default function EvidenceMapWorkspace({
               Finalize Evidence Map
             </button>
           </div>
-        </div>
-      </header>
-      <div className="mx-auto max-w-[1600px]">
-        <div
-          className={`border-b px-4 py-3 text-sm sm:px-6 ${presentation.readOnly ? "border-blue-200 bg-blue-50 text-blue-900" : "border-amber-200 bg-amber-50 text-amber-900"}`}
-        >
+        </header>
+        <div className={`rounded-md border px-3 py-2 text-sm ${presentation.readOnly ? "border-blue-200 bg-blue-50/70 text-blue-900" : "border-amber-200 bg-amber-50/70 text-amber-900"}`}>
           {presentation.readOnly
             ? "Reviewed truth snapshot. Historical reviewed evidence and outcomes are shown separately from the live machine proposal."
             : "Machine proposal. Live proposal fields are shown unchanged; switch modes to compare reviewed truth."}
         </div>
         <Summary rows={presentation.rows} />
-        <div className="sticky top-0 z-20 border-b border-slate-200 bg-slate-50/95 px-4 py-3 sm:px-6">
+        <section aria-label="Search and filters" className="border-b border-slate-200 pb-4">
           <div className="flex flex-wrap gap-2">
             <label className="relative min-w-64 flex-1">
               <Search
@@ -454,57 +460,32 @@ export default function EvidenceMapWorkspace({
                 aria-label="Search rules"
                 type="search"
                 value={filters.query}
-                onChange={(event) =>
-                  setFilters({ ...filters, query: event.target.value })
-                }
+                onChange={(event) => setPresentationFilter("query", event.target.value)}
                 placeholder="Search rules"
                 className="min-h-10 w-full rounded-lg border border-slate-300 bg-white pl-9 pr-3 text-sm"
               />
             </label>
-            <select
-              aria-label="Evidence state"
-              value={filters.evidenceState}
-              onChange={(event) =>
-                setFilters({
-                  ...filters,
-                  evidenceState: event.target
-                    .value as EvidenceMapPresentationFilters["evidenceState"],
-                })
-              }
-              className="rounded-lg border border-slate-300 bg-white px-3 text-sm"
-            >
-              <option value="ALL">Evidence state: All</option>
-              {["FOUND", "UNCLEAR", "MISSING", "N/A"].map((value) => (
-                <option key={value}>{value}</option>
-              ))}
-            </select>
-            <select
-              aria-label="Reviewer outcome"
-              value={filters.reviewerOutcome}
-              onChange={(event) =>
-                setFilters({ ...filters, reviewerOutcome: event.target.value })
-              }
-              className="rounded-lg border border-slate-300 bg-white px-3 text-sm"
-            >
-              <option value="ALL">Reviewer outcome: All</option>
-              {reviewerOutcomes.map((value) => (
-                <option key={value}>{value}</option>
-              ))}
-            </select>
+            <button type="button" aria-expanded={filtersOpen} aria-controls="evidence-map-secondary-filters" onClick={() => setFiltersOpen((current) => !current)} className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 text-sm font-medium text-slate-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"><SlidersHorizontal size={16} /> Filters{activeFilterCount ? ` (${activeFilterCount})` : ""}</button>
             <button
               type="button"
-              disabled={!hasPresentationFilters(filters)}
+              disabled={!filtersActive}
               onClick={() => setFilters(EMPTY_PRESENTATION_FILTERS)}
               className="inline-flex items-center gap-1.5 px-3 text-sm font-medium text-blue-700 disabled:text-slate-400"
             >
               <FilterX size={14} />
-              Clear all
+              Clear filters
             </button>
           </div>
+          {filtersOpen ? <div id="evidence-map-secondary-filters" className="mt-3 grid gap-3 rounded-lg border border-slate-200 bg-white p-3 sm:grid-cols-2 lg:grid-cols-4">
+            <label className="grid gap-1 text-xs font-medium text-slate-600">Evidence state<select aria-label="Evidence state" value={filters.evidenceState} onChange={(event) => setPresentationFilter("evidenceState", event.target.value as EvidenceMapPresentationFilters["evidenceState"])} className="min-h-10 rounded-md border border-slate-300 bg-white px-2 text-sm font-normal text-slate-900"><option value="ALL">All</option>{["FOUND", "UNCLEAR", "MISSING", "N/A"].map((value) => <option key={value}>{value}</option>)}</select></label>
+            <label className="grid gap-1 text-xs font-medium text-slate-600">Applicability<select aria-label="Applicability" value={filters.applicability} onChange={(event) => setPresentationFilter("applicability", event.target.value as EvidenceMapPresentationFilters["applicability"])} className="min-h-10 rounded-md border border-slate-300 bg-white px-2 text-sm font-normal text-slate-900"><option value="ALL">All</option><option value="APPLICABLE">Applicable</option><option value="NOT_APPLICABLE">Not applicable</option><option value="UNKNOWN">Unknown</option></select></label>
+            <label className="grid gap-1 text-xs font-medium text-slate-600">Reviewer outcome<select aria-label="Reviewer outcome" value={filters.reviewerOutcome} onChange={(event) => setPresentationFilter("reviewerOutcome", event.target.value)} className="min-h-10 rounded-md border border-slate-300 bg-white px-2 text-sm font-normal text-slate-900"><option value="ALL">All</option>{reviewerOutcomes.map((value) => <option key={value}>{value}</option>)}</select></label>
+            <label className="grid gap-1 text-xs font-medium text-slate-600">Review state<select aria-label="Review state" value={filters.reviewState} onChange={(event) => setPresentationFilter("reviewState", event.target.value)} className="min-h-10 rounded-md border border-slate-300 bg-white px-2 text-sm font-normal text-slate-900"><option value="ALL">All</option>{[...new Set(presentation.rows.map((row) => row.reviewState))].map((value) => <option key={value}>{value}</option>)}</select></label>
+          </div> : null}
           <p className="mt-2 text-xs text-slate-500">
             {rows.length} of {presentation.rows.length} rules
           </p>
-        </div>
+        </section>
         {message && !presentation.readOnly ? (
           <p
             role="status"
@@ -513,7 +494,7 @@ export default function EvidenceMapWorkspace({
             {message}
           </p>
         ) : null}
-        <section aria-label="Evidence Map rules" className="bg-white">
+        <section aria-label="Evidence Map rules" className="overflow-hidden rounded-lg border border-slate-200 bg-white">
           {rows.map((row) => (
             <article
               key={row.rowId}
@@ -524,7 +505,8 @@ export default function EvidenceMapWorkspace({
                 type="button"
                 onClick={() => toggle(row.rowId)}
                 aria-expanded={expanded.has(row.rowId)}
-                className="grid w-full gap-3 px-4 py-4 text-left sm:px-6 lg:grid-cols-[8rem_minmax(12rem,.8fr)_minmax(16rem,1.4fr)_auto] lg:items-center"
+                aria-controls={`${row.rowId}-details`}
+                className="grid min-h-20 w-full gap-3 px-4 py-4 text-left transition-colors hover:bg-slate-50 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-600 sm:px-6 lg:grid-cols-[8rem_minmax(12rem,.8fr)_minmax(16rem,1.4fr)_auto] lg:items-center motion-reduce:transition-none"
               >
                 <span className="font-mono text-xs font-semibold text-blue-700">
                   {row.ruleReference}

--- a/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
+++ b/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
@@ -8,7 +8,7 @@ import {
   ShieldCheck,
   SlidersHorizontal,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import type {
   Vm0007EvidenceMapDraftPackage,
   Vm0007EvidenceMapDraftRow,
@@ -52,6 +52,16 @@ function Badge({ value }: { value: string }) {
   );
 }
 
+export function createEvidencePreview(quote: string, maxLength = 360): string {
+  if (quote.length <= maxLength) return quote;
+  const boundary = quote.slice(0, maxLength + 1).lastIndexOf(" ");
+  return `${quote.slice(0, boundary > 0 ? boundary : maxLength).trimEnd()}…`;
+}
+
+function hasDistinctRuleTitle(row: EvidenceMapPresentationRow): boolean {
+  return Boolean(row.ruleTitle.trim() && row.ruleTitle.trim().toLocaleLowerCase() !== row.ruleReference.trim().toLocaleLowerCase());
+}
+
 function EvidenceList({
   row,
   rejected = false,
@@ -74,9 +84,7 @@ function EvidenceList({
         </span>
       </div>
       {records.length ? (
-        <div
-          className={`mt-3 divide-y divide-slate-200 rounded-xl px-4 ${rejected ? "bg-amber-50/60" : "bg-emerald-50/50"}`}
-        >
+        <div className="mt-3 space-y-3">
           {records.map((record, index) => (
             <EvidenceRecord key={`${record.spanId}-${index}`} record={record} rejected={rejected} />
           ))}
@@ -98,26 +106,26 @@ function EvidenceRecord({
   rejected: boolean;
 }) {
   const [showFull, setShowFull] = useState(false);
-  const isLong = record.quote.length > 360 || record.quote.split("\n").length > 8;
-  const detailsId = `evidence-${record.spanId}-details`;
+  const quoteId = `evidence-quote-${useId()}`;
+  const isLong = record.quote.length > 360;
+  const visibleQuote = showFull ? record.quote : createEvidencePreview(record.quote);
   return (
-    <article data-evidence-record={rejected ? "rejected" : "accepted"} className="py-4 first:pt-0 last:pb-0">
-      <blockquote className={`whitespace-pre-wrap text-sm leading-6 text-slate-800 ${isLong && !showFull ? "line-clamp-6" : ""}`}>
-        “{record.quote}”
+    <article data-evidence-record={rejected ? "rejected" : "accepted"} className={`rounded-xl border p-4 shadow-sm ${rejected ? "border-amber-200 bg-amber-50/30" : "border-slate-200 bg-white"}`}>
+      <blockquote id={quoteId} className="whitespace-pre-wrap text-[15px] leading-7 text-slate-800">
+        “{visibleQuote}”
       </blockquote>
       {isLong ? (
-        <button type="button" aria-expanded={showFull} aria-controls={detailsId} onClick={() => setShowFull((current) => !current)} className="mt-2 min-h-10 text-sm font-medium text-blue-700 underline decoration-blue-300 underline-offset-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
+        <button type="button" aria-expanded={showFull} aria-controls={quoteId} onClick={() => setShowFull((current) => !current)} className="mt-2 min-h-10 text-sm font-medium text-blue-700 underline decoration-blue-300 underline-offset-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
           {showFull ? "Show less" : "Show full evidence"}
         </button>
       ) : null}
-      <div id={detailsId}>
-        {rejected && record.rejectionReason ? <p className="mt-3 text-sm text-amber-900"><strong>Rejected because:</strong> {record.rejectionReason}</p> : null}
-        <dl className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-xs text-slate-500">
-          <div><dt className="sr-only">Page</dt><dd>Page {record.page ?? record.provenance.page ?? "—"}</dd></div>
-          <div><dt className="sr-only">Section</dt><dd>{record.section || record.provenance.sectionHeading || "No section"}</dd></div>
-          <div title={record.provenance.spanId}><dt className="sr-only">Source span</dt><dd>{record.provenance.docId} · {record.provenance.spanId}</dd></div>
-        </dl>
-      </div>
+      {rejected && record.rejectionReason ? <p className="mt-3 text-sm text-amber-900"><strong>Rejected because:</strong> {record.rejectionReason}</p> : null}
+      <dl className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-xs text-slate-500">
+        <div><dt className="sr-only">Page</dt><dd>Page {record.page ?? record.provenance.page ?? "—"}</dd></div>
+        <div><dt className="sr-only">Section</dt><dd>{record.section || record.provenance.sectionHeading || "No section"}</dd></div>
+        <div><dt className="sr-only">Document</dt><dd>{record.provenance.docId}</dd></div>
+        <div title={record.provenance.spanId}><dt className="sr-only">Source span</dt><dd>{record.provenance.spanId}</dd></div>
+      </dl>
     </article>
   );
 }
@@ -136,18 +144,16 @@ function RuleDetails({
   return (
     <div
       id={`${row.rowId}-details`}
-      className="grid overflow-hidden border-t border-slate-200 bg-slate-50/70 px-4 py-6 sm:px-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,.6fr)] lg:gap-10"
+      className="grid overflow-hidden border-t border-slate-200 bg-white px-4 py-6 sm:px-6 lg:grid-cols-[minmax(16rem,280px)_minmax(0,1fr)_minmax(18rem,300px)] lg:gap-8"
     >
-      <div className="space-y-8">
+      <div className="grid gap-6 lg:col-span-2 lg:grid-cols-[280px_minmax(0,1fr)]">
+        <div className="space-y-6 rounded-xl border border-slate-200 bg-white p-5">
         <section>
           <h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">
             Requirement
           </h3>
           <p className="mt-3 text-sm leading-6 text-slate-800">
             {row.requirementText}
-          </p>
-          <p className="mt-2 font-mono text-xs text-slate-500">
-            {row.stableRuleId}
           </p>
         </section>
         <section>
@@ -221,8 +227,10 @@ function RuleDetails({
             ) : null}
           </dl>
         </section>
+        </div>
+        <div className="space-y-6">
         <EvidenceList row={row} />
-        <EvidenceList row={row} rejected />
+          <EvidenceList row={row} rejected />
         {row.supportedComponents || row.missingComponents ? (
           <section
             data-component-coverage
@@ -237,14 +245,16 @@ function RuleDetails({
             </p>
           </section>
         ) : null}
+        </div>
       </div>
-      <aside className="mt-8 border-t border-slate-200 pt-6 lg:mt-0 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0">
+      <aside className="border-t border-slate-200 pt-6 lg:col-start-3 lg:row-start-1 lg:mt-0 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0">
         <h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">
           Gap and action
         </h3>
-        <p className="mt-3 text-sm leading-6 text-slate-700">
-          {row.clientAction || row.gap || "No action recorded."}
-        </p>
+        <div className="mt-3 space-y-4 text-sm leading-6 text-slate-700">
+          <div><h4 className="font-medium text-slate-950">Gap</h4><p>{row.gap || "No gap recorded."}</p></div>
+          <div><h4 className="font-medium text-slate-950">Client action</h4><p>{row.clientAction || "No client action recorded."}</p></div>
+        </div>
         {!readOnly ? (
           <section className="mt-6">
             <h3 className="text-xs font-semibold uppercase tracking-[.12em] text-slate-500">
@@ -298,7 +308,7 @@ function Summary({ rows }: { rows: readonly EvidenceMapPresentationRow[] }) {
   return (
     <nav
       aria-label="Evidence Map summary"
-      className="flex flex-wrap items-center gap-x-5 gap-y-2 border-y border-slate-200 py-3 text-sm"
+      className="flex flex-wrap items-center gap-x-5 gap-y-2 rounded-xl border border-slate-200 bg-white px-5 py-4 text-sm shadow-sm"
     >
       {items.map(([name, count]) => (
         <div key={name} className="flex items-baseline gap-1.5 border-l border-slate-200 pl-5 first:border-l-0 first:pl-0">
@@ -382,8 +392,8 @@ export default function EvidenceMapWorkspace({
   ) => setFilters((current) => ({ ...current, [key]: value }));
   return (
     <main className="min-h-screen w-full bg-slate-50 text-slate-950">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-4 py-8 md:px-8">
-        <header className="flex flex-col gap-4 border-b border-slate-200 pb-5 lg:flex-row lg:items-start lg:justify-between">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-8 md:px-8">
+        <header className="flex flex-col gap-5 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm lg:flex-row lg:items-center lg:justify-between lg:p-6">
           <div>
             <div className="flex items-center gap-2">
               <FileText size={18} className="text-blue-600" />
@@ -394,8 +404,7 @@ export default function EvidenceMapWorkspace({
                   reviewedSnapshot?.sourceDocument.documentId}
               </p>
             </div>
-            <p className="mt-3 text-xs font-medium uppercase tracking-[.08em] text-slate-500">Evidence Map</p>
-            <h1 className="mt-1 text-2xl font-semibold tracking-tight">Evidence Map · {presentation.readOnly ? "Reviewed truth" : "Machine proposal"}</h1>
+            <h1 className="mt-3 text-2xl font-semibold tracking-tight">Evidence Map · {presentation.readOnly ? "Reviewed truth" : "Machine proposal"}</h1>
             <p className="mt-2 text-xs text-slate-500">
               {pkg?.methodologyId || reviewedSnapshot?.methodologyId}{" "}
               {pkg?.rulebookVersion || reviewedSnapshot?.methodologyVersion} ·
@@ -443,13 +452,13 @@ export default function EvidenceMapWorkspace({
             </button>
           </div>
         </header>
-        <div className={`rounded-md border px-3 py-2 text-sm ${presentation.readOnly ? "border-blue-200 bg-blue-50/70 text-blue-900" : "border-amber-200 bg-amber-50/70 text-amber-900"}`}>
+        <div className={`rounded-lg border px-4 py-3 text-sm ${presentation.readOnly ? "border-blue-200/80 bg-white text-blue-900" : "border-amber-200/80 bg-white text-amber-900"}`}>
           {presentation.readOnly
             ? "Reviewed truth snapshot. Historical reviewed evidence and outcomes are shown separately from the live machine proposal."
             : "Machine proposal. Live proposal fields are shown unchanged; switch modes to compare reviewed truth."}
         </div>
         <Summary rows={presentation.rows} />
-        <section aria-label="Search and filters" className="border-b border-slate-200 pb-4">
+        <section aria-label="Search and filters" className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
           <div className="flex flex-wrap gap-2">
             <label className="relative min-w-64 flex-1">
               <Search
@@ -494,7 +503,10 @@ export default function EvidenceMapWorkspace({
             {message}
           </p>
         ) : null}
-        <section aria-label="Evidence Map rules" className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+        <section aria-label="Evidence Map rules" className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <div className="hidden grid-cols-[8rem_minmax(12rem,1fr)_minmax(7rem,auto)_minmax(8rem,auto)_auto] gap-3 border-b border-slate-200 bg-slate-50/70 px-6 py-3 text-[11px] font-semibold text-slate-500 lg:grid">
+            <span>Rule</span><span>Requirement / preview</span><span>Evidence state</span><span>Reviewer outcome</span><span className="sr-only">Expand</span>
+          </div>
           {rows.map((row) => (
             <article
               key={row.rowId}
@@ -506,25 +518,19 @@ export default function EvidenceMapWorkspace({
                 onClick={() => toggle(row.rowId)}
                 aria-expanded={expanded.has(row.rowId)}
                 aria-controls={`${row.rowId}-details`}
-                className="grid min-h-20 w-full gap-3 px-4 py-4 text-left transition-colors hover:bg-slate-50 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-600 sm:px-6 lg:grid-cols-[8rem_minmax(12rem,.8fr)_minmax(16rem,1.4fr)_auto] lg:items-center motion-reduce:transition-none"
+                className="grid min-h-20 w-full gap-3 px-4 py-4 text-left transition-colors hover:bg-slate-50 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-600 sm:px-6 lg:grid-cols-[8rem_minmax(12rem,1fr)_minmax(7rem,auto)_minmax(8rem,auto)_auto] lg:items-center motion-reduce:transition-none"
               >
                 <span className="font-mono text-xs font-semibold text-blue-700">
                   {row.ruleReference}
                 </span>
                 <div>
-                  <h2 className="text-sm font-semibold">{row.ruleTitle}</h2>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    <Badge value={row.evidenceState} />
-                    <Badge value={row.reviewerOutcome} />
-                  </div>
+                  {hasDistinctRuleTitle(row) ? <h2 className="text-sm font-semibold text-slate-950">{row.ruleTitle}</h2> : <h2 className="sr-only">{row.ruleReference}</h2>}
+                  <p className="mt-1 text-sm leading-5 text-slate-600">
+                    {createEvidencePreview(row.acceptedEvidence[0]?.quote || row.gap || row.clientAction || row.assessmentReason || "No evidence preview recorded.", 180)}
+                  </p>
                 </div>
-                <p className="line-clamp-2 text-sm text-slate-600">
-                  {row.acceptedEvidence[0]?.quote ||
-                    row.gap ||
-                    row.clientAction ||
-                    row.assessmentReason ||
-                    "No evidence preview recorded."}
-                </p>
+                <Badge value={row.evidenceState} />
+                <Badge value={row.reviewerOutcome} />
                 <ChevronDown
                   size={18}
                   className={expanded.has(row.rowId) ? "rotate-180" : ""}

--- a/tests/components/vm0007EvidenceMapDraftPage.test.tsx
+++ b/tests/components/vm0007EvidenceMapDraftPage.test.tsx
@@ -382,19 +382,25 @@ describe("VM0007 Evidence Map review workspace", () => {
     const auditId = "ui-filters";
     savePackage(auditId);
     const { container, root } = await renderPage(auditId);
+    const filtersToggle = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Filters"));
+    expect(filtersToggle?.getAttribute("aria-expanded")).toBe("false");
+    click(filtersToggle ?? null);
+    expect(filtersToggle?.getAttribute("aria-expanded")).toBe("true");
     change(
       container.querySelector('select[aria-label="Evidence state"]'),
       "FOUND",
     );
+    expect(filtersToggle?.textContent).toContain("Filters (1)");
     expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(
       1,
     );
     expect(container.textContent).toContain("1 of 58 rules");
     click(
       Array.from(container.querySelectorAll("button")).find((button) =>
-        button.textContent?.includes("Clear all"),
+        button.textContent?.includes("Clear filters"),
       ) ?? null,
     );
+    expect(filtersToggle?.textContent).toBe(" Filters");
     expect(container.querySelectorAll("[data-evidence-map-row]")).toHaveLength(
       58,
     );

--- a/tests/components/vm0007EvidenceMapDraftPage.test.tsx
+++ b/tests/components/vm0007EvidenceMapDraftPage.test.tsx
@@ -456,6 +456,33 @@ describe("VM0007 Evidence Map review workspace", () => {
     act(() => root.unmount());
   });
 
+  test("uses deterministic full-quote disclosure with unique accessible controls", async () => {
+    const auditId = "ui-long-evidence";
+    const longQuote = Array.from({ length: 80 }, (_, index) => `evidence-word-${index}`).join(" ");
+    const rows = makeRows(auditId);
+    rows[0] = {
+      ...rows[0],
+      acceptedEvidence: rows[0].acceptedEvidence?.map((record) => ({ ...record, quote: longQuote })),
+    };
+    savePackage(auditId, rows);
+    const { container, root } = await renderPage(auditId);
+    click(container.querySelector(`[data-evidence-map-row="${auditId}:R-1"] > button`));
+    const disclosureButtons = Array.from(container.querySelectorAll("button")).filter((button) => button.textContent === "Show full evidence");
+    expect(disclosureButtons).toHaveLength(2);
+    const controls = disclosureButtons.map((button) => button.getAttribute("aria-controls"));
+    expect(new Set(controls).size).toBe(2);
+    for (const id of controls) expect(id && document.getElementById(id)).not.toBeNull();
+    expect(disclosureButtons[0]?.getAttribute("aria-expanded")).toBe("false");
+    expect(container.textContent).not.toContain(longQuote);
+    click(disclosureButtons[0] ?? null);
+    expect(disclosureButtons[0]?.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain(longQuote);
+    expect(Array.from(container.querySelectorAll("button")).some((button) => button.textContent === "Show less")).toBe(true);
+    click(Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "Show less") ?? null);
+    expect(container.textContent).not.toContain(longQuote);
+    act(() => root.unmount());
+  });
+
   test("uses an accessible review panel and the existing reviewer workflow without browser prompts", async () => {
     const promptSpy = jest.spyOn(window, "prompt");
     const auditId = "ui-review";


### PR DESCRIPTION
### Summary

- Polished the RC1 Evidence Map against the supplied Article6 reference: wider max-w-7xl workspace, coherent header, white metric/toolbar/list surfaces, restrained borders, and a modern review-table hierarchy.
- Added desktop Rule / Requirement-preview / Evidence-state / Reviewer-outcome columns while keeping all 58 rows visible.
- Reworked expanded rows into assessment, evidence, and gap/action/review regions; accepted and rejected evidence remain separate cards.
- Removed duplicate rule identifiers when ruleTitle is only a case/whitespace variant of ruleReference.
- Fixed long evidence disclosure with deterministic word-boundary previews, exact full quote restoration, collision-safe useId controls, and aria-controls pointing at the changing quote.
- Used desktop/a.png as the visual reference guide.

### Roadmap-Update
- slug: interactive-evidence-review-mvp
- items:
  - RC1: in_progress

### Compatibility

- No evidenceMapPresentationModel truth mapping changed.
- No audit, parser, persistence, storage key, finalization, report, export, routing, or fixture behavior changed.
- Machine proposal and reviewed truth remain separate; reviewed snapshots remain read-only.

### Validation

- Focused Evidence Map tests: 8 passed.
- git diff --check: passed.
- npm run lint: passed.
- npm run typecheck: passed.
- npm run build: passed.
- npm run pr:check:local: passed.
- Dev server and real Evidence Map route verified with Playwright at 1440px, 1024px, 768px, and 390px: 58 rows and no horizontal overflow at each width.
- Verified expanded reviewed details, accepted/rejected evidence, filters, keyboard-addressable rows, and reduced-motion context.
- Screenshots: /tmp/article6-rc1-1440px.png, /tmp/article6-rc1-1024px.png, /tmp/article6-rc1-768px.png, /tmp/article6-rc1-390px.png, /tmp/article6-rc1-ref-1440-expanded-final.png, /tmp/article6-rc1-ref-1440-filters-final.png.
- Existing smoke script remains blocked by its unrelated prerequisite expecting a Verify control at scripts/test-evidence-map-smoke.cjs:30.