### PR TITLE
test: evaluate VM0007 evidence selection and provenance

### DIFF
--- a/src/lib/preverif/vm0007EvidenceBenchmark.ts
+++ b/src/lib/preverif/vm0007EvidenceBenchmark.ts
@@ -1,0 +1,271 @@
+import {
+  evaluateVm0007Benchmark,
+  machineProposalToBenchmarkRows,
+  reviewedTruthToBenchmarkRows,
+  type Vm0007MachineProposalRow,
+  type Vm0007ReviewedTruthRow,
+} from "./vm0007Benchmark";
+
+export type EvidenceBenchmarkCollection = "accepted" | "rejected";
+export type EvidenceCollectionState = "present" | "absent";
+
+export type EvidenceBenchmarkRecord = Readonly<{
+  quote: unknown;
+  provenance: unknown;
+  rejectionReason?: unknown;
+}>;
+
+export type Vm0007EvidenceBenchmarkMachineRow = Vm0007MachineProposalRow & Readonly<{
+  acceptedEvidence?: unknown;
+  rejectedEvidence?: unknown;
+}>;
+
+export type Vm0007EvidenceBenchmarkReviewedRow = Vm0007ReviewedTruthRow & Readonly<{
+  acceptedEvidence?: unknown;
+  rejectedEvidence?: unknown;
+}>;
+
+export type EvidenceProvenance = Readonly<{
+  docId: string;
+  page: number | null;
+  sectionPath: readonly string[];
+  spanId: string;
+  sectionHeading: string | null;
+  sourceType: string | null;
+}>;
+
+export type EvidencePair = Readonly<{
+  machine: EvidenceBenchmarkRecord & { quote: string; provenance: EvidenceProvenance };
+  reviewed: EvidenceBenchmarkRecord & { quote: string; provenance: EvidenceProvenance };
+}>;
+
+export type ProvenanceField = keyof EvidenceProvenance;
+export const EVIDENCE_PROVENANCE_FIELDS: readonly ProvenanceField[] = [
+  "docId", "page", "sectionPath", "spanId", "sectionHeading", "sourceType",
+];
+
+export type ProvenanceComparison = Readonly<{
+  machine: EvidenceProvenance;
+  reviewed: EvidenceProvenance;
+  fields: Readonly<Record<ProvenanceField, boolean>>;
+  fullMatch: boolean;
+}>;
+
+export type EvidenceSelectionResult = Readonly<{
+  machineCollectionState: EvidenceCollectionState;
+  machineRecordCount: number;
+  reviewedRecordCount: number;
+  matchedRecordCount: number;
+  falsePositiveRecords: readonly EvidenceBenchmarkRecord[];
+  falseNegativeRecords: readonly EvidenceBenchmarkRecord[];
+  exactCollectionMatch: boolean;
+  matchedPairs: readonly EvidencePair[];
+  provenance: Readonly<{
+    comparisons: readonly ProvenanceComparison[];
+    comparedPairCount: number;
+    fullProvenanceMatchCount: number;
+    fullProvenanceMatchRate: number | null;
+    fields: Readonly<Record<ProvenanceField, Readonly<{
+      matchedCount: number;
+      mismatchedCount: number;
+      agreementRate: number | null;
+      mismatchedRuleIds: readonly string[];
+    }>>>;
+  }>;
+  rejectionReasons?: Readonly<{
+    comparedPairCount: number;
+    matchedCount: number;
+    mismatchedCount: number;
+    agreementRate: number | null;
+    mismatched: readonly Readonly<{ machine: string | null; reviewed: string; pair: EvidencePair }>[];
+  }>;
+}>;
+
+export type EvidenceSelectionAggregate = Readonly<{
+  machineRecordCount: number;
+  reviewedRecordCount: number;
+  matchedCount: number;
+  falsePositiveCount: number;
+  falseNegativeCount: number;
+  precision: number | null;
+  recall: number | null;
+  f1: number | null;
+  exactRowMatchCount: number;
+  mismatchedStableRuleIds: readonly string[];
+  machineCollectionAbsentStableRuleIds: readonly string[];
+}>;
+
+export type Vm0007EvidenceBenchmarkRow = Readonly<{
+  stableRuleId: string;
+  accepted: EvidenceSelectionResult;
+  rejected: EvidenceSelectionResult;
+}>;
+
+export type Vm0007EvidenceBenchmarkResult = Readonly<{
+  rows: readonly Vm0007EvidenceBenchmarkRow[];
+  aggregate: Readonly<{
+    accepted: EvidenceSelectionAggregate;
+    rejected: EvidenceSelectionAggregate;
+    acceptedProvenance: EvidenceSelectionResult["provenance"];
+    rejectedProvenance: EvidenceSelectionResult["provenance"];
+    rejectedReasonAgreement: NonNullable<EvidenceSelectionResult["rejectionReasons"]>;
+  }>;
+}>;
+
+const whitespace = /\s+/gu;
+const normalizeText = (value: string) => value.normalize("NFKC").toLowerCase().replace(whitespace, " ").trim();
+export const normalizeEvidenceQuote = normalizeText;
+export const normalizeRejectionReason = normalizeText;
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredText(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`evidence record ${label} must contain a non-empty string`);
+  return value;
+}
+
+function canonicalProvenance(value: unknown, label: string): EvidenceProvenance {
+  if (!record(value)) throw new Error(`evidence record ${label} has malformed provenance`);
+  const text = (field: string) => {
+    if (typeof value[field] !== "string") throw new Error(`evidence record ${label} has malformed provenance.${field}`);
+    return value[field].trim();
+  };
+  const nullableText = (field: string) => {
+    if (value[field] !== null && (typeof value[field] !== "string" || !value[field].trim())) throw new Error(`evidence record ${label} has malformed provenance.${field}`);
+    return value[field] === null ? null : value[field].replace(whitespace, " ").trim();
+  };
+  if (value.page !== null && (typeof value.page !== "number" || !Number.isFinite(value.page))) throw new Error(`evidence record ${label} has malformed provenance.page`);
+  if (!Array.isArray(value.sectionPath) || value.sectionPath.some((item) => typeof item !== "string")) throw new Error(`evidence record ${label} has malformed provenance.sectionPath`);
+  return {
+    docId: text("docId"), page: value.page as number | null,
+    sectionPath: (value.sectionPath as string[]).map((item) => item.replace(whitespace, " ").trim()),
+    spanId: text("spanId"), sectionHeading: nullableText("sectionHeading"), sourceType: nullableText("sourceType"),
+  };
+}
+
+function normalizeRecord(value: unknown, label: string, rejected: boolean): EvidenceBenchmarkRecord & { quote: string; provenance: EvidenceProvenance } {
+  if (!record(value)) throw new Error(`evidence record ${label} is malformed`);
+  const source = record(value.evidence) ? value.evidence : value;
+  const quote = requiredText(source.quote, label);
+  if (!record(source.provenance)) throw new Error(`evidence record ${label} has malformed provenance`);
+  const sourceProvenance = {
+    ...source.provenance,
+    page: source.provenance.page === undefined ? (typeof source.page === "number" ? source.page : null) : source.provenance.page,
+  };
+  const rejectionReason = source.rejectionReason ?? value.rejectionReason;
+  if (rejected && rejectionReason !== undefined && typeof rejectionReason !== "string") throw new Error(`evidence record ${label} has malformed rejectionReason`);
+  return { ...source, quote, provenance: canonicalProvenance(sourceProvenance, label), ...(rejectionReason === undefined ? {} : { rejectionReason }) };
+}
+
+function provenanceKey(provenance: EvidenceProvenance): string {
+  return JSON.stringify([provenance.docId, provenance.page, provenance.sectionPath, provenance.spanId, provenance.sectionHeading, provenance.sourceType]);
+}
+function recordKey(item: EvidenceBenchmarkRecord & { quote: string; provenance: EvidenceProvenance }, rejected: boolean): string {
+  return `${provenanceKey(item.provenance)}\u0000${rejected ? normalizeRejectionReason(typeof item.rejectionReason === "string" ? item.rejectionReason : "") : ""}\u0000${item.quote}`;
+}
+function sortedRecords(values: unknown[], label: string, rejected: boolean) {
+  return values.map((value, index) => normalizeRecord(value, `${label}[${index}]`, rejected)).sort((a, b) => recordKey(a, rejected).localeCompare(recordKey(b, rejected)));
+}
+
+function compareProvenance(machine: EvidenceProvenance, reviewed: EvidenceProvenance): ProvenanceComparison {
+  const fields = Object.fromEntries(EVIDENCE_PROVENANCE_FIELDS.map((field) => [field, JSON.stringify(machine[field]) === JSON.stringify(reviewed[field])])) as Record<ProvenanceField, boolean>;
+  return { machine, reviewed, fields, fullMatch: EVIDENCE_PROVENANCE_FIELDS.every((field) => fields[field]) };
+}
+
+function emptyReasonAggregate() {
+  return { comparedPairCount: 0, matchedCount: 0, mismatchedCount: 0, agreementRate: null, mismatched: [] as Readonly<{ machine: string | null; reviewed: string; pair: EvidencePair }>[] };
+}
+
+function evaluateCollection(machineValue: unknown, reviewedValue: unknown, stableRuleId: string, rejected: boolean): EvidenceSelectionResult {
+  const machineCollectionState = machineValue === undefined ? "absent" : "present";
+  if (machineCollectionState === "present" && !Array.isArray(machineValue)) throw new Error(`machine ${rejected ? "rejected" : "accepted"}Evidence for ${stableRuleId} must be an array`);
+  if (!Array.isArray(reviewedValue)) throw new Error(`reviewed ${rejected ? "rejected" : "accepted"}Evidence for ${stableRuleId} must be a present array`);
+  const machine = sortedRecords(machineValue === undefined ? [] : machineValue as unknown[], `machine ${stableRuleId}`, rejected);
+  const reviewed = sortedRecords(reviewedValue, `reviewed ${stableRuleId}`, rejected);
+  const machineGroups = new Map<string, typeof machine>();
+  const reviewedGroups = new Map<string, typeof reviewed>();
+  for (const item of machine) (machineGroups.get(normalizeEvidenceQuote(item.quote)) ?? (machineGroups.set(normalizeEvidenceQuote(item.quote), []), machineGroups.get(normalizeEvidenceQuote(item.quote))!)).push(item);
+  for (const item of reviewed) (reviewedGroups.get(normalizeEvidenceQuote(item.quote)) ?? (reviewedGroups.set(normalizeEvidenceQuote(item.quote), []), reviewedGroups.get(normalizeEvidenceQuote(item.quote))!)).push(item);
+  const pairs: EvidencePair[] = [], falsePositiveRecords: EvidenceBenchmarkRecord[] = [], falseNegativeRecords: EvidenceBenchmarkRecord[] = [];
+  const allQuotes = [...new Set([...machineGroups.keys(), ...reviewedGroups.keys()])].sort();
+  for (const quote of allQuotes) {
+    const left = [...(machineGroups.get(quote) ?? [])], right = [...(reviewedGroups.get(quote) ?? [])];
+    const used = new Set<number>();
+    const pairedLeft = new Set<number>();
+    for (const item of left) {
+      const leftIndex = left.indexOf(item);
+      const exact = right.findIndex((candidate, index) => !used.has(index) && provenanceKey(candidate.provenance) === provenanceKey(item.provenance));
+      if (exact >= 0) { pairedLeft.add(leftIndex); used.add(exact); pairs.push({ machine: item, reviewed: right[exact] }); }
+    }
+    const remainingLeft = left.filter((_, index) => !pairedLeft.has(index));
+    const remainingRight = right.filter((_, index) => !used.has(index));
+    const pairedRemaining = Math.min(remainingLeft.length, remainingRight.length);
+    for (let index = 0; index < pairedRemaining; index++) {
+      pairs.push({ machine: remainingLeft[index], reviewed: remainingRight[index] });
+    }
+    falsePositiveRecords.push(...remainingLeft.slice(pairedRemaining));
+    falseNegativeRecords.push(...remainingRight.slice(pairedRemaining));
+  }
+  pairs.sort((a, b) => `${normalizeEvidenceQuote(a.machine.quote)}\u0000${recordKey(a.machine, rejected)}\u0000${recordKey(a.reviewed, rejected)}`.localeCompare(`${normalizeEvidenceQuote(b.machine.quote)}\u0000${recordKey(b.machine, rejected)}\u0000${recordKey(b.reviewed, rejected)}`));
+  falsePositiveRecords.sort((a, b) => recordKey(a as typeof machine[number], rejected).localeCompare(recordKey(b as typeof machine[number], rejected)));
+  falseNegativeRecords.sort((a, b) => recordKey(a as typeof reviewed[number], rejected).localeCompare(recordKey(b as typeof reviewed[number], rejected)));
+  const comparisons = pairs.map((pair) => compareProvenance(pair.machine.provenance, pair.reviewed.provenance));
+  const fields = Object.fromEntries(EVIDENCE_PROVENANCE_FIELDS.map((field) => {
+    const mismatchedRuleIds = comparisons.filter((comparison) => !comparison.fields[field]).map(() => stableRuleId);
+    const matchedCount = comparisons.filter((comparison) => comparison.fields[field]).length;
+    return [field, { matchedCount, mismatchedCount: comparisons.length - matchedCount, agreementRate: comparisons.length ? matchedCount / comparisons.length : null, mismatchedRuleIds: mismatchedRuleIds.length ? [stableRuleId] : [] }];
+  })) as unknown as EvidenceSelectionResult["provenance"]["fields"];
+  const provenance = { comparisons, comparedPairCount: comparisons.length, fullProvenanceMatchCount: comparisons.filter((item) => item.fullMatch).length, fullProvenanceMatchRate: comparisons.length ? comparisons.filter((item) => item.fullMatch).length / comparisons.length : null, fields };
+  const rejectionReasons = rejected ? emptyReasonAggregate() : undefined;
+  if (rejected) {
+    for (const pair of pairs) {
+      if (typeof pair.reviewed.rejectionReason !== "string" || !pair.reviewed.rejectionReason.trim()) throw new Error(`reviewed rejected evidence for ${stableRuleId} has missing rejectionReason`);
+      const machineReason = typeof pair.machine.rejectionReason === "string" && pair.machine.rejectionReason.trim() ? pair.machine.rejectionReason : null;
+      rejectionReasons!.comparedPairCount++;
+      if (machineReason !== null && normalizeRejectionReason(machineReason) === normalizeRejectionReason(pair.reviewed.rejectionReason)) rejectionReasons!.matchedCount++;
+      else rejectionReasons!.mismatched.push({ machine: machineReason, reviewed: pair.reviewed.rejectionReason, pair });
+    }
+    rejectionReasons!.mismatchedCount = rejectionReasons!.comparedPairCount - rejectionReasons!.matchedCount;
+    const agreementRate = rejectionReasons!.comparedPairCount ? rejectionReasons!.matchedCount / rejectionReasons!.comparedPairCount : null;
+    return { machineCollectionState, machineRecordCount: machine.length, reviewedRecordCount: reviewed.length, matchedRecordCount: pairs.length, falsePositiveRecords, falseNegativeRecords, exactCollectionMatch: falsePositiveRecords.length === 0 && falseNegativeRecords.length === 0, matchedPairs: pairs, provenance, rejectionReasons: { ...rejectionReasons!, agreementRate } };
+  }
+  return { machineCollectionState, machineRecordCount: machine.length, reviewedRecordCount: reviewed.length, matchedRecordCount: pairs.length, falsePositiveRecords, falseNegativeRecords, exactCollectionMatch: falsePositiveRecords.length === 0 && falseNegativeRecords.length === 0, matchedPairs: pairs, provenance, ...(rejectionReasons ? { rejectionReasons } : {}) };
+}
+
+function aggregate(rows: readonly Vm0007EvidenceBenchmarkRow[], collection: EvidenceBenchmarkCollection): EvidenceSelectionAggregate {
+  const results = rows.map((row) => row[collection]);
+  const machineRecordCount = results.reduce((sum, row) => sum + row.machineRecordCount, 0);
+  const reviewedRecordCount = results.reduce((sum, row) => sum + row.reviewedRecordCount, 0);
+  const matchedCount = results.reduce((sum, row) => sum + row.matchedRecordCount, 0);
+  const falsePositiveCount = results.reduce((sum, row) => sum + row.falsePositiveRecords.length, 0);
+  const falseNegativeCount = results.reduce((sum, row) => sum + row.falseNegativeRecords.length, 0);
+  const precision = machineRecordCount ? matchedCount / machineRecordCount : null;
+  const recall = reviewedRecordCount ? matchedCount / reviewedRecordCount : null;
+  const f1 = precision !== null && recall !== null && precision + recall ? 2 * precision * recall / (precision + recall) : null;
+  return { machineRecordCount, reviewedRecordCount, matchedCount, falsePositiveCount, falseNegativeCount, precision, recall, f1, exactRowMatchCount: results.filter((row) => row.exactCollectionMatch).length, mismatchedStableRuleIds: rows.filter((row) => !row[collection].exactCollectionMatch).map((row) => row.stableRuleId), machineCollectionAbsentStableRuleIds: rows.flatMap((row) => row[collection].machineCollectionState === "absent" ? [row.stableRuleId] : []) };
+}
+
+export function evaluateVm0007EvidenceBenchmark(input: Readonly<{ machineRows: readonly Vm0007EvidenceBenchmarkMachineRow[]; reviewedRows: readonly Vm0007EvidenceBenchmarkReviewedRow[]; expectedStableRuleIds: readonly string[] }>): Vm0007EvidenceBenchmarkResult {
+  const aligned = evaluateVm0007Benchmark({ machineRows: machineProposalToBenchmarkRows(input.machineRows), reviewedRows: reviewedTruthToBenchmarkRows(input.reviewedRows), expectedStableRuleIds: input.expectedStableRuleIds });
+  const machineById = new Map(input.machineRows.map((row) => [typeof row.stableRuleId === "string" ? row.stableRuleId.trim() : "", row]));
+  const reviewedById = new Map(input.reviewedRows.map((row) => [typeof row.ruleId === "string" ? row.ruleId.trim() : "", row]));
+  const rows = aligned.rows.map(({ stableRuleId }) => {
+    const machine = machineById.get(stableRuleId)! as Record<string, unknown>;
+    const reviewed = reviewedById.get(stableRuleId)! as Record<string, unknown>;
+    return { stableRuleId, accepted: evaluateCollection(machine.acceptedEvidence, reviewed.acceptedEvidence, stableRuleId, false), rejected: evaluateCollection(machine.rejectedEvidence, reviewed.rejectedEvidence, stableRuleId, true) };
+  });
+  const rejectionReasons = rows.flatMap((row) => row.rejected.rejectionReasons ? [row.rejected.rejectionReasons] : []);
+  const rejectedReasonAgreement = rejectionReasons.reduce((acc, item) => ({ comparedPairCount: acc.comparedPairCount + item.comparedPairCount, matchedCount: acc.matchedCount + item.matchedCount, mismatchedCount: acc.mismatchedCount + item.mismatchedCount, agreementRate: null, mismatched: [...acc.mismatched, ...item.mismatched] }), emptyReasonAggregate());
+  const rejectedReasonAgreementWithRate = { ...rejectedReasonAgreement, agreementRate: rejectedReasonAgreement.comparedPairCount ? rejectedReasonAgreement.matchedCount / rejectedReasonAgreement.comparedPairCount : null };
+  const provenanceAggregate = (collection: EvidenceBenchmarkCollection) => {
+    const all = rows.map((row) => row[collection].provenance);
+    return { comparisons: all.flatMap((item) => item.comparisons), comparedPairCount: all.reduce((sum, item) => sum + item.comparedPairCount, 0), fullProvenanceMatchCount: all.reduce((sum, item) => sum + item.fullProvenanceMatchCount, 0), fullProvenanceMatchRate: null as number | null, fields: Object.fromEntries(EVIDENCE_PROVENANCE_FIELDS.map((field) => { const matchedCount = all.reduce((sum, item) => sum + item.fields[field].matchedCount, 0); const mismatchedCount = all.reduce((sum, item) => sum + item.fields[field].mismatchedCount, 0); return [field, { matchedCount, mismatchedCount, agreementRate: matchedCount + mismatchedCount ? matchedCount / (matchedCount + mismatchedCount) : null, mismatchedRuleIds: [...new Set(all.flatMap((item) => item.fields[field].mismatchedRuleIds))].sort() }]; })) as unknown as EvidenceSelectionResult["provenance"]["fields"] };
+  };
+  const acceptedProvenance = provenanceAggregate("accepted");
+  const rejectedProvenance = provenanceAggregate("rejected");
+  const acceptedProvenanceWithRate = { ...acceptedProvenance, fullProvenanceMatchRate: acceptedProvenance.comparedPairCount ? acceptedProvenance.fullProvenanceMatchCount / acceptedProvenance.comparedPairCount : null };
+  const rejectedProvenanceWithRate = { ...rejectedProvenance, fullProvenanceMatchRate: rejectedProvenance.comparedPairCount ? rejectedProvenance.fullProvenanceMatchCount / rejectedProvenance.comparedPairCount : null };
+  return { rows, aggregate: { accepted: aggregate(rows, "accepted"), rejected: aggregate(rows, "rejected"), acceptedProvenance: acceptedProvenanceWithRate, rejectedProvenance: rejectedProvenanceWithRate, rejectedReasonAgreement: rejectedReasonAgreementWithRate } };
+}

--- a/src/lib/preverif/vm0007EvidenceBenchmark.ts
+++ b/src/lib/preverif/vm0007EvidenceBenchmark.ts
@@ -15,9 +15,18 @@ export type EvidenceBenchmarkRecord = Readonly<{
   rejectionReason?: unknown;
 }>;
 
+export type Vm0007ProposedEvidence = Readonly<{
+  quote: unknown;
+  provenance: unknown;
+  reason?: unknown;
+  rejectionReason?: unknown;
+}>;
+
 export type Vm0007EvidenceBenchmarkMachineRow = Vm0007MachineProposalRow & Readonly<{
   acceptedEvidence?: unknown;
   rejectedEvidence?: unknown;
+  proposedAcceptedEvidence?: Vm0007ProposedEvidence | null;
+  proposedRejectedEvidence?: Vm0007ProposedEvidence | null;
 }>;
 
 export type Vm0007EvidenceBenchmarkReviewedRow = Vm0007ReviewedTruthRow & Readonly<{
@@ -119,6 +128,27 @@ export const normalizeRejectionReason = normalizeText;
 
 function record(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function machineEvidenceCollection(
+  row: Vm0007EvidenceBenchmarkMachineRow,
+  richField: "acceptedEvidence" | "rejectedEvidence",
+  proposedField: "proposedAcceptedEvidence" | "proposedRejectedEvidence",
+): unknown {
+  if (hasOwn(row, richField)) return row[richField];
+  if (!hasOwn(row, proposedField)) return undefined;
+  const proposed = row[proposedField];
+  if (proposed === null) return [];
+  if (!record(proposed)) return proposed;
+  return [{
+    quote: proposed.quote,
+    provenance: proposed.provenance,
+    ...(proposedField === "proposedRejectedEvidence" ? { rejectionReason: proposed.reason } : {}),
+  }];
 }
 
 function requiredText(value: unknown, label: string): string {
@@ -229,9 +259,9 @@ function evaluateCollection(machineValue: unknown, reviewedValue: unknown, stabl
     }
     rejectionReasons!.mismatchedCount = rejectionReasons!.comparedPairCount - rejectionReasons!.matchedCount;
     const agreementRate = rejectionReasons!.comparedPairCount ? rejectionReasons!.matchedCount / rejectionReasons!.comparedPairCount : null;
-    return { machineCollectionState, machineRecordCount: machine.length, reviewedRecordCount: reviewed.length, matchedRecordCount: pairs.length, falsePositiveRecords, falseNegativeRecords, exactCollectionMatch: falsePositiveRecords.length === 0 && falseNegativeRecords.length === 0, matchedPairs: pairs, provenance, rejectionReasons: { ...rejectionReasons!, agreementRate } };
+    return { machineCollectionState, machineRecordCount: machine.length, reviewedRecordCount: reviewed.length, matchedRecordCount: pairs.length, falsePositiveRecords, falseNegativeRecords, exactCollectionMatch: machineCollectionState === "present" && falsePositiveRecords.length === 0 && falseNegativeRecords.length === 0, matchedPairs: pairs, provenance, rejectionReasons: { ...rejectionReasons!, agreementRate } };
   }
-  return { machineCollectionState, machineRecordCount: machine.length, reviewedRecordCount: reviewed.length, matchedRecordCount: pairs.length, falsePositiveRecords, falseNegativeRecords, exactCollectionMatch: falsePositiveRecords.length === 0 && falseNegativeRecords.length === 0, matchedPairs: pairs, provenance, ...(rejectionReasons ? { rejectionReasons } : {}) };
+  return { machineCollectionState, machineRecordCount: machine.length, reviewedRecordCount: reviewed.length, matchedRecordCount: pairs.length, falsePositiveRecords, falseNegativeRecords, exactCollectionMatch: machineCollectionState === "present" && falsePositiveRecords.length === 0 && falseNegativeRecords.length === 0, matchedPairs: pairs, provenance, ...(rejectionReasons ? { rejectionReasons } : {}) };
 }
 
 function aggregate(rows: readonly Vm0007EvidenceBenchmarkRow[], collection: EvidenceBenchmarkCollection): EvidenceSelectionAggregate {
@@ -252,9 +282,13 @@ export function evaluateVm0007EvidenceBenchmark(input: Readonly<{ machineRows: r
   const machineById = new Map(input.machineRows.map((row) => [typeof row.stableRuleId === "string" ? row.stableRuleId.trim() : "", row]));
   const reviewedById = new Map(input.reviewedRows.map((row) => [typeof row.ruleId === "string" ? row.ruleId.trim() : "", row]));
   const rows = aligned.rows.map(({ stableRuleId }) => {
-    const machine = machineById.get(stableRuleId)! as Record<string, unknown>;
-    const reviewed = reviewedById.get(stableRuleId)! as Record<string, unknown>;
-    return { stableRuleId, accepted: evaluateCollection(machine.acceptedEvidence, reviewed.acceptedEvidence, stableRuleId, false), rejected: evaluateCollection(machine.rejectedEvidence, reviewed.rejectedEvidence, stableRuleId, true) };
+    const machine = machineById.get(stableRuleId)!;
+    const reviewed = reviewedById.get(stableRuleId)!;
+    return {
+      stableRuleId,
+      accepted: evaluateCollection(machineEvidenceCollection(machine, "acceptedEvidence", "proposedAcceptedEvidence"), reviewed.acceptedEvidence, stableRuleId, false),
+      rejected: evaluateCollection(machineEvidenceCollection(machine, "rejectedEvidence", "proposedRejectedEvidence"), reviewed.rejectedEvidence, stableRuleId, true),
+    };
   });
   const rejectionReasons = rows.flatMap((row) => row.rejected.rejectionReasons ? [row.rejected.rejectionReasons] : []);
   const rejectedReasonAgreement = rejectionReasons.reduce((acc, item) => ({ comparedPairCount: acc.comparedPairCount + item.comparedPairCount, matchedCount: acc.matchedCount + item.matchedCount, mismatchedCount: acc.mismatchedCount + item.mismatchedCount, agreementRate: null, mismatched: [...acc.mismatched, ...item.mismatched] }), emptyReasonAggregate());

--- a/tests/lib/preverif/marcondesEvidenceProvenanceBenchmark.test.ts
+++ b/tests/lib/preverif/marcondesEvidenceProvenanceBenchmark.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  evaluateVm0007EvidenceBenchmark,
+  type Vm0007EvidenceBenchmarkMachineRow,
+  type Vm0007EvidenceBenchmarkReviewedRow,
+} from "@/lib/preverif/vm0007EvidenceBenchmark";
+
+const fixtureDir = path.join(process.cwd(), "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map");
+const registry = JSON.parse(fs.readFileSync(path.join(process.cwd(), "public/methodologies/Verra/AFOLU/VM0007/v1-8/rules.json"), "utf8")) as { rules: Array<{ stable_id: string }> };
+const ids = registry.rules.map((rule) => rule.stable_id);
+
+const provenance = (page = 1, spanId = "span-1", sectionPath = ["Section"] ) => ({
+  docId: "doc-1", page, sectionPath, spanId, sectionHeading: "Heading", sourceType: "PDD",
+});
+const evidence = (quote: string, page = 1, spanId = "span-1", reason?: string) => ({ quote, provenance: provenance(page, spanId), ...(reason === undefined ? {} : { rejectionReason: reason }) });
+
+function inputs(overrides: Readonly<{ machineAccepted?: unknown; reviewedAccepted?: unknown; machineRejected?: unknown; reviewedRejected?: unknown }> = {}) {
+  const machineRows: Vm0007EvidenceBenchmarkMachineRow[] = ids.map((stableRuleId, index) => ({
+    stableRuleId, upstreamStatus: "FOUND", proposedApplicability: "APPLICABLE", reviewerOutcome: "CONFORMS", contradictionState: "NONE", draftFindingCandidate: null, clientAction: "retain",
+    acceptedEvidence: index === 0 && "machineAccepted" in overrides ? overrides.machineAccepted : [],
+    rejectedEvidence: index === 0 && "machineRejected" in overrides ? overrides.machineRejected : [],
+  }));
+  const reviewedRows: Vm0007EvidenceBenchmarkReviewedRow[] = ids.map((ruleId, index) => ({
+    ruleId, finalEvidenceState: "FOUND", applicability: "APPLICABLE", reviewerOutcome: "CONFORMS", contradictionState: "NONE", draftFindingCandidate: null, clientAction: "retain",
+    acceptedEvidence: index === 0 && "reviewedAccepted" in overrides ? overrides.reviewedAccepted : [],
+    rejectedEvidence: index === 0 && "reviewedRejected" in overrides ? overrides.reviewedRejected : [],
+  }));
+  return { machineRows, reviewedRows, expectedStableRuleIds: ids };
+}
+
+describe("VM0007 evidence selection and provenance benchmark", () => {
+  it("aligns the real machine and reviewed fixtures across all 58 stable IDs", () => {
+    const machine = JSON.parse(fs.readFileSync(path.join(fixtureDir, "machine-proposal.json"), "utf8"));
+    const reviewed = JSON.parse(fs.readFileSync(path.join(fixtureDir, "gold.json"), "utf8"));
+    const result = evaluateVm0007EvidenceBenchmark({ machineRows: machine.rows, reviewedRows: reviewed.rows, expectedStableRuleIds: ids });
+    expect(result.rows).toHaveLength(58);
+    expect(result.rows.map((row) => row.stableRuleId)).toEqual([...ids].sort());
+    expect(result.aggregate.accepted.machineCollectionAbsentStableRuleIds).toHaveLength(58);
+    expect(result.aggregate.accepted.reviewedRecordCount).toBe(95);
+  });
+
+  it("is deterministic and independent of row or evidence input order", () => {
+    const input = inputs({ machineAccepted: [evidence("  Same   QUOTE ")], reviewedAccepted: [evidence("same quote")] });
+    const first = evaluateVm0007EvidenceBenchmark(input);
+    const reordered = { ...input, machineRows: [...input.machineRows].reverse(), reviewedRows: [...input.reviewedRows].reverse() };
+    expect(evaluateVm0007EvidenceBenchmark(reordered)).toEqual(first);
+    expect(evaluateVm0007EvidenceBenchmark(input)).toEqual(first);
+  });
+
+  it("matches exact normalized quotes only, including duplicate quotes one-to-one", () => {
+    const result = evaluateVm0007EvidenceBenchmark(inputs({
+      machineAccepted: [evidence("A  quote"), evidence("A quote", 2, "span-2"), evidence("A quotation")],
+      reviewedAccepted: [evidence("a quote", 2, "span-2"), evidence(" A\nquote ")],
+    }));
+    const row = result.rows[0];
+    expect(row.accepted.matchedRecordCount).toBe(2);
+    expect(row.accepted.falsePositiveRecords).toHaveLength(1);
+    expect(row.accepted.falseNegativeRecords).toHaveLength(0);
+    expect(row.accepted.provenance.comparedPairCount).toBe(2);
+  });
+
+  it("pairs same quotes with different provenance, but reports provenance mismatches", () => {
+    const machine = evidence("quote", 1, "machine-span");
+    const reviewed = { ...evidence("QUOTE", 2, "reviewed-span"), provenance: provenance(2, "reviewed-span", ["Other Section"]) };
+    const result = evaluateVm0007EvidenceBenchmark(inputs({ machineAccepted: [machine], reviewedAccepted: [reviewed] }));
+    expect(result.rows[0].accepted.exactCollectionMatch).toBe(true);
+    expect(result.rows[0].accepted.provenance.fields.page.mismatchedCount).toBe(1);
+    expect(result.rows[0].accepted.provenance.fields.spanId.mismatchedCount).toBe(1);
+    expect(result.rows[0].accepted.provenance.fields.sectionPath.mismatchedCount).toBe(1);
+    expect(result.aggregate.acceptedProvenance.fullProvenanceMatchCount).toBe(0);
+  });
+
+  it("keeps accepted and rejected collections independent and compares rejection reasons exactly", () => {
+    const result = evaluateVm0007EvidenceBenchmark(inputs({
+      machineAccepted: [evidence("accepted")], reviewedAccepted: [evidence("accepted")],
+      machineRejected: [evidence("rejected", 1, "span-1", "  WRONG reason")], reviewedRejected: [evidence("rejected", 1, "span-1", "right reason")],
+    }));
+    expect(result.rows[0].accepted.matchedRecordCount).toBe(1);
+    expect(result.rows[0].rejected.matchedRecordCount).toBe(1);
+    expect(result.aggregate.rejectedReasonAgreement).toEqual(expect.objectContaining({ comparedPairCount: 1, matchedCount: 0, mismatchedCount: 1, agreementRate: 0 }));
+  });
+
+  it("distinguishes absent machine collections from present empty collections", () => {
+    const input = inputs({ reviewedAccepted: [] });
+    delete input.machineRows[0].acceptedEvidence;
+    const result = evaluateVm0007EvidenceBenchmark(input);
+    expect(result.rows[0].accepted.machineCollectionState).toBe("absent");
+    expect(result.rows[0].accepted.exactCollectionMatch).toBe(true);
+    expect(result.aggregate.accepted.precision).toBe(null);
+    expect(result.aggregate.accepted.recall).toBe(null);
+    expect(result.aggregate.accepted.f1).toBe(null);
+  });
+
+  it.each([
+    ["absent reviewed collection", (input: ReturnType<typeof inputs>) => { delete input.reviewedRows[0].acceptedEvidence; }, "reviewed acceptedEvidence"],
+    ["null reviewed collection", (input: ReturnType<typeof inputs>) => { input.reviewedRows[0].acceptedEvidence = null; }, "reviewed acceptedEvidence"],
+    ["malformed evidence", (input: ReturnType<typeof inputs>) => { input.reviewedRows[0].acceptedEvidence = [{ quote: "quote" }]; }, "malformed provenance"],
+    ["missing reviewed rejection reason", (input: ReturnType<typeof inputs>) => { input.reviewedRows[0].rejectedEvidence = [evidence("rejected")]; }, "missing rejectionReason"],
+  ])("fails closed for %s", (_name, mutate, message) => {
+    const input = inputs({ machineRejected: [evidence("rejected")], reviewedRejected: [evidence("rejected", 1, "span-1", "reason")] });
+    mutate(input);
+    expect(() => evaluateVm0007EvidenceBenchmark(input)).toThrow(message);
+  });
+
+  it("excludes unmatched evidence from provenance and exposes selection false positives/negatives", () => {
+    const result = evaluateVm0007EvidenceBenchmark(inputs({ machineAccepted: [evidence("machine-only")], reviewedAccepted: [evidence("reviewer-only")] }));
+    expect(result.rows[0].accepted.matchedRecordCount).toBe(0);
+    expect(result.rows[0].accepted.falsePositiveRecords).toHaveLength(1);
+    expect(result.rows[0].accepted.falseNegativeRecords).toHaveLength(1);
+    expect(result.rows[0].accepted.provenance.comparedPairCount).toBe(0);
+    expect(result.aggregate.acceptedProvenance.fullProvenanceMatchRate).toBe(null);
+  });
+
+  it("does not mutate machine or reviewed inputs", () => {
+    const input = inputs({ machineAccepted: [evidence("quote")], reviewedAccepted: [evidence("quote")] });
+    const before = JSON.stringify(input);
+    evaluateVm0007EvidenceBenchmark(input);
+    expect(JSON.stringify(input)).toBe(before);
+  });
+});

--- a/tests/lib/preverif/marcondesEvidenceProvenanceBenchmark.test.ts
+++ b/tests/lib/preverif/marcondesEvidenceProvenanceBenchmark.test.ts
@@ -37,8 +37,12 @@ describe("VM0007 evidence selection and provenance benchmark", () => {
     const result = evaluateVm0007EvidenceBenchmark({ machineRows: machine.rows, reviewedRows: reviewed.rows, expectedStableRuleIds: ids });
     expect(result.rows).toHaveLength(58);
     expect(result.rows.map((row) => row.stableRuleId)).toEqual([...ids].sort());
-    expect(result.aggregate.accepted.machineCollectionAbsentStableRuleIds).toHaveLength(58);
+    expect(result.aggregate.accepted.machineCollectionAbsentStableRuleIds).toHaveLength(0);
+    expect(result.rows.find((row) => row.stableRuleId.endsWith("R-1-0001"))?.accepted.machineCollectionState).toBe("present");
+    expect(result.aggregate.accepted.machineRecordCount).toBeGreaterThan(0);
+    expect(result.aggregate.accepted.precision).not.toBe(null);
     expect(result.aggregate.accepted.reviewedRecordCount).toBe(95);
+    expect(result.aggregate.acceptedProvenance.comparedPairCount).toBeGreaterThanOrEqual(0);
   });
 
   it("is deterministic and independent of row or evidence input order", () => {
@@ -87,10 +91,34 @@ describe("VM0007 evidence selection and provenance benchmark", () => {
     delete input.machineRows[0].acceptedEvidence;
     const result = evaluateVm0007EvidenceBenchmark(input);
     expect(result.rows[0].accepted.machineCollectionState).toBe("absent");
-    expect(result.rows[0].accepted.exactCollectionMatch).toBe(true);
+    expect(result.rows[0].accepted.exactCollectionMatch).toBe(false);
+    expect(result.aggregate.accepted.mismatchedStableRuleIds).toContain(result.rows[0].stableRuleId);
+    expect(result.aggregate.accepted.machineCollectionAbsentStableRuleIds).toContain(result.rows[0].stableRuleId);
+    expect(result.aggregate.accepted.exactRowMatchCount).toBe(57);
     expect(result.aggregate.accepted.precision).toBe(null);
     expect(result.aggregate.accepted.recall).toBe(null);
     expect(result.aggregate.accepted.f1).toBe(null);
+  });
+
+  it("adapts proposed evidence only when rich collections are absent", () => {
+    const input = inputs();
+    delete input.machineRows[0].acceptedEvidence;
+    delete input.machineRows[0].rejectedEvidence;
+    input.machineRows[0].proposedAcceptedEvidence = { quote: "proposed accepted", provenance: provenance(3) };
+    input.machineRows[0].proposedRejectedEvidence = { quote: "proposed rejected", provenance: provenance(4), reason: "proposed reason" };
+    input.reviewedRows[0].rejectedEvidence = [evidence("proposed rejected", 4, "span-1", "proposed reason")];
+    const result = evaluateVm0007EvidenceBenchmark(input);
+    expect(result.rows[0].accepted).toEqual(expect.objectContaining({ machineCollectionState: "present", machineRecordCount: 1 }));
+    expect(result.rows[0].rejected).toEqual(expect.objectContaining({ machineCollectionState: "present", machineRecordCount: 1, matchedRecordCount: 1 }));
+    expect(result.rows[0].rejected.rejectionReasons).toEqual(expect.objectContaining({ matchedCount: 1, mismatchedCount: 0 }));
+
+    input.machineRows[0].acceptedEvidence = [];
+    input.machineRows[0].proposedAcceptedEvidence = { quote: "ignored", provenance: provenance(5) };
+    expect(evaluateVm0007EvidenceBenchmark(input).rows[0].accepted.machineRecordCount).toBe(0);
+
+    delete input.machineRows[0].acceptedEvidence;
+    input.machineRows[0].proposedAcceptedEvidence = null;
+    expect(evaluateVm0007EvidenceBenchmark(input).rows[0].accepted).toEqual(expect.objectContaining({ machineCollectionState: "present", machineRecordCount: 0 }));
   });
 
   it.each([


### PR DESCRIPTION
### Roadmap-Update
- slug: interactive-evidence-review-mvp
- items:
  - RC2: in_progress

## Summary

Adds a pure, deterministic VM0007 RC2 evaluator for rich accepted and rejected evidence collections. It reuses the PR1 stable-ID benchmark alignment contract and does not alter production behavior.

## Contract

- Quotes use Unicode NFKC, lowercase, whitespace collapse, and trim; matching is exact normalized-quote equality.
- Evidence collections are order-independent multisets. Exact canonical provenance pairs first; remaining same-quote records pair by sorted provenance key.
- Machine absent collections remain absent; present empty arrays remain present and empty.
- Rich machine evidence arrays take precedence. When they are absent, proposed accepted/rejected evidence is adapted at the benchmark boundary; explicit proposed null becomes present-empty.
- Reviewed collections must be present arrays, including when empty.
- Accepted and rejected selection metrics are reported independently with counts, false positives/negatives, precision, recall, F1, exact-row matches, mismatched IDs, and absent-machine IDs.
- Provenance is measured only for paired evidence and compares docId, page, sectionPath, spanId, sectionHeading, and sourceType independently.
- Rejection reasons are compared only for paired rejected evidence using exact normalized text. Missing machine reasons mismatch; missing reviewed reasons are contract errors.
- Undefined precision, recall, F1, and provenance/reason rates are null.

## Validation

- Focused Jest: npx jest --runInBand tests/lib/preverif/marcondesReviewedGoldComparison.test.ts tests/lib/preverif/marcondesEvidenceProvenanceBenchmark.test.ts — 33 passed
- npm run lint — passed
- npm run typecheck — passed
- git diff --check — passed

Fixtures, reviewed truth, and production behavior were not changed. No baseline artifact or ranked failure taxonomy was added. RC2 PR3 remains responsible for the official baseline artifact and ranked generic failures.