### PR TITLE
chore(roadmap): activate RC2 accuracy benchmark

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -141,7 +141,7 @@ Details: `docs/roadmaps/interactive-evidence-review-mvp/PLAN.md`
 
 1) RC0 — Roadmap contract: Done
 2) RC1 — Readable interactive workspace: Done
-3) RC2 — Accuracy benchmark: Planned
+3) RC2 — Accuracy benchmark: Active
 4) RC3 — Generic accuracy improvements: Planned
 5) RC4 — Guided reviewer interaction: Planned
 6) RC5 — Unseen-PDD validation: Planned

--- a/docs/roadmaps/interactive-evidence-review-mvp/PLAN.md
+++ b/docs/roadmaps/interactive-evidence-review-mvp/PLAN.md
@@ -25,8 +25,8 @@ truthfulness > reviewer usability > measurable accuracy > visual polish
 | Phase | Title | Status | Gate |
 |---|---|---|---|
 | 0 | Roadmap contract | Done | Roadmap files validate and no production code changes |
-| 1 | Readable interactive workspace | Active | A reviewer can scan all 58 rows and understand an expanded row without visual confusion |
-| 2 | Accuracy benchmark | Planned | Highest-impact generic failure modes are ranked and reproducible |
+| 1 | Readable interactive workspace | Done | A reviewer can scan all 58 rows and understand an expanded row without visual confusion |
+| 2 | Accuracy benchmark | Active | Highest-impact generic failure modes are ranked and reproducible |
 | 3 | Generic accuracy improvements | Planned | Accuracy improves without fixture regressions |
 | 4 | Guided reviewer interaction | Planned | A reviewer can complete all 58 decisions without leaving the Evidence Map |
 | 5 | Unseen-PDD validation | Planned | The same workflow works without project-specific fixes |

--- a/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
+++ b/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
@@ -1,6 +1,6 @@
 {
   "RC0": "done",
-  "currentPhase": "RC1",
+  "currentPhase": "RC2",
   "name": "Interactive Evidence Review MVP",
   "phases": {
     "phase_0_roadmap_contract": {
@@ -13,7 +13,7 @@
     },
     "phase_2_accuracy_benchmark": {
       "title": "Accuracy benchmark",
-      "status": "planned"
+      "status": "active"
     },
     "phase_3_generic_accuracy_improvements": {
       "title": "Generic accuracy improvements",


### PR DESCRIPTION
### Summary

- Advances the Interactive Evidence Review MVP current phase from RC1 to RC2.
- Marks RC2 Accuracy benchmark as active while keeping RC1 done.
- Aligns the roadmap phase table with the SSOT.

### Scope

- Documentation and roadmap state only.
- No production, fixture, review, report, export, or UI changes.