### PR TITLE
test: add 58-row accuracy benchmark contract

### DIFF
--- a/src/lib/preverif/vm0007Benchmark.ts
+++ b/src/lib/preverif/vm0007Benchmark.ts
@@ -155,6 +155,14 @@ function requiredReviewedValue(row: Vm0007ReviewedTruthRow, field: keyof Vm0007R
   return row[field];
 }
 
+function requiredReviewedString(row: Vm0007ReviewedTruthRow, field: "contradictionState" | "clientAction", index: number): string {
+  const value = requiredReviewedValue(row, field, index);
+  if (typeof value !== "string") {
+    throw new Error(`reviewed row ${rowLabel(row, index)} has invalid ${field}; expected a string`);
+  }
+  return value;
+}
+
 export function deriveReviewedApplicability(finalEvidenceState: unknown, rowDescription = "reviewed row"): "APPLICABLE" | "NOT_APPLICABLE" {
   if (typeof finalEvidenceState !== "string" || !REVIEWED_EVIDENCE_STATES.has(finalEvidenceState)) {
     throw new Error(`${rowDescription} has invalid finalEvidenceState ${String(finalEvidenceState)}`);
@@ -176,9 +184,12 @@ function validateReviewedTruthRow(row: Vm0007ReviewedTruthRow, index: number): v
   if (Object.prototype.hasOwnProperty.call(row, "applicability") && row.applicability !== expectedApplicability) {
     throw new Error(`${description} applicability ${String(row.applicability)} contradicts canonical applicability ${expectedApplicability}`);
   }
-  requiredReviewedValue(row, "contradictionState", index);
-  requiredReviewedValue(row, "draftFindingCandidate", index);
-  requiredReviewedValue(row, "clientAction", index);
+  requiredReviewedString(row, "contradictionState", index);
+  const draftFindingCandidate = requiredReviewedValue(row, "draftFindingCandidate", index);
+  if (draftFindingCandidate !== null && typeof draftFindingCandidate !== "string") {
+    throw new Error(`${description} has invalid draftFindingCandidate; expected a string or null`);
+  }
+  requiredReviewedString(row, "clientAction", index);
 }
 
 export function machineProposalToBenchmarkRows(rows: readonly Vm0007MachineProposalRow[]): Vm0007BenchmarkSourceRow[] {
@@ -218,6 +229,9 @@ function validateReviewedBenchmarkRows(rows: ReadonlyMap<string, Vm0007Benchmark
       if (row.values[field] === undefined) {
         throw new Error(`reviewed row ${stableRuleId} has absent required benchmark field ${field}`);
       }
+      if (row.values[field] === null && field !== "draftFinding") {
+        throw new Error(`reviewed row ${stableRuleId} has invalid null for ${field}; only draftFinding may be null`);
+      }
     }
     const evidenceState = row.values.evidenceState;
     const reviewerOutcome = row.values.reviewerOutcome;
@@ -227,6 +241,15 @@ function validateReviewedBenchmarkRows(rows: ReadonlyMap<string, Vm0007Benchmark
     }
     if (typeof reviewerOutcome !== "string" || !REVIEWED_OUTCOMES.has(reviewerOutcome)) {
       throw new Error(`reviewed row ${stableRuleId} has invalid reviewerOutcome ${String(reviewerOutcome)}`);
+    }
+    if (typeof row.values.contradictionState !== "string") {
+      throw new Error(`reviewed row ${stableRuleId} has invalid contradictionState; expected a string`);
+    }
+    if (typeof row.values.clientAction !== "string") {
+      throw new Error(`reviewed row ${stableRuleId} has invalid clientAction; expected a string`);
+    }
+    if (row.values.draftFinding !== null && typeof row.values.draftFinding !== "string") {
+      throw new Error(`reviewed row ${stableRuleId} has invalid draftFinding; expected a string or null`);
     }
     const expectedApplicability = deriveReviewedApplicability(evidenceState, `reviewed row ${stableRuleId}`);
     if (applicability !== expectedApplicability || (expectedApplicability === "NOT_APPLICABLE") !== (reviewerOutcome === "NOT_APPLICABLE")) {

--- a/src/lib/preverif/vm0007Benchmark.ts
+++ b/src/lib/preverif/vm0007Benchmark.ts
@@ -77,6 +77,8 @@ export type Vm0007BenchmarkResult = Readonly<{
 }>;
 
 const FIELD_SET = new Set<string>(VM0007_BENCHMARK_FIELDS);
+const REVIEWED_EVIDENCE_STATES = new Set(["FOUND", "UNCLEAR", "MISSING", "N/A"]);
+const REVIEWED_OUTCOMES = new Set(["CONFORMS", "ACTION_REQUIRED", "NOT_APPLICABLE"]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -94,9 +96,10 @@ function normalizedValue(field: Vm0007BenchmarkField, value: BenchmarkValue): Be
   return value;
 }
 
-function valueEquals(field: Vm0007BenchmarkField, left: BenchmarkValue, right: BenchmarkValue): boolean {
+export function compareBenchmarkValues(field: Vm0007BenchmarkField, left: BenchmarkValue, right: BenchmarkValue): boolean {
   const a = normalizedValue(field, left);
   const b = normalizedValue(field, right);
+  if (a.kind === "absent" || b.kind === "absent") return false;
   if (a.kind !== b.kind) return false;
   if (a.kind !== "value" || b.kind !== "value") return true;
   return Object.is(a.value, b.value);
@@ -141,6 +144,43 @@ function sourceValues(values: Vm0007BenchmarkValues): Vm0007BenchmarkValues {
   return values;
 }
 
+function rowLabel(row: Vm0007ReviewedTruthRow, index: number): string {
+  return typeof row.ruleId === "string" && row.ruleId.trim() ? row.ruleId : `index ${index}`;
+}
+
+function requiredReviewedValue(row: Vm0007ReviewedTruthRow, field: keyof Vm0007ReviewedTruthRow, index: number): unknown {
+  if (!Object.prototype.hasOwnProperty.call(row, field) || row[field] === undefined) {
+    throw new Error(`reviewed row ${rowLabel(row, index)} has absent required field ${field}`);
+  }
+  return row[field];
+}
+
+export function deriveReviewedApplicability(finalEvidenceState: unknown, rowDescription = "reviewed row"): "APPLICABLE" | "NOT_APPLICABLE" {
+  if (typeof finalEvidenceState !== "string" || !REVIEWED_EVIDENCE_STATES.has(finalEvidenceState)) {
+    throw new Error(`${rowDescription} has invalid finalEvidenceState ${String(finalEvidenceState)}`);
+  }
+  return finalEvidenceState === "N/A" ? "NOT_APPLICABLE" : "APPLICABLE";
+}
+
+function validateReviewedTruthRow(row: Vm0007ReviewedTruthRow, index: number): void {
+  const description = `reviewed row ${rowLabel(row, index)}`;
+  const finalEvidenceState = requiredReviewedValue(row, "finalEvidenceState", index);
+  const reviewerOutcome = requiredReviewedValue(row, "reviewerOutcome", index);
+  const expectedApplicability = deriveReviewedApplicability(finalEvidenceState, description);
+  if (typeof reviewerOutcome !== "string" || !REVIEWED_OUTCOMES.has(reviewerOutcome)) {
+    throw new Error(`${description} has invalid reviewerOutcome ${String(reviewerOutcome)}`);
+  }
+  if ((expectedApplicability === "NOT_APPLICABLE") !== (reviewerOutcome === "NOT_APPLICABLE")) {
+    throw new Error(`${description} contradicts reviewed applicability: finalEvidenceState=${String(finalEvidenceState)} requires reviewerOutcome=${expectedApplicability === "NOT_APPLICABLE" ? "NOT_APPLICABLE" : "CONFORMS or ACTION_REQUIRED"}`);
+  }
+  if (Object.prototype.hasOwnProperty.call(row, "applicability") && row.applicability !== expectedApplicability) {
+    throw new Error(`${description} applicability ${String(row.applicability)} contradicts canonical applicability ${expectedApplicability}`);
+  }
+  requiredReviewedValue(row, "contradictionState", index);
+  requiredReviewedValue(row, "draftFindingCandidate", index);
+  requiredReviewedValue(row, "clientAction", index);
+}
+
 export function machineProposalToBenchmarkRows(rows: readonly Vm0007MachineProposalRow[]): Vm0007BenchmarkSourceRow[] {
   return rows.map((row) => ({
     stableRuleId: row.stableRuleId,
@@ -156,19 +196,43 @@ export function machineProposalToBenchmarkRows(rows: readonly Vm0007MachinePropo
 }
 
 export function reviewedTruthToBenchmarkRows(rows: readonly Vm0007ReviewedTruthRow[]): Vm0007BenchmarkSourceRow[] {
-  return rows.map((row) => ({
+  return rows.map((row, index) => {
+    validateReviewedTruthRow(row, index);
+    return {
     stableRuleId: row.ruleId,
     values: sourceValues({
       evidenceState: row.finalEvidenceState,
-      applicability: Object.prototype.hasOwnProperty.call(row, "applicability")
-        ? row.applicability
-        : row.reviewerOutcome === "NOT_APPLICABLE" ? "NOT_APPLICABLE" : row.reviewerOutcome === undefined ? undefined : "APPLICABLE",
+      applicability: deriveReviewedApplicability(row.finalEvidenceState, `reviewed row ${rowLabel(row, index)}`),
       reviewerOutcome: row.reviewerOutcome,
       contradictionState: row.contradictionState,
       draftFinding: row.draftFindingCandidate,
       clientAction: row.clientAction,
     }),
-  }));
+    };
+  });
+}
+
+function validateReviewedBenchmarkRows(rows: ReadonlyMap<string, Vm0007BenchmarkSourceRow>): void {
+  for (const [stableRuleId, row] of rows) {
+    for (const field of VM0007_BENCHMARK_FIELDS) {
+      if (row.values[field] === undefined) {
+        throw new Error(`reviewed row ${stableRuleId} has absent required benchmark field ${field}`);
+      }
+    }
+    const evidenceState = row.values.evidenceState;
+    const reviewerOutcome = row.values.reviewerOutcome;
+    const applicability = row.values.applicability;
+    if (typeof evidenceState !== "string" || !REVIEWED_EVIDENCE_STATES.has(evidenceState)) {
+      throw new Error(`reviewed row ${stableRuleId} has invalid evidenceState ${String(evidenceState)}`);
+    }
+    if (typeof reviewerOutcome !== "string" || !REVIEWED_OUTCOMES.has(reviewerOutcome)) {
+      throw new Error(`reviewed row ${stableRuleId} has invalid reviewerOutcome ${String(reviewerOutcome)}`);
+    }
+    const expectedApplicability = deriveReviewedApplicability(evidenceState, `reviewed row ${stableRuleId}`);
+    if (applicability !== expectedApplicability || (expectedApplicability === "NOT_APPLICABLE") !== (reviewerOutcome === "NOT_APPLICABLE")) {
+      throw new Error(`reviewed row ${stableRuleId} has contradictory applicability: evidenceState=${evidenceState}, applicability=${String(applicability)}, reviewerOutcome=${reviewerOutcome}`);
+    }
+  }
 }
 
 export function evaluateVm0007Benchmark(input: Readonly<{
@@ -182,6 +246,7 @@ export function evaluateVm0007Benchmark(input: Readonly<{
   if (expectedErrors) throw new Error(expectedErrors);
   const machineById = validateSourceRows("machine", input.machineRows, expected);
   const reviewedById = validateSourceRows("reviewed", input.reviewedRows, expected);
+  validateReviewedBenchmarkRows(reviewedById);
 
   const rows = [...expected].sort().map((stableRuleId) => {
     const machineValues = valuesFromRecord(machineById.get(stableRuleId)!.values);
@@ -189,7 +254,7 @@ export function evaluateVm0007Benchmark(input: Readonly<{
     const fields = Object.fromEntries(VM0007_BENCHMARK_FIELDS.map((field) => {
       const machine = machineValues[field];
       const reviewed = reviewedValues[field];
-      return [field, { machine, reviewed, matches: valueEquals(field, machine, reviewed) }];
+      return [field, { machine, reviewed, matches: compareBenchmarkValues(field, machine, reviewed) }];
     })) as Readonly<Record<Vm0007BenchmarkField, BenchmarkFieldResult>>;
     return { stableRuleId, machineValues, reviewedValues, fields, fullyMatches: VM0007_BENCHMARK_FIELDS.every((field) => fields[field].matches) };
   });

--- a/src/lib/preverif/vm0007Benchmark.ts
+++ b/src/lib/preverif/vm0007Benchmark.ts
@@ -1,0 +1,214 @@
+export const VM0007_BENCHMARK_ROW_COUNT = 58 as const;
+
+export const VM0007_BENCHMARK_FIELDS = [
+  "evidenceState",
+  "applicability",
+  "reviewerOutcome",
+  "contradictionState",
+  "draftFinding",
+  "clientAction",
+] as const;
+
+export type Vm0007BenchmarkField = (typeof VM0007_BENCHMARK_FIELDS)[number];
+
+export type BenchmarkValue<T = unknown> =
+  | Readonly<{ kind: "value"; value: T }>
+  | Readonly<{ kind: "null" }>
+  | Readonly<{ kind: "absent" }>;
+
+export type Vm0007BenchmarkValues = Readonly<Record<Vm0007BenchmarkField, unknown>>;
+
+export type Vm0007BenchmarkSourceRow = Readonly<{
+  stableRuleId: unknown;
+  values: Vm0007BenchmarkValues;
+}>;
+
+export type Vm0007MachineProposalRow = Readonly<{
+  stableRuleId: unknown;
+  upstreamStatus?: unknown;
+  proposedApplicability?: unknown;
+  reviewerOutcome?: unknown;
+  contradictionState?: unknown;
+  draftFindingCandidate?: unknown;
+  clientAction?: unknown;
+}>;
+
+export type Vm0007ReviewedTruthRow = Readonly<{
+  ruleId: unknown;
+  finalEvidenceState?: unknown;
+  applicability?: unknown;
+  reviewerOutcome?: unknown;
+  contradictionState?: unknown;
+  draftFindingCandidate?: unknown;
+  clientAction?: unknown;
+}>;
+
+export type BenchmarkFieldResult = Readonly<{
+  machine: BenchmarkValue;
+  reviewed: BenchmarkValue;
+  matches: boolean;
+}>;
+
+export type Vm0007BenchmarkRowResult = Readonly<{
+  stableRuleId: string;
+  machineValues: Readonly<Record<Vm0007BenchmarkField, BenchmarkValue>>;
+  reviewedValues: Readonly<Record<Vm0007BenchmarkField, BenchmarkValue>>;
+  fields: Readonly<Record<Vm0007BenchmarkField, BenchmarkFieldResult>>;
+  fullyMatches: boolean;
+}>;
+
+export type Vm0007BenchmarkAggregate = Readonly<{
+  totalExpectedRows: number;
+  totalAlignedRows: number;
+  fields: Readonly<Record<Vm0007BenchmarkField, Readonly<{
+    matchedCount: number;
+    mismatchedCount: number;
+    agreementRate: number;
+    mismatchedRuleIds: readonly string[];
+  }>>>;
+  totalFullyMatchingRows: number;
+  totalRowsWithAtLeastOneMismatch: number;
+  mismatchedRuleIds: readonly string[];
+}>;
+
+export type Vm0007BenchmarkResult = Readonly<{
+  rows: readonly Vm0007BenchmarkRowResult[];
+  aggregate: Vm0007BenchmarkAggregate;
+}>;
+
+const FIELD_SET = new Set<string>(VM0007_BENCHMARK_FIELDS);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function explicitValue(value: unknown): BenchmarkValue {
+  if (value === undefined) return { kind: "absent" };
+  if (value === null) return { kind: "null" };
+  return { kind: "value", value };
+}
+
+function normalizedValue(field: Vm0007BenchmarkField, value: BenchmarkValue): BenchmarkValue {
+  if (value.kind !== "value") return value;
+  if (field !== "clientAction" && typeof value.value === "string") return { kind: "value", value: value.value.trim() };
+  return value;
+}
+
+function valueEquals(field: Vm0007BenchmarkField, left: BenchmarkValue, right: BenchmarkValue): boolean {
+  const a = normalizedValue(field, left);
+  const b = normalizedValue(field, right);
+  if (a.kind !== b.kind) return false;
+  if (a.kind !== "value" || b.kind !== "value") return true;
+  return Object.is(a.value, b.value);
+}
+
+function valuesFromRecord(values: Vm0007BenchmarkValues): Readonly<Record<Vm0007BenchmarkField, BenchmarkValue>> {
+  return Object.fromEntries(VM0007_BENCHMARK_FIELDS.map((field) => [field, explicitValue(values[field])])) as Readonly<Record<Vm0007BenchmarkField, BenchmarkValue>>;
+}
+
+function validateSourceRows(side: string, rows: readonly Vm0007BenchmarkSourceRow[], expectedIds: ReadonlySet<string>): Map<string, Vm0007BenchmarkSourceRow> {
+  const errors: string[] = [];
+  if (rows.length !== VM0007_BENCHMARK_ROW_COUNT) {
+    errors.push(`${side} row count ${rows.length}; expected exactly ${VM0007_BENCHMARK_ROW_COUNT}`);
+  }
+
+  const byId = new Map<string, Vm0007BenchmarkSourceRow>();
+  const missingIds: string[] = [];
+  const duplicateIds: string[] = [];
+  for (const [index, row] of rows.entries()) {
+    const id = typeof row?.stableRuleId === "string" ? row.stableRuleId.trim() : "";
+    if (!id) {
+      missingIds.push(`index ${index}`);
+      continue;
+    }
+    if (byId.has(id)) duplicateIds.push(id);
+    byId.set(id, row);
+  }
+  if (missingIds.length) errors.push(`${side} missing or empty stable IDs at ${missingIds.join(", ")}`);
+  if (duplicateIds.length) errors.push(`${side} duplicate stable IDs: ${[...new Set(duplicateIds)].sort().join(", ")}`);
+
+  const unexpected = [...byId.keys()].filter((id) => !expectedIds.has(id)).sort();
+  const missingExpected = [...expectedIds].filter((id) => !byId.has(id)).sort();
+  if (unexpected.length) errors.push(`${side} unexpected stable IDs: ${unexpected.join(", ")}`);
+  if (missingExpected.length) errors.push(`${side} missing expected stable IDs: ${missingExpected.join(", ")}`);
+  if (errors.length) throw new Error(errors.join("; "));
+  return byId;
+}
+
+function sourceValues(values: Vm0007BenchmarkValues): Vm0007BenchmarkValues {
+  if (!isRecord(values)) throw new Error("Benchmark row values must be an object");
+  if (Object.keys(values).some((field) => !FIELD_SET.has(field))) throw new Error("Benchmark row values contain an unsupported field");
+  return values;
+}
+
+export function machineProposalToBenchmarkRows(rows: readonly Vm0007MachineProposalRow[]): Vm0007BenchmarkSourceRow[] {
+  return rows.map((row) => ({
+    stableRuleId: row.stableRuleId,
+    values: sourceValues({
+      evidenceState: row.upstreamStatus,
+      applicability: row.proposedApplicability,
+      reviewerOutcome: row.reviewerOutcome,
+      contradictionState: row.contradictionState,
+      draftFinding: row.draftFindingCandidate,
+      clientAction: row.clientAction,
+    }),
+  }));
+}
+
+export function reviewedTruthToBenchmarkRows(rows: readonly Vm0007ReviewedTruthRow[]): Vm0007BenchmarkSourceRow[] {
+  return rows.map((row) => ({
+    stableRuleId: row.ruleId,
+    values: sourceValues({
+      evidenceState: row.finalEvidenceState,
+      applicability: Object.prototype.hasOwnProperty.call(row, "applicability")
+        ? row.applicability
+        : row.reviewerOutcome === "NOT_APPLICABLE" ? "NOT_APPLICABLE" : row.reviewerOutcome === undefined ? undefined : "APPLICABLE",
+      reviewerOutcome: row.reviewerOutcome,
+      contradictionState: row.contradictionState,
+      draftFinding: row.draftFindingCandidate,
+      clientAction: row.clientAction,
+    }),
+  }));
+}
+
+export function evaluateVm0007Benchmark(input: Readonly<{
+  machineRows: readonly Vm0007BenchmarkSourceRow[];
+  reviewedRows: readonly Vm0007BenchmarkSourceRow[];
+  expectedStableRuleIds: readonly string[];
+}>): Vm0007BenchmarkResult {
+  const expected = new Set(input.expectedStableRuleIds.map((id) => id.trim()).filter(Boolean));
+  if (expected.size !== VM0007_BENCHMARK_ROW_COUNT) throw new Error(`expected stable ID registry contains ${expected.size} IDs; expected exactly ${VM0007_BENCHMARK_ROW_COUNT}`);
+  const expectedErrors = input.expectedStableRuleIds.length !== expected.size ? "expected stable ID registry contains duplicate, missing, or empty IDs" : "";
+  if (expectedErrors) throw new Error(expectedErrors);
+  const machineById = validateSourceRows("machine", input.machineRows, expected);
+  const reviewedById = validateSourceRows("reviewed", input.reviewedRows, expected);
+
+  const rows = [...expected].sort().map((stableRuleId) => {
+    const machineValues = valuesFromRecord(machineById.get(stableRuleId)!.values);
+    const reviewedValues = valuesFromRecord(reviewedById.get(stableRuleId)!.values);
+    const fields = Object.fromEntries(VM0007_BENCHMARK_FIELDS.map((field) => {
+      const machine = machineValues[field];
+      const reviewed = reviewedValues[field];
+      return [field, { machine, reviewed, matches: valueEquals(field, machine, reviewed) }];
+    })) as Readonly<Record<Vm0007BenchmarkField, BenchmarkFieldResult>>;
+    return { stableRuleId, machineValues, reviewedValues, fields, fullyMatches: VM0007_BENCHMARK_FIELDS.every((field) => fields[field].matches) };
+  });
+
+  const fields = Object.fromEntries(VM0007_BENCHMARK_FIELDS.map((field) => {
+    const mismatchedRuleIds = rows.filter((row) => !row.fields[field].matches).map((row) => row.stableRuleId);
+    const matchedCount = rows.length - mismatchedRuleIds.length;
+    return [field, { matchedCount, mismatchedCount: mismatchedRuleIds.length, agreementRate: matchedCount / rows.length, mismatchedRuleIds }];
+  })) as unknown as Readonly<Vm0007BenchmarkAggregate["fields"]>;
+  const mismatchedRuleIds = rows.filter((row) => !row.fullyMatches).map((row) => row.stableRuleId);
+  return {
+    rows,
+    aggregate: {
+      totalExpectedRows: expected.size,
+      totalAlignedRows: rows.length,
+      fields,
+      totalFullyMatchingRows: rows.length - mismatchedRuleIds.length,
+      totalRowsWithAtLeastOneMismatch: mismatchedRuleIds.length,
+      mismatchedRuleIds,
+    },
+  };
+}

--- a/tests/lib/preverif/marcondesReviewedGoldComparison.test.ts
+++ b/tests/lib/preverif/marcondesReviewedGoldComparison.test.ts
@@ -96,6 +96,18 @@ describe("VM0007 RC2 benchmark contract", () => {
     expect(() => evaluateVm0007Benchmark(input)).toThrow("reviewed row expected-01 has absent required benchmark field clientAction");
   });
 
+  it.each(["clientAction", "contradictionState"] as const)("rejects null reviewed %s", (field) => {
+    const input = syntheticInput();
+    input.reviewedRows[0].values[field] = null;
+    expect(() => evaluateVm0007Benchmark(input)).toThrow(`reviewed row expected-01 has invalid null for ${field}; only draftFinding may be null`);
+  });
+
+  it.each(["clientAction", "contradictionState"] as const)("rejects non-string reviewed %s", (field) => {
+    const input = syntheticInput();
+    input.reviewedRows[0].values[field] = 123;
+    expect(() => evaluateVm0007Benchmark(input)).toThrow(`reviewed row expected-01 has invalid ${field}; expected a string`);
+  });
+
   it("rejects contradictory reviewed applicability semantics", () => {
     const input = syntheticInput();
     input.reviewedRows[0].values.evidenceState = "N/A";

--- a/tests/lib/preverif/marcondesReviewedGoldComparison.test.ts
+++ b/tests/lib/preverif/marcondesReviewedGoldComparison.test.ts
@@ -1,145 +1,126 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import fs from "node:fs";
 import path from "node:path";
 
-import { loadMethodRules } from "@/app/m/_lib/methodRules";
-import { auditEvidence, type EvidenceAuditStatus } from "@/lib/preverif/evidenceAudit";
-import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif/vm0007EvidenceContracts";
-import type { EvidenceDocument } from "@/lib/quickCheck/evidence/evidenceTypes";
+import {
+  evaluateVm0007Benchmark,
+  machineProposalToBenchmarkRows,
+  reviewedTruthToBenchmarkRows,
+  type Vm0007MachineProposalRow,
+  type Vm0007ReviewedTruthRow,
+} from "@/lib/preverif/vm0007Benchmark";
 
 const fixtureDir = path.join(process.cwd(), "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map");
-const reviewedRuleIds = [
-  "R-1-0001", "R-1-0002", "R-1-0004", "R-1-0005", "R-2-0005", "R-2-0007", "R-3-0001", "R-3-0005", "R-6-0001", "R-6-0008",
-  "R-1-0003", "R-1-0006", "R-1-0007", "R-1-0008", "R-1-0009", "R-1-0010", "R-1-0011", "R-1-0012", "R-1-0013", "R-1-0014", "R-1-0015",
-  "R-2-0001", "R-2-0002", "R-2-0006", "R-2-0008", "R-2-0016", "R-3-0002", "R-3-0006", "R-2-0003", "R-2-0004", "R-2-0009", "R-2-0010",
-  "R-2-0011", "R-2-0012", "R-2-0013", "R-2-0014", "R-2-0015", "R-3-0003", "R-3-0004", "R-3-0007", "R-3-0008", "R-4-0001", "R-4-0002",
-  "R-5-0001", "R-5-0002", "R-5-0003", "R-5-0004", "R-5-0005",
-] as const;
+const rulesPath = path.join(process.cwd(), "public/methodologies/Verra/AFOLU/VM0007/v1-8/rules.json");
 
-const resolvedIrrelevantScopeRows = ["R-2-0007", "R-2-0008", "R-2-0010", "R-2-0012"] as const;
-
-type JsonRecord = Record<string, any>;
+type JsonRecord = Record<string, unknown>;
 
 function readJson(name: string): JsonRecord {
   return JSON.parse(fs.readFileSync(path.join(fixtureDir, name), "utf8")) as JsonRecord;
 }
 
-function marcondesEvidenceDocument(): EvidenceDocument {
-  const extraction = readJson("raw-document-extraction.json");
-  const spans = extraction.pages.map((page: { pageNumber: number; text: string }) => ({
-    spanId: `marcondes-pdd:page:${page.pageNumber}:project-evidence`,
-    docId: "marcondes-pdd",
-    page: page.pageNumber,
-    sectionId: `Marcondes PDD page ${page.pageNumber}`,
-    heading: `Marcondes PDD page ${page.pageNumber}`,
-    headingPath: [`Marcondes PDD page ${page.pageNumber}`],
-    sectionPath: [`Marcondes PDD page ${page.pageNumber}`],
-    blockType: "paragraph" as const,
-    text: page.pageNumber === 12
-      ? page.text.match(/The project is eligible[\s\S]*?associated with deforestation\./)?.[0] ?? ""
-      : page.text,
-    normalizedText: page.text.toLowerCase(),
-    charStart: null,
-    charEnd: null,
-    reliability: "primary" as const,
-    confidence: 1,
-  }));
-  return {
-    docId: "marcondes-pdd",
-    rawText: extraction.pages.map((page: { text: string }) => page.text).join("\f"),
-    parserSource: "saved-document-extraction",
-    parserAdapterId: "pymupdf",
-    spans,
+function fixtureInputs() {
+  const machine = readJson("machine-proposal.json");
+  const reviewed = readJson("gold.json");
+  const registry = JSON.parse(fs.readFileSync(rulesPath, "utf8")) as { rules: Array<{ stable_id: string }> };
+  const machineRows = machineProposalToBenchmarkRows(machine.rows as Vm0007MachineProposalRow[]);
+  const reviewedRows = reviewedTruthToBenchmarkRows(reviewed.rows as Vm0007ReviewedTruthRow[]);
+  return { machineRows, reviewedRows, expectedStableRuleIds: registry.rules.map((rule) => rule.stable_id) };
+}
+
+function syntheticInput() {
+  const expectedStableRuleIds = Array.from({ length: 58 }, (_, index) => `expected-${String(index + 1).padStart(2, "0")}`);
+  const values = {
+    evidenceState: "FOUND",
+    applicability: "APPLICABLE",
+    reviewerOutcome: "CONFORMS",
+    contradictionState: "NONE_IDENTIFIED",
+    draftFinding: null,
+    clientAction: "retain",
   };
+  const machineRows = expectedStableRuleIds.map((stableRuleId) => ({ stableRuleId, values: { ...values } }));
+  const reviewedRows = expectedStableRuleIds.map((stableRuleId) => ({ stableRuleId, values: { ...values } }));
+  return { machineRows, reviewedRows, expectedStableRuleIds };
 }
 
-function stateForStatus(status: EvidenceAuditStatus): "FOUND" | "UNCLEAR" | "MISSING" | "N/A" {
-  if (status === "supported_by_pdd") return "FOUND";
-  if (status === "missing_evidence") return "MISSING";
-  if (status === "not_applicable") return "N/A";
-  return "UNCLEAR";
-}
+describe("VM0007 RC2 benchmark contract", () => {
+  it("aligns the real 58-row machine proposal and reviewed truth by the stable ID registry", () => {
+    const result = evaluateVm0007Benchmark(fixtureInputs());
+    expect(result.aggregate).toEqual(expect.objectContaining({ totalExpectedRows: 58, totalAlignedRows: 58 }));
+    expect(result.rows).toHaveLength(58);
+    expect(result.rows.map((row) => row.stableRuleId)).toEqual([...result.rows].map((row) => row.stableRuleId).sort());
+    expect(result.aggregate.mismatchedRuleIds.length).toBeGreaterThan(0);
+  });
 
-describe("Marcondes reviewed gold comparison", () => {
-  it("evaluates every reviewed row and reports exact matches, mismatches, and corrected false FOUND cases", async () => {
-    const rules = (await loadMethodRules("VM0007", "v1-8")).rules;
-    const gold = readJson("gold.json");
-    const previous = readJson("machine-proposal.json");
-    const audit = auditEvidence({
-      rules,
-      evidenceDocument: marcondesEvidenceDocument(),
-      getContract: getVm0007EvidenceContract,
-      normalizeRuleId: normalizeVm0007RuleId,
-      versionContext: { methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "v1.8" },
-    });
-    const goldByRule = new Map(gold.rows.map((row: JsonRecord) => [row.ruleReference, row]));
-    const previousByRule = new Map(previous.rows.map((row: JsonRecord) => [row.ruleReference, row]));
-    const comparison = reviewedRuleIds.map((ruleId) => {
-      const result = audit.results.find((row) => row.ruleId === ruleId)!;
-      const reviewed = goldByRule.get(ruleId)!;
-      const prior = previousByRule.get(`Verra.AFOLU.VM0007.v1-8.${ruleId}`)!;
-      const machineState = stateForStatus(result.status);
-      return {
-        ruleId,
-        before: prior.rawAuditStatus,
-        after: result.status,
-        gold: reviewed.finalEvidenceState,
-        exact: machineState === reviewed.finalEvidenceState,
-        correctedFalseFound: prior.rawAuditStatus === "supported_by_pdd" && result.status !== "supported_by_pdd",
-        evidenceTypes: result.evidence?.map((evidence) => evidence.evidenceType),
-      };
-    });
-    const mismatches = comparison.filter((row) => !row.exact);
-    const corrections = comparison.filter((row) => row.correctedFalseFound);
-    const totals = Object.fromEntries([
-      "supported_by_pdd", "partially_supported", "missing_evidence", "not_applicable", "manual_review_needed",
-    ].map((status) => [status, audit.results.filter((row) => row.status === status).length]));
+  it("is independent of input order and deterministic across repeated runs", () => {
+    const input = fixtureInputs();
+    const first = evaluateVm0007Benchmark(input);
+    const reordered = {
+      ...input,
+      machineRows: [...input.machineRows].reverse(),
+      reviewedRows: [...input.reviewedRows].sort(() => -1),
+    };
+    expect(evaluateVm0007Benchmark(reordered)).toEqual(first);
+    expect(evaluateVm0007Benchmark(input)).toEqual(first);
+  });
 
-    console.log("Marcondes reviewed gold comparison", JSON.stringify({
-      reviewed: comparison.length,
-      exactMatches: comparison.length - mismatches.length,
-      mismatches,
-      correctedFalseFound: corrections.map((row) => row.ruleId),
-      totals,
-    }, null, 2));
+  it.each([
+    ["duplicate machine IDs", (input: ReturnType<typeof syntheticInput>) => ({ ...input, machineRows: [...input.machineRows.slice(0, -1), input.machineRows[0]] }), "machine duplicate stable IDs"],
+    ["duplicate reviewed IDs", (input: ReturnType<typeof syntheticInput>) => ({ ...input, reviewedRows: [...input.reviewedRows.slice(0, -1), input.reviewedRows[0]] }), "reviewed duplicate stable IDs"],
+    ["missing machine IDs", (input: ReturnType<typeof syntheticInput>) => ({ ...input, machineRows: input.machineRows.slice(0, -1) }), "machine row count 57"],
+    ["missing reviewed IDs", (input: ReturnType<typeof syntheticInput>) => ({ ...input, reviewedRows: input.reviewedRows.slice(0, -1) }), "reviewed row count 57"],
+    ["unexpected IDs", (input: ReturnType<typeof syntheticInput>) => ({ ...input, machineRows: input.machineRows.map((row, index) => index === 0 ? { ...row, stableRuleId: "unexpected-id" } : row) }), "machine unexpected stable IDs"],
+    ["empty IDs", (input: ReturnType<typeof syntheticInput>) => ({ ...input, reviewedRows: input.reviewedRows.map((row, index) => index === 0 ? { ...row, stableRuleId: "" } : row) }), "reviewed missing or empty stable IDs"],
+  ])("rejects %s", (_name, mutate, expectedMessage) => {
+    expect(() => evaluateVm0007Benchmark(mutate(syntheticInput()))).toThrow(expectedMessage);
+  });
 
-    expect(audit.results).toHaveLength(58);
-    expect(comparison).toHaveLength(48);
-    expect(comparison.length - mismatches.length).toBeGreaterThanOrEqual(37);
-    expect(comparison.length - mismatches.length).toBe(37);
-    const reconciliation = readJson("mismatch-reconciliation.json");
-    expect(reconciliation.rows).toHaveLength(15);
-    expect(new Set(reconciliation.rows.map((row: JsonRecord) => row.ruleId)).size).toBe(15);
-    const stableRuleId = (ruleId: string) => ruleId.startsWith("Verra.") ? ruleId : `Verra.AFOLU.VM0007.v1-8.${ruleId}`;
-    const activeReconciliationRows = reconciliation.rows.filter((row: JsonRecord) =>
-      !resolvedIrrelevantScopeRows.some((ruleId) => row.ruleId.endsWith(ruleId)),
-    );
-    expect(mismatches.map((row) => stableRuleId(row.ruleId)).sort()).toEqual(activeReconciliationRows.map((row: JsonRecord) => row.ruleId).sort());
-    for (const ruleId of resolvedIrrelevantScopeRows) {
-      expect(comparison.find((row) => row.ruleId === ruleId)).toEqual(expect.objectContaining({
-        exact: true,
-        gold: "UNCLEAR",
-      }));
+  it("evaluates every supported field with explicit absent and null semantics", () => {
+    const input = syntheticInput();
+    input.machineRows[0].values.evidenceState = null;
+    input.reviewedRows[0].values.evidenceState = undefined;
+    input.machineRows[1].values.reviewerOutcome = undefined;
+    input.reviewedRows[1].values.reviewerOutcome = "CONFORMS";
+    const result = evaluateVm0007Benchmark(input);
+    expect(result.rows[0].fields.evidenceState).toEqual({ machine: { kind: "null" }, reviewed: { kind: "absent" }, matches: false });
+    expect(result.rows[1].fields.reviewerOutcome).toEqual({ machine: { kind: "absent" }, reviewed: { kind: "value", value: "CONFORMS" }, matches: false });
+    for (const field of ["evidenceState", "applicability", "reviewerOutcome", "contradictionState", "draftFinding", "clientAction"] as const) {
+      expect(result.aggregate.fields[field]).toEqual(expect.objectContaining({ matchedCount: expect.any(Number), mismatchedCount: expect.any(Number), agreementRate: expect.any(Number), mismatchedRuleIds: expect.any(Array) }));
     }
-    for (const mismatch of mismatches) {
-      const record = reconciliation.rows.find((row: JsonRecord) => row.ruleId === stableRuleId(mismatch.ruleId))!;
-      const goldRow = goldByRule.get(mismatch.ruleId)!;
-      expect(record.machineState).toBe(stateForStatus(mismatch.after));
-      expect(record.goldState).toBe(mismatch.gold);
-      expect(record.requirementReviewed).toBe(goldRow.requirement);
-      expect(record.methodologyTraceability).toEqual(goldRow.methodologyTraceability);
-      expect(record.pagesInspected).toEqual([...new Set(goldRow.acceptedEvidence.map((evidence: JsonRecord) => evidence.page))]);
-      expect(record.acceptedEvidenceReferences).toEqual(goldRow.acceptedEvidence.map((evidence: JsonRecord) => ({ page: evidence.page, section: evidence.section, spanId: evidence.spanId, quote: evidence.quote })));
-      expect(record.rejectedEvidenceReferences).toEqual(goldRow.rejectedEvidence.map((evidence: JsonRecord) => ({ page: evidence.page, section: evidence.section, spanId: evidence.spanId, quote: evidence.quote, rejectionReason: evidence.rejectionReason })));
-      expect(record.failureClassification).toEqual(expect.stringMatching(/^MACHINE_/));
-      expect(record.decision).toBe("GOLD_RETAINED");
-      expect(record.reconciliationRationale).toEqual(expect.any(String));
+  });
+
+  it("derives aggregate counts exclusively from per-row field results", () => {
+    const result = evaluateVm0007Benchmark(fixtureInputs());
+    for (const field of ["evidenceState", "applicability", "reviewerOutcome", "contradictionState", "draftFinding", "clientAction"] as const) {
+      const fieldResult = result.aggregate.fields[field];
+      expect(fieldResult.matchedCount).toBe(result.rows.filter((row) => row.fields[field].matches).length);
+      expect(fieldResult.mismatchedCount).toBe(result.rows.filter((row) => !row.fields[field].matches).length);
+      expect(fieldResult.agreementRate).toBe(fieldResult.matchedCount / result.rows.length);
+      expect(fieldResult.mismatchedRuleIds).toEqual(result.rows.filter((row) => !row.fields[field].matches).map((row) => row.stableRuleId));
     }
-    expect(totals.supported_by_pdd).toBeGreaterThan(0);
-    expect(totals.partially_supported).toBeLessThan(57);
-    expect(totals.not_applicable).toBeGreaterThan(0);
-    expect(corrections.length).toBeGreaterThan(0);
-    expect(comparison.some((row) => row.ruleId === "R-4-0001" && row.gold === "FOUND" && row.after === "partially_supported")).toBe(true);
-    expect(comparison.filter((row) => row.gold === "N/A" && row.after === "not_applicable").length).toBeGreaterThan(0);
+    expect(result.aggregate.totalFullyMatchingRows).toBe(result.rows.filter((row) => row.fullyMatches).length);
+    expect(result.aggregate.totalRowsWithAtLeastOneMismatch).toBe(result.rows.filter((row) => !row.fullyMatches).length);
+  });
+
+  it("does not mutate either source dataset", () => {
+    const machine = readJson("machine-proposal.json");
+    const reviewed = readJson("gold.json");
+    const registry = JSON.parse(fs.readFileSync(rulesPath, "utf8")) as { rules: Array<{ stable_id: string }> };
+    const machineRows = machineProposalToBenchmarkRows(machine.rows as Vm0007MachineProposalRow[]);
+    const reviewedRows = reviewedTruthToBenchmarkRows(reviewed.rows as Vm0007ReviewedTruthRow[]);
+    const input = { machineRows, reviewedRows, expectedStableRuleIds: registry.rules.map((rule) => rule.stable_id) };
+    const machineBefore = JSON.stringify(machine);
+    const reviewedBefore = JSON.stringify(reviewed);
+    const machineRowsBefore = JSON.stringify(machineRows);
+    const reviewedRowsBefore = JSON.stringify(reviewedRows);
+    evaluateVm0007Benchmark(input);
+    expect(JSON.stringify(machine)).toBe(machineBefore);
+    expect(JSON.stringify(reviewed)).toBe(reviewedBefore);
+    expect(JSON.stringify(machineRows)).toBe(machineRowsBefore);
+    expect(JSON.stringify(reviewedRows)).toBe(reviewedRowsBefore);
+  });
+
+  it("rejects an incomplete expected stable-ID registry", () => {
+    const input = syntheticInput();
+    expect(() => evaluateVm0007Benchmark({ ...input, expectedStableRuleIds: input.expectedStableRuleIds.slice(0, 57) })).toThrow("expected exactly 58");
   });
 });

--- a/tests/lib/preverif/marcondesReviewedGoldComparison.test.ts
+++ b/tests/lib/preverif/marcondesReviewedGoldComparison.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import {
+  compareBenchmarkValues,
   evaluateVm0007Benchmark,
   machineProposalToBenchmarkRows,
   reviewedTruthToBenchmarkRows,
@@ -77,15 +78,59 @@ describe("VM0007 RC2 benchmark contract", () => {
   it("evaluates every supported field with explicit absent and null semantics", () => {
     const input = syntheticInput();
     input.machineRows[0].values.evidenceState = null;
-    input.reviewedRows[0].values.evidenceState = undefined;
+    input.reviewedRows[0].values.evidenceState = "FOUND";
     input.machineRows[1].values.reviewerOutcome = undefined;
     input.reviewedRows[1].values.reviewerOutcome = "CONFORMS";
     const result = evaluateVm0007Benchmark(input);
-    expect(result.rows[0].fields.evidenceState).toEqual({ machine: { kind: "null" }, reviewed: { kind: "absent" }, matches: false });
+    expect(result.rows[0].fields.evidenceState).toEqual({ machine: { kind: "null" }, reviewed: { kind: "value", value: "FOUND" }, matches: false });
     expect(result.rows[1].fields.reviewerOutcome).toEqual({ machine: { kind: "absent" }, reviewed: { kind: "value", value: "CONFORMS" }, matches: false });
+    expect(compareBenchmarkValues("evidenceState", { kind: "absent" }, { kind: "absent" })).toBe(false);
     for (const field of ["evidenceState", "applicability", "reviewerOutcome", "contradictionState", "draftFinding", "clientAction"] as const) {
       expect(result.aggregate.fields[field]).toEqual(expect.objectContaining({ matchedCount: expect.any(Number), mismatchedCount: expect.any(Number), agreementRate: expect.any(Number), mismatchedRuleIds: expect.any(Array) }));
     }
+  });
+
+  it("rejects an absent reviewed required value", () => {
+    const input = syntheticInput();
+    input.reviewedRows[0].values.clientAction = undefined;
+    expect(() => evaluateVm0007Benchmark(input)).toThrow("reviewed row expected-01 has absent required benchmark field clientAction");
+  });
+
+  it("rejects contradictory reviewed applicability semantics", () => {
+    const input = syntheticInput();
+    input.reviewedRows[0].values.evidenceState = "N/A";
+    input.reviewedRows[0].values.applicability = "NOT_APPLICABLE";
+    input.reviewedRows[0].values.reviewerOutcome = "CONFORMS";
+    expect(() => evaluateVm0007Benchmark(input)).toThrow(/reviewed row expected-01 has contradictory applicability/);
+
+    input.reviewedRows[0].values.evidenceState = "FOUND";
+    input.reviewedRows[0].values.reviewerOutcome = "NOT_APPLICABLE";
+    expect(() => evaluateVm0007Benchmark(input)).toThrow(/reviewed row expected-01 has contradictory applicability/);
+  });
+
+  it("rejects explicit reviewed applicability that conflicts with the canonical derivation", () => {
+    expect(() => reviewedTruthToBenchmarkRows([{
+      ruleId: "rule-1",
+      finalEvidenceState: "N/A",
+      applicability: "APPLICABLE",
+      reviewerOutcome: "NOT_APPLICABLE",
+      contradictionState: "NONE_IDENTIFIED",
+      draftFindingCandidate: null,
+      clientAction: "retain",
+    }])).toThrow("applicability APPLICABLE contradicts canonical applicability NOT_APPLICABLE");
+  });
+
+  it("evaluates valid N/A and applicable reviewed rows using the canonical applicability", () => {
+    const input = syntheticInput();
+    input.machineRows[0].values.evidenceState = "N/A";
+    input.machineRows[0].values.applicability = "NOT_APPLICABLE";
+    input.machineRows[0].values.reviewerOutcome = "NOT_APPLICABLE";
+    input.reviewedRows[0].values.evidenceState = "N/A";
+    input.reviewedRows[0].values.applicability = "NOT_APPLICABLE";
+    input.reviewedRows[0].values.reviewerOutcome = "NOT_APPLICABLE";
+    const result = evaluateVm0007Benchmark(input);
+    expect(result.rows[0].fields.applicability.matches).toBe(true);
+    expect(result.rows[1].reviewedValues.applicability).toEqual({ kind: "value", value: "APPLICABLE" });
   });
 
   it("derives aggregate counts exclusively from per-row field results", () => {


### PR DESCRIPTION
### Roadmap-Update
- slug: interactive-evidence-review-mvp
- items:
  - RC2: in_progress

## Summary

This PR replaces the former 48-row Marcondes comparison with one reusable deterministic 58-row benchmark contract.

- Aligns exactly 58 machine proposal rows with exactly 58 reviewed Marcondes truth rows using the stable VM0007 rule-ID registry.
- Evaluates evidence state, applicability, reviewer outcome, contradiction state, draft finding, and client action independently.
- Preserves explicit value, null, and absent states. `clientAction` remains an exact structured/free-text value comparison; no new taxonomy is introduced.
- Adds strict count, duplicate, missing/empty, unexpected, and expected-ID safeguards.
- Derives all aggregate counts, rates, and mismatch IDs from per-row results.

## Scope boundaries

No evidence/provenance scoring, baseline artifact, ranked failures, production accuracy fix, production audit logic, reviewed truth, machine fixture truth, UI, persistence, report, export, retrieval, routing, or parsing changes are included.

## Validation

Focused test run:

`npx jest --runInBand tests/lib/preverif/marcondesReviewedGoldComparison.test.ts`

Result: 1 suite passed, 12 tests passed.

`git diff --check` passed. The repository pre-push hook also ran lint and typecheck successfully. Expensive broad checks (`npm run pr:gate`, `npm run pr:check:local`, build, full Jest, and full test suite) are intentionally deferred to GitHub Actions per task scope.

No reviewed truth or machine-proposal fixture values changed.

RC2 follow-up work remains: evidence and provenance evaluation, then the official baseline artifact and ranked failures.